### PR TITLE
errhttp.Write: return chosen http-status-code

### DIFF
--- a/pkg/util/errhttp/writer.go
+++ b/pkg/util/errhttp/writer.go
@@ -33,7 +33,7 @@ type ErrorOptions struct {
 // generic 500 Internal Server Error payload by default, this is
 // overrideable by providing [WithFallback] for a custom fallback
 // error.
-func Write(ctx context.Context, err error, w http.ResponseWriter, opts ...func(ErrorOptions) ErrorOptions) {
+func Write(ctx context.Context, err error, w http.ResponseWriter, opts ...func(ErrorOptions) ErrorOptions) int {
 	opt := ErrorOptions{}
 	for _, o := range opts {
 		opt = o(opt)
@@ -48,7 +48,7 @@ func Write(ctx context.Context, err error, w http.ResponseWriter, opts ...func(E
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(int(status.Code))
 			_ = json.NewEncoder(w).Encode(status)
-			return
+			return int(status.Code)
 		}
 
 		gErr = fallbackOrInternalError(err, opt)
@@ -74,6 +74,7 @@ func Write(ctx context.Context, err error, w http.ResponseWriter, opts ...func(E
 	if err != nil {
 		defaultLogger.FromContext(ctx).Error("error while writing error", "error", err)
 	}
+	return pub.StatusCode
 }
 
 // WithFallback sets the default error returned to the user if the error

--- a/pkg/util/errhttp/writer_test.go
+++ b/pkg/util/errhttp/writer_test.go
@@ -14,15 +14,17 @@ import (
 
 func TestWrite(t *testing.T) {
 	// Error without k8s context
-	recorder := doError(t, context.Background())
+	recorder, returnedStatusCode := doError(t, context.Background())
 	assert.Equal(t, http.StatusGatewayTimeout, recorder.Code)
+	assert.Equal(t, http.StatusGatewayTimeout, returnedStatusCode)
 	assert.JSONEq(t, `{"message": "Timeout", "messageId": "test.thisIsExpected", "statusCode": 504}`, recorder.Body.String())
 
 	// Another request, but within the k8s framework
-	recorder = doError(t, request.WithRequestInfo(context.Background(), &request.RequestInfo{
+	recorder, returnedStatusCode = doError(t, request.WithRequestInfo(context.Background(), &request.RequestInfo{
 		APIGroup: "TestGroup",
 	}))
 	assert.Equal(t, http.StatusGatewayTimeout, recorder.Code)
+	assert.Equal(t, http.StatusGatewayTimeout, returnedStatusCode)
 	assert.JSONEq(t, `{
 		"status": "Failure",
 		"reason": "Timeout",
@@ -33,18 +35,19 @@ func TestWrite(t *testing.T) {
 	  }`, recorder.Body.String())
 }
 
-func doError(t *testing.T, ctx context.Context) *httptest.ResponseRecorder {
+func doError(t *testing.T, ctx context.Context) (*httptest.ResponseRecorder, int) {
 	t.Helper()
 
 	const msgID = "test.thisIsExpected"
 	base := errutil.Timeout(msgID)
+	var statusCode int
 	handler := func(writer http.ResponseWriter, _ *http.Request) {
-		Write(ctx, base.Errorf("got expected error"), writer)
+		statusCode = Write(ctx, base.Errorf("got expected error"), writer)
 	}
 
 	req := httptest.NewRequest("GET", "http://localhost:3000/fake", nil)
 	recorder := httptest.NewRecorder()
 
 	handler(recorder, req)
-	return recorder
+	return recorder, statusCode
 }


### PR DESCRIPTION
`errhttp.Write` automatically chooses a http-response-code.
sometimes i need to know the code that was chosen, to add it to a metric.

this PR adjusts `errhttp.Write` to return the chosen http-status-code.

as the function previously did not return anything, this change should be backward compatible.