### PR TITLE
Alerting: Remove config sync on remote secondary alertmanager shutdown

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
@@ -135,7 +135,7 @@ func TestMultiorgAlertmanager_RemoteSecondaryMode(t *testing.T) {
 		lastConfig = fakeAM.config
 	}
 
-	// It should send config and state on shutdown.
+	// It should send state on shutdown.
 	{
 		// Let's change the configuration and state again.
 		require.NoError(t, configStore.SaveAlertmanagerConfiguration(ctx, &models.SaveAlertmanagerConfigurationCmd{
@@ -145,10 +145,10 @@ func TestMultiorgAlertmanager_RemoteSecondaryMode(t *testing.T) {
 			LastApplied:               time.Now().Unix(),
 		}))
 
-		// Both state and config should be updated when shutting the Alertmanager down.
+		// State should be updated when shutting the Alertmanager down.
 		moa.StopAndWait()
 		require.Eventually(t, func() bool {
-			return fakeAM.config != lastConfig && fakeAM.state != lastState
+			return fakeAM.state != lastState
 		}, 15*time.Second, 300*time.Millisecond)
 	}
 }

--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -386,7 +386,6 @@ func TestForkedAlertmanager_ModeRemoteSecondary(t *testing.T) {
 			internal, remote, forked := genTestAlertmanagers(tt, modeRemoteSecondary)
 			internal.EXPECT().StopAndWait().Once()
 			remote.EXPECT().StopAndWait().Once()
-			remote.EXPECT().CompareAndSendConfiguration(mock.Anything, mock.Anything).Return(nil).Once()
 			remote.EXPECT().SendState(mock.Anything).Return(nil).Once()
 			forked.StopAndWait()
 		}
@@ -395,21 +394,6 @@ func TestForkedAlertmanager_ModeRemoteSecondary(t *testing.T) {
 			// An error in the remote Alertmanager should't be a problem.
 			// These errors are caught and logged.
 			internal, remote, forked := genTestAlertmanagers(tt, modeRemoteSecondary)
-			internal.EXPECT().StopAndWait().Once()
-			remote.EXPECT().StopAndWait().Once()
-			remote.EXPECT().CompareAndSendConfiguration(mock.Anything, mock.Anything).Return(expErr).Once()
-			remote.EXPECT().SendState(mock.Anything).Return(expErr).Once()
-			forked.StopAndWait()
-		}
-
-		{
-			// An error when retrieving the configuration should cause
-			// CompareAndSendConfiguration not to be called.
-			internal, remote, forked := genTestAlertmanagers(tt, modeRemoteSecondary)
-			secondaryForked, ok := forked.(*RemoteSecondaryForkedAlertmanager)
-			require.True(t, ok)
-			secondaryForked.store = &errConfigStore{}
-
 			internal.EXPECT().StopAndWait().Once()
 			remote.EXPECT().StopAndWait().Once()
 			remote.EXPECT().SendState(mock.Anything).Return(expErr).Once()

--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -803,10 +803,3 @@ func genTestAlertmanagers(t *testing.T, mode int, options ...func(RemoteSecondar
 	}
 	return internal, remote, newRemotePrimaryForkedAlertmanager(log.NewNopLogger(), internal, remote)
 }
-
-// errConfigStore returns an error when a method is called.
-type errConfigStore struct{}
-
-func (s *errConfigStore) GetLatestAlertmanagerConfiguration(context.Context, int64) (*models.AlertConfiguration, error) {
-	return nil, errors.New("test error")
-}

--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -261,15 +261,6 @@ func (fam *RemoteSecondaryForkedAlertmanager) StopAndWait() {
 	if err := fam.remote.SendState(ctx); err != nil {
 		fam.log.Error("Error sending state to the remote Alertmanager while stopping", "err", err)
 	}
-
-	config, err := fam.store.GetLatestAlertmanagerConfiguration(ctx, fam.orgID)
-	if err != nil {
-		fam.log.Error("Error getting latest Alertmanager configuration while stopping", "err", err)
-		return
-	}
-	if err := fam.remote.CompareAndSendConfiguration(ctx, config); err != nil {
-		fam.log.Error("Error sending configuration to the remote Alertmanager while stopping", "err", err)
-	}
 }
 
 func (fam *RemoteSecondaryForkedAlertmanager) Ready() bool {


### PR DESCRIPTION
Keep only state synchronization during shutdown.

Refactor related to moving config preparation out of individual alertmanager implementations, they will no longer be responsible for calling `PrepareConfig`, so rebuilding the config on shutdown will be out of scope for the alertmanager.
