### PR TITLE
Adding Query with assitant functionaliity to Tempo

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -16,7 +16,6 @@ import {
   withTheme2,
 } from '@grafana/ui';
 
-
 import TraceQLSearch from './SearchTraceQLEditor/TraceQLSearch';
 import { ServiceGraphSection } from './ServiceGraphSection';
 import { TempoQueryType } from './dataquery.gen';

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -15,6 +15,8 @@ import {
   withTheme2,
 } from '@grafana/ui';
 
+import { QueryWithAssistantButton } from '@grafana/assistant';
+
 import TraceQLSearch from './SearchTraceQLEditor/TraceQLSearch';
 import { ServiceGraphSection } from './ServiceGraphSection';
 import { TempoQueryType } from './dataquery.gen';
@@ -156,26 +158,35 @@ class TempoQueryFieldComponent extends PureComponent<Props, State> {
           <InlineFieldRow>
             <InlineField label="Query type" grow={true}>
               <Stack gap={1} alignItems="center" justifyContent="space-between">
-                <RadioButtonGroup<TempoQueryType>
-                  options={queryTypeOptions}
-                  value={query.queryType}
-                  onChange={(v) => {
-                    reportInteraction('grafana_traces_query_type_changed', {
-                      datasourceType: 'tempo',
-                      app: app ?? '',
-                      grafana_version: config.buildInfo.version,
-                      newQueryType: v,
-                      previousQueryType: query.queryType ?? '',
-                    });
+                <Stack gap={1} alignItems="center">
+                  <RadioButtonGroup<TempoQueryType>
+                    options={queryTypeOptions}
+                    value={query.queryType}
+                    onChange={(v) => {
+                      reportInteraction('grafana_traces_query_type_changed', {
+                        datasourceType: 'tempo',
+                        app: app ?? '',
+                        grafana_version: config.buildInfo.version,
+                        newQueryType: v,
+                        previousQueryType: query.queryType ?? '',
+                      });
 
-                    this.onClearResults();
-                    onChange({
-                      ...query,
-                      queryType: v,
-                    });
-                  }}
-                  size="md"
-                />
+                      this.onClearResults();
+                      onChange({
+                        ...query,
+                        queryType: v,
+                      });
+                    }}
+                    size="md"
+                  />
+                  <QueryWithAssistantButton
+                    currentQuery={query}
+                    queries={[query]}
+                    dataSourceInstanceSettings={datasource.instanceSettings}
+                    datasourceApi={null}
+                    app={app}
+                  />
+                </Stack>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { PureComponent } from 'react';
 
+import { QueryWithAssistantButton } from '@grafana/assistant';
 import { CoreApp, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import {
@@ -15,7 +16,6 @@ import {
   withTheme2,
 } from '@grafana/ui';
 
-import { QueryWithAssistantButton } from '@grafana/assistant';
 
 import TraceQLSearch from './SearchTraceQLEditor/TraceQLSearch';
 import { ServiceGraphSection } from './ServiceGraphSection';

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -154,38 +154,40 @@ class TempoQueryFieldComponent extends PureComponent<Props, State> {
           </div>
         </Modal>
         {!isAlerting && (
+          <InlineFieldRow className={css({ marginBottom: this.props.theme.spacing(1) })}>
+            <QueryWithAssistantButton
+              currentQuery={query}
+              queries={[query]}
+              dataSourceInstanceSettings={datasource.instanceSettings}
+              datasourceApi={null}
+              app={app}
+            />
+          </InlineFieldRow>
+        )}
+        {!isAlerting && (
           <InlineFieldRow>
             <InlineField label="Query type" grow={true}>
               <Stack gap={1} alignItems="center" justifyContent="space-between">
-                <Stack gap={1} alignItems="center">
-                  <RadioButtonGroup<TempoQueryType>
-                    options={queryTypeOptions}
-                    value={query.queryType}
-                    onChange={(v) => {
-                      reportInteraction('grafana_traces_query_type_changed', {
-                        datasourceType: 'tempo',
-                        app: app ?? '',
-                        grafana_version: config.buildInfo.version,
-                        newQueryType: v,
-                        previousQueryType: query.queryType ?? '',
-                      });
+                <RadioButtonGroup<TempoQueryType>
+                  options={queryTypeOptions}
+                  value={query.queryType}
+                  onChange={(v) => {
+                    reportInteraction('grafana_traces_query_type_changed', {
+                      datasourceType: 'tempo',
+                      app: app ?? '',
+                      grafana_version: config.buildInfo.version,
+                      newQueryType: v,
+                      previousQueryType: query.queryType ?? '',
+                    });
 
-                      this.onClearResults();
-                      onChange({
-                        ...query,
-                        queryType: v,
-                      });
-                    }}
-                    size="md"
-                  />
-                  <QueryWithAssistantButton
-                    currentQuery={query}
-                    queries={[query]}
-                    dataSourceInstanceSettings={datasource.instanceSettings}
-                    datasourceApi={null}
-                    app={app}
-                  />
-                </Stack>
+                    this.onClearResults();
+                    onChange({
+                      ...query,
+                      queryType: v,
+                    });
+                  }}
+                  size="md"
+                />
                 <Button
                   variant="secondary"
                   size="sm"

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -5,6 +5,7 @@
   "version": "13.0.0-pre",
   "dependencies": {
     "@emotion/css": "11.13.5",
+    "@grafana/assistant": "^0.1.24",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/lezer-traceql": "0.0.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,6 +3167,7 @@ __metadata:
   resolution: "@grafana-plugins/tempo@workspace:public/app/plugins/datasource/tempo"
   dependencies:
     "@emotion/css": "npm:11.13.5"
+    "@grafana/assistant": "npm:^0.1.24"
     "@grafana/data": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/lezer-traceql": "npm:0.0.25"
@@ -3316,6 +3317,21 @@ __metadata:
   linkType: soft
 
 "@grafana/assistant@npm:0.1.24":
+  version: 0.1.24
+  resolution: "@grafana/assistant@npm:0.1.24"
+  peerDependencies:
+    "@grafana/data": ">=12.1.0"
+    "@grafana/runtime": ">=12.1.0"
+    "@grafana/scenes": ">=5.41.0"
+    "@grafana/schema": ">=12.1.0"
+    "@grafana/ui": ">=12.1.0"
+    react: ">=18.0.0"
+    rxjs: ">=7.0.0"
+  checksum: 10/4bedf11eee2d311047442c1e2c4d192c1bdbed4485d76c0be22c0196d71dc40c615bee605de4092163af8d5254f6dde7f4b8b221c5d8f0161aa5c734b37b372f
+  languageName: node
+  linkType: hard
+
+"@grafana/assistant@npm:^0.1.24":
   version: 0.1.24
   resolution: "@grafana/assistant@npm:0.1.24"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,22 +3342,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/assistant@npm:0.1.24":
-  version: 0.1.24
-  resolution: "@grafana/assistant@npm:0.1.24"
-  peerDependencies:
-    "@grafana/data": ">=12.1.0"
-    "@grafana/runtime": ">=12.1.0"
-    "@grafana/scenes": ">=5.41.0"
-    "@grafana/schema": ">=12.1.0"
-    "@grafana/ui": ">=12.1.0"
-    react: ">=18.0.0"
-    rxjs: ">=7.0.0"
-  checksum: 10/4bedf11eee2d311047442c1e2c4d192c1bdbed4485d76c0be22c0196d71dc40c615bee605de4092163af8d5254f6dde7f4b8b221c5d8f0161aa5c734b37b372f
-  languageName: node
-  linkType: hard
-
-"@grafana/assistant@npm:^0.1.24":
+"@grafana/assistant@npm:0.1.24, @grafana/assistant@npm:^0.1.24":
   version: 0.1.24
   resolution: "@grafana/assistant@npm:0.1.24"
   peerDependencies:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This change add a Query with Assistant button to Tempo. 

**Why do we need this feature?**

This allows us to create an additional entry point to Grafana Assistant and enable the user to use NL to explore their data .

**Who is this feature for?**

Anyone using Grafana and Grafana Assistant. 


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
