### PR TITLE
Plugins: Add `X-Plugin-Id` header to requests

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -48,6 +48,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		query.HeaderPanelPluginId,
 		query.HeaderDashboardTitle,
 		query.HeaderPanelTitle,
+		query.HeaderPluginID,
 	}
 
 	for _, headerName := range headersList {

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -114,6 +114,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 		req.Header[`X-Panel-Id`] = []string{"2"}
 		req.Header[`X-Query-Group-Id`] = []string{"d26e337d-cb53-481a-9212-0112537b3c1a"}
 		req.Header[`X-Grafana-From-Expr`] = []string{"true"}
+		req.Header[`X-Plugin-Id`] = []string{"jaeger"}
 
 		pluginCtx := backend.PluginContext{
 			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
@@ -134,13 +135,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.QueryDataReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.QueryDataReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.QueryDataReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.QueryDataReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `jaeger`, cdt.QueryDataReq.GetHTTPHeader(`X-Plugin-Id`))
 		})
 
 		t.Run("tracing headers are set for health check", func(t *testing.T) {
@@ -158,13 +160,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.CheckHealthReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.CheckHealthReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.CheckHealthReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.CheckHealthReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `jaeger`, cdt.CheckHealthReq.GetHTTPHeader(`X-Plugin-Id`))
 		})
 
 		t.Run("tracing headers are set for subscribe stream", func(t *testing.T) {
@@ -182,13 +185,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.SubscribeStreamReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.SubscribeStreamReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `jaeger`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Plugin-Id`))
 		})
 
 		t.Run("tracing headers are set for publish stream", func(t *testing.T) {
@@ -206,13 +210,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.PublishStreamReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.PublishStreamReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.PublishStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.PublishStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.PublishStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.PublishStreamReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.PublishStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.PublishStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `jaeger`, cdt.PublishStreamReq.GetHTTPHeader(`X-Plugin-Id`))
 		})
 
 		t.Run("tracing headers are set for run stream", func(t *testing.T) {
@@ -230,13 +235,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			}, &backend.StreamSender{})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.RunStreamReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.RunStreamReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.RunStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.RunStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.RunStreamReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.RunStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `jaeger`, cdt.RunStreamReq.GetHTTPHeader(`X-Plugin-Id`))
 		})
 
 		t.Run("sanitizes grpc header values for invalid utf-8", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This PR adds `X-Plugin-Id` header to backend requests. We already set it in the frontend but never actually forward it.

**Why do we need this feature?**

BigQuery data source expects the header to get forwarded here https://github.com/grafana/google-bigquery-datasource/blob/main/pkg/bigquery/driver/query_labels.go#L73

**Who is this feature for?**

Plugin developers.