### PR TITLE
Provisioning: Onboarding wizard add give feedback link

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -4,9 +4,9 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { AppEvents, GrafanaTheme2 } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { t, Trans } from '@grafana/i18n';
 import { getAppEvents } from '@grafana/runtime';
-import { Box, ConfirmModal, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Box, ConfirmModal, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { RepositoryViewList } from 'app/api/clients/provisioning/v0alpha1';
 import { FormPrompt } from 'app/core/components/FormPrompt/FormPrompt';
 
@@ -209,7 +209,12 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
           />
           <Stack direction="column">
             <Box marginBottom={2}>
-              <Text element="h2">{`${visibleStepIndex + 1}. ${currentStepConfig?.title ?? ''}`}</Text>
+              <Stack justifyContent="space-between">
+                <Text element="h2">{`${visibleStepIndex + 1}. ${currentStepConfig?.title ?? ''}`}</Text>
+                <TextLink href={'https://forms.gle/fnT7HGvpa8ar2sKq6'} external>
+                  <Trans i18nKey="provisioning.wizard.give-feedback-link">Give feedback</Trans>
+                </TextLink>
+              </Stack>
             </Box>
 
             {hasStepError && 'error' in stepStatusInfo && (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13475,6 +13475,7 @@
       "github-app-select-connection": "Select a GitHub App connection",
       "github-enterprise-alert-body": "GitHub Enterprise Server is currently only supported through the Pure Git repository type. Native GitHub Enterprise integration is planned and will be available in the upcoming months.",
       "github-enterprise-alert-title": "GitHub Enterprise Server",
+      "give-feedback-link": "Give feedback",
       "step-bootstrap": "Choose what to synchronize",
       "step-configure-repo": "Configure repository",
       "step-connect": "Connect",


### PR DESCRIPTION
**What is this feature?**

Added "Give feedback" link for onboarding wizard (every step will show). 
<img width="941" height="584" alt="image" src="https://github.com/user-attachments/assets/34186bc1-3f67-4f2b-9186-6f96f0261740" />


**Why do we need this feature?**

Allow user provide feedback to our google form

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/975

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
