### PR TITLE
Cloudwatch: Add id to metric expression datalinks

### DIFF
--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
@@ -177,7 +177,8 @@ func (q *CloudWatchQuery) BuildDeepLink(startTime time.Time, endTime time.Time) 
 	}
 
 	if q.isSearchExpression() {
-		metricExpressions := &metricExpression{Expression: q.UsedExpression}
+		// The deeplink API requires an ID for the metric expression. We use a fixed ID here because we only link to a single expression.
+		metricExpressions := &metricExpression{Expression: q.UsedExpression, ID: "a"}
 		metricExpressions.Label = q.Label
 		link.Metrics = []any{metricExpressions}
 	} else {

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
@@ -90,6 +90,27 @@ func TestCloudWatchQuery(t *testing.T) {
 			assert.Contains(t, deepLink, "label")
 		})
 
+		t.Run("includes id and it's a math expression query", func(t *testing.T) {
+			startTime := time.Now()
+			endTime := startTime.Add(2 * time.Hour)
+			query := &CloudWatchQuery{
+				RefId:            "A",
+				Region:           "us-east-1",
+				Statistic:        "Average",
+				Expression:       "SEARCH(someexpression)",
+				Period:           300,
+				Id:               "id1",
+				MatchExact:       true,
+				Label:            "${PROP('Namespace')}",
+				MetricQueryType:  MetricQueryTypeSearch,
+				MetricEditorMode: MetricEditorModeRaw,
+			}
+
+			deepLink, err := query.BuildDeepLink(startTime, endTime)
+			require.NoError(t, err)
+			assert.Contains(t, deepLink, "id%22%3A%22a%22")
+		})
+
 		t.Run("includes account id in case its a metric stat query and an account id is set", func(t *testing.T) {
 			startTime := time.Now()
 			endTime := startTime.Add(2 * time.Hour)

--- a/pkg/tsdb/cloudwatch/models/types.go
+++ b/pkg/tsdb/cloudwatch/models/types.go
@@ -13,6 +13,7 @@ type cloudWatchLink struct {
 type metricExpression struct {
 	Expression string `json:"expression"`
 	Label      string `json:"label,omitempty"`
+	ID         string `json:"id"`
 }
 
 type metricStatMeta struct {


### PR DESCRIPTION
port of https://github.com/grafana/grafana-cloudwatch-datasource/pull/493