### PR TITLE
Dashboard: Query latency display on panel headers

### DIFF
--- a/docs/sources/visualizations/dashboards/troubleshoot-dashboards/index.md
+++ b/docs/sources/visualizations/dashboards/troubleshoot-dashboards/index.md
@@ -57,3 +57,18 @@ The graph in this next image shows bars instead of lines and has the **No value*
 {{< figure src="/static/img/docs/troubleshooting/grafana_null_zero.png" max-width="1200px" alt="Graph with null values not connected" >}}
 
 As you can see, there's a significant difference in the visualizations.
+
+## Debug dashboard performance with metrics
+
+Grafana can display live query timing information directly on each panel header, letting you quickly identify which panels are slow without opening the panel inspector.
+
+To toggle the query latency display, press **D** followed by **P** while viewing a dashboard. Each panel header shows a speedometer icon and the time the last query took — for example, `234ms` or `1.2s`. While a query is running, the timer counts up in real time so you can see how long it's been waiting. When the query finishes, the display settles on the final elapsed time.
+
+To identify slow panels:
+
+- Press **D** then **P** to reveal query times across all panels.
+- Look for panels with noticeably higher times. These are candidates for optimization — consider reducing the queried time range, applying data source-side aggregation, or splitting a heavy panel into smaller ones.
+- Hover over the timing badge on any panel for a tooltip showing the exact query duration in milliseconds.
+- Press **D** then **P** again to hide the metrics when you're done.
+
+The query latency display is off by default and isn't persisted — it resets each time you load the dashboard.

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -202,6 +202,13 @@ export const useShortcuts = () => {
             keys: ['d', 'x'],
             description: t('help-modal.shortcuts-description.toggle-exemplars', 'Toggle exemplars in all panel'),
           },
+          {
+            keys: ['d', 'p'],
+            description: t(
+              'help-modal.shortcuts-description.toggle-query-latency',
+              'Toggle query latency display on panel headers'
+            ),
+          },
         ],
       },
       {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -165,6 +165,8 @@ export interface DashboardSceneState extends SceneObjectState {
   editPane: DashboardEditPane;
   /** Manages dragging/dropping of layout items */
   layoutOrchestrator: DashboardLayoutOrchestrator;
+  /** Show query latency badges on panel headers */
+  showQueryLatency?: boolean;
 }
 
 export class DashboardScene extends SceneObjectBase<DashboardSceneState> implements LayoutParent {

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -13,7 +13,6 @@ import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelLinksBehavior } from './PanelMenuBehavior';
 import { PanelNotices } from './PanelNotices';
-import { PanelQueryLatency } from './PanelQueryLatency';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { PanelTimeRange } from './panel-timerange/PanelTimeRange';
 
@@ -65,7 +64,6 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
       })
     );
     titleItems.push(new PanelNotices());
-    titleItems.push(new PanelQueryLatency({}));
 
     let title;
     if (config.featureToggles.preferLibraryPanelTitle) {

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -13,6 +13,7 @@ import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelLinksBehavior } from './PanelMenuBehavior';
 import { PanelNotices } from './PanelNotices';
+import { PanelQueryLatency } from './PanelQueryLatency';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { PanelTimeRange } from './panel-timerange/PanelTimeRange';
 
@@ -64,6 +65,7 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
       })
     );
     titleItems.push(new PanelNotices());
