### PR TITLE
Tweaks for SidebarButton styles

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -197,4 +197,4 @@ export const Sidebar = Object.assign(SidebarComp, {
   PaneHeader: SidebarPaneHeader,
 });
 
-export { type SidebarPosition, type SidebarContextValue, useSidebar } from './useSidebar';
+export { SidebarContext, type SidebarPosition, type SidebarContextValue, useSidebar } from './useSidebar';

--- a/packages/grafana-ui/src/components/Sidebar/SidebarButton.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/SidebarButton.tsx
@@ -60,7 +60,7 @@ function renderIcon(icon: IconName | React.ReactNode) {
   }
 
   if (isIconName(icon)) {
-    return <Icon name={icon} size="lg" />;
+    return <Icon name={icon} size="md" />;
   }
 
   return icon;
@@ -100,7 +100,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       width: theme.spacing(5),
     }),
     iconWrapper: css({
-      padding: 3,
+      padding: 4,
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -131,7 +131,8 @@ const getStyles = (theme: GrafanaTheme2) => {
         right: 0,
         bottom: 0,
         width: '100%',
-        height: '2px',
+        height: '4px',
+        clipPath: 'inset(2px 0 0 0)',
         borderBottomLeftRadius: theme.shape.radius.sm,
         borderBottomRightRadius: theme.shape.radius.sm,
         backgroundImage: theme.colors.gradients.brandHorizontal,

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -466,7 +466,13 @@ export { RunnerPlugin } from './slate-plugins/runner';
 export { SelectionShortcutsPlugin } from './slate-plugins/selection_shortcuts';
 export { SlatePrism, type Token } from './slate-plugins/slate-prism';
 export { SuggestionsPlugin } from './slate-plugins/suggestions';
-export { Sidebar, useSidebar, type SidebarPosition, type SidebarContextValue } from './components/Sidebar/Sidebar';
+export {
+  Sidebar,
+  SidebarContext,
+  useSidebar,
+  type SidebarPosition,
+  type SidebarContextValue,
+} from './components/Sidebar/Sidebar';
 
 // @deprecated import from @grafana/schema
 export {

--- a/public/app/features/alerting/unified/integration/AlertRulesToolbarButton.tsx
+++ b/public/app/features/alerting/unified/integration/AlertRulesToolbarButton.tsx
@@ -37,23 +37,8 @@ export default function AlertRulesToolbarButton({ dashboardUid }: AlertRulesTool
 
   // Use Sidebar.Button when rendered inside the dashboard sidebar for consistent padding and icon size
   if (sidebarContext) {
-    return (
-      <Sidebar.Button
-        icon="bell"
-        title={title}
-        tooltip={tooltip}
-        onClick={onShowDrawer}
-        key="button-alerting"
-      />
-    );
+    return <Sidebar.Button icon="bell" title={title} tooltip={tooltip} onClick={onShowDrawer} key="button-alerting" />;
   }
 
-  return (
-    <ToolbarButton
-      tooltip={tooltip}
-      icon="bell"
-      onClick={onShowDrawer}
-      key="button-alerting"
-    />
-  );
+  return <ToolbarButton tooltip={tooltip} icon="bell" onClick={onShowDrawer} key="button-alerting" />;
 }

--- a/public/app/features/alerting/unified/integration/AlertRulesToolbarButton.tsx
+++ b/public/app/features/alerting/unified/integration/AlertRulesToolbarButton.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 
 import { t } from '@grafana/i18n';
-import { ModalsContext, ToolbarButton } from '@grafana/ui';
+import { ModalsContext, Sidebar, SidebarContext, ToolbarButton } from '@grafana/ui';
 
 import { alertRuleApi } from '../api/alertRuleApi';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
@@ -14,6 +14,7 @@ interface AlertRulesToolbarButtonProps {
 
 export default function AlertRulesToolbarButton({ dashboardUid }: AlertRulesToolbarButtonProps) {
   const { showModal, hideModal } = useContext(ModalsContext);
+  const sidebarContext = useContext(SidebarContext);
 
   const { data: namespaces = [] } = alertRuleApi.endpoints.prometheusRuleNamespaces.useQuery({
     ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
@@ -31,9 +32,25 @@ export default function AlertRulesToolbarButton({ dashboardUid }: AlertRulesTool
     });
   };
 
+  const tooltip = t('dashboard.toolbar.alert-rules', 'Alert rules');
+  const title = t('dashboard.toolbar.alert-rules', 'Alert rules');
+
+  // Use Sidebar.Button when rendered inside the dashboard sidebar for consistent padding and icon size
+  if (sidebarContext) {
+    return (
+      <Sidebar.Button
+        icon="bell"
+        title={title}
+        tooltip={tooltip}
+        onClick={onShowDrawer}
+        key="button-alerting"
+      />
+    );
+  }
+
   return (
     <ToolbarButton
-      tooltip={t('dashboard.toolbar.alert-rules', 'Alert rules')}
+      tooltip={tooltip}
       icon="bell"
       onClick={onShowDrawer}
       key="button-alerting"


### PR DESCRIPTION
- Align alert rules button style to match other buttons 
- Tweaked active state border to have same visual border radius
- Adjust SidebarButton icon size from lg to md
- Increase padding to maintain button size

Before:
<img width="67" height="844" alt="Screenshot 2026-03-17 at 13 40 43" src="https://github.com/user-attachments/assets/94e8b1c0-6437-42c6-afd7-49538bba222c" />

After:
<img width="97" height="398" alt="Screenshot 2026-03-17 at 13 36 58" src="https://github.com/user-attachments/assets/19667c76-948c-4441-9bcf-8fc403f00f68" />

Before:
<img width="73" height="51" alt="Screenshot 2026-03-17 at 13 40 57" src="https://github.com/user-attachments/assets/33bd75f4-d983-4ed3-adfe-25c43e29af80" />

After:
<img width="64" height="52" alt="Screenshot 2026-03-17 at 13 37 03" src="https://github.com/user-attachments/assets/cf8efd6d-7fe3-4e5c-8cde-3774f8249b86" />

Before:
<img width="87" height="97" alt="Screenshot 2026-03-17 at 13 41 03" src="https://github.com/user-attachments/assets/2b28afe6-4573-487d-8189-bd98586f8c79" />

After:
<img width="154" height="104" alt="Screenshot 2026-03-17 at 13 37 12" src="https://github.com/user-attachments/assets/8a1334b1-0ca9-44b2-a2e8-1743cb916b8d" />



/no-changelog
/no-backport
