### PR TITLE
Alerting: move get managed route to the service so it can use provisioning permissions

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -187,7 +187,6 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterProvisioningApiEndpoints(NewProvisioningApi(&ProvisioningSrv{
 		log:                 logger,
 		policies:            api.Policies,
-		routeService:        api.RouteService,
 		contactPointService: api.ContactPointService,
 		templates:           api.Templates,
 		muteTimings:         api.MuteTimings,

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -29,7 +29,6 @@ const disableProvenanceHeaderName = "X-Disable-Provenance"
 type ProvisioningSrv struct {
 	log                 log.Logger
 	policies            NotificationPolicyService
-	routeService        routeService
 	contactPointService ContactPointService
 	templates           TemplateService
 	muteTimings         MuteTimingService
@@ -58,9 +57,6 @@ type NotificationPolicyService interface {
 	GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, string, error)
 	UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p alerting_models.Provenance, version string) (definitions.Route, string, error)
 	ResetPolicyTree(ctx context.Context, orgID int64, provenance alerting_models.Provenance) (definitions.Route, error)
-}
-
-type routeService interface {
 	GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error)
 }
 
@@ -118,7 +114,7 @@ func (srv *ProvisioningSrv) RouteGetPolicyTreeExport(c *contextmodel.ReqContext)
 		return exportResponse(c, e)
 	}
 
-	managedRoute, err := srv.routeService.GetManagedRoute(c.Req.Context(), c.GetOrgID(), routeName, c.SignedInUser)
+	managedRoute, err := srv.policies.GetManagedRoute(c.Req.Context(), c.GetOrgID(), routeName, c.SignedInUser)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to export notification policy tree", err)
 	}

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -2081,8 +2082,8 @@ func TestApiNotificationPolicyExportSnapshot(t *testing.T) {
 	rev := legacy_storage.ConfigRevision{
 		Config: policy_exports.Config(),
 	}
-	sut.policies = newFakeNotificationPolicyService(rev)
-	sut.routeService = routes.NewFakeService(rev)
+	p := newFakeNotificationPolicyService(rev)
+	sut.policies = p
 
 	policies := []string{legacy_storage.UserDefinedRoutingTreeName} //nolint:prealloc
 	for policy := range policy_exports.Config().ManagedRoutes {
@@ -2312,7 +2313,6 @@ func createProvisioningSrvSutFromEnv(t *testing.T, env *testEnvironment) Provisi
 	return ProvisioningSrv{
 		log:                 env.log,
 		policies:            newFakeNotificationPolicyService(rev),
-		routeService:        rs,
 		contactPointService: provisioning.NewContactPointService(receiverAuthz, configStore, env.secrets, env.prov, env.xact, receiverSvc, env.log, env.store, ngalertfakes.NewFakeReceiverPermissionsService()),
 		templates:           provisioning.NewTemplateService(configStore, env.prov, env.xact, env.log),
 		muteTimings:         provisioning.NewMuteTimingService(configStore, env.prov, env.xact, env.log, env.store, rs),
@@ -2342,7 +2342,6 @@ func createTestRequestCtx() contextmodel.ReqContext {
 }
 
 type fakeNotificationPolicyService struct {
-	NotificationPolicyService
 	config legacy_storage.ConfigRevision
 	prov   models.Provenance
 }
@@ -2361,6 +2360,10 @@ func createFakeNotificationPolicyService() *fakeNotificationPolicyService {
 		},
 		prov: models.ProvenanceAPI,
 	}
+}
+
+func (f *fakeNotificationPolicyService) GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error) {
+	return routes.NewFakeService(f.config).GetManagedRoute(ctx, orgID, name, user)
 }
 
 func (f *fakeNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, string, error) {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -514,7 +514,7 @@ func (ng *AlertNG) init() error {
 	}
 
 	// Provisioning
-	policyService := provisioning.NewNotificationPolicyService(configStore, ng.store, ng.store, ng.Cfg.UnifiedAlerting, ng.Log)
+	policyService := provisioning.NewNotificationPolicyService(configStore, ng.store, ng.store, routeService, ng.Cfg.UnifiedAlerting, ng.Log)
 	contactPointService := provisioning.NewContactPointService(provisioningReceiverAuthz, configStore, ng.SecretsService, ng.store, ng.store, provisioningReceiverService, ng.Log, ng.store, ng.ResourcePermissions)
 	templateService := provisioning.NewTemplateService(configStore, ng.store, ng.store, ng.Log)
 	templateServiceWithLimits := templateService.WithLimitsProvider(limitsProvider)

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/alerting/definition"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -15,6 +16,10 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+type managedRoutesService interface {
+	GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error)
+}
+
 type NotificationPolicyService struct {
 	configStore     alertmanagerConfigStore
 	provenanceStore ProvisioningStore
@@ -22,10 +27,11 @@ type NotificationPolicyService struct {
 	log             log.Logger
 	settings        setting.UnifiedAlertingSettings
 	validator       validation.ProvenanceStatusTransitionValidator
+	routeService    managedRoutesService
 }
 
 func NewNotificationPolicyService(am alertmanagerConfigStore, prov ProvisioningStore,
-	xact TransactionManager, settings setting.UnifiedAlertingSettings, log log.Logger) *NotificationPolicyService {
+	xact TransactionManager, routeService managedRoutesService, settings setting.UnifiedAlertingSettings, log log.Logger) *NotificationPolicyService {
 	return &NotificationPolicyService{
 		configStore:     am,
 		provenanceStore: prov,
@@ -33,6 +39,7 @@ func NewNotificationPolicyService(am alertmanagerConfigStore, prov ProvisioningS
 		log:             log,
 		settings:        settings,
 		validator:       validation.ValidateProvenanceRelaxed,
+		routeService:    routeService,
 	}
 }
 
@@ -164,4 +171,10 @@ func (nps *NotificationPolicyService) checkOptimisticConcurrency(current definit
 		return ErrVersionConflict.Errorf("provided version %s of routing tree does not match current version %s", desiredVersion, currentVersion)
 	}
 	return nil
+}
+
+// GetManagedRoute returns managed route by name.
+func (nps *NotificationPolicyService) GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error) {
+	// This is a workaround for exporting managed routes to include provisioning permissions to access authorization.
+	return nps.routeService.GetManagedRoute(ctx, orgID, name, user)
 }

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -325,7 +325,16 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 		features = ps.alertingStore.FeatureToggles
 	}
 	configStore := legacy_storage.NewAlertmanagerConfigStore(ps.alertingStore, notifier.NewExtraConfigsCrypto(ps.secretService), features)
