### PR TITLE
chore(migration): remove per item log

### DIFF
--- a/pkg/registry/apps/shorturl/migrator/migrator.go
+++ b/pkg/registry/apps/shorturl/migrator/migrator.go
@@ -130,7 +130,6 @@ func (m *shortURLMigrator) MigrateShortURLs(ctx context.Context, orgId int64, op
 
 		for _, req := range chunk {
 			count++
-			opts.Progress(count, fmt.Sprintf("%s (%d)", req.Key.Name, len(req.Value)))
 
 			err = stream.Send(req)
 			if err != nil {


### PR DESCRIPTION
Removes the per item log for shorturl migrations. For big instances it can create thousand of log lines.