### PR TITLE
A11y(#118641): improve timepicker error messages for screen readers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local Claude Code personal instructions (not for shared use)
+CLAUDE.local.md
+
 node_modules
 npm-debug.log
 yarn-error.log

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -258,10 +258,16 @@ describe('TimeRangeForm', () => {
 
           await user.click(screen.getByRole('button', { name: 'Apply time range' }));
 
-          const error = screen.getAllByRole('status').filter((el) => el.textContent?.trim());
-
-          expect(error).toHaveLength(2);
-          expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
+          // Both inputs should be marked invalid and their aria-describedby targets populated
+          const fromEl = screen.getByLabelText('From');
+          const toEl = screen.getByLabelText('To');
+          expect(fromEl).toHaveAttribute('aria-invalid', 'true');
+          expect(toEl).toHaveAttribute('aria-invalid', 'true');
+          // onApply writes the error description to the describedby target so focus announces it
+          const fromDescribedById = fromEl.getAttribute('aria-describedby')!;
+          expect(document.getElementById(fromDescribedById)).toHaveTextContent(
+            'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time'
+          );
         });
       });
 
@@ -361,11 +367,10 @@ describe('TimeRangeForm', () => {
           to: '2021-06-19 23:59:00',
         },
       };
-      const { getAllByRole } = setup(invalidTimeRange, 'Asia/Tokyo');
-      const error = getAllByRole('status').filter((el) => el.textContent?.trim());
-
-      expect(error).toHaveLength(1);
-      expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
+      setup(invalidTimeRange, 'Asia/Tokyo');
+      // Visual error bubble is inside aria-hidden; getByText searches full DOM
+      expect(screen.getByText(/Enter a date.*From field/)).toBeInTheDocument();
+      expect(screen.queryByText(/Enter a date.*To field/)).not.toBeInTheDocument();
     });
 
     it('should show error on invalid range', () => {
@@ -377,10 +382,8 @@ describe('TimeRangeForm', () => {
           to: '2021-06-17 23:59:00',
         },
       };
-      const { getAllByRole } = setup(invalidTimeRange, 'Asia/Tokyo');
-      const error = getAllByRole('status').filter((el) => el.textContent?.trim());
-
-      expect(error[0]).toHaveTextContent('"From" date must be before "To"');
+      setup(invalidTimeRange, 'Asia/Tokyo');
+      expect(screen.getByText('"From" date must be before "To"')).toBeInTheDocument();
     });
 
     it('should not show range error when "to" is invalid', () => {
@@ -392,11 +395,10 @@ describe('TimeRangeForm', () => {
           to: 'foo',
         },
       };
-      const { getAllByRole } = setup(invalidTimeRange, 'Asia/Tokyo');
-      const error = getAllByRole('status').filter((el) => el.textContent?.trim());
-
-      expect(error).toHaveLength(1);
-      expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
+      setup(invalidTimeRange, 'Asia/Tokyo');
+      // To field error is shown, not a range error
+      expect(screen.getByText(/Enter a date.*To field/)).toBeInTheDocument();
+      expect(screen.queryByText('"From" date must be before "To"')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -262,7 +262,7 @@ describe('TimeRangeForm', () => {
 
           expect(error).toHaveLength(2);
           expect(error[0]).toBeVisible();
-          expect(error[0]).toHaveTextContent('Please enter a past date or "now"');
+          expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
         });
       });
 
@@ -367,7 +367,7 @@ describe('TimeRangeForm', () => {
 
       expect(error).toHaveLength(1);
       expect(error[0]).toBeVisible();
-      expect(error[0]).toHaveTextContent('Please enter a past date or "now"');
+      expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
     });
 
     it('should show error on invalid range', () => {
@@ -383,7 +383,7 @@ describe('TimeRangeForm', () => {
       const error = getAllByRole('alert');
 
       expect(error[0]).toBeVisible();
-      expect(error[0]).toHaveTextContent('"From" can\'t be after "To"');
+      expect(error[0]).toHaveTextContent('"From" date must be before "To"');
     });
 
     it('should not show range error when "to" is invalid', () => {
@@ -400,7 +400,7 @@ describe('TimeRangeForm', () => {
 
       expect(error).toHaveLength(1);
       expect(error[0]).toBeVisible();
-      expect(error[0]).toHaveTextContent('Please enter a past date or "now"');
+      expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
     });
   });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -258,10 +258,9 @@ describe('TimeRangeForm', () => {
 
           await user.click(screen.getByRole('button', { name: 'Apply time range' }));
 
-          const error = screen.getAllByRole('alert');
+          const error = screen.getAllByRole('status').filter((el) => el.textContent?.trim());
 
           expect(error).toHaveLength(2);
-          expect(error[0]).toBeVisible();
           expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
         });
       });
@@ -363,10 +362,9 @@ describe('TimeRangeForm', () => {
         },
       };
       const { getAllByRole } = setup(invalidTimeRange, 'Asia/Tokyo');
-      const error = getAllByRole('alert');
+      const error = getAllByRole('status').filter((el) => el.textContent?.trim());
 
       expect(error).toHaveLength(1);
-      expect(error[0]).toBeVisible();
       expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
     });
 
