### PR TITLE
Yarn: Enable global cache

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,6 @@
 compressionLevel: mixed
 
-enableGlobalCache: false
+enableGlobalCache: true
 
 enableTelemetry: false
 


### PR DESCRIPTION
## Summary
- Switches `enableGlobalCache` from `false` to `true` in `.yarnrc.yml`
- This makes Yarn use a shared global cache instead of per-project caches, reducing disk usage and improving install times

## Test plan
- [x] Verified `yarn config get enableGlobalCache` returns `true`
- [x] Verified `yarn install` completes successfully with the new setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)