### PR TITLE
TraceView: fix inconsistent span title style for rpc/uninstrumented spans

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -509,13 +509,21 @@ const UnthemedSpanBarRow = React.memo<SpanBarRowProps>((props) => {
               </span>
             )}
             {rpc && (
-              <span>
+              <span
+                className={cx(styles.svcName, {
+                  [styles.svcNameChildrenCollapsed]: isParent && !isChildrenExpanded,
+                })}
+              >
                 <Icon name={'arrow-right'} /> <i className={styles.rpcColorMarker} style={{ background: rpc.color }} />
                 {rpc.serviceName}
               </span>
             )}
             {noInstrumentedServer && (
-              <span>
+              <span
+                className={cx(styles.svcName, {
+                  [styles.svcNameChildrenCollapsed]: isParent && !isChildrenExpanded,
+                })}
+              >
                 <Icon name={'arrow-right'} />{' '}
                 <i className={styles.rpcColorMarker} style={{ background: noInstrumentedServer.color }} />
                 {noInstrumentedServer.serviceName}


### PR DESCRIPTION
**What is this PR about?**

Fixes #119674

The span title in `SpanBarRow` renders differently for rpc and uninstrumented server spans compared to regular spans. The `rpc` and `noInstrumentedServer` `<span>` wrappers were missing the `svcName` className that the regular service name span has — so their font size, weight, and margin don't match.

**What was the root cause?**

In `SpanBarRow.tsx`, the `showServiceName` block correctly applies `styles.svcName` (and conditionally `styles.svcNameChildrenCollapsed`), but the `rpc` and `noInstrumentedServer` blocks just use a bare `<span>` with no className at all.

**What changed?**

Added the same `cx(styles.svcName, { [styles.svcNameChildrenCollapsed]: isParent && !isChildrenExpanded })` className to both the `rpc` and `noInstrumentedServer` span elements, matching the styling of the regular service name span.

This is exactly the fix suggested in the issue by the reporter, who identified both the problem and the solution.