### PR TITLE
Import dashboard: v1 collapsed row panels

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -643,6 +643,65 @@ describe('applyV1Inputs', () => {
     expect(vars[1].current?.value).toBe('http://my-app:7070');
   });
 
+  describe('row panels', () => {
+    type RowPanel = { type: string; collapsed: boolean; datasource?: { uid: string }; panels: PanelWithTargets[] };
+
+    const makeForm = (): ImportDashboardDTO => ({
+      title: 'new-title',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    });
+
+    it('replaces datasources in panels nested inside a collapsed row', () => {
+      const dashboard = {
+        title: 'old',
+        uid: 'old',
+        panels: [
+          {
+            type: 'row',
+            collapsed: true,
+            panels: [
+              { datasource: { uid: '${DS}' }, targets: [{ datasource: { uid: '${DS}' } }] },
+              { datasource: { uid: '${DS}' }, targets: [{ datasource: { uid: '${DS}' } }] },
+            ],
+          },
+        ],
+      } as unknown as Dashboard;
+
+      const result = applyV1Inputs(dashboard, sampleV1Inputs, makeForm());
+
+      const row = result.panels?.[0] as unknown as RowPanel;
+      expect(row.panels[0].datasource?.uid).toBe('ds-uid');
+      expect(row.panels[0].targets?.[0].datasource?.uid).toBe('ds-uid');
+      expect(row.panels[1].datasource?.uid).toBe('ds-uid');
+      expect(row.panels[1].targets?.[0].datasource?.uid).toBe('ds-uid');
+    });
+
+    it("replaces the row panel's own datasource when it is templated", () => {
+      const dashboard = {
+        title: 'old',
+        uid: 'old',
+        panels: [
+          {
+            type: 'row',
+            collapsed: true,
+            datasource: { uid: '${DS}' },
+            panels: [{ datasource: { uid: '${DS}' }, targets: [] }],
+          },
+        ],
+      } as unknown as Dashboard;
+
+      const result = applyV1Inputs(dashboard, sampleV1Inputs, makeForm());
+
+      const row = result.panels?.[0] as unknown as RowPanel;
+      expect(row.datasource?.uid).toBe('ds-uid');
+    });
+  });
+
   it('replaces target datasource UIDs in panels with built-in datasources like Mixed', () => {
     const dashboard = {
       title: 'old',

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -656,124 +656,79 @@ describe('applyV1Inputs', () => {
       folder: { uid: 'folder' },
     });
 
-    it('replaces datasources in panels nested inside a collapsed row', () => {
+    it('should import dashboards with both collapsed and uncollapsed rows', () => {
       const dashboard = {
         title: 'old',
         uid: 'old',
         panels: [
+          { type: 'row', collapsed: false, title: 'Summary' },
+          { datasource: { uid: '${DS}' }, targets: [{ datasource: { uid: '${DS}' } }] },
           {
             type: 'row',
             collapsed: true,
+            panels: [{ datasource: { uid: '${DS}' }, targets: [{ datasource: { uid: '${DS}' } }] }],
+          },
+          { type: 'row', collapsed: false, title: 'Appendix' },
+        ],
+      } as unknown as Dashboard;
+
+      const result = applyV1Inputs(dashboard, sampleV1Inputs, makeForm());
+
+      expect(result.panels).toHaveLength(4);
+      expect((result.panels?.[0] as unknown as { type: string }).type).toBe('row');
+      expect((result.panels?.[1] as unknown as PanelWithTargets).datasource?.uid).toBe('ds-uid');
+      const collapsedRow = result.panels?.[2] as unknown as RowPanel;
+      expect(collapsedRow.panels[0].datasource?.uid).toBe('ds-uid');
+      expect(collapsedRow.panels[0].targets?.[0].datasource?.uid).toBe('ds-uid');
+      expect((result.panels?.[3] as unknown as { type: string }).type).toBe('row');
+    });
+
+    it('replaces datasources in collapsed row children', () => {
+      const dashboard = {
+        title: 'old',
+        uid: 'old',
+        panels: [
+          { type: 'row', collapsed: false, title: 'Summary' },
+          {
+            datasource: { type: 'datasource', uid: '-- Mixed --' },
+            targets: [
+              { datasource: { type: 'grafana-bigquery-datasource', uid: '${DS}' }, refId: 'A' },
+              { datasource: { type: 'grafana-athena-datasource', uid: '${DS}' }, refId: 'B' },
+            ],
+          },
+          {
+            type: 'row',
+            collapsed: true,
+            datasource: { uid: '${DS}' },
             panels: [
               { datasource: { uid: '${DS}' }, targets: [{ datasource: { uid: '${DS}' } }] },
               { datasource: { uid: '${DS}' }, targets: [{ datasource: { uid: '${DS}' } }] },
             ],
           },
+          { type: 'row', collapsed: false, title: 'Appendix' },
         ],
       } as unknown as Dashboard;
 
       const result = applyV1Inputs(dashboard, sampleV1Inputs, makeForm());
 
-      const row = result.panels?.[0] as unknown as RowPanel;
+      expect(result.panels).toHaveLength(4);
+
+      expect((result.panels?.[0] as unknown as { type: string }).type).toBe('row');
+
+      expect(result.panels?.[1].datasource?.uid).toBe('-- Mixed --');
+      const mixedPanel = result.panels?.[1] as PanelWithTargets;
+      expect(mixedPanel.targets?.[0].datasource?.uid).toBe('ds-uid');
+      expect(mixedPanel.targets?.[1].datasource?.uid).toBe('ds-uid');
+
+      const row = result.panels?.[2] as unknown as RowPanel;
+      expect(row.datasource?.uid).toBe('ds-uid');
       expect(row.panels[0].datasource?.uid).toBe('ds-uid');
       expect(row.panels[0].targets?.[0].datasource?.uid).toBe('ds-uid');
       expect(row.panels[1].datasource?.uid).toBe('ds-uid');
       expect(row.panels[1].targets?.[0].datasource?.uid).toBe('ds-uid');
+
+      expect((result.panels?.[3] as unknown as { type: string }).type).toBe('row');
     });
-
-    it("replaces the row panel's own datasource when it is templated", () => {
-      const dashboard = {
-        title: 'old',
-        uid: 'old',
-        panels: [
-          {
-            type: 'row',
-            collapsed: true,
-            datasource: { uid: '${DS}' },
-            panels: [{ datasource: { uid: '${DS}' }, targets: [] }],
-          },
-        ],
-      } as unknown as Dashboard;
-
-      const result = applyV1Inputs(dashboard, sampleV1Inputs, makeForm());
-
-      const row = result.panels?.[0] as unknown as RowPanel;
-      expect(row.datasource?.uid).toBe('ds-uid');
-    });
-  });
-
-  it('replaces target datasource UIDs in panels with built-in datasources like Mixed', () => {
-    const dashboard = {
-      title: 'old',
-      uid: 'old',
-      panels: [
-        {
-          datasource: { type: 'datasource', uid: '-- Mixed --' },
-          targets: [
-            { datasource: { type: 'grafana-bigquery-datasource', uid: '${DS}' }, refId: 'A' },
-            { datasource: { type: 'grafana-athena-datasource', uid: '${DS}' }, refId: 'B' },
-          ],
-        },
-      ],
-    } as unknown as Dashboard;
-
-    const form: ImportDashboardDTO = {
-      title: 'new-title',
-      uid: 'new-uid',
-      gnetId: '',
-      constants: [],
-      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
-      elements: [],
-      folder: { uid: 'folder' },
-    };
-
-    const result = applyV1Inputs(dashboard, sampleV1Inputs, form);
-
-    expect(result.panels?.[0].datasource?.uid).toBe('-- Mixed --');
-
-    const panel = result.panels?.[0] as PanelWithTargets;
-    expect(panel.targets?.[0].datasource?.uid).toBe('ds-uid');
-    expect(panel.targets?.[1].datasource?.uid).toBe('ds-uid');
-  });
-
-  it('replaces datasource UIDs in panels inside collapsed rows', () => {
-    const dashboard = {
-      title: 'old',
-      uid: 'old',
-      panels: [
-        {
-          type: 'row',
-          collapsed: true,
-          title: 'My Row',
-          panels: [
-            {
-              datasource: { uid: '${DS}' },
-              targets: [{ datasource: { uid: '${DS}' } }],
-            },
-          ],
-        },
-      ],
-    } as unknown as Dashboard;
-
-    const form: ImportDashboardDTO = {
-      title: 'new-title',
-      uid: 'new-uid',
-      gnetId: '',
-      constants: [],
-      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
-      elements: [],
-      folder: { uid: 'folder' },
-    };
-
-    const result = applyV1Inputs(dashboard, sampleV1Inputs, form);
-
-    // The row panel itself should be preserved
-    const rowPanel = result.panels?.[0] as unknown as { type: string; panels: PanelWithTargets[] };
-    expect(rowPanel.type).toBe('row');
-
-    // The child panel inside the collapsed row should have its datasource replaced
-    expect(rowPanel.panels[0].datasource?.uid).toBe('ds-uid');
-    expect(rowPanel.panels[0].targets?.[0].datasource?.uid).toBe('ds-uid');
   });
 });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -67,10 +67,6 @@ function hasUid(query: Record<string, unknown> | {}): query is { uid: string } {
   return 'uid' in query && typeof query['uid'] === 'string';
 }
 
-function isRowPanel(panel: Panel | RowPanel): panel is RowPanel {
-  return panel.type === 'row';
-}
-
 function getExportLabel(labels?: { [ExportLabel]?: string }): string | undefined {
   if (!labels) {
     return undefined;
@@ -312,12 +308,7 @@ export function applyV1Inputs(
     return processAnnotation(annotation, inputs, form);
   });
 
-  // Row panels with collapsed=true store their child panels in panel.panels[] rather than
-  // dashboard.panels[]. We recurse one level deep — v1 dashboards do not nest rows further.
-  const panels = (dashboard.panels ?? []).map((panel: Panel | RowPanel) => {
-    if (isRowPanel(panel)) {
-      return { ...panel, panels: panel.panels.map((p: Panel) => processPanel(p, inputs, form)) };
-    }
+  const panels = (dashboard.panels ?? []).map((panel: Panel) => {
     return processPanel(panel, inputs, form);
   });
 
@@ -639,7 +630,7 @@ function processPanel(
     return {
       ...panel,
       ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
-      panels: panel.panels?.map((nestedPanel) => {
+      panels: panel.panels.map((nestedPanel) => {
         return processPanel(nestedPanel, inputs, form);
       }),
     };

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -1,9 +1,8 @@
 import { DataSourceInstanceSettings, VariableModel } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
-import { Panel, RowPanel } from '@grafana/schema';
+import { AnnotationQuery, Dashboard, Panel, RowPanel } from '@grafana/schema';
 import { AnnotationQueryKind, Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-import { AnnotationQuery, Dashboard } from '@grafana/schema/dist/esm/veneer/dashboard.types';
 import { isRecord } from 'app/core/utils/isRecord';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { isDashboardV1Resource, isDashboardV2Resource, isDashboardV2Spec } from 'app/features/dashboard/api/utils';
@@ -592,8 +591,29 @@ function processAnnotation(
   return annotation;
 }
 
-function processPanel(panel: Panel, inputs: { dataSources: DataSourceInput[] }, form: ImportDashboardDTO): Panel {
-  const queries = panel.targets?.map((target) => {
+function resolveInputDatasource(
+  datasource: Panel['datasource'],
+  inputs: { dataSources: DataSourceInput[] },
+  form: ImportDashboardDTO
+): Panel['datasource'] {
+  if (datasource && hasUid(datasource) && datasource.uid.startsWith('$')) {
+    const userInput = checkUserInputMatch(datasource.uid, inputs.dataSources, form.dataSources);
+    if (userInput) {
+      return {
+        ...datasource,
+        uid: userInput.uid,
+      };
+    }
+  }
+  return datasource;
+}
+
+function resolveInputTargets(
+  targets: Panel['targets'],
+  inputs: { dataSources: DataSourceInput[] },
+  form: ImportDashboardDTO
+): Panel['targets'] {
+  return targets?.map((target) => {
     if (target.datasource && hasUid(target.datasource) && target.datasource.uid.startsWith('$')) {
       const userInput = checkUserInputMatch(target.datasource.uid, inputs.dataSources, form.dataSources);
       if (userInput) {
@@ -608,21 +628,27 @@ function processPanel(panel: Panel, inputs: { dataSources: DataSourceInput[] }, 
     }
     return target;
   });
+}
 
-  const panelDs =
-    panel.datasource && panel.datasource.uid && panel.datasource.uid.startsWith('$')
-      ? checkUserInputMatch(panel.datasource.uid, inputs.dataSources, form.dataSources)
-      : undefined;
+function processPanel(
+  panel: Panel | RowPanel,
+  inputs: { dataSources: DataSourceInput[] },
+  form: ImportDashboardDTO
+): Panel | RowPanel {
+  if ('panels' in panel) {
+    return {
+      ...panel,
+      ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
+      panels: panel.panels?.map((nestedPanel) => {
+        return processPanel(nestedPanel, inputs, form);
+      }),
+    };
+  }
 
   return {
     ...panel,
-    ...(queries && { targets: queries }),
-    ...(panelDs && {
-      datasource: {
-        ...panel.datasource,
-        uid: panelDs.uid,
-      },
-    }),
+    ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
+    ...(panel.targets && { targets: resolveInputTargets(panel.targets, inputs, form) }),
   };
 }
 


### PR DESCRIPTION
**What is this feature?**

Fixes datasource `__inputs` variable interpolation for panels nested inside collapsed rows during dashboard import as they have different structure comparing to uncollapsed

uncollapsed:
```
{
  "panels": [
    { "type": "row", "collapsed": false, "panels": [] },
    { "type": "timeseries", "id": 1, "datasource": { "uid": "${DS__X}" } },
    { "type": "timeseries", "id": 2, "datasource": { "uid": "${DS__X}" } }
  ]
}
```

collapsed:
```
{
  "panels": [
    {
      "type": "row",
      "collapsed": true,
      "panels": [
        { "type": "timeseries", "id": 1, "datasource": { "uid": "${DS__X}" } },
        { "type": "timeseries", "id": 2, "datasource": { "uid": "${DS__X}" } }
      ]
    }
  ]
}
```