### PR TITLE
Provisioning: Fix editors not being able to open dashboard preview

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -119,7 +119,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/admin/orgs/edit/:id", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), hs.Index)
 	r.Get("/admin/provisioning", reqOrgAdmin, hs.Index)
-	r.Get("/admin/provisioning/*", reqOrgAdmin, hs.Index)
+	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(), hs.Index)
 
 	if hs.Cfg.CloudMigration.Enabled {
 		r.Get("/admin/migrate-to-cloud", authorize(cloudmigration.MigrationAssistantAccess), hs.Index)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -119,7 +119,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/admin/orgs/edit/:id", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), hs.Index)
 	r.Get("/admin/provisioning", reqOrgAdmin, hs.Index)
-	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(), hs.Index)
+	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(reqOrgAdmin), hs.Index)
 
 	if hs.Cfg.CloudMigration.Enabled {
 		r.Get("/admin/migrate-to-cloud", authorize(cloudmigration.MigrationAssistantAccess), hs.Index)

--- a/pkg/middleware/provisioning_auth.go
+++ b/pkg/middleware/provisioning_auth.go
@@ -4,17 +4,20 @@ import (
 	"strings"
 
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // ProvisioningAuth returns a middleware that gates /admin/provisioning/* routes.
 // Dashboard preview paths (/{slug}/dashboard/preview/{path}) only require a
-// signed-in user, while all other sub-paths still require OrgAdmin.
+// signed-in user, while all other sub-paths still require OrgAdmin via the
+// provided fallback handler.
 //
 // This allows non-admin users to access preview links posted in pull-request
 // comments by the git-sync backend, without relaxing access to the rest of
 // the provisioning admin UI.
-func ProvisioningAuth() func(c *contextmodel.ReqContext) {
+func ProvisioningAuth(fallback web.Handler) func(c *contextmodel.ReqContext) {
+	reqOrgAdmin := fallback.(func(*contextmodel.ReqContext))
+
 	return func(c *contextmodel.ReqContext) {
 		if isProvisioningPreviewPath(c.Req.URL.Path) {
 			if !c.IsSignedIn {
@@ -23,9 +26,7 @@ func ProvisioningAuth() func(c *contextmodel.ReqContext) {
 			return
 		}
 
-		if c.OrgRole != org.RoleAdmin {
-			accessForbidden(c)
-		}
+		reqOrgAdmin(c)
 	}
 }
 

--- a/pkg/middleware/provisioning_auth.go
+++ b/pkg/middleware/provisioning_auth.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"strings"
+
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+// ProvisioningAuth returns a middleware that gates /admin/provisioning/* routes.
+// Dashboard preview paths (/{slug}/dashboard/preview/{path}) only require a
+// signed-in user, while all other sub-paths still require OrgAdmin.
+//
+// This allows non-admin users to access preview links posted in pull-request
+// comments by the git-sync backend, without relaxing access to the rest of
+// the provisioning admin UI.
+func ProvisioningAuth() func(c *contextmodel.ReqContext) {
+	return func(c *contextmodel.ReqContext) {
+		if isProvisioningPreviewPath(c.Req.URL.Path) {
+			if !c.IsSignedIn {
+				notAuthorized(c)
+			}
+			return
+		}
+
+		if c.OrgRole != org.RoleAdmin {
+			accessForbidden(c)
+		}
+	}
+}
+
+const provisioningPrefix = "/admin/provisioning/"
+
+// isProvisioningPreviewPath reports whether urlPath matches the pattern
+// /admin/provisioning/{slug}/dashboard/preview/{rest}.
+func isProvisioningPreviewPath(urlPath string) bool {
+	if !strings.HasPrefix(urlPath, provisioningPrefix) {
+		return false
+	}
+
+	remainder := urlPath[len(provisioningPrefix):]
+
+	// remainder must be: {slug}/dashboard/preview/{rest}
+	// Find first slash to skip the slug segment.
+	slashIdx := strings.IndexByte(remainder, '/')
+	if slashIdx < 1 {
+		return false
+	}
+
+	return strings.HasPrefix(remainder[slashIdx+1:], "dashboard/preview/")
+}

--- a/pkg/middleware/provisioning_auth_test.go
+++ b/pkg/middleware/provisioning_auth_test.go
@@ -125,7 +125,7 @@ func TestProvisioningAuth(t *testing.T) {
 				c.IsSignedIn = tt.isSignedIn
 				c.OrgRole = tt.orgRole
 			}))
-			server.Use(ProvisioningAuth())
+			server.Use(ProvisioningAuth(ReqOrgAdmin))
 			server.Get("/admin/provisioning/*", func(c *contextmodel.ReqContext) {
 				reached = true
 				c.Resp.WriteHeader(http.StatusOK)

--- a/pkg/middleware/provisioning_auth_test.go
+++ b/pkg/middleware/provisioning_auth_test.go
@@ -1,0 +1,146 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestIsProvisioningPreviewPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"/admin/provisioning/my-repo/dashboard/preview/path/to/file.json", true},
+		{"/admin/provisioning/my-repo/dashboard/preview/nested/dir/dash.json", true},
+		{"/admin/provisioning/repo-name/dashboard/preview/file.json", true},
+		{"/admin/provisioning/my-repo/dashboard/preview/path/with spaces/file.json", true},
+
+		{"/admin/provisioning", false},
+		{"/admin/provisioning/", false},
+		{"/admin/provisioning/my-repo", false},
+		{"/admin/provisioning/my-repo/edit", false},
+		{"/admin/provisioning/my-repo/file/something", false},
+		{"/admin/provisioning/my-repo/dashboard/preview", false},
+		{"/admin/provisioning/my-repo/dashboard/preview/", true},
+		{"/dashboard/provisioning/my-repo/preview/file.json", false},
+		{"/other/path", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isProvisioningPreviewPath(tt.path))
+		})
+	}
+}
+
+func TestProvisioningAuth(t *testing.T) {
+	tests := []struct {
+		desc       string
+		url        string
+		isSignedIn bool
+		orgRole    org.RoleType
+		expCode    int
+		expReached bool
+	}{
+		{
+			desc:       "preview path with signed-in viewer should be allowed",
+			url:        "/admin/provisioning/my-repo/dashboard/preview/path/to/file.json",
+			isSignedIn: true,
+			orgRole:    org.RoleViewer,
+			expCode:    http.StatusOK,
+			expReached: true,
+		},
+		{
+			desc:       "preview path with signed-in editor should be allowed",
+			url:        "/admin/provisioning/my-repo/dashboard/preview/path/to/file.json",
+			isSignedIn: true,
+			orgRole:    org.RoleEditor,
+			expCode:    http.StatusOK,
+			expReached: true,
+		},
+		{
+			desc:       "preview path with signed-in admin should be allowed",
+			url:        "/admin/provisioning/my-repo/dashboard/preview/path/to/file.json",
+			isSignedIn: true,
+			orgRole:    org.RoleAdmin,
+			expCode:    http.StatusOK,
+			expReached: true,
+		},
+		{
+			desc:       "preview path with anonymous user should redirect to login",
+			url:        "/admin/provisioning/my-repo/dashboard/preview/path/to/file.json",
+			isSignedIn: false,
+			orgRole:    org.RoleViewer,
+			expCode:    http.StatusFound,
+			expReached: false,
+		},
+		{
+			desc:       "non-preview path with admin should be allowed",
+			url:        "/admin/provisioning/my-repo",
+			isSignedIn: true,
+			orgRole:    org.RoleAdmin,
+			expCode:    http.StatusOK,
+			expReached: true,
+		},
+		{
+			desc:       "non-preview path with viewer should be forbidden",
+			url:        "/admin/provisioning/my-repo",
+			isSignedIn: true,
+			orgRole:    org.RoleViewer,
+			expCode:    http.StatusFound,
+			expReached: false,
+		},
+		{
+			desc:       "non-preview path with editor should be forbidden",
+			url:        "/admin/provisioning/my-repo/edit",
+			isSignedIn: true,
+			orgRole:    org.RoleEditor,
+			expCode:    http.StatusFound,
+			expReached: false,
+		},
+		{
+			desc:       "preview path with query params should be allowed for viewer",
+			url:        "/admin/provisioning/my-repo/dashboard/preview/file.json?ref=abc&pull_request_url=http%3A%2F%2Fgithub.com",
+			isSignedIn: true,
+			orgRole:    org.RoleViewer,
+			expCode:    http.StatusOK,
+			expReached: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var reached bool
+			server := web.New()
+			server.UseMiddleware(web.Renderer("../../public/views", "[[", "]]"))
+			server.Use(contextProvider(func(c *contextmodel.ReqContext) {
+				c.IsSignedIn = tt.isSignedIn
+				c.OrgRole = tt.orgRole
+			}))
+			server.Use(ProvisioningAuth())
+			server.Get("/admin/provisioning/*", func(c *contextmodel.ReqContext) {
+				reached = true
+				c.Resp.WriteHeader(http.StatusOK)
+			})
+
+			request, err := http.NewRequest(http.MethodGet, tt.url, nil)
+			require.NoError(t, err)
+			recorder := httptest.NewRecorder()
+
+			server.ServeHTTP(recorder, request)
+
+			res := recorder.Result()
+			assert.Equal(t, tt.expCode, res.StatusCode)
+			assert.Equal(t, tt.expReached, reached)
+			require.NoError(t, res.Body.Close())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Dashboard preview URLs under `/admin/provisioning/*/dashboard/preview/*` now only require `reqSignedIn` instead of `reqOrgAdmin`
- Non-admin users (editors, viewers) can now access preview links posted in PR comments by the git-sync backend
- All other `/admin/provisioning/*` paths still require OrgAdmin — no change in behavior for the admin UI

## Context

Related to #119987. The current backend route `/admin/provisioning/*` uses `reqOrgAdmin`, which blocks non-admin users from accessing dashboard preview links before the SPA even loads. The frontend redirect added in that PR is ineffective because the backend middleware rejects the request first.

This PR takes a backend-only approach that is **backward-compatible with all frontend versions**, avoiding issues during the ~8-week frontend rollout window. No URL changes are made — the existing frontend route at `/admin/provisioning/:slug/dashboard/preview/*` continues to work.

### How it works

A new `ProvisioningAuth()` middleware replaces `reqOrgAdmin` on the `/admin/provisioning/*` catch-all route. It checks the URL path:
- **Preview paths** (`/{slug}/dashboard/preview/{rest}`): only requires the user to be signed in
- **All other paths**: requires OrgAdmin (same as before)

The Grafana web framework stops the handler chain once a response is written (`pkg/web/macaron.go`), so when the middleware allows a preview request through without writing a forbidden response, `hs.Index` serves the SPA normally.

## Test plan

- [x] Unit tests for path detection (`isProvisioningPreviewPath`) — 13 cases
- [x] Integration tests for the middleware (`TestProvisioningAuth`) — 8 cases covering viewer/editor/admin on preview paths, anonymous rejection, and admin-only on non-preview paths
- [x] Full `pkg/middleware/` test suite passes
- [ ] Manual: sign in as an editor, navigate to a preview link — should load the dashboard preview
- [ ] Manual: sign in as an editor, navigate to `/admin/provisioning` — should be blocked (403/redirect)

Fixes grafana/git-ui-sync-project#963

Made with [Cursor](https://cursor.com)