### PR TITLE
feat(profile): hide change password for external users

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { ProfileButton } from './ProfileButton';
 
@@ -16,12 +17,24 @@ jest.mock('app/plugins/panel/news/feed', () => ({
 describe('ProfileButton', () => {
   let mainView: HTMLDivElement;
   let user: ReturnType<typeof userEvent.setup>;
+  const originalContextSrvUser = { ...contextSrv.user };
   const defaultProps = {
     profileNode: {
       id: 'profile',
       text: 'Test User',
       url: '/profile',
-      children: [],
+      children: [
+        {
+          id: 'profile/settings',
+          text: 'Profile settings',
+          url: '/profile',
+        },
+        {
+          id: 'profile/password',
+          text: 'Change password',
+          url: '/profile/password',
+        },
+      ],
     },
     onToggleKioskMode: jest.fn(),
   };
@@ -38,6 +51,7 @@ describe('ProfileButton', () => {
 
   afterEach(() => {
     document.body.removeChild(mainView);
+    contextSrv.user = { ...originalContextSrvUser };
   });
 
   it('should return focus to the profile button when the news feed drawer is closed', async () => {
@@ -59,5 +73,15 @@ describe('ProfileButton', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
     expect(profileButton).toHaveFocus();
+  });
+
+  it('should hide change password entry for external users', async () => {
+    contextSrv.user = { ...contextSrv.user, authenticatedBy: 'oauth_google' };
+    render(<ProfileButton {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /profile/i }));
+
+    expect(screen.queryByRole('menuitem', { name: /change password/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /profile settings/i })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
@@ -14,6 +14,8 @@ import { NewsContainer } from '../News/NewsDrawer';
 
 import { TopNavBarMenu } from './TopNavBarMenu';
 
+const CHANGE_PASSWORD_NODE_ID = 'profile/password';
+
 export interface Props {
   profileNode: NavModelItem;
   onToggleKioskMode: () => void;
@@ -24,13 +26,17 @@ export function ProfileButton({ profileNode, onToggleKioskMode }: Props) {
   const node = enrichWithInteractionTracking(cloneDeep(profileNode), false);
   const [showNewsDrawer, onToggleShowNewsDrawer] = useToggle(false);
   const [showThemeDrawer, onToggleThemeDrawer] = useToggle(false);
+  const shouldHideChangePassword = contextSrv.isExternalUser();
 
   if (!node) {
     return null;
   }
 
   const renderMenu = () => (
-    <TopNavBarMenu node={profileNode}>
+    <TopNavBarMenu
+      node={profileNode}
+      filterItem={(item) => !shouldHideChangePassword || item.id !== CHANGE_PASSWORD_NODE_ID}
+    >
       <>
         {config.featureToggles.grafanaconThemes && (
           <MenuItem icon="palette" onClick={onToggleThemeDrawer} label={t('profile.change-theme', 'Change theme')} />

--- a/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
@@ -9,9 +9,10 @@ import { enrichWithInteractionTracking } from '../MegaMenu/utils';
 export interface TopNavBarMenuProps {
   node: NavModelItem;
   children?: React.ReactNode;
+  filterItem?: (item: NavModelItem) => boolean;
 }
 
-export function TopNavBarMenu({ node: nodePlain, children }: TopNavBarMenuProps) {
+export function TopNavBarMenu({ node: nodePlain, children, filterItem = () => true }: TopNavBarMenuProps) {
   const styles = useStyles2(getStyles);
   const node = enrichWithInteractionTracking(cloneDeep(nodePlain), false);
 
@@ -31,7 +32,7 @@ export function TopNavBarMenu({ node: nodePlain, children }: TopNavBarMenuProps)
         </div>
       }
     >
-      {node.children?.map((item) => {
+      {node.children?.filter(filterItem).map((item) => {
         return item.url ? (
           <MenuItem url={item.url} label={item.text} icon={item.icon} target={item.target} key={item.id} />
         ) : (

--- a/public/app/core/reducers/navModel.test.ts
+++ b/public/app/core/reducers/navModel.test.ts
@@ -1,8 +1,11 @@
-import { NavIndex } from '@grafana/data';
+import { NavIndex, NavModelItem } from '@grafana/data';
 
 import { reducerTester } from '../../../test/core/redux/reducerTester';
 
-import { navIndexReducer, updateNavIndex, updateConfigurationSubtitle } from './navModel';
+import config, { updateConfig } from 'app/core/config';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { buildInitialState, navIndexReducer, updateNavIndex, updateConfigurationSubtitle } from './navModel';
 
 describe('navModelReducer', () => {
   describe('when updateNavIndex is dispatched', () => {
@@ -78,5 +81,76 @@ describe('navModelReducer', () => {
         .whenActionIsDispatched(updateConfigurationSubtitle(newOrgName))
         .thenStateShouldEqual(expectedState);
     });
+  });
+});
+
+describe('buildInitialState', () => {
+  const originalBootData = config.bootData;
+  const originalIsExternal = (contextSrv.user as { isExternal?: boolean }).isExternal;
+  const originalAuthenticatedBy = contextSrv.user.authenticatedBy;
+  const profileNavChildren: NavModelItem[] = [
+    {
+      id: 'profile/settings',
+      text: 'Profile settings',
+    },
+    {
+      id: 'profile/password',
+      text: 'Change password',
+    },
+  ];
+  const navTreeMock: NavModelItem[] = [
+    { id: 'home', text: 'Home', children: [] },
+    { id: 'profile', text: 'Profile', children: profileNavChildren },
+  ];
+
+  afterEach(() => {
+    updateConfig({ bootData: originalBootData });
+    (contextSrv.user as { isExternal?: boolean }).isExternal = originalIsExternal;
+    contextSrv.user.authenticatedBy = originalAuthenticatedBy;
+  });
+
+  it('removes change password nav entry for external users', () => {
+    updateConfig({
+      bootData: {
+        ...(originalBootData ?? {}),
+        navTree: navTreeMock,
+      } as any,
+    });
+    (contextSrv.user as { isExternal?: boolean }).isExternal = true;
+
+    const navIndex = buildInitialState();
+
+    expect(navIndex['profile/password']).toBeUndefined();
+    expect(navIndex['profile/settings']).toBeDefined();
+  });
+
+  it('keeps change password nav entry for internal users', () => {
+    updateConfig({
+      bootData: {
+        ...(originalBootData ?? {}),
+        navTree: navTreeMock,
+      } as any,
+    });
+    (contextSrv.user as { isExternal?: boolean }).isExternal = false;
+
+    const navIndex = buildInitialState();
+
+    expect(navIndex['profile/password']).toBeDefined();
+  });
+
+  it('removes change password nav entry when authenticated by external provider', () => {
+    updateConfig({
+      bootData: {
+        ...(originalBootData ?? {}),
+        navTree: navTreeMock,
+      } as any,
+    });
+    (contextSrv.user as { isExternal?: boolean }).isExternal = false;
+    contextSrv.user.authenticatedBy = 'oauth_google';
+
+    const navIndex = buildInitialState();
+
+    expect(navIndex['profile/password']).toBeUndefined();
+    expect(navIndex['profile/settings']).toBeDefined();
   });
 });

--- a/public/app/core/reducers/navModel.ts
+++ b/public/app/core/reducers/navModel.ts
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 
 import { NavIndex, NavModel, NavModelItem } from '@grafana/data';
 import config from 'app/core/config';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { getNavSubTitle, getNavTitle } from '../utils/navBarItem-translations';
 
@@ -10,7 +11,7 @@ export const HOME_NAV_ID = 'home';
 
 export function buildInitialState(): NavIndex {
   const navIndex: NavIndex = {};
-  const rootNodes = cloneDeep(config.bootData.navTree);
+  const rootNodes = filterNavTree(cloneDeep(config.bootData.navTree));
   const homeNav = rootNodes.find((node) => node.id === HOME_NAV_ID);
   const otherRootNodes = rootNodes.filter((node) => node.id !== HOME_NAV_ID);
 
@@ -22,6 +23,33 @@ export function buildInitialState(): NavIndex {
   buildNavIndex(navIndex, otherRootNodes, navIndex[HOME_NAV_ID]);
 
   return navIndex;
+}
+
+function filterNavTree(children: NavModelItem[]) {
+  const shouldHideChangePassword = contextSrv.isExternalUser();
+  const filterFn = (item: NavModelItem) => {
+    if (!shouldHideChangePassword) {
+      return true;
+    }
+    return item.id !== 'profile/password';
+  };
+
+  return mapAndFilter(children, filterFn);
+}
+
+function mapAndFilter(children: NavModelItem[], filterFn: (item: NavModelItem) => boolean) {
+  const filtered: NavModelItem[] = [];
+
+  for (const child of children) {
+    if (child.children) {
+      child.children = mapAndFilter(child.children, filterFn);
+    }
+    if (filterFn(child)) {
+      filtered.push(child);
+    }
+  }
+
+  return filtered;
 }
 
 function buildNavIndex(navIndex: NavIndex, children: NavModelItem[], parentItem?: NavModelItem) {

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -16,6 +16,12 @@ import { CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
 
+type CurrentUserWithExternalFlag = {
+  isExternal?: boolean;
+};
+
+const PASSWORD_AUTH_MODULE = 'password';
+
 // When set to auto, the interval will be based on the query range
 // NOTE: this is defined here rather than TimeSrv so we avoid circular dependencies
 export const AutoRefreshInterval = 'auto';
@@ -182,6 +188,16 @@ export class ContextSrv {
       return intervals.filter((str) => str !== '').filter(this.isAllowedInterval);
     }
     return intervals;
+  }
+
+  isExternalUser() {
+    const user = this.user as CurrentUserWithExternalFlag;
+    if (user?.isExternal) {
+      return true;
+    }
+
+    const authModule = this.user?.authenticatedBy;
+    return Boolean(authModule && authModule !== PASSWORD_AUTH_MODULE);
   }
 
   hasAccessToExplore() {

--- a/public/app/features/profile/ChangePasswordForm.tsx
+++ b/public/app/features/profile/ChangePasswordForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
-import { Button, Field, LinkButton, Stack } from '@grafana/ui';
+import { Alert, Button, Field, LinkButton, Stack } from '@grafana/ui';
 import { Form } from 'app/core/components/Form/Form';
 import {
   ValidationLabels,
@@ -19,9 +19,10 @@ export interface Props {
   user: UserDTO;
   isSaving: boolean;
   onChangePassword: (payload: ChangePasswordFields) => void;
+  isExternalUser?: boolean;
 }
 
-export const ChangePasswordForm = ({ user, onChangePassword, isSaving }: Props) => {
+export const ChangePasswordForm = ({ user, onChangePassword, isSaving, isExternalUser = false }: Props) => {
   const [displayValidationLabels, setDisplayValidationLabels] = useState(false);
   const [pristine, setPristine] = useState(true);
 
@@ -45,12 +46,27 @@ export const ChangePasswordForm = ({ user, onChangePassword, isSaving }: Props) 
     );
   }
 
+  const handleSubmit = (payload: ChangePasswordFields) => {
+    if (isExternalUser) {
+      return;
+    }
+    onChangePassword(payload);
+  };
+  const isFormDisabled = isExternalUser;
+
   return (
-    <Form onSubmit={onChangePassword} maxWidth={400}>
+    <Form onSubmit={handleSubmit} maxWidth={400}>
       {({ register, errors, getValues, watch }) => {
         const newPassword = watch('newPassword');
         return (
           <>
+            {isFormDisabled && (
+              <Alert severity="info" title={t('profile.change-password.external-user-title', 'Managed externally')}>
+                <Trans i18nKey="profile.change-password.external-user-message">
+                  Your password is managed outside of Grafana. Contact your administrator to make changes.
+                </Trans>
+              </Alert>
+            )}
             <Field
               label={t('profile.change-password.old-password-label', 'Old password')}
               invalid={!!errors.oldPassword}
@@ -59,6 +75,7 @@ export const ChangePasswordForm = ({ user, onChangePassword, isSaving }: Props) 
               <PasswordField
                 id="current-password"
                 autoComplete="current-password"
+                disabled={isFormDisabled}
                 {...register('oldPassword', {
                   required: t('profile.change-password.old-password-required', 'Old password is required'),
                 })}
@@ -74,6 +91,7 @@ export const ChangePasswordForm = ({ user, onChangePassword, isSaving }: Props) 
                 id="new-password"
                 autoComplete="new-password"
                 onFocus={() => setDisplayValidationLabels(true)}
+                disabled={isFormDisabled}
                 {...register('newPassword', {
                   onBlur: () => setPristine(false),
                   required: t('profile.change-password.new-password-required', 'New password is required'),
@@ -107,6 +125,7 @@ export const ChangePasswordForm = ({ user, onChangePassword, isSaving }: Props) 
               <PasswordField
                 id="confirm-new-password"
                 autoComplete="new-password"
+                disabled={isFormDisabled}
                 {...register('confirmNew', {
                   required: t(
                     'profile.change-password.confirm-password-required',
@@ -119,7 +138,7 @@ export const ChangePasswordForm = ({ user, onChangePassword, isSaving }: Props) 
               />
             </Field>
             <Stack>
-              <Button variant="primary" disabled={isSaving} type="submit">
+              <Button variant="primary" disabled={isSaving || isFormDisabled} type="submit">
                 <Trans i18nKey="profile.change-password.change-password-button">Change Password</Trans>
               </Button>
               <LinkButton variant="secondary" href={`${config.appSubUrl}/profile`} fill="outline">

--- a/public/app/features/profile/ChangePasswordPage.test.tsx
+++ b/public/app/features/profile/ChangePasswordPage.test.tsx
@@ -109,4 +109,18 @@ describe('ChangePasswordPage', () => {
     expect(screen.getByText('Password cannot be changed here.')).toBeInTheDocument();
     config.disableLoginForm = false;
   });
+
+  it('should disable inputs when user is external', async () => {
+    await getTestContext({
+      user: { ...defaultProps.user!, isExternal: true },
+    });
+
+    expect(
+      screen.getByText('Your password is managed outside of Grafana. Contact your administrator to make changes.')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Old password')).toBeDisabled();
+    expect(screen.getByLabelText('New password')).toBeDisabled();
+    expect(screen.getByLabelText('Confirm password')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Change Password' })).toBeDisabled();
+  });
 });

--- a/public/app/features/profile/ChangePasswordPage.tsx
+++ b/public/app/features/profile/ChangePasswordPage.tsx
@@ -29,13 +29,19 @@ export type Props = OwnProps & ConnectedProps<typeof connector>;
 
 export function ChangePasswordPage({ loadUser, isUpdating, user, changePassword }: Props) {
   useMount(() => loadUser());
+  const isExternalUser = Boolean(user?.isExternal);
 
   return (
     <Page navId="profile/password">
       <Page.Contents isLoading={!Boolean(user)}>
         {user ? (
           <>
-            <ChangePasswordForm user={user} onChangePassword={changePassword} isSaving={isUpdating} />
+            <ChangePasswordForm
+              user={user}
+              onChangePassword={changePassword}
+              isSaving={isUpdating}
+              isExternalUser={isExternalUser}
+            />
           </>
         ) : null}
       </Page.Contents>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12706,6 +12706,8 @@
       "change-password-button": "Change Password",
       "confirm-password-label": "Confirm password",
       "confirm-password-required": "New password confirmation is required",
+      "external-user-title": "Managed externally",
+      "external-user-message": "Your password is managed outside of Grafana. Contact your administrator to make changes.",
       "ldap-auth-proxy-message": "You cannot change password when signed in with LDAP or auth proxy.",
       "new-password-label": "New password",
       "new-password-required": "New password is required",


### PR DESCRIPTION
**What is this feature?**

Hide the “Change password” entry from the profile menu and navigation for users authenticated via external identity providers (for example OAuth or auth proxy), and disable the change password form for external users while showing an explanatory message.

**Why do we need this feature?**

For users whose credentials are managed by an external identity provider, Grafana cannot change their password directly. Showing a functional “Change password” action in this case is confusing and can lead to failed operations or support tickets. This change makes the UI consistent with how authentication is actually handled and guides users to the correct place to manage their password.

**Who is this feature for?**

This is for Grafana users authenticated through external providers (OAuth, SSO, auth proxy, etc.), as well as administrators who want a clearer, less confusing user experience around password management.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:  
- [ ] The “Change password” menu item is hidden for external users in the profile menu and nav tree, but still visible for users authenticated with the built-in password module.  
- [ ] The change password page disables all inputs and the submit button for external users, and instead shows the new “Managed externally” informational alert with the correct copy and translations.  
- [ ] The new `contextSrv.isExternalUser()` helper correctly identifies external users based on `isExternal` and `authenticatedBy`, and existing behavior is unchanged for internal/password users.  
- [ ] Tests for `ProfileButton`, `TopNavBarMenu`, `navModel.buildInitialState`, and `ChangePasswordPage` cover these scenarios and pass reliably. 