### PR TITLE
Chore: Bump Ubuntu base image from 22.04 to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG JS_SRC=js-builder
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
 FROM alpine:3.23.3 AS alpine-base
-FROM ubuntu:22.04 AS ubuntu-base
+FROM ubuntu:24.04 AS ubuntu-base
 FROM golang:1.26.1-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base
 # Javascript build stage

--- a/Makefile
+++ b/Makefile
@@ -504,7 +504,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
 	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
-	--build-arg BASE_IMAGE=ubuntu:22.04 \
+	--build-arg BASE_IMAGE=ubuntu:24.04 \
 	--build-arg GO_IMAGE=golang:$(GO_VERSION) \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS)

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -62,7 +62,7 @@ docker_build () {
     base_image="${base_arch}alpine:3.23.3"
   else
     libc=""
-    base_image="${base_arch}ubuntu:22.04"
+    base_image="${base_arch}ubuntu:24.04"
   fi
 
   grafana_tgz=${GRAFANA_TGZ:-"grafana-latest.linux-${arch}${libc}.tar.gz"}

--- a/pkg/build/daggerbuild/artifacts/package_targz.go
+++ b/pkg/build/daggerbuild/artifacts/package_targz.go
@@ -375,7 +375,7 @@ func verifyTarball(
 	// This grafana service runs in the background for the e2e tests
 	service := d.Container(dagger.ContainerOpts{
 		Platform: platform,
-	}).From("ubuntu:22.04").
+	}).From("ubuntu:24.04").
 		WithExec([]string{"apt-get", "update", "-yq"}).
 		WithExec([]string{"apt-get", "install", "-yq", "ca-certificates"}).
 		WithDirectory("/src", archive).

--- a/pkg/build/daggerbuild/fpm/verify.go
+++ b/pkg/build/daggerbuild/fpm/verify.go
@@ -25,7 +25,7 @@ func VerifyDeb(ctx context.Context, d *dagger.Client, file *dagger.File, src *da
 	// This grafana service runs in the background for the e2e tests
 	service := d.Container(dagger.ContainerOpts{
 		Platform: platform,
-	}).From("ubuntu:22.04").
+	}).From("ubuntu:24.04").
 		WithFile("/src/package.deb", file).
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "install", "-yq", "ca-certificates"}).

--- a/scripts/verify-repo-update/Dockerfile.deb
+++ b/scripts/verify-repo-update/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG REPO_CONFIG=grafana.list.oss
 ARG PACKAGE=grafana


### PR DESCRIPTION
## Summary

- Bumps the Ubuntu base image from 22.04 (Jammy) to 24.04 LTS (Noble Numbat) across all Docker build files
- Ubuntu 24.04 has been available since April 2024 and is supported until 2029
- This brings glibc from 2.35 to 2.39, along with newer system packages and security patches

## Changes

All 6 occurrences of `ubuntu:22.04` updated to `ubuntu:24.04`:

| File | Context |
|------|---------|
| `Dockerfile` | Main `ubuntu-base` stage |
| `Makefile` | `build-docker-full-ubuntu` target |
| `packaging/docker/build.sh` | Packaging script |
| `pkg/build/daggerbuild/artifacts/package_targz.go` | Dagger e2e test container |
| `pkg/build/daggerbuild/fpm/verify.go` | Dagger .deb verification container |
| `scripts/verify-repo-update/Dockerfile.deb` | .deb repo update verification |

## Motivation

- Ubuntu 22.04 ships glibc 2.35. Some community plugins now require glibc >= 2.38, which is only available on Ubuntu 24.04+
- Alpine (the default base) is regularly bumped by Dependabot (currently 3.23.3), but Dependabot doesn't auto-bump across Ubuntu LTS tracks
- The last Ubuntu bump (18.04 → 22.04) was in November 2022 — over 3 years ago

## Test plan

- [x] CI passes (the Docker build, .deb verification, and tarball e2e tests all exercise the Ubuntu image)
- [ ] Verify `grafana/grafana:*-ubuntu` images start correctly
- [ ] Verify no regressions in `apt-get install` steps (ca-certificates, curl, tzdata, musl)

Made with [Cursor](https://cursor.com)