### PR TITLE
Provisioning: set checksum on provisioned folders

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -177,7 +177,7 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 		leafPath := strings.TrimSuffix(opts.Path, "/")
 		err = safepath.Walk(ctx, opts.Path, func(ctx context.Context, segPath string) error {
 			folderPath := segPath + "/"
-			existing, readErr := ReadFolderMetadata(ctx, r.repo, folderPath, opts.Ref)
+			existing, _, readErr := ReadFolderMetadata(ctx, r.repo, folderPath, opts.Ref)
 			if readErr == nil {
 				if segPath == leafPath {
 					return apierrors.NewAlreadyExists(

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -128,18 +128,18 @@ func marshalFolderManifest(folder *folders.Folder) ([]byte, error) {
 	return data, nil
 }
 
-// ReadFolderMetadata reads _folder.json from folderPath and returns the Folder resource.
-func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath, ref string) (*folders.Folder, error) {
+// ReadFolderMetadata reads _folder.json from folderPath and returns the Folder resource and its file hash.
+func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath, ref string) (*folders.Folder, string, error) {
 	metadataPath := safepath.Join(folderPath, folderMetadataFileName)
 	info, err := repo.Read(ctx, metadataPath, ref)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	var f folders.Folder
 	if err := json.Unmarshal(info.Data, &f); err != nil {
-		return nil, fmt.Errorf("parse folder manifest: %w", err)
+		return nil, "", fmt.Errorf("parse folder manifest: %w", err)
 	}
-	return &f, nil
+	return &f, info.Hash, nil
 }
 
 // WriteFolderMetadata creates _folder.json into folderPath and returns the stable UID.
@@ -175,7 +175,7 @@ func ParseFolderWithMetadata(ctx context.Context, reader repository.Reader, path
 		return f, nil
 	}
 
-	meta, err := ReadFolderMetadata(ctx, reader, path, ref)
+	meta, hash, err := ReadFolderMetadata(ctx, reader, path, ref)
 	if err != nil {
 		if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
 			return f, nil
@@ -189,6 +189,7 @@ func ParseFolderWithMetadata(ctx context.Context, reader repository.Reader, path
 	if meta.Spec.Title != "" {
 		f.Title = meta.Spec.Title
 	}
+	f.MetadataHash = hash
 	return f, nil
 }
 
@@ -207,7 +208,7 @@ func ParseFolderResource(ctx context.Context, reader repository.Reader, path, re
 	)
 
 	if folderMetadataEnabled {
-		folderObj, err = ReadFolderMetadata(ctx, reader, path, ref)
+		folderObj, _, err = ReadFolderMetadata(ctx, reader, path, ref)
 		if err != nil && !errors.Is(err, repository.ErrFileNotFound) {
 			return nil, fmt.Errorf("read folder metadata: %w", err)
 		}

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsFolderMetadataFile(t *testing.T) {
@@ -29,16 +31,17 @@ func TestReadFolderMetadata(t *testing.T) {
 	validData, err := json.Marshal(manifest)
 	require.NoError(t, err)
 
-	t.Run("valid _folder.json returns Folder with correct UID", func(t *testing.T) {
+	t.Run("valid _folder.json returns Folder with correct UID and hash", func(t *testing.T) {
 		rw := repository.NewMockReaderWriter(t)
 		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
-			Return(&repository.FileInfo{Data: validData}, nil)
+			Return(&repository.FileInfo{Data: validData, Hash: "abc123"}, nil)
 
-		result, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
+		result, hash, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, stableUID, result.Name)
+		assert.Equal(t, "abc123", hash)
 	})
 
 	t.Run("read error returns error", func(t *testing.T) {
@@ -46,7 +49,7 @@ func TestReadFolderMetadata(t *testing.T) {
 		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
 			Return(nil, errors.New("file not found"))
 
-		_, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
+		_, _, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
 
 		require.Error(t, err)
 	})
@@ -56,9 +59,54 @@ func TestReadFolderMetadata(t *testing.T) {
 		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
 			Return(&repository.FileInfo{Data: []byte("not-json")}, nil)
 
-		_, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
+		_, _, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
 
 		require.Error(t, err)
+	})
+}
+
+func TestParseFolderWithMetadata_MetadataHash(t *testing.T) {
+	const stableUID = "stable-uid"
+	manifest := NewFolderManifest(stableUID, "My Folder")
+	validData, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	cfg := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "repo-a", Namespace: "default"},
+		Spec:       provisioning.RepositorySpec{Sync: provisioning.SyncOptions{Target: provisioning.SyncTargetTypeFolder}},
+	}
+
+	t.Run("populates MetadataHash when metadata exists", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(cfg)
+		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
+			Return(&repository.FileInfo{Data: validData, Hash: "metadata-hash-123"}, nil)
+
+		f, err := ParseFolderWithMetadata(context.Background(), rw, "my-folder/", "", true)
+		require.NoError(t, err)
+		assert.Equal(t, stableUID, f.ID)
+		assert.Equal(t, "My Folder", f.Title)
+		assert.Equal(t, "metadata-hash-123", f.MetadataHash)
+	})
+
+	t.Run("MetadataHash is empty when metadata disabled", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(cfg)
+
+		f, err := ParseFolderWithMetadata(context.Background(), rw, "my-folder/", "", false)
+		require.NoError(t, err)
+		assert.Empty(t, f.MetadataHash)
+	})
+
+	t.Run("MetadataHash is empty when _folder.json missing", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(cfg)
+		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
+			Return(nil, repository.ErrFileNotFound)
+
+		f, err := ParseFolderWithMetadata(context.Background(), rw, "my-folder/", "", true)
+		require.NoError(t, err)
+		assert.Empty(t, f.MetadataHash)
 	})
 }
 

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -169,13 +169,11 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			needsUpdate = true
 		}
 
-		if folder.MetadataHash != "" {
-			source, _ := meta.GetSourceProperties()
-			if source.Checksum != folder.MetadataHash {
-				source.Checksum = folder.MetadataHash
-				meta.SetSourceProperties(source)
-				needsUpdate = true
-			}
+		source, _ := meta.GetSourceProperties()
+		if source.Checksum != folder.MetadataHash {
+			source.Checksum = folder.MetadataHash
+			meta.SetSourceProperties(source)
+			needsUpdate = true
 		}
 
 		if needsUpdate {

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -155,17 +155,36 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			return fmt.Errorf("target folder is managed by a different repository (%s)", current)
 		}
 
+		meta, err := utils.MetaAccessor(obj)
+		if err != nil {
+			return fmt.Errorf("create meta accessor: %w", err)
+		}
+
+		needsUpdate := false
 		currentTitle, _, _ := unstructured.NestedString(obj.Object, "spec", "title")
 		if currentTitle != folder.Title {
+			if err := unstructured.SetNestedField(obj.Object, folder.Title, "spec", "title"); err != nil {
+				return fmt.Errorf("set folder title: %w", err)
+			}
+			needsUpdate = true
+		}
+
+		if folder.MetadataHash != "" {
+			source, _ := meta.GetSourceProperties()
+			if source.Checksum != folder.MetadataHash {
+				source.Checksum = folder.MetadataHash
+				meta.SetSourceProperties(source)
+				needsUpdate = true
+			}
+		}
+
+		if needsUpdate {
 			ctx, _, err = identity.WithProvisioningIdentity(ctx, cfg.GetNamespace())
 			if err != nil {
 				return fmt.Errorf("unable to use provisioning identity %w", err)
 			}
-			if err := unstructured.SetNestedField(obj.Object, folder.Title, "spec", "title"); err != nil {
-				return fmt.Errorf("set folder title: %w", err)
-			}
 			if _, err := fm.client.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
-				return fmt.Errorf("update folder title: %w", err)
+				return fmt.Errorf("update folder: %w", err)
 			}
 		}
 
@@ -212,7 +231,8 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 		Identity: cfg.GetName(),
 	})
 	meta.SetSourceProperties(utils.SourceProperties{
-		Path: folder.Path,
+		Path:     folder.Path,
+		Checksum: folder.MetadataHash,
 	})
 
 	if _, err := fm.client.Create(ctx, obj, metav1.CreateOptions{}); err != nil {

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -1140,16 +1140,21 @@ func TestEnsureFolderExists_MetadataHashUpdate(t *testing.T) {
 		require.Empty(t, client.updateCalls, "should not update when title and hash both match")
 	})
 
