### PR TITLE
IAM: Extract `Mappers` service from resource permissions

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -97,7 +97,7 @@ func RegisterAPIService(
 	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller)
 	registerMetrics(reg)
 
-	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappers())
+	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappersRegistry())
 
 	// When resourcepermissions are in Mode5 (unistore only), search must error; pass nil backend so the handler returns that error.
 	resourcePermsSearchBackend := resource.StorageBackend(rpStorage)
@@ -179,7 +179,7 @@ func NewAPIService(
 	tracingService tracing.Tracer,
 ) *IdentityAccessManagementAPIBuilder {
 	store := legacy.NewLegacySQLStores(dbProvider)
-	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappers())
+	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappersRegistry())
 	registerMetrics(reg)
 
 	globalRoleAuthorizer := globalRoleApiInstaller.GetAuthorizer()

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -97,7 +97,7 @@ func RegisterAPIService(
 	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller)
 	registerMetrics(reg)
 
-	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider)
+	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappers())
 
 	// When resourcepermissions are in Mode5 (unistore only), search must error; pass nil backend so the handler returns that error.
 	resourcePermsSearchBackend := resource.StorageBackend(rpStorage)
@@ -179,7 +179,7 @@ func NewAPIService(
 	tracingService tracing.Tracer,
 ) *IdentityAccessManagementAPIBuilder {
 	store := legacy.NewLegacySQLStores(dbProvider)
-	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider)
+	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappers())
 	registerMetrics(reg)
 
 	globalRoleAuthorizer := globalRoleApiInstaller.GetAuthorizer()

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type Mapper interface {
@@ -47,4 +49,101 @@ func (m mapper) ActionSet(level string) (string, error) {
 
 func (m mapper) ScopePattern() string {
 	return m.resource + ":uid:%"
+}
+
+type mapperEntry struct {
+	mapper  Mapper
+	enabled func() bool // nil = always enabled
+}
+
+// Mappers is a registry of resource permission mappers.
+// RegisterMapper must only be called during Wire init (before the server starts serving requests).
+// No mutex is needed because all registrations happen sequentially during startup.
+type Mappers struct {
+	entries map[schema.GroupResource]mapperEntry
+	reverse map[string]schema.GroupResource // scope prefix -> GroupResource
+}
+
+// NewMappers initialises the registry with folders and dashboards (always enabled).
+func NewMappers() *Mappers {
+	m := &Mappers{
+		entries: make(map[schema.GroupResource]mapperEntry),
+		reverse: make(map[string]schema.GroupResource),
+	}
+	m.RegisterMapper(
+		schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"},
+		NewMapper("folders", defaultLevels), nil,
+	)
+	m.RegisterMapper(
+		schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"},
+		NewMapper("dashboards", defaultLevels), nil,
+	)
+	return m
+}
+
+// ProvideMappers is a Wire provider that returns a new Mappers registry.
+func ProvideMappers() *Mappers {
+	return NewMappers()
+}
+
+// RegisterMapper registers a mapper for the given GroupResource.
+// The scope prefix is derived from mapper.ScopePattern() — no separate parameter is needed.
+// enabled may be nil, which means the mapper is always enabled.
+func (m *Mappers) RegisterMapper(gr schema.GroupResource, mapper Mapper, enabled func() bool) {
+	prefix := strings.SplitN(mapper.ScopePattern(), ":", 2)[0]
+	m.entries[gr] = mapperEntry{mapper: mapper, enabled: enabled}
+	m.reverse[prefix] = gr
+}
+
+// Get returns the mapper for the given GroupResource regardless of enabled state.
+// Use this for reads of existing data.
+func (m *Mappers) Get(gr schema.GroupResource) (Mapper, bool) {
+	e, ok := m.entries[gr]
+	if !ok {
+		return nil, false
+	}
+	return e.mapper, true
+}
+
+// IsEnabled reports whether the mapper for the given GroupResource is registered and enabled.
+func (m *Mappers) IsEnabled(gr schema.GroupResource) bool {
+	e, ok := m.entries[gr]
+	return ok && (e.enabled == nil || e.enabled())
+}
+
+// ParseScope parses a scope string (e.g. "folders:uid:abc") into a groupResourceName.
+func (m *Mappers) ParseScope(scope string) (*groupResourceName, error) {
+	parts := strings.SplitN(scope, ":", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("%w: %s", errInvalidScope, scope)
+	}
+	gr, ok := m.reverse[parts[0]]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errUnknownGroupResource, parts[0])
+	}
+	return &groupResourceName{Group: gr.Group, Resource: gr.Resource, Name: parts[2]}, nil
+}
+
+// EnabledActionSets returns the action sets for all currently-enabled mappers.
+func (m *Mappers) EnabledActionSets() []string {
+	out := make([]string, 0, 3*len(m.entries))
+	for _, e := range m.entries {
+		if e.enabled != nil && !e.enabled() {
+			continue
+		}
+		out = append(out, e.mapper.ActionSets()...)
+	}
+	return out
+}
+
+// EnabledScopePatterns returns the scope patterns for all currently-enabled mappers.
+func (m *Mappers) EnabledScopePatterns() []string {
+	out := make([]string, 0, len(m.entries))
+	for _, e := range m.entries {
+		if e.enabled != nil && !e.enabled() {
+			continue
+		}
+		out = append(out, e.mapper.ScopePattern())
+	}
+	return out
 }

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -8,10 +8,28 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// Mapper translates between K8s GroupResource and legacy RBAC scopes/action sets.
+// It knows how to produce RBAC scopes (e.g., "folders:uid:abc") and action sets
+// (e.g., "folders:view") for a specific resource type (folders, dashboards, datasources, etc.).
 type Mapper interface {
+	// ActionSets returns all available RBAC action sets for this resource type.
+	// These are used to query the database for permissions (e.g., ["folders:view", "folders:edit", "folders:admin"]).
 	ActionSets() []string
+
+	// Scope returns the full RBAC scope for a given resource name.
+	// Used when creating/updating permissions to store the scope in the permission table.
+	// Example: Scope("abc") returns "folders:uid:abc".
 	Scope(name string) string
+
+	// ActionSet returns the RBAC action set for a given permission level.
+	// Used when creating managed roles to determine which action set to grant.
+	// Example: ActionSet("view") returns "folders:view".
 	ActionSet(level string) (string, error)
+
+	// ScopePattern returns the SQL LIKE pattern for querying scopes of this resource type.
+	// Used in list queries with SQL LIKE to match all permissions for this resource type
+	// regardless of the specific resource identifier (UID). The % wildcard matches any UID.
+	// Example: "folders:uid:%" matches "folders:uid:abc", "folders:uid:xyz", etc.
 	ScopePattern() string
 }
 
