### PR TITLE
Unified Storage: Refactor manager update check to compare only kind and identity

### DIFF
--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -34,27 +34,16 @@ func checkManagerPropertiesOnCreate(auth authtypes.AuthInfo, obj utils.GrafanaMe
 }
 
 func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.GrafanaMetaAccessor, old utils.GrafanaMetaAccessor) error {
-	objKind := obj.GetAnnotation(utils.AnnoKeyManagerKind)
-	oldKind := old.GetAnnotation(utils.AnnoKeyManagerKind)
-	if objKind == "" && objKind == oldKind {
-		return nil // not managed
+	managerNew, hasNew := obj.GetManagerProperties()
+	managerOld, hasOld := old.GetManagerProperties()
+
+	if !hasNew && !hasOld {
+		return nil // neither old nor new are managed
 	}
 
-	// Check the current settings
-	err := checkManagerPropertiesOnCreate(auth, obj)
-	if err != nil { // new settings failed
-		return err
-	}
-
-	managerNew, okNew := obj.GetManagerProperties()
-	managerOld, okOld := old.GetManagerProperties()
-	if managerNew == managerOld || (okNew && !okOld) { // added manager is OK
-		return nil
-	}
-
-	if !okNew && okOld {
-		// This allows removing the managedBy annotations if you were allowed to write them originally
-		if err := checkManagerPropertiesOnCreate(auth, old); err != nil {
+	// Removing a manager: the caller must be authorized for the *old* manager.
+	if !hasNew && hasOld {
+		if err := enforceManagerProperties(auth, old); err != nil {
 			return &apierrors.StatusError{ErrStatus: metav1.Status{
 				Status:  metav1.StatusFailure,
 				Code:    http.StatusForbidden,
@@ -65,7 +54,9 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 		return nil
 	}
 
-	if okNew && okOld && managerNew != managerOld {
+	// Changing the owner (kind or identity) is not allowed.
+	// Remove the old manager first, then add the new one.
+	if hasOld && (managerNew.Kind != managerOld.Kind || managerNew.Identity != managerOld.Identity) {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
 			Code:    http.StatusForbidden,
@@ -73,7 +64,9 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 			Message: "Cannot change resource manager; remove the existing manager first, then add the new one",
 		}}
 	}
-	return nil
+
+	// Adding a manager or updating flags on the same owner.
+	return enforceManagerProperties(auth, obj)
 }
 
 func enforceManagerProperties(auth authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error {


### PR DESCRIPTION
Follow-up to #120521. Addresses [review feedback](https://github.com/grafana/grafana/pull/120521/changes/BASE..0f026d4e72d93e597ee3b5250c3eefad332cbbcd#r2952669641).

## Problem

The manager change check in `checkManagerPropertiesOnUpdateSpec` compared the full `ManagerProperties` struct, which meant updating operational flags like `AllowsEdits` or `Suspended` on an existing manager would be rejected as a "manager change". It also had a confusing control flow: an early-exit based on `AnnoKeyManagerKind`, followed by an intermediate `enforceManagerProperties` call, then separate `ok`-based branches that were hard to reason about.

## Changes

Refactors `checkManagerPropertiesOnUpdateSpec` into a linear flow with clear early returns for each transition:

1. **Not managed** (`!hasNew && !hasOld`) -- return nil
2. **Removing** (`!hasNew && hasOld`) -- authorize against the old manager, return
3. **Owner changed** (`hasOld && kind/identity differ`) -- reject with Forbidden
4. **Adding or updating flags** -- authorize against the new manager

Key improvements:
- Compares only `Kind` and `Identity`, not the full struct. Updating `AllowsEdits` or `Suspended` no longer requires a remove-then-add workflow.
- Uses `GetManagerProperties()` as the single source of truth for whether a resource is managed, instead of the previous mismatch where the early-exit checked `AnnoKeyManagerKind` but `GetManagerProperties` keys off `AnnoKeyManagerIdentity`.
- `enforceManagerProperties` is called once at the end for the common path (add / same-owner update), instead of being scattered across three branches.
- `.Kind` and `.Identity` are only accessed when `hasOld` is true, avoiding reliance on zero-value struct semantics.

## Test plan

Existing unit tests in `managed_test.go` and integration tests in `pkg/tests/apis/provisioning/managed_test.go` (from #120521) cover all transitions and pass without changes.