-	t.Run("skips hash comparison when MetadataHash is empty", func(t *testing.T) {
+	t.Run("clears checksum when MetadataHash is empty and stored hash exists", func(t *testing.T) {
 		config := newTestRepoConfig("test-repo")
 		rw := repository.NewMockReaderWriter(t)
 		rw.On("Config").Return(config)
 
 		tree := NewEmptyFolderTree()
 
+		var updatedObj *unstructured.Unstructured
 		client := &fakeDynamicResourceClient{
 			getFn: func(name string) (*unstructured.Unstructured, error) {
 				return managedFolderWithChecksum(name, "Same Title", config.Name, "my-folder", "stored-hash"), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj
+				return obj, nil
 			},
 		}
 
@@ -1158,11 +1163,15 @@ func TestEnsureFolderExists_MetadataHashUpdate(t *testing.T) {
 			ID:           "folder-uid",
 			Title:        "Same Title",
 			Path:         "my-folder",
-			MetadataHash: "", // empty — e.g. metadata disabled
+			MetadataHash: "", // empty — e.g. metadata deleted
 		}, "")
 
 		require.NoError(t, err)
-		require.Empty(t, client.updateCalls, "should not update when MetadataHash is empty")
+		require.Equal(t, []string{"folder-uid"}, client.updateCalls, "should update to clear the stored checksum")
+		require.NotNil(t, updatedObj)
+
+		checksum, _, _ := unstructured.NestedString(updatedObj.Object, "metadata", "annotations", "grafana.app/sourceChecksum")
+		require.Empty(t, checksum, "checksum should be cleared")
 	})
 }
 

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -962,7 +962,7 @@ func TestEnsureFolderPathExist_ReconcileTitle(t *testing.T) {
 		fm := NewFolderManager(rw, client, tree, WithFolderMetadataEnabled(true))
 		_, err := fm.EnsureFolderPathExist(ctx, "my-folder/dashboard.json")
 		require.Error(t, err)
-		require.ErrorContains(t, err, "update folder title")
+		require.ErrorContains(t, err, "update folder")
 		require.ErrorContains(t, err, "conflict")
 	})
 
