### PR TITLE
datasources: querier: refactor code to prepare for further changes

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dsquerierclient"
 	service "github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -121,141 +122,145 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		r.logger.Debug("Connect name is not name")
 		return nil, errorsK8s.NewNotFound(schema.GroupResource{}, name)
 	}
-	b := r.builder
 
 	return http.HandlerFunc(func(w http.ResponseWriter, httpreq *http.Request) {
-		w.Header().Set("X-Ds-Querier", b.instanceProvider.GetMode())
+		namespace := request.NamespaceValue(connectCtx)
+		queryDatasources(w, httpreq, namespace, r.builder)
+	}), nil
+}
 
-		ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
-		defer span.End()
-		ctx = request.WithNamespace(ctx, request.NamespaceValue(connectCtx))
-		traceId := span.SpanContext().TraceID()
-		connectLogger := b.log.New("traceId", traceId.String(), "rule_uid", httpreq.Header.Get("X-Rule-Uid"))
-		responder := newResponderWrapper(incomingResponder,
-			func(statusCode *int, obj runtime.Object) {
-				if *statusCode/100 == 4 {
-					span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
-				}
+func queryDatasources(w http.ResponseWriter, httpreq *http.Request, namespace string, b *QueryAPIBuilder) {
+	w.Header().Set("X-Ds-Querier", b.instanceProvider.GetMode())
 
-				if *statusCode >= 500 {
-					o, ok := obj.(*query.QueryDataResponse)
-					if ok && o.Responses != nil {
-						for refId, response := range o.Responses {
-							if response.ErrorSource == backend.ErrorSourceDownstream {
-								*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
-								span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
-								span.SetAttributes(attribute.String("error.source", "downstream"))
-								break
-							} else if response.Error != nil {
-								connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
-								span.SetStatus(codes.Error, "500 error without downstream error source")
-							} else {
-								span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
-								span.SetAttributes(attribute.String("error.ref_id", refId))
-							}
+	ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
+	defer span.End()
+	ctx = request.WithNamespace(ctx, namespace)
+	traceId := span.SpanContext().TraceID()
+	connectLogger := b.log.New("traceId", traceId.String(), "rule_uid", httpreq.Header.Get("X-Rule-Uid"))
+	responder := newResponderWrapper(ctx, w,
+		func(statusCode *int, obj runtime.Object) {
+			if *statusCode/100 == 4 {
+				span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+			}
+
+			if *statusCode >= 500 {
+				o, ok := obj.(*query.QueryDataResponse)
+				if ok && o.Responses != nil {
+					for refId, response := range o.Responses {
+						if response.ErrorSource == backend.ErrorSourceDownstream {
+							*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
+							span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+							span.SetAttributes(attribute.String("error.source", "downstream"))
+							break
+						} else if response.Error != nil {
+							connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
+							span.SetStatus(codes.Error, "500 error without downstream error source")
+						} else {
+							span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
+							span.SetAttributes(attribute.String("error.ref_id", refId))
 						}
 					}
 				}
-				connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
-				b.reportStatus(ctx, *statusCode)
-			},
+			}
+			connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
+			b.reportStatus(ctx, *statusCode)
+		},
 
-			func(err error) {
-				connectLogger.Error("error caught in handler", "err", err, "caller", getCaller(ctx))
-				span.SetStatus(codes.Error, "query error")
+		func(err error) {
+			connectLogger.Error("error caught in handler", "err", err, "caller", getCaller(ctx))
+			span.SetStatus(codes.Error, "query error")
 
-				if err == nil {
-					return
-				}
-
-				span.RecordError(err)
-
-				statusCode := 0
-				var k8sErr *errorsK8s.StatusError
-				if errors.As(err, &k8sErr) {
-					statusCode = int(k8sErr.Status().Code)
-				} else {
-					// we do not know what kind of error it is,
-					// we do not know what status code will get assigned to it,
-					// so we use the zero to indicate the unknown.
-					connectLogger.Debug("Connect: unknown error returned", "error", err)
-				}
-				b.reportStatus(ctx, statusCode)
-			})
-
-		raw := &query.QueryDataRequest{}
-		err := web.Bind(httpreq, raw)
-		if err != nil {
-			connectLogger.Error("Hit unexpected error when reading query", "err", err)
-			err = errorsK8s.NewBadRequest("error reading query")
-			// TODO: can we wrap the error so details are not lost?!
-			// errutil.BadRequest(
-			// 	"query.bind",
-			// 	errutil.WithPublicMessage("Error reading query")).
-			// 	Errorf("error reading: %w", err)
-			responder.Error(err)
-			return
-		}
-
-		qdr, err := handleQuery(ctx, *raw, *b, httpreq, *responder, connectLogger)
-
-		if err != nil {
-			connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
-			logEmptyRefids(raw.Queries, connectLogger)
-			if qdr != nil { // if we have a response, we assume the err is set in the response
-				responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-					QueryDataResponse: *qdr,
-				})
-				return
-			} else {
-				var errorDataResponse backend.DataResponse
-
-				badRequestErrors := []error{
-					service.ErrInvalidDatasourceID,
-					service.ErrNoQueriesFound,
-					service.ErrMissingDataSourceInfo,
-					service.ErrQueryParamMismatch,
-					service.ErrDuplicateRefId,
-					datasources.ErrDataSourceNotFound,
-				}
-				isTypedBadRequestError := false
-				for _, badRequestError := range badRequestErrors {
-					if errors.Is(err, badRequestError) {
-						isTypedBadRequestError = true
-					}
-				}
-				if isTypedBadRequestError {
-					errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-				} else if strings.Contains(err.Error(), "expression request error") {
-					connectLogger.Error("Error calling TransformData in an expression", "err", err)
-					errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-				} else {
-					connectLogger.Error("unknown error, treated as a 500", "err", err)
-					responder.Error(err)
-					return
-				}
-				// TODO ensure errors also return the refId wherever possible
-				errorRefId := raw.Queries[0].RefID
-				if errorRefId == "" {
-					errorRefId = "A"
-				}
-
-				qdr = &backend.QueryDataResponse{
-					Responses: map[string]backend.DataResponse{
-						errorRefId: errorDataResponse,
-					},
-				}
-				responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-					QueryDataResponse: *qdr,
-				})
+			if err == nil {
 				return
 			}
-		}
 
-		responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-			QueryDataResponse: *qdr, // wrap the backend response as a QueryDataResponse
+			span.RecordError(err)
+
+			statusCode := 0
+			var k8sErr *errorsK8s.StatusError
+			if errors.As(err, &k8sErr) {
+				statusCode = int(k8sErr.Status().Code)
+			} else {
+				// we do not know what kind of error it is,
+				// we do not know what status code will get assigned to it,
+				// so we use the zero to indicate the unknown.
+				connectLogger.Debug("Connect: unknown error returned", "error", err)
+			}
+			b.reportStatus(ctx, statusCode)
 		})
-	}), nil
+
+	raw := &query.QueryDataRequest{}
+	err := web.Bind(httpreq, raw)
+	if err != nil {
+		connectLogger.Error("Hit unexpected error when reading query", "err", err)
+		err = errorsK8s.NewBadRequest("error reading query")
+		// TODO: can we wrap the error so details are not lost?!
+		// errutil.BadRequest(
+		// 	"query.bind",
+		// 	errutil.WithPublicMessage("Error reading query")).
+		// 	Errorf("error reading: %w", err)
+		responder.Error(err)
+		return
+	}
+
+	qdr, err := handleQuery(ctx, *raw, *b, httpreq, *responder, connectLogger)
+
+	if err != nil {
+		connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
+		logEmptyRefids(raw.Queries, connectLogger)
+		if qdr != nil { // if we have a response, we assume the err is set in the response
+			responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+				QueryDataResponse: *qdr,
+			})
+			return
+		} else {
+			var errorDataResponse backend.DataResponse
+
+			badRequestErrors := []error{
+				service.ErrInvalidDatasourceID,
+				service.ErrNoQueriesFound,
+				service.ErrMissingDataSourceInfo,
+				service.ErrQueryParamMismatch,
+				service.ErrDuplicateRefId,
+				datasources.ErrDataSourceNotFound,
+			}
+			isTypedBadRequestError := false
+			for _, badRequestError := range badRequestErrors {
+				if errors.Is(err, badRequestError) {
+					isTypedBadRequestError = true
+				}
+			}
+			if isTypedBadRequestError {
+				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+			} else if strings.Contains(err.Error(), "expression request error") {
+				connectLogger.Error("Error calling TransformData in an expression", "err", err)
+				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+			} else {
+				connectLogger.Error("unknown error, treated as a 500", "err", err)
+				responder.Error(err)
+				return
+			}
+			// TODO ensure errors also return the refId wherever possible
+			errorRefId := raw.Queries[0].RefID
+			if errorRefId == "" {
+				errorRefId = "A"
+			}
+
+			qdr = &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					errorRefId: errorDataResponse,
+				},
+			}
+			responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+				QueryDataResponse: *qdr,
+			})
+			return
+		}
+	}
+
+	responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+		QueryDataResponse: *qdr, // wrap the backend response as a QueryDataResponse
+	})
 }
 
 type preparedQuery struct {
@@ -376,14 +381,16 @@ func handleQuery(
 }
 
 type responderWrapper struct {
-	wrapped    rest.Responder
+	w          http.ResponseWriter
+	ctx        context.Context
 	onObjectFn func(statusCode *int, obj runtime.Object)
 	onErrorFn  func(err error)
 }
 
-func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
+func newResponderWrapper(ctx context.Context, w http.ResponseWriter, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
 	return &responderWrapper{
-		wrapped:    responder,
+		w:          w,
+		ctx:        ctx,
 		onObjectFn: onObjectFn,
 		onErrorFn:  onErrorFn,
 	}
@@ -394,7 +401,12 @@ func (r responderWrapper) Object(statusCode int, obj runtime.Object) {
 		r.onObjectFn(&statusCode, obj)
 	}
 
-	r.wrapped.Object(statusCode, obj)
+	// Write the value as JSON
+	r.w.Header().Set("Content-Type", "application/json")
+	r.w.WriteHeader(statusCode)
+	if err := json.NewEncoder(r.w).Encode(obj); err != nil {
+		http.Error(r.w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (r responderWrapper) Error(err error) {
@@ -402,7 +414,7 @@ func (r responderWrapper) Error(err error) {
 		r.onErrorFn(err)
 	}
 
-	r.wrapped.Error(err)
+	errhttp.Write(r.ctx, err, r.w)
 }
 
 func logEmptyRefids(queries []v0alpha1.DataQuery, logger log.Logger) {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -202,13 +202,19 @@ func TestQueryAPI(t *testing.T) {
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
-			require.NoError(t, mr.err, "Should not have error in responder")
-			require.Equal(t, tc.expectedStatus, mr.statusCode, "Should return expected status code")
-			require.NotNil(t, mr.response, "Should have a response object")
+			result := rr.Result()
+			defer func() {
+				_ = result.Body.Close()
+			}()
+
+			require.False(t, mr.responderUsed, "Responder should be unused")
+
+			require.Equal(t, tc.expectedStatus, result.StatusCode, "Should return expected status code")
 
 			// Verify the response is the expected type
-			qdr, ok := mr.response.(*queryapi.QueryDataResponse)
-			require.True(t, ok, "Response should be QueryDataResponse type")
+			qdr := &queryapi.QueryDataResponse{}
+			err = json.NewDecoder(result.Body).Decode(qdr)
+			require.NoError(t, err, "Failed to decode response body")
 			require.NotNil(t, qdr.Responses, "Should have responses")
 
 			// Load expected frames from testdata if provided
@@ -248,20 +254,17 @@ func TestQueryAPI(t *testing.T) {
 }
 
 type mockResponder struct {
-	statusCode int
-	response   runtime.Object
-	err        error
+	responderUsed bool
 }
 
 // Object writes the provided object to the response. Invoking this method multiple times is undefined.
 func (m *mockResponder) Object(statusCode int, obj runtime.Object) {
-	m.statusCode = statusCode
-	m.response = obj
+	m.responderUsed = true
 }
 
 // Error writes the provided error to the response. This method may only be invoked once.
 func (m *mockResponder) Error(err error) {
-	m.err = err
+	m.responderUsed = true
 }
 
 type mockClient struct {


### PR DESCRIPTION
WIP
part of https://github.com/grafana/grafana/issues/120663

i recommend reading the diff using `hide whitespace`.

this PR only extracts the request-handling into a separate function.

the real change in this PR is how we write the `QueryDataResponse` into the http-response:
- currently this is done through k8s-ish mechanisms
- in this PR it is done manually

this will allow us to have better control over what http-response-codes get generated in what situation.