### PR TITLE
E2E: Fix table-nested test timeout and hover state

### DIFF
--- a/e2e-playwright/panels-suite/table-nested.spec.ts
+++ b/e2e-playwright/panels-suite/table-nested.spec.ts
@@ -201,6 +201,9 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     selectors,
     page,
   }) => {
+    // This test performs many UI interactions on a nested table (which renders slower than a flat one).
+    // The default timeout is not enough for CI.
+    test.slow();
     const panelEditPage = await gotoPanelEditPage({
       dashboard: {
         uid: NESTED_COMPLEX_DASHBOARD_UID,
@@ -254,6 +257,7 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     // click cell inspect, check that cell inspection pops open in the side as we'd expect.
     const loremIpsumText = await loremIpsumCell.textContent();
     expect(loremIpsumText).toBeDefined();
+    await loremIpsumCell.hover(); // ensure the cell actions are visible before clicking
     await loremIpsumCell.getByLabel('Inspect value').click();
     await expect(page.getByRole('dialog').getByText(loremIpsumText!)).toBeVisible();
   });


### PR DESCRIPTION
## What is this feature?

Fixes a flaky Playwright e2e test that fails in CI with `Target page, context or browser has been closed`. The test performs many sequential UI interactions on a nested table, which renders slower than flat tables, causing it to exceed the default 30-second timeout in CI.

## Why do we need this feature?

The test was timing out and being killed mid-assertion. This fix provides adequate time for all interactions to complete and ensures the cell actions are properly visible before attempting to click the inspect button.

## Special notes for your reviewer:

- `test.slow()` triples the timeout from 30s to 90s for this test
- Added explicit hover before clicking "Inspect value" to ensure cell actions CSS is active