@@ -996,8 +996,173 @@ func TestEnsureFolderPathExist_ReconcileTitle(t *testing.T) {
 		var pathErr *PathCreationError
 		require.ErrorAs(t, err, &pathErr)
 		require.Equal(t, "parent", pathErr.Path)
-		require.ErrorContains(t, err, "update folder title")
+		require.ErrorContains(t, err, "update folder")
 		require.ErrorContains(t, err, "conflict")
+	})
+}
+
+func TestEnsureFolderExists_MetadataHashUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	newTestRepoConfig := func(name string) *provisioning.Repository {
+		return &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{Target: provisioning.SyncTargetTypeFolder},
+			},
+		}
+	}
+
+	managedFolderWithChecksum := func(name, title, managerIdentity, sourcePath, checksum string) *unstructured.Unstructured {
+		annotations := map[string]interface{}{
+			"grafana.app/managerId": managerIdentity,
+		}
+		if sourcePath != "" {
+			annotations["grafana.app/sourcePath"] = sourcePath
+		}
+		if checksum != "" {
+			annotations["grafana.app/sourceChecksum"] = checksum
+		}
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "folder.grafana.app/v1beta1",
+				"kind":       "Folder",
+				"metadata": map[string]interface{}{
+					"name":        name,
+					"namespace":   "default",
+					"annotations": annotations,
+				},
+				"spec": map[string]interface{}{
+					"title": title,
+				},
+			},
+		}
+	}
+
+	t.Run("updates checksum when hash changed but title unchanged", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		var updatedObj *unstructured.Unstructured
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithChecksum(name, "Same Title", config.Name, "my-folder", "old-hash"), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:           "folder-uid",
+			Title:        "Same Title",
+			Path:         "my-folder",
+			MetadataHash: "new-hash",
+		}, "")
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"folder-uid"}, client.updateCalls, "should update even though title is unchanged")
+		require.NotNil(t, updatedObj)
+
+		// Verify checksum was updated
+		checksum, _, _ := unstructured.NestedString(updatedObj.Object, "metadata", "annotations", "grafana.app/sourceChecksum")
+		require.Equal(t, "new-hash", checksum)
+
+		// Verify title was NOT changed
+		title, _, _ := unstructured.NestedString(updatedObj.Object, "spec", "title")
+		require.Equal(t, "Same Title", title)
+	})
+
+	t.Run("preserves existing source path when updating checksum", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		var updatedObj *unstructured.Unstructured
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithChecksum(name, "Title", config.Name, "original/path", "old-hash"), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:           "folder-uid",
+			Title:        "Title",
+			Path:         "my-folder",
+			MetadataHash: "new-hash",
+		}, "")
+
+		require.NoError(t, err)
+		require.NotNil(t, updatedObj)
+
+		// Verify existing sourcePath is preserved, not overwritten with folder.Path
+		sourcePath, _, _ := unstructured.NestedString(updatedObj.Object, "metadata", "annotations", "grafana.app/sourcePath")
+		require.Equal(t, "original/path", sourcePath, "existing sourcePath should be preserved")
+
+		checksum, _, _ := unstructured.NestedString(updatedObj.Object, "metadata", "annotations", "grafana.app/sourceChecksum")
+		require.Equal(t, "new-hash", checksum)
+	})
+
+	t.Run("no update when both title and hash match", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithChecksum(name, "Same Title", config.Name, "my-folder", "same-hash"), nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:           "folder-uid",
+			Title:        "Same Title",
+			Path:         "my-folder",
+			MetadataHash: "same-hash",
+		}, "")
+
+		require.NoError(t, err)
+		require.Empty(t, client.updateCalls, "should not update when title and hash both match")
+	})
+
+	t.Run("skips hash comparison when MetadataHash is empty", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithChecksum(name, "Same Title", config.Name, "my-folder", "stored-hash"), nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:           "folder-uid",
+			Title:        "Same Title",
+			Path:         "my-folder",
+			MetadataHash: "", // empty — e.g. metadata disabled
+		}, "")
+
+		require.NoError(t, err)
+		require.Empty(t, client.updateCalls, "should not update when MetadataHash is empty")
 	})
 }
 

