### PR TITLE
Secrets: Use updated field for making inactive secure values eligible for garbage collection

### DIFF
--- a/pkg/registry/apis/secret/garbagecollectionworker/worker_test.go
+++ b/pkg/registry/apis/secret/garbagecollectionworker/worker_test.go
@@ -124,6 +124,53 @@ func TestBasic(t *testing.T) {
 	})
 }
 
+func TestGCDoesNotDeleteInFlightVersion(t *testing.T) {
+	sut := testutils.Setup(t)
+
+	// Create and activate v1
+	sv1, err := sut.CreateSv(t.Context())
+	require.NoError(t, err)
+
+	// Advance time to wait for grace period
+	sut.Clock.AdvanceBy(10 * time.Minute)
+
+	// Create from metadata storage directly to insert v2 as *inactive*
+	// Here we do not call SetVersionToActive explicitly to simulate the in-flight window
+	sv2, err := sut.SecureValueMetadataStorage.Create(t.Context(), sv1.Status.Keeper, &secretv1beta1.SecureValue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sv1.Name,
+			Namespace: sv1.Namespace,
+		},
+		Spec: secretv1beta1.SecureValueSpec{
+			Description: "v2",
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("new-value")),
+			Decrypters:  []string{"decrypter1"},
+		},
+	}, "actor-uid")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), sv2.Status.Version)
+
+	// Force the GC, nothing should have been cleaned, v1 is active and v2 is within the grace period
+	// If we were relying on the `created` field to check for eligible secure values, v2 would get deleted here!
+	cleaned, err := sut.GarbageCollectionWorker.CleanupInactiveSecureValues(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, cleaned)
+
+	// Activate v2 and read it
+	err = sut.SecureValueMetadataStorage.SetVersionToActive(t.Context(), xkube.Namespace(sv2.Namespace), sv2.Name, sv2.Status.Version)
+	require.NoError(t, err)
+
+	read, err := sut.SecureValueService.Read(t.Context(), xkube.Namespace(sv2.Namespace), sv2.Name)
+	require.NoError(t, err)
+	require.Equal(t, sv2.Status.Version, read.Status.Version)
+
+	// Force the GC again, this time we expect v1 to be cleaned since v2 was activated
+	cleaned, err = sut.GarbageCollectionWorker.CleanupInactiveSecureValues(t.Context())
+	require.NoError(t, err)
+	require.Len(t, cleaned, 1)
+	require.Equal(t, sv1.Status.Version, cleaned[0].Status.Version)
+}
+
 func TestProperty(t *testing.T) {
 	t.Parallel()
 
@@ -190,8 +237,9 @@ func TestProperty(t *testing.T) {
 			"cleanup": func(t *rapid.T) {
 				// Taken from secureValueMetadataStorage.acquireLeases
 				minAge := 300 * time.Second
+				leaseTTL := 30 * time.Second
 				maxBatchSize := sut.GarbageCollectionWorker.Cfg.SecretsManagement.GCWorkerMaxBatchSize
-				modelDeleted, modelErr := model.CleanupInactiveSecureValues(sut.Clock.Now(), minAge, maxBatchSize)
+				modelDeleted, modelErr := model.CleanupInactiveSecureValues(sut.Clock.Now(), minAge, leaseTTL, maxBatchSize)
 				deleted, err := sut.GarbageCollectionWorker.CleanupInactiveSecureValues(t.Context())
 				require.ErrorIs(t, err, modelErr)
 

--- a/pkg/registry/apis/secret/testutils/model_gsm.go
+++ b/pkg/registry/apis/secret/testutils/model_gsm.go
@@ -15,6 +15,7 @@ type ModelSecureValue struct {
 	*secretv1beta1.SecureValue
 	active       bool
 	created      time.Time
+	updated      time.Time
 	leaseCreated time.Time
 }
 
@@ -88,7 +89,7 @@ func (m *ModelGsm) Create(now time.Time, sv *secretv1beta1.SecureValue) (*secret
 		created = sv.created
 	}
 
-	modelSv := &ModelSecureValue{SecureValue: sv, active: false, created: created}
+	modelSv := &ModelSecureValue{SecureValue: sv, active: false, created: created, updated: now}
 	modelSv.Status.Version = m.getNewVersionNumber(modelSv.Namespace, modelSv.Name)
 	modelSv.Status.ExternalID = fmt.Sprintf("%d", modelSv.Status.Version)
 	modelSv.Status.Keeper = keeper.name
@@ -265,13 +266,18 @@ func (m *ModelGsm) Read(namespace, name string) (*secretv1beta1.SecureValue, err
 }
 
 func (m *ModelGsm) LeaseInactiveSecureValues(now time.Time, minAge, leaseTTL time.Duration, maxBatchSize uint16) ([]*ModelSecureValue, error) {
+	// Match the SQL's ROW_NUMBER() OVER (ORDER BY created ASC)
+	slices.SortStableFunc(m.SecureValues, func(a, b *ModelSecureValue) int {
+		return a.created.Compare(b.created)
+	})
+
 	out := make([]*ModelSecureValue, 0)
 
 	for _, sv := range m.SecureValues {
 		if len(out) >= int(maxBatchSize) {
 			break
 		}
-		if !sv.active && now.Sub(sv.created) > minAge && now.Sub(sv.leaseCreated) > leaseTTL {
+		if !sv.active && now.Sub(sv.updated) > minAge && now.Sub(sv.leaseCreated) > leaseTTL {
 			sv.leaseCreated = now
 			out = append(out, sv)
 		}
@@ -280,36 +286,18 @@ func (m *ModelGsm) LeaseInactiveSecureValues(now time.Time, minAge, leaseTTL tim
 	return out, nil
 }
 
-func (m *ModelGsm) CleanupInactiveSecureValues(now time.Time, minAge time.Duration, maxBatchSize uint16) ([]*ModelSecureValue, error) {
-	// Using a slice to allow duplicates
-	toDelete := make([]*ModelSecureValue, 0)
-
-	// The implementation query sorts by created time ascending
-	slices.SortFunc(m.SecureValues, func(a, b *ModelSecureValue) int {
-		if a.created.Before(b.created) {
-			return -1
-		} else if a.created.After(b.created) {
-			return 1
-		}
-		return 0
-	})
-
-	for _, sv := range m.SecureValues {
-		if len(toDelete) >= int(maxBatchSize) {
-			break
-		}
-
-		if !sv.active && now.Sub(sv.created) > minAge {
-			toDelete = append(toDelete, sv)
-		}
+func (m *ModelGsm) CleanupInactiveSecureValues(now time.Time, minAge, leaseTTL time.Duration, maxBatchSize uint16) ([]*ModelSecureValue, error) {
+	leased, err := m.LeaseInactiveSecureValues(now, minAge, leaseTTL, maxBatchSize)
+	if err != nil {
+		return nil, err
 	}
 
 	// PERF: The slices are always small
 	m.SecureValues = slices.DeleteFunc(m.SecureValues, func(v1 *ModelSecureValue) bool {
-		return slices.ContainsFunc(toDelete, func(v2 *ModelSecureValue) bool {
+		return slices.ContainsFunc(leased, func(v2 *ModelSecureValue) bool {
 			return v2.UID == v1.UID
 		})
 	})
 
-	return toDelete, nil
+	return leased, nil
 }

--- a/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
@@ -11,7 +11,7 @@ WHERE {{ .Ident "guid" }} IN (
     FROM {{ .Ident "secret_secure_value" }}
     WHERE
       {{ .Ident "active" }} = FALSE AND
-      {{ .Arg .Now }} - {{ .Ident "created" }} > {{ .Arg .MinAge }} AND
+      {{ .Arg .Now }} - {{ .Ident "updated" }} > {{ .Arg .MinAge }} AND
       {{ .Arg .Now }} - {{ .Ident "lease_created" }} > {{ .Arg .LeaseTTL }}
   ) AS sub
   WHERE rn <= {{ .Arg .MaxBatchSize }}

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
@@ -11,7 +11,7 @@ WHERE `guid` IN (
     FROM `secret_secure_value`
     WHERE
       `active` = FALSE AND
-      10 - `created` > 300 AND
+      10 - `updated` > 300 AND
       10 - `lease_created` > 30
   ) AS sub
   WHERE rn <= 10

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
@@ -11,7 +11,7 @@ WHERE "guid" IN (
     FROM "secret_secure_value"
     WHERE
       "active" = FALSE AND
-      10 - "created" > 300 AND
+      10 - "updated" > 300 AND
       10 - "lease_created" > 30
   ) AS sub
   WHERE rn <= 10

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
@@ -11,7 +11,7 @@ WHERE "guid" IN (
     FROM "secret_secure_value"
     WHERE
       "active" = FALSE AND
-      10 - "created" > 300 AND
+      10 - "updated" > 300 AND
       10 - "lease_created" > 30
   ) AS sub
   WHERE rn <= 10


### PR DESCRIPTION
The GC must not delete an in-flight version whose `created` timestamp was inherited from an older version.

The added test simulates the race where GC runs between `metadata.Create` (inactive) and `SetVersionToActive` during `createNewVersion`.

Without the fix, which uses `updated` instead of `created` in the lease query, the inherited `created` timestamp makes the new version immediately GC-eligible.
