### PR TITLE
Dashboard datasource: Emit data when streaming

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -336,7 +336,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
             count++;
             return interval(0);
           }),
-          first((val) => val.state === LoadingState.Done || val.state === LoadingState.Error)
+          first((val) => val.state === LoadingState.Done || val.state === LoadingState.Error || val.state === LoadingState.Streaming)
         );
       }
 

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -336,7 +336,12 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
             count++;
             return interval(0);
           }),
-          first((val) => val.state === LoadingState.Done || val.state === LoadingState.Error || val.state === LoadingState.Streaming)
+          first(
+            (val) =>
+              val.state === LoadingState.Done ||
+              val.state === LoadingState.Error ||
+              val.state === LoadingState.Streaming
+          )
         );
       }
 


### PR DESCRIPTION
Bug reported [here](https://github.com/grafana/support-escalations/issues/21201)
It looks like the dashboard datasource targeted a streaming query (LoadingStatus.Streaming and `lokiQuerySplitting` toggle on) causing the data not to be emitted. 
I couldn't repro this locally cause I don't have data, but I tested it with [Graft](https://github.com/grafana/plugin-graft/blob/main/docs/setup.md) and original panel, and it fixes it

this might have fixed it, but it hasn't been implemented yet: https://github.com/grafana/grafana/issues/118659