@@ -380,9 +378,8 @@ describe('TimeRangeForm', () => {
         },
       };
       const { getAllByRole } = setup(invalidTimeRange, 'Asia/Tokyo');
-      const error = getAllByRole('alert');
+      const error = getAllByRole('status').filter((el) => el.textContent?.trim());
 
-      expect(error[0]).toBeVisible();
       expect(error[0]).toHaveTextContent('"From" date must be before "To"');
     });
 
@@ -396,10 +393,9 @@ describe('TimeRangeForm', () => {
         },
       };
       const { getAllByRole } = setup(invalidTimeRange, 'Asia/Tokyo');
-      const error = getAllByRole('alert');
+      const error = getAllByRole('status').filter((el) => el.textContent?.trim());
 
       expect(error).toHaveLength(1);
-      expect(error[0]).toBeVisible();
       expect(error[0]).toHaveTextContent('Enter a date (YYYY-MM-DD HH:mm:ss) or relative time');
     });
   });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -19,6 +19,7 @@ import { t, Trans } from '@grafana/i18n';
 import { useStyles2 } from '../../../themes/ThemeContext';
 import { Button } from '../../Button/Button';
 import { Field } from '../../Forms/Field';
+import { FieldValidationMessage } from '../../Forms/FieldValidationMessage';
 import { Icon } from '../../Icon/Icon';
 import { Input } from '../../Input/Input';
 import { TextLink } from '../../Link/TextLink';
