### PR TITLE
MultiCombobox: Fix remove button for hidden options (#115922)

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -209,6 +209,22 @@ describe('MultiCombobox', () => {
     expect(onChange).toHaveBeenCalledWith(options.filter((o) => o.value !== 'a'));
   });
 
+  it('should remove value when clicking on the close icon of the pill when pills are collapsed due to width constraint', async () => {
+    const options = [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+      { label: 'D', value: 'd' },
+    ];
+    const onChange = jest.fn();
+    render(<MultiCombobox width={40} options={options} value={['a', 'b', 'c', 'd']} onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    const removeButton = await screen.findByRole('button', { name: 'Remove D' });
+    await user.click(removeButton);
+    expect(onChange).toHaveBeenCalledWith(options.filter((o) => o.value !== 'd'));
+  });
+
   it('should remove all selected items when clicking on clear all button', async () => {
     const options = [
       { label: 'A', value: 'a' },

--- a/packages/grafana-ui/src/components/Combobox/ValuePill.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ValuePill.tsx
@@ -27,6 +27,9 @@ export const ValuePill = forwardRef<HTMLSpanElement, ValuePillProps>(
               name="times"
               size="md"
               aria-label={removeButtonLabel}
+              onMouseDown={(e) => {
+                e.preventDefault();
+              }}
               onClick={(e) => {
                 e.stopPropagation();
                 onRemove();


### PR DESCRIPTION

**What is this feature?**

This pull request prevents the MultiComboBox component from closing when clicking on the remove button (X) allowing for the selected option to be removed.

**Why do we need this feature?**

So the options selected can be removed by clicking on the (X), even when they are hidden due to width constraints. 

**Who is this feature for?**

Everyone using MultiComboBox

**Which issue(s) does this PR fix?**:

Fixes #115922

**Special notes for your reviewer:**

**Before**
https://github.com/user-attachments/assets/c42cf7e8-1558-4985-9de2-2764c3ea377d

**After**
https://github.com/user-attachments/assets/f203784d-e3f4-44b2-9b51-05d94e7a0ff0

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
