### PR TITLE
`grafana-iam`: Only check users permissions for resource permissions search

### DIFF
--- a/pkg/registry/apis/iam/authorizer/resource_permissions.go
+++ b/pkg/registry/apis/iam/authorizer/resource_permissions.go
@@ -52,9 +52,9 @@ func isAccessPolicy(authInfo types.AuthInfo) bool {
 	return types.IsIdentityType(authInfo.GetIdentityType(), types.TypeAccessPolicy)
 }
 
-// hasUsersPermissionsRead returns true if the caller has users.permissions:read (e.g. scope users:*).
-// When true, the caller may see all resource permissions without per-resource get_permissions checks.
-func (r *ResourcePermissionsAuthorizer) hasUsersPermissionsRead(ctx context.Context, authInfo types.AuthInfo, namespace string) (bool, error) {
+// HasUsersPermissionsRead returns true if the caller has users.permissions:read for the given user name.
+// When true, the caller may see all resource permissions that a given user has without per-resource get_permissions checks.
+func (r *ResourcePermissionsAuthorizer) HasUsersPermissionsRead(ctx context.Context, authInfo types.AuthInfo, namespace, name string) (bool, error) {
 	if authInfo == nil {
 		return false, storewrapper.ErrUnauthenticated
 	}
@@ -63,7 +63,7 @@ func (r *ResourcePermissionsAuthorizer) hasUsersPermissionsRead(ctx context.Cont
 		Group:     iamv0.GROUP,
 		Resource:  "users",
 		Verb:      utils.VerbGetPermissions,
-		Name:      "*",
+		Name:      name,
 	}
 	res, err := r.accessClient.Check(ctx, authInfo, checkReq, "")
 	if err != nil {
@@ -74,7 +74,7 @@ func (r *ResourcePermissionsAuthorizer) hasUsersPermissionsRead(ctx context.Cont
 
 // CanViewTargets returns only items for which the caller has get_permissions on the target resource.
 // getTarget(i) supplies the resource identity for item i; when ok is false that item is excluded.
-// If the caller has users.permissions:read, returns all items without per-resource checks.
+// Callers should check HasUsersPermissionsRead before calling this and short-circuit if true.
 func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context, authInfo types.AuthInfo, items []T, getTarget func(i int) (namespace, apiGroup, resource, name string, ok bool)) ([]T, error) {
 	if authInfo == nil {
 		return nil, storewrapper.ErrUnauthenticated
@@ -82,14 +82,6 @@ func CanViewTargets[T any](r *ResourcePermissionsAuthorizer, ctx context.Context
 	n := len(items)
 	if n == 0 {
 		return nil, nil
-	}
-	// if caller has users.permissions:read, allow all items
-	if ns, _, _, _, ok := getTarget(0); ok {
-		if allowAll, err := r.hasUsersPermissionsRead(ctx, authInfo, ns); err != nil {
-			return nil, err
-		} else if allowAll {
-			return items, nil
-		}
 	}
 	accessPolicy := isAccessPolicy(authInfo)
 
@@ -162,13 +154,6 @@ func (r *ResourcePermissionsAuthorizer) AfterGet(ctx context.Context, obj runtim
 	}
 	switch o := obj.(type) {
 	case *iamv0.ResourcePermission:
-		// if the caller has users.permissions:read, allow access without checking the specific resource
-		if ok, err := r.hasUsersPermissionsRead(ctx, authInfo, o.Namespace); err != nil {
-			return err
-		} else if ok {
-			return nil
-		}
-
 		target := o.Spec.Resource
 		targetGR := schema.GroupResource{Group: target.ApiGroup, Resource: target.Resource}
 

--- a/pkg/registry/apis/iam/authorizer/resource_permissions_test.go
+++ b/pkg/registry/apis/iam/authorizer/resource_permissions_test.go
@@ -84,32 +84,6 @@ func TestResourcePermissions_AfterGet(t *testing.T) {
 	}
 }
 
-func TestResourcePermissions_AfterGet_WithUsersPermissionsRead(t *testing.T) {
-	// When the user has users.permissions:read, AfterGet allows access without checking get_permissions on the specific resource.
-	fold1 := newResourcePermission("folder.grafana.app", "folders", "fold-1")
-	checkFunc := func(id types.AuthInfo, req *types.CheckRequest, folder string) (types.CheckResponse, error) {
-		require.NotNil(t, id)
-		// First (and only) check is for users.permissions:read (Group=iam.grafana.app, Resource=users, Name=*)
-		require.Equal(t, iamv0.GROUP, req.Group)
-		require.Equal(t, "users", req.Resource)
-		require.Equal(t, utils.VerbGetPermissions, req.Verb)
-		require.Equal(t, "*", req.Name)
-		return types.CheckResponse{Allowed: true}, nil
-	}
-	getParentFunc := func(ctx context.Context, gr schema.GroupResource, namespace, name string) (string, error) {
-		return "fold-1", nil
-	}
-	accessClient := &fakeAccessClient{checkFunc: checkFunc}
-	fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
-	ctx := types.WithAuthInfo(context.Background(), user)
-
-	err := resPermAuthz.AfterGet(ctx, fold1)
-	require.NoError(t, err)
-	require.True(t, accessClient.checkCalled, "accessClient.Check should be called for users.permissions:read")
-	require.False(t, fakeParentProvider.getParentCalled, "GetParent should not be called when user has users.permissions:read")
-}
-
 func TestResourcePermissions_FilterList(t *testing.T) {
 	// In this test, the user has permission to access only fold-1 and dash-2.
 	// We verify that FilterList returns only those two objects (uses BatchCheck).
@@ -122,13 +96,6 @@ func TestResourcePermissions_FilterList(t *testing.T) {
 		},
 	}
 
-	// First Check is for users.permissions:read; deny so FilterList proceeds to BatchCheck.
-	checkFunc := func(id types.AuthInfo, req *types.CheckRequest, folder string) (types.CheckResponse, error) {
-		if req.Group == iamv0.GROUP && req.Resource == "users" {
-			return types.CheckResponse{Allowed: false}, nil
-		}
-		return types.CheckResponse{}, nil
-	}
 	// FilterList uses CanViewTargets -> BatchCheck. Allow fold-1 (index 0) and dash-2 (index 2), deny fold-2 (index 1).
 	batchCheckFunc := func(_ context.Context, id types.AuthInfo, req types.BatchCheckRequest) (types.BatchCheckResponse, error) {
 		require.NotNil(t, id)
@@ -150,7 +117,7 @@ func TestResourcePermissions_FilterList(t *testing.T) {
 		return "", nil
 	}
 
-	accessClient := &fakeAccessClient{checkFunc: checkFunc, batchCheckFunc: batchCheckFunc}
+	accessClient := &fakeAccessClient{batchCheckFunc: batchCheckFunc}
 	fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
 	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
 	ctx := types.WithAuthInfo(context.Background(), user)
@@ -166,41 +133,6 @@ func TestResourcePermissions_FilterList(t *testing.T) {
 	require.Len(t, filtered.Items, 2, "response list should have 2 items after filtering")
 	require.Equal(t, "fold-1", filtered.Items[0].Spec.Resource.Name)
 	require.Equal(t, "dash-2", filtered.Items[1].Spec.Resource.Name)
-}
-
-func TestResourcePermissions_FilterList_WithUsersPermissionsRead(t *testing.T) {
-	// When the user has users.permissions:read, FilterList returns all items without per-resource BatchCheck.
-	list := &iamv0.ResourcePermissionList{
-		Items: []iamv0.ResourcePermission{
-			*newResourcePermission("folder.grafana.app", "folders", "fold-1"),
-			*newResourcePermission("folder.grafana.app", "folders", "fold-2"),
-			*newResourcePermission("dashboard.grafana.app", "dashboards", "dash-2"),
-		},
-	}
-	checkFunc := func(id types.AuthInfo, req *types.CheckRequest, folder string) (types.CheckResponse, error) {
-		require.Equal(t, iamv0.GROUP, req.Group)
-		require.Equal(t, "users", req.Resource)
-		require.Equal(t, utils.VerbGetPermissions, req.Verb)
-		require.Equal(t, "*", req.Name)
-		return types.CheckResponse{Allowed: true}, nil
-	}
-	getParentFunc := func(ctx context.Context, gr schema.GroupResource, namespace, name string) (string, error) {
-		return "", nil
-	}
-	accessClient := &fakeAccessClient{checkFunc: checkFunc}
-	fakeParentProvider := &fakeParentProvider{hasParent: true, getParentFunc: getParentFunc}
-	resPermAuthz := NewResourcePermissionsAuthorizer(accessClient, fakeParentProvider)
-	ctx := types.WithAuthInfo(context.Background(), user)
-
-	obj, err := resPermAuthz.FilterList(ctx, list)
-	require.NoError(t, err)
-	require.NotNil(t, obj)
-	require.True(t, accessClient.checkCalled, "Check should be called for users.permissions:read")
-	require.False(t, accessClient.batchCheckCalled, "BatchCheck should not be called when user has users.permissions:read")
-	require.False(t, fakeParentProvider.getParentCalled, "GetParent should not be called when user has users.permissions:read")
-	filtered, ok := obj.(*iamv0.ResourcePermissionList)
-	require.True(t, ok)
-	require.Len(t, filtered.Items, 3, "all 3 items should be returned when user has users.permissions:read")
 }
 
 func TestResourcePermissions_beforeWrite(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/search_handler.go
+++ b/pkg/registry/apis/iam/resourcepermission/search_handler.go
@@ -137,7 +137,7 @@ func (h *ResourcePermissionsSearchHandler) DoSearch(w http.ResponseWriter, r *ht
 		errhttp.Write(ctx, err, w)
 		return
 	}
-	permissions = filterPermissionsByGet(ctx, namespace, permissions, h.backend, h.authorizer)
+	permissions = filterPermissionsByGet(ctx, namespace, userUID, permissions, h.backend, h.authorizer)
 	result := &iamv0.PermissionsSearchResult{
 		Permissions: permissions,
 	}
@@ -146,9 +146,11 @@ func (h *ResourcePermissionsSearchHandler) DoSearch(w http.ResponseWriter, r *ht
 }
 
 // filterPermissionsByGet returns only permissions for which the caller has get_permissions on the target resource.
+// userUID is the subject being searched; it is used to check scoped users.permissions:read access.
 func filterPermissionsByGet(
 	ctx context.Context,
 	namespace string,
+	userUID string,
 	perms []iamv0.PermissionSpec,
 	backend *ResourcePermSqlBackend,
 	authorizer *iamauthorizer.ResourcePermissionsAuthorizer,
@@ -159,6 +161,12 @@ func filterPermissionsByGet(
 	authInfo, ok := types.AuthInfoFrom(ctx)
 	if !ok {
 		return nil
+	}
+	// caller with users.permissions:read on this specific user (or wildcard) may skip per-resource checks
+	if allowAll, err := authorizer.HasUsersPermissionsRead(ctx, authInfo, namespace, userUID); err != nil {
+		return nil
+	} else if allowAll {
+		return perms
 	}
 	filtered, err := iamauthorizer.CanViewTargets(authorizer, ctx, authInfo, perms, func(i int) (string, string, string, string, bool) {
 		grn, err := backend.ParseScope(perms[i].Scope)


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/120477.

In this PR, I'm keeping the `HasUsersPermissionsRead` check scoped only to the search endpoint.

We know for sure we need it there to avoid breaking the legacy endpoint redirect. I decided against applying the same shortcut to the list endpoint because we don't explicitly need it yet. By keeping this change minimal, we limit the chances of collateral damage and unintended side effects.

Additionally, the list permission was previously checking for a `*` wildcard to determine global access. We eventually want to migrate to using an empty string ("") for this instead, so removing the wildcard check now will make that future migration easier.

**I don't have a remarkably strong opinion on this, but I think deferring the list implementation until we actually need it is the safest approach.**

Side note: keeping the check tied specifically to `userUid` prevents a potential (but unlikely) regression where someone was only allowed to see a subset of user's permissions.

**Changes:**

* Exports `HasUsersPermissionsRead` and adds a name parameter so callers can perform a `user-scoped` check before hand.
* Removes the blanket `users.permissions:read` shortcut from `CanViewTargets`, `AfterGet`, and `FilterList` — these paths now always go through per-resource batch/single checks, which is the correct gate.
* Adds a targeted preflight in `filterPermissionsByGet` (search handler): checks `users.permissions:read` against the searched `userUID` before falling through to per-item batch checks. A caller with scoped access to that user bypasses redundant per-resource checks.
* Removes tests that covered the now-deleted shortcuts; cleans up dead `checkFunc` setup in `TestResourcePermissions_FilterList`.