@@ -44,32 +45,48 @@ interface Props {
 interface InputState {
   value: string;
   invalid: boolean;
+  // Visual error content — rendered inside aria-hidden wrapper so role="alert" is suppressed
   errorMessage: React.ReactNode;
+  // Plain-text error — rendered in polite live region and linked via aria-describedby
+  errorDescription: string;
 }
 
 const DOCS_LINK = 'https://grafana.com/docs/grafana/latest/dashboards/time-range-controls';
 
-function fieldErrorMessage(field: 'From' | 'To') {
+const ERROR_MESSAGES = {
+  from: {
+    description: () =>
+      t(
+        'time-picker.range-content.from-error',
+        'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the From field.'
+      ),
+  },
+  to: {
+    description: () =>
+      t(
+        'time-picker.range-content.to-error',
+        'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the To field.'
+      ),
+  },
+  range: {
+    description: () => t('time-picker.range-content.range-error', '"From" date must be before "To"'),
+  },
+};
+
+function fieldErrorMessage(type: 'from' | 'to' | 'range'): React.ReactNode {
+  const desc = ERROR_MESSAGES[type].description();
+  if (type === 'range') {
+    return desc;
+  }
   return (
     <>
-      {t(
-        field === 'From' ? 'time-picker.range-content.from-error' : 'time-picker.range-content.to-error',
-        field === 'From'
-          ? 'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the From field.'
-          : 'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the To field.'
-      )}{' '}
+      {desc}{' '}
       <TextLink href={DOCS_LINK} external>
         {t('time-picker.range-content.error-see-docs', 'See time range syntax')}
       </TextLink>
     </>
   );
 }
-
-const ERROR_MESSAGES = {
-  from: () => fieldErrorMessage('From'),
-  to: () => fieldErrorMessage('To'),
-  range: () => t('time-picker.range-content.range-error', '"From" date must be before "To"'),
-};
 
 export const TimeRangeContent = (props: Props) => {
   const {
@@ -91,10 +108,12 @@ export const TimeRangeContent = (props: Props) => {
 
   const fromInputRef = useRef<HTMLInputElement>(null);
   const toInputRef = useRef<HTMLInputElement>(null);
-  const announceRef = useRef<HTMLDivElement>(null);
 
   const fromFieldId = useId();
   const toFieldId = useId();
+  // IDs for the polite live regions — linked to inputs via aria-describedby
+  const fromErrorId = `${fromFieldId}-error`;
+  const toErrorId = `${toFieldId}-error`;
 
   // Synchronize internal state with external value
   useEffect(() => {
@@ -113,20 +132,7 @@ export const TimeRangeContent = (props: Props) => {
 
   const onApply = useCallback(() => {
     if (to.invalid || from.invalid) {
-      // Announce the failure via the polite live region, then focus the first invalid field.
-      // The live region text is cleared and re-set so screen readers always re-announce it.
-      if (announceRef.current) {
-        announceRef.current.textContent = '';
-        // Yield to let the DOM clear before re-setting so screen readers detect the change
-        requestAnimationFrame(() => {
-          if (announceRef.current) {
-            announceRef.current.textContent = t(
-              'time-picker.range-content.submit-error',
-              'Please correct the errors in the time range fields before applying.'
-            );
-          }
-        });
-      }
+      // Focus first invalid field — aria-describedby will announce the error naturally
       if (from.invalid) {
         fromInputRef.current?.focus();
       } else {
@@ -211,40 +217,71 @@ export const TimeRangeContent = (props: Props) => {
   return (
     <div>
       <div className={style.fieldContainer}>
-        <Field
-          label={t('time-picker.range-content.from-input', 'From')}
-          invalid={from.invalid}
-          error={from.errorMessage}
-        >
-          <Input
-            id={fromFieldId}
-            ref={fromInputRef}
-            onClick={(event) => event.stopPropagation()}
-            onChange={(event) => onChange(event.currentTarget.value, to.value)}
-            addonAfter={icon}
-            onKeyDown={submitOnEnter}
-            data-testid={selectors.components.TimePicker.fromField}
-            value={from.value}
-          />
-        </Field>
+        {/*
+         * Field does not receive `error` — that would render FieldValidationMessage with role="alert"
+         * (assertive), which interrupts speech on every keystroke. Instead we:
+         *   1. Render FieldValidationMessage inside aria-hidden (visual only, no live region)
+         *   2. Render a role="status" (polite) live region for screen reader announcements
+         *   3. Link the input to the polite region via aria-describedby
+         */}
+        <div className={style.fieldWrapper}>
+          <Field
+            label={t('time-picker.range-content.from-input', 'From')}
+            invalid={from.invalid}
+            noMargin={from.invalid}
+          >
+            <Input
+              id={fromFieldId}
+              ref={fromInputRef}
+              aria-invalid={from.invalid || undefined}
+              aria-describedby={from.invalid ? fromErrorId : undefined}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => onChange(event.currentTarget.value, to.value)}
+              addonAfter={icon}
+              onKeyDown={submitOnEnter}
+              data-testid={selectors.components.TimePicker.fromField}
+              value={from.value}
+            />
+          </Field>
+          {from.invalid && (
+            <div aria-hidden="true" className={style.fieldValidationWrapper}>
+              <FieldValidationMessage>{from.errorMessage}</FieldValidationMessage>
+            </div>
+          )}
+          {/* Polite live region — announces without interrupting; also the aria-describedby target */}
+          <div id={fromErrorId} role="status" className={style.srOnly}>
+            {from.invalid ? from.errorDescription : ''}
+          </div>
+        </div>
         {fyTooltip}
       </div>
       <div className={style.fieldContainer}>
-        <Field label={t('time-picker.range-content.to-input', 'To')} invalid={to.invalid} error={to.errorMessage}>
-          <Input
-            id={toFieldId}
-            ref={toInputRef}
-            onClick={(event) => event.stopPropagation()}
-            onChange={(event) => onChange(from.value, event.currentTarget.value)}
-            addonAfter={icon}
-            onKeyDown={submitOnEnter}
-            data-testid={selectors.components.TimePicker.toField}
-            value={to.value}
-          />
-        </Field>
+        <div className={style.fieldWrapper}>
+          <Field label={t('time-picker.range-content.to-input', 'To')} invalid={to.invalid} noMargin={to.invalid}>
+            <Input
+              id={toFieldId}
+              ref={toInputRef}
+              aria-invalid={to.invalid || undefined}
+              aria-describedby={to.invalid ? toErrorId : undefined}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => onChange(from.value, event.currentTarget.value)}
+              addonAfter={icon}
+              onKeyDown={submitOnEnter}
+              data-testid={selectors.components.TimePicker.toField}
+              value={to.value}
+            />
+          </Field>
+          {to.invalid && (
+            <div aria-hidden="true" className={style.fieldValidationWrapper}>
+              <FieldValidationMessage>{to.errorMessage}</FieldValidationMessage>
+            </div>
+          )}
+          <div id={toErrorId} role="status" className={style.srOnly}>
+            {to.invalid ? to.errorDescription : ''}
+          </div>
+        </div>
         {fyTooltip}
       </div>
-      <div ref={announceRef} aria-live="polite" className={style.srOnly} />
       <div className={style.buttonsContainer}>
         <Button
           data-testid={selectors.components.TimePicker.copyTimeRange}
@@ -303,13 +340,20 @@ function valueToState(
   // If "To" is invalid, we should not check the range anyways
   const rangeInvalid = isRangeInvalid(fromValue, toValue, timeZone) && !toInvalid;
 
+  const fromErrorType = rangeInvalid && !fromInvalid ? 'range' : 'from';
   return [
     {
       value: fromValue,
       invalid: fromInvalid || rangeInvalid,
-      errorMessage: rangeInvalid && !fromInvalid ? ERROR_MESSAGES.range() : ERROR_MESSAGES.from(),
+      errorMessage: fieldErrorMessage(fromErrorType),
+      errorDescription: ERROR_MESSAGES[fromErrorType].description(),
     },
-    { value: toValue, invalid: toInvalid, errorMessage: ERROR_MESSAGES.to() },
+    {
+      value: toValue,
+      invalid: toInvalid,
+      errorMessage: fieldErrorMessage('to'),
+      errorDescription: ERROR_MESSAGES.to.description(),
+    },
   ];
 }
 
@@ -330,6 +374,13 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     fieldContainer: css({
       display: 'flex',
+    }),
+    fieldWrapper: css({
+      flex: 1,
+    }),
+    fieldValidationWrapper: css({
+      marginTop: theme.spacing(0.5),
+      marginBottom: theme.spacing(2),
     }),
     buttonsContainer: css({
       display: 'flex',

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -22,7 +22,6 @@ import { Field } from '../../Forms/Field';
 import { FieldValidationMessage } from '../../Forms/FieldValidationMessage';
 import { Icon } from '../../Icon/Icon';
 import { Input } from '../../Input/Input';
-import { TextLink } from '../../Link/TextLink';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { WeekStart } from '../WeekStartPicker';
 import { commonFormat } from '../commonFormat';
@@ -81,9 +80,11 @@ function fieldErrorMessage(type: 'from' | 'to' | 'range'): React.ReactNode {
   return (
     <>
       {desc}{' '}
-      <TextLink href={DOCS_LINK} external>
+      {/* Plain <a> inherits font-size from FieldValidationMessage (12px).
+          TextLink would apply theme.typography.body (14px) and look oversized. */}
+      <a href={DOCS_LINK} target="_blank" rel="noreferrer">
         {t('time-picker.range-content.error-see-docs', 'See time range syntax')}
-      </TextLink>
+      </a>
     </>
   );
 }

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -47,7 +47,8 @@ interface InputState {
 }
 
 const ERROR_MESSAGES = {
-  default: () => t('time-picker.range-content.default-error', 'Please enter a past date or "{{now}}"', { now: 'now' }),
+  from: () => t('time-picker.range-content.from-error', 'Please enter a past date or "now" in the From field'),
+  to: () => t('time-picker.range-content.to-error', 'Please enter a past date or "now" in the To field'),
   range: () => t('time-picker.range-content.range-error', '"From" can\'t be after "To"'),
 };
 
@@ -261,9 +262,9 @@ function valueToState(
     {
       value: fromValue,
       invalid: fromInvalid || rangeInvalid,
-      errorMessage: rangeInvalid && !fromInvalid ? ERROR_MESSAGES.range() : ERROR_MESSAGES.default(),
+      errorMessage: rangeInvalid && !fromInvalid ? ERROR_MESSAGES.range() : ERROR_MESSAGES.from(),
     },
-    { value: toValue, invalid: toInvalid, errorMessage: ERROR_MESSAGES.default() },
+    { value: toValue, invalid: toInvalid, errorMessage: ERROR_MESSAGES.to() },
   ];
 }
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -108,10 +108,14 @@ export const TimeRangeContent = (props: Props) => {
 
   const fromInputRef = useRef<HTMLInputElement>(null);
   const toInputRef = useRef<HTMLInputElement>(null);
+  // Refs to the aria-describedby target divs — updated imperatively on blur/submit
+  // so the error text is only announced when the user explicitly leaves a field or submits,
+  // not on every keystroke (which would interrupt the input's own speech output).
+  const fromErrorRef = useRef<HTMLDivElement>(null);
+  const toErrorRef = useRef<HTMLDivElement>(null);
 
   const fromFieldId = useId();
   const toFieldId = useId();
-  // IDs for the polite live regions — linked to inputs via aria-describedby
   const fromErrorId = `${fromFieldId}-error`;
   const toErrorId = `${toFieldId}-error`;
 
@@ -132,7 +136,14 @@ export const TimeRangeContent = (props: Props) => {
 
   const onApply = useCallback(() => {
     if (to.invalid || from.invalid) {
-      // Focus first invalid field — aria-describedby will announce the error naturally
+      // Update the aria-describedby targets imperatively before focusing so the screen
+      // reader reads the error description when focus lands on the invalid field.
+      if (fromErrorRef.current) {
+        fromErrorRef.current.textContent = from.invalid ? from.errorDescription : '';
+      }
+      if (toErrorRef.current) {
+        toErrorRef.current.textContent = to.invalid ? to.errorDescription : '';
+      }
       if (from.invalid) {
         fromInputRef.current?.focus();
       } else {
@@ -145,7 +156,17 @@ export const TimeRangeContent = (props: Props) => {
     const timeRange = rangeUtil.convertRawToRange(raw, timeZone, fiscalYearStartMonth, commonFormat);
 
     onApplyFromProps(timeRange);
-  }, [from.invalid, from.value, onApplyFromProps, timeZone, to.invalid, to.value, fiscalYearStartMonth]);
+  }, [
+    from.errorDescription,
+    from.invalid,
+    from.value,
+    onApplyFromProps,
+    timeZone,
+    to.errorDescription,
+    to.invalid,
+    to.value,
+    fiscalYearStartMonth,
+  ]);
 
   const onChange = useCallback(
     (from: DateTime | string, to: DateTime | string) => {
@@ -219,10 +240,10 @@ export const TimeRangeContent = (props: Props) => {
       <div className={style.fieldContainer}>
         {/*
          * Field does not receive `error` — that would render FieldValidationMessage with role="alert"
-         * (assertive), which interrupts speech on every keystroke. Instead we:
-         *   1. Render FieldValidationMessage inside aria-hidden (visual only, no live region)
-         *   2. Render a role="status" (polite) live region for screen reader announcements
-         *   3. Link the input to the polite region via aria-describedby
+         * (assertive), which interrupts speech on every keystroke. Instead:
+         *   1. FieldValidationMessage sits inside aria-hidden (visual only, no live region)
+         *   2. A plain div (no aria-live) is the aria-describedby target — updated imperatively
+         *      only on blur or submit, so the error is never announced mid-typing
          */}
         <div className={style.fieldWrapper}>
           <Field
@@ -234,9 +255,14 @@ export const TimeRangeContent = (props: Props) => {
               id={fromFieldId}
               ref={fromInputRef}
               aria-invalid={from.invalid || undefined}
-              aria-describedby={from.invalid ? fromErrorId : undefined}
+              aria-describedby={fromErrorId}
               onClick={(event) => event.stopPropagation()}
               onChange={(event) => onChange(event.currentTarget.value, to.value)}
+              onBlur={() => {
+                if (fromErrorRef.current) {
+                  fromErrorRef.current.textContent = from.invalid ? from.errorDescription : '';
+                }
+              }}
               addonAfter={icon}
               onKeyDown={submitOnEnter}
               data-testid={selectors.components.TimePicker.fromField}
@@ -248,10 +274,9 @@ export const TimeRangeContent = (props: Props) => {
               <FieldValidationMessage>{from.errorMessage}</FieldValidationMessage>
             </div>
           )}
-          {/* Polite live region — announces without interrupting; also the aria-describedby target */}
-          <div id={fromErrorId} role="status" className={style.srOnly}>
-            {from.invalid ? from.errorDescription : ''}
-          </div>
+          {/* Plain div — no aria-live. Only populated on blur/submit so the error is read
+              on the next focus event, not mid-keystroke. */}
+          <div id={fromErrorId} ref={fromErrorRef} className={style.srOnly} />
         </div>
         {fyTooltip}
       </div>
@@ -262,9 +287,14 @@ export const TimeRangeContent = (props: Props) => {
               id={toFieldId}
               ref={toInputRef}
               aria-invalid={to.invalid || undefined}
-              aria-describedby={to.invalid ? toErrorId : undefined}
+              aria-describedby={toErrorId}
               onClick={(event) => event.stopPropagation()}
               onChange={(event) => onChange(from.value, event.currentTarget.value)}
+              onBlur={() => {
+                if (toErrorRef.current) {
+                  toErrorRef.current.textContent = to.invalid ? to.errorDescription : '';
+                }
+              }}
               addonAfter={icon}
               onKeyDown={submitOnEnter}
               data-testid={selectors.components.TimePicker.toField}
@@ -276,9 +306,7 @@ export const TimeRangeContent = (props: Props) => {
               <FieldValidationMessage>{to.errorMessage}</FieldValidationMessage>
             </div>
           )}
-          <div id={toErrorId} role="status" className={style.srOnly}>
-            {to.invalid ? to.errorDescription : ''}
-          </div>
+          <div id={toErrorId} ref={toErrorRef} className={style.srOnly} />
         </div>
         {fyTooltip}
       </div>

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -44,44 +44,34 @@ interface Props {
 interface InputState {
   value: string;
   invalid: boolean;
-  // Visual error content — rendered inside aria-hidden wrapper so role="alert" is suppressed
   errorMessage: React.ReactNode;
-  // Plain-text error — rendered in polite live region and linked via aria-describedby
   errorDescription: string;
 }
 
 const DOCS_LINK = 'https://grafana.com/docs/grafana/latest/dashboards/time-range-controls';
 
 const ERROR_MESSAGES = {
-  from: {
-    description: () =>
-      t(
-        'time-picker.range-content.from-error',
-        'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the From field.'
-      ),
-  },
-  to: {
-    description: () =>
-      t(
-        'time-picker.range-content.to-error',
-        'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the To field.'
-      ),
-  },
-  range: {
-    description: () => t('time-picker.range-content.range-error', '"From" date must be before "To"'),
-  },
+  from: () =>
+    t(
+      'time-picker.range-content.from-error',
+      'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the From field.'
+    ),
+  to: () =>
+    t(
+      'time-picker.range-content.to-error',
+      'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the To field.'
+    ),
+  range: () => t('time-picker.range-content.range-error', '"From" date must be before "To"'),
 };
 
 function fieldErrorMessage(type: 'from' | 'to' | 'range'): React.ReactNode {
-  const desc = ERROR_MESSAGES[type].description();
+  const desc = ERROR_MESSAGES[type]();
   if (type === 'range') {
     return desc;
   }
   return (
     <>
       {desc}{' '}
-      {/* Plain <a> inherits font-size from FieldValidationMessage (12px).
-          TextLink would apply theme.typography.body (14px) and look oversized. */}
       <a href={DOCS_LINK} target="_blank" rel="noreferrer">
         {t('time-picker.range-content.error-see-docs', 'See time range syntax')}
       </a>
@@ -109,9 +99,6 @@ export const TimeRangeContent = (props: Props) => {
 
   const fromInputRef = useRef<HTMLInputElement>(null);
   const toInputRef = useRef<HTMLInputElement>(null);
-  // Refs to the aria-describedby target divs — updated imperatively on blur/submit
-  // so the error text is only announced when the user explicitly leaves a field or submits,
-  // not on every keystroke (which would interrupt the input's own speech output).
   const fromErrorRef = useRef<HTMLDivElement>(null);
   const toErrorRef = useRef<HTMLDivElement>(null);
 
@@ -137,8 +124,6 @@ export const TimeRangeContent = (props: Props) => {
 
   const onApply = useCallback(() => {
     if (to.invalid || from.invalid) {
-      // Update the aria-describedby targets imperatively before focusing so the screen
-      // reader reads the error description when focus lands on the invalid field.
       if (fromErrorRef.current) {
         fromErrorRef.current.textContent = from.invalid ? from.errorDescription : '';
       }
@@ -239,13 +224,9 @@ export const TimeRangeContent = (props: Props) => {
   return (
     <div>
       <div className={style.fieldContainer}>
-        {/*
-         * Field does not receive `error` — that would render FieldValidationMessage with role="alert"
-         * (assertive), which interrupts speech on every keystroke. Instead:
-         *   1. FieldValidationMessage sits inside aria-hidden (visual only, no live region)
-         *   2. A plain div (no aria-live) is the aria-describedby target — updated imperatively
-         *      only on blur or submit, so the error is never announced mid-typing
-         */}
+        {/* Field does not receive `error` — role="alert" inside Field interrupts speech on every
+            keystroke. FieldValidationMessage is rendered aria-hidden (visual only); errors are
+            announced via aria-describedby targets updated imperatively on blur/submit. */}
         <div className={style.fieldWrapper}>
           <Field
             label={t('time-picker.range-content.from-input', 'From')}
@@ -275,8 +256,6 @@ export const TimeRangeContent = (props: Props) => {
               <FieldValidationMessage>{from.errorMessage}</FieldValidationMessage>
             </div>
           )}
-          {/* Plain div — no aria-live. Only populated on blur/submit so the error is read
-              on the next focus event, not mid-keystroke. */}
           <div id={fromErrorId} ref={fromErrorRef} className={style.srOnly} />
         </div>
         {fyTooltip}
@@ -375,13 +354,13 @@ function valueToState(
       value: fromValue,
       invalid: fromInvalid || rangeInvalid,
       errorMessage: fieldErrorMessage(fromErrorType),
-      errorDescription: ERROR_MESSAGES[fromErrorType].description(),
+      errorDescription: ERROR_MESSAGES[fromErrorType](),
     },
     {
       value: toValue,
       invalid: toInvalid,
       errorMessage: fieldErrorMessage('to'),
-      errorDescription: ERROR_MESSAGES.to.description(),
+      errorDescription: ERROR_MESSAGES.to(),
     },
   ];
 }

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -21,6 +21,7 @@ import { Button } from '../../Button/Button';
 import { Field } from '../../Forms/Field';
 import { Icon } from '../../Icon/Icon';
 import { Input } from '../../Input/Input';
+import { TextLink } from '../../Link/TextLink';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { WeekStart } from '../WeekStartPicker';
 import { commonFormat } from '../commonFormat';
@@ -43,13 +44,31 @@ interface Props {
 interface InputState {
   value: string;
   invalid: boolean;
-  errorMessage: string;
+  errorMessage: React.ReactNode;
+}
+
+const DOCS_LINK = 'https://grafana.com/docs/grafana/latest/dashboards/time-range-controls';
+
+function fieldErrorMessage(field: 'From' | 'To') {
+  return (
+    <>
+      {t(
+        field === 'From' ? 'time-picker.range-content.from-error' : 'time-picker.range-content.to-error',
+        field === 'From'
+          ? 'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the From field.'
+          : 'Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the To field.'
+      )}{' '}
+      <TextLink href={DOCS_LINK} external>
+        {t('time-picker.range-content.error-see-docs', 'See time range syntax')}
+      </TextLink>
+    </>
+  );
 }
 
 const ERROR_MESSAGES = {
-  from: () => t('time-picker.range-content.from-error', 'Please enter a past date or "now" in the From field'),
-  to: () => t('time-picker.range-content.to-error', 'Please enter a past date or "now" in the To field'),
-  range: () => t('time-picker.range-content.range-error', '"From" can\'t be after "To"'),
+  from: () => fieldErrorMessage('From'),
+  to: () => fieldErrorMessage('To'),
+  range: () => t('time-picker.range-content.range-error', '"From" date must be before "To"'),
 };
 
 export const TimeRangeContent = (props: Props) => {
@@ -68,13 +87,11 @@ export const TimeRangeContent = (props: Props) => {
 
   const [from, setFrom] = useState<InputState>(fromValue);
   const [to, setTo] = useState<InputState>(toValue);
-  // Pre-touch fields that are already invalid when the form opens (e.g. an existing invalid range)
-  const [fromTouched, setFromTouched] = useState(fromValue.invalid);
-  const [toTouched, setToTouched] = useState(toValue.invalid);
   const [isOpen, setOpen] = useState(false);
 
   const fromInputRef = useRef<HTMLInputElement>(null);
   const toInputRef = useRef<HTMLInputElement>(null);
+  const announceRef = useRef<HTMLDivElement>(null);
 
   const fromFieldId = useId();
   const toFieldId = useId();
@@ -84,8 +101,6 @@ export const TimeRangeContent = (props: Props) => {
     const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone);
     setFrom(fromValue);
     setTo(toValue);
-    setFromTouched(fromValue.invalid);
-    setToTouched(toValue.invalid);
   }, [value.raw.from, value.raw.to, timeZone]);
 
   const onOpen = useCallback(
@@ -98,9 +113,20 @@ export const TimeRangeContent = (props: Props) => {
 
   const onApply = useCallback(() => {
     if (to.invalid || from.invalid) {
-      // Reveal errors and focus first invalid field so screen readers announce it
-      setFromTouched(true);
-      setToTouched(true);
+      // Announce the failure via the polite live region, then focus the first invalid field.
+      // The live region text is cleared and re-set so screen readers always re-announce it.
+      if (announceRef.current) {
+        announceRef.current.textContent = '';
+        // Yield to let the DOM clear before re-setting so screen readers detect the change
+        requestAnimationFrame(() => {
+          if (announceRef.current) {
+            announceRef.current.textContent = t(
+              'time-picker.range-content.submit-error',
+              'Please correct the errors in the time range fields before applying.'
+            );
+          }
+        });
+      }
       if (from.invalid) {
         fromInputRef.current?.focus();
       } else {
@@ -187,7 +213,7 @@ export const TimeRangeContent = (props: Props) => {
       <div className={style.fieldContainer}>
         <Field
           label={t('time-picker.range-content.from-input', 'From')}
-          invalid={from.invalid && fromTouched}
+          invalid={from.invalid}
           error={from.errorMessage}
         >
           <Input
@@ -195,7 +221,6 @@ export const TimeRangeContent = (props: Props) => {
             ref={fromInputRef}
             onClick={(event) => event.stopPropagation()}
             onChange={(event) => onChange(event.currentTarget.value, to.value)}
-            onBlur={() => setFromTouched(true)}
             addonAfter={icon}
             onKeyDown={submitOnEnter}
             data-testid={selectors.components.TimePicker.fromField}
@@ -205,17 +230,12 @@ export const TimeRangeContent = (props: Props) => {
         {fyTooltip}
       </div>
       <div className={style.fieldContainer}>
-        <Field
-          label={t('time-picker.range-content.to-input', 'To')}
-          invalid={to.invalid && toTouched}
-          error={to.errorMessage}
-        >
+        <Field label={t('time-picker.range-content.to-input', 'To')} invalid={to.invalid} error={to.errorMessage}>
           <Input
             id={toFieldId}
             ref={toInputRef}
             onClick={(event) => event.stopPropagation()}
             onChange={(event) => onChange(from.value, event.currentTarget.value)}
-            onBlur={() => setToTouched(true)}
             addonAfter={icon}
             onKeyDown={submitOnEnter}
             data-testid={selectors.components.TimePicker.toField}
@@ -224,6 +244,7 @@ export const TimeRangeContent = (props: Props) => {
         </Field>
         {fyTooltip}
       </div>
+      <div ref={announceRef} aria-live="polite" className={style.srOnly} />
       <div className={style.buttonsContainer}>
         <Button
           data-testid={selectors.components.TimePicker.copyTimeRange}
@@ -318,6 +339,17 @@ function getStyles(theme: GrafanaTheme2) {
     tooltip: css({
       paddingLeft: theme.spacing(1),
       paddingTop: theme.spacing(3),
+    }),
+    srOnly: css({
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      padding: 0,
+      margin: '-1px',
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0,
     }),
   };
 }

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { FormEvent, useCallback, useEffect, useId, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useId, useRef, useState } from 'react';
 import * as React from 'react';
 
 import {
@@ -68,7 +68,13 @@ export const TimeRangeContent = (props: Props) => {
 
   const [from, setFrom] = useState<InputState>(fromValue);
   const [to, setTo] = useState<InputState>(toValue);
+  // Pre-touch fields that are already invalid when the form opens (e.g. an existing invalid range)
+  const [fromTouched, setFromTouched] = useState(fromValue.invalid);
+  const [toTouched, setToTouched] = useState(toValue.invalid);
   const [isOpen, setOpen] = useState(false);
+
+  const fromInputRef = useRef<HTMLInputElement>(null);
+  const toInputRef = useRef<HTMLInputElement>(null);
 
   const fromFieldId = useId();
   const toFieldId = useId();
@@ -78,6 +84,8 @@ export const TimeRangeContent = (props: Props) => {
     const [fromValue, toValue] = valueToState(value.raw.from, value.raw.to, timeZone);
     setFrom(fromValue);
     setTo(toValue);
+    setFromTouched(fromValue.invalid);
+    setToTouched(toValue.invalid);
   }, [value.raw.from, value.raw.to, timeZone]);
 
   const onOpen = useCallback(
@@ -90,6 +98,14 @@ export const TimeRangeContent = (props: Props) => {
 
   const onApply = useCallback(() => {
     if (to.invalid || from.invalid) {
+      // Reveal errors and focus first invalid field so screen readers announce it
+      setFromTouched(true);
+      setToTouched(true);
+      if (from.invalid) {
+        fromInputRef.current?.focus();
+      } else {
+        toInputRef.current?.focus();
+      }
       return;
     }
 
@@ -171,13 +187,15 @@ export const TimeRangeContent = (props: Props) => {
       <div className={style.fieldContainer}>
         <Field
           label={t('time-picker.range-content.from-input', 'From')}
-          invalid={from.invalid}
+          invalid={from.invalid && fromTouched}
           error={from.errorMessage}
         >
           <Input
             id={fromFieldId}
+            ref={fromInputRef}
             onClick={(event) => event.stopPropagation()}
             onChange={(event) => onChange(event.currentTarget.value, to.value)}
+            onBlur={() => setFromTouched(true)}
             addonAfter={icon}
             onKeyDown={submitOnEnter}
             data-testid={selectors.components.TimePicker.fromField}
@@ -187,11 +205,17 @@ export const TimeRangeContent = (props: Props) => {
         {fyTooltip}
       </div>
       <div className={style.fieldContainer}>
-        <Field label={t('time-picker.range-content.to-input', 'To')} invalid={to.invalid} error={to.errorMessage}>
+        <Field
+          label={t('time-picker.range-content.to-input', 'To')}
+          invalid={to.invalid && toTouched}
+          error={to.errorMessage}
+        >
           <Input
             id={toFieldId}
+            ref={toInputRef}
             onClick={(event) => event.stopPropagation()}
             onChange={(event) => onChange(from.value, event.currentTarget.value)}
+            onBlur={() => setToTouched(true)}
             addonAfter={icon}
             onKeyDown={submitOnEnter}
             data-testid={selectors.components.TimePicker.toField}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14953,11 +14953,13 @@
     },
     "range-content": {
       "apply-button": "Apply time range",
-      "default-error": "Please enter a past date or \"{{now}}\"",
+      "error-see-docs": "See time range syntax",
       "fiscal-year": "Fiscal year: {{from}} - {{to}}",
+      "from-error": "Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the From field.",
       "from-input": "From",
       "open-input-calendar": "Open calendar",
-      "range-error": "\"From\" can't be after \"To\"",
+      "range-error": "\"From\" date must be before \"To\"",
+      "to-error": "Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (e.g. now, now-1h) in the To field.",
       "to-input": "To"
     },
     "range-picker": {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/118641

## Summary

- **Field-specific error messages**: replaced the single generic error with separate `from`/`to` variants that name the field and include format hints (`YYYY-MM-DD HH:mm:ss` or relative time). Added a "See time range syntax" link for the docs.
- **Screen reader announcement fix**: `Field`'s `error` prop renders `FieldValidationMessage` with `role="alert"` (assertive), which interrupted speech on every keystroke. The new approach:
  1. `FieldValidationMessage` is rendered inside `aria-hidden="true"` (visual-only, no live region)
  2. Each input has `aria-invalid` and `aria-describedby` pointing to a plain hidden div
  3. The div is populated **imperatively** on blur or form submit only — never mid-keystroke
- **Submit with invalid fields**: the `onApply` handler now populates the `aria-describedby` targets and focuses the first invalid field, so the screen reader announces the error description when focus lands.

<img width="754" height="525" alt="image" src="https://github.com/user-attachments/assets/1cdfd490-f074-4d9f-b986-ac5f1b3414c8" />


## Test plan

- [ ] Open the time range picker, type an invalid value in From, tab away — screen reader announces the field-specific error once on blur
- [ ] Type into From while invalid — no mid-keystroke interruption
- [ ] Click "Apply time range" with both fields invalid — focus moves to From, screen reader announces the error
- [ ] Verify "See time range syntax" link in error bubble navigates to docs
- [ ] All existing `TimeRangeContent` tests pass (`yarn jest --no-watch TimeRangeContent`)