### PR TITLE
test: AI-generated unit tests

### DIFF
--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.test.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.test.ts
@@ -1,0 +1,236 @@
+import { DataFrame, getDefaultTimeRange, LoadingState, PanelData, toDataFrame } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneDataNode, VizPanel } from '@grafana/scenes';
+
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
+import { activateFullSceneTree } from '../../utils/test-utils';
+import { ConditionalRenderingGroup } from '../group/ConditionalRenderingGroup';
+
+import { ConditionalRenderingData } from './ConditionalRenderingData';
+
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
+
+const seriesWithData = toDataFrame({ fields: [{ name: 'value', values: [1, 2, 3] }] });
+const emptySeries = toDataFrame({ fields: [{ name: 'value', values: [] }] });
+
+function buildPanelData(overrides: Partial<PanelData> = {}): PanelData {
+  return {
+    state: LoadingState.Done,
+    series: [],
+    timeRange: getDefaultTimeRange(),
+    ...overrides,
+  };
+}
+
+function buildSceneTree({
+  condition,
+  series,
+  loadingState = LoadingState.Done,
+}: {
+  condition: ConditionalRenderingData;
+  series: DataFrame[];
+  loadingState?: LoadingState;
+}) {
+  const group = new ConditionalRenderingGroup({
+    conditions: [condition],
+    condition: 'and',
+    visibility: 'show',
+    result: true,
+    renderHidden: true,
+  });
+
+  const dataNode = new SceneDataNode({
+    data: buildPanelData({ state: loadingState, series }),
+  });
+
+  const gridItem = new AutoGridItem({
+    body: new VizPanel({ title: 'Test Panel', pluginId: 'timeseries', $data: dataNode }),
+    conditionalRendering: group,
+  });
+
+  return { group, gridItem, dataNode };
+}
+
+describe('ConditionalRenderingData', () => {
+  describe('evaluation', () => {
+    test('when value=true and data provider has series with rows, result is true', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [seriesWithData] });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when value=true and data provider has only empty series, result is false', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [emptySeries] });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when value=true and data provider has no series at all, result is false', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [] });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when value=true and data provider has mixed series, result is true', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [emptySeries, seriesWithData, emptySeries] });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when value=false and data provider has series with rows, result is false', () => {
+      const condition = new ConditionalRenderingData({ value: false, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [seriesWithData] });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when value=false and data provider has only empty series, result is true', () => {
+      const condition = new ConditionalRenderingData({ value: false, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [emptySeries] });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when data provider is in Loading state, result is undefined', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [seriesWithData], loadingState: LoadingState.Loading });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBeUndefined();
+    });
+
+    test('when data provider is in NotStarted state, result is undefined', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({
+        condition,
+        series: [seriesWithData],
+        loadingState: LoadingState.NotStarted,
+      });
+
+      activateFullSceneTree(gridItem);
+
+      expect(condition.state.result).toBeUndefined();
+    });
+
+    test('when no panel exists in the parent, result is undefined', () => {
+      const dataCondition = new ConditionalRenderingData({ value: true, result: undefined });
+      const group = new ConditionalRenderingGroup({
+        conditions: [dataCondition],
+        condition: 'and',
+        visibility: 'show',
+        result: true,
+        renderHidden: true,
+      });
+
+      activateFullSceneTree(group);
+
+      expect(dataCondition.state.result).toBeUndefined();
+    });
+  });
+
+  describe('reactivity', () => {
+    test('when data provider state changes, result is recalculated', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem, dataNode } = buildSceneTree({ condition, series: [] });
+
+      activateFullSceneTree(gridItem);
+
+      dataNode.setState({ data: buildPanelData({ series: [seriesWithData] }) });
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when result changes, it triggers a group check', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { group, gridItem, dataNode } = buildSceneTree({ condition, series: [] });
+
+      activateFullSceneTree(gridItem);
+
+      const checkSpy = jest.spyOn(group, 'check');
+
+      dataNode.setState({ data: buildPanelData({ series: [seriesWithData] }) });
+
+      expect(checkSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('changeValue', () => {
+    test('when value changes, result is recalculated', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [seriesWithData] });
+
+      activateFullSceneTree(gridItem);
+
+      condition.changeValue(false);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when value is set to the same value, state and result are not updated', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+      const { gridItem } = buildSceneTree({ condition, series: [seriesWithData] });
+
+      activateFullSceneTree(gridItem);
+
+      const resultBefore = condition.state.result;
+      const setStateSpy = jest.spyOn(condition, 'setState');
+
+      condition.changeValue(true);
+
+      expect(setStateSpy).not.toHaveBeenCalled();
+      expect(condition.state.result).toBe(resultBefore);
+    });
+  });
+
+  describe('serialization', () => {
+    test('serialize() returns the correct kind and spec', () => {
+      const condition = new ConditionalRenderingData({ value: true, result: undefined });
+
+      const result = condition.serialize();
+
+      expect(result).toEqual({
+        kind: 'ConditionalRenderingData',
+        spec: { value: true },
+      });
+    });
+
+    test('deserialize() creates an instance with the correct state', () => {
+      const model = { kind: 'ConditionalRenderingData' as const, spec: { value: false } };
+
+      const condition = ConditionalRenderingData.deserialize(model);
+
+      expect(condition).toBeInstanceOf(ConditionalRenderingData);
+      expect(condition.state.value).toBe(false);
+      expect(condition.state.result).toBeUndefined();
+    });
+  });
+
+  test('createEmpty() defaults to value=true and result=undefined', () => {
+    const condition = ConditionalRenderingData.createEmpty();
+
+    expect(condition).toBeInstanceOf(ConditionalRenderingData);
+    expect(condition.state.value).toBe(true);
+    expect(condition.state.result).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.test.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.test.ts
@@ -1,0 +1,174 @@
+import { dateTime } from '@grafana/data';
+import { SceneTimeRange } from '@grafana/scenes';
+
+import { activateFullSceneTree } from '../../utils/test-utils';
+import { ConditionalRenderingGroup } from '../group/ConditionalRenderingGroup';
+
+import { ConditionalRenderingTimeRangeSize } from './ConditionalRenderingTimeRangeSize';
+
+function buildSceneTree({
+  condition,
+  from,
+  to,
+}: {
+  condition: ConditionalRenderingTimeRangeSize;
+  from: string;
+  to: string;
+}) {
+  const timeRange = new SceneTimeRange({ from, to });
+
+  const group = new ConditionalRenderingGroup({
+    conditions: [condition],
+    condition: 'and',
+    visibility: 'show',
+    result: true,
+    renderHidden: false,
+    $timeRange: timeRange,
+  });
+
+  return { group, timeRange };
+}
+
+describe('ConditionalRenderingTimeRangeSize', () => {
+  describe('evaluation', () => {
+    test('when time range (1h) is shorter than threshold (7d), result is true', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-1h', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when time range (30d) is longer than threshold (7d), result is false', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-30d', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when time range equals threshold exactly, result is true', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-7d', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when interval value is invalid, result is undefined', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: 'abc', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-1h', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      expect(condition.state.result).toBeUndefined();
+    });
+
+    test('when interval value is empty, result is undefined', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-1h', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      expect(condition.state.result).toBeUndefined();
+    });
+  });
+
+  describe('reactivity', () => {
+    test('when time range changes, result is recalculated', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group, timeRange } = buildSceneTree({ condition, from: 'now-1h', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      const now = dateTime();
+      timeRange.onTimeRangeChange({
+        from: dateTime(now).subtract(30, 'days'),
+        to: now,
+        raw: { from: 'now-30d', to: 'now' },
+      });
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when result changes, it triggers a group check', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group, timeRange } = buildSceneTree({ condition, from: 'now-1h', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      const checkSpy = jest.spyOn(group, 'check');
+
+      const now = dateTime();
+      timeRange.onTimeRangeChange({
+        from: dateTime(now).subtract(30, 'days'),
+        to: now,
+        raw: { from: 'now-30d', to: 'now' },
+      });
+
+      expect(checkSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('changeValue', () => {
+    test('when value changes, result is recalculated', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-30d', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      condition.changeValue('90d');
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when value is set to the same value, state and result are not updated', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+      const { group } = buildSceneTree({ condition, from: 'now-1h', to: 'now' });
+
+      activateFullSceneTree(group);
+
+      const resultBefore = condition.state.result;
+      const setStateSpy = jest.spyOn(condition, 'setState');
+
+      condition.changeValue('7d');
+
+      expect(setStateSpy).not.toHaveBeenCalled();
+      expect(condition.state.result).toBe(resultBefore);
+    });
+  });
+
+  describe('serialization', () => {
+    test('serialize() returns the correct kind and spec', () => {
+      const condition = new ConditionalRenderingTimeRangeSize({ value: '7d', result: undefined });
+
+      const result = condition.serialize();
+
+      expect(result).toEqual({
+        kind: 'ConditionalRenderingTimeRangeSize',
+        spec: { value: '7d' },
+      });
+    });
+
+    test('deserialize() creates an instance with the correct state', () => {
+      const model = { kind: 'ConditionalRenderingTimeRangeSize' as const, spec: { value: '30d' } };
+
+      const condition = ConditionalRenderingTimeRangeSize.deserialize(model);
+
+      expect(condition).toBeInstanceOf(ConditionalRenderingTimeRangeSize);
+      expect(condition.state.value).toBe('30d');
+      expect(condition.state.result).toBeUndefined();
+    });
+  });
+
+  test('createEmpty() defaults to value=7d and result=undefined', () => {
+    const condition = ConditionalRenderingTimeRangeSize.createEmpty();
+
+    expect(condition).toBeInstanceOf(ConditionalRenderingTimeRangeSize);
+    expect(condition.state.value).toBe('7d');
+    expect(condition.state.result).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.test.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.test.ts
@@ -1,0 +1,446 @@
+import { CustomVariable, EmbeddedScene, SceneVariableSet } from '@grafana/scenes';
+
+import { activateFullSceneTree } from '../../utils/test-utils';
+import { ConditionalRenderingGroup } from '../group/ConditionalRenderingGroup';
+
+import { ConditionalRenderingVariable } from './ConditionalRenderingVariable';
+
+function buildSceneTree({
+  condition,
+  variables,
+}: {
+  condition: ConditionalRenderingVariable;
+  variables: CustomVariable[];
+}) {
+  const group = new ConditionalRenderingGroup({
+    conditions: [condition],
+    condition: 'and',
+    visibility: 'show',
+    result: true,
+    renderHidden: false,
+  });
+
+  const scene = new EmbeddedScene({
+    $variables: new SceneVariableSet({ variables }),
+    body: group,
+  });
+
+  return { group, scene };
+}
+
+describe('ConditionalRenderingVariable', () => {
+  describe('evaluation', () => {
+    test('when operator is = and variable value matches, result is true', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is = and variable value does not match, result is false', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: 'staging',
+        text: 'staging',
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when operator is = and multi-value variable includes comparison value, result is true', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: ['dev', 'staging'],
+        text: ['dev', 'staging'],
+        isMulti: true,
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'staging',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is = and multi-value variable with All selected matches All comparison, result is true', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: '$__all',
+        text: 'All',
+        isMulti: true,
+        includeAll: true,
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'All',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is != and variable value matches, result is false', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '!=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when operator is != and variable value does not match, result is true', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: 'staging',
+        text: 'staging',
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '!=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is =~ and variable value matches regex, result is true', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: 'staging',
+        text: 'staging',
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=~',
+        value: 'stag.*',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is =~ and variable value does not match regex, result is false', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=~',
+        value: 'stag.*',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when operator is =~ and regex is invalid, result is true', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=~',
+        value: '[invalid',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is =~ and multi-value variable has a matching value, result is true', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: ['dev', 'staging'],
+        text: ['dev', 'staging'],
+        isMulti: true,
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=~',
+        value: 'stag.*',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when operator is !~ and variable value matches regex, result is false', () => {
+      const variable = new CustomVariable({
+        name: 'env',
+        query: 'dev,staging,prod',
+        value: 'staging',
+        text: 'staging',
+      });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '!~',
+        value: 'stag.*',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when operator is !~ and variable value does not match regex, result is true', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '!~',
+        value: 'stag.*',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when variable name is empty, result is undefined', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: '',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBeUndefined();
+    });
+
+    test('when variable is not found in the scene, result is undefined', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'nonexistent',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBeUndefined();
+    });
+  });
+
+  describe('reactivity', () => {
+    test('when variable value changes, result is recalculated', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+
+      variable.changeValueTo('staging', 'staging');
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when result changes, it triggers a group check', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { group, scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      const checkSpy = jest.spyOn(group, 'check');
+
+      variable.changeValueTo('staging', 'staging');
+
+      expect(checkSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('change methods', () => {
+    test('when changeVariable() is called, result is recalculated', () => {
+      const envVar = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const regionVar = new CustomVariable({ name: 'region', query: 'us,eu', value: 'us', text: 'us' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'us',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [envVar, regionVar] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(false);
+
+      condition.changeVariable('region');
+
+      expect(condition.state.result).toBe(true);
+    });
+
+    test('when changeOperator() is called, result is recalculated', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+
+      condition.changeOperator('!=');
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when changeValue() is called, result is recalculated', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      expect(condition.state.result).toBe(true);
+
+      condition.changeValue('staging');
+
+      expect(condition.state.result).toBe(false);
+    });
+
+    test('when changeValue() is called with the same value, state and result are not updated', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'dev,staging,prod', value: 'dev', text: 'dev' });
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '=',
+        value: 'dev',
+        result: undefined,
+      });
+      const { scene } = buildSceneTree({ condition, variables: [variable] });
+
+      activateFullSceneTree(scene);
+
+      const resultBefore = condition.state.result;
+      const setStateSpy = jest.spyOn(condition, 'setState');
+
+      condition.changeValue('dev');
+
+      expect(setStateSpy).not.toHaveBeenCalled();
+      expect(condition.state.result).toBe(resultBefore);
+    });
+  });
+
+  describe('serialization', () => {
+    test('serialize() maps short operators to long names', () => {
+      const condition = new ConditionalRenderingVariable({
+        variable: 'env',
+        operator: '!=',
+        value: 'dev',
+        result: undefined,
+      });
+
+      const result = condition.serialize();
+
+      expect(result).toEqual({
+        kind: 'ConditionalRenderingVariable',
+        spec: { variable: 'env', operator: 'notEquals', value: 'dev' },
+      });
+    });
+
+    test('deserialize() maps long operator names to short ones', () => {
+      const model = {
+        kind: 'ConditionalRenderingVariable' as const,
+        spec: { variable: 'env', operator: 'matches' as const, value: 'stag.*' },
+      };
+
+      const condition = ConditionalRenderingVariable.deserialize(model);
+
+      expect(condition).toBeInstanceOf(ConditionalRenderingVariable);
+      expect(condition.state.variable).toBe('env');
+      expect(condition.state.operator).toBe('=~');
+      expect(condition.state.value).toBe('stag.*');
+      expect(condition.state.result).toBeUndefined();
+    });
+  });
+
+  test('createEmpty() defaults to operator = and empty value', () => {
+    const condition = ConditionalRenderingVariable.createEmpty('env');
+
+    expect(condition).toBeInstanceOf(ConditionalRenderingVariable);
+    expect(condition.state.variable).toBe('env');
+    expect(condition.state.operator).toBe('=');
+    expect(condition.state.value).toBe('');
+    expect(condition.state.result).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.test.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.test.ts
@@ -1,0 +1,190 @@
+import { SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+
+import { ConditionalRenderingChangedEvent } from '../../edit-pane/shared';
+import { activateFullSceneTree } from '../../utils/test-utils';
+import { ConditionalRenderingConditions } from '../conditions/types';
+
+import { ConditionalRenderingGroup, ConditionalRenderingGroupState } from './ConditionalRenderingGroup';
+
+interface StubConditionState extends SceneObjectState {
+  value: boolean;
+  result: boolean | undefined;
+}
+
+class StubCondition extends SceneObjectBase<StubConditionState> {
+  public forceCheckCalled = false;
+
+  public forceCheck() {
+    this.forceCheckCalled = true;
+  }
+
+  public changeValue(value: boolean) {
+    this.setState({ value, result: value });
+  }
+
+  public serialize() {
+    return { kind: 'ConditionalRenderingData' as const, spec: { value: this.state.value } };
+  }
+
+  public renderCmp() {
+    return null as never;
+  }
+}
+
+function buildGroup({
+  conditions = [],
+  condition = 'and',
+  visibility = 'show',
+  result = true,
+  renderHidden = false,
+}: Partial<ConditionalRenderingGroupState> = {}) {
+  const group = new ConditionalRenderingGroup({
+    conditions,
+    condition,
+    visibility,
+    result,
+    renderHidden,
+  });
+
+  return { group };
+}
+
+function buildConditions({ results = [] }: { results: Array<boolean | undefined> }) {
+  return results.map(
+    (result) => new StubCondition({ value: result ?? false, result }) as unknown as ConditionalRenderingConditions
+  );
+}
+
+describe('ConditionalRenderingGroup', () => {
+  describe('check', () => {
+    describe('when visibility=show and condition=and', () => {
+      test('when all conditions are true, result is true', () => {
+        const conditions = buildConditions({ results: [true, true, true] });
+        const { group } = buildGroup({ conditions, visibility: 'show', condition: 'and' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(true);
+      });
+
+      test('when one condition is false, result is false', () => {
+        const conditions = buildConditions({ results: [true, false, true] });
+        const { group } = buildGroup({ conditions, visibility: 'show', condition: 'and' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(false);
+      });
+    });
+
+    describe('when visibility=show and condition=or', () => {
+      test('when at least one condition is true, result is true', () => {
+        const conditions = buildConditions({ results: [false, true, false] });
+        const { group } = buildGroup({ conditions, visibility: 'show', condition: 'or' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(true);
+      });
+
+      test('when all conditions are false, result is false', () => {
+        const conditions = buildConditions({ results: [false, false, false] });
+        const { group } = buildGroup({ conditions, visibility: 'show', condition: 'or' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(false);
+      });
+    });
+
+    describe('when visibility=hide and condition=and', () => {
+      test('when all conditions are true, result is false (negated)', () => {
+        const conditions = buildConditions({ results: [true, true] });
+        const { group } = buildGroup({ conditions, visibility: 'hide', condition: 'and' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(false);
+      });
+
+      test('when one condition is false, result is true (negated)', () => {
+        const conditions = buildConditions({ results: [true, false] });
+        const { group } = buildGroup({ conditions, visibility: 'hide', condition: 'and' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(true);
+      });
+    });
+
+    describe('when visibility=hide and condition=or', () => {
+      test('when at least one condition is true, result is false (negated)', () => {
+        const conditions = buildConditions({ results: [false, true] });
+        const { group } = buildGroup({ conditions, visibility: 'hide', condition: 'or' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(false);
+      });
+
+      test('when all conditions are false, result is true (negated)', () => {
+        const conditions = buildConditions({ results: [false, false] });
+        const { group } = buildGroup({ conditions, visibility: 'hide', condition: 'or' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(true);
+      });
+    });
+
+    describe('when conditions have undefined results', () => {
+      test('conditions with undefined result are filtered out', () => {
+        const conditions = buildConditions({ results: [undefined, true] });
+        const { group } = buildGroup({ conditions, visibility: 'show', condition: 'and' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(true);
+      });
+
+      test('when all conditions have undefined result, result defaults to true', () => {
+        const conditions = buildConditions({ results: [undefined, undefined] });
+        const { group } = buildGroup({ conditions, visibility: 'show', condition: 'and' });
+
+        activateFullSceneTree(group);
+
+        expect(group.state.result).toBe(true);
+      });
+    });
+
+    test('when conditions list is empty, result defaults to true', () => {
+      const { group } = buildGroup({ conditions: [], visibility: 'show', condition: 'and' });
+
+      activateFullSceneTree(group);
+
+      expect(group.state.result).toBe(true);
+    });
+
+    test('when result changes, publishes ConditionalRenderingChangedEvent', () => {
+      const conditions = buildConditions({ results: [true] });
+      const { group } = buildGroup({ conditions, visibility: 'show', condition: 'and', result: false });
+      const eventHandler = jest.fn();
+
+      group.subscribeToEvent(ConditionalRenderingChangedEvent, eventHandler);
+      activateFullSceneTree(group);
+
+      expect(eventHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test('when result does not change, no event is published', () => {
+      const conditions = buildConditions({ results: [true] });
+      const { group } = buildGroup({ conditions, visibility: 'show', condition: 'and', result: true });
+      const eventHandler = jest.fn();
+
+      group.subscribeToEvent(ConditionalRenderingChangedEvent, eventHandler);
+      activateFullSceneTree(group);
+
+      expect(eventHandler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/conditional-rendering/hooks/useIsConditionallyHidden.test.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/hooks/useIsConditionallyHidden.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { ConditionalRenderingGroup } from '../group/ConditionalRenderingGroup';
+
+import { ConditionalRenderingOverlay } from './ConditionalRenderingOverlay';
+import { useIsConditionallyHidden } from './useIsConditionallyHidden';
+
+function buildConditionalRenderingGroup({
+  result = true,
+  renderHidden = false,
+}: { result?: boolean; renderHidden?: boolean } = {}): ConditionalRenderingGroup {
+  return new ConditionalRenderingGroup({
+    condition: 'and',
+    visibility: 'show',
+    conditions: [],
+    result,
+    renderHidden,
+  });
+}
+
+describe('useIsConditionallyHidden', () => {
+  test('when no conditionalRendering is provided, defaults to a visible tuple', () => {
+    const { result } = renderHook(() => useIsConditionallyHidden());
+
+    expect(result.current).toEqual([false, undefined, null, false]);
+  });
+
+  test('when the group result is true, returns a visible tuple', () => {
+    const group = buildConditionalRenderingGroup({ result: true });
+
+    const { result } = renderHook(() => useIsConditionallyHidden(group));
+
+    expect(result.current).toEqual([false, undefined, null, false]);
+  });
+
+  test('when the group result changes from true to false, updates the tuple to a hidden tuple', () => {
+    const group = buildConditionalRenderingGroup({ result: true });
+
+    const { result } = renderHook(() => useIsConditionallyHidden(group));
+
+    expect(result.current).toEqual([false, undefined, null, false]);
+
+    act(() => {
+      group.setState({ result: false });
+    });
+
+    expect(result.current).toEqual([
+      true,
+      'dashboard-visible-hidden-element',
+      expect.objectContaining({ type: ConditionalRenderingOverlay }),
+      false,
+    ]);
+  });
+
+  test('when renderHidden is true, forwards it as the last tuple element', () => {
+    const group = buildConditionalRenderingGroup({ renderHidden: true });
+
+    const { result } = renderHook(() => useIsConditionallyHidden(group));
+
+    expect(result.current.at(-1)).toBe(true);
+  });
+
+  test('when hidden and renderHidden is true, returns isHidden=true with renderHidden=true', () => {
+    const group = buildConditionalRenderingGroup({ renderHidden: true });
+
+    const { result } = renderHook(() => useIsConditionallyHidden(group));
+
+    act(() => {
+      group.setState({ result: false });
+    });
+
+    expect(result.current).toEqual([
+      true,
+      'dashboard-visible-hidden-element',
+      expect.objectContaining({ type: ConditionalRenderingOverlay }),
+      true,
+    ]);
+  });
+});

--- a/public/app/features/dashboard-scene/saving/DetectChangesWorker.test.ts
+++ b/public/app/features/dashboard-scene/saving/DetectChangesWorker.test.ts
@@ -1,0 +1,140 @@
+import { Dashboard } from '@grafana/schema';
+import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { detectDashboardChanges, isDashboardV2Spec } from './DetectChangesWorker';
+
+function buildV1Dashboard(overrides: Partial<Dashboard> = {}): Dashboard {
+  return {
+    title: 'Test dashboard',
+    schemaVersion: 39,
+    ...overrides,
+  } as Dashboard;
+}
+
+function buildV2Spec(overrides: Partial<DashboardV2Spec> = {}): DashboardV2Spec {
+  return {
+    title: 'Test dashboard',
+    elements: {},
+    ...overrides,
+  } as DashboardV2Spec;
+}
+
+describe('detectDashboardChanges', () => {
+  test('when initial and changed are identical, then hasChanges is false', () => {
+    const initial = buildV1Dashboard();
+    const changed = buildV1Dashboard();
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.diffCount).toBe(0);
+    expect(result.diffs).toEqual({});
+  });
+
+  test('when changed has a modified property, then hasChanges is true', () => {
+    const initial = buildV1Dashboard({ title: 'Original' });
+    const changed = buildV1Dashboard({ title: 'Updated' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.diffCount).toBe(1);
+    expect(result.diffs['title']).toEqual(
+      expect.arrayContaining([expect.objectContaining({ op: 'replace', value: 'Updated', originalValue: 'Original' })])
+    );
+  });
+
+  test('when changed has an added property, then detects the addition', () => {
+    const initial = buildV1Dashboard();
+    const changed = buildV1Dashboard({ description: 'A new description' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.diffs['description']).toEqual(
+      expect.arrayContaining([expect.objectContaining({ op: 'add', value: 'A new description' })])
+    );
+  });
+
+  test('when changed has a removed property, then detects the removal', () => {
+    const initial = buildV1Dashboard({ description: 'Will be removed' });
+    const changed = buildV1Dashboard();
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.diffs['description']).toEqual(
+      expect.arrayContaining([expect.objectContaining({ op: 'remove', originalValue: 'Will be removed' })])
+    );
+  });
+
+  test('when changed has multiple differences, then diffCount reflects the total', () => {
+    const initial = buildV1Dashboard({ title: 'Original', description: 'Old desc' });
+    const changed = buildV1Dashboard({ title: 'Updated' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.diffCount).toBe(2);
+  });
+
+  test('when changed is a v2 spec and initial is a v1 Dashboard, then hasMigratedToV2 is true', () => {
+    const initial = buildV1Dashboard();
+    const changed = buildV2Spec({ title: 'Migrated' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasMigratedToV2).toBe(true);
+  });
+
+  test('when both are v2 specs, then hasMigratedToV2 is false', () => {
+    const initial = buildV2Spec();
+    const changed = buildV2Spec({ title: 'Updated' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasMigratedToV2).toBe(false);
+  });
+
+  test('when both are v1 Dashboards, then hasMigratedToV2 is false', () => {
+    const initial = buildV1Dashboard();
+    const changed = buildV1Dashboard({ title: 'Updated' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasMigratedToV2).toBe(false);
+  });
+
+  test('when changed is a v1 Dashboard and initial is a v2 spec, then hasMigratedToV2 is false', () => {
+    const initial = buildV2Spec();
+    const changed = buildV1Dashboard({ title: 'Downgraded' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.hasMigratedToV2).toBe(false);
+  });
+
+  test('returns changedSaveModel and initialSaveModel unchanged', () => {
+    const initial = buildV1Dashboard({ title: 'Initial' });
+    const changed = buildV1Dashboard({ title: 'Changed' });
+
+    const result = detectDashboardChanges(changed, initial);
+
+    expect(result.changedSaveModel).toBe(changed);
+    expect(result.initialSaveModel).toBe(initial);
+  });
+});
+
+describe('isDashboardV2Spec', () => {
+  test('when object has elements property, then returns true', () => {
+    const spec = buildV2Spec();
+
+    expect(isDashboardV2Spec(spec)).toBe(true);
+  });
+
+  test('when object does not have elements property, then returns false', () => {
+    const dashboard = buildV1Dashboard();
+
+    expect(isDashboardV2Spec(dashboard)).toBe(false);
+  });
+});

--- a/public/app/features/dashboard-scene/saving/SaveDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardForm.test.tsx
@@ -1,0 +1,354 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { selectors } from '@grafana/e2e-selectors';
+import { SceneObjectRef } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+
+import { SaveDashboardDrawer } from './SaveDashboardDrawer';
+import { SaveDashboardForm, SaveDashboardFormCommonOptions } from './SaveDashboardForm';
+import { DashboardChangeInfo } from './shared';
+import { useSaveDashboard } from './useSaveDashboard';
+
+jest.mock('./useSaveDashboard');
+const useSaveDashboardMock = jest.mocked(useSaveDashboard);
+
+function buildChangeInfo(overrides: Partial<DashboardChangeInfo>): DashboardChangeInfo {
+  return {
+    changedSaveModel: {},
+    initialSaveModel: {},
+    diffs: {},
+    diffCount: 0,
+    hasChanges: false,
+    hasTimeChanges: false,
+    hasVariableValueChanges: false,
+    hasRefreshChange: false,
+    ...overrides,
+  } as DashboardChangeInfo;
+}
+
+function buildDrawer(overrides: Partial<ConstructorParameters<typeof SaveDashboardDrawer>[0]> = {}) {
+  const dashboard = new DashboardScene({});
+  const drawer = new SaveDashboardDrawer({
+    dashboardRef: new SceneObjectRef(dashboard),
+    ...overrides,
+  });
+  drawer.activate();
+  return drawer;
+}
+
+function renderCommonOptions(
+  changeInfo: DashboardChangeInfo,
+  drawerOverrides: Partial<ConstructorParameters<typeof SaveDashboardDrawer>[0]> = {}
+) {
+  const drawer = buildDrawer(drawerOverrides);
+  const renderResult = render(<SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />);
+
+  return {
+    ...renderResult,
+    drawer,
+    user: userEvent.setup(),
+    elements: {
+      timeRangeCheckbox: () => renderResult.queryByTestId(selectors.pages.SaveDashboardModal.saveTimerange),
+      refreshCheckbox: () => renderResult.queryByTestId(selectors.pages.SaveDashboardModal.saveRefresh),
+      variablesCheckbox: () => renderResult.queryByTestId(selectors.pages.SaveDashboardModal.saveVariables),
+      variablesWarningAlert: () => renderResult.queryByTestId(selectors.pages.SaveDashboardModal.variablesWarningAlert),
+    },
+  };
+}
+
+interface RenderSaveFormOptions {
+  changeInfo?: Partial<DashboardChangeInfo>;
+  drawerOverrides?: Partial<ConstructorParameters<typeof SaveDashboardDrawer>[0]>;
+  error?: Error;
+  loading?: boolean;
+  onSaveDashboard?: jest.Mock;
+}
+
+function renderSaveForm({
+  changeInfo: changeInfoOverrides = {},
+  drawerOverrides = {},
+  error,
+  loading = false,
+  onSaveDashboard = jest.fn(),
+}: RenderSaveFormOptions = {}) {
+  const dashboard = new DashboardScene({});
+  dashboard.activate();
+
+  const drawer = new SaveDashboardDrawer({
+    dashboardRef: new SceneObjectRef(dashboard),
+    ...drawerOverrides,
+  });
+  drawer.activate();
+
+  const changeInfo = buildChangeInfo({ hasChanges: true, ...changeInfoOverrides });
+
+  useSaveDashboardMock.mockReturnValue({
+    state: { loading, error },
+    onSaveDashboard,
+  } as unknown as ReturnType<typeof useSaveDashboard>);
+
+  const renderResult = render(<SaveDashboardForm dashboard={dashboard} drawer={drawer} changeInfo={changeInfo} />);
+
+  return {
+    ...renderResult,
+    dashboard,
+    drawer,
+    user: userEvent.setup(),
+    elements: {
+      messageTextarea: () => renderResult.getByLabelText('message') as HTMLTextAreaElement,
+      saveButton: () =>
+        renderResult.queryByTestId(
+          selectors.components.Drawer.DashboardSaveDrawer.saveButton
+        ) as HTMLButtonElement | null,
+      cancelButton: () => renderResult.queryByRole('button', { name: 'Cancel' }),
+      noChangesText: () => renderResult.queryByText('No changes to save'),
+      migrationWarning: () => renderResult.queryByText('Dashboard irreversibly changed'),
+      messageTooLong: () => renderResult.queryByText('Message too long'),
+      versionMismatch: () => renderResult.queryByText('Someone else has updated this dashboard'),
+      saveAndOverwrite: () => renderResult.queryByText('Save and overwrite'),
+      nameExists: () => renderResult.queryByText('Name already exists'),
+      pluginDashboard: () => renderResult.queryByText('Plugin dashboard'),
+      failedToSave: () => renderResult.queryByText('Failed to save dashboard'),
+    },
+  };
+}
+
+describe('<SaveDashboardFormCommonOptions />', () => {
+  test('when no changes exist, renders no checkboxes', () => {
+    const changeInfo = buildChangeInfo({
+      hasTimeChanges: false,
+      hasRefreshChange: false,
+      hasVariableValueChanges: false,
+    });
+
+    const { elements } = renderCommonOptions(changeInfo);
+
+    expect(elements.timeRangeCheckbox()).not.toBeInTheDocument();
+    expect(elements.refreshCheckbox()).not.toBeInTheDocument();
+    expect(elements.variablesCheckbox()).not.toBeInTheDocument();
+  });
+
+  test('when hasTimeChanges is true, renders the save time range checkbox', () => {
+    const changeInfo = buildChangeInfo({ hasTimeChanges: true });
+
+    const { elements } = renderCommonOptions(changeInfo);
+
+    expect(elements.timeRangeCheckbox()).toBeInTheDocument();
+    expect(elements.refreshCheckbox()).not.toBeInTheDocument();
+    expect(elements.variablesCheckbox()).not.toBeInTheDocument();
+  });
+
+  test('when hasRefreshChange is true, renders the save refresh checkbox', () => {
+    const changeInfo = buildChangeInfo({ hasRefreshChange: true });
+
+    const { elements } = renderCommonOptions(changeInfo);
+
+    expect(elements.refreshCheckbox()).toBeInTheDocument();
+    expect(elements.timeRangeCheckbox()).not.toBeInTheDocument();
+    expect(elements.variablesCheckbox()).not.toBeInTheDocument();
+  });
+
+  test('when hasVariableValueChanges is true, renders the save variables checkbox', () => {
+    const changeInfo = buildChangeInfo({ hasVariableValueChanges: true });
+
+    const { elements } = renderCommonOptions(changeInfo);
+
+    expect(elements.variablesCheckbox()).toBeInTheDocument();
+    expect(elements.timeRangeCheckbox()).not.toBeInTheDocument();
+    expect(elements.refreshCheckbox()).not.toBeInTheDocument();
+  });
+
+  test('when all changes exist, renders all three checkboxes', () => {
+    const changeInfo = buildChangeInfo({
+      hasTimeChanges: true,
+      hasRefreshChange: true,
+      hasVariableValueChanges: true,
+    });
+
+    const { elements } = renderCommonOptions(changeInfo);
+
+    expect(elements.timeRangeCheckbox()).toBeInTheDocument();
+    expect(elements.refreshCheckbox()).toBeInTheDocument();
+    expect(elements.variablesCheckbox()).toBeInTheDocument();
+  });
+
+  describe('when save variables is checked', () => {
+    test('if showVariablesWarning is true, renders the warning alert', () => {
+      const changeInfo = buildChangeInfo({ hasVariableValueChanges: true });
+
+      const { elements } = renderCommonOptions(changeInfo, {
+        saveVariables: true,
+        showVariablesWarning: true,
+      });
+
+      expect(elements.variablesWarningAlert()).toBeInTheDocument();
+    });
+
+    test('if showVariablesWarning is false, does not render the warning alert', () => {
+      const changeInfo = buildChangeInfo({ hasVariableValueChanges: true });
+
+      const { elements } = renderCommonOptions(changeInfo, {
+        saveVariables: true,
+        showVariablesWarning: false,
+      });
+
+      expect(elements.variablesWarningAlert()).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when save variables is unchecked', () => {
+    test('does not render the warning alert even if showVariablesWarning is true', () => {
+      const changeInfo = buildChangeInfo({ hasVariableValueChanges: true });
+
+      const { elements } = renderCommonOptions(changeInfo, {
+        saveVariables: false,
+        showVariablesWarning: true,
+      });
+
+      expect(elements.variablesWarningAlert()).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('<SaveDashboardForm />', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('renders the message textarea with an empty default value', () => {
+    const { elements } = renderSaveForm();
+
+    expect(elements.messageTextarea()).toBeInTheDocument();
+    expect(elements.messageTextarea().value).toBe('');
+  });
+
+  test('when user types a message, updates the textarea value', async () => {
+    const { elements, user } = renderSaveForm();
+
+    await user.type(elements.messageTextarea(), 'Fixed layout bug');
+
+    expect(elements.messageTextarea().value).toBe('Fixed layout bug');
+  });
+
+  describe('when there are no changes', () => {
+    test('renders "No changes to save" and disables the save button', () => {
+      const { elements } = renderSaveForm({ changeInfo: { hasChanges: false } });
+
+      expect(elements.noChangesText()).toBeInTheDocument();
+      expect(elements.saveButton()).toBeDisabled();
+    });
+  });
+
+  describe('when there are changes', () => {
+    test('renders enabled save button without "No changes to save"', () => {
+      const { elements } = renderSaveForm({ changeInfo: { hasChanges: true } });
+
+      expect(elements.noChangesText()).not.toBeInTheDocument();
+      expect(elements.saveButton()).toBeEnabled();
+    });
+  });
+
+  describe('migration warning', () => {
+    test('when hasMigratedToV2 is true, renders the migration warning alert', () => {
+      const { elements } = renderSaveForm({ changeInfo: { hasMigratedToV2: true } });
+
+      expect(elements.migrationWarning()).toBeInTheDocument();
+    });
+
+    test('when hasMigratedToV2 is false, does not render the migration warning alert', () => {
+      const { elements } = renderSaveForm({ changeInfo: { hasMigratedToV2: false } });
+
+      expect(elements.migrationWarning()).not.toBeInTheDocument();
+    });
+  });
+
+  test('when user clicks Cancel, calls dashboard.closeModal()', async () => {
+    const { elements, user, dashboard } = renderSaveForm();
+    jest.spyOn(dashboard, 'closeModal').mockImplementation(() => {});
+
+    await user.click(elements.cancelButton()!);
+
+    expect(dashboard.closeModal).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when message exceeds 500 characters', () => {
+    test('renders the "Message too long" error instead of save/cancel buttons', async () => {
+      const { elements, user } = renderSaveForm();
+
+      await user.type(elements.messageTextarea(), 'a'.repeat(501));
+
+      expect(elements.messageTooLong()).toBeInTheDocument();
+      expect(elements.saveButton()).not.toBeInTheDocument();
+      expect(elements.cancelButton()).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when message is exactly 500 characters', () => {
+    test('renders the normal footer with save and cancel buttons', async () => {
+      const { elements, user } = renderSaveForm();
+
+      await user.type(elements.messageTextarea(), 'a'.repeat(500));
+
+      expect(elements.messageTooLong()).not.toBeInTheDocument();
+      expect(elements.saveButton()).toBeInTheDocument();
+      expect(elements.cancelButton()).toBeInTheDocument();
+    });
+  });
+
+  describe('error footer states', () => {
+    test('when a version-mismatch error occurs, renders the overwrite prompt', () => {
+      const error = Object.assign(new Error('version-mismatch'), {
+        status: 412,
+        data: { status: 'version-mismatch', message: 'version-mismatch error' },
+      });
+
+      const { elements } = renderSaveForm({ error });
+
+      expect(elements.versionMismatch()).toBeInTheDocument();
+      expect(elements.saveAndOverwrite()).toBeInTheDocument();
+    });
+
+    test('when a name-exists error occurs, renders the NameAlreadyExistsError', () => {
+      const error = Object.assign(new Error('name-exists'), {
+        status: 412,
+        data: { status: 'name-exists', message: 'name-exists error' },
+      });
+
+      const { elements } = renderSaveForm({ error });
+
+      expect(elements.nameExists()).toBeInTheDocument();
+    });
+
+    test('when a plugin-dashboard error occurs, renders the plugin dashboard warning', () => {
+      const error = Object.assign(new Error('plugin-dashboard'), {
+        status: 412,
+        data: { status: 'plugin-dashboard', message: 'plugin-dashboard error' },
+      });
+
+      const { elements } = renderSaveForm({ error });
+
+      expect(elements.pluginDashboard()).toBeInTheDocument();
+      expect(elements.saveAndOverwrite()).toBeInTheDocument();
+    });
+
+    test('when a generic error occurs, renders the "Failed to save dashboard" alert with the error message', () => {
+      const error = new Error('Something went wrong');
+
+      const { elements, getByText } = renderSaveForm({ error });
+
+      expect(elements.failedToSave()).toBeInTheDocument();
+      expect(getByText('Something went wrong')).toBeInTheDocument();
+    });
+
+    test('when no error and no changes, does not render any error alert', () => {
+      const { elements } = renderSaveForm({ changeInfo: { hasChanges: false } });
+
+      expect(elements.failedToSave()).not.toBeInTheDocument();
+      expect(elements.versionMismatch()).not.toBeInTheDocument();
+      expect(elements.pluginDashboard()).not.toBeInTheDocument();
+      expect(elements.nameExists()).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
@@ -1,0 +1,138 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { saveAs } from 'file-saver';
+
+import { SceneObjectRef } from '@grafana/scenes';
+import { Dashboard } from '@grafana/schema';
+
+import { DashboardScene } from '../scene/DashboardScene';
+
+import { SaveDashboardDrawer } from './SaveDashboardDrawer';
+import { SaveProvisionedDashboardForm } from './SaveProvisionedDashboardForm';
+import { DashboardChangeInfo } from './shared';
+
+jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
+
+jest.mock('react-virtualized-auto-sizer', () => {
+  return ({ children }: { children: (size: { height: number; width: number }) => React.ReactNode }) =>
+    children({ height: 600, width: 800 });
+});
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: ({ value }: { value: string }) => <pre data-testid="code-editor">{value}</pre>,
+}));
+
+function buildChangeInfo(overrides: Partial<DashboardChangeInfo> = {}): DashboardChangeInfo {
+  return {
+    changedSaveModel: { title: 'My provisioned dashboard' },
+    initialSaveModel: {},
+    diffs: {},
+    diffCount: 0,
+    hasChanges: false,
+    hasTimeChanges: false,
+    hasVariableValueChanges: false,
+    hasRefreshChange: false,
+    ...overrides,
+  } as DashboardChangeInfo;
+}
+
+interface RenderOptions {
+  changeInfo?: Partial<DashboardChangeInfo>;
+  provisionedExternalId?: string;
+}
+
+function renderProvisionedForm({
+  changeInfo: changeInfoOverrides = {},
+  provisionedExternalId = '/etc/grafana/provisioning/dashboards/my-dashboard.json',
+}: RenderOptions = {}) {
+  const dashboard = new DashboardScene({
+    meta: { provisionedExternalId },
+  });
+  dashboard.activate();
+
+  const drawer = new SaveDashboardDrawer({
+    dashboardRef: new SceneObjectRef(dashboard),
+  });
+  drawer.activate();
+
+  const changeInfo = buildChangeInfo(changeInfoOverrides);
+
+  const renderResult = render(
+    <SaveProvisionedDashboardForm dashboard={dashboard} drawer={drawer} changeInfo={changeInfo} />
+  );
+
+  return {
+    ...renderResult,
+    dashboard,
+    drawer,
+    user: userEvent.setup(),
+    elements: {
+      cancelButton: () => renderResult.getByRole('button', { name: 'Cancel' }),
+      copyJsonButton: () => renderResult.getByRole('button', { name: 'Copy JSON to clipboard' }),
+      saveJsonButton: () => renderResult.getByRole('button', { name: 'Save JSON to file' }),
+    },
+  };
+}
+
+describe('<SaveProvisionedDashboardForm />', () => {
+  test('renders the provisioning explanation text', () => {
+    const { getByText } = renderProvisionedForm();
+
+    expect(
+      getByText(/This dashboard cannot be saved from the Grafana UI because it has been provisioned/)
+    ).toBeInTheDocument();
+  });
+
+  test('renders the file path from dashboard meta', () => {
+    const { getByText } = renderProvisionedForm({
+      provisionedExternalId: '/etc/grafana/dashboards/custom.json',
+    });
+
+    expect(getByText(/\/etc\/grafana\/dashboards\/custom\.json/)).toBeInTheDocument();
+  });
+
+  test('renders the JSON code editor with the serialized dashboard model', () => {
+    const changedSaveModel: Dashboard = { title: 'My provisioned dashboard', uid: 'abc', schemaVersion: 42 };
+
+    const { getByTestId } = renderProvisionedForm({ changeInfo: { changedSaveModel } });
+
+    expect(getByTestId('code-editor').textContent).toBe(JSON.stringify(changedSaveModel, null, 2));
+  });
+
+  test('renders Cancel, "Copy JSON to clipboard", and "Save JSON to file" buttons', () => {
+    const { elements } = renderProvisionedForm();
+
+    expect(elements.cancelButton()).toBeInTheDocument();
+    expect(elements.copyJsonButton()).toBeInTheDocument();
+    expect(elements.saveJsonButton()).toBeInTheDocument();
+  });
+
+  test('when user clicks Cancel, calls drawer.onClose()', async () => {
+    const { elements, user, dashboard } = renderProvisionedForm();
+    dashboard.setInitialSaveModel({ title: '', schemaVersion: 42, panels: [] });
+    dashboard.setState({ overlay: {} as SaveDashboardDrawer });
+
+    await user.click(elements.cancelButton());
+
+    expect(dashboard.state.overlay).toBeUndefined();
+  });
+
+  test('when user clicks "Save JSON to file", calls saveAs with a Blob containing the dashboard JSON', async () => {
+    const changedSaveModel: Dashboard = { title: 'My provisioned dashboard', schemaVersion: 42 };
+
+    const { elements, user } = renderProvisionedForm({ changeInfo: { changedSaveModel } });
+
+    await user.click(elements.saveJsonButton());
+
+    const saveAsMock = jest.mocked(saveAs);
+    expect(saveAsMock).toHaveBeenCalledTimes(1);
+    const [data, filename] = saveAsMock.mock.calls[0];
+    expect(data).toBeInstanceOf(Blob);
+    expect(filename).toMatch(/^My provisioned dashboard-\d+\.json$/);
+
+    const blob = data as Blob;
+    expect(blob.type).toBe('application/json;charset=utf-8');
+    expect(await blob.text()).toBe(JSON.stringify(changedSaveModel, null, 2));
+  });
+});

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.test.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.test.ts
@@ -1,0 +1,395 @@
+import { renderHook, act } from '@testing-library/react';
+import { Location } from 'history';
+
+import { locationUtil } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import { Dashboard } from '@grafana/schema';
+import { appEvents } from 'app/core/app_events';
+import { updateDashboardName } from 'app/core/reducers/navBarTree';
+import { SaveDashboardResponseDTO } from 'app/types/dashboard';
+import { DashboardSavedEvent } from 'app/types/events';
+
+import { updateDashboardUidLastUsedDatasource } from '../../dashboard/utils/dashboard';
+import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardInteractions } from '../utils/interactions';
+import { trackDashboardSceneCreatedOrSaved } from '../utils/tracking';
+
+import { useSaveDashboard } from './useSaveDashboard';
+
+const saveDashboardMutationMock = jest.fn();
+const notifyAppMock = { success: jest.fn(), error: jest.fn(), warning: jest.fn() };
+const dispatchMock = jest.fn();
+
+jest.mock('app/features/browse-dashboards/api/browseDashboardsAPI', () => ({
+  ...jest.requireActual('app/features/browse-dashboards/api/browseDashboardsAPI'),
+  useSaveDashboardMutation: () => [saveDashboardMutationMock],
+}));
+
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => notifyAppMock,
+}));
+
+jest.mock('app/types/store', () => ({
+  ...jest.requireActual('app/types/store'),
+  useDispatch: () => dispatchMock,
+}));
+
+jest.mock('app/core/app_events', () => ({
+  appEvents: {
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    publish: jest.fn(),
+  },
+}));
+
+jest.mock('../../dashboard/utils/dashboard', () => ({
+  updateDashboardUidLastUsedDatasource: jest.fn(),
+}));
+
+jest.mock('../utils/interactions', () => ({
+  DashboardInteractions: {
+    dashboardCopied: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/tracking', () => ({
+  trackDashboardSceneCreatedOrSaved: jest.fn(),
+}));
+
+function buildSaveResult(overrides: Partial<SaveDashboardResponseDTO> = {}): SaveDashboardResponseDTO {
+  return {
+    slug: 'my-dashboard',
+    status: 'success',
+    uid: 'abc123',
+    url: '/d/abc123',
+    version: 2,
+    ...overrides,
+  };
+}
+
+function buildScene(overrides: Partial<{ title: string; meta: Record<string, unknown> }> = {}) {
+  return {
+    state: {
+      title: overrides.title ?? 'My Dashboard',
+      meta: { slug: 'my-dashboard', isStarred: false, ...(overrides.meta ?? {}) },
+    },
+    getSaveModel: jest.fn().mockReturnValue({ title: 'My Dashboard', uid: 'abc123' }),
+    getSaveAsModel: jest.fn().mockReturnValue({ title: 'Copy of My Dashboard', uid: '' }),
+    saveCompleted: jest.fn(),
+    getTransformationCounts: jest.fn().mockReturnValue({}),
+    getExpressionCounts: jest.fn().mockReturnValue({}),
+  } as unknown as DashboardScene;
+}
+
+function buildDefaultOptions() {
+  return {
+    folderUid: 'folder-1',
+    message: 'Updated layout',
+    overwrite: false,
+    k8s: undefined,
+  };
+}
+
+function buildLocation(overrides: Partial<Location> = {}): Location {
+  return {
+    pathname: '/d/abc123',
+    search: '',
+    hash: '',
+    state: undefined,
+    key: 'default',
+    ...overrides,
+  };
+}
+
+describe('useSaveDashboard()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    jest.spyOn(locationService, 'getLocation').mockReturnValue(buildLocation());
+    jest.spyOn(locationService, 'push').mockImplementation(() => {});
+    jest.spyOn(locationUtil, 'stripBaseFromUrl').mockImplementation((url) => url);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('returns initial idle state', () => {
+    const { result } = renderHook(() => useSaveDashboard());
+
+    expect(result.current.state.loading).toBe(false);
+    expect(result.current.state.error).toBeUndefined();
+    expect(result.current.onSaveDashboard).toEqual(expect.any(Function));
+  });
+
+  describe('when saving a dashboard', () => {
+    test('calls the save mutation with the scene save model and options', async () => {
+      const scene = buildScene();
+      const options = buildDefaultOptions();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult() });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, options));
+
+      expect(saveDashboardMutationMock).toHaveBeenCalledWith({
+        dashboard: { title: 'My Dashboard', uid: 'abc123' },
+        folderUid: 'folder-1',
+        message: 'Updated layout',
+        overwrite: false,
+        showErrorAlert: false,
+        k8s: undefined,
+      });
+    });
+
+    test('calls scene.saveCompleted with the save model and result data', async () => {
+      const scene = buildScene();
+      const saveResult = buildSaveResult();
+      saveDashboardMutationMock.mockResolvedValue({ data: saveResult });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(scene.saveCompleted).toHaveBeenCalledWith(
+        { title: 'My Dashboard', uid: 'abc123' },
+        expect.objectContaining({ uid: 'abc123', url: '/d/abc123' }),
+        'folder-1'
+      );
+    });
+
+    test('publishes a DashboardSavedEvent', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult() });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(appEvents.publish).toHaveBeenCalledWith(expect.any(DashboardSavedEvent));
+    });
+
+    test('shows a success notification', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult() });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(notifyAppMock.success).toHaveBeenCalledWith('Dashboard saved');
+    });
+
+    test('calls updateDashboardUidLastUsedDatasource with the result UID', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult({ uid: 'saved-uid' }) });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(updateDashboardUidLastUsedDatasource).toHaveBeenCalledWith('saved-uid');
+    });
+
+    test('navigates to the new URL when it differs from the current location', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult({ url: '/d/new-uid' }) });
+      jest
+        .spyOn(locationService, 'getLocation')
+        .mockReturnValue(buildLocation({ pathname: '/d/old-uid', search: '?orgId=1' }));
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+      jest.runAllTimers();
+
+      expect(locationService.push).toHaveBeenCalledWith({ pathname: '/d/new-uid', search: '?orgId=1' });
+    });
+
+    test('does not navigate when the URL has not changed', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult({ url: '/d/abc123' }) });
+      jest.spyOn(locationService, 'getLocation').mockReturnValue(buildLocation());
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+      jest.runAllTimers();
+
+      expect(locationService.push).not.toHaveBeenCalled();
+    });
+
+    test('dispatches updateDashboardName when the dashboard is starred', async () => {
+      const scene = buildScene({ meta: { isStarred: true } });
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult({ uid: 'abc123', url: '/d/abc123' }) });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        updateDashboardName({ id: 'abc123', title: 'My Dashboard', url: '/d/abc123' })
+      );
+    });
+
+    test('does not dispatch updateDashboardName when the dashboard is not starred', async () => {
+      const scene = buildScene({ meta: { isStarred: false } });
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult() });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    test('returns the original result data', async () => {
+      const scene = buildScene();
+      const saveResult = buildSaveResult();
+      saveDashboardMutationMock.mockResolvedValue({ data: saveResult });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      let returnValue: SaveDashboardResponseDTO | undefined;
+      await act(async () => {
+        returnValue = await result.current.onSaveDashboard(scene, buildDefaultOptions());
+      });
+
+      expect(returnValue).toEqual(saveResult);
+    });
+  });
+
+  describe('when saving as a copy', () => {
+    test('calls scene.getSaveAsModel instead of getSaveModel', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult() });
+
+      const { result } = renderHook(() => useSaveDashboard(true));
+
+      await act(() =>
+        result.current.onSaveDashboard(scene, {
+          ...buildDefaultOptions(),
+          saveAsCopy: true,
+          isNew: true,
+          title: 'Copy title',
+          description: 'Copy desc',
+          copyTags: true,
+        })
+      );
+
+      expect(scene.getSaveAsModel).toHaveBeenCalledWith({
+        isNew: true,
+        title: 'Copy title',
+        description: 'Copy desc',
+        copyTags: true,
+      });
+      expect(saveDashboardMutationMock).toHaveBeenCalledWith(
+        expect.objectContaining({ dashboard: { title: 'Copy of My Dashboard', uid: '' } })
+      );
+    });
+
+    test('tracks DashboardInteractions.dashboardCopied', async () => {
+      const scene = buildScene();
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult({ url: '/d/copy-uid' }) });
+
+      const { result } = renderHook(() => useSaveDashboard(true));
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(DashboardInteractions.dashboardCopied).toHaveBeenCalledWith({
+        name: 'My Dashboard',
+        url: '/d/copy-uid',
+      });
+      expect(trackDashboardSceneCreatedOrSaved).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when not saving as a copy', () => {
+    test('calls trackDashboardSceneCreatedOrSaved with correct arguments', async () => {
+      const scene = buildScene();
+      const transformationCounts = { sum: 1 };
+      const expressionCounts = { math: 2 };
+      (scene.getTransformationCounts as jest.Mock).mockReturnValue(transformationCounts);
+      (scene.getExpressionCounts as jest.Mock).mockReturnValue(expressionCounts);
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult({ url: '/d/abc123' }) });
+
+      const { result } = renderHook(() => useSaveDashboard(false));
+
+      await act(() => result.current.onSaveDashboard(scene, { ...buildDefaultOptions(), isNew: true }));
+
+      expect(trackDashboardSceneCreatedOrSaved).toHaveBeenCalledWith(true, scene, {
+        name: 'My Dashboard',
+        url: '/d/abc123',
+        transformation_counts: transformationCounts,
+        expression_counts: expressionCounts,
+      });
+      expect(DashboardInteractions.dashboardCopied).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('slug patching', () => {
+    test('when result has no slug but scene has a slug, patches resultData.slug and resultData.url', async () => {
+      const scene = buildScene({ meta: { slug: 'scene-slug' } });
+      saveDashboardMutationMock.mockResolvedValue({
+        data: buildSaveResult({ slug: '', url: '/d/abc123' }),
+      });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(scene.saveCompleted).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ slug: 'scene-slug', url: '/d/abc123/scene-slug' }),
+        expect.anything()
+      );
+    });
+
+    test('when result already has a slug, does not patch', async () => {
+      const scene = buildScene({ meta: { slug: 'scene-slug' } });
+      saveDashboardMutationMock.mockResolvedValue({
+        data: buildSaveResult({ slug: 'result-slug', url: '/d/abc123' }),
+      });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(scene.saveCompleted).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ slug: 'result-slug', url: '/d/abc123' }),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('when rawDashboardJSON is provided', () => {
+    test('uses rawDashboardJSON instead of scene.getSaveModel()', async () => {
+      const scene = buildScene();
+      const rawJSON = { title: 'Raw JSON Dashboard', uid: 'raw-uid' } as Dashboard;
+      saveDashboardMutationMock.mockResolvedValue({ data: buildSaveResult() });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, { ...buildDefaultOptions(), rawDashboardJSON: rawJSON }));
+
+      expect(scene.getSaveModel).not.toHaveBeenCalled();
+      expect(saveDashboardMutationMock).toHaveBeenCalledWith(expect.objectContaining({ dashboard: rawJSON }));
+    });
+  });
+
+  describe('when the save mutation returns an error', () => {
+    test('throws the error so useAsyncFn captures it in state.error', async () => {
+      const scene = buildScene();
+      const saveError = { status: 412, data: { status: 'version-mismatch', message: 'conflict' } };
+      saveDashboardMutationMock.mockResolvedValue({ error: saveError });
+
+      const { result } = renderHook(() => useSaveDashboard());
+
+      await act(() => result.current.onSaveDashboard(scene, buildDefaultOptions()));
+
+      expect(result.current.state.error).toEqual(saveError);
+      expect(scene.saveCompleted).not.toHaveBeenCalled();
+      expect(notifyAppMock.success).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.test.ts
@@ -1,0 +1,486 @@
+import { VizPanel } from '@grafana/scenes';
+import {
+  Spec as DashboardV2Spec,
+  AutoGridLayoutItemKind,
+  defaultPanelSpec,
+  defaultLibraryPanelKind,
+  PanelKind,
+  LibraryPanelKind,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { ConditionalRenderingVariable } from '../../conditional-rendering/conditions/ConditionalRenderingVariable';
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
+import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';
+import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
+
+import {
+  serializeAutoGridLayout,
+  serializeAutoGridItem,
+  deserializeAutoGridLayout,
+  deserializeAutoGridItem,
+} from './AutoGridLayoutSerializer';
+import './test-matchers';
+
+jest.mock('../../utils/dashboardSceneGraph', () => {
+  const original = jest.requireActual('../../utils/dashboardSceneGraph');
+  return {
+    ...original,
+    dashboardSceneGraph: {
+      ...original.dashboardSceneGraph,
+      getElementIdentifierForVizPanel: jest.fn().mockImplementation((panel: VizPanel) => {
+        return panel?.state?.key || 'panel-1';
+      }),
+    },
+  };
+});
+
+function buildPanel(overrides: Partial<PanelKind['spec']> = {}): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      ...defaultPanelSpec(),
+      id: 1,
+      title: 'Test Panel',
+      ...overrides,
+    },
+  };
+}
+
+function buildLibraryPanel(overrides: Partial<LibraryPanelKind['spec']> = {}): LibraryPanelKind {
+  const base = defaultLibraryPanelKind();
+  return {
+    kind: 'LibraryPanel',
+    spec: {
+      ...base.spec,
+      id: 1,
+      title: 'Library Panel',
+      libraryPanel: { uid: 'lib-uid', name: 'lib-name' },
+      ...overrides,
+    },
+  };
+}
+
+function buildAutoGridItem(overrides: Partial<AutoGridItem['state']> = {}): AutoGridItem {
+  return new AutoGridItem({
+    body: new VizPanel({ key: 'panel-1', title: 'Test Panel', pluginId: 'timeseries' }),
+    ...overrides,
+  });
+}
+
+function buildLayoutManager(
+  overrides: Partial<ConstructorParameters<typeof AutoGridLayoutManager>[0]> = {},
+  children: AutoGridItem[] = []
+): AutoGridLayoutManager {
+  return new AutoGridLayoutManager({
+    ...overrides,
+    layout: new AutoGridLayout({ children }),
+  });
+}
+
+describe('serializeAutoGridLayout', () => {
+  describe('when the layout has no children', () => {
+    it('serializes to an empty items array with layout metadata', () => {
+      const layoutManager = buildLayoutManager();
+
+      const result = serializeAutoGridLayout(layoutManager);
+
+      expect(result).toEqual({
+        kind: 'AutoGridLayout',
+        spec: {
+          maxColumnCount: 3,
+          fillScreen: undefined,
+          columnWidthMode: 'standard',
+          columnWidth: undefined,
+          rowHeightMode: 'standard',
+          rowHeight: undefined,
+          items: [],
+        },
+      });
+    });
+  });
+
+  describe('when columnWidth and rowHeight are named strings', () => {
+    it('serializes the mode fields and omits numeric values', () => {
+      const layoutManager = buildLayoutManager({ columnWidth: 'narrow', rowHeight: 'tall' });
+
+      const result = serializeAutoGridLayout(layoutManager);
+
+      expect(result.spec).toMatchObject({
+        columnWidthMode: 'narrow',
+        columnWidth: undefined,
+        rowHeightMode: 'tall',
+        rowHeight: undefined,
+      });
+    });
+  });
+
+  describe('when columnWidth and rowHeight are custom numbers', () => {
+    it('serializes mode as custom with the numeric values', () => {
+      const layoutManager = buildLayoutManager({ columnWidth: 500, rowHeight: 250 });
+
+      const result = serializeAutoGridLayout(layoutManager);
+
+      expect(result.spec).toMatchObject({
+        columnWidthMode: 'custom',
+        columnWidth: 500,
+        rowHeightMode: 'custom',
+        rowHeight: 250,
+      });
+    });
+  });
+
+  describe('when fillScreen equals the default (false)', () => {
+    it('omits fillScreen from the output', () => {
+      const layoutManager = buildLayoutManager({ fillScreen: false });
+
+      expect(serializeAutoGridLayout(layoutManager)).toBeAutoGridLayoutWith((spec) => {
+        expect(spec.fillScreen).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when fillScreen differs from the default', () => {
+    it('includes fillScreen in the output', () => {
+      const layoutManager = buildLayoutManager({ fillScreen: true });
+
+      expect(serializeAutoGridLayout(layoutManager)).toBeAutoGridLayoutWith((spec) => {
+        expect(spec.fillScreen).toBe(true);
+      });
+    });
+  });
+
+  describe('when isSnapshot is false', () => {
+    it('preserves the repeat config on items', () => {
+      const child = buildAutoGridItem({ variableName: 'env' });
+      const layoutManager = buildLayoutManager({}, [child]);
+
+      expect(serializeAutoGridLayout(layoutManager, false)).toBeAutoGridLayoutWith((spec) => {
+        expect(spec.items).toHaveLength(1);
+        expect(spec.items[0].spec.repeat).toEqual({ mode: 'variable', value: 'env' });
+      });
+    });
+  });
+
+  describe('when isSnapshot is true', () => {
+    it('expands repeated panels and removes repeat config', () => {
+      const sourcePanel = new VizPanel({ key: 'panel-1', title: 'Source', pluginId: 'timeseries' });
+      const clonePanel = new VizPanel({ key: 'clone-1', title: 'Clone', pluginId: 'timeseries' });
+      const child = buildAutoGridItem({
+        body: sourcePanel,
+        variableName: 'env',
+        repeatedPanels: [clonePanel],
+      });
+      const layoutManager = buildLayoutManager({}, [child]);
+
+      expect(serializeAutoGridLayout(layoutManager, true)).toBeAutoGridLayoutWith((spec) => {
+        expect(spec.items).toHaveLength(2);
+        expect(spec.items[0].spec.repeat).toBeUndefined();
+        expect(spec.items[0].spec.element.name).toBe('panel-1');
+        expect(spec.items[1].spec.element.name).toBe('clone-1');
+      });
+    });
+  });
+});
+
+describe('serializeAutoGridItem', () => {
+  describe('when the item has no variableName and no conditional rendering', () => {
+    it('serializes only the element reference', () => {
+      const item = buildAutoGridItem();
+
+      const result = serializeAutoGridItem(item);
+
+      expect(result).toEqual({
+        kind: 'AutoGridLayoutItem',
+        spec: {
+          element: { kind: 'ElementReference', name: 'panel-1' },
+        },
+      });
+    });
+  });
+
+  describe('when the item has a variableName', () => {
+    it('includes repeat config', () => {
+      const item = buildAutoGridItem({ variableName: 'region' });
+
+      const result = serializeAutoGridItem(item);
+
+      expect(result.spec.repeat).toEqual({ mode: 'variable', value: 'region' });
+    });
+  });
+
+  describe('when the item has conditional rendering with items', () => {
+    it('includes conditionalRendering in the output', () => {
+      const condRendering = new ConditionalRenderingGroup({
+        condition: 'and',
+        visibility: 'show',
+        renderHidden: false,
+        conditions: [ConditionalRenderingVariable.createEmpty('myVar')],
+        result: true,
+      });
+      const item = buildAutoGridItem({ conditionalRendering: condRendering });
+
+      const result = serializeAutoGridItem(item);
+
+      expect(result.spec.conditionalRendering).toBeDefined();
+      expect(result.spec.conditionalRendering?.spec.items).toHaveLength(1);
+    });
+  });
+
+  describe('when the item has conditional rendering with no items', () => {
+    it('omits conditionalRendering from the output', () => {
+      const item = buildAutoGridItem();
+
+      const result = serializeAutoGridItem(item);
+
+      expect(result.spec.conditionalRendering).toBeUndefined();
+    });
+  });
+});
+
+describe('serializeAutoGridLayout snapshot edge cases', () => {
+  describe('when a snapshot child has no repeatedPanels', () => {
+    it('returns only the base item without repeat', () => {
+      const child = buildAutoGridItem({ variableName: 'env' });
+      const layoutManager = buildLayoutManager({}, [child]);
+
+      expect(serializeAutoGridLayout(layoutManager, true)).toBeAutoGridLayoutWith((spec) => {
+        expect(spec.items).toHaveLength(1);
+        expect(spec.items[0].spec.repeat).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when a snapshot child has repeatedPanels', () => {
+    it('returns the base item plus one entry per clone', () => {
+      const sourcePanel = new VizPanel({ key: 'panel-1', title: 'Source', pluginId: 'timeseries' });
+      const clone1 = new VizPanel({ key: 'clone-1', title: 'Clone 1', pluginId: 'timeseries' });
+      const clone2 = new VizPanel({ key: 'clone-2', title: 'Clone 2', pluginId: 'timeseries' });
+      const child = buildAutoGridItem({
+        body: sourcePanel,
+        variableName: 'env',
+        repeatedPanels: [clone1, clone2],
+      });
+      const layoutManager = buildLayoutManager({}, [child]);
+
+      expect(serializeAutoGridLayout(layoutManager, true)).toBeAutoGridLayoutWith((spec) => {
+        expect(spec.items).toHaveLength(3);
+        expect(spec.items.map((item) => item.spec.element.name)).toEqual(['panel-1', 'clone-1', 'clone-2']);
+      });
+    });
+  });
+
+  describe('when a snapshot clone has no key', () => {
+    it('throws an error', () => {
+      const sourcePanel = new VizPanel({ key: 'panel-1', title: 'Source', pluginId: 'timeseries' });
+      const cloneWithoutKey = new VizPanel({ title: 'No key', pluginId: 'timeseries' });
+      cloneWithoutKey.setState({ key: undefined });
+      const child = buildAutoGridItem({
+        body: sourcePanel,
+        variableName: 'env',
+        repeatedPanels: [cloneWithoutKey],
+      });
+      const layoutManager = buildLayoutManager({}, [child]);
+
+      expect(() => serializeAutoGridLayout(layoutManager, true)).toThrow(
+        'Snapshot serialization expected repeat clone to have a key'
+      );
+    });
+  });
+});
+
+describe('deserializeAutoGridLayout', () => {
+  describe('when layout kind is not AutoGridLayout', () => {
+    it('throws an error', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'GridLayout',
+        spec: { items: [] },
+      };
+
+      expect(() => deserializeAutoGridLayout(layout, {}, false)).toThrow('Invalid layout kind');
+    });
+  });
+
+  describe('when items are empty', () => {
+    it('returns an AutoGridLayoutManager with no children', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: { columnWidthMode: 'standard', rowHeightMode: 'standard', maxColumnCount: 3, items: [] },
+      };
+
+      const result = deserializeAutoGridLayout(layout, {}, false);
+
+      expect(result).toBeInstanceOf(AutoGridLayoutManager);
+      expect(result.state.layout.state.children).toHaveLength(0);
+    });
+  });
+
+  describe('when columnWidthMode is custom', () => {
+    it('uses the numeric columnWidth value', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: {
+          columnWidthMode: 'custom',
+          columnWidth: 600,
+          rowHeightMode: 'standard',
+          maxColumnCount: 3,
+          items: [],
+        },
+      };
+
+      const result = deserializeAutoGridLayout(layout, {}, false);
+
+      expect(result.state.columnWidth).toBe(600);
+    });
+  });
+
+  describe('when columnWidthMode is a named string', () => {
+    it('uses the named string as columnWidth', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: { columnWidthMode: 'wide', rowHeightMode: 'standard', maxColumnCount: 3, items: [] },
+      };
+
+      const result = deserializeAutoGridLayout(layout, {}, false);
+
+      expect(result.state.columnWidth).toBe('wide');
+    });
+  });
+
+  describe('when rowHeightMode is custom', () => {
+    it('uses the numeric rowHeight value', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: {
+          columnWidthMode: 'standard',
+          rowHeightMode: 'custom',
+          rowHeight: 400,
+          maxColumnCount: 3,
+          items: [],
+        },
+      };
+
+      const result = deserializeAutoGridLayout(layout, {}, false);
+
+      expect(result.state.rowHeight).toBe(400);
+    });
+  });
+
+  describe('when rowHeightMode is a named string', () => {
+    it('uses the named string as rowHeight', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: { columnWidthMode: 'standard', rowHeightMode: 'short', maxColumnCount: 3, items: [] },
+      };
+
+      const result = deserializeAutoGridLayout(layout, {}, false);
+
+      expect(result.state.rowHeight).toBe('short');
+    });
+  });
+
+  describe('when fillScreen is undefined', () => {
+    it('defaults to false', () => {
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: { columnWidthMode: 'standard', rowHeightMode: 'standard', maxColumnCount: 3, items: [] },
+      };
+
+      const result = deserializeAutoGridLayout(layout, {}, false);
+
+      expect(result.state.fillScreen).toBe(false);
+    });
+  });
+
+  describe('when a panelIdGenerator is provided', () => {
+    it('uses the generator for panel IDs', () => {
+      let nextId = 100;
+      const panelIdGenerator = () => nextId++;
+      const panel = buildPanel({ id: 1 });
+      const elements: DashboardV2Spec['elements'] = { 'panel-1': panel };
+      const layout: DashboardV2Spec['layout'] = {
+        kind: 'AutoGridLayout',
+        spec: {
+          columnWidthMode: 'standard',
+          rowHeightMode: 'standard',
+          maxColumnCount: 3,
+          items: [
+            {
+              kind: 'AutoGridLayoutItem',
+              spec: { element: { kind: 'ElementReference', name: 'panel-1' } },
+            },
+          ],
+        },
+      };
+
+      const result = deserializeAutoGridLayout(layout, elements, false, panelIdGenerator);
+
+      expect(result.state.layout.state.children[0].state.key).toBe('grid-item-100');
+    });
+  });
+});
+
+describe('deserializeAutoGridItem', () => {
+  describe('when the element is not found in elements', () => {
+    it('throws an error', () => {
+      const item: AutoGridLayoutItemKind = {
+        kind: 'AutoGridLayoutItem',
+        spec: { element: { kind: 'ElementReference', name: 'missing-panel' } },
+      };
+
+      expect(() => deserializeAutoGridItem(item, {})).toThrow(
+        'Panel with uid missing-panel not found in the dashboard elements'
+      );
+    });
+  });
+
+  describe('when the element is a PanelKind', () => {
+    it('builds a VizPanel and wraps it in an AutoGridItem', () => {
+      const panel = buildPanel({ id: 5, title: 'My Panel' });
+      const elements: DashboardV2Spec['elements'] = { 'panel-5': panel };
+      const item: AutoGridLayoutItemKind = {
+        kind: 'AutoGridLayoutItem',
+        spec: { element: { kind: 'ElementReference', name: 'panel-5' } },
+      };
+
+      expect(deserializeAutoGridItem(item, elements)).toBeAutoGridItemWith((result) => {
+        expect(result.state.body.state.title).toBe('My Panel');
+        expect(result.state.key).toBe('grid-item-5');
+      });
+    });
+  });
+
+  describe('when the element is a LibraryPanelKind', () => {
+    it('builds a library panel and wraps it in an AutoGridItem', () => {
+      const libPanel = buildLibraryPanel({ id: 7, title: 'Lib Panel' });
+      const elements: DashboardV2Spec['elements'] = { 'lib-7': libPanel };
+      const item: AutoGridLayoutItemKind = {
+        kind: 'AutoGridLayoutItem',
+        spec: { element: { kind: 'ElementReference', name: 'lib-7' } },
+      };
+
+      expect(deserializeAutoGridItem(item, elements)).toBeAutoGridItemWith((result) => {
+        expect(result.state.body.state.title).toBe('Lib Panel');
+        expect(result.state.key).toBe('grid-item-7');
+      });
+    });
+  });
+
+  describe('when the item has repeat config', () => {
+    it('sets variableName on the AutoGridItem', () => {
+      const panel = buildPanel({ id: 3 });
+      const elements: DashboardV2Spec['elements'] = { 'panel-3': panel };
+      const item: AutoGridLayoutItemKind = {
+        kind: 'AutoGridLayoutItem',
+        spec: {
+          element: { kind: 'ElementReference', name: 'panel-3' },
+          repeat: { mode: 'variable', value: 'host' },
+        },
+      };
+
+      const result = deserializeAutoGridItem(item, elements);
+
+      expect(result.state.variableName).toBe('host');
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.test.ts
@@ -1,0 +1,547 @@
+import { SceneGridLayout, VizPanel } from '@grafana/scenes';
+import {
+  Spec as DashboardV2Spec,
+  defaultPanelSpec,
+  GridLayoutItemKind,
+  PanelKind,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { LibraryPanelBehavior } from '../../scene/LibraryPanelBehavior';
+import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
+
+import {
+  deserializeDefaultGridLayout,
+  deserializeGridItem,
+  gridItemToGridLayoutItemKind,
+  serializeDefaultGridLayout,
+} from './DefaultGridLayoutSerializer';
+import './test-matchers';
+
+jest.mock('../../utils/dashboardSceneGraph', () => {
+  const original = jest.requireActual('../../utils/dashboardSceneGraph');
+  return {
+    ...original,
+    dashboardSceneGraph: {
+      ...original.dashboardSceneGraph,
+      getElementIdentifierForVizPanel: jest.fn().mockImplementation((panel: VizPanel) => {
+        return panel?.state?.key || 'panel-1';
+      }),
+    },
+  };
+});
+
+function buildPanelElement(overrides: Partial<PanelKind['spec']> = {}): PanelKind {
+  return {
+    kind: 'Panel',
+    spec: {
+      ...defaultPanelSpec(),
+      id: 1,
+      title: 'Test Panel',
+      ...overrides,
+    },
+  };
+}
+
+function buildGridItem(overrides: Partial<DashboardGridItem['state']> = {}): DashboardGridItem {
+  return new DashboardGridItem({
+    key: 'grid-item-1',
+    x: 0,
+    y: 0,
+    width: 12,
+    height: 8,
+    body: new VizPanel({ key: 'panel-1', title: 'Test Panel', pluginId: 'timeseries' }),
+    ...overrides,
+  });
+}
+
+function buildLayoutManager(children: DashboardGridItem[] = []): DefaultGridLayoutManager {
+  return new DefaultGridLayoutManager({
+    grid: new SceneGridLayout({ children }),
+  });
+}
+
+describe('serializeDefaultGridLayout', () => {
+  it('serializes an empty grid', () => {
+    const manager = buildLayoutManager();
+
+    const result = serializeDefaultGridLayout(manager);
+
+    expect(result).toEqual({
+      kind: 'GridLayout',
+      spec: { items: [] },
+    });
+  });
+
+  it('serializes a single panel', () => {
+    const manager = buildLayoutManager([buildGridItem({ x: 1, y: 2, width: 10, height: 6 })]);
+
+    const result = serializeDefaultGridLayout(manager);
+
+    expect(result).toEqual({
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: {
+              x: 1,
+              y: 2,
+              width: 10,
+              height: 6,
+              element: { kind: 'ElementReference', name: 'panel-1' },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('serializes multiple panels preserving order', () => {
+    const manager = buildLayoutManager([
+      buildGridItem({
+        key: 'grid-item-1',
+        x: 0,
+        y: 0,
+        width: 12,
+        height: 8,
+        body: new VizPanel({ key: 'panel-A', title: 'Panel A', pluginId: 'timeseries' }),
+      }),
+      buildGridItem({
+        key: 'grid-item-2',
+        x: 12,
+        y: 0,
+        width: 12,
+        height: 8,
+        body: new VizPanel({ key: 'panel-B', title: 'Panel B', pluginId: 'timeseries' }),
+      }),
+    ]);
+
+    expect(serializeDefaultGridLayout(manager)).toBeGridLayoutWith(({ items }) => {
+      expect(items).toHaveLength(2);
+      expect(items[0].spec.element.name).toBe('panel-A');
+      expect(items[1].spec.element.name).toBe('panel-B');
+    });
+  });
+});
+
+describe('gridItemToGridLayoutItemKind', () => {
+  it('produces correct position and element reference', () => {
+    const gridItem = buildGridItem({ x: 3, y: 5, width: 6, height: 4 });
+
+    const result = gridItemToGridLayoutItemKind(gridItem);
+
+    expect(result).toEqual({
+      kind: 'GridLayoutItem',
+      spec: {
+        x: 3,
+        y: 5,
+        width: 6,
+        height: 4,
+        element: { kind: 'ElementReference', name: 'panel-1' },
+      },
+    });
+  });
+
+  it('uses yOverride instead of the item y', () => {
+    const gridItem = buildGridItem({ y: 10 });
+
+    const result = gridItemToGridLayoutItemKind(gridItem, 42);
+
+    expect(result.spec.y).toBe(42);
+  });
+
+  it('includes repeat options when variableName is set', () => {
+    const gridItem = buildGridItem({ variableName: 'server', itemHeight: 8 });
+
+    const result = gridItemToGridLayoutItemKind(gridItem);
+
+    expect(result.spec.repeat).toEqual({
+      mode: 'variable',
+      value: 'server',
+    });
+  });
+
+  it('includes maxPerRow in repeat options', () => {
+    const gridItem = buildGridItem({ variableName: 'server', maxPerRow: 3, itemHeight: 8 });
+
+    const result = gridItemToGridLayoutItemKind(gridItem);
+
+    expect(result.spec.repeat?.maxPerRow).toBe(3);
+  });
+
+  it('includes direction in repeat options', () => {
+    const gridItem = buildGridItem({ variableName: 'server', repeatDirection: 'v', itemHeight: 8 });
+
+    const result = gridItemToGridLayoutItemKind(gridItem);
+
+    expect(result.spec.repeat?.direction).toBe('v');
+  });
+
+  it('throws when body is not a VizPanel', () => {
+    // Cast needed: DashboardGridItemState requires VizPanel, but we need a non-VizPanel to test the guard
+    const gridItem = new DashboardGridItem({
+      key: 'grid-item-1',
+      x: 0,
+      y: 0,
+      width: 12,
+      height: 8,
+      body: {} as VizPanel,
+    });
+
+    expect(() => gridItemToGridLayoutItemKind(gridItem)).toThrow('DashboardGridItem body expected to be VizPanel');
+  });
+});
+
+describe('deserializeDefaultGridLayout', () => {
+  it('throws for non-GridLayout kind', () => {
+    const layout = {
+      kind: 'RowsLayout',
+      spec: { rows: [] },
+    } as unknown as DashboardV2Spec['layout'];
+
+    expect(() => deserializeDefaultGridLayout(layout, {}, false)).toThrow('Invalid layout kind');
+  });
+
+  it('deserializes empty items', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'GridLayout',
+      spec: { items: [] },
+    };
+
+    const result = deserializeDefaultGridLayout(layout, {}, false);
+
+    expect(result).toBeInstanceOf(DefaultGridLayoutManager);
+    expect(result.state.grid.state.children).toHaveLength(0);
+  });
+
+  it('deserializes a single panel element', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: {
+              x: 2,
+              y: 3,
+              width: 10,
+              height: 5,
+              element: { kind: 'ElementReference', name: 'panel-1' },
+            },
+          },
+        ],
+      },
+    };
+    const elements: DashboardV2Spec['elements'] = {
+      'panel-1': buildPanelElement({ id: 1, title: 'My Panel' }),
+    };
+
+    const result = deserializeDefaultGridLayout(layout, elements, false);
+
+    expect(result.state.grid.state.children).toHaveLength(1);
+    expect(result.state.grid.state.children[0]).toBeDashboardGridItemWith((child) => {
+      expect(child.state.x).toBe(2);
+      expect(child.state.y).toBe(3);
+      expect(child.state.width).toBe(10);
+      expect(child.state.height).toBe(5);
+      expect(child.state.body).toBeInstanceOf(VizPanel);
+    });
+  });
+
+  it('deserializes a panel with repeat options', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: {
+              x: 0,
+              y: 0,
+              width: 12,
+              height: 8,
+              element: { kind: 'ElementReference', name: 'panel-1' },
+              repeat: { mode: 'variable', value: 'server', direction: 'v', maxPerRow: 2 },
+            },
+          },
+        ],
+      },
+    };
+    const elements: DashboardV2Spec['elements'] = {
+      'panel-1': buildPanelElement(),
+    };
+
+    const result = deserializeDefaultGridLayout(layout, elements, false);
+
+    expect(result.state.grid.state.children[0]).toBeDashboardGridItemWith((child) => {
+      expect(child.state.variableName).toBe('server');
+      expect(child.state.repeatDirection).toBe('v');
+      expect(child.state.maxPerRow).toBe(2);
+    });
+  });
+
+  it('forces width to 24 when repeat direction is horizontal', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: {
+              x: 0,
+              y: 0,
+              width: 6,
+              height: 8,
+              element: { kind: 'ElementReference', name: 'panel-1' },
+              repeat: { mode: 'variable', value: 'env', direction: 'h' },
+            },
+          },
+        ],
+      },
+    };
+    const elements: DashboardV2Spec['elements'] = {
+      'panel-1': buildPanelElement(),
+    };
+
+    const result = deserializeDefaultGridLayout(layout, elements, false);
+
+    expect(result.state.grid.state.children[0]).toBeDashboardGridItemWith((child) => {
+      expect(child.state.width).toBe(24);
+    });
+  });
+
+  it('deserializes a library panel element', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: {
+              x: 0,
+              y: 0,
+              width: 12,
+              height: 8,
+              element: { kind: 'ElementReference', name: 'lib-panel-1' },
+            },
+          },
+        ],
+      },
+    };
+    const elements: DashboardV2Spec['elements'] = {
+      'lib-panel-1': {
+        kind: 'LibraryPanel',
+        spec: { id: 10, title: 'Lib Panel', libraryPanel: { uid: 'lib-uid', name: 'lib-name' } },
+      },
+    };
+
+    const result = deserializeDefaultGridLayout(layout, elements, false);
+
+    expect(result.state.grid.state.children[0]).toBeDashboardGridItemWith((child) => {
+      expect(child.state.body).toBeInstanceOf(VizPanel);
+      const behaviors = child.state.body.state.$behaviors ?? [];
+      const libBehavior = behaviors.find((b) => b instanceof LibraryPanelBehavior);
+      expect(libBehavior).toBeDefined();
+    });
+  });
+
+  it('preserves order when deserializing multiple items', () => {
+    const items: GridLayoutItemKind[] = [
+      {
+        kind: 'GridLayoutItem',
+        spec: { x: 0, y: 0, width: 12, height: 8, element: { kind: 'ElementReference', name: 'p1' } },
+      },
+      {
+        kind: 'GridLayoutItem',
+        spec: { x: 12, y: 0, width: 12, height: 8, element: { kind: 'ElementReference', name: 'p2' } },
+      },
+      {
+        kind: 'GridLayoutItem',
+        spec: { x: 0, y: 8, width: 24, height: 4, element: { kind: 'ElementReference', name: 'p3' } },
+      },
+    ];
+    const layout: DashboardV2Spec['layout'] = { kind: 'GridLayout', spec: { items } };
+    const elements: DashboardV2Spec['elements'] = {
+      p1: buildPanelElement({ id: 1, title: 'P1' }),
+      p2: buildPanelElement({ id: 2, title: 'P2' }),
+      p3: buildPanelElement({ id: 3, title: 'P3' }),
+    };
+
+    const result = deserializeDefaultGridLayout(layout, elements, false);
+
+    const children = result.state.grid.state.children;
+    expect(children).toHaveLength(3);
+    expect(children[0]).toBeDashboardGridItemWith((child) => expect(child.state.x).toBe(0));
+    expect(children[1]).toBeDashboardGridItemWith((child) => expect(child.state.x).toBe(12));
+    expect(children[2]).toBeDashboardGridItemWith((child) => expect(child.state.width).toBe(24));
+  });
+
+  it('uses custom panelIdGenerator for keys', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'GridLayout',
+      spec: {
+        items: [
+          {
+            kind: 'GridLayoutItem',
+            spec: { x: 0, y: 0, width: 12, height: 8, element: { kind: 'ElementReference', name: 'p1' } },
+          },
+        ],
+      },
+    };
+    const elements: DashboardV2Spec['elements'] = {
+      p1: buildPanelElement({ id: 1 }),
+    };
+    let counter = 100;
+    const panelIdGenerator = () => counter++;
+
+    const result = deserializeDefaultGridLayout(layout, elements, false, panelIdGenerator);
+
+    expect(result.state.grid.state.children[0]).toBeDashboardGridItemWith((child) => {
+      expect(child.state.key).toBe('grid-item-100');
+    });
+  });
+});
+
+describe('deserializeGridItem', () => {
+  it('throws when the element reference is not found', () => {
+    const item: GridLayoutItemKind = {
+      kind: 'GridLayoutItem',
+      spec: { x: 0, y: 0, width: 12, height: 8, element: { kind: 'ElementReference', name: 'missing' } },
+    };
+    const elements: DashboardV2Spec['elements'] = {};
+
+    expect(() => deserializeGridItem(item, elements)).toThrow(
+      'Panel with uid missing not found in the dashboard elements'
+    );
+  });
+});
+
+describe('repeaterToLayoutItems (via serializeDefaultGridLayout)', () => {
+  it('serializes a repeater as a single item when not a snapshot', () => {
+    const manager = buildLayoutManager([buildGridItem({ variableName: 'host', itemHeight: 8 })]);
+
+    expect(serializeDefaultGridLayout(manager, false)).toBeGridLayoutWith(({ items }) => {
+      expect(items).toHaveLength(1);
+      expect(items[0].spec.repeat).toEqual({
+        mode: 'variable',
+        value: 'host',
+      });
+    });
+  });
+
+  it('serializes expanded horizontal clones in snapshot mode', () => {
+    const sourcePanel = new VizPanel({ key: 'panel-1', title: 'Source', pluginId: 'timeseries' });
+    const clone1 = new VizPanel({
+      key: 'clone-1',
+      title: 'Clone 1',
+      pluginId: 'timeseries',
+      repeatSourceKey: 'panel-1',
+    });
+    const clone2 = new VizPanel({
+      key: 'clone-2',
+      title: 'Clone 2',
+      pluginId: 'timeseries',
+      repeatSourceKey: 'panel-1',
+    });
+
+    const gridItem = new DashboardGridItem({
+      key: 'grid-item-1',
+      x: 0,
+      y: 0,
+      width: 24,
+      height: 8,
+      itemHeight: 8,
+      body: sourcePanel,
+      variableName: 'host',
+      repeatDirection: 'h',
+      maxPerRow: 2,
+      repeatedPanels: [clone1, clone2],
+    });
+
+    const manager = buildLayoutManager([gridItem]);
+
+    expect(serializeDefaultGridLayout(manager, true)).toBeGridLayoutWith(({ items }) => {
+      expect(items).toHaveLength(3);
+      expect(items[0].spec.element.name).toBe('panel-1');
+      expect(items[1].spec.element.name).toBe('clone-1');
+      expect(items[2].spec.element.name).toBe('clone-2');
+    });
+  });
+
+  it('serializes expanded vertical clones in snapshot mode', () => {
+    const sourcePanel = new VizPanel({ key: 'panel-1', title: 'Source', pluginId: 'timeseries' });
+    const clone1 = new VizPanel({
+      key: 'clone-1',
+      title: 'Clone 1',
+      pluginId: 'timeseries',
+      repeatSourceKey: 'panel-1',
+    });
+
+    const gridItem = new DashboardGridItem({
+      key: 'grid-item-1',
+      x: 5,
+      y: 10,
+      width: 12,
+      height: 16,
+      itemHeight: 8,
+      body: sourcePanel,
+      variableName: 'host',
+      repeatDirection: 'v',
+      repeatedPanels: [clone1],
+    });
+
+    const manager = buildLayoutManager([gridItem]);
+
+    expect(serializeDefaultGridLayout(manager, true)).toBeGridLayoutWith(({ items }) => {
+      expect(items).toHaveLength(2);
+      expect(items[0].spec.x).toBe(5);
+      expect(items[0].spec.y).toBe(10);
+      expect(items[1].spec.x).toBe(5);
+      expect(items[1].spec.y).toBe(18);
+    });
+  });
+
+  it('returns empty array for snapshot of a library panel repeater', () => {
+    const libPanel = new VizPanel({
+      key: 'panel-1',
+      title: 'Lib',
+      pluginId: 'timeseries',
+      $behaviors: [new LibraryPanelBehavior({ uid: 'lib-uid', name: 'lib-name' })],
+    });
+
+    const gridItem = new DashboardGridItem({
+      key: 'grid-item-1',
+      x: 0,
+      y: 0,
+      width: 24,
+      height: 8,
+      itemHeight: 8,
+      body: libPanel,
+      variableName: 'host',
+      repeatedPanels: [
+        new VizPanel({ key: 'clone-1', title: 'Clone', pluginId: 'timeseries', repeatSourceKey: 'panel-1' }),
+      ],
+    });
+
+    const manager = buildLayoutManager([gridItem]);
+
+    expect(serializeDefaultGridLayout(manager, true)).toBeGridLayoutWith(({ items }) => {
+      expect(items).toEqual([]);
+    });
+  });
+
+  it('falls back to single item when snapshot repeater has not expanded yet', () => {
+    const gridItem = buildGridItem({ variableName: 'host', itemHeight: 8 });
+
+    const manager = buildLayoutManager([gridItem]);
+
+    expect(serializeDefaultGridLayout(manager, true)).toBeGridLayoutWith(({ items }) => {
+      expect(items).toHaveLength(1);
+      expect(items[0].spec.repeat).toEqual({
+        mode: 'variable',
+        value: 'host',
+      });
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
@@ -1,13 +1,40 @@
-import { SceneGridLayout } from '@grafana/scenes';
+import { SceneGridLayout, VizPanel } from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
+import { ConditionalRenderingVariable } from '../../conditional-rendering/conditions/ConditionalRenderingVariable';
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
+import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
 
-import { deserializeRowsLayout, serializeRowsLayout } from './RowsLayoutSerializer';
+import { deserializeRowsLayout, serializeRow, serializeRowsLayout } from './RowsLayoutSerializer';
+
+jest.mock('../../utils/dashboardSceneGraph', () => {
+  const original = jest.requireActual('../../utils/dashboardSceneGraph');
+  return {
+    ...original,
+    dashboardSceneGraph: {
+      ...original.dashboardSceneGraph,
+      getElementIdentifierForVizPanel: jest.fn().mockImplementation((panel: VizPanel) => {
+        return panel?.state?.key || 'panel-1';
+      }),
+    },
+  };
+});
+
+function buildRowItem(overrides: Partial<RowItem['state']> = {}): RowItem {
+  return new RowItem({
+    title: 'Row 1',
+    collapse: false,
+    layout: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({ children: [] }),
+    }),
+    ...overrides,
+  });
+}
 
 describe('deserialization', () => {
   it('should deserialize rows layout with default grid child', () => {
@@ -169,6 +196,132 @@ describe('deserialization', () => {
 
     const row = deserialized.state.rows[0];
     expect(row.state.repeatByVariable).toBe('foo');
+  });
+
+  it('throws for non-RowsLayout kind', () => {
+    const layout = {
+      kind: 'TabsLayout',
+      spec: { tabs: [] },
+    } as unknown as DashboardV2Spec['layout'];
+
+    expect(() => deserializeRowsLayout(layout, {}, false)).toThrow('Invalid layout kind');
+  });
+
+  it('should deserialize row with conditional rendering', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'RowsLayout',
+      spec: {
+        rows: [
+          {
+            kind: 'RowsLayoutRow',
+            spec: {
+              title: 'Conditional',
+              collapse: false,
+              layout: { kind: 'GridLayout', spec: { items: [] } },
+              conditionalRendering: {
+                kind: 'ConditionalRenderingGroup',
+                spec: {
+                  visibility: 'show',
+                  condition: 'and',
+                  items: [
+                    {
+                      kind: 'ConditionalRenderingVariable',
+                      spec: { variable: 'env', operator: 'equals', value: 'prod' },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const deserialized = deserializeRowsLayout(layout, {}, false);
+
+    const condRendering = deserialized.state.rows[0].state.conditionalRendering;
+    expect(condRendering).toBeInstanceOf(ConditionalRenderingGroup);
+    expect(condRendering?.state.conditions).toHaveLength(1);
+  });
+});
+
+describe('serializeRowsLayout', () => {
+  it('filters out rows with repeatSourceKey', () => {
+    const source = buildRowItem({ title: 'Source' });
+    const clone = buildRowItem({ title: 'Clone', repeatSourceKey: 'source-key' });
+    const manager = new RowsLayoutManager({ rows: [source, clone] });
+
+    const serialized = serializeRowsLayout(manager);
+
+    expect(serialized.kind).toBe('RowsLayout');
+    if (serialized.kind !== 'RowsLayout') {
+      throw new Error('unexpected');
+    }
+    expect(serialized.spec.rows).toHaveLength(1);
+    expect(serialized.spec.rows[0].spec.title).toBe('Source');
+  });
+});
+
+describe('serializeRow', () => {
+  it('normalizes Y coordinates to be relative within the row', () => {
+    const row = buildRowItem({
+      layout: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({
+          children: [
+            new DashboardGridItem({
+              key: 'grid-item-1',
+              x: 0,
+              y: 10,
+              width: 12,
+              height: 8,
+              body: new VizPanel({ key: 'panel-A', title: 'A', pluginId: 'timeseries' }),
+            }),
+            new DashboardGridItem({
+              key: 'grid-item-2',
+              x: 12,
+              y: 14,
+              width: 12,
+              height: 4,
+              body: new VizPanel({ key: 'panel-B', title: 'B', pluginId: 'timeseries' }),
+            }),
+          ],
+        }),
+      }),
+    });
+
+    const result = serializeRow(row);
+
+    expect(result.spec.layout.kind).toBe('GridLayout');
+    if (result.spec.layout.kind !== 'GridLayout') {
+      throw new Error('unexpected');
+    }
+    const items = result.spec.layout.spec.items;
+    expect(items[0].spec.y).toBe(0);
+    expect(items[1].spec.y).toBe(4);
+  });
+
+  it('includes conditional rendering when it has items', () => {
+    const condRendering = new ConditionalRenderingGroup({
+      condition: 'and',
+      visibility: 'show',
+      renderHidden: false,
+      conditions: [ConditionalRenderingVariable.createEmpty('myVar')],
+      result: true,
+    });
+    const row = buildRowItem({ conditionalRendering: condRendering });
+
+    const result = serializeRow(row);
+
+    expect(result.spec.conditionalRendering).toBeDefined();
+    expect(result.spec.conditionalRendering?.spec.items).toHaveLength(1);
+  });
+
+  it('omits conditional rendering when it has no items', () => {
+    const row = buildRowItem();
+
+    const result = serializeRow(row);
+
+    expect(result.spec.conditionalRendering).toBeUndefined();
   });
 });
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
@@ -1,26 +1,171 @@
+import { SceneGridLayout } from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
+import { ConditionalRenderingVariable } from '../../conditional-rendering/conditions/ConditionalRenderingVariable';
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
+import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
+import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';
 
-import { deserializeTabsLayout } from './TabsLayoutSerializer';
+import { deserializeTabsLayout, serializeTab, serializeTabsLayout } from './TabsLayoutSerializer';
+import './test-matchers';
 
-describe('deserialization', () => {
-  it('should deserialize tabs layout with row child', () => {
+function buildTabItem(overrides: Partial<TabItem['state']> = {}): TabItem {
+  return new TabItem({
+    title: 'Tab 1',
+    layout: new AutoGridLayoutManager({
+      layout: new AutoGridLayout({}),
+    }),
+    ...overrides,
+  });
+}
+
+function buildTabsLayoutManager(tabs: TabItem[] = []): TabsLayoutManager {
+  return new TabsLayoutManager({ tabs });
+}
+
+describe('serializeTabsLayout', () => {
+  it('serializes an empty tabs layout', () => {
+    const manager = buildTabsLayoutManager();
+
+    const result = serializeTabsLayout(manager);
+
+    expect(result).toEqual({
+      kind: 'TabsLayout',
+      spec: { tabs: [] },
+    });
+  });
+
+  it('serializes a single tab with its title and child layout', () => {
+    const tab = buildTabItem({ title: 'Overview' });
+    const manager = buildTabsLayoutManager([tab]);
+
+    expect(serializeTabsLayout(manager)).toBeTabsLayoutWith(({ tabs }) => {
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].spec.title).toBe('Overview');
+      expect(tabs[0].spec.layout.kind).toBe('AutoGridLayout');
+    });
+  });
+
+  it('serializes multiple tabs preserving order', () => {
+    const tab1 = buildTabItem({ title: 'First' });
+    const tab2 = buildTabItem({
+      title: 'Second',
+      layout: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({ children: [] }),
+      }),
+    });
+    const manager = buildTabsLayoutManager([tab1, tab2]);
+
+    expect(serializeTabsLayout(manager)).toBeTabsLayoutWith(({ tabs }) => {
+      expect(tabs).toHaveLength(2);
+      expect(tabs[0].spec.title).toBe('First');
+      expect(tabs[0].spec.layout.kind).toBe('AutoGridLayout');
+      expect(tabs[1].spec.title).toBe('Second');
+      expect(tabs[1].spec.layout.kind).toBe('GridLayout');
+    });
+  });
+
+  it('filters out tabs with repeatSourceKey', () => {
+    const source = buildTabItem({ title: 'Source' });
+    const clone = buildTabItem({ title: 'Clone', repeatSourceKey: 'source-key' });
+    const manager = buildTabsLayoutManager([source, clone]);
+
+    expect(serializeTabsLayout(manager)).toBeTabsLayoutWith(({ tabs }) => {
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].spec.title).toBe('Source');
+    });
+  });
+
+  it('includes repeat config when repeatByVariable is set', () => {
+    const tab = buildTabItem({ title: 'Repeated', repeatByVariable: 'env' });
+    const manager = buildTabsLayoutManager([tab]);
+
+    expect(serializeTabsLayout(manager)).toBeTabsLayoutWith(({ tabs }) => {
+      expect(tabs[0].spec.repeat).toEqual({
+        mode: 'variable',
+        value: 'env',
+      });
+    });
+  });
+});
+
+describe('serializeTab', () => {
+  it('includes repeat config when repeatByVariable is set', () => {
+    const tab = buildTabItem({ title: 'Repeated', repeatByVariable: 'region' });
+
+    const result = serializeTab(tab);
+
+    expect(result).toMatchObject({
+      kind: 'TabsLayoutTab',
+      spec: {
+        title: 'Repeated',
+        repeat: { mode: 'variable', value: 'region' },
+      },
+    });
+  });
+
+  it('omits repeat when repeatByVariable is undefined', () => {
+    const tab = buildTabItem({ title: 'Static' });
+
+    const result = serializeTab(tab);
+
+    expect(result.spec.repeat).toBeUndefined();
+  });
+
+  it('includes conditional rendering when it has items', () => {
+    const condRendering = new ConditionalRenderingGroup({
+      condition: 'and',
+      visibility: 'show',
+      renderHidden: false,
+      conditions: [ConditionalRenderingVariable.createEmpty('myVar')],
+      result: true,
+    });
+    const tab = buildTabItem({ conditionalRendering: condRendering });
+
+    const result = serializeTab(tab);
+
+    expect(result.spec.conditionalRendering).toBeDefined();
+    expect(result.spec.conditionalRendering?.spec.items).toHaveLength(1);
+  });
+
+  it('omits conditional rendering when it has no items', () => {
+    const tab = buildTabItem();
+
+    const result = serializeTab(tab);
+
+    expect(result.spec.conditionalRendering).toBeUndefined();
+  });
+});
+
+describe('deserializeTabsLayout', () => {
+  it('throws for non-TabsLayout kind', () => {
+    const layout = {
+      kind: 'RowsLayout',
+      spec: { rows: [] },
+    } as unknown as DashboardV2Spec['layout'];
+
+    expect(() => deserializeTabsLayout(layout, {}, false)).toThrow('Invalid layout kind');
+  });
+
+  it('deserializes tabs layout with row child', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
         tabs: [{ kind: 'TabsLayoutTab', spec: { title: 'Tab 1', layout: { kind: 'RowsLayout', spec: { rows: [] } } } }],
       },
     };
+
     const deserialized = deserializeTabsLayout(layout, {}, false);
+
     expect(deserialized).toBeInstanceOf(TabsLayoutManager);
     expect(deserialized.state.tabs[0].state.layout).toBeInstanceOf(RowsLayoutManager);
   });
 
-  it('should deserialize tabs layout with responsive grid child', () => {
+  it('deserializes tabs layout with responsive grid child', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
@@ -38,12 +183,14 @@ describe('deserialization', () => {
         ],
       },
     };
+
     const deserialized = deserializeTabsLayout(layout, {}, false);
+
     expect(deserialized).toBeInstanceOf(TabsLayoutManager);
     expect(deserialized.state.tabs[0].state.layout).toBeInstanceOf(AutoGridLayoutManager);
   });
 
-  it('should deserialize tabs layout with default grid child', () => {
+  it('deserializes tabs layout with default grid child', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
@@ -55,12 +202,14 @@ describe('deserialization', () => {
         ],
       },
     };
+
     const deserialized = deserializeTabsLayout(layout, {}, false);
+
     expect(deserialized).toBeInstanceOf(TabsLayoutManager);
     expect(deserialized.state.tabs[0].state.layout).toBeInstanceOf(DefaultGridLayoutManager);
   });
 
-  it('should handle multiple tabs', () => {
+  it('deserializes multiple tabs preserving order', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
@@ -79,21 +228,84 @@ describe('deserialization', () => {
         ],
       },
     };
+
     const deserialized = deserializeTabsLayout(layout, {}, false);
+
     expect(deserialized).toBeInstanceOf(TabsLayoutManager);
+    expect(deserialized.state.tabs).toHaveLength(2);
+    expect(deserialized.state.tabs[0].state.title).toBe('Tab 1');
     expect(deserialized.state.tabs[0].state.layout).toBeInstanceOf(AutoGridLayoutManager);
+    expect(deserialized.state.tabs[1].state.title).toBe('Tab 2');
     expect(deserialized.state.tabs[1].state.layout).toBeInstanceOf(DefaultGridLayoutManager);
   });
 
-  it('should handle 0 tabs', () => {
+  it('deserializes 0 tabs', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'TabsLayout',
+      spec: { tabs: [] },
+    };
+
+    const deserialized = deserializeTabsLayout(layout, {}, false);
+
+    expect(deserialized).toBeInstanceOf(TabsLayoutManager);
+    expect(deserialized.state.tabs).toHaveLength(0);
+  });
+
+  it('deserializes tab with repeat config', () => {
     const layout: DashboardV2Spec['layout'] = {
       kind: 'TabsLayout',
       spec: {
-        tabs: [],
+        tabs: [
+          {
+            kind: 'TabsLayoutTab',
+            spec: {
+              title: 'Repeated',
+              layout: { kind: 'GridLayout', spec: { items: [] } },
+              repeat: { mode: 'variable', value: 'env' },
+            },
+          },
+        ],
       },
     };
+
     const deserialized = deserializeTabsLayout(layout, {}, false);
-    expect(deserialized).toBeInstanceOf(TabsLayoutManager);
-    expect(deserialized.state.tabs).toHaveLength(0);
+
+    expect(deserialized.state.tabs[0].state.repeatByVariable).toBe('env');
+  });
+
+  it('deserializes tab with conditional rendering', () => {
+    const layout: DashboardV2Spec['layout'] = {
+      kind: 'TabsLayout',
+      spec: {
+        tabs: [
+          {
+            kind: 'TabsLayoutTab',
+            spec: {
+              title: 'Conditional',
+              layout: { kind: 'GridLayout', spec: { items: [] } },
+              conditionalRendering: {
+                kind: 'ConditionalRenderingGroup',
+                spec: {
+                  visibility: 'show',
+                  condition: 'and',
+                  items: [
+                    {
+                      kind: 'ConditionalRenderingVariable',
+                      spec: { variable: 'myVar', operator: 'equals', value: 'foo' },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const deserialized = deserializeTabsLayout(layout, {}, false);
+
+    const condRendering = deserialized.state.tabs[0].state.conditionalRendering;
+    expect(condRendering).toBeInstanceOf(ConditionalRenderingGroup);
+    expect(condRendering?.state.conditions).toHaveLength(1);
   });
 });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/test-matchers.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/test-matchers.ts
@@ -1,0 +1,152 @@
+import {
+  Spec as DashboardV2Spec,
+  AutoGridLayoutSpec,
+  GridLayoutSpec,
+  TabsLayoutSpec,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
+import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBeAutoGridLayout(): R;
+      toBeAutoGridLayoutWith(fn: (spec: AutoGridLayoutSpec) => void): R;
+      toBeAutoGridItem(): R;
+      toBeAutoGridItemWith(fn: (item: AutoGridItem) => void): R;
+      toBeGridLayout(): R;
+      toBeGridLayoutWith(fn: (spec: GridLayoutSpec) => void): R;
+      toBeDashboardGridItem(): R;
+      toBeDashboardGridItemWith(fn: (item: DashboardGridItem) => void): R;
+      toBeTabsLayout(): R;
+      toBeTabsLayoutWith(fn: (spec: TabsLayoutSpec) => void): R;
+    }
+  }
+}
+
+function getReceivedName(received: unknown): string {
+  if (typeof received === 'object' && received !== null) {
+    return received.constructor?.name ?? typeof received;
+  }
+  return typeof received;
+}
+
+expect.extend({
+  toBeAutoGridLayout(received: DashboardV2Spec['layout']) {
+    const pass = received?.kind === 'AutoGridLayout';
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected layout not to be AutoGridLayout, but got kind "${received.kind}"`
+          : `expected layout to be AutoGridLayout, but got kind "${received.kind}"`,
+    };
+  },
+  toBeAutoGridLayoutWith(received: DashboardV2Spec['layout'], fn: (spec: AutoGridLayoutSpec) => void) {
+    const pass = received?.kind === 'AutoGridLayout';
+    if (pass) {
+      fn(received.spec);
+    }
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected layout not to be AutoGridLayout, but got kind "${received.kind}"`
+          : `expected layout to be AutoGridLayout, but got kind "${received.kind}"`,
+    };
+  },
+  toBeAutoGridItem(received: unknown) {
+    const pass = received instanceof AutoGridItem;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected value not to be an AutoGridItem`
+          : `expected value to be an AutoGridItem, but got ${getReceivedName(received)}`,
+    };
+  },
+  toBeAutoGridItemWith(received: unknown, fn: (item: AutoGridItem) => void) {
+    const pass = received instanceof AutoGridItem;
+    if (pass) {
+      fn(received);
+    }
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected value not to be an AutoGridItem`
+          : `expected value to be an AutoGridItem, but got ${getReceivedName(received)}`,
+    };
+  },
+  toBeGridLayout(received: DashboardV2Spec['layout']) {
+    const pass = received?.kind === 'GridLayout';
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected layout not to be GridLayout, but got kind "${received.kind}"`
+          : `expected layout to be GridLayout, but got kind "${received.kind}"`,
+    };
+  },
+  toBeGridLayoutWith(received: DashboardV2Spec['layout'], fn: (spec: GridLayoutSpec) => void) {
+    const pass = received?.kind === 'GridLayout';
+    if (pass) {
+      fn(received.spec);
+    }
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected layout not to be GridLayout, but got kind "${received.kind}"`
+          : `expected layout to be GridLayout, but got kind "${received.kind}"`,
+    };
+  },
+  toBeDashboardGridItem(received: unknown) {
+    const pass = received instanceof DashboardGridItem;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected value not to be a DashboardGridItem`
+          : `expected value to be a DashboardGridItem, but got ${getReceivedName(received)}`,
+    };
+  },
+  toBeDashboardGridItemWith(received: unknown, fn: (item: DashboardGridItem) => void) {
+    const pass = received instanceof DashboardGridItem;
+    if (pass) {
+      fn(received);
+    }
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected value not to be a DashboardGridItem`
+          : `expected value to be a DashboardGridItem, but got ${getReceivedName(received)}`,
+    };
+  },
+  toBeTabsLayout(received: DashboardV2Spec['layout']) {
+    const pass = received?.kind === 'TabsLayout';
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected layout not to be TabsLayout, but got kind "${received.kind}"`
+          : `expected layout to be TabsLayout, but got kind "${received.kind}"`,
+    };
+  },
+  toBeTabsLayoutWith(received: DashboardV2Spec['layout'], fn: (spec: TabsLayoutSpec) => void) {
+    const pass = received?.kind === 'TabsLayout';
+    if (pass) {
+      fn(received.spec);
+    }
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected layout not to be TabsLayout, but got kind "${received.kind}"`
+          : `expected layout to be TabsLayout, but got kind "${received.kind}"`,
+    };
+  },
+});


### PR DESCRIPTION
### Coverage gap analysis of dynamic dashboards (`dashboard-scene` folder)

| # | Area | Untested files (with logic) | Total untested LOC | Why focus here |
|---|------|----------------------------|-------------------|----------------|
| **🧪 1** | **Saving / Save forms** | `SaveDashboardAsForm.tsx` (240), `SaveDashboardForm.tsx` (264), `SaveProvisionedDashboardForm.tsx` (96), `useSaveDashboard.ts` (99), `DetectChangesWorker.ts` (39) | **~738** | **Critical user path** — save-as, overwrite, provisioned save all have different branching logic (permissions, folder selection, overwrite confirmation). A bug here means data loss. Only `SaveDashboardDrawer` and `DashboardSceneChangeTracker` have tests; the actual form logic & hook are untested. |
| **🧪 2** | **Layout serializers** | `AutoGridLayoutSerializer.ts` (149), `DefaultGridLayoutSerializer.ts` (216) | **~365** | `RowsLayoutSerializer` and `TabsLayoutSerializer` have tests, but the two most common layouts (**default grid** and **auto-grid**) don't. These are the scene-to-JSON and JSON-to-scene round-trip paths — regressions silently corrupt saved dashboards. |
| **3** | **Panel inspect** | `InspectDataTab.tsx` (76), `InspectQueryTab.tsx` (36), `InspectStatsTab.tsx` (30), `InspectMetaDataTab.tsx` (32), `PanelInspectDrawer.tsx` (123) | **~297** | Only `InspectJsonTab` and `HelpWizard` are tested. The data/query/stats tabs are core debugging tools for users. The drawer orchestration (`PanelInspectDrawer`) has no tests either. |
| **4** | **Layout items (Rows/Tabs)** | `RowItem.tsx` (247), `RowItemEditor.tsx` (172), `TabItem.tsx` (278), `TabItemEditor.tsx` (145), `AutoGridItem.tsx` (159), `AutoGridLayout.tsx` (233) | **~1,234** | Layout managers have tests, but the **individual layout items** (which implement `EditableDashboardElement`, handle panel operations, clone, repeat) are not directly tested. `TabItem` alone is 278 lines with complex state. |
| **5** | **Sharing (snapshots, external, internal)** | `ShareSnapshot.tsx` (178), `UpsertSnapshot.tsx` (78), `ShareInternally.tsx` (108), `ShareConfiguration.tsx` (145), `ShareDrawerConfirmAction.tsx` (52) | **~561** | `ShareExternally` and `ShareButton` are tested, but snapshots, internal sharing, and the configuration flow are not. These involve API calls and permission checks. |
| **6** | **Mutation API individual commands** | `movePanel.ts` (132), `movePanelsHelper.ts` (108), `updateLayout.ts` (211), `getLayout.ts` (123), `addRow.ts` (91), `addTab.ts` (85), + 12 more | **~1,200+** | `layoutCommands.test.ts` (72 cases) exercises many of these via integration, but the **individual handler functions** have no isolated unit tests. `updateLayout` (211 LOC) and `movePanel` (132 LOC) have particularly complex logic worth testing in isolation. |
| **🧪 7** | **Conditional rendering utilities** | `serializers.ts` (25), `utils.ts` (33), `useConditionalRenderingEditor.tsx` (59), `ConditionalRenderingOverlay.tsx` (55) | **~172** | The three condition types have tests, but the shared serializers/utils and the editor hook are untested. These are the glue that connects the condition model to the UI. |
| **8** | **Panel edit (viz picker, splitter)** | `PanelVizTypePicker.tsx` (223), `useSnappingSplitter.ts` (129), `PanelEditControls.tsx` (41), `ShareDataProvider.tsx` (28) | **~421** | The viz type picker is a complex UI component (search, filtering, recent panels). The snapping splitter hook manages drag state and keyboard shortcuts. |
| **9** | **Scene components** | `AlertStatesDataLayer.ts` (182), `DashboardReloadBehavior.ts` (85), `DashboardDataLayerSet.tsx` (90), `PanelNonApplicableDrilldownsSubHeader.tsx` (171), `DrilldownControls.tsx` (74) | **~602** | `AlertStatesDataLayer` has non-trivial polling and state management. `DashboardReloadBehavior` handles auto-refresh. These are background behaviors that are easy to regress silently. |

### ✨ Skill used

```text
---
name: add-unit-tests
description: >-
  Write unit tests for dashboard-scene React components and React hooks
  following established team conventions. Use when creating or modifying
  component/hook tests under public/app/features/dashboard-scene/.
---

# Dashboard-Scene Unit Testing Patterns

> This skill applies only when testing **React components** and/or **React hooks**.

## Workflow

- **Start by checking if there are any existing tests** for the feature or component being tested. Look for `*.test.ts` / `*.test.tsx` files in the same directory or nearby.
- **Create the list of tests to implement to have full feature coverage** (not code coverage), including edge cases. Think in terms of user-visible behaviors and business rules, not lines of code. Present the list to the user for approval before starting implementation.
- **When writing tests, if there are existing tests, favor consistency, ALWAYS.** Preserve existing conventions when adding new tests, unless explicitly specified (e.g. `test()` vs `it()`, naming style, setup helpers shape).
- **After implementing each test, pause and ask for confirmation** before moving to the next one. Do not batch-implement the full list without user approval at each step.

## Structure & Organization

- **One `describe` block per component/function** under test. Nested `describe` blocks group related scenarios and follow the `component → scenario/context → expected behaviour` pattern: `describe('<Component />', () => { describe('when X', () => { test('then Y', ...) }) })`.
- **When a scenario has multiple outcomes**, put `when X` in a nested `describe` and each outcome in its own `test('then Y', ...)`. For a single outcome, skip the nesting: `test('when X then Y', ...)`.
- **Test names use natural language** — `test('renders ...')` or `test('if X, then Y')`.
- **Follow the Arrange-Act-Assert pattern**: set up the test data and render (Arrange), perform the interaction or trigger the behavior (Act), then verify the outcome (Assert). Keep the three phases visually distinct with a blank line between each.
- **The "when..." in a test name should mirror the Arrange phase.** This keeps each test self-explanatory: a reader should be able to scan the name and the code and understand it at a glance, without chasing shared setup or abstractions.
- **Feature toggles get their own top-level `describe` block** (e.g. `describe('ComponentName with featureX enabled', ...)`). Feature toggles are temporary — isolating their tests in a dedicated `describe` makes it straightforward to delete the entire block when the toggle is removed.

## Setup — Builder Functions

- Create a **`build*()` factory** that returns a named-property object with sensible defaults, so tests destructure only what they need: `const { visibleVar1, hiddenVar1 } = buildTestVariables()`.
- For component tests, create a **`render*()` wrapper** that calls RTL `render(...)` and returns `{ ...renderResult, elements, actions }`:
  - **`elements`** — lazy getters (functions) for DOM queries. Cast to specific HTML types when needed (`as HTMLTextAreaElement`).
  - **`actions`** — named functions wrapping multi-step user interactions (`fireEvent` or `userEvent`).
- Initialize **`userEvent.setup()`** inside the render wrapper and return it as `user`.
- For scene tests, instantiate `DashboardScene` with the relevant state, call `activateFullSceneTree(dashboardScene)`, spy on methods if needed.

### Skeleton example

import { fireEvent, render } from '@testing-library/react';
import userEvent from '@testing-library/user-event';

function buildTestItems() {
  return {
    item1: new SomeSceneObject({ name: 'item1', enabled: true }),
    item2: new SomeSceneObject({ name: 'item2', enabled: false }),
  };
}

function renderComponent(props: Partial<ComponentProps>) {
  const renderResult = render(<Component {...defaults} {...props} />);

  return {
    ...renderResult,
    user: userEvent.setup(),
    elements: {
      nameInput: () => renderResult.getByTestId('name-input') as HTMLInputElement,
    },
    actions: {
      changeName(value: string) {
        fireEvent.change(renderResult.getByTestId('name-input'), { target: { value } });
        fireEvent.blur(renderResult.getByTestId('name-input'));
      },
    },
  };
}

describe('<Component />', () => {
  describe('when an item is passed as prop', () => {
    test('renders the default state', () => {
      const { item1 } = buildTestItems();

      const { elements } = renderComponent({ item: item1 });

      expect(elements.nameInput().value).toBe('item1');
    });
  });
});

## Assertions

- **Be specific when writing assertions**: avoid shortcuts like `expect.anything()`; spell out the expected value(s). Assert explicit error messages, not just that some error is thrown.

## Edge Cases & Robustness

- **Empty state** is always tested (`options: []`, `variables: []`) — typically as a dedicated test case.
- **Preservation of order** is explicitly asserted (arrays compared with `toEqual`).
- **Error paths** are tested with `expect.assertions(n)` + try/catch when the function throws.
```