### PR TITLE
Provisioning: delete/move resource form no default values state fix

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardDrawer.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardDrawer.tsx
@@ -28,11 +28,11 @@ export function DeleteProvisionedDashboardDrawer({ dashboard, onDismiss }: Props
     error,
   } = useProvisionedDashboardData(dashboard);
 
-  if (repoDataStatus === RepoViewStatus.Loading || !defaultValues) {
+  if (repoDataStatus === RepoViewStatus.Loading) {
     return <Spinner />;
   }
 
-  if (repoDataStatus === RepoViewStatus.Error) {
+  if (repoDataStatus === RepoViewStatus.Error || !defaultValues) {
     return <FormLoadingErrorAlert error={error} />;
   }
 

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer.tsx
@@ -33,11 +33,11 @@ export function MoveProvisionedDashboardDrawer({
     error,
   } = useProvisionedDashboardData(dashboard);
 
-  if (repoDataStatus === RepoViewStatus.Loading || !defaultValues) {
+  if (repoDataStatus === RepoViewStatus.Loading) {
     return <Spinner />;
   }
 
-  if (repoDataStatus === RepoViewStatus.Error) {
+  if (repoDataStatus === RepoViewStatus.Error || !defaultValues) {
     return <FormLoadingErrorAlert error={error} />;
   }
 


### PR DESCRIPTION
**What is this feature?**

Delete and move form, when there's no default values, show error instead of loading state

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
