### PR TITLE
unified-storage: fix ring and distributor racing on startup

### DIFF
--- a/pkg/server/ring.go
+++ b/pkg/server/ring.go
@@ -71,6 +71,10 @@ func (ms *ModuleServer) initSearchServerRing() (services.Service, error) {
 		if err != nil {
 			return fmt.Errorf("failed to start the ring: %s", err)
 		}
+		err = searchServerRing.AwaitRunning(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to start the ring: %s", err)
+		}
 		err = pool.StartAsync(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to start the ring client pool: %s", err)


### PR DESCRIPTION
we introduced [a change](https://github.com/grafana/grafana/pull/118254/changes#diff-393411afd2402c1d6066fdadbcb444651c3c80c0d8e548a1503af859ea3a8becR54) to the distributor that is racing with the ring service being ready. 