+    titleItems.push(new PanelQueryLatency({}));
 
     let title;
     if (config.featureToggles.preferLibraryPanelTitle) {

--- a/public/app/features/dashboard-scene/scene/PanelQueryLatency.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelQueryLatency.test.tsx
@@ -1,0 +1,225 @@
+import { act, render, screen } from '@testing-library/react';
+import { NEVER } from 'rxjs';
+
+import { DataQueryRequest, DataSourceApi, LoadingState, PanelData } from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+
+import { activateFullSceneTree } from '../utils/test-utils';
+
+import { DashboardScene } from './DashboardScene';
+import { PanelQueryLatency } from './PanelQueryLatency';
+import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+
+// Use NEVER so the query runner never auto-runs; data is injected manually in each test.
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getRunRequest: () => (_ds: DataSourceApi, _request: DataQueryRequest) => NEVER,
+  getDataSourceSrv: () => ({
+    get: jest.fn().mockResolvedValue({ getRef: () => ({ uid: 'ds-1', type: 'test' }) }),
+    getInstanceSettings: jest.fn().mockResolvedValue({ uid: 'ds-1', type: 'test' }),
+  }),
+  getPluginImportUtils: () => ({
+    getPanelPluginFromCache: jest.fn(() => undefined),
+  }),
+}));
+
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: () => undefined,
+});
+
+describe('PanelQueryLatency', () => {
+  it('renders nothing when showQueryLatency is false (default)', async () => {
+    const { latencyItem, queryRunner } = buildScene();
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Done, startTime: 1000, endTime: 1500 }) });
+    });
+
+    expect(screen.queryByText(/\d+ms|\d+\.\d+s/)).not.toBeInTheDocument();
+  });
+
+  it('renders the latency badge when showQueryLatency is true and query is done', async () => {
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Done, startTime: 1000, endTime: 1234 }) });
+    });
+
+    expect(screen.getByText('234ms')).toBeInTheDocument();
+  });
+
+  it('formats durations >= 1000ms as seconds', async () => {
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Done, startTime: 1000, endTime: 2500 }) });
+    });
+
+    expect(screen.getByText('1.5s')).toBeInTheDocument();
+  });
+
+  it('renders nothing when query is done but endTime is missing', async () => {
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Done, startTime: 1000, endTime: undefined }) });
+    });
+
+    expect(screen.queryByText(/\d+ms|\d+\.\d+s/)).not.toBeInTheDocument();
+  });
+
+  it('counts up while a query is loading', async () => {
+    const startTime = 1000;
+    // Fake timers must be set up before render so the setInterval in useEffect
+    // is registered under fake timers and can be advanced with jest.
+    jest.useFakeTimers();
+    jest.setSystemTime(startTime);
+
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Loading, startTime }) });
+    });
+
+    // Initially elapsed is 0 (Date.now() - startTime = 0)
+    expect(screen.getByText('0ms')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText('300ms')).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('snaps to final time when query completes', async () => {
+    const startTime = 1000;
+    jest.useFakeTimers();
+    jest.setSystemTime(startTime);
+
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Loading, startTime }) });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    act(() => {
+      queryRunner.setState({
+        data: makePanelData({ state: LoadingState.Done, startTime, endTime: startTime + 457 }),
+      });
+    });
+
+    expect(screen.getByText('457ms')).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('renders the speedometer icon', async () => {
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<PanelQueryLatency.Component model={latencyItem} />));
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Done, startTime: 1000, endTime: 1200 }) });
+    });
+
+    expect(screen.getByText('200ms')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});
+
+// --- helpers ---
+
+interface DataOptions {
+  state: LoadingState;
+  startTime: number;
+  endTime?: number;
+}
+
+function makePanelData({ state, startTime, endTime }: DataOptions): PanelData {
+  return {
+    state,
+    series: [],
+    timeRange: { from: {} as never, to: {} as never, raw: { from: 'now-6h', to: 'now' } },
+    request: {
+      requestId: 'test',
+      interval: '1m',
+      intervalMs: 60000,
+      range: { from: {} as never, to: {} as never, raw: { from: 'now-6h', to: 'now' } },
+      scopedVars: {},
+      targets: [],
+      timezone: 'browser',
+      app: 'dashboard',
+      startTime,
+      endTime,
+    },
+  };
+}
+
+function buildScene() {
+  const latencyItem = new PanelQueryLatency({});
+
+  const queryRunner = new SceneQueryRunner({
+    datasource: { uid: 'ds-1' },
+    queries: [{ refId: 'A' }],
+  });
+
+  const panel = new VizPanel({
+    key: 'panel-1',
+    title: 'Test Panel',
+    pluginId: 'timeseries',
+    titleItems: [latencyItem],
+    $data: queryRunner,
+  });
+
+  const scene = new DashboardScene({
+    title: 'Test dashboard',
+    uid: 'test-dash',
+    body: DefaultGridLayoutManager.fromVizPanels([panel]),
+  });
+
+  activateFullSceneTree(scene);
+
+  return { scene, panel, latencyItem, queryRunner };
+}

--- a/public/app/features/dashboard-scene/scene/PanelQueryLatency.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelQueryLatency.test.tsx
@@ -108,7 +108,8 @@ describe('PanelQueryLatency', () => {
       queryRunner.setState({ data: makePanelData({ state: LoadingState.Loading, startTime }) });
     });
 