--- a/pkg/registry/apis/provisioning/resources/id.go
+++ b/pkg/registry/apis/provisioning/resources/id.go
@@ -101,6 +101,9 @@ type Folder struct {
 	ID string
 	// Path is the full path to the folder, as given to the parse function.
 	Path string
+	// MetadataHash is the hash of the _folder.json file content.
+	// Empty when folder metadata is disabled or no _folder.json exists.
+	MetadataHash string
 }
 
 func ParseFolder(dirPath, repositoryName string) Folder {

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -216,7 +216,7 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 			// When folder metadata is enabled and the parent folder has a _folder.json,
 			// use the stable UID from that file instead of the hash-derived one.
 			if r.folderMetadataEnabled && r.reader != nil {
-				if meta, err := ReadFolderMetadata(ctx, r.reader, dirPath, ""); err == nil && meta.Name != "" {
+				if meta, _, err := ReadFolderMetadata(ctx, r.reader, dirPath, ""); err == nil && meta.Name != "" {
 					folderID = meta.Name
 				}
 			}

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -1,6 +1,7 @@
 package foldermetadata
 
 import (
+	//nolint:gosec // Test SHA-1 hash (generated for testing purposes only, never used in production)
 	"crypto/sha1"
 	"encoding/hex"
 	"os"
@@ -41,7 +42,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 			Target: "folder",
 			Copies: map[string]string{
 				// Dashboard inside a folder that intentionally has no _folder.json
-				"testdata/all-panels.json": "myfolder/dashboard.json",
+				"../testdata/all-panels.json": "myfolder/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -81,8 +82,8 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 			Target: "folder",
 			Copies: map[string]string{
 				// Two dashboards in separate folders, neither has a _folder.json
-				"testdata/all-panels.json":    "folderA/dashboard1.json",
-				"testdata/timeline-demo.json": "folderB/dashboard2.json",
+				"../testdata/all-panels.json":    "folderA/dashboard1.json",
+				"../testdata/timeline-demo.json": "folderB/dashboard2.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -127,9 +128,9 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 			Target: "folder",
 			Copies: map[string]string{
 				// Dashboard in folder without _folder.json → MissingFolderMetadata
-				"testdata/all-panels.json": "myfolder/dashboard.json",
+				"../testdata/all-panels.json": "myfolder/dashboard.json",
 				// Invalid dashboard at root → ResourceInvalid
-				"testdata/dashboard-missing-name.json": "bad-dashboard.json",
+				"../testdata/dashboard-missing-name.json": "bad-dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -179,7 +180,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagDisabled(t *
 		Name:   repo,
 		Target: "folder",
 		Copies: map[string]string{
-			"testdata/all-panels.json": "myfolder/dashboard.json",
+			"../testdata/all-panels.json": "myfolder/dashboard.json",
 		},
 		SkipSync:               true,
 		SkipResourceAssertions: true,
@@ -249,7 +250,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "my-team/dashboard.json",
+				"../testdata/all-panels.json": "my-team/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -271,7 +272,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "reports/dashboard.json",
+				"../testdata/all-panels.json": "reports/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -290,7 +291,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "analytics/dashboard.json",
+				"../testdata/all-panels.json": "analytics/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -312,7 +313,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "parent/child/dashboard.json",
+				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -334,7 +335,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "old-dir/dashboard.json",
+				"../testdata/all-panels.json": "old-dir/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -398,7 +399,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "my-folder/dashboard.json",
+				"../testdata/all-panels.json": "my-folder/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -418,7 +419,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "plain-folder/dashboard.json",
+				"../testdata/all-panels.json": "plain-folder/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,
@@ -463,7 +464,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
 			Name:   repo,
 			Target: "folder",
 			Copies: map[string]string{
-				"testdata/all-panels.json": "parent/child/dashboard.json",
+				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
 			SkipSync:               true,
 			SkipResourceAssertions: true,

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -1,9 +1,10 @@
-package provisioning
+package foldermetadata
 
 import (
-	"encoding/json"
+	"crypto/sha1"
+	"encoding/hex"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,13 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
+
+// sha1Hex computes the SHA-1 hash of data and returns the lowercase hex string.
+// This matches the hash algorithm used by the local filesystem repository.
+func sha1Hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}
 
 // TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled verifies that when the
 // provisioningFolderMetadata feature flag is enabled, a full sync on a repository that has folders
@@ -197,30 +205,6 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagDisabled(t *
 	helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonSuccess)
 }
 
-// folderMetadataJSON generates a valid _folder.json payload with a stable UID and title.
-func folderMetadataJSON(uid, title string) []byte {
-	folder := map[string]any{
-		"apiVersion": "folder.grafana.app/v1beta1",
-		"kind":       "Folder",
-		"metadata": map[string]any{
-			"name": uid,
-		},
-		"spec": map[string]any{
-			"title": title,
-		},
-	}
-	data, _ := json.MarshalIndent(folder, "", "\t")
-	return data
-}
-
-// writeToProvisioningPath writes raw content to a relative path under the provisioning directory.
-func writeToProvisioningPath(t *testing.T, helper *common.ProvisioningTestHelper, relativePath string, data []byte) {
-	t.Helper()
-	fullPath := path.Join(helper.ProvisioningPath, relativePath)
-	require.NoError(t, os.MkdirAll(path.Dir(fullPath), 0o750))
-	require.NoError(t, os.WriteFile(fullPath, data, 0o600))
-}
-
 // requireRepoFolderTitle lists all folders managed by repoName and asserts that
 // exactly one with the given sourcePath has the expected title.
 func requireRepoFolderTitle(t *testing.T, helper *common.ProvisioningTestHelper, repoName, expectedSourcePath, expectedTitle string) {
@@ -361,12 +345,133 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 		requireRepoFolderTitle(t, helper, repo, "old-dir", "My Team")
 
 		// Rename directory: old-dir → new-dir (keep _folder.json with same UID and title).
-		oldPath := path.Join(helper.ProvisioningPath, "old-dir")
-		newPath := path.Join(helper.ProvisioningPath, "new-dir")
+		oldPath := filepath.Join(helper.ProvisioningPath, "old-dir")
+		newPath := filepath.Join(helper.ProvisioningPath, "new-dir")
 		require.NoError(t, os.Rename(oldPath, newPath))
 
 		// Second sync — title must remain "My Team" (from _folder.json), not "new-dir".
 		helper.SyncAndWait(t, repo, nil)
 		requireRepoFolderTitle(t, helper, repo, "new-dir", "My Team")
+	})
+}
+
+// requireRepoFolderChecksum lists all folders managed by repoName and asserts that
+// one with the given sourcePath has the expected sourceChecksum annotation value.
+func requireRepoFolderChecksum(t *testing.T, helper *common.ProvisioningTestHelper, repoName, expectedSourcePath, expectedChecksum string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		for _, f := range list.Items {
+			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if mgr != repoName {
+				continue
+			}
+			srcPath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			if srcPath != expectedSourcePath {
+				continue
+			}
+			checksum, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourceChecksum")
+			assert.Equal(c, expectedChecksum, checksum, "sourceChecksum mismatch for folder at path %q", expectedSourcePath)
+			return
+		}
+		c.Errorf("no folder managed by %q at path %q found", repoName, expectedSourcePath)
+	}, 30*time.Second, 100*time.Millisecond,
+		"expected folder at path %q for repo %q to have sourceChecksum %q", expectedSourcePath, repoName, expectedChecksum)
+}
+
+// TestIntegrationProvisioning_FullSync_FolderMetadataChecksum verifies that
+// full sync persists the _folder.json hash as sourceChecksum on the Grafana folder.
+func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("folder has sourceChecksum after sync with _folder.json", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-checksum"
+
+		metadataContent := folderMetadataJSON("checksum-uid-1", "Checksum Folder")
+		writeToProvisioningPath(t, helper, "my-folder/_folder.json", metadataContent)
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "my-folder/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		requireRepoFolderTitle(t, helper, repo, "my-folder", "Checksum Folder")
+		requireRepoFolderChecksum(t, helper, repo, "my-folder", sha1Hex(metadataContent))
+	})
+
+	t.Run("folder without _folder.json has no sourceChecksum", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-no-meta-checksum"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "plain-folder/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		// Folder should exist but without sourceChecksum
+		requireRepoFolderTitle(t, helper, repo, "plain-folder", "plain-folder")
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			list, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+			if !assert.NoError(c, err) {
+				return
+			}
+			for _, f := range list.Items {
+				mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+				if mgr != repo {
+					continue
+				}
+				srcPath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+				if srcPath != "plain-folder" {
+					continue
+				}
+				checksum, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourceChecksum")
+				assert.Empty(c, checksum, "folder without _folder.json should not have sourceChecksum")
+				return
+			}
+			c.Errorf("folder not found")
+		}, 30*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("nested folders both have sourceChecksum", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-checksum-nested"
+
+		parentContent := folderMetadataJSON("parent-ck-uid", "Parent")
+		childContent := folderMetadataJSON("child-ck-uid", "Child")
+		writeToProvisioningPath(t, helper, "parent/_folder.json", parentContent)
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", childContent)
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"testdata/all-panels.json": "parent/child/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+
+		requireRepoFolderChecksum(t, helper, repo, "parent", sha1Hex(parentContent))
+		requireRepoFolderChecksum(t, helper, repo, "parent/child", sha1Hex(childContent))
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Store the `_folder.json` file hash on the Grafana folder object as `sourceChecksum` (`grafana.app/sourceChecksum` annotation).

When a folder is created or updated during sync, and it has a `_folder.json` metadata file, the SHA-1 hash of that file's content is persisted alongside the folder's other source properties. This is a data-only change — no new sync behavior is triggered by the hash yet.

**Why do we need this feature?**

Today, when a user edits `_folder.json` (e.g. changes the folder title) and no other files in that directory change, the full sync silently ignores the edit. There is no mechanism to detect that `_folder.json` changed because its hash is never stored.

This PR lays the foundation for detecting those changes. By persisting the hash now, follow-up PRs can cheaply compare the stored hash against the source tree's hash during sync — without re-reading the file — and trigger reconciliation only when something actually changed. Without this stored hash, there is nothing to compare against.

**Who is this feature for?**

Users of GitSync

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/936

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
