### PR TITLE
Provisioning: Mark TruffleHog false positive in fields.ts

### DIFF
--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -91,7 +91,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
       prWorkflow: {
         label: t('provisioning.github.pr-workflow-label', 'Enable pull request option when saving'),
         description: t(
-          'provisioning.github.pr-workflow-description',
+          'provisioning.github.pr-workflow-description', // trufflehog:ignore
           'Allows users to choose whether to open a pull request when saving changes. If the repository does not allow direct changes to the main branch, a pull request may still be required.'
         ),
       },


### PR DESCRIPTION
## Summary

- Adds `// trufflehog:ignore` to suppress a false positive secret detection on the translation key `provisioning.github.pr-workflow-description` in `public/app/features/provisioning/Wizard/fields.ts:94`
- This was flagged as a possible Gitlab secret in [#120492](https://github.com/grafana/grafana/pull/120492#issuecomment-4073266098) but is clearly just an i18n key

## Test plan

- Verify TruffleHog scan no longer flags `fields.ts:94`
- Verify the provisioning wizard still works correctly (no functional change)

Made with [Cursor](https://cursor.com)