### PR TITLE
Live: Add RBAC for pushing to live

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -591,6 +591,20 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		},
 		Grants: []string{string(org.RoleAdmin)},
 	}
+
+	livePushRole := ac.RoleRegistration{
+		Role: ac.RoleDTO{
+			Name:        "fixed:live:writer",
+			DisplayName: "Writer",
+			Description: "Push metrics and events to Grafana Live streams (via /api/live/push).",
+			Group:       "Live",
+			Permissions: []ac.Permission{
+				{Action: ac.ActionLivePush},
+			},
+		},
+		Grants: []string{string(org.RoleEditor), string(org.RoleAdmin)},
+	}
+
 	roles := []ac.RoleRegistration{provisioningWriterRole, datasourcesReaderRole, builtInDatasourceReader, datasourcesWriterRole,
 		datasourcesIdReaderRole, datasourcesCreatorRole, orgReaderRole, orgWriterRole,
 		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, teamsReaderRole, datasourcesExplorerRole,
@@ -599,7 +613,8 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		foldersCreatorRole, foldersReaderRole, generalFolderReaderRole, foldersWriterRole,
 		publicDashboardsWriterRole, featuremgmtReaderRole, featuremgmtWriterRole, libraryPanelsCreatorRole,
 		libraryPanelsReaderRole, libraryPanelsWriterRole, libraryPanelsGeneralReaderRole, libraryPanelsGeneralWriterRole,
-		snapshotsCreatorRole, snapshotsDeleterRole, snapshotsReaderRole, allAnnotationsReaderRole, allAnnotationsWriterRole}
+		snapshotsCreatorRole, snapshotsDeleterRole, snapshotsReaderRole, allAnnotationsReaderRole, allAnnotationsWriterRole,
+		livePushRole}
 
 	return hs.accesscontrolService.DeclareFixedRoles(roles...)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -545,7 +545,7 @@ func (hs *HTTPServer) registerRoutes() {
 			liveRoute.Post("/publish", routing.Wrap(hs.Live.HandleHTTPPublish))
 
 			// POST influx line protocol.
-			liveRoute.Post("/push/:streamId", hs.LivePushGateway.Handle)
+			liveRoute.Post("/push/:streamId", authorize(ac.EvalPermission(ac.ActionLivePush)), hs.LivePushGateway.Handle)
 
 			// List available streams and fields
 			liveRoute.Get("/list", routing.Wrap(hs.Live.HandleListHTTP))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -542,7 +542,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Group("/live", func(liveRoute routing.RouteRegister) {
 			// Note: push and publish do not use the same auth.
-			// Publish is channel-based and uses per-channel PublishAuth from pipeline rules, 
+			// Publish is channel-based and uses per-channel PublishAuth from pipeline rules,
 			// and Push is a single managed-stream endpoint where RBAC is used.
 
 			// the channel path is in the name

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -541,6 +541,10 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Post("/frontend-metrics", routing.Wrap(hs.PostFrontendMetrics))
 
 		apiRoute.Group("/live", func(liveRoute routing.RouteRegister) {
+			// Note: push and publish do not use the same auth.
+			// Publish is channel-based and uses per-channel PublishAuth from pipeline rules, 
+			// and Push is a single managed-stream endpoint where RBAC is used.
+
 			// the channel path is in the name
 			liveRoute.Post("/publish", routing.Wrap(hs.Live.HandleHTTPPublish))
 

--- a/pkg/api/live_test.go
+++ b/pkg/api/live_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/live"
+	"github.com/grafana/grafana/pkg/services/live/pushhttp"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestLivePush_AccessControl(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.AppURL = "http://localhost:3000/"
+	gLive, err := live.ProvideService(cfg,
+		routing.NewRouteRegister(),
+		nil, nil, nil, nil,
+		&usagestats.UsageStatsMock{T: t},
+		featuremgmt.WithFeatures(),
+		&dashboards.FakeDashboardService{}, nil)
+	require.NoError(t, err)
+	gateway := pushhttp.ProvideService(cfg, gLive)
+
+	tests := []struct {
+		desc         string
+		permissions  []accesscontrol.Permission
+		expectedCode int
+	}{
+		{
+			desc:         "should return 403 when user does not have live:push permission",
+			permissions:  []accesscontrol.Permission{},
+			expectedCode: http.StatusForbidden,
+		},
+		{
+			desc: "should return 200 when user has live:push permission and sends valid Influx line protocol",
+			permissions: []accesscontrol.Permission{
+				{Action: accesscontrol.ActionLivePush},
+			},
+			expectedCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			server := SetupAPITestServer(t, func(hs *HTTPServer) {
+				hs.Cfg = cfg
+				hs.Live = gLive
+				hs.LivePushGateway = gateway
+				hs.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+			})
+
+			req := server.NewRequest(http.MethodPost, "/api/live/push/mystream", strings.NewReader("cpu usage=0.5"))
+			req = webtest.RequestWithSignedInUser(req, authedUserWithPermissions(1, 1, tt.permissions))
+
+			res, err := server.Send(req)
+			require.NoError(t, err)
+			defer func() { _ = res.Body.Close() }()
+
+			assert.Equal(t, tt.expectedCode, res.StatusCode, "response status for %s", tt.desc)
+		})
+	}
+}

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -529,6 +529,9 @@ const (
 
 	// Usage stats actions
 	ActionUsageStatsRead = "server.usagestats.report:read"
+
+	// Live (Grafana Live) actions
+	ActionLivePush = "live:push"
 )
 
 var (


### PR DESCRIPTION
**What is this feature?**

This PR adds a `live:push` permission and grants it to Editors & Admins by default. Viewers can no longer push unless they are given the `live:push` permission.

Note: for those using the "Live" (alpha) panel, this will be a breaking change, and viewers will no longer be able to use the "Publish" button
i.e:
```
[panels]                                                                                                                                                                
enable_alpha = true 
```
And having a panel "Live", set-up with "Influx" as the Publish. 

This panel is meant for debugging live, so hopefully this is mainly used by admins / editors. If not, you can add the `live:push` permission to viewers.