### PR TITLE
Remote Alertmanager: Remove silence UID from metrics

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	alertingClusterPB "github.com/grafana/alerting/cluster/clusterpb"
+	alertingInstrument "github.com/grafana/alerting/http/instrument"
 	"github.com/grafana/alerting/http/v0mimir"
 	alertingModels "github.com/grafana/alerting/models"
 	alertingNotify "github.com/grafana/alerting/notify"
@@ -44,6 +45,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/sender"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/util/cmputil"
+)
+
+const (
+	silenceOperationName = "/alertmanager/api/v2/silence/{uid}"
 )
 
 type stateStore interface {
@@ -517,6 +522,9 @@ func (am *Alertmanager) DeleteSilence(ctx context.Context, silenceID string) err
 		}
 	}()
 
+	// Remove the silence UID from the operation name.
+	ctx = context.WithValue(ctx, alertingInstrument.OperationNameContextKey, silenceOperationName)
+
 	params := amsilence.NewDeleteSilenceParamsWithContext(ctx).WithSilenceID(strfmt.UUID(silenceID))
 	_, err := am.amClient.Silence.DeleteSilence(params)
 	if err != nil {
@@ -531,6 +539,9 @@ func (am *Alertmanager) GetSilence(ctx context.Context, silenceID string) (apimo
 			am.log.Error("Panic while getting silence", "err", r)
 		}
 	}()
+
+	// Remove the silence UID from the operation name.
+	ctx = context.WithValue(ctx, alertingInstrument.OperationNameContextKey, silenceOperationName)
 
 	params := amsilence.NewGetSilenceParamsWithContext(ctx).WithSilenceID(strfmt.UUID(silenceID))
 	res, err := am.amClient.Silence.GetSilence(params)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -47,9 +47,7 @@ import (
 	"github.com/grafana/grafana/pkg/util/cmputil"
 )
 
-const (
-	silenceOperationName = "/alertmanager/api/v2/silence/{uid}"
-)
+const silenceOperationName = "/alertmanager/api/v2/silence/{uid}"
 
 type stateStore interface {
 	GetSilences(ctx context.Context) (string, error)


### PR DESCRIPTION
This PR removes silence UIDs from the `operation` label, reducing the cardinality of the `grafana_alerting_remote_alertmanager_latency_seconds_*` metrics.

Before the change:
```
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="DELETE /alertmanager/api/v2/silence/55f6f4ab-4a5e-44a9-8d72-9aa68a5ab829",status_code="200",le="0.005"} 
...
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="DELETE /alertmanager/api/v2/silence/7661ed30-d12f-4de7-b071-f7cb8d6597b9",status_code="200",le="0.005"} 1
...
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="DELETE /alertmanager/api/v2/silence/a8829149-3475-4ca3-9460-e91f85829d59",status_code="200",le="0.005"} 1
...
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="GET /alertmanager/api/v2/silence/55f6f4ab-4a5e-44a9-8d72-9aa68a5ab829",status_code="200",le="0.005"} 1
...
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="GET /alertmanager/api/v2/silence/7661ed30-d12f-4de7-b071-f7cb8d6597b9",status_code="200",le="0.005"} 1
...
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="GET /alertmanager/api/v2/silence/a8829149-3475-4ca3-9460-e91f85829d59",status_code="200",le="0.005"} 1
...
```

After the change:
```
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="DELETE /alertmanager/api/v2/silence/{uid}",status_code="200",le="0.005"} 2
...
grafana_alerting_remote_alertmanager_latency_seconds_bucket{operation="GET /alertmanager/api/v2/silence/{uid}",status_code="200",le="0.005"} 2
...
```