### PR TITLE
Tooling: DataViz lint updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,18 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 - **Frontend tests**: The `yarn test` script includes `--watch` by default. Always use `yarn jest --no-watch` or add `--watchAll=false` to run tests once and exit.
 - **Backend tests**: Some packages (e.g. `pkg/api/`) have slow test compilation (~2 min) due to large dependency graphs. Use targeted test runs with `-run TestName` where possible.
 - All standard build/test/lint commands are documented in the Commands section above.
+
+### Static analysis
+
+- check generated code against the appropriate static analysis tools (for example, generate JavaScript and TypeScript should pass type checks as well as ESLint and Prettier), and attempt to remediate issues automatically.
+- always confirm with the user before adding exceptions to static analysis (like inline ESLint or TS ignore comments).
+
+#### Frontend static analysis advice
+
+- for ESLint specifically, there is an `eslint-suppressions.json` file which contains ESLint excpetions per file. This file can be regenerated from ESLint using `yarn lint:ts --suppress-all`.
+- the rule for whether an ESLint exception should be added to the suppressions file or inlined is:
+  - if we intend to fix the exception eventually, it should be in `eslint-suppressions.json`
+  - if we do not intend to fix it, then it should be an inline comment.
+- if the user is asking to add new static analysis rules, always consider:
+  - whether a currently installed ESLint plugin has a rule that satisfies the request, rather than creating a new custom rule
+  - whether TypeScript types could enforce the requested rule. we should prefer good TypeScript types over ESLint rules in general.

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -549,6 +549,11 @@
       "count": 1
     }
   },
+  "packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksInlineEditorBase.tsx": {
+    "unicorn/no-array-for-each": {
+      "count": 1
+    }
+  },
   "packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
@@ -726,9 +731,38 @@
       "count": 1
     }
   },
+  "packages/grafana-ui/src/components/Table/TableNG/Cells/DataLinksCell.test.tsx": {
+    "unicorn/no-array-for-each": {
+      "count": 2
+    }
+  },
   "packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "unicorn/no-array-for-each": {
+      "count": 6
+    }
+  },
+  "packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 4
+    },
+    "react/display-name": {
+      "count": 1
+    }
+  },
+  "packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx": {
+    "jsx-a11y/anchor-is-valid": {
+      "count": 1
+    }
+  },
+  "packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1
     }
   },
   "packages/grafana-ui/src/components/Table/TableRT/ExpandedRow.tsx": {
@@ -764,6 +798,9 @@
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    },
+    "unicorn/no-array-for-each": {
       "count": 2
     }
   },
@@ -808,6 +845,14 @@
       "count": 1
     }
   },
+  "packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1
+    }
+  },
   "packages/grafana-ui/src/components/VizLegend/types.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
@@ -828,6 +873,14 @@
   },
   "packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.tsx": {
     "react/no-unescaped-entities": {
+      "count": 2
+    }
+  },
+  "packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 2
+    },
+    "jsx-a11y/no-static-element-interactions": {
       "count": 2
     }
   },
@@ -3775,6 +3828,11 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/barchart/migrations.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/barchart/quadtree.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
@@ -3783,6 +3841,11 @@
   "public/app/plugins/panel/bargauge/BarGaugePanel.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
+    }
+  },
+  "public/app/plugins/panel/bargauge/presets.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 2
     }
   },
   "public/app/plugins/panel/candlestick/CandlestickPanel.tsx": {
@@ -3818,8 +3881,18 @@
       "count": 2
     }
   },
+  "public/app/plugins/panel/canvas/editor/element/utils.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/canvas/editor/layer/tree.ts": {
     "unicorn/no-array-for-each": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/panel/canvas/utils.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
   },
@@ -3860,6 +3933,11 @@
   "public/app/plugins/panel/gauge/v1/GaugePanel.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
+    }
+  },
+  "public/app/plugins/panel/gauge/v2/presets.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 6
     }
   },
   "public/app/plugins/panel/geomap/GeomapPanel.tsx": {
@@ -4018,6 +4096,9 @@
     }
   },
   "public/app/plugins/panel/table/migrations.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 4
     }
@@ -4069,6 +4150,11 @@
   "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    }
+  },
+  "public/app/plugins/panel/timeseries/presets.ts": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 2
     }
   },
   "public/app/plugins/panel/xychart/SeriesEditor.tsx": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -746,7 +746,7 @@
   },
   "packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 4
+      "count": 2
     },
     "react/display-name": {
       "count": 1
@@ -911,9 +911,6 @@
     }
   },
   "packages/grafana-ui/src/components/uPlot/utils.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
@@ -3825,11 +3822,6 @@
       "count": 1
     },
     "unicorn/no-array-for-each": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/panel/barchart/migrations.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
   },

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -731,6 +731,11 @@
       "count": 2
     }
   },
+  "packages/grafana-ui/src/components/Table/TableRT/ExpandedRow.tsx": {
+    "unicorn/no-array-for-each": {
+      "count": 1
+    }
+  },
   "packages/grafana-ui/src/components/Table/TableRT/Filter.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
@@ -3765,6 +3770,9 @@
   "public/app/plugins/panel/barchart/bars.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    },
+    "unicorn/no-array-for-each": {
+      "count": 1
     }
   },
   "public/app/plugins/panel/barchart/quadtree.ts": {
@@ -3790,6 +3798,11 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx": {
+    "unicorn/no-array-for-each": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx": {
     "no-restricted-syntax": {
       "count": 1
@@ -3803,6 +3816,11 @@
   "public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx": {
     "no-restricted-syntax": {
       "count": 2
+    }
+  },
+  "public/app/plugins/panel/canvas/editor/layer/tree.ts": {
+    "unicorn/no-array-for-each": {
+      "count": 1
     }
   },
   "public/app/plugins/panel/debug/CursorView.tsx": {
@@ -3905,6 +3923,11 @@
       "count": 2
     }
   },
+  "public/app/plugins/panel/geomap/utils/layers.ts": {
+    "unicorn/no-array-for-each": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/geomap/utils/tooltip.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
@@ -4004,16 +4027,29 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx": {
+    "unicorn/no-array-for-each": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/timeseries/migrations.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 4
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 6
+    },
+    "unicorn/no-array-for-each": {
+      "count": 1
     }
   },
   "public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx": {
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx": {
+    "unicorn/no-array-for-each": {
       "count": 1
     }
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -556,6 +556,29 @@ module.exports = [
     },
   },
 
