### PR TITLE
Alerting: Add frontend only alertingPolicyRoutingSettings feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1623,6 +1623,11 @@ export interface FeatureToggles {
   */
   alertingMultiplePolicies?: boolean;
   /**
+  * Use notification settings policy field instead of labels for named policy routing in alert rules
+  * @default false
+  */
+  alertingPolicyRoutingSettings?: boolean;
+  /**
   * Registers an API server for each backend app plugin exposing a settings endpoint
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2571,6 +2571,15 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "alertingPolicyRoutingSettings",
+			Description:  "Use notification settings policy field instead of labels for named policy routing in alert rules",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+		},
+		{
 			Name:            "appPluginAPIServer",
 			Description:     "Registers an API server for each backend app plugin exposing a settings endpoint",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -319,6 +319,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,kubernetesTeamSync,experimental,@grafana/identity-access-team,false,false,false
 2026-03-06,kubernetesTeamService,experimental,@grafana/identity-access-team,false,false,false
 2026-02-18,alertingMultiplePolicies,experimental,@grafana/alerting-squad,false,false,false
+2026-03-16,alertingPolicyRoutingSettings,experimental,@grafana/alerting-squad,false,false,true
 2026-02-11,appPluginAPIServer,experimental,@grafana/plugins-platform-backend,false,true,false
 2026-02-18,alertingIgnorePendingForNoDataAndError,experimental,@grafana/alerting-squad,false,false,false
 2026-02-18,alertingNotificationHistoryRuleViewer,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -568,6 +568,21 @@
     },
     {
       "metadata": {
+        "name": "alertingPolicyRoutingSettings",
+        "resourceVersion": "1773692781781",
+        "creationTimestamp": "2026-03-16T20:26:21Z"
+      },
+      "spec": {
+        "description": "Use notification settings policy field instead of labels for named policy routing in alert rules",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingPrometheusRulesPrimary",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2024-09-27T12:27:16Z"


### PR DESCRIPTION
**What is this feature?**

This PR adds a new frontend only feature flag `alertingPolicyRoutingSettings` that will be used to gate the frontend changes related to using notification settings policy field instead of labels for named policy routing in alert rules.

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/alerting-squad/issues/1459

**Special notes for your reviewer:**