### PR TITLE
Expressions: Show successful query data when some expressions fail

### DIFF
--- a/packages/grafana-runtime/src/utils/queryResponse.test.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.test.ts
@@ -1,6 +1,6 @@
 import { FetchError, FetchResponse } from 'src/services';
 
-import { DataQuery, toDataFrameDTO, DataFrame } from '@grafana/data';
+import { DataQuery, LoadingState, toDataFrameDTO, DataFrame } from '@grafana/data';
 
 import { BackendDataSourceResponse, cachedResponseNotice, toDataQueryResponse, toTestingStatus } from './queryResponse';
 
@@ -471,6 +471,70 @@ describe('Query Response parser', () => {
         },
       ]
     `);
+  });
+
+  describe('partial error handling', () => {
+    test('should set state to Done when some queries succeed and some fail', () => {
+      const input = {
+        data: {
+          results: {
+            A: {
+              error: 'query A failed',
+              status: 400,
+            },
+            B: {
+              frames: [
+                {
+                  schema: {
+                    refId: 'B',
+                    fields: [
+                      { name: 'time', type: 'time' },
+                      { name: 'value', type: 'number' },
+                    ],
+                  },
+                  data: { values: [[1000], [42]] },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as FetchResponse<BackendDataSourceResponse>;
+
+      const res = toDataQueryResponse(input);
+
+      expect(res.state).toBe(LoadingState.Done);
+      expect(res.errors).toHaveLength(1);
+      expect(res.errors?.[0].refId).toBe('A');
+      expect(res.error?.refId).toBe('A');
+      expect(res.data).toHaveLength(1);
+      expect(res.data[0].refId).toBe('B');
+    });
+
+    test('should set state to Error when all queries fail with no data', () => {
+      const input = {
+        data: {
+          results: {
+            A: { error: 'query A failed', status: 400 },
+            B: { error: 'query B failed', status: 500 },
+          },
+        },
+      } as unknown as FetchResponse<BackendDataSourceResponse>;
+
+      const res = toDataQueryResponse(input);
+
+      expect(res.state).toBe(LoadingState.Error);
+      expect(res.errors).toHaveLength(2);
+      expect(res.data).toHaveLength(0);
+    });
+
+    test('should set state to Done when a single query has both error and frames', () => {
+      const res = toDataQueryResponse(resWithError);
+
+      // A query returning both error and frames has usable data — state should be Done
+      expect(res.state).toBe(LoadingState.Done);
+      expect(res.errors).toHaveLength(1);
+      expect(res.data).toHaveLength(1);
+    });
   });
 
   describe('should convert to TestingStatus', () => {

--- a/packages/grafana-runtime/src/utils/queryResponse.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.ts
@@ -107,7 +107,6 @@ export function toDataQueryResponse(
         } else {
           rsp.errors = [{ ...errorObj }];
         }
-        rsp.state = LoadingState.Error;
       }
 
       if (dr.frames?.length) {
@@ -141,6 +140,12 @@ export function toDataQueryResponse(
           rsp.data.push(toDataFrame(s));
         }
       }
+    }
+
+    // Only set Error state when all queries failed and there's no usable data.
+    // When some queries succeed, use `Done` + errors so panels can render the successful data.
+    if ((rsp.errors?.length ?? 0) > 0 && rsp.data.length === 0) {
+      rsp.state = LoadingState.Error;
     }
   }
 

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.test.tsx
@@ -159,7 +159,7 @@ describe('PanelStateWrapper', () => {
           subject.next({ state: LoadingState.Loading, series: [], timeRange: getDefaultTimeRange() });
           subject.next({
             state: LoadingState.Done,
-            series: [{ name: 'DataB-1', fields: [] } as DataFrame],
+            series: [{ name: 'DataB-1', fields: [], length: 0 } as DataFrame],
             errors: scenario.errors,
             timeRange: getDefaultTimeRange(),
           });

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import { ReplaySubject } from 'rxjs';
 
-import { EventBusSrv, getDefaultTimeRange, LoadingState, PanelData, PanelPlugin } from '@grafana/data';
+import { DataFrame, EventBusSrv, getDefaultTimeRange, LoadingState, PanelData, PanelPlugin } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { PanelQueryRunner } from '../../query/state/PanelQueryRunner';
@@ -119,6 +119,47 @@ describe('PanelStateWrapper', () => {
           subject.next({
             state: LoadingState.Error,
             series: [],
+            errors: scenario.errors,
+            timeRange: getDefaultTimeRange(),
+          });
+        });
+
+        const newProps = { ...props, isInView: true };
+        rerender(
+          <Provider store={store}>
+            <PanelStateWrapper {...newProps} />
+          </Provider>
+        );
+
+        const button = screen.getByTestId(selectors.components.Panels.Panel.status('error'));
+        expect(button).toBeInTheDocument();
+        await act(async () => {
+          fireEvent.focus(button);
+        });
+        expect(await screen.findByText(scenario.expectedMessage)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when state is Done but partial errors are present', () => {
+    [
+      {
+        errors: [{ message: 'expression C failed' }],
+        expectedMessage: 'expression C failed',
+      },
+      {
+        errors: [{ message: 'expression C failed' }, { message: 'expression D failed' }],
+        expectedMessage: 'Multiple errors found. Click for more details',
+      },
+    ].forEach((scenario) => {
+      it(`then it should show error status: ${scenario.expectedMessage}`, async () => {
+        const { rerender, props, subject, store } = setupTestContext({});
+
+        act(() => {
+          subject.next({ state: LoadingState.Loading, series: [], timeRange: getDefaultTimeRange() });
+          subject.next({
+            state: LoadingState.Done,
+            series: [{ name: 'DataB-1', fields: [] } as DataFrame],
             errors: scenario.errors,
             timeRange: getDefaultTimeRange(),
           });

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -337,9 +337,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         const { errors: doneErrors, error: doneError } = data;
         if (doneErrors?.length) {
           errorMessage =
-            doneErrors.length === 1
-              ? doneErrors[0].message
-              : 'Multiple errors found. Click for more details';
+            doneErrors.length === 1 ? doneErrors[0].message : 'Multiple errors found. Click for more details';
         } else if (doneError) {
           errorMessage = doneError.message;
         }

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -333,6 +333,16 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         }
         break;
       case LoadingState.Done:
+        // Surface partial errors (some queries succeeded, some failed)
+        const { errors: doneErrors, error: doneError } = data;
+        if (doneErrors?.length) {
+          errorMessage =
+            doneErrors.length === 1
+              ? doneErrors[0].message
+              : 'Multiple errors found. Click for more details';
+        } else if (doneError) {
+          errorMessage = doneError.message;
+        }
         // If we are doing a snapshot save data in panel model
         if (dashboard.snapshot) {
           panel.snapshotData = data.series.map((frame) => toDataFrameDTO(frame));

--- a/public/app/features/explore/ResponseErrorContainer.test.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.test.tsx
@@ -10,48 +10,59 @@ import { ResponseErrorContainer } from './ResponseErrorContainer';
 import { createEmptyQueryResponse, makeExplorePaneState } from './state/utils';
 
 describe('ResponseErrorContainer', () => {
-  it('shows error message if it does not contain refId', async () => {
-    const errorMessage = 'test error';
-    setup({
-      message: errorMessage,
+  describe('LoadingState.Error', () => {
+    it('shows error message if it does not contain refId', async () => {
+      const errorMessage = 'test error';
+      setup({ state: LoadingState.Error, error: { message: errorMessage } });
+      const errorEl = screen.getByTestId(selectors.components.Alert.alertV2('error'));
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveTextContent(errorMessage);
     });
-    const errorEl = screen.getByTestId(selectors.components.Alert.alertV2('error'));
-    expect(errorEl).toBeInTheDocument();
-    expect(errorEl).toHaveTextContent(errorMessage);
+
+    it('does not show error if there is a refId', async () => {
+      setup({ state: LoadingState.Error, error: { refId: 'someId', message: 'test error' } });
+      expect(screen.queryByTestId(selectors.components.Alert.alertV2('error'))).not.toBeInTheDocument();
+    });
+
+    it('shows error.data.message if error.message does not exist', async () => {
+      setup({ state: LoadingState.Error, error: { data: { message: 'test error' } } });
+      const errorEl = screen.getByTestId(selectors.components.Alert.alertV2('error'));
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveTextContent('test error');
+    });
   });
 
-  it('do not show error if there is a refId', async () => {
-    const errorMessage = 'test error';
-    setup({
-      refId: 'someId',
-      message: errorMessage,
+  describe('LoadingState.Done — partial failure', () => {
+    it('shows error from errors[] when state is Done and error has no refId', async () => {
+      const errorMessage = 'expression failed';
+      setup({ state: LoadingState.Done, errors: [{ message: errorMessage }] });
+      const errorEl = screen.getByTestId(selectors.components.Alert.alertV2('error'));
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveTextContent(errorMessage);
     });
-    const errorEl = screen.queryByTestId(selectors.components.Alert.alertV2('error'));
-    expect(errorEl).not.toBeInTheDocument();
-  });
 
-  it('shows error.data.message if error.message does not exist', async () => {
-    const errorMessage = 'test error';
-    setup({
-      data: {
-        message: 'test error',
-      },
+    it('does not show error when all errors in errors[] have a refId', async () => {
+      setup({ state: LoadingState.Done, errors: [{ refId: 'A', message: 'query error' }] });
+      expect(screen.queryByTestId(selectors.components.Alert.alertV2('error'))).not.toBeInTheDocument();
     });
-    const errorEl = screen.getByTestId(selectors.components.Alert.alertV2('error'));
-    expect(errorEl).toBeInTheDocument();
-    expect(errorEl).toHaveTextContent(errorMessage);
+
+    it('does not show error when Done with no errors', async () => {
+      setup({ state: LoadingState.Done });
+      expect(screen.queryByTestId(selectors.components.Alert.alertV2('error'))).not.toBeInTheDocument();
+    });
   });
 });
 
-function setup(error: DataQueryError) {
+function setup({ state, error, errors }: { state: LoadingState; error?: DataQueryError; errors?: DataQueryError[] }) {
   const store = configureStore();
   store.getState().explore.panes = {
     left: {
       ...makeExplorePaneState(),
       queryResponse: {
         ...createEmptyQueryResponse(),
-        state: LoadingState.Error,
+        state,
         error,
+        errors,
       },
     },
   };

--- a/public/app/features/explore/ResponseErrorContainer.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.tsx
@@ -1,4 +1,4 @@
-import { LoadingState } from '@grafana/data';
+import { DataQueryError, LoadingState, PanelData } from '@grafana/data';
 import { useSelector } from 'app/types/store';
 
 import { ErrorContainer } from './ErrorContainer';
@@ -6,12 +6,23 @@ import { ErrorContainer } from './ErrorContainer';
 interface Props {
   exploreId: string;
 }
+
+function getQueryError(queryResponse: PanelData | undefined): DataQueryError | undefined {
+  if (queryResponse?.state === LoadingState.Error) {
+    return queryResponse.error;
+  }
+  if (queryResponse?.state === LoadingState.Done) {
+    return queryResponse.errors?.find((e) => !e.refId);
+  }
+  return undefined;
+}
+
 export function ResponseErrorContainer(props: Props) {
   const queryResponse = useSelector((state) => state.explore.panes[props.exploreId]!.queryResponse);
-  const queryError = queryResponse?.state === LoadingState.Error ? queryResponse?.error : undefined;
+  const queryError = getQueryError(queryResponse);
 
-  // Errors with ref ids are shown below the corresponding query
-  if (queryError?.refId) {
+  // No error, or error with a refId (shown below the corresponding query)
+  if (!queryError || queryError.refId) {
     return null;
   }
 

--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -466,6 +466,52 @@ describe('runRequest', () => {
       expect(ctx.results[0].series[1].name).toBe('DataB-2');
     });
   });
+
+  runRequestScenario('When errors are present but there is no data', (ctx) => {
+    ctx.setup(() => {
+      ctx.start();
+      ctx.emitPacket({
+        data: [],
+        errors: [{ message: 'expression A failed' }],
+      });
+    });
+
+    it('should set state to Error when there is no data', () => {
+      expect(ctx.results[0].state).toBe(LoadingState.Error);
+    });
+
+    it('should include the errors', () => {
+      expect(ctx.results[0].errors).toHaveLength(1);
+      expect(ctx.results[0].errors?.[0].message).toBe('expression A failed');
+    });
+
+    it('should have no series', () => {
+      expect(ctx.results[0].series).toHaveLength(0);
+    });
+  });
+
+  runRequestScenario('When both packet.error and packet.errors are present alongside data', (ctx) => {
+    ctx.setup(() => {
+      ctx.start();
+      ctx.emitPacket({
+        data: [{ name: 'DataB-1', refId: 'B' } as DataFrame],
+        error: { message: 'primary error' },
+        errors: [{ message: 'expression A failed' }, { message: 'expression C failed' }],
+      });
+    });
+
+    it('should set state to Done because data is present', () => {
+      expect(ctx.results[0].state).toBe(LoadingState.Done);
+    });
+
+    it('should capture packet.error', () => {
+      expect(ctx.results[0].error?.message).toBe('primary error');
+    });
+
+    it('should capture both entries from packet.errors', () => {
+      expect(ctx.results[0].errors).toHaveLength(2);
+    });
+  });
 });
 
 describe('callQueryMethodWithMigration', () => {

--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -390,6 +390,61 @@ describe('runRequest', () => {
     });
   });
 
+  runRequestScenario('After response with partial errors (some queries succeed, some fail)', (ctx) => {
+    ctx.setup(() => {
+      ctx.start();
+      ctx.emitPacket({
+        data: [{ name: 'DataB-1', refId: 'B' } as DataFrame],
+        errors: [{ refId: 'A', message: 'query A failed' }],
+        state: LoadingState.Done,
+      });
+    });
+
+    it('should have state Done when data is present alongside errors', () => {
+      expect(ctx.results[0].state).toEqual(LoadingState.Done);
+    });
+
+    it('should include errors', () => {
+      expect(ctx.results[0].errors).toHaveLength(1);
+      expect(ctx.results[0].errors?.[0].refId).toBe('A');
+    });
+
+    it('should include the successful data', () => {
+      expect(ctx.results[0].series).toHaveLength(1);
+      expect(ctx.results[0].series[0].name).toBe('DataB-1');
+    });
+  });
+
+  runRequestScenario('After multiple packets where errors accumulate across packets', (ctx) => {
+    ctx.setup(() => {
+      ctx.start();
+      ctx.emitPacket({
+        data: [{ name: 'DataB-1', refId: 'B' } as DataFrame],
+        errors: [{ refId: 'A', message: 'query A failed' }],
+        key: 'B',
+      });
+      ctx.emitPacket({
+        data: [{ name: 'DataD-1', refId: 'D' } as DataFrame],
+        errors: [{ refId: 'C', message: 'query C failed' }],
+        key: 'D',
+      });
+    });
+
+    it('should accumulate errors from all packets', () => {
+      expect(ctx.results[1].errors).toHaveLength(2);
+      expect(ctx.results[1].errors?.[0].refId).toBe('A');
+      expect(ctx.results[1].errors?.[1].refId).toBe('C');
+    });
+
+    it('should have state Done when data is present', () => {
+      expect(ctx.results[1].state).toEqual(LoadingState.Done);
+    });
+
+    it('should include all successful data', () => {
+      expect(ctx.results[1].series).toHaveLength(2);
+    });
+  });
+
   runRequestScenario('When some queries are hidden', (ctx) => {
     ctx.setup(() => {
       ctx.request.targets = [{ refId: 'A', hide: true }, { refId: 'B' }];

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -57,10 +57,15 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
   for (const key in packets) {
     const packet = packets[key];
 
-    if (packet.error || packet.errors?.length) {
-      loadingState = LoadingState.Error;
+    if (packet.error) {
       error = packet.error;
-      errors = packet.errors;
+    }
+    if (packet.errors?.length) {
+      if (errors) {
+        errors = [...errors, ...packet.errors];
+      } else {
+        errors = [...packet.errors];
+      }
     }
 
     if (packet.data && packet.data.length) {
@@ -73,6 +78,12 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
         series.push(dataItem);
       }
     }
+  }
+
+  // Only set Error state when all data failed and there's nothing to render.
+  // When some queries succeed, use Done + errors so panels can render the successful data.
+  if ((errors?.length || error) && series.length === 0) {
+    loadingState = LoadingState.Error;
   }
 
   const timeRange = getRequestTimeRange(request, loadingState);

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -61,11 +61,7 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
       error = packet.error;
     }
     if (packet.errors?.length) {
-      if (errors) {
-        errors = [...errors, ...packet.errors];
-      } else {
-        errors = [...packet.errors];
-      }
+      errors = [...(errors ?? []), ...packet.errors];
     }
 
     if (packet.data && packet.data.length) {


### PR DESCRIPTION
## Motivation

This PR closes #119939.

When a Server-Side Expression (SSE) node fails, the backend returns a mixed response: error frames for the failed expression, but valid data frames for any queries that ran independently and succeeded. Currently, that mixed response is treated as a total failure, where the panel discards the successful data and only shows an error view, even though there was perfectly good data to render.

The root problem is in two places in the query-response pipeline:

- **`toDataQueryResponse()`** (`@grafana/runtime`): called by `DataSourceWithBackend.query`, the base class for all backend data sources. It was setting `LoadingState.Error` as soon as *any* per-query error appeared in the response, regardless of whether other queries returned data.
- **`processResponsePacket()`** (`runRequest.ts`): which accumulates streamed response packets into `PanelData`. Same logic: any error in any packet triggered `LoadingState.Error` for the whole panel.

A third gap: `PanelStateWrapper.onDataUpdate()` only read `data.errors` in the `LoadingState.Error` branch. Even with the upstream logic fixed, the error indicator would have been silently dropped on the `Done` path.

A fourth gap, caught in review: `ResponseErrorContainer` in Explore had the same pattern — error display was gated on `LoadingState.Error`, so partial failures (now arriving as `Done` + `errors[]`) would have been silently swallowed in Explore too.

## Changes

- `toDataQueryResponse()`: set `LoadingState.Error` only when errors are present **and** `rsp.data` is empty (i.e., there is nothing to render). If some queries succeeded, return `Done` + `errors[]`.
- `processResponsePacket()`: same condition — `LoadingState.Error` only when errors exist and `series` is empty.
- `PanelStateWrapper.onDataUpdate()`: extract `errorMessage` from `data.errors` in the `Done` case as well as the `Error` case, so partial-failure error banners still surface on panels that have data.
- `ResponseErrorContainer` (Explore): extracted a `getQueryError()` helper that also surfaces errors from `errors[]` when state is `Done`, closing the same gap that existed in `PanelStateWrapper`.

## Risks

| Path                   | How changed?                               | Notes                                                                                                                                                                                                                              |
|------------------------|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| All failures (no data) | Unchanged                                    | If every query fails and there is no data, `LoadingState.Error` is still set and panels render the full error screen as before. No regression risk there.                                                                          |
| Partial failure        | New behavior, not modified existing behavior | Before this fix, panels could never reach `LoadingState.Done` with errors present. That state simply didn't occur. This means there's no existing logic that depended on this combination, and no rollback risk from changing it. |
| Explore error display  | Fixed gap                                    | `ResponseErrorContainer` previously silenced errors on `Done` state. This PR surfaces them from `errors[]`. This should only affect the Explore error banner.                                    |

One remaining area worth calling out: `toDataQueryResponse` is exported from `@grafana/runtime` as a public API. External plugin authors who call it directly and branch on `LoadingState.Error` to gate rendering will now see `Done` in partial-failure cases. The new behavior is semantically correct (render the data), but it's a subtle shift in the contract of the function. Worth a mention in the public changelog.

**Overall confidence: high.** The change is strictly additive on the partial-failure path, the all-failures path is untouched, and all four layers have test coverage for both cases.

## Testing

- Unit tests added/extended for `toDataQueryResponse`, `processResponsePacket`, `PanelStateWrapper.onDataUpdate`, and `ResponseErrorContainer` covering all-failures, partial-failure, and all-success cases.
- Manual: dashboard panel with a SQL expression referencing a failing expression alongside a healthy metric query — panel renders the metric data with an error banner rather than a full error screen.

## Checklist

- [x] Tests added for all four changed layers
- [x] Explore partial-failure path fixed and tested (`ResponseErrorContainer`)
- [ ] `@grafana/runtime` public API change to `toDataQueryResponse` noted in changelog