### PR TITLE
A11y: Fix missing focus indicator on dashboard location items

### DIFF
--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -354,7 +354,8 @@ const getColumnStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexWrap: 'nowrap',
       gap: theme.spacing(1),
-      overflow: 'hidden',
+      // No overflow:hidden here — it would clip the focus ring (box-shadow) from child <a> elements.
+      // The parent cell already clips the container width. Each locationItem handles its own truncation.
     }),
     locationItem: css({
       alignItems: 'center',


### PR DESCRIPTION
## Summary

- Removes `overflow: hidden` from `locationContainer` in `SearchResultsTable`, which was silently clipping the focus ring (box-shadow) from child `<a>` elements
- The parent `cell` already provides the overflow boundary; each `locationItem` handles its own text truncation via its own `overflow: hidden`
- No custom focus styles needed — the global `a:focus-visible` rule (`getFocusStyles`) now works naturally, identical to the name column

Fixes #118643 (WCAG 2.4.7 Focus Visible, Sev3)

## Why `overflow: hidden` was safe to remove

Checked git history back to the introduction of `locationContainer` in #70814. It was added alongside a flex layout refactor with no accompanying bug reference or comment — almost certainly precautionary rather than fixing a real overflow issue. The parent `cell` already clips this container.

## Test plan

- [ ] Tab to a location item in the dashboards browse table — focus ring should match the name column style
- [ ] Verify location text still truncates correctly for long folder paths
- [ ] Test both light and dark themes
