### PR TITLE
FS: Support multiple parallel Tilt instances via PORT and WORKSPACE_NAME

### DIFF
--- a/devenv/frontend-service/Tiltfile
+++ b/devenv/frontend-service/Tiltfile
@@ -1,3 +1,18 @@
+# --- Workspace configuration
+# WORKSPACE_NAME identifies this workspace instance (used for Docker project
+# name and cookie scoping). PORT provides a unique base port. Together they
+# allow multiple instances to run in parallel without conflicts.
+workspace_name = os.environ.get('WORKSPACE_NAME', 'dev')
+base_port = int(os.environ.get('PORT', '3000'))
+port_proxy    = base_port       # +0  main gateway
+port_cdn      = base_port + 1   # +1  CDN server
+port_api      = base_port + 2   # +2  grafana-api direct
+port_fs       = base_port + 3   # +3  frontend-service direct
+port_alloy    = base_port + 4   # +4  alloy UI
+port_faro     = base_port + 5   # +5  faro receiver
+port_goff     = base_port + 6   # +6  go feature flag
+# port_tilt   = base_port + 9   # +9  tilt UI (set in run.sh)
+
 # --- Frontend processes
 local_resource(
   'yarn install',
@@ -44,14 +59,52 @@ local_resource(
 )
 
 # --- Docker Compose
-# define service overrides needed for running with enterprise
-# this mounts the dev license into the grafana-api service
 base_config = read_yaml('./docker-compose.yaml')
+
+# Ports and port-dependent environment variables are set here rather than in
+# docker-compose.yaml so they can be derived from PORT.
+compose_overrides = {'services': {
+  'proxy': {
+    'ports': [
+      '%d:80' % port_proxy,
+      '%d:81' % port_cdn,
+    ],
+  },
+  'grafana-api': {
+    'ports': ['%d:3000' % port_api],
+    'environment': {
+      'GF_SERVER_CDN_URL': 'http://localhost:%d' % port_cdn,
+      'GF_AUTH_LOGIN_COOKIE_NAME': 'grafana_fs_%s_login' % workspace_name,
+    },
+  },
+  'frontend-service': {
+    'ports': ['%d:3000' % port_fs],
+    'environment': {
+      'GF_SERVER_CDN_URL': 'http://localhost:%d' % port_cdn,
+      'GF_LOG_FRONTEND_CUSTOM_ENDPOINT': 'http://localhost:%d/collect' % port_faro,
+    },
+  },
+  'alloy': {
+    'ports': [
+      '%d:12345' % port_alloy,
+      '%d:12347' % port_faro,
+    ],
+  },
+  'goff': {
+    'ports': ['%d:1031/tcp' % port_goff],
+  },
+}}
+
+# Enterprise overrides: mount dev license into grafana-api
 base_volumes = base_config['services']['grafana-api']['volumes']
 enterprise_overrides = {'services':{'grafana-api': {'volumes': base_volumes + ['../../data/license.jwt:/grafana/data/license.jwt'] }}}
 
-# check if license exists and apply enterprise overrides if so
-docker_compose(["./docker-compose.yaml", encode_yaml(enterprise_overrides)]) if os.path.exists("../../data/license.jwt") else docker_compose("./docker-compose.yaml")
+compose_files = ["./docker-compose.yaml", encode_yaml(compose_overrides)]
+if os.path.exists("../../data/license.jwt"):
+  compose_files.append(encode_yaml(enterprise_overrides))
+
+# Use a unique project name per workspace so multiple instances don't conflict
+docker_compose(compose_files, project_name='grafana-fs-%s' % workspace_name)
 dc_resource("proxy",
   resource_deps=["grafana-api", "frontend-service"],
   labels=["services"]

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -10,9 +10,7 @@ services:
       - ../../public/build:/cdn/public/build
       - ../../public/app/plugins:/cdn/public/app/plugins
       - ../../public/fonts:/cdn/public/fonts
-    ports:
-      - '3000:80' # Gateway
-      - '3010:81' # CDN
+    # ports are set dynamically in the Tiltfile (derived from PORT)
     depends_on:
       - grafana-api
       - frontend-service
@@ -37,17 +35,14 @@ services:
       OTEL_BSP_SCHEDULE_DELAY: 500
       GF_DEFAULT_APP_MODE: development
       GF_PANELS_ENABLE_ALPHA: true
-      GF_SERVER_CDN_URL: http://localhost:3010
       GF_FEATURE_TOGGLES_ENABLE: enableNativeHTTPHistogram
       GF_DATABASE_URL: postgres://grafana:grafana@postgres:5432/grafana
       GF_SERVER_ROUTER_LOGGING: true
       GF_LOG_LEVEL: info
-      GF_AUTH_LOGIN_COOKIE_NAME: grafana_fs_dev_login # set a custom cookie name to not conflict with other instances running on localhost
       OTEL_SERVICE_NAME: grafana-api
       GF_TRACING_OPENTELEMETRY_OTLP_ADDRESS: 'alloy:4317'
       GF_TRACING_OPENTELEMETRY_OTLP_PROPAGATION: jaeger,w3c
-    ports:
-      - '3011:3000'
+    # ports are set dynamically in the Tiltfile (derived from PORT)
     labels:
       - 'alloy.logs=true'
 
@@ -59,8 +54,7 @@ services:
     entrypoint: ['bin/grafana', 'server', 'target']
     volumes:
       - ./configs/frontend-service.local.ini:/grafana/conf/custom.ini
-    ports:
-      - '3012:3000'
+    # ports are set dynamically in the Tiltfile (derived from PORT)
     labels:
       - 'alloy.logs=true'
     environment:
@@ -72,7 +66,6 @@ services:
       GF_SECURITY_CONTENT_SECURITY_POLICY: true
       GF_SECURITY_CONTENT_SECURITY_POLICY_TEMPLATE: "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
       GF_FEATURE_TOGGLES_ENABLE: enableNativeHTTPHistogram
-      GF_SERVER_CDN_URL: http://localhost:3010
       GF_SERVER_ROUTER_LOGGING: true
       GF_LOG_LEVEL: info
       OTEL_SERVICE_NAME: frontend-service
@@ -80,15 +73,12 @@ services:
       GF_TRACING_OPENTELEMETRY_OTLP_PROPAGATION: jaeger,w3c
       GF_FEATURE_TOGGLES_OPENFEATURE_PROVIDER: ofrep
       GF_FEATURE_TOGGLES_OPENFEATURE_URL: http://goff:1031
-      # Faro (Grafana JavaScript Agent) configuration - sends frontend observability data to Loki via Alloy
       GF_LOG_FRONTEND_ENABLED: true
-      GF_LOG_FRONTEND_CUSTOM_ENDPOINT: http://localhost:12347/collect
 
   goff:
     image: gofeatureflag/go-feature-flag:latest
     command: /go-feature-flag --config /config/config.yaml
-    ports:
-      - 1031:1031/tcp
+    # ports are set dynamically in the Tiltfile (derived from PORT)
     configs:
       - source: goff_config
         target: /config/config.yaml
@@ -112,9 +102,7 @@ services:
       - ./configs/alloy:/alloy-config
       - /var/run/docker.sock:/var/run/docker.sock # To scrape Docker container logs
       - alloy-data:/var/lib/alloy/data
-    ports:
-      - '12346:12345' # Alloy UI
-      - '12347:12347' # Faro receiver
+    # ports are set dynamically in the Tiltfile (derived from PORT)
     command:
       - run
       - --server.http.listen-addr=0.0.0.0:12345

--- a/devenv/frontend-service/run.sh
+++ b/devenv/frontend-service/run.sh
@@ -1,10 +1,23 @@
 # Script called from makefile to auto down the tilt environment on ctrl + c.
 # Paths are relative to the makefile
 
+TILT_FILE_ARGS=(-f devenv/frontend-service/Tiltfile)
+TILT_ARGS=("${TILT_FILE_ARGS[@]}")
+
+# When PORT is set, derive a unique Tilt UI port so multiple
+# instances can run in parallel without conflicting on the default 10350.
+if [[ -n "${PORT}" ]]; then
+  TILT_PORT=$((PORT + 9))
+  TILT_ARGS+=(--port "${TILT_PORT}")
+fi
+
+GRAFANA_PORT="${PORT:-3000}"
+echo "Grafana will be available at http://localhost:${GRAFANA_PORT} once ready."
+
 function tilt_down()
 {
     echo "Tearing down Tilt environment... (this might take a little while)"
-    tilt down -f devenv/frontend-service/Tiltfile
+    tilt down "${TILT_FILE_ARGS[@]}"
 }
 
 # Create placeholder files to prevent docker from creating folders here instead
@@ -16,4 +29,4 @@ if [[ "${AUTO_DOWN}" != "false" ]]; then
   trap tilt_down SIGINT
 fi
 
-tilt up -f devenv/frontend-service/Tiltfile
+tilt up "${TILT_ARGS[@]}"


### PR DESCRIPTION
**What is this feature?**

This PR enables running multiple frontend-service instances simultaneously without port or resource name conflicts, which is useful for parallel (agentic) development workflows.

The services in the `make frontend-service` tiltfile now use a contiguous block of ports, starting from port 3000. Setting the `PORT=7000 make frontend-service` will change the range of ports used, running Grafana itself on port 7000.

Additionally, setting the env var `WORKSPACE_NAME` will be used as a suffix for the docker compose project name. 

These two changes make it possible to run multiple parallel instances of the development stack locally, perfect for multiple-agent development workflows with tools like Conductor. e.g. in one folder run `WORKSPACE_NAME=capybara PORT=7000 make frontend-service` and have Grafana running on port 7000, and in another run `WORKSPACE_NAME=zebra PORT=8000 make frontend-service` and have Grafana on port 8000.