-    // Initially elapsed is 0 (Date.now() - startTime = 0)
+    // Immediately after loading starts, elapsed is computed as Date.now() - startTime.
+    // Since system time equals startTime here, elapsed = 0ms.
     expect(screen.getByText('0ms')).toBeInTheDocument();
 
     act(() => {
@@ -149,6 +150,48 @@ describe('PanelQueryLatency', () => {
     expect(screen.getByText('457ms')).toBeInTheDocument();
 
     jest.useRealTimers();
+  });
+
+  it('shows timing when query ends in an error state', async () => {
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Error, startTime: 1000, endTime: 1350 }) });
+    });
+
+    expect(screen.getByText('350ms')).toBeInTheDocument();
+  });
+
+  it('clamps negative durations to 0ms', async () => {
+    const { latencyItem, scene, queryRunner } = buildScene();
+    scene.setState({ showQueryLatency: true });
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={latencyItem} />);
+    });
+
+    // endTime before startTime (clock skew / buggy plugin)
+    act(() => {
+      queryRunner.setState({ data: makePanelData({ state: LoadingState.Done, startTime: 1000, endTime: 900 }) });
+    });
+
+    expect(screen.getByText('0ms')).toBeInTheDocument();
+  });
+
+  it('renders nothing when not attached to a DashboardScene', async () => {
+    // Render the component with an unattached model (no parent scene).
+    const detachedItem = new PanelQueryLatency({});
+
+    await act(async () => {
+      render(<PanelQueryLatency.Component model={detachedItem} />);
+    });
+
+    expect(screen.queryByText(/\d+ms|\d+\.\d+s/)).not.toBeInTheDocument();
   });
 
   it('renders the speedometer icon', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
 
 import { GrafanaTheme2, LoadingState } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -18,19 +19,47 @@ function PanelQueryLatencyRenderer({ model }: SceneComponentProps<PanelQueryLate
   const { data } = dataObject.useState();
   const styles = useStyles2(getStyles);
 
-  if (!showQueryLatency || !data || data.state !== LoadingState.Done || !data.request?.endTime) {
+  const isLoading = data?.state === LoadingState.Loading;
+  const startTime = data?.request?.startTime;
+
+  const [elapsed, setElapsed] = useState<number>(0);
+
+  useEffect(() => {
+    if (!isLoading || !startTime) {
+      return;
+    }
+    const interval = setInterval(() => setElapsed(Date.now() - startTime), 100);
+    return () => clearInterval(interval);
+  }, [isLoading, startTime]);
+
+  if (!showQueryLatency || !data?.request?.startTime) {
     return null;
   }
 
-  const ms = data.request.endTime - data.request.startTime;
+  let ms: number;
+  let running: boolean;
+
+  if (data.state === LoadingState.Done && data.request.endTime) {
+    ms = data.request.endTime - data.request.startTime;
+    running = false;
+  } else if (isLoading) {
+    ms = elapsed;
+    running = true;
+  } else {
+    return null;
+  }
+
   const label = ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+  const tooltipText = running
+    ? t('panel-query-latency.tooltip-running', 'Query running: {{ms}}ms', { ms })
+    : t('panel-query-latency.tooltip', 'Query time: {{ms}}ms', { ms });
 
   return (
-    <Tooltip content={t('panel-query-latency.tooltip', 'Query time: {{ms}}ms', { ms })}>
+    <Tooltip content={tooltipText}>
       <PanelChrome.TitleItem>
         <Stack gap={0.5} alignItems="center">
           <Icon name="tachometer-fast" size="sm" />
-          <span className={styles.latency}>{label}</span>
+          <span className={running ? styles.latencyRunning : styles.latency}>{label}</span>
         </Stack>
       </PanelChrome.TitleItem>
     </Tooltip>
@@ -40,6 +69,11 @@ function PanelQueryLatencyRenderer({ model }: SceneComponentProps<PanelQueryLate
 const getStyles = (theme: GrafanaTheme2) => ({
   latency: css({
     color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    whiteSpace: 'nowrap',
+  }),
+  latencyRunning: css({
+    color: theme.colors.text.disabled,
     fontSize: theme.typography.bodySmall.fontSize,
     whiteSpace: 'nowrap',
   }),

--- a/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
@@ -1,0 +1,46 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2, LoadingState } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState, sceneGraph } from '@grafana/scenes';
+import { Icon, PanelChrome, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+
+import { getDashboardSceneFor } from '../utils/utils';
+
+export class PanelQueryLatency extends SceneObjectBase<SceneObjectState> {
+  public static Component = PanelQueryLatencyRenderer;
+}
+
+function PanelQueryLatencyRenderer({ model }: SceneComponentProps<PanelQueryLatency>) {
+  const dashboard = getDashboardSceneFor(model);
+  const { showQueryLatency } = dashboard.useState();
+  const dataObject = sceneGraph.getData(model);
+  const { data } = dataObject.useState();
+  const styles = useStyles2(getStyles);
+
+  if (!showQueryLatency || !data || data.state !== LoadingState.Done || !data.request?.endTime) {
+    return null;
+  }
+
+  const ms = data.request.endTime - data.request.startTime;
+  const label = ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+
+  return (
+    <Tooltip content={t('panel-query-latency.tooltip', 'Query time: {{ms}}ms', { ms })}>
+      <PanelChrome.TitleItem>
+        <Stack gap={0.5} alignItems="center">
+          <Icon name="tachometer-fast" size="sm" />
+          <span className={styles.latency}>{label}</span>
+        </Stack>
+      </PanelChrome.TitleItem>
+    </Tooltip>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  latency: css({
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    whiteSpace: 'nowrap',
+  }),
+});

--- a/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
@@ -13,8 +13,7 @@ export class PanelQueryLatency extends SceneObjectBase<SceneObjectState> {
 }
 
 function PanelQueryLatencyRenderer({ model }: SceneComponentProps<PanelQueryLatency>) {
-  const dashboard = getDashboardSceneFor(model);
-  const { showQueryLatency } = dashboard.useState();
+  const { showQueryLatency } = getDashboardSceneFor(model).useState();
   const dataObject = sceneGraph.getData(model);
   const { data } = dataObject.useState();
   const styles = useStyles2(getStyles);

--- a/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelQueryLatency.tsx
@@ -6,14 +6,19 @@ import { t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState, sceneGraph } from '@grafana/scenes';
 import { Icon, PanelChrome, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { getDashboardSceneFor } from '../utils/utils';
+import { DashboardScene } from './DashboardScene';
 
 export class PanelQueryLatency extends SceneObjectBase<SceneObjectState> {
   public static Component = PanelQueryLatencyRenderer;
 }
 
 function PanelQueryLatencyRenderer({ model }: SceneComponentProps<PanelQueryLatency>) {
-  const { showQueryLatency } = getDashboardSceneFor(model).useState();
+  // Guard: component may render before it's attached to a DashboardScene (e.g. during
+  // library panel reloads). All hooks must be called before this check.
+  const root = model.getRoot();
+  const isDashboard = root instanceof DashboardScene;
+
+  const { showQueryLatency } = isDashboard ? root.useState() : { showQueryLatency: false };
   const dataObject = sceneGraph.getData(model);
   const { data } = dataObject.useState();
   const styles = useStyles2(getStyles);
@@ -21,28 +26,29 @@ function PanelQueryLatencyRenderer({ model }: SceneComponentProps<PanelQueryLate
   const isLoading = data?.state === LoadingState.Loading;
   const startTime = data?.request?.startTime;
 
-  const [elapsed, setElapsed] = useState<number>(0);
+  const [elapsed, setElapsed] = useState<number>(() => (isLoading && startTime ? Date.now() - startTime : 0));
 
   useEffect(() => {
     if (!isLoading || !startTime) {
       return;
     }
+    setElapsed(Date.now() - startTime);
     const interval = setInterval(() => setElapsed(Date.now() - startTime), 100);
     return () => clearInterval(interval);
   }, [isLoading, startTime]);
 
-  if (!showQueryLatency || !data?.request?.startTime) {
+  if (!isDashboard || !showQueryLatency || !data?.request?.startTime) {
     return null;
   }
 
   let ms: number;
   let running: boolean;
 
-  if (data.state === LoadingState.Done && data.request.endTime) {
-    ms = data.request.endTime - data.request.startTime;
+  if ((data.state === LoadingState.Done || data.state === LoadingState.Error) && data.request.endTime) {
+    ms = Math.max(0, data.request.endTime - data.request.startTime);
     running = false;
   } else if (isLoading) {
-    ms = elapsed;
+    ms = Math.max(0, elapsed);
     running = true;
   } else {
     return null;

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -128,6 +128,12 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     onTrigger: withFocusedPanel(scene, toggleVizPanelLegend),
   });
 
+  // Toggle query latency badges
+  keybindings.addBinding({
+    key: 'd p',
+    onTrigger: () => scene.setState({ showQueryLatency: !scene.state.showQueryLatency }),
+  });
+
   // Refresh
   keybindings.addBinding({
     key: 'd r',

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -33,6 +33,7 @@ import { LibraryPanelBehavior } from '../../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../../scene/PanelLinks';
 import { panelLinksBehavior, panelMenuBehavior } from '../../scene/PanelMenuBehavior';
 import { PanelNotices } from '../../scene/PanelNotices';
+import { PanelQueryLatency } from '../../scene/PanelQueryLatency';
 import { VizPanelHeaderActions } from '../../scene/VizPanelHeaderActions';
 import { VizPanelSubHeader } from '../../scene/VizPanelSubHeader';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
@@ -57,6 +58,7 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
   );
 
   titleItems.push(new PanelNotices());
+  titleItems.push(new PanelQueryLatency({}));
 
   const queryOptions = panel.spec.data.spec.queryOptions;
   const timeOverrideShown = (queryOptions.timeFrom || queryOptions.timeShift) && !queryOptions.hideTimeOverride;
@@ -129,6 +131,7 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
   );
 
   titleItems.push(new PanelNotices());
+  titleItems.push(new PanelQueryLatency({}));
 
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(id ?? panel.spec.id),

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -46,6 +46,7 @@ import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelLinksBehavior, panelMenuBehavior } from '../scene/PanelMenuBehavior';
 import { PanelNotices } from '../scene/PanelNotices';
+import { PanelQueryLatency } from '../scene/PanelQueryLatency';
 import { VizPanelHeaderActions } from '../scene/VizPanelHeaderActions';
 import { VizPanelSubHeader } from '../scene/VizPanelSubHeader';
 import { DashboardGridItem, RepeatDirection } from '../scene/layout-default/DashboardGridItem';
@@ -475,6 +476,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
   );
 
   titleItems.push(new PanelNotices());
+  titleItems.push(new PanelQueryLatency({}));
 
   const timeOverrideShown = (panel.timeFrom || panel.timeShift) && !panel.hideTimeOverride;
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10491,6 +10491,7 @@
       "toggle-panel-edit": "Toggle panel edit view",
       "toggle-panel-fullscreen": "Toggle panel fullscreen view",
       "toggle-panel-legend": "Toggle panel legend",
+      "toggle-query-latency": "Toggle query latency display on panel headers",
       "zoom-in-time-range": "Zoom in time range",
       "zoom-out-time-range": "Zoom out time range"
     },
@@ -12309,6 +12310,10 @@
     "loading": "Loading options",
     "no-options": "No options found",
     "search-placeholder": "Search"
+  },
+  "panel-query-latency": {
+    "tooltip": "Query time: {{ms}}ms",
+    "tooltip-running": "Query running: {{ms}}ms"
   },
   "panel-type-filter": {
     "clear-button": "Clear types",


### PR DESCRIPTION
## What

Adds a live query latency badge to each panel's title bar in Scenes-based dashboards. Toggle it on and off with **D → P**.

While a query is running, the timer counts up in real time next to a speedometer icon. Once the query finishes it settles on the exact elapsed time. Hover the badge for a tooltip showing the precise duration in milliseconds.

<img width="657" height="380" alt="panel metrics" src="https://github.com/user-attachments/assets/a8db327e-4058-4a17-a4ca-b1e05c214ece" />

Much simpler implementation than my previous attempt #114921.

## Why

When a dashboard is slow it's not obvious which panel is the bottleneck. Previously you'd have to open the panel inspector on each panel individually. This surfaces query timing for every panel at once, making it fast to spot the slow ones and move on.

## How to use

1. Open any dashboard.
2. Press **D** then **P** to reveal query times across all panel headers.
3. Look for panels with noticeably higher times — these are candidates for optimisation.
4. Press **D** then **P** again to hide the badges.

The display is off by default and resets on page load — it's a debugging aid, not a permanent UI change.

## Changes

| Area | What changed |
|---|---|
| `PanelQueryLatency.tsx` _(new)_ | `SceneObjectBase` that renders the latency badge. Reads `request.startTime`/`endTime` from `PanelData` — the same values shown in the panel inspector's Stats tab. A 100ms interval drives the live counter while `LoadingState.Loading`; clears and snaps to the final duration on completion. Dimmed colour while running, secondary colour when done. |
| `DashboardSceneState` | Adds `showQueryLatency?: boolean` flag (default off). |
| `keyboardShortcuts.ts` | Registers the `d p` binding to toggle the flag on the active dashboard. |
| `HelpModal.tsx` | Documents `d p` in the in-product **?** shortcuts screen under the Dashboard category, with a `t()` i18n key. |
| Serialization (3 files) | Injects `PanelQueryLatency` into `titleItems` at all four panel construction sites: `buildGridItemForPanel`, `buildVizPanel`, `buildLibraryPanel`, and `LibraryPanelBehavior`. |
| Troubleshoot dashboards docs | New section: _"Debug dashboard performance with metrics"_. |

## Testing

- Open a dashboard, press **D → P** — latency badges appear on all panels.
- Trigger a manual refresh — watch counters tick up while queries are in flight, then snap to the final value.
- Press **D → P** again — badges disappear.
- Press **?** — the `d p` shortcut appears in the Dashboard section of the help modal.
- Verify badges appear for standard panels, v2 schema panels, and library panels.