### PR TITLE
Auth: Add disable_forgot_password config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -641,6 +641,10 @@ disable_login_form = false
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt.
 disable_signout_menu = false
 
+# Set to true to hide the "Forgot your password?" link on the login page.
+# Useful when passwords are managed externally (e.g. LDAP, SSO).
+disable_forgot_password = false
+
 # URL to redirect the user to after sign out
 signout_redirect_url =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -631,6 +631,9 @@
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt, defaults to false
 ;disable_signout_menu = false
 
+# Set to true to hide the "Forgot your password?" link on the login page, defaults to false
+;disable_forgot_password = false
+
 # URL to redirect the user to after sign out
 ;signout_redirect_url =
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -385,4 +385,5 @@ export interface AuthSettings {
   passwordlessEnabled?: boolean;
   basicAuthStrongPasswordPolicy?: boolean;
   disableSignoutMenu?: boolean;
+  disableForgotPassword?: boolean;
 }

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -35,6 +35,7 @@ type FrontendSettingsAuthDTO struct {
 	BasicAuthStrongPasswordPolicy bool `json:"basicAuthStrongPasswordPolicy"`
 	PasswordlessEnabled           bool `json:"passwordlessEnabled"`
 	DisableSignoutMenu            bool `json:"disableSignoutMenu"`
+	DisableForgotPassword         bool `json:"disableForgotPassword"`
 }
 
 type FrontendSettingsBuildInfoDTO struct {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -409,6 +409,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		DisableLogin:                  hs.Cfg.DisableLogin,
 		BasicAuthStrongPasswordPolicy: hs.Cfg.BasicAuthStrongPasswordPolicy,
 		DisableSignoutMenu:            hs.Cfg.DisableSignoutMenu,
+		DisableForgotPassword:         hs.Cfg.DisableForgotPassword,
 	}
 
 	//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -280,6 +280,7 @@ type Cfg struct {
 	DisableLogin                  bool
 	AdminEmail                    string
 	DisableLoginForm              bool
+	DisableForgotPassword         bool
 	SignoutRedirectUrl            string
 	IDResponseHeaderEnabled       bool
 	IDResponseHeaderPrefix        string
@@ -1908,6 +1909,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	cfg.DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	cfg.DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
+	cfg.DisableForgotPassword = auth.Key("disable_forgot_password").MustBool(false)
 
 	// Deprecated
 	cfg.OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)

--- a/public/app/core/components/Login/LoginPage.test.tsx
+++ b/public/app/core/components/Login/LoginPage.test.tsx
@@ -57,6 +57,16 @@ describe('Login Page', () => {
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', '/signup');
   });
 
+  it('hides forgot password link when disableForgotPassword is set', () => {
+    runtimeMock.config.auth.disableForgotPassword = true;
+    render(<LoginPage />);
+
+    expect(screen.queryByRole('link', { name: 'Forgot your password?' })).not.toBeInTheDocument();
+
+    // cleanup
+    runtimeMock.config.auth.disableForgotPassword = false;
+  });
+
   it('should pass validation checks for username field', async () => {
     render(<LoginPage />);
 

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -60,7 +60,7 @@ const LoginPage = () => {
                     isLoggingIn={isLoggingIn}
                   >
                     <Stack justifyContent="flex-end">
-                      {!config.auth.disableLogin && (
+                      {!config.auth.disableLogin && !config.auth.disableForgotPassword && (
                         <LinkButton
                           className={styles.forgottenPassword}
                           fill="text"


### PR DESCRIPTION
## What is this PR about?

Adds a new `disable_forgot_password` option under the `[auth]` section in `grafana.ini` that hides the "Forgot your password?" link on the login page.

## Why?

In environments using external authentication (LDAP, Active Directory, SSO), the "Forgot your password?" link is misleading — users click it but can't reset their LDAP/SSO password through Grafana. This causes confusion and unnecessary support tickets.

Currently the only way to hide it is to set `disable_login = true`, which also hides the entire login form.

## Configuration

```ini
[auth]
# Set to true to hide the "Forgot your password?" link on the login page.
# Useful when passwords are managed externally (e.g. LDAP, SSO).
disable_forgot_password = true
```

Default is `false` (no behavior change).

## Changes

Full-stack implementation following the same pattern as `disable_signout_menu`:

| Layer | File | Change |
|---|---|---|
| INI config | `conf/defaults.ini`, `conf/sample.ini` | Add `disable_forgot_password` option |
| Go config | `pkg/setting/setting.go` | Add `DisableForgotPassword` field + parsing |
| Go DTO | `pkg/api/dtos/frontend_settings.go` | Add to `FrontendSettingsAuthDTO` |
| Go handler | `pkg/api/frontendsettings.go` | Wire config value to DTO |
| TS types | `packages/grafana-data/src/types/config.ts` | Add `disableForgotPassword` to `AuthSettings` |
| React | `public/app/core/components/Login/LoginPage.tsx` | Hide link when config is set |

Closes #113075