### PR TITLE
Provisioning: Remove experimental banner for on-prem Git Sync

### DIFF
--- a/public/app/features/provisioning/GettingStarted/GettingStartedPage.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStartedPage.tsx
@@ -1,9 +1,6 @@
-import { Trans, t } from '@grafana/i18n';
-import { Alert, Stack, Text, TextLink } from '@grafana/ui';
+import { t } from '@grafana/i18n';
 import { Repository } from 'app/api/clients/provisioning/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
-
-import { isOnPrem } from '../utils/isOnPrem';
 
 import GettingStarted from './GettingStarted';
 
@@ -21,32 +18,8 @@ export default function GettingStartedPage({ items }: Props) {
       )}
     >
       <Page.Contents>
-        <Stack direction="column" gap={3}>
-          <Banner />
-          <GettingStarted items={items} />
-        </Stack>
+        <GettingStarted items={items} />
       </Page.Contents>
     </Page>
-  );
-}
-
-function Banner() {
-  if (!isOnPrem()) {
-    return null;
-  }
-
-  return (
-    <Alert severity="info" title={''}>
-      <Text>
-        <Trans i18nKey={'provisioning.banner.message'}>
-          This feature is currently under active development. For the best experience and latest improvements, we
-          recommend using the{' '}
-          <TextLink href={'https://grafana.com/grafana/download/nightly'} external>
-            nightly build
-          </TextLink>{' '}
-          of Grafana.
-        </Trans>
-      </Text>
-    </Alert>
   );
 }

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -213,7 +213,6 @@ export const SynchronizeStep = memo(function SynchronizeStep({
           </Stack>
         </Alert>
       )}
-      {/* Migration/export functionality is experimental and gated behind the provisioningExport feature flag */}
       {config.featureToggles.provisioningExport && (
         <>
           <Text element="h3">

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12758,9 +12758,6 @@
     "title-loaded-pull-request-in-repo": "This resource is loaded from the branch you just created in {{repoType}} and it is only visible to you"
   },
   "provisioning": {
-    "banner": {
-      "message": "This feature is currently under active development. For the best experience and latest improvements, we recommend using the <2>nightly build</2> of Grafana."
-    },
     "bitbucket": {
       "branch-required": "Branch is required",
       "permissions": {


### PR DESCRIPTION
Part of: https://github.com/grafana/git-ui-sync-project/issues/944#issue-4016310333

## Summary
- Removes the on-prem info banner in the Provisioning Getting Started page that labeled the feature as "currently under active development" and recommended using nightly builds
- Removes an outdated "experimental" code comment in the SynchronizeStep wizard

## Test plan
- [ ] Verify the Getting Started page for Provisioning no longer shows an info banner on OSS/Enterprise instances
- [ ] Verify Cloud instances still show the preview badge (unchanged — gated by `!isOnPrem()` in `FeaturesList.tsx`)
- [ ] Verify the synchronization wizard still works correctly


Made with [Cursor](https://cursor.com)