### PR TITLE
Dashboard: Fix _initialState not updated after saving from JSON Model editor

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -205,6 +205,29 @@ describe('DashboardScene', () => {
         expect(scene.state.meta.version).toEqual(2);
       });
 
+      it('refreshInitialState should update _initialState so discarding later changes preserves the saved state', () => {
+        const originalTimeRange = scene.state.$timeRange!.state;
+        expect(originalTimeRange.from).toBe('now-6h');
+
+        scene.saveCompleted({} as Dashboard, {
+          slug: 'slug',
+          uid: 'dash-1',
+          url: 'sss',
+          version: 2,
+          status: 'aaa',
+        });
+
+        const newTimeRange = new SceneTimeRange({ from: 'now-7d', to: 'now', timeZone: 'browser' });
+        scene.setState({ $timeRange: newTimeRange });
+
+        scene.refreshInitialState();
+
+        scene.setState({ title: 'Another change' });
+        scene.discardChangesAndKeepEditing();
+
+        expect(scene.state.$timeRange!.state.from).toBe('now-7d');
+      });
+
       it('Should exit edit mode after saving from unsaved changes modal when dashboardNewLayouts is enabled', () => {
         const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
         config.featureToggles.dashboardNewLayouts = true;

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -599,6 +599,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     return this._initialState;
   }
 
+  public refreshInitialState() {
+    this._initialState = sceneUtils.cloneSceneObjectState(this.state);
+  }
+
   public addPanel(vizPanel: VizPanel): void {
     if (!this.state.isEditing) {
       this.onEnterEditMode();

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -93,6 +93,8 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
       dashboard.setState(newState);
     }
 
+    dashboard.refreshInitialState();
+
     this.setState({ jsonText: this.getJsonText() });
 
     // We also need to resume tracking changes since the change handler won't see any later edit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Fix for a bug where saving time settings (or any dashboard state) from the JSON Model editor causes those changes to be reverted if the user subsequently discards an unrelated change.

**Why do we need this feature?**

When a user saves from the JSON Model editor, `saveCompleted()` captures `_initialState` **before** `onSaveSuccess()` applies the new scene state. This means `_initialState` holds stale (pre-save) state. If the user then makes another edit and discards it, `discardChangesAndKeepEditing()` or `exitEditModeConfirmed(true)` restores the stale `_initialState`, reverting changes that were already persisted to the backend.

**Reproduction steps:**
1. Open a dashboard in edit mode
2. Navigate to Dashboard Settings > JSON Model
3. Change time settings (e.g., `time.from` from `"now-6h"` to `"now-7d"`)
4. Click "Save changes" — backend correctly saves the new time settings
5. Make another change (e.g., edit a panel title)
6. Discard the panel title change via "Discard changes"
7. **Bug**: The time settings are also reverted to the old values

**Who is this feature for?**

All Grafana users who edit dashboards via the JSON Model editor.

**Which issue(s) does this PR fix?**:

Fixes grafana/support-escalations#21251

**Root cause analysis**

The issue is in the ordering of operations during the JSON model save flow:

1. `useSaveDashboard` calls `scene.saveCompleted(saveModel, result)` which sets `_initialState = cloneSceneObjectState(this.state)` — at this point the scene still has the **old** time settings
2. Then `JsonModelEditView.onSaveSuccess()` transforms the saved JSON back to a scene and calls `dashboard.setState(newState)` — updating the scene to the **new** time settings
3. But `_initialState` is never refreshed after step 2

**Fix**

- Add a `refreshInitialState()` public method to `DashboardScene`
- Call it from `JsonModelEditView.onSaveSuccess` after `dashboard.setState(newState)`

This ensures `_initialState` matches the newly saved state, so subsequent "discard" operations don't revert already-persisted changes.

**Introducing PR**: https://github.com/grafana/grafana/pull/84343 by @dprokop — introduced `onSaveSuccess` without updating `_initialState`. Follow-up https://github.com/grafana/grafana/pull/109607 by @bfmatei added `resumeTrackingChanges()` but also did not address the staleness.

**Impact**
- No data loss — changes ARE correctly saved to the backend; the bug only affects the in-memory `_initialState` snapshot
- A page reload always restores the correct saved state

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

CC: @ivanortegaalba
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3f4deda-1ba0-4c95-ba66-5fd1d06c083f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3f4deda-1ba0-4c95-ba66-5fd1d06c083f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