@@ -96,7 +114,8 @@ func (m *MappersRegistry) RegisterMapper(gr schema.GroupResource, mapper Mapper,
 }
 
 // Get returns the mapper for the given GroupResource regardless of enabled state.
-// Use this for reads of existing data.
+// Use this when reading or writing existing data - the mapper provides the RBAC translation
+// even if the feature is currently disabled (to preserve existing permissions).
 func (m *MappersRegistry) Get(gr schema.GroupResource) (Mapper, bool) {
 	e, ok := m.entries[gr]
 	if !ok {
@@ -106,12 +125,17 @@ func (m *MappersRegistry) Get(gr schema.GroupResource) (Mapper, bool) {
 }
 
 // IsEnabled reports whether the mapper for the given GroupResource is registered and enabled.
+// Use this for admission control (create/update validation) to gate whether new permissions
+// can be created for this resource type based on feature flags or licensing.
 func (m *MappersRegistry) IsEnabled(gr schema.GroupResource) bool {
 	e, ok := m.entries[gr]
 	return ok && (e.enabled == nil || e.enabled())
 }
 
-// ParseScope parses a scope string (e.g. "folders:uid:abc") into a groupResourceName.
+// ParseScope parses an RBAC scope string (e.g., "folders:uid:abc") into a groupResourceName.
+// Used when reading permissions from the database for two purposes:
+//   1. Populating the ResourcePermission Spec (Group, Resource, Name fields)
+//   2. Making AccessClient Check requests to authorize viewing the resource
 func (m *MappersRegistry) ParseScope(scope string) (*groupResourceName, error) {
 	parts := strings.SplitN(scope, ":", 3)
 	if len(parts) != 3 {
@@ -125,6 +149,8 @@ func (m *MappersRegistry) ParseScope(scope string) (*groupResourceName, error) {
 }
 
 // EnabledActionSets returns the action sets for all currently-enabled mappers.
+// Used by list operations to query the database for permissions across all enabled resource types.
+// Only includes mappers whose enabled closure returns true (or nil).
 func (m *MappersRegistry) EnabledActionSets() []string {
 	out := make([]string, 0, 3*len(m.entries))
 	for _, e := range m.entries {
@@ -137,6 +163,8 @@ func (m *MappersRegistry) EnabledActionSets() []string {
 }
 
 // EnabledScopePatterns returns the scope patterns for all currently-enabled mappers.
+// Used by list operations to find all resource permissions across all enabled resource types.
+// Only includes mappers whose enabled closure returns true (or nil).
 func (m *MappersRegistry) EnabledScopePatterns() []string {
 	out := make([]string, 0, len(m.entries))
 	for _, e := range m.entries {

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -56,17 +56,17 @@ type mapperEntry struct {
 	enabled func() bool // nil = always enabled
 }
 
-// Mappers is a registry of resource permission mappers.
+// MappersRegistry is a registry of resource permission mappers.
 // RegisterMapper must only be called during Wire init (before the server starts serving requests).
 // No mutex is needed because all registrations happen sequentially during startup.
-type Mappers struct {
+type MappersRegistry struct {
 	entries map[schema.GroupResource]mapperEntry
 	reverse map[string]schema.GroupResource // scope prefix -> GroupResource
 }
 
-// NewMappers initialises the registry with folders and dashboards (always enabled).
-func NewMappers() *Mappers {
-	m := &Mappers{
+// NewMappersRegistry initialises the registry with folders and dashboards (always enabled).
+func NewMappersRegistry() *MappersRegistry {
+	m := &MappersRegistry{
 		entries: make(map[schema.GroupResource]mapperEntry),
 		reverse: make(map[string]schema.GroupResource),
 	}
@@ -81,15 +81,15 @@ func NewMappers() *Mappers {
 	return m
 }
 
-// ProvideMappers is a Wire provider that returns a new Mappers registry.
-func ProvideMappers() *Mappers {
-	return NewMappers()
+// ProvideMappersRegistry is a Wire provider that returns a new MappersRegistry.
+func ProvideMappersRegistry() *MappersRegistry {
+	return NewMappersRegistry()
 }
 
 // RegisterMapper registers a mapper for the given GroupResource.
 // The scope prefix is derived from mapper.ScopePattern() — no separate parameter is needed.
 // enabled may be nil, which means the mapper is always enabled.
-func (m *Mappers) RegisterMapper(gr schema.GroupResource, mapper Mapper, enabled func() bool) {
+func (m *MappersRegistry) RegisterMapper(gr schema.GroupResource, mapper Mapper, enabled func() bool) {
 	prefix := strings.SplitN(mapper.ScopePattern(), ":", 2)[0]
 	m.entries[gr] = mapperEntry{mapper: mapper, enabled: enabled}
 	m.reverse[prefix] = gr
@@ -97,7 +97,7 @@ func (m *Mappers) RegisterMapper(gr schema.GroupResource, mapper Mapper, enabled
 
 // Get returns the mapper for the given GroupResource regardless of enabled state.
 // Use this for reads of existing data.
-func (m *Mappers) Get(gr schema.GroupResource) (Mapper, bool) {
+func (m *MappersRegistry) Get(gr schema.GroupResource) (Mapper, bool) {
 	e, ok := m.entries[gr]
 	if !ok {
 		return nil, false
@@ -106,13 +106,13 @@ func (m *Mappers) Get(gr schema.GroupResource) (Mapper, bool) {
 }
 
 // IsEnabled reports whether the mapper for the given GroupResource is registered and enabled.
-func (m *Mappers) IsEnabled(gr schema.GroupResource) bool {
+func (m *MappersRegistry) IsEnabled(gr schema.GroupResource) bool {
 	e, ok := m.entries[gr]
 	return ok && (e.enabled == nil || e.enabled())
 }
 
 // ParseScope parses a scope string (e.g. "folders:uid:abc") into a groupResourceName.
-func (m *Mappers) ParseScope(scope string) (*groupResourceName, error) {
+func (m *MappersRegistry) ParseScope(scope string) (*groupResourceName, error) {
 	parts := strings.SplitN(scope, ":", 3)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("%w: %s", errInvalidScope, scope)
@@ -125,7 +125,7 @@ func (m *Mappers) ParseScope(scope string) (*groupResourceName, error) {
 }
 
 // EnabledActionSets returns the action sets for all currently-enabled mappers.
-func (m *Mappers) EnabledActionSets() []string {
+func (m *MappersRegistry) EnabledActionSets() []string {
 	out := make([]string, 0, 3*len(m.entries))
 	for _, e := range m.entries {
 		if e.enabled != nil && !e.enabled() {
@@ -137,7 +137,7 @@ func (m *Mappers) EnabledActionSets() []string {
 }
 
 // EnabledScopePatterns returns the scope patterns for all currently-enabled mappers.
-func (m *Mappers) EnabledScopePatterns() []string {
+func (m *MappersRegistry) EnabledScopePatterns() []string {
 	out := make([]string, 0, len(m.entries))
 	for _, e := range m.entries {
 		if e.enabled != nil && !e.enabled() {

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -27,8 +27,7 @@ type Mapper interface {
 	ActionSet(level string) (string, error)
 
 	// ScopePattern returns the SQL LIKE pattern for querying scopes of this resource type.
-	// Used in list queries with SQL LIKE to match all permissions for this resource type
-	// regardless of the specific resource identifier (UID). The % wildcard matches any UID.
+	// Used in list queries with SQL LIKE to match all permissions for this resource type.
 	// Example: "folders:uid:%" matches "folders:uid:abc", "folders:uid:xyz", etc.
 	ScopePattern() string
 }
@@ -134,8 +133,8 @@ func (m *MappersRegistry) IsEnabled(gr schema.GroupResource) bool {
 
 // ParseScope parses an RBAC scope string (e.g., "folders:uid:abc") into a groupResourceName.
 // Used when reading permissions from the database for two purposes:
-//   1. Populating the ResourcePermission Spec (Group, Resource, Name fields)
-//   2. Making AccessClient Check requests to authorize viewing the resource
+//  1. Populating the ResourcePermission Spec (Group, Resource, Name fields)
+//  2. Making AccessClient Check requests to authorize viewing the resource
 func (m *MappersRegistry) ParseScope(scope string) (*groupResourceName, error) {
 	parts := strings.SplitN(scope, ":", 3)
 	if len(parts) != 3 {

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -1,0 +1,155 @@
+package resourcepermission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// --- NewMappers defaults ---
+
+func TestNewMappers_Defaults(t *testing.T) {
+	m := NewMappers()
+
+	folderGR := schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}
+	dashGR := schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}
+
+	t.Run("folders mapper is registered and enabled", func(t *testing.T) {
+		_, ok := m.Get(folderGR)
+		assert.True(t, ok)
+		assert.True(t, m.IsEnabled(folderGR))
+	})
+
+	t.Run("dashboards mapper is registered and enabled", func(t *testing.T) {
+		_, ok := m.Get(dashGR)
+		assert.True(t, ok)
+		assert.True(t, m.IsEnabled(dashGR))
+	})
+
+	t.Run("unknown group/resource returns not found", func(t *testing.T) {
+		_, ok := m.Get(schema.GroupResource{Group: "other.grafana.app", Resource: "other"})
+		assert.False(t, ok)
+		assert.False(t, m.IsEnabled(schema.GroupResource{Group: "other.grafana.app", Resource: "other"}))
+	})
+}
+
+// --- RegisterMapper ---
+
+func TestMappers_RegisterMapper(t *testing.T) {
+	t.Run("nil enabled func is always enabled", func(t *testing.T) {
+		m := NewMappers()
+		gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
+		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), nil)
+
+		_, ok := m.Get(gr)
+		assert.True(t, ok)
+		assert.True(t, m.IsEnabled(gr))
+	})
+
+	t.Run("disabled mapper is Get-able but not IsEnabled", func(t *testing.T) {
+		m := NewMappers()
+		gr := schema.GroupResource{Group: "loki.datasource.grafana.app", Resource: "datasources"}
+		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), func() bool { return false })
+
+		_, ok := m.Get(gr)
+		assert.True(t, ok, "Get should succeed regardless of enabled state")
+		assert.False(t, m.IsEnabled(gr))
+	})
+
+	t.Run("disabled mapper is excluded from EnabledScopePatterns and EnabledActionSets", func(t *testing.T) {
+		m := NewMappers()
+		gr := schema.GroupResource{Group: "loki.datasource.grafana.app", Resource: "datasources"}
+		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), func() bool { return false })
+
+		for _, p := range m.EnabledScopePatterns() {
+			assert.NotEqual(t, "datasources:uid:%", p)
+		}
+		for _, a := range m.EnabledActionSets() {
+			assert.NotEqual(t, "datasources:query", a)
+		}
+	})
+}
+
+// --- ParseScope ---
+
+func TestMappers_ParseScope(t *testing.T) {
+	m := NewMappers()
+
+	t.Run("parses folder scope", func(t *testing.T) {
+		grn, err := m.ParseScope("folders:uid:fold1")
+		require.NoError(t, err)
+		assert.Equal(t, "folder.grafana.app", grn.Group)
+		assert.Equal(t, "folders", grn.Resource)
+		assert.Equal(t, "fold1", grn.Name)
+	})
+
+	t.Run("parses dashboard scope", func(t *testing.T) {
+		grn, err := m.ParseScope("dashboards:uid:dash1")
+		require.NoError(t, err)
+		assert.Equal(t, "dashboard.grafana.app", grn.Group)
+		assert.Equal(t, "dashboards", grn.Resource)
+		assert.Equal(t, "dash1", grn.Name)
+	})
+
+	t.Run("parses dynamically registered datasource scope", func(t *testing.T) {
+		m2 := NewMappers()
+		gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
+		m2.RegisterMapper(gr, NewMapper("datasources", []string{"query", "edit", "admin"}), nil)
+
+		grn, err := m2.ParseScope("datasources:uid:abc")
+		require.NoError(t, err)
+		assert.Equal(t, "datasource.grafana.app", grn.Group)
+		assert.Equal(t, "datasources", grn.Resource)
+		assert.Equal(t, "abc", grn.Name)
+	})
+
+	t.Run("unknown scope prefix returns error", func(t *testing.T) {
+		_, err := m.ParseScope("unknown:uid:x")
+		assert.ErrorIs(t, err, errUnknownGroupResource)
+	})
+
+	t.Run("malformed scope (no colons) returns error", func(t *testing.T) {
+		_, err := m.ParseScope("nocolons")
+		assert.ErrorIs(t, err, errInvalidScope)
+	})
+
+	t.Run("only two parts returns error", func(t *testing.T) {
+		_, err := m.ParseScope("folders:uid")
+		assert.ErrorIs(t, err, errInvalidScope)
+	})
+}
+
+// --- EnabledActionSets / EnabledScopePatterns ---
+
+func TestMappers_EnabledFiltered(t *testing.T) {
+	gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
+
+	t.Run("enabled mapper contributes to both slices", func(t *testing.T) {
+		m := NewMappers()
+		m.RegisterMapper(gr, NewMapper("datasources", []string{"query", "edit"}), nil)
+
+		assert.Contains(t, m.EnabledScopePatterns(), "datasources:uid:%")
+		assert.Contains(t, m.EnabledActionSets(), "datasources:query")
+		assert.Contains(t, m.EnabledActionSets(), "datasources:edit")
+	})
+
+	t.Run("disabled mapper is excluded from both slices", func(t *testing.T) {
+		m := NewMappers()
+		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), func() bool { return false })
+
+		assert.NotContains(t, m.EnabledScopePatterns(), "datasources:uid:%")
+		assert.NotContains(t, m.EnabledActionSets(), "datasources:query")
+	})
+
+	t.Run("defaults always appear in both slices", func(t *testing.T) {
+		m := NewMappers()
+		patterns := m.EnabledScopePatterns()
+		assert.Contains(t, patterns, "folders:uid:%")
+		assert.Contains(t, patterns, "dashboards:uid:%")
+		actions := m.EnabledActionSets()
+		assert.Contains(t, actions, "folders:view")
+		assert.Contains(t, actions, "dashboards:edit")
+	})
+}

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -8,10 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// --- NewMappers defaults ---
+// --- NewMappersRegistry defaults ---
 
-func TestNewMappers_Defaults(t *testing.T) {
-	m := NewMappers()
+func TestNewMappersRegistry_Defaults(t *testing.T) {
+	m := NewMappersRegistry()
 
 	folderGR := schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}
 	dashGR := schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}
@@ -37,9 +37,9 @@ func TestNewMappers_Defaults(t *testing.T) {
 
 // --- RegisterMapper ---
 
-func TestMappers_RegisterMapper(t *testing.T) {
+func TestMappersRegistry_RegisterMapper(t *testing.T) {
 	t.Run("nil enabled func is always enabled", func(t *testing.T) {
-		m := NewMappers()
+		m := NewMappersRegistry()
 		gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
 		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), nil)
 
@@ -49,7 +49,7 @@ func TestMappers_RegisterMapper(t *testing.T) {
 	})
 
 	t.Run("disabled mapper is Get-able but not IsEnabled", func(t *testing.T) {
-		m := NewMappers()
+		m := NewMappersRegistry()
 		gr := schema.GroupResource{Group: "loki.datasource.grafana.app", Resource: "datasources"}
 		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), func() bool { return false })
 
@@ -59,7 +59,7 @@ func TestMappers_RegisterMapper(t *testing.T) {
 	})
 
 	t.Run("disabled mapper is excluded from EnabledScopePatterns and EnabledActionSets", func(t *testing.T) {
-		m := NewMappers()
+		m := NewMappersRegistry()
 		gr := schema.GroupResource{Group: "loki.datasource.grafana.app", Resource: "datasources"}
 		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), func() bool { return false })
 
@@ -74,8 +74,8 @@ func TestMappers_RegisterMapper(t *testing.T) {
 
 // --- ParseScope ---
 
-func TestMappers_ParseScope(t *testing.T) {
-	m := NewMappers()
+func TestMappersRegistry_ParseScope(t *testing.T) {
+	m := NewMappersRegistry()
 
 	t.Run("parses folder scope", func(t *testing.T) {
 		grn, err := m.ParseScope("folders:uid:fold1")
@@ -94,7 +94,7 @@ func TestMappers_ParseScope(t *testing.T) {
 	})
 
 	t.Run("parses dynamically registered datasource scope", func(t *testing.T) {
-		m2 := NewMappers()
+		m2 := NewMappersRegistry()
 		gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
 		m2.RegisterMapper(gr, NewMapper("datasources", []string{"query", "edit", "admin"}), nil)
 
@@ -123,11 +123,11 @@ func TestMappers_ParseScope(t *testing.T) {
 
 // --- EnabledActionSets / EnabledScopePatterns ---
 
-func TestMappers_EnabledFiltered(t *testing.T) {
+func TestMappersRegistry_EnabledFiltered(t *testing.T) {
 	gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
 
 	t.Run("enabled mapper contributes to both slices", func(t *testing.T) {
-		m := NewMappers()
+		m := NewMappersRegistry()
 		m.RegisterMapper(gr, NewMapper("datasources", []string{"query", "edit"}), nil)
 
 		assert.Contains(t, m.EnabledScopePatterns(), "datasources:uid:%")
@@ -136,7 +136,7 @@ func TestMappers_EnabledFiltered(t *testing.T) {
 	})
 
 	t.Run("disabled mapper is excluded from both slices", func(t *testing.T) {
-		m := NewMappers()
+		m := NewMappersRegistry()
 		m.RegisterMapper(gr, NewMapper("datasources", []string{"query"}), func() bool { return false })
 
 		assert.NotContains(t, m.EnabledScopePatterns(), "datasources:uid:%")
@@ -144,7 +144,7 @@ func TestMappers_EnabledFiltered(t *testing.T) {
 	})
 
 	t.Run("defaults always appear in both slices", func(t *testing.T) {
-		m := NewMappers()
+		m := NewMappersRegistry()
 		patterns := m.EnabledScopePatterns()
 		assert.Contains(t, patterns, "folders:uid:%")
 		assert.Contains(t, patterns, "dashboards:uid:%")

--- a/pkg/registry/apis/iam/resourcepermission/models.go
+++ b/pkg/registry/apis/iam/resourcepermission/models.go
@@ -237,22 +237,16 @@ func (g *groupResourceName) v0alpha1() v0alpha1.ResourcePermissionspecResource {
 
 // ParseScope parses a scope string (e.g. folders:uid:1) into a groupResourceName (e.g. {folder.grafana.app, folders, fold1}).
 func (s *ResourcePermSqlBackend) ParseScope(scope string) (*groupResourceName, error) {
-	parts := strings.SplitN(scope, ":", 3)
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("%w: %s", errInvalidScope, scope)
-	}
-	gr, ok := s.reverseMappers[parts[0]]
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", errUnknownGroupResource, parts[0])
-	}
-	return &groupResourceName{
-		Group:    gr.Group,
-		Resource: gr.Resource,
-		Name:     parts[2],
-	}, nil
+	return s.mappers.ParseScope(scope)
 }
 
-// splitResourceName splits a resource name in the format <group>-<resource>-<name> (e.g. dashboard.grafana.app-dashboards-ad5rwqs) into its components
+// splitResourceName splits a resource name in the format <group>-<resource>-<name>
+// (e.g. dashboard.grafana.app-dashboards-ad5rwqs) into its components.
+//
+// FIXME: strings.SplitN(name, "-", 3) mangles groups that contain hyphens
+// (e.g. grafana-testdata-datasource.datasource.grafana.app). A delimiter-free
+// encoding (e.g. base64-encoded group, or a different separator) is needed
+// before datasource permissions can work with hyphenated plugin IDs.
 func splitResourceName(resourceName string) (*groupResourceName, error) {
 	// e.g. dashboard.grafana.app-dashboards-ad5rwqs
 	parts := strings.SplitN(resourceName, "-", 3)
@@ -269,12 +263,11 @@ func splitResourceName(resourceName string) (*groupResourceName, error) {
 	}, nil
 }
 
-// getResourceMapper returns the Mapper of the given group and resource to access levels and scope prefix for that resource.
+// getResourceMapper returns the Mapper for the given group and resource.
 func (s *ResourcePermSqlBackend) getResourceMapper(group, resource string) (Mapper, error) {
-	mapper, ok := s.mappers[schema.GroupResource{Group: group, Resource: resource}]
+	mapper, ok := s.mappers.Get(schema.GroupResource{Group: group, Resource: resource})
 	if !ok {
 		return nil, fmt.Errorf("%w: %s/%s", errUnknownGroupResource, group, resource)
 	}
-
 	return mapper, nil
 }

--- a/pkg/registry/apis/iam/resourcepermission/models_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/models_test.go
@@ -15,7 +15,7 @@ func setupBackendNoDB(t *testing.T) *ResourcePermSqlBackend {
 	noProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
 		return nil, nil
 	}
-	return ProvideStorageBackend(noProvider, NewMappers())
+	return ProvideStorageBackend(noProvider, NewMappersRegistry())
 }
 
 func TestToV0ResourcePermissions(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/models_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/models_test.go
@@ -15,7 +15,7 @@ func setupBackendNoDB(t *testing.T) *ResourcePermSqlBackend {
 	noProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
 		return nil, nil
 	}
-	return ProvideStorageBackend(noProvider)
+	return ProvideStorageBackend(noProvider, NewMappers())
 }
 
 func TestToV0ResourcePermissions(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -24,19 +24,12 @@ func (s *ResourcePermSqlBackend) newRoleIterator(ctx context.Context, dbHelper *
 	var (
 		scope string
 
-		actionSets    = make([]string, 0, 3*len(s.mappers))
-		scopePatterns = make([]string, 0, len(s.mappers))
+		actionSets    = s.mappers.EnabledActionSets()
+		scopePatterns = s.mappers.EnabledScopePatterns()
 
 		assignments = make([]rbacAssignment, 0, 8)
 		scopes      = make([]string, 0, 8)
 	)
-
-	for _, mapper := range s.mappers {
-		actionSets = append(actionSets, mapper.ActionSets()...)
-	}
-	for _, mapper := range s.mappers {
-		scopePatterns = append(scopePatterns, mapper.ScopePattern())
-	}
 
 	// Run in a transaction to ensure a consistent view of the data
 	err := dbHelper.DB.GetSqlxSession().WithTransaction(ctx, func(tx *session.SessionTx) error {
@@ -101,10 +94,7 @@ func (s *ResourcePermSqlBackend) newRoleIterator(ctx context.Context, dbHelper *
 }
 
 func (s *ResourcePermSqlBackend) latestUpdate(ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper, ns types.NamespaceInfo) int64 {
-	scopePatterns := make([]string, 0, len(s.mappers)*3)
-	for _, mapper := range s.mappers {
-		scopePatterns = append(scopePatterns, mapper.ScopePattern())
-	}
+	scopePatterns := s.mappers.EnabledScopePatterns()
 	query, args, err := buildLatestUpdateQueryFromTemplate(dbHelper, ns.OrgID, scopePatterns)
 	if err != nil {
 		s.logger.FromContext(ctx).Warn("Failed to build latest update query", "error", err)
@@ -547,10 +537,7 @@ func (s *ResourcePermSqlBackend) ListDirectPermissionsForUser(ctx context.Contex
 		s.logger.FromContext(ctx).Error("Failed to get database helper", "error", err)
 		return nil, errDatabaseHelper
 	}
-	actionSets := make([]string, 0, 3*len(s.mappers))
-	for _, mapper := range s.mappers {
-		actionSets = append(actionSets, mapper.ActionSets()...)
-	}
+	actionSets := s.mappers.EnabledActionSets()
 	var assignments []rbacAssignment
 	err = dbHelper.DB.GetSqlxSession().WithTransaction(ctx, func(tx *session.SessionTx) error {
 		assignments, err = s.getRbacAssignmentsWithTx(ctx, dbHelper, tx, &ListResourcePermissionsQuery{

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -111,7 +111,7 @@ func setupBackend(t *testing.T) *ResourcePermSqlBackend {
 		return sqlHelper, nil
 	}
 
-	return ProvideStorageBackend(dbProvider, NewMappers())
+	return ProvideStorageBackend(dbProvider, NewMappersRegistry())
 }
 
 func setupTestRoles(t *testing.T, store db.DB) {

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -111,7 +111,7 @@ func setupBackend(t *testing.T) *ResourcePermSqlBackend {
 		return sqlHelper, nil
 	}
 
-	return ProvideStorageBackend(dbProvider)
+	return ProvideStorageBackend(dbProvider, NewMappers())
 }
 
 func setupTestRoles(t *testing.T, store db.DB) {
@@ -689,7 +689,7 @@ func TestIntegration_UpdateResourcePermission_VerbChange(t *testing.T) {
 	require.NoError(t, err)
 	setupTestRoles(t, sql.DB)
 
-	mapper := backend.mappers[schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}]
+	mapper, _ := backend.mappers.Get(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"})
 	grn := &groupResourceName{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "test-dash"}
 
 	t.Run("should allow changing verb for same entity", func(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/types"
@@ -33,31 +32,20 @@ type ResourcePermSqlBackend struct {
 	dbProvider    legacysql.LegacyDatabaseProvider
 	identityStore IdentityStore
 	logger        log.Logger
-
-	mappers        map[schema.GroupResource]Mapper // group/resource -> rbac mapper
-	reverseMappers map[string]schema.GroupResource // rbac kind -> group/resource
+	mappers       *Mappers
 
 	subscribers []chan *resource.WrittenEvent
 	mutex       sync.Mutex
 }
 
-func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider) *ResourcePermSqlBackend {
+func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers *Mappers) *ResourcePermSqlBackend {
 	return &ResourcePermSqlBackend{
 		dbProvider:    dbProvider,
 		identityStore: idStore.NewLegacySQLStores(dbProvider),
 		logger:        log.New("resourceperm_storage_backend"),
-
-		mappers: map[schema.GroupResource]Mapper{
-			{Group: "folder.grafana.app", Resource: "folders"}:       NewMapper("folders", defaultLevels),
-			{Group: "dashboard.grafana.app", Resource: "dashboards"}: NewMapper("dashboards", defaultLevels),
-		},
-		reverseMappers: map[string]schema.GroupResource{
-			"folders":    {Group: "folder.grafana.app", Resource: "folders"},
-			"dashboards": {Group: "dashboard.grafana.app", Resource: "dashboards"},
-		},
-
-		subscribers: make([]chan *resource.WrittenEvent, 0),
-		mutex:       sync.Mutex{},
+		mappers:       mappers,
+		subscribers:   make([]chan *resource.WrittenEvent, 0),
+		mutex:         sync.Mutex{},
 	}
 }
 

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -32,13 +32,13 @@ type ResourcePermSqlBackend struct {
 	dbProvider    legacysql.LegacyDatabaseProvider
 	identityStore IdentityStore
 	logger        log.Logger
-	mappers       *Mappers
+	mappers       *MappersRegistry
 
 	subscribers []chan *resource.WrittenEvent
 	mutex       sync.Mutex
 }
 
-func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers *Mappers) *ResourcePermSqlBackend {
+func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers *MappersRegistry) *ResourcePermSqlBackend {
 	return &ResourcePermSqlBackend{
 		dbProvider:    dbProvider,
 		identityStore: idStore.NewLegacySQLStores(dbProvider),

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
@@ -131,7 +131,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	}
 
 	t.Run("should error with invalid namespace", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 
 		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
 			Type: resourcepb.WatchEvent_ADDED,
@@ -144,7 +144,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should error if resource name is empty", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -180,7 +180,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should error if the resource is unknown", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -216,7 +216,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should work with valid resource permission", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 		backend.identityStore = NewFakeIdentityStore(t)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
@@ -670,7 +670,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	}
 
 	t.Run("should error with invalid namespace", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 
 		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
 			Type: resourcepb.WatchEvent_MODIFIED,
@@ -683,7 +683,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should error if resource name is empty", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -719,7 +719,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should error if the resource is unknown", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -755,7 +755,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should work with valid resource permission", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider, NewMappers())
+		backend := ProvideStorageBackend(dbProvider, NewMappersRegistry())
 		backend.identityStore = NewFakeIdentityStore(t)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
@@ -131,7 +131,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	}
 
 	t.Run("should error with invalid namespace", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 
 		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
 			Type: resourcepb.WatchEvent_ADDED,
@@ -144,7 +144,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should error if resource name is empty", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -180,7 +180,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should error if the resource is unknown", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -216,7 +216,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should work with valid resource permission", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 		backend.identityStore = NewFakeIdentityStore(t)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
@@ -670,7 +670,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	}
 
 	t.Run("should error with invalid namespace", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 
 		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
 			Type: resourcepb.WatchEvent_MODIFIED,
@@ -683,7 +683,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should error if resource name is empty", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -719,7 +719,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should error if the resource is unknown", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -755,7 +755,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should work with valid resource permission", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, NewMappers())
 		backend.identityStore = NewFakeIdentityStore(t)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{


### PR DESCRIPTION
## Summary

Extract `Mappers` service from `storage_backend.go` into `mapper.go` to later enable enterprise registration of datasource resource permission mappers.

**Key changes:**
- Created `Mappers` registry with `NewMappers()` and `ProvideMappers()` Wire provider
- Added `RegisterMapper(gr, mapper, enabled)` for dynamic mapper registration at init time
- `Get()` returns mapper regardless of enabled state (for reading existing data)
- `IsEnabled()` checks enabled closure for admission gating
- `EnabledActionSets()` and `EnabledScopePatterns()` filter by enablement (for list queries)
- Removed `findGroupKey` wildcard resolution for now - will be added later when needed for datasource permissions

This is a prerequisite for enterprise to register datasource permissions.

## Test plan

- [x] Unit tests for `Mappers` registry (`mapper_test.go`)
- [x] All existing tests pass
- [x] IAM package compiles successfully


Made with [Cursor](https://cursor.com)