### PR TITLE
Docs: Remove early access note from schema v2

### DIFF
--- a/docs/sources/as-code/observability-as-code/schema-v2/_index.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/_index.md
@@ -1,5 +1,5 @@
 ---
-description: A reference for the JSON dashboard schemas used with Observability as Code, including the experimental V2 schema.
+description: A reference for the JSON dashboard schemas used with Observability as Code, including the V2 schema.
 keywords:
   - configuration
   - as code
@@ -23,11 +23,11 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-Dashboard JSON schema v2 is an [experimental](https://grafana.com/docs/release-life-cycle/) feature in self-managed Grafana. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
+Dashboard JSON schema v2 is a [public preview](https://grafana.com/docs/release-life-cycle/) feature. Support is limited to enablement, configuration, and some troubleshooting. Documentation is limited, and SLAs are not available.
 
 **Do not enable this feature in production environments as it may result in the irreversible loss of data.**
 
-The feature is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Cloud. For more information, refer to the [Cloud documentation](https://grafana.com/docs/grafana-cloud/visualizations/dashboards/build-dashboards/view-dashboard-json-model/#dashboard-json-model).
+For more information, refer to the [Cloud documentation](https://grafana.com/docs/grafana-cloud/visualizations/dashboards/build-dashboards/view-dashboard-json-model/#dashboard-json-model).
 
 {{< /admonition >}}
 
@@ -38,7 +38,6 @@ Observability as Code works with all versions of the JSON model, and it's fully 
 ## Before you begin
 
 Schema v2 is automatically enabled with the Dynamic Dashboards feature toggle.
-To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
 It also requires the new dashboards API feature toggle, `kubernetesDashboards`, to be enabled as well.
 
 For more information on how dashboards behave depending on your feature flag configuration, refer to [Notes and limitations](#notes-and-limitations).


### PR DESCRIPTION
## Summary

- Removes the early access form link from the schema v2 docs — the feature is now being rolled out and is no longer behind a feature request (FR)
- Updates release stage from `experimental` to `public preview` (matching the pattern from #120206)
- Removes the early access sentence from the "Before you begin" section

Resolves: https://github.com/grafana/support-escalations/issues/21186

## Test plan
- [ ] Verify the admonition no longer references the early access form
- [ ] Verify "Before you begin" section no longer asks users to request access
- [ ] Verify the public preview language matches the rest of the docs (see #120206 for reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)