### PR TITLE
Dashboard: Optimize DashboardDocumentBuilder by avoiding full JSON unmarshal

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -185,18 +185,21 @@ func (m ResourceReferences) Less(i, j int) bool {
 	return strings.Compare(a, b) > 0
 }
 
-// Create a new indexable document based on a generic k8s resource
-func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.GrafanaMetaAccessor) *IndexableDocument {
-	title := obj.FindTitle(key.Name)
-	if title == key.Name {
-		// TODO: something wrong with FindTitle
-		spec, err := obj.GetSpec()
-		if err == nil {
-			specValue, ok := spec.(map[string]any)
-			if ok {
-				specTitle, ok := specValue["title"].(string)
+// NewIndexableDocument creates a new indexable document based on a generic k8s resource
+// If title is empty, resolve it by calling obj.FindTitle and obj.GetSpec (in that order)
+func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.GrafanaMetaAccessor, title string) *IndexableDocument {
+	if title == "" {
+		title = obj.FindTitle(key.Name)
+		if title == key.Name {
+			// TODO: something wrong with FindTitle
+			spec, err := obj.GetSpec()
+			if err == nil {
+				specValue, ok := spec.(map[string]any)
 				if ok {
-					title = specTitle
+					specTitle, ok := specValue["title"].(string)
+					if ok {
+						title = specTitle
+					}
 				}
 			}
 		}
@@ -258,7 +261,7 @@ func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resour
 		return nil, err
 	}
 
-	doc := NewIndexableDocument(key, rv, obj)
+	doc := NewIndexableDocument(key, rv, obj, "")
 
 	sfKey := strings.ToLower(key.GetGroup() + "/" + key.GetResource())
 	doc.SelectableFields = getSelectableFieldsFromObject(tmp, s.selectableFields[sfKey])

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -278,11 +277,8 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 	summary.UID = obj.GetName()
 	summary.ID = obj.GetDeprecatedInternalID() // nolint:staticcheck
 
-	doc := resource.NewIndexableDocument(key, rv, obj)
+	doc := resource.NewIndexableDocument(key, rv, obj, summary.Title)
 	// TODO: add selectable fields
-	doc.Title = summary.Title
-	doc.TitleNgram = summary.Title
-	doc.TitlePhrase = strings.ToLower(summary.Title)
 	doc.Description = summary.Description
 	doc.Tags = summary.Tags
 

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -3,9 +3,11 @@ package builders
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -242,8 +244,8 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 		return nil, fmt.Errorf("invalid namespace")
 	}
 
-	tmp := &unstructured.Unstructured{}
-	err := tmp.UnmarshalJSON(value)
+	// Do not unmarshal spec, ReadDashboardWithLogContext already does that for the fields we need
+	tmp, err := unmarshalMetadataOnly(value)
 	if err != nil {
 		return nil, err
 	}
@@ -279,6 +281,8 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 	doc := resource.NewIndexableDocument(key, rv, obj)
 	// TODO: add selectable fields
 	doc.Title = summary.Title
+	doc.TitleNgram = summary.Title
+	doc.TitlePhrase = strings.ToLower(summary.Title)
 	doc.Description = summary.Description
 	doc.Tags = summary.Tags
 
@@ -363,6 +367,27 @@ func DashboardFields() []string {
 	}
 
 	return append(baseFields, UsageInsightsFields()...)
+}
+
+// unmarshalMetadataOnly parses a K8s resource JSON and returns an
+// unstructured.Unstructured with only metadata populated (spec is omitted).
+// This avoids the cost of recursively parsing the (potentially huge) dashboard specs.
+func unmarshalMetadataOnly(data []byte) (*unstructured.Unstructured, error) {
+	var partial struct {
+		APIVersion string                 `json:"apiVersion"`
+		Kind       string                 `json:"kind"`
+		Metadata   map[string]interface{} `json:"metadata"`
+	}
+	if err := json.Unmarshal(data, &partial); err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": partial.APIVersion,
+			"kind":       partial.Kind,
+			"metadata":   partial.Metadata,
+		},
+	}, nil
 }
 
 func UsageInsightsFields() []string {

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -98,7 +98,7 @@ func NewIndexableDocumentFromValue(key *resourcepb.ResourceKey, rv int64, value 
 		return nil, err
 	}
 
-	doc := resource.NewIndexableDocument(key, rv, obj)
+	doc := resource.NewIndexableDocument(key, rv, obj, "")
 	doc.Fields = make(map[string]any)
 	doc.SelectableFields, err = BuildSelectableFields(resObj, kind)
 	return doc, err

--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -154,6 +154,39 @@ func TestDashboardDocumentBuilder(t *testing.T) {
 	})
 }
 
+func BenchmarkDashboardBuildDocument(b *testing.B) {
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+		Name:      "aaa",
+	}
+
+	info, err := DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
+		return &DashboardDocumentBuilder{
+			Namespace:        namespace,
+			Blob:             blob,
+			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
+		}, nil
+	})
+	require.NoError(b, err)
+
+	builder, err := info.Namespaced(context.Background(), key.Namespace, nil)
+	require.NoError(b, err)
+
+	data, err := os.ReadFile(filepath.Join("testdata", "doc", "dashboard-aaa.json"))
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, err := builder.BuildDocument(context.Background(), key, 1234, data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestBuildSelectableFields(t *testing.T) {
 	tb := &iamv0.TeamBinding{}
 	tb.Spec.Subject.Name = "subject name"


### PR DESCRIPTION
## Summary
- Replace `unstructured.UnmarshalJSON` (which recursively parses the entire dashboard JSON including the huge `spec`) with a metadata-only partial unmarshal that skips `spec` entirely
- Only `metadata`, `apiVersion`, and `kind` are needed from the unstructured parse — the actual dashboard content is parsed separately via `ReadDashboardWithLogContext`
- Add benchmark test for `BuildDocument`

Relates to ticket: https://github.com/grafana/search-and-storage-team/issues/702

## Benchmark results (small 3KB test dashboard)

| Metric | Before (full unmarshal) | After (metadata-only) | Improvement |
|---|---|---|---|
| **ns/op** | ~33,000 | ~24,400 | **~26% faster** |
| **B/op** | 30,188 | 18,978 | **~37% less memory** |
| **allocs/op** | 586 | 379 | **~35% fewer allocs** |

Savings scale with dashboard size — production dashboards with large specs (100KB+) will see much larger improvements.

## Test plan
- [x] Existing `TestDashboardDocumentBuilder` snapshot test passes with unchanged output
- [x] All builder tests pass (`go test ./pkg/storage/unified/search/builders/...`)
- [x] New `BenchmarkDashboardBuildDocument` confirms improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)