-	routeService := routes.NewService(configStore, ps.alertingStore, ps.alertingStore, ps.Cfg.UnifiedAlerting, features, ps.log, validation.ValidateProvenanceRelaxed, ps.tracer)
+	routeService := routes.NewService(
+		configStore,
+		ps.alertingStore,
+		ps.alertingStore,
+		ps.Cfg.UnifiedAlerting,
+		features,
+		ps.log,
+		validation.ValidateProvenanceRelaxed,
+		ps.tracer,
+	)
 	receiverAuthz := alertingauthz.NewReceiverAccess[*ngmodels.Receiver](ps.ac, true)
 	receiverSvc := notifier.NewReceiverService(
 		receiverAuthz,
@@ -343,7 +352,7 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 	contactPointService := provisioning.NewContactPointService(receiverAuthz, configStore, ps.secretService,
 		ps.alertingStore, ps.SQLStore, receiverSvc, ps.log, ps.alertingStore, ps.resourcePermissions)
 	notificationPolicyService := provisioning.NewNotificationPolicyService(configStore,
-		ps.alertingStore, ps.SQLStore, ps.Cfg.UnifiedAlerting, ps.log)
+		ps.alertingStore, ps.SQLStore, routeService, ps.Cfg.UnifiedAlerting, ps.log)
 	mutetimingsService := provisioning.NewMuteTimingService(configStore, ps.alertingStore, ps.alertingStore, ps.log, ps.alertingStore, routeService)
 	templateService := provisioning.NewTemplateService(configStore, ps.alertingStore, ps.alertingStore, ps.log)
 	cfg := prov_alerting.ProvisionerConfig{


### PR DESCRIPTION
Refactors route provisioning service to serve GetManagedEndpoint. 
This is needed in future PR to better handle permissions