### PR TITLE
CommandPalette: Fix flaky empty state test

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.test.tsx
+++ b/public/app/features/commandPalette/CommandPalette.test.tsx
@@ -45,7 +45,7 @@ const triggerEmptyState = async () => {
 describe('CommandPalette', () => {
   it('should render empty state with AI Assistant button when no results and assistant is available', async () => {
     // Mock assistant being available
-    (useAssistant as jest.Mock).mockReturnValue({ isAvailable: true });
+    (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: true });
     setup();
     await triggerEmptyState();
 
@@ -57,7 +57,7 @@ describe('CommandPalette', () => {
 
   it('should render empty state without AI Assistant button when assistant is not available', async () => {
     // Mock assistant being unavailable
-    (useAssistant as jest.Mock).mockReturnValue({ isAvailable: false });
+    (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: false });
     setup();
     await triggerEmptyState();
 

--- a/public/app/features/commandPalette/CommandPalette.test.tsx
+++ b/public/app/features/commandPalette/CommandPalette.test.tsx
@@ -36,10 +36,11 @@ const setup = () => {
 };
 
 const triggerEmptyState = async () => {
+  const user = userEvent.setup();
   // Type a nonsense query to trigger the empty state naturally, rather than relying on
   // kbar's useThrottledValue timing with an empty search (which causes flakiness)
   const input = screen.getByPlaceholderText('Search or jump to...');
-  await userEvent.type(input, 'zzznomatch');
+  await user.type(input, 'zzznomatch');
 };
 
 describe('CommandPalette', () => {

--- a/public/app/features/commandPalette/CommandPalette.test.tsx
+++ b/public/app/features/commandPalette/CommandPalette.test.tsx
@@ -1,5 +1,5 @@
 import { KBarProvider } from 'kbar';
-import { render, screen } from 'test/test-utils';
+import { render, screen, userEvent } from 'test/test-utils';
 
 import { useAssistant } from '@grafana/assistant';
 import { setPluginLinksHook } from '@grafana/runtime';
@@ -35,11 +35,19 @@ const setup = () => {
   );
 };
 
+const triggerEmptyState = async () => {
+  // Type a nonsense query to trigger the empty state naturally, rather than relying on
+  // kbar's useThrottledValue timing with an empty search (which causes flakiness)
+  const input = screen.getByPlaceholderText('Search or jump to...');
+  await userEvent.type(input, 'zzznomatch');
+};
+
 describe('CommandPalette', () => {
   it('should render empty state with AI Assistant button when no results and assistant is available', async () => {
     // Mock assistant being available
-    (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: true });
+    (useAssistant as jest.Mock).mockReturnValue({ isAvailable: true });
     setup();
+    await triggerEmptyState();
 
     // Check if empty state message is rendered
     expect(await screen.findByText('No results found')).toBeInTheDocument();
@@ -49,8 +57,9 @@ describe('CommandPalette', () => {
 
   it('should render empty state without AI Assistant button when assistant is not available', async () => {
     // Mock assistant being unavailable
-    (useAssistant as jest.Mock).mockReturnValue({ isLoading: false, isAvailable: false });
+    (useAssistant as jest.Mock).mockReturnValue({ isAvailable: false });
     setup();
+    await triggerEmptyState();
 
     // Check if empty state message is rendered
     expect(await screen.findByText('No results found')).toBeInTheDocument();


### PR DESCRIPTION
**What is this feature?**
FIxes flakey test. Types a nonsense search query (`zzznomatch`) in the command palette tests so the empty state is triggered by genuinely having no matches, rather than relying on timing.

**Why do we need this feature?**
Flakey flakey 🥐 

The tests were flaky because `useRegisterStaticActions()` registers nav actions with kbar, and `useMatches()` returns them when the search is empty. kbar's `useThrottledValue` introduces timing variability — sometimes actions register before the throttled value updates (test fails), sometimes after (test passes).

**Who is this feature for?**
UI devs
