### PR TITLE
feat(authz): add kubernetesAuthzDatasourceResourcePermissions feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1191,6 +1191,11 @@ export interface FeatureToggles {
   */
   kubernetesAuthzRolesAndRoleBindingsRedirect?: boolean;
   /**
+  * Enables datasource resource permissions via the K8s IAM resource permission APIs
+  * @default false
+  */
+  kubernetesAuthzDatasourceResourcePermissions?: boolean;
+  /**
   * Enables restore deleted dashboards feature
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1873,6 +1873,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "kubernetesAuthzDatasourceResourcePermissions",
+			Description:  "Enables datasource resource permissions via the K8s IAM resource permission APIs",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+		},
+		{
 			Name:        "restoreDashboards",
 			Description: "Enables restore deleted dashboards feature",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -233,6 +233,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,kubernetesAuthzTeamLBACRuleApi,experimental,@grafana/identity-access-team,false,false,false
 2026-01-12,kubernetesAuthzRoleBindingsApi,experimental,@grafana/identity-access-team,false,false,false
 2026-03-16,kubernetesAuthzRolesAndRoleBindingsRedirect,experimental,@grafana/identity-access-team,false,false,false
+2026-03-17,kubernetesAuthzDatasourceResourcePermissions,experimental,@grafana/identity-access-team,false,false,false
 2025-05-23,restoreDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,false
 2025-12-10,recentlyViewedDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-01-13,experimentRecentlyViewedDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -658,6 +658,10 @@ const (
 	// Redirects the traffic from the legacy roles and role bindings endpoints to the new K8s AuthZ endpoints
 	FlagKubernetesAuthzRolesAndRoleBindingsRedirect = "kubernetesAuthzRolesAndRoleBindingsRedirect"
 
+	// FlagKubernetesAuthzDatasourceResourcePermissions
+	// Enables datasource resource permissions via the K8s IAM resource permission APIs
+	FlagKubernetesAuthzDatasourceResourcePermissions = "kubernetesAuthzDatasourceResourcePermissions"
+
 	// FlagRestoreDashboards
 	// Enables restore deleted dashboards feature
 	FlagRestoreDashboards = "restoreDashboards"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2616,6 +2616,20 @@
     },
     {
       "metadata": {
+        "name": "kubernetesAuthzDatasourceResourcePermissions",
+        "resourceVersion": "1773784985598",
+        "creationTimestamp": "2026-03-17T22:03:05Z"
+      },
+      "spec": {
+        "description": "Enables datasource resource permissions via the K8s IAM resource permission APIs",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesAuthzGlobalRolesApi",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-01-15T08:13:46Z"


### PR DESCRIPTION
## Summary
- Adds a new experimental feature toggle `kubernetesAuthzDatasourceResourcePermissions` that will gate datasource resource permissions via the K8s IAM resource permission APIs
- Regenerates the feature toggle Go, TypeScript, CSV, and JSON artifacts via `make gen-feature-toggles`

## Test plan
- [ ] `make gen-feature-toggles` passes cleanly with the new toggle present

Made with [Cursor](https://cursor.com)