### PR TITLE
Unified Storage: Block changing manager properties

### DIFF
--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -62,6 +62,16 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 				Message: "Can not remove resource manager from resource",
 			}}
 		}
+		return nil
+	}
+
+	if okNew && okOld && managerNew != managerOld {
+		return &apierrors.StatusError{ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusForbidden,
+			Reason:  metav1.StatusReasonForbidden,
+			Message: "Cannot change resource manager; remove the existing manager first, then add the new one",
+		}}
 	}
 	return nil
 }

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -118,6 +118,75 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
+			name: "changing manager identity is blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+						utils.AnnoKeyManagerIdentity: "xyz",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+						utils.AnnoKeyManagerIdentity: "abc",
+					},
+				},
+			},
+		},
+		{
+			name: "changing manager kind is blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindKubectl),
+						utils.AnnoKeyManagerIdentity: "abc",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+						utils.AnnoKeyManagerIdentity: "abc",
+					},
+				},
+			},
+		},
+		{
+			name: "changing manager kind and identity is blocked",
+			auth: provisioner,
+			err:  "Cannot change resource manager",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "def",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+						utils.AnnoKeyManagerIdentity: "abc",
+					},
+				},
+			},
+		},
+		{
 			name: "audience includes provisioning group",
 			auth: &serviceauthn.Identity{
 				Type: authtypes.TypeAccessPolicy,

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -229,6 +229,10 @@ func (s *Storage) prepareObjectForUpdate(ctx context.Context, updateObject runti
 		}
 	}
 
+	if err := checkManagerPropertiesOnUpdateSpec(info, obj, previous); err != nil {
+		return v, err
+	}
+
 	// Mark the resource as changed
 	if v.hasChanged {
 		obj.SetGeneration(previous.GetGeneration() + 1)
@@ -238,11 +242,6 @@ func (s *Storage) prepareObjectForUpdate(ctx context.Context, updateObject runti
 		}
 		obj.SetUpdatedBy(updatedBy)
 		obj.SetUpdatedTimestampMillis(time.Now().UnixMilli())
-
-		// Only validate when the generation has changed
-		if err := checkManagerPropertiesOnUpdateSpec(info, obj, previous); err != nil {
-			return v, err
-		}
 	} else {
 		obj.SetGeneration(previous.GetGeneration())
 		obj.SetAnnotation(utils.AnnoKeyUpdatedBy, previous.GetAnnotation(utils.AnnoKeyUpdatedBy))

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -1,0 +1,87 @@
+package provisioning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t)
+	ctx := context.Background()
+
+	const repo = "managed-change-test"
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo,
+		Target: "folder",
+		Copies: map[string]string{
+			"testdata/all-panels.json": "all-panels.json",
+		},
+		ExpectedDashboards: 1,
+		ExpectedFolders:    1,
+	})
+
+	const dashboardUID = "n1jR8vnnz"
+	var dashboard *unstructured.Unstructured
+	var err error
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		dashboard, err = helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		if err != nil {
+			collect.Errorf("dashboard not found yet: %s", err.Error())
+			return
+		}
+		annotations := dashboard.GetAnnotations()
+		assert.Equal(collect, string(utils.ManagerKindRepo), annotations[utils.AnnoKeyManagerKind])
+		assert.Equal(collect, repo, annotations[utils.AnnoKeyManagerIdentity])
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should be provisioned with repo manager")
+
+	t.Run("changing manager from repo to kubectl is blocked", func(t *testing.T) {
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		annotations[utils.AnnoKeyManagerKind] = string(utils.ManagerKindKubectl)
+		annotations[utils.AnnoKeyManagerIdentity] = "some-kubectl-manager"
+		fresh.SetAnnotations(annotations)
+
+		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.Error(t, err, "should not be able to change manager from repo to kubectl")
+		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
+
+		unchanged, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, string(utils.ManagerKindRepo), unchanged.GetAnnotations()[utils.AnnoKeyManagerKind])
+		require.Equal(t, repo, unchanged.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+	})
+
+	t.Run("changing manager from repo to terraform is blocked", func(t *testing.T) {
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		annotations[utils.AnnoKeyManagerKind] = string(utils.ManagerKindTerraform)
+		annotations[utils.AnnoKeyManagerIdentity] = "some-terraform-manager"
+		fresh.SetAnnotations(annotations)
+
+		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.Error(t, err, "should not be able to change manager from repo to terraform")
+		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
+
+		unchanged, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, string(utils.ManagerKindRepo), unchanged.GetAnnotations()[utils.AnnoKeyManagerKind])
+		require.Equal(t, repo, unchanged.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+	})
+}


### PR DESCRIPTION
## Motivation

Previously, an update could silently change a resource's manager from one value to another (e.g., `repo:abc` to `terraform:xyz`). This opened the door to accidental collisions between two competing managers — for example, a Terraform apply could unintentionally take over a resource that was already managed by a repository, or vice versa, leading to unpredictable reconciliation conflicts and data loss.

## What changed

`checkManagerPropertiesOnUpdateSpec` now rejects any update that changes manager properties when both the old and new objects have a manager set. Only two transitions are allowed:

- **Add**: unmanaged -> managed (no manager to a manager)
- **Remove**: managed -> unmanaged (a manager to no manager)

Direct changes (managed -> differently managed) return a `403 Forbidden` with the message:
> Cannot change resource manager; remove the existing manager first, then add the new one

This enforces an explicit two-step workflow (remove, then add) that makes manager ownership transfers intentional and auditable, preventing silent takeovers by competing managers.

## Test plan

- [x] Unit tests in `managed_test.go`: 3 new cases covering identity change, kind change, and both — blocked even for the provisioning service account
- [ ] Integration test in `pkg/tests/apis/provisioning/managed_test.go`: provisions a dashboard via repo, attempts to change manager to kubectl/terraform, asserts Forbidden
- [ ] Integration test in `pkg/tests/apis/dashboard/integration/api_validation_test.go`: marks dashboard as kubectl-managed, rejects identity/kind changes, validates remove-then-add workflow