+  // Dataviz panel and UI component rules
+  {
+    name: 'grafana/dataviz-panel-rules',
+    files: [
+      'public/app/plugins/panel/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/BarGauge/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/DataLinks/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/Gauge/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/RadialGauge/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/Sparkline/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/Table/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/ValuePicker/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/VizLayout/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/VizLegend/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/VizRepeater/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/VizTooltip/**/*.{ts,tsx}',
+      'packages/grafana-ui/src/components/uPlot/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'unicorn/no-array-for-each': 'error',
+    },
+  },
+
   // Old betterer rules config:
   {
     files: ['**/*.{js,jsx,ts,tsx}'],

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -1,12 +1,7 @@
 import { toDataFrame } from '../dataframe/processDataFrame';
 import { DataFrame, TIME_SERIES_TIME_FIELD_NAME, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../types/dataFrame';
 
-import {
-  cacheFrameAndFieldIndices,
-  decoupleHideFromState,
-  getFieldDisplayName,
-  getFrameDisplayName,
-} from './fieldState';
+import { cacheFieldOrigins, decoupleHideFromState, getFieldDisplayName, getFrameDisplayName } from './fieldState';
 
 interface TitleScenario {
   frames: DataFrame[];
@@ -316,7 +311,7 @@ describe('decoupleHideFromState', () => {
   });
 });
 
-describe('cacheFrameAndFieldIndices', () => {
+describe('cacheFieldOrigins', () => {
   it('should add origin with frame and field index to field state', () => {
     const frame1 = toDataFrame({
       fields: [{ name: 'Field 1' }, { name: 'Field 2' }],
@@ -330,7 +325,7 @@ describe('cacheFrameAndFieldIndices', () => {
     expect(frame2.fields[0].state?.origin).toBeUndefined();
     expect(frame2.fields[1].state?.origin).toBeUndefined();
 
-    cacheFrameAndFieldIndices([frame1, frame2]);
+    cacheFieldOrigins([frame1, frame2]);
 
     expect(frame1.fields[0].state?.origin).toEqual({ frameIndex: 0, fieldIndex: 0 });
     expect(frame1.fields[1].state?.origin).toEqual({ frameIndex: 0, fieldIndex: 1 });
@@ -345,7 +340,7 @@ describe('cacheFrameAndFieldIndices', () => {
 
     frame.fields[0].state = { origin: { frameIndex: 10, fieldIndex: 10 } };
 
-    cacheFrameAndFieldIndices([frame]);
+    cacheFieldOrigins([frame]);
 
     expect(frame.fields[0].state?.origin).toEqual({ frameIndex: 0, fieldIndex: 0 });
   });

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -1,7 +1,12 @@
 import { toDataFrame } from '../dataframe/processDataFrame';
 import { DataFrame, TIME_SERIES_TIME_FIELD_NAME, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../types/dataFrame';
 
-import { decoupleHideFromState, getFieldDisplayName, getFrameDisplayName } from './fieldState';
+import {
+  cacheFrameAndFieldIndices,
+  decoupleHideFromState,
+  getFieldDisplayName,
+  getFrameDisplayName,
+} from './fieldState';
 
 interface TitleScenario {
   frames: DataFrame[];
@@ -308,5 +313,40 @@ describe('decoupleHideFromState', () => {
     });
 
     expect(frame.fields[0].state?.hideFrom).not.toBeUndefined();
+  });
+});
+
+describe('cacheFrameAndFieldIndices', () => {
+  it('should add origin with frame and field index to field state', () => {
+    const frame1 = toDataFrame({
+      fields: [{ name: 'Field 1' }, { name: 'Field 2' }],
+    });
+    const frame2 = toDataFrame({
+      fields: [{ name: 'Field 3' }, { name: 'Field 4' }],
+    });
+
+    expect(frame1.fields[0].state?.origin).toBeUndefined();
+    expect(frame1.fields[1].state?.origin).toBeUndefined();
+    expect(frame2.fields[0].state?.origin).toBeUndefined();
+    expect(frame2.fields[1].state?.origin).toBeUndefined();
+
+    cacheFrameAndFieldIndices([frame1, frame2]);
+
+    expect(frame1.fields[0].state?.origin).toEqual({ frameIndex: 0, fieldIndex: 0 });
+    expect(frame1.fields[1].state?.origin).toEqual({ frameIndex: 0, fieldIndex: 1 });
+    expect(frame2.fields[0].state?.origin).toEqual({ frameIndex: 1, fieldIndex: 0 });
+    expect(frame2.fields[1].state?.origin).toEqual({ frameIndex: 1, fieldIndex: 1 });
+  });
+
+  it('should override existing origin', () => {
+    const frame = toDataFrame({
+      fields: [{ name: 'Field 1', state: { origin: { frameIndex: 10, fieldIndex: 10 } } }],
+    });
+
+    frame.fields[0].state = { origin: { frameIndex: 10, fieldIndex: 10 } };
+
+    cacheFrameAndFieldIndices([frame]);
+
+    expect(frame.fields[0].state?.origin).toEqual({ frameIndex: 0, fieldIndex: 0 });
   });
 });

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -284,7 +284,7 @@ function getSingleLabelName(frames: DataFrame[]): string | null {
   return singleName;
 }
 
-export function cacheFrameAndFieldIndices(frames: DataFrame[]) {
+export function cacheFieldOrigins(frames: DataFrame[]) {
   for (let frameIndex = 0; frameIndex < frames.length; frameIndex++) {
     const frame = frames[frameIndex];
     for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -283,3 +283,19 @@ function getSingleLabelName(frames: DataFrame[]): string | null {
 
   return singleName;
 }
+
+export function cacheFrameAndFieldIndices(frames: DataFrame[]) {
+  for (let frameIndex = 0; frameIndex < frames.length; frameIndex++) {
+    const frame = frames[frameIndex];
+    for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {
+      const field = frame.fields[fieldIndex];
+      field.state = {
+        ...field.state,
+        origin: {
+          frameIndex,
+          fieldIndex,
+        },
+      };
+    }
+  }
+}

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -158,7 +158,7 @@ export {
   getFieldDisplayName,
   getFrameDisplayName,
   cacheFieldDisplayNames,
-  cacheFrameAndFieldIndices,
+  cacheFieldOrigins,
   getUniqueFieldName,
 } from './field/fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax, getMinMaxAndDelta } from './field/scale';

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -158,6 +158,7 @@ export {
   getFieldDisplayName,
   getFrameDisplayName,
   cacheFieldDisplayNames,
+  cacheFrameAndFieldIndices,
   getUniqueFieldName,
 } from './field/fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax, getMinMaxAndDelta } from './field/scale';

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -143,8 +143,12 @@ export function getFieldTypeForReducer(id: ReducerID, fallback: FieldType): Fiel
       : fallback;
 }
 
+let _allReducerIds: ReducerID[];
 export function isReducerID(id: string): id is ReducerID {
-  return Object.keys(ReducerID).includes(id);
+  if (!_allReducerIds) {
+    _allReducerIds = Object.values(ReducerID);
+  }
+  return _allReducerIds.some((reducerId) => reducerId === id);
 }
 
 // Internal function

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -5,6 +5,7 @@ import {
   FieldColorModeId,
   FieldConfig,
   fieldReducers,
+  isReducerID,
   PanelModel,
   ReduceDataOptions,
   ReducerID,
@@ -431,23 +432,25 @@ function getReducersFromLegend(obj: Record<string, unknown>): string[] {
 }
 
 // same as public/app/plugins/panel/barchart/migrations.ts
-function getReducerForMigration(reducers: string[] | undefined) {
-  const transformReducers: string[] = [];
+function getReducerForMigration(reducers: string[] | undefined): ReducerID[] {
+  const transformReducers: ReducerID[] = [];
+  if (!reducers) {
+    return [ReducerID.sum];
+  }
 
-  reducers?.forEach((reducer) => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    if (!Object.values(ReducerID).includes(reducer as ReducerID)) {
-      if (reducer === 'current') {
-        transformReducers.push(ReducerID.lastNotNull);
-      } else if (reducer === 'total') {
-        transformReducers.push(ReducerID.sum);
-      } else if (reducer === 'avg') {
-        transformReducers.push(ReducerID.mean);
-      }
-    } else {
+  for (const reducer of reducers) {
+    if (isReducerID(reducer)) {
       transformReducers.push(reducer);
+    } else if (reducer === 'current') {
+      transformReducers.push(ReducerID.lastNotNull);
+    } else if (reducer === 'total') {
+      transformReducers.push(ReducerID.sum);
+    } else if (reducer === 'avg') {
+      transformReducers.push(ReducerID.mean);
+    } else {
+      console.warn(`Unknown reducer ${reducer} found during migration, ignoring`);
     }
-  });
+  }
 
-  return reducers ? transformReducers : [ReducerID.sum];
+  return transformReducers;
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
@@ -1,4 +1,4 @@
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { memo, MemoExoticComponent, NamedExoticComponent } from 'react';
 
 import { Field, FieldType, GrafanaTheme2, isDataFrame, isTimeSeriesFrame } from '@grafana/data';

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { memo, MemoExoticComponent, NamedExoticComponent } from 'react';
 
 import { Field, FieldType, GrafanaTheme2, isDataFrame, isTimeSeriesFrame } from '@grafana/data';

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.tsx
@@ -94,7 +94,6 @@ const CELL_REGISTRY: Record<TableCellOptions['type'], CellRegistryEntry> = {
     ),
   },
   [TableCellDisplayMode.Sparkline]: {
-    // eslint-disable-next-line react/display-name
     renderer: wrapComponentInMemo(
       (props: TableCellRendererProps) => (
         <SparklineCell

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import memoize from 'micro-memoize';
 import { memo, useRef, useState } from 'react';
 
@@ -66,7 +66,10 @@ export const Filter = memo(({ name, rows, filter, setFilter, field, iconClassNam
         }
       }}
     >
-      <Icon name="filter" className={clsx(iconClassName, filterEnabled ? styles.filterIconEnabled : '')} />
+      <Icon
+        name="filter"
+        className={clsx(iconClassName ?? '', filterEnabled ? (styles.filterIconEnabled ?? '') : '')}
+      />
       {isPopoverVisible && ref.current && (
         <Popover
           content={

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import memoize from 'micro-memoize';
 import { memo, useRef, useState } from 'react';
 

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -26,7 +26,7 @@ interface Props {
   parentIndex?: number;
 }
 
-export const Filter = memo(({ name, rows, filter, setFilter, field, iconClassName, parentIndex }: Props) => {
+export const Filter = memo(({ name, rows, filter, setFilter, field, iconClassName = '', parentIndex }: Props) => {
   const filterKey = typeof parentIndex === 'number' ? `${name}-${parentIndex}` : name;
   const filterValue = filter[filterKey]?.filtered;
 
@@ -66,10 +66,7 @@ export const Filter = memo(({ name, rows, filter, setFilter, field, iconClassNam
         }
       }}
     >
-      <Icon
-        name="filter"
-        className={clsx(iconClassName ?? '', filterEnabled ? (styles.filterIconEnabled ?? '') : '')}
-      />
+      <Icon name="filter" className={clsx(iconClassName, filterEnabled ? styles.filterIconEnabled : '')} />
       {isPopoverVisible && ref.current && (
         <Popover
           content={

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -80,6 +80,7 @@ import {
   CellRootRenderer,
   FromFieldsResult,
   InspectCellProps,
+  isTableColumn,
   TableCellStyleOptions,
   TableColumn,
   TableNGProps,
@@ -218,7 +219,12 @@ export function TableNG(props: TableNGProps) {
   const [tooltipState, setTooltipState] = useState<DataLinksActionsTooltipState>();
   const onCellClick: OnCellClick = useCallback(
     ({ column, row }, ev) => {
-      const field = (column as unknown as TableColumn).field;
+      if (!isTableColumn(column)) {
+        console.warn(`${column.key} was not correctly configured within the Table panel.`);
+        return;
+      }
+
+      const field = column.field;
 
       // let the click event through for the expander column, since it has its own click handler for expanding/collapsing rows.
       if (column.key === EXPANDED_COLUMN_KEY) {
@@ -653,8 +659,8 @@ export function TableNG(props: TableNGProps) {
               {...props}
               className={clsx(
                 props.className ?? '',
-                cellParentStyles ?? '',
-                cellSpecificStyles != null && maxRowHeight == null ? `${cellSpecificStyles ?? ''}` : ''
+                cellParentStyles,
+                cellSpecificStyles != null && maxRowHeight == null ? cellSpecificStyles : ''
               )}
               style={style}
             />
@@ -750,10 +756,10 @@ export function TableNG(props: TableNGProps) {
               cellOptions: tooltipCellOptions,
               classes: tooltipClasses,
               className: clsx(
-                tooltipClasses.tooltipContent ?? '',
-                tooltipDefaultStyles ?? '',
+                tooltipClasses.tooltipContent,
+                tooltipDefaultStyles,
                 tooltipSpecificStyles ?? '',
-                tooltipLinkStyles ?? ''
+                tooltipLinkStyles
               ),
               data: frame,
               disableSanitizeHtml,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,6 +1,6 @@
 import 'react-data-grid/lib/styles.css';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import memoize from 'micro-memoize';
 import {
   CSSProperties,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,6 +1,6 @@
 import 'react-data-grid/lib/styles.css';
 
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import memoize from 'micro-memoize';
 import {
   CSSProperties,
@@ -656,9 +656,9 @@ export function TableNG(props: TableNGProps) {
               key={key}
               {...props}
               className={clsx(
-                props.className,
-                cellParentStyles,
-                cellSpecificStyles != null && maxRowHeight == null ? cellSpecificStyles : ''
+                props.className ?? '',
+                cellParentStyles ?? '',
+                cellSpecificStyles != null && maxRowHeight == null ? `${cellSpecificStyles ?? ''}` : ''
               )}
               style={style}
             />
@@ -710,7 +710,7 @@ export function TableNG(props: TableNGProps) {
           );
 
           if (maxRowHeight != null) {
-            result = <div className={clsx(maxHeightClassName, cellSpecificStyles)}>{result}</div>;
+            result = <div className={clsx(maxHeightClassName ?? '', cellSpecificStyles ?? '')}>{result}</div>;
           }
 
           return result;
@@ -754,10 +754,10 @@ export function TableNG(props: TableNGProps) {
               cellOptions: tooltipCellOptions,
               classes: tooltipClasses,
               className: clsx(
-                tooltipClasses.tooltipContent,
-                tooltipDefaultStyles,
-                tooltipSpecificStyles,
-                tooltipLinkStyles
+                tooltipClasses.tooltipContent ?? '',
+                tooltipDefaultStyles ?? '',
+                tooltipSpecificStyles ?? '',
+                tooltipLinkStyles ?? ''
               ),
               data: frame,
               disableSanitizeHtml,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -218,8 +218,6 @@ export function TableNG(props: TableNGProps) {
   const [tooltipState, setTooltipState] = useState<DataLinksActionsTooltipState>();
   const onCellClick: OnCellClick = useCallback(
     ({ column, row }, ev) => {
-      // we attach field to the column, but it doesn't
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const field = (column as unknown as TableColumn).field;
 
       // let the click event through for the expander column, since it has its own click handler for expanding/collapsing rows.
@@ -381,8 +379,6 @@ export function TableNG(props: TableNGProps) {
       return (row: TableRow) => (expandedRows.has(row.__index) ? TABLE.MAX_CELL_HEIGHT : 0);
     }
     if (typeof rowHeight === 'function') {
-      // this is safe because we only return a (row: TableRow) => string function when defaultNestedRowHeight is a string.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return rowHeight as unknown as (row: TableRow) => number;
     }
     if (typeof rowHeight === 'string') {
@@ -1024,7 +1020,6 @@ export function TableNG(props: TableNGProps) {
  */
 const renderRowFactory =
   (fields: Field[], panelContext: PanelContext, expandedRows: Set<number>, enableSharedCrosshair: boolean) =>
-  // eslint-disable-next-line react/display-name
   (key: React.Key, props: RenderRowProps<TableRow, TableSummaryRow>): React.ReactNode => {
     const { row } = props;
     const rowIdx = row.__index;

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -56,7 +56,6 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
     }
   }, [filterable, displayName, filter, setFilter]);
 
-  /* eslint-disable jsx-a11y/no-static-element-interactions */
   return (
     <Stack
       ref={ref}

--- a/packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx
@@ -27,7 +27,6 @@ export const MaybeWrapWithLink = memo(({ field, rowIdx, children }: MaybeWrapWit
   // as faux link that acts as hit-area for tooltip activation
   else if (linksCount + actionsCount > 0) {
     return (
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
       <a title={t('table.link-wrapper.menu', 'view data links and actions')} aria-haspopup="menu">
         {children}
       </a>

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -10,7 +10,6 @@ export const TableCellActions = memo(
   ({ field, value, setInspectCell, onCellFilterAdded, className, cellInspect, showFilters }: TableCellActionsProps) => (
     // stopping propagation to prevent clicks within the actions menu from triggering the cell click events
     // for things like the data links tooltip.
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div className={className} onClick={(ev) => ev.stopPropagation()}>
       {cellInspect && (
         <IconButton

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -342,3 +342,7 @@ export interface FromFieldsResult {
 export interface FooterFieldState extends FieldState {
   lastProcessedRowCount: number;
 }
+
+export function isTableColumn(col: Column<TableRow, TableSummaryRow>): col is TableColumn {
+  return Object.prototype.hasOwnProperty.call(col, 'field');
+}

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendList.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendList.tsx
@@ -30,7 +30,6 @@ export const VizLegendList = <T extends unknown>({
   const styles = useStyles2(getStyles);
 
   if (!itemRenderer) {
-    /* eslint-disable-next-line react/display-name */
     itemRenderer = (item) => (
       <VizLegendListItem
         item={item}

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -78,7 +78,6 @@ export const VizLegendTable = <T extends unknown>({
   const limitedItems = useMemo(() => (curLimit > 0 ? items.slice(0, curLimit) : items), [items, curLimit]);
 
   if (!itemRenderer) {
-    /* eslint-disable-next-line react/display-name */
     itemRenderer = (item, index) => (
       <LegendTableItem
         key={`${item.label}-${index}`}
@@ -112,7 +111,6 @@ export const VizLegendTable = <T extends unknown>({
               }}
             >
               {columnTitle === nameSortKey && filterAction && (
-                // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                 <span className={styles.filterAction} onClick={(e) => e.stopPropagation()}>
                   {filterAction}
                 </span>

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -49,13 +49,13 @@ export const VizLegendTable = <T extends unknown>({
   if (sortKey != null) {
     let itemVals = new Map<VizLegendItem, number>();
 
-    items.forEach((item) => {
+    for (const item of items) {
       if (sortKey !== nameSortKey && item.getDisplayValues) {
         const stat = item.getDisplayValues().find((stat) => stat.title === sortKey);
         const val = stat == null || Number.isNaN(stat.numeric) ? -Infinity : stat.numeric;
         itemVals.set(item, val);
       }
-    });
+    }
 
     let sortMult = sortDesc ? -1 : 1;
 

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -156,7 +156,6 @@ export const VizTooltipRow = ({
                       {SUCCESSFULLY_COPIED_TEXT}
                     </InlineToast>
                   )}
-                  {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
                   <div
                     className={clsx(styles.label, isActive ? styles.activeSeries : '', CAN_COPY ? styles.copy : '')}
                     onMouseEnter={onMouseEnterLabel}
@@ -194,7 +193,6 @@ export const VizTooltipRow = ({
                 {SUCCESSFULLY_COPIED_TEXT}
               </InlineToast>
             )}
-            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
             <div
               className={clsx(styles.value, CAN_COPY ? styles.copy : '')}
               style={innerValueScrollStyle}

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipWrapper.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipWrapper.tsx
@@ -11,7 +11,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 }
 
-export const VizTooltipWrapper = ({ children, className }: Props) => {
+export const VizTooltipWrapper = ({ children, className = '' }: Props) => {
   const styles = useStyles2(getStyles);
   return (
     <div className={clsx(styles, className)} data-testid={selectors.components.Panels.Visualization.Tooltip.Wrapper}>

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -170,23 +170,25 @@ export const getContentItems = (
     });
   }
 
-  _restFields?.forEach((field) => {
-    if (!field.config.custom?.hideFrom?.tooltip) {
-      const { colorIndicator, colorPlacement } = getIndicatorAndPlacement(field);
-      const rawValue = field.values[dataIdxs[0]!];
-      const display = getTooltipDisplayValue(rawValue, field);
+  if (_restFields) {
+    for (const field of _restFields) {
+      if (!field.config.custom?.hideFrom?.tooltip) {
+        const { colorIndicator, colorPlacement } = getIndicatorAndPlacement(field);
+        const rawValue = field.values[dataIdxs[0]!];
+        const display = getTooltipDisplayValue(rawValue, field);
 
-      rows.push({
-        label: field.state?.displayName ?? field.name,
-        value: display.text,
-        color: FALLBACK_COLOR,
-        colorIndicator,
-        colorPlacement,
-        lineStyle: field.config.custom?.lineStyle,
-        isHiddenFromViz: true,
-      });
+        rows.push({
+          label: field.state?.displayName ?? field.name,
+          value: display.text,
+          color: FALLBACK_COLOR,
+          colorIndicator,
+          colorPlacement,
+          lineStyle: field.config.custom?.lineStyle,
+          isHiddenFromViz: true,
+        });
+      }
     }
-  });
+  }
 
   if (sortOrder !== SortOrder.None && rows.length > 1) {
     const cmp = allNumeric ? numberCmp : stringCmp;

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -235,11 +235,11 @@ export class UPlotConfigBuilder {
       config.padding = this.padding;
     }
 
-    this.stackingGroups.forEach((group) => {
-      getStackingBands(group).forEach((band) => {
+    for (const group of this.stackingGroups) {
+      for (const band of getStackingBands(group)) {
         this.addBand(band);
-      });
-    });
+      }
+    }
 
     if (this.bands.length) {
       config.bands = this.bands;

--- a/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
@@ -182,7 +182,8 @@ export function getDataRange(plot: uPlot, scaleKey: string) {
   let min = Infinity;
   let max = -Infinity;
 
-  for (const [seriesIdx, ser] of plot.series.entries()) {
+  for (let seriesIdx = 0; seriesIdx < plot.series.length; seriesIdx++) {
+    const ser = plot.series[seriesIdx];
     if (ser.show && ser.scale === scaleKey) {
       // uPlot skips finding data min/max when a scale has a pre-defined range
       if (ser.min == null) {

--- a/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
@@ -182,7 +182,7 @@ export function getDataRange(plot: uPlot, scaleKey: string) {
   let min = Infinity;
   let max = -Infinity;
 
-  plot.series.forEach((ser, seriesIdx) => {
+  for (const [seriesIdx, ser] of plot.series.entries()) {
     if (ser.show && ser.scale === scaleKey) {
       // uPlot skips finding data min/max when a scale has a pre-defined range
       if (ser.min == null) {
@@ -198,7 +198,7 @@ export function getDataRange(plot: uPlot, scaleKey: string) {
         max = Math.max(max, ser.max!);
       }
     }
-  });
+  }
 
   if (max === min) {
     min = sc.min!;

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -440,7 +440,7 @@ export const TooltipPlugin2 = ({
 
             // get y selections
             if (yDrag) {
-              config.scales.forEach((scale) => {
+              for (const scale of config.scales) {
                 const key = scale.props.scaleKey;
 
                 if (key !== 'x') {
@@ -453,7 +453,7 @@ export const TooltipPlugin2 = ({
 
                   ySels.push(ySel);
                 }
-              });
+              }
             }
 
             if (xDrag) {

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -68,13 +68,14 @@ export function getStackingBands(group: StackingGroup) {
 
   let rSeries = series.slice().reverse();
 
-  for (const [i, si] of rSeries.entries()) {
+  for (let i = 0; i < rSeries.length; i++) {
+    const si = rSeries[i];
     if (i !== lastIdx) {
       let nextIdx = rSeries[i + 1];
       bands.push({
         series: [si, nextIdx],
         // fill direction is inverted from stack direction
-        dir: (-1 * dir) as 1 | -1,
+        dir: dir === 1 ? -1 : 1,
       });
     }
   }
@@ -87,12 +88,9 @@ export function getStackingBands(group: StackingGroup) {
 export function getStackingGroups(frame: DataFrame) {
   let groups: Map<string, StackingGroup> = new Map();
 
-  for (const [i, { config, values, type }] of frame.fields.entries()) {
-    // skip x or time field
-    if (i === 0) {
-      continue;
-    }
-
+  // skip x or time field, start with 1
+  for (let i = 1; i < frame.fields.length; i++) {
+    const { config, values, type } = frame.fields[i];
     let { custom } = config;
 
     if (custom == null) {

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -68,7 +68,7 @@ export function getStackingBands(group: StackingGroup) {
 
   let rSeries = series.slice().reverse();
 
-  rSeries.forEach((si, i) => {
+  for (const [i, si] of rSeries.entries()) {
     if (i !== lastIdx) {
       let nextIdx = rSeries[i + 1];
       bands.push({
@@ -77,7 +77,7 @@ export function getStackingBands(group: StackingGroup) {
         dir: (-1 * dir) as 1 | -1,
       });
     }
-  });
+  }
 
   return bands;
 }
@@ -87,35 +87,35 @@ export function getStackingBands(group: StackingGroup) {
 export function getStackingGroups(frame: DataFrame) {
   let groups: Map<string, StackingGroup> = new Map();
 
-  frame.fields.forEach(({ config, values, type }, i) => {
+  for (const [i, { config, values, type }] of frame.fields.entries()) {
     // skip x or time field
     if (i === 0) {
-      return;
+      continue;
     }
 
     let { custom } = config;
 
     if (custom == null) {
-      return;
+      continue;
     }
 
     // TODO: currently all AlignedFrame fields end up in uplot series & data, even custom.hideFrom?.viz
     // ideally hideFrom.viz fields would be excluded so we can remove this
     if (custom.hideFrom?.viz) {
-      return;
+      continue;
     }
 
     let { stacking } = custom;
 
     if (stacking == null) {
-      return;
+      continue;
     }
 
     let { mode: stackingMode, group: stackingGroup } = stacking;
 
     // not stacking
     if (stackingMode === StackingMode.None) {
-      return;
+      continue;
     }
 
     // will this be stacked up or down after any transforms applied
@@ -147,7 +147,7 @@ export function getStackingGroups(frame: DataFrame) {
     }
 
     group.series.push(i);
-  });
+  }
 
   return [...groups.values()];
 }
@@ -171,14 +171,14 @@ export function preparePlotData2(
 
   // figure out at which time indices each stacking group has any values
   // (needed to avoid absorbing initial accum 0s at unrelated joined timestamps)
-  stackingGroups.forEach((group, groupIdx) => {
+  for (const [groupIdx, group] of stackingGroups.entries()) {
     let groupValsAtX = anyValsAtX[groupIdx];
 
-    group.series.forEach((seriesIdx) => {
+    for (const seriesIdx of group.series) {
       let field = frame.fields[seriesIdx];
 
       if (field.config.custom?.hideFrom?.viz) {
-        return;
+        continue;
       }
 
       let vals = field.values;
@@ -188,22 +188,22 @@ export function preparePlotData2(
           groupValsAtX[i] = true;
         }
       }
-    });
-  });
+    }
+  }
 
-  frame.fields.forEach((field, i) => {
+  for (const [i, field] of frame.fields.entries()) {
     let vals = field.values;
 
     if (i === 0) {
       data[i] = vals;
-      return;
+      continue;
     }
 
     let { custom } = field.config;
 
     if (!custom || custom.hideFrom?.viz) {
       data[i] = vals;
-      return;
+      continue;
     }
 
     // apply transforms
@@ -245,7 +245,7 @@ export function preparePlotData2(
         }
       }
     }
-  });
+  }
 
   if (onStackMeta) {
     let accumsBySeriesIdx = data.map((vals, i) => {
@@ -259,9 +259,9 @@ export function preparePlotData2(
   }
 
   // re-compute by percent
-  frame.fields.forEach((field, i) => {
+  for (const [i, field] of frame.fields.entries()) {
     if (i === 0 || field.config.custom?.hideFrom?.viz) {
-      return;
+      continue;
     }
 
     let stackingMode = field.config.custom?.stacking?.mode;
@@ -282,7 +282,7 @@ export function preparePlotData2(
         }
       }
     }
-  });
+  }
 
   return data;
 }

--- a/packages/grafana-ui/src/types/clsx.d.ts
+++ b/packages/grafana-ui/src/types/clsx.d.ts
@@ -1,0 +1,5 @@
+declare module 'clsx' {
+  type ClassValue = string;
+  function clsx(...inputs: ClassValue[]): string;
+  export = clsx;
+}

--- a/packages/grafana-ui/src/types/clsx.d.ts
+++ b/packages/grafana-ui/src/types/clsx.d.ts
@@ -1,5 +1,17 @@
 declare module 'clsx' {
   type ClassValue = string;
+  /**
+   * an optimized classnames function that only accepts strings as input, and returns a string as output.
+   *
+   * this is a deliberate, custom override of the clsx type definitions.
+   * the `toVal` method in clsx is fast and simple, but is at its fastest and simplest when
+   * processing only strings https://github.com/lukeed/clsx/blob/master/src/index.js#L1-L28
+   *
+   * if a more complex use case is warranted, we still have `cx` from Emotion we can use, so
+   * adding this TypeScript shim on top of clsx forces us to use clsx only in its optimal case,
+   * and we only want to use clsx for optimized code anyway.
+   */
   function clsx(...inputs: ClassValue[]): string;
   export = clsx;
+  export { clsx };
 }

--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
@@ -33,17 +33,17 @@ const GroupedModeView = ({ rules, options }: Props) => {
     const hasInstancesWithMatchingLabels = (rule: CombinedRuleWithLocation) =>
       groupBy ? alertHasEveryLabelForCombinedRules(rule, groupBy) : true;
 
-    rules.forEach((rule) => {
+    for (const rule of rules) {
       const alertingRule = getAlertingRule(rule);
       const hasInstancesMatching = hasInstancesWithMatchingLabels(rule);
 
-      (alertingRule?.alerts ?? []).forEach((alert) => {
+      for (const alert of alertingRule?.alerts ?? []) {
         const mapKey = hasInstancesMatching ? createMapKey(groupBy, alert.labels) : UNGROUPED_KEY;
 
         const existingAlerts = groupedRules.get(mapKey)?.alerts ?? [];
         groupedRules.set(mapKey, { rule, alerts: [...existingAlerts, alert] });
-      });
-    });
+      }
+    }
 
     // move the "UNGROUPED" key to the last item in the Map, items are shown in insertion order
     const ungrouped = groupedRules.get(UNGROUPED_KEY)?.alerts ?? [];

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -454,13 +454,13 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
   });
 
   const init = (u: uPlot) => {
-    u.root.querySelectorAll<HTMLDivElement>('.u-cursor-pt').forEach((el) => {
+    for (const el of u.root.querySelectorAll<HTMLDivElement>('.u-cursor-pt')) {
       el.style.borderRadius = '0';
 
       if (opts.fullHighlight) {
         el.style.zIndex = '-1';
       }
-    });
+    }
   };
 
   const cursor: uPlot.Cursor = {
@@ -519,10 +519,10 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
     qt.clear();
 
     // clear the path cache to force drawBars() to rebuild new quadtree
-    u.series.forEach((s) => {
+    for (const s of u.series) {
       // @ts-ignore
       s._paths = null;
-    });
+    }
 
     if (isStacked) {
       barsPctLayout = [null, ...distrOne(u.data[0].length, u.data.length - 1)];

--- a/public/app/plugins/panel/barchart/migrations.ts
+++ b/public/app/plugins/panel/barchart/migrations.ts
@@ -56,20 +56,22 @@ export const changeToBarChartPanelMigrationHandler: PanelTypeChangedHandler = (p
 const getReducer = (reducers: string[] | undefined) => {
   const transformReducers: string[] = [];
 
-  reducers?.forEach((reducer) => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    if (!Object.values(ReducerID).includes(reducer as ReducerID)) {
-      if (reducer === 'current') {
-        transformReducers.push(ReducerID.lastNotNull);
-      } else if (reducer === 'total') {
-        transformReducers.push(ReducerID.sum);
-      } else if (reducer === 'avg') {
-        transformReducers.push(ReducerID.mean);
+  if (reducers) {
+    for (const reducer of reducers) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      if (!Object.values(ReducerID).includes(reducer as ReducerID)) {
+        if (reducer === 'current') {
+          transformReducers.push(ReducerID.lastNotNull);
+        } else if (reducer === 'total') {
+          transformReducers.push(ReducerID.sum);
+        } else if (reducer === 'avg') {
+          transformReducers.push(ReducerID.mean);
+        }
+      } else {
+        transformReducers.push(reducer);
       }
-    } else {
-      transformReducers.push(reducer);
     }
-  });
+  }
 
   return reducers ? transformReducers : [ReducerID.sum];
 };

--- a/public/app/plugins/panel/barchart/migrations.ts
+++ b/public/app/plugins/panel/barchart/migrations.ts
@@ -1,4 +1,4 @@
-import { FieldMatcherID, PanelTypeChangedHandler, ReducerID } from '@grafana/data';
+import { FieldMatcherID, isReducerID, PanelTypeChangedHandler, ReducerID } from '@grafana/data';
 import { AxisPlacement } from '@grafana/ui';
 
 /*
@@ -53,27 +53,28 @@ export const changeToBarChartPanelMigrationHandler: PanelTypeChangedHandler = (p
 };
 
 // same as grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
-const getReducer = (reducers: string[] | undefined) => {
-  const transformReducers: string[] = [];
+function getReducer(reducers: string[] | undefined): ReducerID[] {
+  const transformReducers: ReducerID[] = [];
+  if (!reducers) {
+    return [ReducerID.sum];
+  }
 
-  if (reducers) {
-    for (const reducer of reducers) {
-      if (!Object.values(ReducerID).includes(reducer as ReducerID)) {
-        if (reducer === 'current') {
-          transformReducers.push(ReducerID.lastNotNull);
-        } else if (reducer === 'total') {
-          transformReducers.push(ReducerID.sum);
-        } else if (reducer === 'avg') {
-          transformReducers.push(ReducerID.mean);
-        }
-      } else {
-        transformReducers.push(reducer);
-      }
+  for (const reducer of reducers) {
+    if (isReducerID(reducer)) {
+      transformReducers.push(reducer);
+    } else if (reducer === 'current') {
+      transformReducers.push(ReducerID.lastNotNull);
+    } else if (reducer === 'total') {
+      transformReducers.push(ReducerID.sum);
+    } else if (reducer === 'avg') {
+      transformReducers.push(ReducerID.mean);
+    } else {
+      console.warn(`Unknown reducer ${reducer} found during migration, ignoring`);
     }
   }
 
-  return reducers ? transformReducers : [ReducerID.sum];
-};
+  return transformReducers;
+}
 
 interface GraphOptions {
   xaxis: {

--- a/public/app/plugins/panel/barchart/migrations.ts
+++ b/public/app/plugins/panel/barchart/migrations.ts
@@ -58,7 +58,6 @@ const getReducer = (reducers: string[] | undefined) => {
 
   if (reducers) {
     for (const reducer of reducers) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       if (!Object.values(ReducerID).includes(reducer as ReducerID)) {
         if (reducer === 'current') {
           transformReducers.push(ReducerID.lastNotNull);

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -73,8 +73,12 @@ function mockDataFrame() {
     state: {},
   });
 
-  df1.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
-  df2.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+  for (const f of df1.fields) {
+    f.config.custom = f.config.custom ?? {};
+  }
+  for (const f of df2.fields) {
+    f.config.custom = f.config.custom ?? {};
+  }
 
   const info = prepSeries([df1], fieldConfig, StackingMode.None, createTheme());
 
@@ -197,7 +201,9 @@ describe('BarChart utils', () => {
           { name: 'value', values: [1, 2, 3, 4, 5] },
         ],
       });
-      df.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+      for (const f of df.fields) {
+        f.config.custom = f.config.custom ?? {};
+      }
 
       const info = prepSeries([df], fieldConfig, StackingMode.None, createTheme());
       const warning = assertIsDefined('warn' in info ? info : null);
@@ -211,7 +217,9 @@ describe('BarChart utils', () => {
           { name: 'value', type: FieldType.boolean, values: [true, true, true, true, true] },
         ],
       });
-      df.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+      for (const f of df.fields) {
+        f.config.custom = f.config.custom ?? {};
+      }
 
       const info = prepSeries([df], fieldConfig, StackingMode.None, createTheme());
       const warning = assertIsDefined('warn' in info ? info : null);
@@ -225,7 +233,9 @@ describe('BarChart utils', () => {
           { name: 'value', values: [-10, NaN, 10, -Infinity, +Infinity] },
         ],
       });
-      df.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+      for (const f of df.fields) {
+        f.config.custom = f.config.custom ?? {};
+      }
 
       const info = prepSeries([df], fieldConfig, StackingMode.None, createTheme());
 
@@ -250,7 +260,9 @@ describe('BarChart utils', () => {
           { name: 'c', values: [10, 10, 10], state: { calcs: { min: 10 } } },
         ],
       });
-      df.fields.forEach((f) => (f.config.custom = f.config.custom ?? {}));
+      for (const f of df.fields) {
+        f.config.custom = f.config.custom ?? {};
+      }
 
       const info = prepSeries([df], fieldConfig, StackingMode.Percent, createTheme());
 

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -97,7 +97,7 @@ export function prepSeries(
             (field) => field.state?.displayName === colorFieldName || field.name === colorFieldName
           );
 
-    frame.fields.forEach((field) => {
+    for (const field of frame.fields) {
       if (field !== xField) {
         if (field.type === FieldType.number && !field.config.custom?.hideFrom?.viz) {
           const field2 = {
@@ -121,7 +121,7 @@ export function prepSeries(
           _rest.push(field);
         }
       }
-    });
+    }
 
     let warn: string | null = null;
 

--- a/public/app/plugins/panel/bargauge/BarGaugeLegend.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugeLegend.tsx
@@ -13,12 +13,14 @@ interface BarGaugeLegendProps extends VizLegendOptions, Omit<VizLayoutLegendProp
 export const BarGaugeLegend = memo(
   ({ data, placement, calcs, displayMode, ...vizLayoutLegendProps }: BarGaugeLegendProps) => {
     const theme = useTheme2();
-    let legendItems: VizLegendItem[] = [];
 
     cacheFieldDisplayNames(data);
 
-    for (const [frameIndex, series] of data.entries()) {
-      for (const [i, field] of series.fields.entries()) {
+    let legendItems: VizLegendItem[] = [];
+    for (let frameIndex = 0; frameIndex < data.length; frameIndex++) {
+      const series = data[frameIndex];
+      for (let i = 0; i < series.fields.length; i++) {
+        const field = series.fields[i];
         const fieldIndex = i + 1;
 
         if (field.type === FieldType.time || field.config.custom?.hideFrom?.legend) {

--- a/public/app/plugins/panel/bargauge/BarGaugeLegend.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugeLegend.tsx
@@ -17,12 +17,12 @@ export const BarGaugeLegend = memo(
 
     cacheFieldDisplayNames(data);
 
-    data.forEach((series, frameIndex) => {
-      series.fields.forEach((field, i) => {
+    for (const [frameIndex, series] of data.entries()) {
+      for (const [i, field] of series.fields.entries()) {
         const fieldIndex = i + 1;
 
         if (field.type === FieldType.time || field.config.custom?.hideFrom?.legend) {
-          return;
+          continue;
         }
 
         const label = field.state?.displayName ?? field.name;
@@ -38,8 +38,8 @@ export const BarGaugeLegend = memo(
         };
 
         legendItems.push(item);
-      });
-    });
+      }
+    }
 
     return (
       <VizLayout.Legend placement={placement} {...vizLayoutLegendProps}>

--- a/public/app/plugins/panel/bargauge/presets.ts
+++ b/public/app/plugins/panel/bargauge/presets.ts
@@ -14,7 +14,6 @@ import { defaultOptions, Options } from './panelcfg.gen';
 const defaultPresetThresholds = {
   mode: ThresholdsMode.Percentage,
   steps: [
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     { value: null as unknown as number, color: 'green' },
     { value: 60, color: 'orange' },
     { value: 80, color: 'red' },

--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -113,12 +113,12 @@ export class CanvasPanel extends Component<Props, State> {
               activePanelSubject.next({ panel: this });
             }
 
-            canvasInstances.forEach((canvasInstance) => {
+            for (const canvasInstance of canvasInstances) {
               if (canvasInstance !== activeCanvasPanel) {
                 canvasInstance.scene.clearCurrentSelection(true);
                 canvasInstance.scene.connections.select(undefined);
               }
-            });
+            }
 
             this.panelContext?.onInstanceStateChange!({ scene: this.scene, selected: v, layer: this.scene.root });
           },
@@ -144,12 +144,12 @@ export class CanvasPanel extends Component<Props, State> {
               activePanelSubject.next({ panel: this });
             }
 
-            canvasInstances.forEach((canvasInstance) => {
+            for (const canvasInstance of canvasInstances) {
               if (canvasInstance !== activeCanvasPanel) {
                 canvasInstance.scene.clearCurrentSelection(true);
                 canvasInstance.scene.connections.select(undefined);
               }
-            });
+            }
 
             setTimeout(() => {
               this.forceUpdate();

--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -73,9 +73,9 @@ export const CanvasContextMenu = ({ scene, panel, onVisibilityChange }: Props) =
 
   useEffect(() => {
     if (scene.selecto) {
-      scene.selecto.getSelectableElements().forEach((element) => {
+      for (const element of scene.selecto.getSelectableElements()) {
         element.addEventListener('contextmenu', handleContextMenu);
-      });
+      }
     }
   }, [handleContextMenu, scene.selecto]);
 

--- a/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
@@ -85,19 +85,19 @@ export const CanvasTooltip = ({ scene }: Props) => {
   if ((element.options.links?.length ?? 0) > 0 && element.getLinks) {
     const linkLookup = new Set<string>();
 
-    element.getLinks({ valueRowIndex: getRowIndex(element.data.field, scene) }).forEach((link) => {
+    for (const link of element.getLinks({ valueRowIndex: getRowIndex(element.data.field, scene) })) {
       const key = `${link.title}/${link.href}`;
       if (!linkLookup.has(key)) {
         links.push(link);
         linkLookup.add(key);
       }
-    });
+    }
   }
 
   if (scene.data?.series) {
-    getElementFields(scene.data?.series, element.options).forEach((field) => {
+    for (const field of getElementFields(scene.data?.series, element.options)) {
       links.push(...getDataLinks(field, getRowIndex(element.data.field, scene)));
-    });
+    }
   }
 
   const actions: Array<ActionModel<Field>> = [];
@@ -131,13 +131,13 @@ export const CanvasTooltip = ({ scene }: Props) => {
       'canvas'
     );
 
-    actionsModel.forEach((action) => {
+    for (const action of actionsModel) {
       const key = `${action.title}/${Math.random()}`;
       if (!actionLookup.has(key)) {
         actions.push(action);
         actionLookup.add(key);
       }
-    });
+    }
   }
 
   return (

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -153,7 +153,8 @@ export class Connections {
 
     // re-calculate the position of the existing anchors on hover
     // and hide the rest of the anchors if there are more than the custom ones
-    for (const [index, anchor] of anchors.entries()) {
+    for (let index = 0; index < anchors.length; index++) {
+      const anchor = anchors[index];
       if (index >= anchorsAmount) {
         anchor.style.display = 'none';
       } else {

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -153,7 +153,7 @@ export class Connections {
 
     // re-calculate the position of the existing anchors on hover
     // and hide the rest of the anchors if there are more than the custom ones
-    anchors.forEach((anchor, index) => {
+    for (const [index, anchor] of anchors.entries()) {
       if (index >= anchorsAmount) {
         anchor.style.display = 'none';
       } else {
@@ -162,7 +162,7 @@ export class Connections {
         anchor.style.left = `calc(${x * 50 + 50}% - ${HALF_SIZE}px - ${ANCHOR_PADDING}px)`;
         anchor.style.display = 'block';
       }
-    });
+    }
 
     const elementBoundingRect = element.div!.getBoundingClientRect();
     const transformScale = this.scene.scale;

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -148,7 +148,7 @@ export class Connections2 {
 
     // re-calculate the position of the existing anchors on hover
     // and hide the rest of the anchors if there are more than the custom ones
-    anchors.forEach((anchor, index) => {
+    for (const [index, anchor] of anchors.entries()) {
       if (index >= anchorsAmount) {
         anchor.style.display = 'none';
       } else {
@@ -157,7 +157,7 @@ export class Connections2 {
         anchor.style.left = `calc(${x * 50 + 50}% - ${HALF_SIZE}px - ${ANCHOR_PADDING}px)`;
         anchor.style.display = 'block';
       }
-    });
+    }
 
     const { top, left, width, height, rotation } = getElementTransformAndDimensions(element.div!);
 

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -148,7 +148,8 @@ export class Connections2 {
 
     // re-calculate the position of the existing anchors on hover
     // and hide the rest of the anchors if there are more than the custom ones
-    for (const [index, anchor] of anchors.entries()) {
+    for (let index = 0; index < anchors.length; index++) {
+      const anchor = anchors[index];
       if (index >= anchorsAmount) {
         anchor.style.display = 'none';
       } else {

--- a/public/app/plugins/panel/canvas/editor/element/ActionsEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/ActionsEditor.tsx
@@ -12,9 +12,9 @@ export function ActionsEditor({ value, onChange, item, context }: Props) {
       actions={value}
       onChange={(actions) => {
         if (actions.some(({ oneClick }) => oneClick === true)) {
-          dataLinks.forEach((link) => {
+          for (const link of dataLinks) {
             link.oneClick = false;
-          });
+          }
         }
         onChange(actions);
       }}

--- a/public/app/plugins/panel/canvas/editor/element/DataLinksEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/DataLinksEditor.tsx
@@ -12,9 +12,9 @@ export function DataLinksEditor({ value, onChange, item, context }: Props) {
       links={value}
       onChange={(links) => {
         if (links.some(({ oneClick }) => oneClick === true)) {
-          actions.forEach((action) => {
+          for (const action of actions) {
             action.oneClick = false;
-          });
+          }
         }
         onChange(links);
       }}

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -53,15 +53,17 @@ export const getRequest = (api: APIEditorConfig) => {
   };
 
   if (api.headerParams) {
-    api.headerParams.forEach(([name, value]) => {
+    for (const [name, value] of api.headerParams) {
       requestHeaders[interpolateVariables(name)] = interpolateVariables(value);
-    });
+    }
   }
 
   if (api.queryParams) {
-    api.queryParams?.forEach(([name, value]) => {
-      url.searchParams.append(interpolateVariables(name), interpolateVariables(value));
-    });
+    if (api.queryParams) {
+      for (const [name, value] of api.queryParams) {
+        url.searchParams.append(interpolateVariables(name), interpolateVariables(value));
+      }
+    }
 
     request.url = url.toString();
   }

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -90,7 +90,6 @@ const getData = (api: APIEditorConfig) => {
 const getEndpoint = (endpoint: string) => {
   const isRelativeUrl = endpoint.startsWith('/');
   if (isRelativeUrl) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const sanitizedRelativeURL = textUtil.sanitizeUrl(endpoint) as RelativeUrl;
     endpoint = createAbsoluteUrl(sanitizedRelativeURL, []);
   }

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -114,7 +114,8 @@ export function getConnections(sceneByName: Map<string, ElementState>) {
   const connections: ConnectionState[] = [];
   for (let v of sceneByName.values()) {
     if (v.options.connections) {
-      for (const [index, c] of v.options.connections.entries()) {
+      for (let index = 0; index < v.options.connections.length; index++) {
+        const c = v.options.connections[index];
         // @TODO Remove after v10.x
         if (isString(c.color)) {
           c.color = { fixed: c.color };

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -414,7 +414,7 @@ export function applyStyles(styles: React.CSSProperties, target: HTMLDivElement)
 
 export function removeStyles(styles: React.CSSProperties, target: HTMLDivElement) {
   for (const key in styles) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     target.style[key as any] = '';
   }
 }

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -114,7 +114,7 @@ export function getConnections(sceneByName: Map<string, ElementState>) {
   const connections: ConnectionState[] = [];
   for (let v of sceneByName.values()) {
     if (v.options.connections) {
-      v.options.connections.forEach((c, index) => {
+      for (const [index, c] of v.options.connections.entries()) {
         // @TODO Remove after v10.x
         if (isString(c.color)) {
           c.color = { fixed: c.color };
@@ -136,7 +136,7 @@ export function getConnections(sceneByName: Map<string, ElementState>) {
             targetOriginal: c.targetOriginal ?? undefined,
           });
         }
-      });
+      }
     }
   }
 
@@ -149,11 +149,11 @@ export function getConnectionsByTarget(element: ElementState, scene: Scene) {
 
 export function updateConnectionsForSource(element: ElementState, scene: Scene) {
   const targetConnections = getConnectionsByTarget(element, scene);
-  targetConnections.forEach((connection) => {
+  for (const connection of targetConnections) {
     const sourceConnections = connection.source.options.connections?.splice(0) ?? [];
     const connections = sourceConnections.filter((con) => con.targetName !== element.getName());
     connection.source.onChange({ ...connection.source.options, connections });
-  });
+  }
 
   // Update scene connection state to clear out old connections
   scene.connections.updateState();
@@ -377,8 +377,8 @@ export function getElementFields(frames: DataFrame[], opts: CanvasElementOptions
   const fields = new Set<Field>();
   const cfg = opts.config ?? {};
 
-  frames.forEach((frame) => {
-    frame.fields.forEach((field) => {
+  for (const frame of frames) {
+    for (const field of frame.fields) {
       const name = getFieldDisplayName(field, frame, frames);
 
       // (intentional fall-through)
@@ -401,8 +401,8 @@ export function getElementFields(frames: DataFrame[], opts: CanvasElementOptions
         case cfg.rpm?.field:
           fields.add(field);
       }
-    });
-  });
+    }
+  }
 
   return [...fields];
 }

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -91,8 +91,8 @@ async function fetchDashboards(options: Options, replaceVars: InterpolateFunctio
     }
   }
 
-  if (starred && starred.status === 'fulfilled') {
-    for (const dash of starred.value!.view) {
+  if (starred && starred.status === 'fulfilled' && starred.value) {
+    for (const dash of starred.value.view) {
       if (!dash.uid) {
         continue;
       }

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -79,29 +79,29 @@ async function fetchDashboards(options: Options, replaceVars: InterpolateFunctio
   }
 
   if (searched && searched.status === 'fulfilled') {
-    searched?.value?.view.forEach((dash) => {
+    for (const dash of searched?.value?.view) {
       if (!dash.uid) {
-        return;
+        continue;
       }
       if (dashMap.has(dash.uid)) {
         dashMap.get(dash.uid)!.isSearchResult = true;
       } else {
         dashMap.set(dash.uid, { ...dash, isSearchResult: true });
       }
-    });
+    }
   }
 
   if (starred && starred.status === 'fulfilled') {
-    starred?.value?.view.forEach((dash) => {
+    for (const dash of starred?.value?.view) {
       if (!dash.uid) {
-        return;
+        continue;
       }
       if (dashMap.has(dash.uid)) {
         dashMap.get(dash.uid)!.isStarred = true;
       } else {
         dashMap.set(dash.uid, { ...dash, isStarred: true });
       }
-    });
+    }
   }
 
   return dashMap;

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -78,8 +78,8 @@ async function fetchDashboards(options: Options, replaceVars: InterpolateFunctio
     }
   }
 
-  if (searched && searched.status === 'fulfilled') {
-    for (const dash of searched?.value?.view) {
+  if (searched && searched.status === 'fulfilled' && searched.value) {
+    for (const dash of searched.value.view) {
       if (!dash.uid) {
         continue;
       }
@@ -92,7 +92,7 @@ async function fetchDashboards(options: Options, replaceVars: InterpolateFunctio
   }
 
   if (starred && starred.status === 'fulfilled') {
-    for (const dash of starred?.value?.view) {
+    for (const dash of starred.value!.view) {
       if (!dash.uid) {
         continue;
       }

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -54,7 +54,9 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
   const previousVersion = parseFloat(panel.pluginVersion || '6.1');
   if (previousVersion < 6.3) {
     const oldProps = ['starred', 'recent', 'search', 'headings', 'limit', 'query', 'folderId'] as const;
-    oldProps.forEach((prop) => delete panel[prop]);
+    for (const prop of oldProps) {
+      delete panel[prop];
+    }
   }
 
   // Convert the folderId to folderUID. Uses the API to do the conversion.

--- a/public/app/plugins/panel/gauge/v2/presets.ts
+++ b/public/app/plugins/panel/gauge/v2/presets.ts
@@ -45,7 +45,6 @@ const defaultPreset = (): VisualizationSuggestion<Options, GraphFieldConfig> => 
         thresholds: {
           mode: ThresholdsMode.Percentage,
           steps: [
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             { value: null as unknown as number, color: 'green' },
             { value: 60, color: '#EAB839' },
             { value: 80, color: 'red' },
@@ -93,7 +92,6 @@ const segmentedPreset = (): VisualizationSuggestion<Options, GraphFieldConfig> =
         thresholds: {
           mode: ThresholdsMode.Percentage,
           steps: [
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             { value: null as unknown as number, color: 'green' },
             { value: 60, color: '#EAB839' },
             { value: 80, color: 'red' },
@@ -180,7 +178,6 @@ const circlePreset = (): VisualizationSuggestion<Options, GraphFieldConfig> => {
         thresholds: {
           mode: ThresholdsMode.Percentage,
           steps: [
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             { value: null as unknown as number, color: 'green' },
             { value: 60, color: '#EAB839' },
             { value: 80, color: 'red' },

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -177,12 +177,15 @@ export class GeomapPanel extends Component<Props, State> {
   doOptionsUpdate(selected: number) {
     const { options, onOptionsChange } = this.props;
     const layers = this.layers;
-    for (const l of this.map?.getLayers()) {
+    // the return type of `getLayers` is `Collection<Layer>` which cannot use a `for...of` loop, so we have to use `forEach`
+    // eslint-disable-next-line unicorn/no-array-for-each
+    this.map?.getLayers()?.forEach((l) => {
       if (l instanceof MeasureVectorLayer) {
         this.map?.removeLayer(l);
         this.map?.addLayer(l);
       }
-    }
+    });
+
     onOptionsChange({
       ...options,
       basemap: layers[0].options,

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -177,12 +177,12 @@ export class GeomapPanel extends Component<Props, State> {
   doOptionsUpdate(selected: number) {
     const { options, onOptionsChange } = this.props;
     const layers = this.layers;
-    this.map?.getLayers().forEach((l) => {
+    for (const l of this.map?.getLayers()) {
       if (l instanceof MeasureVectorLayer) {
         this.map?.removeLayer(l);
         this.map?.addLayer(l);
       }
-    });
+    }
     onOptionsChange({
       ...options,
       basemap: layers[0].options,

--- a/public/app/plugins/panel/geomap/layers/data/geojsonDynamic.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonDynamic.ts
@@ -273,7 +273,7 @@ export function updateFeaturePropertiesForTooltip(
   const field = findField(frame, idField);
   if (field) {
     idToIdx.clear();
-    field.values.forEach((v, i) => idToIdx.set(String(v), i));
+    for (const [i, v] of field.values.entries()) {idToIdx.set(String(v), i);}
     
     source.forEachFeature((feature) => {
       const featureId = feature.getId();

--- a/public/app/plugins/panel/geomap/layers/data/geojsonDynamic.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonDynamic.ts
@@ -273,7 +273,10 @@ export function updateFeaturePropertiesForTooltip(
   const field = findField(frame, idField);
   if (field) {
     idToIdx.clear();
-    for (const [i, v] of field.values.entries()) {idToIdx.set(String(v), i);}
+    for (let i = 0; i < field.values.length; i++) {
+      const v = field.values[i];
+      idToIdx.set(String(v), i);
+    }
     
     source.forEachFeature((feature) => {
       const featureId = feature.getId();

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -276,7 +276,7 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
                         [crosshairPointCoords[mapIndex.x1], mapExtents[mapIndex.y2]],
                       ])
                     );
-                    lineFeatures.forEach((feature) => feature.setStyle(lineStyle));
+                    for (const feature of lineFeatures) {feature.setStyle(lineStyle);}
                   }
                 }
               }
@@ -288,7 +288,7 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
     subscriptions.add(
       eventBus.subscribe(DataHoverClearEvent, (event) => {
         crosshairFeature.setStyle(new Style({}));
-        lineFeatures.forEach((feature) => feature.setStyle(new Style({})));
+        for (const feature of lineFeatures) {feature.setStyle(new Style({}));}
       })
     );
 

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -276,7 +276,9 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
                         [crosshairPointCoords[mapIndex.x1], mapExtents[mapIndex.y2]],
                       ])
                     );
-                    for (const feature of lineFeatures) {feature.setStyle(lineStyle);}
+                    for (const feature of lineFeatures) {
+                      feature.setStyle(lineStyle);
+                    }
                   }
                 }
               }
@@ -288,7 +290,9 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
     subscriptions.add(
       eventBus.subscribe(DataHoverClearEvent, (event) => {
         crosshairFeature.setStyle(new Style({}));
-        for (const feature of lineFeatures) {feature.setStyle(new Style({}));}
+        for (const feature of lineFeatures) {
+          feature.setStyle(new Style({}));
+        }
       })
     );
 

--- a/public/app/plugins/panel/geomap/suggestions.ts
+++ b/public/app/plugins/panel/geomap/suggestions.ts
@@ -33,10 +33,12 @@ export const geomapSuggestionsSupplier: VisualizationSuggestionsSupplier<Options
             showMeasure: false,
           };
           // FIXME: this doesn't work. I want to disable legends in the preview.
-          s.options?.layers?.forEach((layer) => {
-            layer.config = layer.config || {};
-            layer.config.showLegend = false;
-          });
+          if (s.options?.layers) {
+            for (const layer of s.options?.layers) {
+              layer.config = layer.config || {};
+              layer.config.showLegend = false;
+            }
+          }
         },
       },
     },

--- a/public/app/plugins/panel/geomap/utils/actions.ts
+++ b/public/app/plugins/panel/geomap/utils/actions.ts
@@ -74,7 +74,9 @@ export const getActions = (panel: GeomapPanel) => {
       // Add the layers in the right order
       const group = panel.map?.getLayers()!;
       group.clear();
-      panel.layers.forEach((v) => group.push(v.layer));
+      for (const v of panel.layers) {
+        group.push(v.layer);
+      }
     },
   };
 

--- a/public/app/plugins/panel/geomap/utils/tooltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.ts
@@ -160,9 +160,9 @@ export const pointerMoveListener = (evt: MapBrowserEvent, panel: GeomapPanel) =>
 
   if (!layers.length) {
     // clear mouse events
-    panel.layers.forEach((layer) => {
+    for (const layer of panel.layers) {
       layer.mouseEvents.next(undefined);
-    });
+    }
   }
 
   const found = Boolean(layers.length);

--- a/public/app/plugins/panel/geomap/utils/utils.ts
+++ b/public/app/plugins/panel/geomap/utils/utils.ts
@@ -78,7 +78,7 @@ async function initGeojsonFiles() {
   for (let folder of ['maps', 'gazetteer']) {
     ds.listFiles(folder).subscribe({
       next: (frame) => {
-        frame.forEach((item) => {
+        for (const item of frame) {
           if (item.name.endsWith('.geojson')) {
             const value = `public/${folder}/${item.name}`;
             publicGeoJSONFiles!.push({
@@ -86,7 +86,7 @@ async function initGeojsonFiles() {
               label: value,
             });
           }
-        });
+        }
       },
     });
   }

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -300,7 +300,7 @@ const HeatmapHoverCell = ({
     }
 
     const vals: VizTooltipItem[] = getDisplayData(fromIdx, toIdx);
-    vals.forEach((val) => {
+    for (const val of vals) {
       contentItems.push({
         label: val.label,
         value: val.value,
@@ -309,7 +309,7 @@ const HeatmapHoverCell = ({
         colorPlacement: ColorPlacement.trailing,
         isActive: val.isActive,
       });
-    });
+    }
   }
 
   let footer: ReactNode;

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -102,9 +102,9 @@ export function prepareHeatmapData({
 
   const exemplars = annotations?.find((f) => f.name === 'exemplar');
 
-  exemplars?.fields.forEach((field) => {
+  for (const field of exemplars?.fields) {
     field.getLinks = getLinksSupplier(exemplars, field, field.state?.scopedVars ?? {}, replaceVariables);
-  });
+  }
 
   if (options.calculate) {
     // if calculate is true, we need to have the default values for the calculation if they don't exist
@@ -170,14 +170,14 @@ export function prepareHeatmapData({
   }
 
   // config data links
-  rowsHeatmap.fields.forEach((field) => {
+  for (const field of rowsHeatmap.fields) {
     if ((field.config.links?.length ?? 0) === 0) {
-      return;
+      continue;
     }
 
     // this expects that the tooltip is able to identify the field and rowIndex from a dense hovered index
     field.getLinks = getLinksSupplier(rowsHeatmap!, field, field.state?.scopedVars ?? {}, replaceVariables);
-  });
+  }
 
   return {
     ...getDenseHeatmapData(

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -101,9 +101,10 @@ export function prepareHeatmapData({
   cacheFieldDisplayNames(frames);
 
   const exemplars = annotations?.find((f) => f.name === 'exemplar');
-
-  for (const field of exemplars?.fields) {
-    field.getLinks = getLinksSupplier(exemplars, field, field.state?.scopedVars ?? {}, replaceVariables);
+  if (exemplars != null) {
+    for (const field of exemplars.fields) {
+      field.getLinks = getLinksSupplier(exemplars, field, field.state?.scopedVars ?? {}, replaceVariables);
+    }
   }
 
   if (options.calculate) {

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -102,13 +102,13 @@ export function prepConfig(opts: PrepConfigOpts) {
   let builder = new UPlotConfigBuilder(timeZone);
 
   builder.addHook('init', (u) => {
-    u.root.querySelectorAll<HTMLElement>('.u-cursor-pt').forEach((el) => {
+    for (const el of u.root.querySelectorAll<HTMLElement>('.u-cursor-pt')) {
       Object.assign(el.style, {
         borderRadius: '0',
         border: '1px solid white',
         background: 'transparent',
       });
-    });
+    }
   });
 
   if (isTime) {
@@ -136,12 +136,12 @@ export function prepConfig(opts: PrepConfigOpts) {
     qt.clear();
 
     // force-clear the path cache to cause drawBars() to rebuild new quadtree
-    u.series.forEach((s, i) => {
+    for (const [i, s] of u.series.entries()) {
       if (i > 0) {
         // @ts-ignore
         s._paths = null;
       }
-    });
+    }
   });
 
   builder.setMode(2);
@@ -685,10 +685,10 @@ export function heatmapPathsDense(opts: PathbuilderOpts) {
         //	u.ctx.globalAlpha = 0.8;
         u.ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
         u.ctx.clip();
-        fillPaths.forEach((p, i) => {
+        for (const [i, p] of fillPaths.entries()) {
           u.ctx.fillStyle = fillPalette[i];
           u.ctx.fill(p);
-        });
+        }
         u.ctx.restore();
 
         return null;
@@ -755,10 +755,10 @@ export function heatmapPathsPoints(opts: PointsBuilderOpts, exemplarColor: strin
         u.ctx.save();
         u.ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
         u.ctx.clip();
-        fillPaths.forEach((p, i) => {
+        for (const [i, p] of fillPaths.entries()) {
           u.ctx.fillStyle = fillPalette[i];
           u.ctx.fill(p);
-        });
+        }
         u.ctx.restore();
       }
     );
@@ -873,10 +873,10 @@ export function heatmapPathsSparse(opts: PathbuilderOpts) {
         //	u.ctx.globalAlpha = 0.8;
         u.ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
         u.ctx.clip();
-        fillPaths.forEach((p, i) => {
+        for (const [i, p] of fillPaths.entries()) {
           u.ctx.fillStyle = fillPalette[i];
           u.ctx.fill(p);
-        });
+        }
         u.ctx.restore();
 
         //console.timeEnd('heatmapPathsSparse');

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -136,7 +136,8 @@ export function prepConfig(opts: PrepConfigOpts) {
     qt.clear();
 
     // force-clear the path cache to cause drawBars() to rebuild new quadtree
-    for (const [i, s] of u.series.entries()) {
+    for (let i = 0; i < u.series.length; i++) {
+      const s = u.series[i];
       if (i > 0) {
         // @ts-ignore
         s._paths = null;
@@ -685,7 +686,8 @@ export function heatmapPathsDense(opts: PathbuilderOpts) {
         //	u.ctx.globalAlpha = 0.8;
         u.ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
         u.ctx.clip();
-        for (const [i, p] of fillPaths.entries()) {
+        for (let i = 0; i < fillPaths.length; i++) {
+          const p = fillPaths[i];
           u.ctx.fillStyle = fillPalette[i];
           u.ctx.fill(p);
         }
@@ -755,7 +757,8 @@ export function heatmapPathsPoints(opts: PointsBuilderOpts, exemplarColor: strin
         u.ctx.save();
         u.ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
         u.ctx.clip();
-        for (const [i, p] of fillPaths.entries()) {
+        for (let i = 0; i < fillPaths.length; i++) {
+          const p = fillPaths[i];
           u.ctx.fillStyle = fillPalette[i];
           u.ctx.fill(p);
         }
@@ -873,7 +876,8 @@ export function heatmapPathsSparse(opts: PathbuilderOpts) {
         //	u.ctx.globalAlpha = 0.8;
         u.ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
         u.ctx.clip();
-        for (const [i, p] of fillPaths.entries()) {
+        for (let i = 0; i < fillPaths.length; i++) {
+          const p = fillPaths[i];
           u.ctx.fillStyle = fillPalette[i];
           u.ctx.fill(p);
         }

--- a/public/app/plugins/panel/histogram/HistogramPanel.tsx
+++ b/public/app/plugins/panel/histogram/HistogramPanel.tsx
@@ -7,6 +7,7 @@ import {
   PanelProps,
   buildHistogram,
   cacheFieldDisplayNames,
+  cacheFrameAndFieldIndices,
   getHistogramFields,
 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
@@ -27,19 +28,7 @@ export const HistogramPanel = ({ data, options, width, height }: Props) => {
       return undefined;
     }
 
-    // stamp origins for legend's calcs (from raw values)
-    for (const [frameIndex, frame] of data.series.entries()) {
-      for (const [fieldIndex, field] of frame.fields.entries()) {
-        field.state = {
-          ...field.state,
-          origin: {
-            frameIndex,
-            fieldIndex,
-          },
-        };
-      }
-    }
-
+    cacheFrameAndFieldIndices(data.series);
     cacheFieldDisplayNames(data.series);
 
     if (

--- a/public/app/plugins/panel/histogram/HistogramPanel.tsx
+++ b/public/app/plugins/panel/histogram/HistogramPanel.tsx
@@ -28,8 +28,8 @@ export const HistogramPanel = ({ data, options, width, height }: Props) => {
     }
 
     // stamp origins for legend's calcs (from raw values)
-    data.series.forEach((frame, frameIndex) => {
-      frame.fields.forEach((field, fieldIndex) => {
+    for (const [frameIndex, frame] of data.series.entries()) {
+      for (const [fieldIndex, field] of frame.fields.entries()) {
         field.state = {
           ...field.state,
           origin: {
@@ -37,8 +37,8 @@ export const HistogramPanel = ({ data, options, width, height }: Props) => {
             fieldIndex,
           },
         };
-      });
-    });
+      }
+    }
 
     cacheFieldDisplayNames(data.series);
 

--- a/public/app/plugins/panel/histogram/HistogramPanel.tsx
+++ b/public/app/plugins/panel/histogram/HistogramPanel.tsx
@@ -7,7 +7,7 @@ import {
   PanelProps,
   buildHistogram,
   cacheFieldDisplayNames,
-  cacheFrameAndFieldIndices,
+  cacheFieldOrigins,
   getHistogramFields,
 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
@@ -28,7 +28,7 @@ export const HistogramPanel = ({ data, options, width, height }: Props) => {
       return undefined;
     }
 
-    cacheFrameAndFieldIndices(data.series);
+    cacheFieldOrigins(data.series);
     cacheFieldDisplayNames(data.series);
 
     if (

--- a/public/app/plugins/panel/logstable/fieldSelector/LogsTableFields.test.tsx
+++ b/public/app/plugins/panel/logstable/fieldSelector/LogsTableFields.test.tsx
@@ -55,10 +55,10 @@ describe('LogsTableFields', () => {
     expect(screen.getByText('Selected fields')).toBeVisible();
     expect(screen.getByPlaceholderText(/search fields by name/i)).toBeVisible();
 
-    [LOGS_DATAPLANE_TIMESTAMP_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, 'service', 'backend'].forEach((label) => {
+    for (const label of [LOGS_DATAPLANE_TIMESTAMP_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, 'service', 'backend']) {
       expect(screen.getByRole('checkbox', { name: label })).toBeInTheDocument();
       expect(screen.getByText(label)).toBeVisible();
-    });
+    }
   });
 
   it('Should collapse', async () => {

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -61,7 +61,7 @@ export const buildColumnsWithMeta = (
     pendingLabelState = Object.fromEntries(labelCardinality);
 
     // Convert count to percent of log lines
-    for (const key of Object.keys(pendingLabelState)) {
+    for (const key in pendingLabelState) {
       pendingLabelState[key].percentOfLinesWithLabel = normalize(
         pendingLabelState[key].percentOfLinesWithLabel,
         numberOfLogLines

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -40,7 +40,7 @@ export const buildColumnsWithMeta = (
   // If we have labels and log lines
   if (dataFrame.fields.length && numberOfLogLines) {
     // Iterate through all of fields
-    dataFrame.fields.forEach((field) => {
+    for (const field of dataFrame.fields) {
       const fieldName = getFieldDisplayName(field);
       // Count the valid values
       const countOfValues = field.values.reduce((acc: number, value) => {
@@ -55,22 +55,22 @@ export const buildColumnsWithMeta = (
         active: false,
         index: undefined,
       });
-    });
+    }
 
     // Converting the map to an object
     pendingLabelState = Object.fromEntries(labelCardinality);
 
     // Convert count to percent of log lines
-    Object.keys(pendingLabelState).forEach((key) => {
+    for (const key of Object.keys(pendingLabelState)) {
       pendingLabelState[key].percentOfLinesWithLabel = normalize(
         pendingLabelState[key].percentOfLinesWithLabel,
         numberOfLogLines
       );
-    });
+    }
   }
 
   // Normalize the other fields
-  otherFields.forEach((field) => {
+  for (const field of otherFields) {
     const fieldName = getFieldDisplayName(field);
     const isActive = pendingLabelState[fieldName]?.active;
     const index = pendingLabelState[fieldName]?.index;
@@ -93,16 +93,16 @@ export const buildColumnsWithMeta = (
         index: undefined,
       };
     }
-  });
+  }
 
-  displayedFields.forEach((fieldName, idx) => {
+  for (const [idx, fieldName] of displayedFields.entries()) {
     if (pendingLabelState[fieldName]) {
       pendingLabelState[fieldName].active = true;
       pendingLabelState[fieldName].index = idx;
     } else {
       console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
     }
-  });
+  }
 
   // If nothing is selected, then select the default columns
   if (displayedFields.length === 0) {

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -95,7 +95,8 @@ export const buildColumnsWithMeta = (
     }
   }
 
-  for (const [idx, fieldName] of displayedFields.entries()) {
+  for (let idx = 0; idx < displayedFields.length; idx++) {
+    const fieldName = displayedFields[idx];
     if (pendingLabelState[fieldName]) {
       pendingLabelState[fieldName].active = true;
       pendingLabelState[fieldName].index = idx;

--- a/public/app/plugins/panel/nodeGraph/EdgeLabel.tsx
+++ b/public/app/plugins/panel/nodeGraph/EdgeLabel.tsx
@@ -57,7 +57,8 @@ export const EdgeLabel = memo(function EdgeLabel(props: Props) {
   let offset = stats.length > 1 ? -5 : 2.5;
 
   const contents: JSX.Element[] = [];
-  for (const [index, stat] of stats.entries()) {
+  for (let index = 0; index < stats.length; index++) {
+    const stat = stats[index];
     contents.push(
       <text key={index} className={styles.text} x={middle.x} y={middle.y + offset} textAnchor={'middle'}>
         {stat}

--- a/public/app/plugins/panel/nodeGraph/EdgeLabel.tsx
+++ b/public/app/plugins/panel/nodeGraph/EdgeLabel.tsx
@@ -57,14 +57,14 @@ export const EdgeLabel = memo(function EdgeLabel(props: Props) {
   let offset = stats.length > 1 ? -5 : 2.5;
 
   const contents: JSX.Element[] = [];
-  stats.forEach((stat, index) => {
+  for (const [index, stat] of stats.entries()) {
     contents.push(
       <text key={index} className={styles.text} x={middle.x} y={middle.y + offset} textAnchor={'middle'}>
         {stat}
       </text>
     );
     offset += 15;
-  });
+  }
 
   return (
     <g className={styles.mainGroup}>

--- a/public/app/plugins/panel/nodeGraph/layout.ts
+++ b/public/app/plugins/panel/nodeGraph/layout.ts
@@ -274,7 +274,8 @@ function gridLayout(
     });
   }
 
-  for (const [index, node] of nodes.entries()) {
+  for (let index = 0; index < nodes.length; index++) {
+    const node = nodes[index];
     const row = Math.floor(index / perRow);
     const column = index % perRow;
     node.x = column * spacingHorizontal - midPoint;

--- a/public/app/plugins/panel/status-history/utils.ts
+++ b/public/app/plugins/panel/status-history/utils.ts
@@ -10,13 +10,13 @@ export const getDataLinks = (field: Field, rowIdx: number) => {
 
     const linkLookup = new Set<string>();
 
-    field.getLinks({ calculatedValue: disp, valueRowIndex: rowIdx }).forEach((link) => {
+    for (const link of field.getLinks({ calculatedValue: disp, valueRowIndex: rowIdx })) {
       const key = `${link.title}/${link.href}`;
       if (!linkLookup.has(key)) {
         links.push(link);
         linkLookup.add(key);
       }
-    });
+    }
   }
 
   return links;
@@ -46,13 +46,13 @@ export const getFieldActions = (
       visualizationType
     );
 
-    actionsModel.forEach((action) => {
+    for (const action of actionsModel) {
       const key = `${action.title}`;
       if (!actionLookup.has(key)) {
         actions.push(action);
         actionLookup.add(key);
       }
-    });
+    }
   }
 
   return actions;

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -212,14 +212,14 @@ const getCellActions = (
       const actionsOut: Array<ActionModel<Field>> = [];
       const actionLookup = new Set<string>();
 
-      actions.forEach((action) => {
+      for (const action of actions) {
         const key = action.title;
 
         if (!actionLookup.has(key)) {
           actionsOut.push(action);
           actionLookup.add(key);
         }
-      });
+      }
 
       return actionsOut;
     }

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -366,7 +366,6 @@ interface LegacyTableFooterOptions {
 export const migrateFooterV2 = (panel: PanelModel<Options>) => {
   if (panel.options && 'footer' in panel.options) {
     // we need to cast the footer to the old type to work with it here.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const oldFooter = panel.options.footer as LegacyTableFooterOptions;
 
     if (oldFooter.show) {

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -281,22 +281,26 @@ export const migrateFromParentRowIndexToNestedFrames = (frames: DataFrame[] | nu
     (frame: DataFrame | undefined): frame is DataFrame => !!frame && frame.length !== 0
   );
 
-  mainFrames?.forEach((frame) => {
-    const subFrames = frames?.filter((df) => frame.refId === df.refId && df.meta?.custom?.parentRowIndex !== undefined);
-    const subFramesGrouped = groupBy(subFrames, (frame: DataFrame) => frame.meta?.custom?.parentRowIndex);
-    const subFramesByIndex = Object.keys(subFramesGrouped).map((key) => subFramesGrouped[key]);
-    const migratedFrame = { ...frame };
+  if (mainFrames) {
+    for (const frame of mainFrames) {
+      const subFrames = frames?.filter(
+        (df) => frame.refId === df.refId && df.meta?.custom?.parentRowIndex !== undefined
+      );
+      const subFramesGrouped = groupBy(subFrames, (frame: DataFrame) => frame.meta?.custom?.parentRowIndex);
+      const subFramesByIndex = Object.keys(subFramesGrouped).map((key) => subFramesGrouped[key]);
+      const migratedFrame = { ...frame };
 
-    if (subFrames && subFrames.length > 0) {
-      migratedFrame.fields.push({
-        name: 'nested',
-        type: FieldType.nestedFrames,
-        config: {},
-        values: subFramesByIndex,
-      });
+      if (subFrames && subFrames.length > 0) {
+        migratedFrame.fields.push({
+          name: 'nested',
+          type: FieldType.nestedFrames,
+          config: {},
+          values: subFramesByIndex,
+        });
+      }
+      migratedFrames.push(migratedFrame);
     }
-    migratedFrames.push(migratedFrame);
-  });
+  }
 
   return migratedFrames;
 };

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -73,11 +73,11 @@ export const TimeSeriesPanel = ({
       frames.forEach((frame: DataFrame) => {
         const diffMs = frame.meta?.timeCompare?.diffMs ?? 0;
 
-        frame.fields.forEach((field) => {
+        for (const field of frame.fields) {
           if (field.type !== FieldType.time) {
             compareDiffMs.push(diffMs);
           }
-        });
+        }
 
         if (diffMs !== 0) {
           // Check if the compared frame needs time alignment

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.test.tsx
@@ -206,10 +206,10 @@ describe('AnnotationsPlugin2', () => {
         await event(thirdMarker);
         const tags = screen.getAllByTestId('annotation-tag');
 
-        expectedTags.forEach((tag, index) => {
+        for (const [index, tag] of expectedTags.entries()) {
           expect(tags[index]).toBeVisible();
           expect(tags[index]).toHaveTextContent(tag);
-        });
+        }
       });
 
       describe('pinning', () => {

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -57,9 +57,9 @@ const DEFAULT_ANNOTATION_COLOR_HEX8 = tinycolor(DEFAULT_ANNOTATION_COLOR).toHex8
 
 function getVals(frame: DataFrame) {
   let vals: Record<string, any[]> = {};
-  frame.fields.forEach((f) => {
+  for (const f of frame.fields) {
     vals[f.name] = f.values;
-  });
+  }
 
   return vals;
 }
@@ -164,7 +164,7 @@ export const AnnotationsPlugin2 = ({
       ctx.clip();
 
       // Multi-lane annotations do not support vertical lines or shaded regions
-      xAnnos.forEach((frame) => {
+      for (const frame of xAnnos) {
         let vals = getVals(frame);
         if (!multiLane) {
           let y0 = u.bbox.top;
@@ -192,10 +192,10 @@ export const AnnotationsPlugin2 = ({
             }
           }
         }
-      });
+      }
 
       // xMin, xMax, yMin, yMax, color, lineWidth, lineStyle, fillOpacity, text
-      xyAnnos.forEach((frame) => {
+      for (const frame of xyAnnos) {
         let vals = getVals(frame);
 
         let xKey = config.scales[0].props.scaleKey;
@@ -225,7 +225,7 @@ export const AnnotationsPlugin2 = ({
           ctx.strokeStyle = color;
           ctx.strokeRect(x0, y0, x1 - x0, y1 - y0);
         }
-      });
+      }
 
       ctx.restore();
     });

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.test.tsx
@@ -231,10 +231,10 @@ describe('AnnotationsPlugin2', () => {
         await event(thirdMarker);
         const tags = screen.getAllByTestId('annotation-tag');
 
-        expectedTags.forEach((tag, index) => {
+        for (const [index, tag] of expectedTags.entries()) {
           expect(tags[index]).toBeVisible();
           expect(tags[index]).toHaveTextContent(tag);
-        });
+        }
       });
 
       describe('pinning', () => {

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.tsx
@@ -135,7 +135,7 @@ export const AnnotationsPlugin2Cluster = ({
       const shouldRenderLine = (lineWidth !== undefined ? lineWidth > 0 : undefined) ?? !options?.multiLane;
 
       // Multi-lane annotations do not support vertical lines or shaded regions
-      xAnnos.forEach((frame) => {
+      for (const frame of xAnnos) {
         const vals = getVals<AnnotationVals>(frame);
 
         // render line
@@ -174,10 +174,10 @@ export const AnnotationsPlugin2Cluster = ({
             }
           }
         }
-      });
+      }
 
       // xMin, xMax, yMin, yMax, color, lineWidth, lineStyle, fillOpacity, text
-      xyAnnos.forEach((frame) => {
+      for (const frame of xyAnnos) {
         const vals = getVals<XYAnnoVals>(frame);
 
         const xKey = config.scales[0].props.scaleKey;
@@ -207,7 +207,7 @@ export const AnnotationsPlugin2Cluster = ({
           ctx.strokeStyle = color;
           ctx.strokeRect(x0, y0, x1 - x0, y1 - y0);
         }
-      });
+      }
 
       ctx.restore();
     });

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -112,7 +112,7 @@ export const getVisibleLabels = (config: UPlotConfigBuilder, frames: DataFrame[]
   const visibleSeries = config.series.filter((series) => series.props.show);
   const visibleLabels: LabelWithExemplarUIData[] = [];
   if (frames?.length) {
-    visibleSeries.forEach((plotInstance) => {
+    for (const plotInstance of visibleSeries) {
       const frameIndex = plotInstance.props?.dataFrameFieldIndex?.frameIndex;
       const fieldIndex = plotInstance.props?.dataFrameFieldIndex?.fieldIndex;
 
@@ -126,7 +126,7 @@ export const getVisibleLabels = (config: UPlotConfigBuilder, frames: DataFrame[]
           });
         }
       }
-    });
+    }
   }
 
   return { labels: visibleLabels, totalSeriesCount: config.series.length };

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationMarker2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationMarker2.tsx
@@ -81,7 +81,7 @@ export const AnnotationMarker2 = ({
   const actions: ActionModel[] = [];
 
   if (isHovering || isPinned) {
-    frame.fields.forEach((field) => {
+    for (const field of frame.fields) {
       // Since field overrides are not yet supported for annotation frames, every value in the field will have the same links... except the clustering index because it's generated on-the-fly and not had getFieldOverrides called on it
       const annotationIndexForLinks = isClustering ? 0 : annoIdx;
 
@@ -91,7 +91,7 @@ export const AnnotationMarker2 = ({
       if (canExecuteActions) {
         actions.push(...getFieldActions(frame, field, replaceVariables, annotationIndexForLinks));
       }
-    });
+    }
   }
 
   const isEditing = editAnnotationId !== null;

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationMarker2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationMarker2.tsx
@@ -78,14 +78,14 @@ export const AnnotationMarker2 = ({
   const actions: ActionModel[] = [];
 
   if (isHovering || isPinned) {
-    frame.fields.forEach((field) => {
+    for (const field of frame.fields) {
       // @todo https://github.com/grafana/grafana/issues/119619, need to set getLinks on field, or applyFieldOverrides on dataframe
       links.push(...getDataLinks(field, annoIdx));
 
       if (canExecuteActions) {
         actions.push(...getFieldActions(frame, field, replaceVariables, annoIdx));
       }
-    });
+    }
   }
 
   // Is the annotation being edited

--- a/public/app/plugins/panel/timeseries/presets.ts
+++ b/public/app/plugins/panel/timeseries/presets.ts
@@ -187,7 +187,6 @@ const FC_SINGLE_THRESHOLD_SCHEME: FieldConfigSource<Partial<GraphFieldConfig>> =
     thresholds: {
       mode: ThresholdsMode.Percentage,
       steps: [
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         { value: null as unknown as number, color: 'green' },
         { value: 40, color: '#EAB839' },
         { value: 60, color: 'red' },

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -287,35 +287,35 @@ export const setClassicPaletteIdxs = (frames: DataFrame[], theme: GrafanaTheme2,
 
         if (mainFrame && mainFrame.fields.length === frame.fields.length) {
           // Match series indices with main frame
-          frame.fields.forEach((field, fieldIdx) => {
+          for (const [fieldIdx, field] of frame.fields.entries()) {
             if (shouldProcessField(field, fieldIdx)) {
               const mainField = mainFrame.fields[fieldIdx];
               updateFieldDisplay(field, mainField.state?.seriesIndex ?? seriesIndex++);
             }
-          });
+          }
         } else {
           // Fallback
-          frame.fields.forEach((field, fieldIdx) => {
+          for (const [fieldIdx, field] of frame.fields.entries()) {
             if (shouldProcessField(field, fieldIdx)) {
               updateFieldDisplay(field, seriesIndex++);
             }
-          });
+          }
         }
       } else {
         // Fallback when no baseRefId
-        frame.fields.forEach((field, fieldIdx) => {
+        for (const [fieldIdx, field] of frame.fields.entries()) {
           if (shouldProcessField(field, fieldIdx)) {
             updateFieldDisplay(field, seriesIndex++);
           }
-        });
+        }
       }
     } else {
       // Main frames
-      frame.fields.forEach((field, fieldIdx) => {
+      for (const [fieldIdx, field] of frame.fields.entries()) {
         if (shouldProcessField(field, fieldIdx)) {
           updateFieldDisplay(field, seriesIndex++);
         }
-      });
+      }
     }
   }
 };
@@ -342,13 +342,13 @@ export function getGroupedFilters(
   if (xField && xField.labels && xField.config.filterable) {
     const seriesFilters: AdHocFilterItem[] = [];
 
-    Object.entries(xField.labels).forEach(([key, value]) => {
+    for (const [key, value] of Object.entries(xField.labels)) {
       seriesFilters.push({
         key,
         operator: FILTER_FOR_OPERATOR,
         value,
       });
-    });
+    }
 
     groupingFilters.push(...getFiltersBasedOnGrouping(seriesFilters));
   }

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -287,7 +287,8 @@ export const setClassicPaletteIdxs = (frames: DataFrame[], theme: GrafanaTheme2,
 
         if (mainFrame && mainFrame.fields.length === frame.fields.length) {
           // Match series indices with main frame
-          for (const [fieldIdx, field] of frame.fields.entries()) {
+          for (let fieldIdx = 0; fieldIdx < frame.fields.length; fieldIdx++) {
+            const field = frame.fields[fieldIdx];
             if (shouldProcessField(field, fieldIdx)) {
               const mainField = mainFrame.fields[fieldIdx];
               updateFieldDisplay(field, mainField.state?.seriesIndex ?? seriesIndex++);
@@ -295,7 +296,8 @@ export const setClassicPaletteIdxs = (frames: DataFrame[], theme: GrafanaTheme2,
           }
         } else {
           // Fallback
-          for (const [fieldIdx, field] of frame.fields.entries()) {
+          for (let fieldIdx = 0; fieldIdx < frame.fields.length; fieldIdx++) {
+            const field = frame.fields[fieldIdx];
             if (shouldProcessField(field, fieldIdx)) {
               updateFieldDisplay(field, seriesIndex++);
             }
@@ -303,7 +305,8 @@ export const setClassicPaletteIdxs = (frames: DataFrame[], theme: GrafanaTheme2,
         }
       } else {
         // Fallback when no baseRefId
-        for (const [fieldIdx, field] of frame.fields.entries()) {
+        for (let fieldIdx = 0; fieldIdx < frame.fields.length; fieldIdx++) {
+          const field = frame.fields[fieldIdx];
           if (shouldProcessField(field, fieldIdx)) {
             updateFieldDisplay(field, seriesIndex++);
           }
@@ -311,7 +314,8 @@ export const setClassicPaletteIdxs = (frames: DataFrame[], theme: GrafanaTheme2,
       }
     } else {
       // Main frames
-      for (const [fieldIdx, field] of frame.fields.entries()) {
+      for (let fieldIdx = 0; fieldIdx < frame.fields.length; fieldIdx++) {
+        const field = frame.fields[fieldIdx];
         if (shouldProcessField(field, fieldIdx)) {
           updateFieldDisplay(field, seriesIndex++);
         }

--- a/public/app/plugins/panel/xychart/SeriesEditor.tsx
+++ b/public/app/plugins/panel/xychart/SeriesEditor.tsx
@@ -65,8 +65,8 @@ export const SeriesEditor = ({
         ? FieldNamePickerBaseNameMode.IncludeAll
         : FieldNamePickerBaseNameMode.OnlyBaseNames;
 
-  context.data.forEach((frame, frameIndex) => {
-    frame.fields.forEach((field, fieldIndex) => {
+  for (const [frameIndex, frame] of context.data.entries()) {
+    for (const [fieldIndex, field] of frame.fields.entries()) {
       field.state = {
         ...field.state,
         origin: {
@@ -74,8 +74,8 @@ export const SeriesEditor = ({
           fieldIndex,
         },
       };
-    });
-  });
+    }
+  }
 
   const frameInputId = useId();
   const xFieldInputId = useId();

--- a/public/app/plugins/panel/xychart/SeriesEditor.tsx
+++ b/public/app/plugins/panel/xychart/SeriesEditor.tsx
@@ -11,6 +11,7 @@ import {
   FieldNamePickerBaseNameMode,
   FieldType,
   GrafanaTheme2,
+  cacheFrameAndFieldIndices,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, Field, IconButton, Select, useStyles2 } from '@grafana/ui';
@@ -65,17 +66,7 @@ export const SeriesEditor = ({
         ? FieldNamePickerBaseNameMode.IncludeAll
         : FieldNamePickerBaseNameMode.OnlyBaseNames;
 
-  for (const [frameIndex, frame] of context.data.entries()) {
-    for (const [fieldIndex, field] of frame.fields.entries()) {
-      field.state = {
-        ...field.state,
-        origin: {
-          frameIndex,
-          fieldIndex,
-        },
-      };
-    }
-  }
+  cacheFrameAndFieldIndices(context.data);
 
   const frameInputId = useId();
   const xFieldInputId = useId();

--- a/public/app/plugins/panel/xychart/SeriesEditor.tsx
+++ b/public/app/plugins/panel/xychart/SeriesEditor.tsx
@@ -11,7 +11,7 @@ import {
   FieldNamePickerBaseNameMode,
   FieldType,
   GrafanaTheme2,
-  cacheFrameAndFieldIndices,
+  cacheFieldOrigins,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, Field, IconButton, Select, useStyles2 } from '@grafana/ui';
@@ -66,7 +66,7 @@ export const SeriesEditor = ({
         ? FieldNamePickerBaseNameMode.IncludeAll
         : FieldNamePickerBaseNameMode.OnlyBaseNames;
 
-  cacheFrameAndFieldIndices(context.data);
+  cacheFieldOrigins(context.data);
 
   const frameInputId = useId();
   const xFieldInputId = useId();

--- a/public/app/plugins/panel/xychart/XYChartPanel.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.tsx
@@ -66,7 +66,7 @@ export const XYChartPanel2 = (props: Props2) => {
 
     const items: VizLegendItem[] = [];
 
-    series.forEach((s, idx) => {
+    for (const [idx, s] of series.entries()) {
       let yField = s.y.field;
       let config = yField.config;
       let custom = config.custom;
@@ -82,7 +82,7 @@ export const XYChartPanel2 = (props: Props2) => {
           getDisplayValues: () => getDisplayValuesForCalcs(props.options.legend.calcs, yField, theme),
         });
       }
-    });
+    }
 
     const { placement, displayMode, width, sortBy, sortDesc } = props.options.legend;
 

--- a/public/app/plugins/panel/xychart/XYChartPanel.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.tsx
@@ -66,7 +66,8 @@ export const XYChartPanel2 = (props: Props2) => {
 
     const items: VizLegendItem[] = [];
 
-    for (const [idx, s] of series.entries()) {
+    for (let idx = 0; idx < series.length; idx++) {
+      const s = series[idx];
       let yField = s.y.field;
       let config = yField.config;
       let custom = config.custom;

--- a/public/app/plugins/panel/xychart/XYChartTooltip.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.tsx
@@ -116,14 +116,14 @@ export const XYChartTooltip = ({
     addedFields.add(colorField);
   }
 
-  series._rest.forEach((field) => {
+  for (const field of series._rest) {
     if (!hideFromTooltip(field)) {
       contentItems.push({
         label: stripSeriesName(field.state?.displayName ?? field.name, label),
         value: fmt(field, field.values[rowIndex]),
       });
     }
-  });
+  }
 
   let footer: ReactNode;
 

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -352,7 +352,7 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
     formatValue: xIsTime ? undefined : (v, decimals) => formattedValueToString(xField.display!(v, decimals)),
   });
 
-  for (const [si, s] of xySeries.entries()) {
+  for (const s of xySeries.values()) {
     let field = s.y.field;
 
     const lineColor = s.color.fixed;

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -287,12 +287,12 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
     qt.clear();
 
     // force-clear the path cache to cause drawBars() to rebuild new quadtree
-    u.series.forEach((s, i) => {
+    for (const [i, s] of u.series.entries()) {
       if (i > 0) {
         // @ts-ignore
         s._paths = null;
       }
-    });
+    }
   });
 
   builder.setMode(2);
@@ -352,7 +352,7 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
     formatValue: xIsTime ? undefined : (v, decimals) => formattedValueToString(xField.display!(v, decimals)),
   });
 
-  xySeries.forEach((s, si) => {
+  for (const [si, s] of xySeries.entries()) {
     let field = s.y.field;
 
     const lineColor = s.color.fixed;
@@ -429,7 +429,7 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
       fillColor: colorManipulator.alpha(pointColor ?? '#ffff', 0.5),
       show: !field.state?.hideFrom?.viz,
     });
-  });
+  }
 
   const dispColors = xySeries.map((s): FieldColorValuesWithCache => {
     const cfg: FieldColorValuesWithCache = {
@@ -458,9 +458,9 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
 
     const { size: sizeRange, color: colorRange } = getGlobalRanges(xySeries);
 
-    xySeries.forEach((s, i) => {
+    for (const [i, s] of xySeries.entries()) {
       dispColors[i].values = dispColors[i].getAll(s.color.field?.values ?? [], colorRange.min, colorRange.max);
-    });
+    }
 
     return [
       null,
@@ -523,8 +523,8 @@ const getGlobalRanges = (xySeries: XYSeries[]) => {
     },
   };
 
-  xySeries.forEach((series) => {
-    [series.size, series.color].forEach((facet, fi) => {
+  for (const series of xySeries) {
+    for (const [fi, facet] of [series.size, series.color].entries()) {
       if (facet.field != null) {
         let range = fi === 0 ? ranges.size : ranges.color;
 
@@ -544,8 +544,8 @@ const getGlobalRanges = (xySeries: XYSeries[]) => {
           }
         }
       }
-    });
-  });
+    }
+  }
 
   return ranges;
 };

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -287,7 +287,8 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
     qt.clear();
 
     // force-clear the path cache to cause drawBars() to rebuild new quadtree
-    for (const [i, s] of u.series.entries()) {
+    for (let i = 0; i < u.series.length; i++) {
+      const s = u.series[i];
       if (i > 0) {
         // @ts-ignore
         s._paths = null;
@@ -458,7 +459,8 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
 
     const { size: sizeRange, color: colorRange } = getGlobalRanges(xySeries);
 
-    for (const [i, s] of xySeries.entries()) {
+    for (let i = 0; i < xySeries.length; i++) {
+      const s = xySeries[i];
       dispColors[i].values = dispColors[i].getAll(s.color.field?.values ?? [], colorRange.min, colorRange.max);
     }
 
@@ -524,7 +526,9 @@ const getGlobalRanges = (xySeries: XYSeries[]) => {
   };
 
   for (const series of xySeries) {
-    for (const [fi, facet] of [series.size, series.color].entries()) {
+    const facets = [series.size, series.color];
+    for (let fi = 0; fi < facets.length; fi++) {
+      const facet = facets[fi];
       if (facet.field != null) {
         let range = fi === 0 ? ranges.size : ranges.color;
 

--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -53,7 +53,7 @@ export function prepSeries(
 
   const { palette, getColorByName } = config.theme2.visualization;
 
-  for (const [seriesIdx, seriesCfg] of mappedSeries.entries()) {
+  for (const seriesCfg of mappedSeries) {
     if (mapping === SeriesMapping.Manual) {
       if (seriesCfg.frame?.matcher == null || seriesCfg.x?.matcher == null || seriesCfg.y?.matcher == null) {
         continue;
@@ -197,7 +197,7 @@ export function prepSeries(
     let paletteIdx = 0;
 
     // todo: populate min, max, mode from field + hints
-    for (const [i, s] of series.entries()) {
+    for (const s of series) {
       if (s.color.field == null) {
         // derive fixed color from y field config
         let colorCfg = s.y.field.config.color ?? { mode: FieldColorModeId.PaletteClassic };

--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -53,10 +53,10 @@ export function prepSeries(
 
   const { palette, getColorByName } = config.theme2.visualization;
 
-  mappedSeries.forEach((seriesCfg, seriesIdx) => {
+  for (const [seriesIdx, seriesCfg] of mappedSeries.entries()) {
     if (mapping === SeriesMapping.Manual) {
       if (seriesCfg.frame?.matcher == null || seriesCfg.x?.matcher == null || seriesCfg.y?.matcher == null) {
-        return;
+        continue;
       }
     }
 
@@ -78,10 +78,10 @@ export function prepSeries(
     let frameMatcher = seriesCfg.frame ? getFrameMatcher2(seriesCfg.frame.matcher) : null;
 
     // loop over all frames and fields, adding a new series for each y dim
-    frames.forEach((frame, frameIdx) => {
+    for (const [frameIdx, frame] of frames.entries()) {
       // must match frame in manual mode
       if (frameMatcher != null && !frameMatcher(frame, frameIdx)) {
-        return;
+        continue;
       }
 
       // shared across each series in this frame
@@ -105,19 +105,19 @@ export function prepSeries(
       // x field is required
       if (x != null) {
         // match y fields and create series
-        onlyNumFields.forEach((field) => {
+        for (const field of onlyNumFields) {
           if (field === x) {
-            return;
+            continue;
           }
 
           // in auto mode don't reuse already-mapped fields
           if (mapping === SeriesMapping.Auto && (field === color || field === size)) {
-            return;
+            continue;
           }
 
           // in manual mode only add single series for this config
           if (mapping === SeriesMapping.Manual && frameSeries.length > 0) {
-            return;
+            continue;
           }
 
           // if we match non-excluded y, create series
@@ -164,14 +164,14 @@ export function prepSeries(
 
             frameSeries.push(ser);
           }
-        });
+        }
 
         if (frameSeries.length === 0) {
           // TODO: could not create series, skip & show error?
         }
 
         // populate rest fields
-        frame.fields.forEach((field) => {
+        for (const field of frame.fields) {
           let isUsedField = frameSeries.some(
             ({ x, y, color, size }) =>
               x.field === field || y.field === field || color.field === field || size.field === field
@@ -180,14 +180,14 @@ export function prepSeries(
           if (!isUsedField) {
             restFields.push(field);
           }
-        });
+        }
 
         series.push(...frameSeries);
       } else {
         // x is missing in this frame!
       }
-    });
-  });
+    }
+  }
 
   if (series.length === 0) {
     // TODO: could not create series, skip & show error?
@@ -197,7 +197,7 @@ export function prepSeries(
     let paletteIdx = 0;
 
     // todo: populate min, max, mode from field + hints
-    series.forEach((s, i) => {
+    for (const [i, s] of series.entries()) {
       if (s.color.field == null) {
         // derive fixed color from y field config
         let colorCfg = s.y.field.config.color ?? { mode: FieldColorModeId.PaletteClassic };
@@ -218,7 +218,7 @@ export function prepSeries(
         s.size.fixed = s.y.field.config.custom.pointSize?.fixed ?? 5;
         // ser.size.mode =
       }
-    });
+    }
 
     autoNameSeries(series);
 
@@ -240,9 +240,9 @@ function autoNameSeries(series: XYSeries[]) {
   const { prefix, suffix } = findCommonPrefixSuffixLengths(names);
 
   if (prefix < Infinity || suffix < Infinity) {
-    series.forEach((s, i) => {
+    for (const [i, s] of series.entries()) {
       s.name.value = names[i].slice(prefix, names[i].length - suffix).join(' ');
-    });
+    }
   }
 }
 

--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -78,7 +78,8 @@ export function prepSeries(
     let frameMatcher = seriesCfg.frame ? getFrameMatcher2(seriesCfg.frame.matcher) : null;
 
     // loop over all frames and fields, adding a new series for each y dim
-    for (const [frameIdx, frame] of frames.entries()) {
+    for (let frameIdx = 0; frameIdx < frames.length; frameIdx++) {
+      const frame = frames[frameIdx];
       // must match frame in manual mode
       if (frameMatcher != null && !frameMatcher(frame, frameIdx)) {
         continue;
@@ -240,7 +241,8 @@ function autoNameSeries(series: XYSeries[]) {
   const { prefix, suffix } = findCommonPrefixSuffixLengths(names);
 
   if (prefix < Infinity || suffix < Infinity) {
-    for (const [i, s] of series.entries()) {
+    for (let i = 0; i < series.length; i++) {
+      const s = series[i];
       s.name.value = names[i].slice(prefix, names[i].length - suffix).join(' ');
     }
   }


### PR DESCRIPTION
- [chore: add unicorn/no-array-for-each rule for dataviz files](https://github.com/grafana/grafana/commit/aa82e6e628fa04ce73c05d93745c84fbf7e90eeb)
  - in general, for loops are faster and have greater control flow capabilities than `Array.prototype.forEach`, and on DataViz we'd generally just prefer to be consistent about using a true for loop given that it's not always obvious which parts of our code need to be optimized for huge arrays.
- [chore: add TypeScript types to enforce clsx only receives strings](https://github.com/grafana/grafana/commit/ce8be06480a354da0c62e8219b45bae9ab465e55)
  - we are moving to using `clsx` from  Emotion's `cx` as much as possible, and specifically we want to only pass strings into clsx. This adds a TypeScript rule which makes passing non-strings into that method an official type error.
  - an alternative approach to this would be adding a function which has strings as the type, and then delegates to clsx or just does the concatenation itself, banning `clsx` direct imports. But this felt like a good experiment with the AI agent, to see if it could implement a somewhat sophisticated TypeScript override.
- Updated AGENTS.md with some of the improvements I thought the model could have made as I worked through this today.
- Moves several common ESLint exclusions into the eslint-suppressions.json file and out of inline excludes. This will help the DataViz team better take stock of exclusions we can actually fix.