### PR TITLE
agents: add CLAUDE.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 # START Technical documentation
 /.vale.ini  @grafana/docs-tooling
 /AGENTS.md  @grafana/docs-tooling
+/CLAUDE.md  @grafana/docs-tooling
 
 # `make docs` procedure and related workflows are owned @grafana/docs-tooling. Slack #docs.
 /docs/                                                                            @grafana/docs-tooling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
i understand that the `AGENTS.md` is the standardized file location, but i do not think `claude code` reads that file.

i could not find any documentation confirming this, and also my tests show that while `codex` does read `AGENTS.md`, `claude` only reads `CLAUDE.md`.

this PR adds a `CLAUDE.md` that just includes `AGENTS.md`. this way it will work in both `claude` and other tools.