### PR TITLE
IAM: Inject resource permissions MappersRegistry and extend create/update/delete validation

### DIFF
--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -60,6 +60,7 @@ type IdentityAccessManagementAPIBuilder struct {
 	teamLBACApiInstaller             TeamLBACApiInstaller
 	externalGroupMappingApiInstaller ExternalGroupMappingApiInstaller
 	resourcePermissionsStorage       resource.StorageBackend
+	mappers                          *resourcepermission.MappersRegistry
 	roleBindingsStorage              RoleBindingStorageBackend
 
 	// Required for resource permissions authorization

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -931,6 +931,8 @@ func (b *IdentityAccessManagementAPIBuilder) validateDelete(ctx context.Context,
 			return b.teamLBACApiInstaller.ValidateOnDelete(ctx, oldObj)
 		}
 		return nil
+	case *iamv0.ResourcePermission:
+		return resourcepermission.ValidateDeleteInput(ctx, oldObj.Name, b.mappers)
 	}
 	return nil
 }

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -90,6 +90,7 @@ func RegisterAPIService(
 	userService legacyuser.Service,
 	teamService teamservice.Service,
 	restConfig apiserver.RestConfigProvider,
+	mappers *resourcepermission.MappersRegistry,
 ) (*IdentityAccessManagementAPIBuilder, error) {
 	dbProvider := legacysql.NewDatabaseProvider(sql)
 	store := legacy.NewLegacySQLStores(dbProvider)
@@ -97,7 +98,7 @@ func RegisterAPIService(
 	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller)
 	registerMetrics(reg)
 
-	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappersRegistry())
+	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, mappers)
 
 	// When resourcepermissions are in Mode5 (unistore only), search must error; pass nil backend so the handler returns that error.
 	resourcePermsSearchBackend := resource.StorageBackend(rpStorage)
@@ -129,6 +130,7 @@ func RegisterAPIService(
 		teamLBACApiInstaller:              teamLBACApiInstaller,
 		externalGroupMappingApiInstaller:  externalGroupMappingApiInstaller,
 		resourcePermissionsStorage:        rpStorage,
+		mappers:                           mappers,
 		roleBindingsStorage:               roleBindingsStorage,
 		teamGroupsHandler:                 teamGroupsHandlerImpl,
 		externalGroupMappingSearchHandler: externalGroupMappingSearchHandler,
@@ -177,9 +179,10 @@ func NewAPIService(
 	tokenExchanger authn.TokenExchanger,
 	authorizerDialConfigs map[schema.GroupResource]iamauthorizer.DialConfig,
 	tracingService tracing.Tracer,
+	mappers *resourcepermission.MappersRegistry,
 ) *IdentityAccessManagementAPIBuilder {
 	store := legacy.NewLegacySQLStores(dbProvider)
-	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, resourcepermission.NewMappersRegistry())
+	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, mappers)
 	registerMetrics(reg)
 
 	globalRoleAuthorizer := globalRoleApiInstaller.GetAuthorizer()
@@ -199,6 +202,7 @@ func NewAPIService(
 		display:                    user.NewLegacyDisplayREST(store),
 		tracing:                    tracingService,
 		resourcePermissionsStorage: resourcePermissionsStorage,
+		mappers:                    mappers,
 		roleBindingsStorage:        roleBindingsStorage,
 		logger:                     log.New("iam.apis"),
 		features:                   features,
@@ -858,7 +862,7 @@ func (b *IdentityAccessManagementAPIBuilder) validateCreate(ctx context.Context,
 	case *iamv0.TeamBinding:
 		return teambinding.ValidateOnCreate(ctx, typedObj)
 	case *iamv0.ResourcePermission:
-		return resourcepermission.ValidateCreateAndUpdateInput(ctx, typedObj)
+		return resourcepermission.ValidateCreateAndUpdateInput(ctx, typedObj, b.mappers)
 	case *iamv0.ExternalGroupMapping:
 		return b.externalGroupMappingApiInstaller.ValidateOnCreate(ctx, typedObj)
 	case *iamv0.Role:
@@ -881,7 +885,7 @@ func (b *IdentityAccessManagementAPIBuilder) validateUpdate(ctx context.Context,
 		}
 		return user.ValidateOnUpdate(ctx, b.userSearchClient, oldUserObj, typedObj)
 	case *iamv0.ResourcePermission:
-		return resourcepermission.ValidateCreateAndUpdateInput(ctx, typedObj)
+		return resourcepermission.ValidateCreateAndUpdateInput(ctx, typedObj, b.mappers)
 	case *iamv0.Team:
 		oldTeamObj, ok := oldObj.(*iamv0.Team)
 		if !ok {

--- a/pkg/registry/apis/iam/resourcepermission/validate.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
-func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.ResourcePermission) error {
+func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.ResourcePermission, mappers *MappersRegistry) error {
 	if v0ResourcePerm == nil {
 		return fmt.Errorf("resource permission cannot be nil")
 	}
@@ -26,6 +28,11 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 		grn.Resource != v0ResourcePerm.Spec.Resource.Resource ||
 		grn.Name != v0ResourcePerm.Spec.Resource.Name {
 		return fmt.Errorf("resource permission name does not match spec: %w", errInvalidSpec)
+	}
+
+	// Check that the group/resource is registered and enabled
+	if !mappers.IsEnabled(schema.GroupResource{Group: grn.Group, Resource: grn.Resource}) {
+		return fmt.Errorf("unknown or disabled group/resource %s/%s: %w", grn.Group, grn.Resource, errUnknownGroupResource)
 	}
 
 	// Check for duplicate entities (same kind and name should appear only once)

--- a/pkg/registry/apis/iam/resourcepermission/validate.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
@@ -11,28 +12,28 @@ import (
 
 func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.ResourcePermission, mappers *MappersRegistry) error {
 	if v0ResourcePerm == nil {
-		return fmt.Errorf("resource permission cannot be nil")
+		return apierrors.NewBadRequest("resource permission cannot be nil")
 	}
 
 	if len(v0ResourcePerm.Spec.Permissions) == 0 {
-		return fmt.Errorf("resource permission must have at least one permission: %w", errInvalidSpec)
+		return apierrors.NewBadRequest(fmt.Sprintf("resource permission must have at least one permission: %s", errInvalidSpec))
 	}
 
 	grn, err := splitResourceName(v0ResourcePerm.Name)
 	if err != nil {
-		return fmt.Errorf("invalid resource permission name: %w", err)
+		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource permission name: %s", err))
 	}
 
 	// Validate that the group/resource/name in the name matches the spec
 	if grn.Group != v0ResourcePerm.Spec.Resource.ApiGroup ||
 		grn.Resource != v0ResourcePerm.Spec.Resource.Resource ||
 		grn.Name != v0ResourcePerm.Spec.Resource.Name {
-		return fmt.Errorf("resource permission name does not match spec: %w", errInvalidSpec)
+		return apierrors.NewBadRequest(fmt.Sprintf("resource permission name does not match spec: %s", errInvalidSpec))
 	}
 
 	// Check that the group/resource is registered and enabled
 	if !mappers.IsEnabled(schema.GroupResource{Group: grn.Group, Resource: grn.Resource}) {
-		return fmt.Errorf("unknown or disabled group/resource %s/%s: %w", grn.Group, grn.Resource, errUnknownGroupResource)
+		return apierrors.NewBadRequest(fmt.Sprintf("unknown or disabled group/resource %s/%s", grn.Group, grn.Resource))
 	}
 
 	// Check for duplicate entities (same kind and name should appear only once)
@@ -40,7 +41,7 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 	for _, perm := range v0ResourcePerm.Spec.Permissions {
 		key := fmt.Sprintf("%s:%s", perm.Kind, perm.Name)
 		if seen[key] {
-			return fmt.Errorf("duplicate entity found: kind=%s, name=%s (each entity can only appear once per resource): %w", perm.Kind, perm.Name, errInvalidSpec)
+			return apierrors.NewBadRequest(fmt.Sprintf("duplicate entity found: kind=%s, name=%s (each entity can only appear once per resource): %s", perm.Kind, perm.Name, errInvalidSpec))
 		}
 		seen[key] = true
 	}
@@ -55,12 +56,12 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 func ValidateDeleteInput(ctx context.Context, name string, mappers *MappersRegistry) error {
 	grn, err := splitResourceName(name)
 	if err != nil {
-		return fmt.Errorf("invalid resource permission name: %w", err)
+		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource permission name: %s", err))
 	}
 
 	// Check that the group/resource is registered and enabled
 	if !mappers.IsEnabled(schema.GroupResource{Group: grn.Group, Resource: grn.Resource}) {
-		return fmt.Errorf("unknown or disabled group/resource %s/%s: %w", grn.Group, grn.Resource, errUnknownGroupResource)
+		return apierrors.NewBadRequest(fmt.Sprintf("unknown or disabled group/resource %s/%s", grn.Group, grn.Resource))
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/resourcepermission/validate.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate.go
@@ -47,3 +47,21 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 
 	return nil
 }
+
+// ValidateDeleteInput validates a resource permission delete operation.
+// It ensures the resource being deleted has a known/registered group/resource type.
+// This prevents deletes of resource permissions for resource types that aren't
+// enabled or registered in the system.
+func ValidateDeleteInput(ctx context.Context, name string, mappers *MappersRegistry) error {
+	grn, err := splitResourceName(name)
+	if err != nil {
+		return fmt.Errorf("invalid resource permission name: %w", err)
+	}
+
+	// Check that the group/resource is registered and enabled
+	if !mappers.IsEnabled(schema.GroupResource{Group: grn.Group, Resource: grn.Resource}) {
+		return fmt.Errorf("unknown or disabled group/resource %s/%s: %w", grn.Group, grn.Resource, errUnknownGroupResource)
+	}
+
+	return nil
+}

--- a/pkg/registry/apis/iam/resourcepermission/validate_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate_test.go
@@ -168,3 +168,49 @@ func TestValidateOnCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDeleteInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		objName string
+		want    error
+	}{
+		{
+			name:    "invalid name - should fail",
+			objName: "some-invalid-name",
+			want:    errInvalidName,
+		},
+		{
+			name:    "enabled group/resource (folder) - should pass",
+			objName: "folder.grafana.app-folders-test_folder",
+			want:    nil,
+		},
+		{
+			name:    "enabled group/resource (dashboard) - should pass",
+			objName: "dashboard.grafana.app-dashboards-test_dashboard",
+			want:    nil,
+		},
+		{
+			name:    "disabled group/resource - should fail",
+			objName: "disabled.grafana.app-resources-test_resource",
+			want:    errUnknownGroupResource,
+		},
+		{
+			name:    "unknown group/resource - should fail",
+			objName: "unknown.group-app-resources-test",
+			want:    errUnknownGroupResource,
+		},
+	}
+
+	mappers := NewMappersRegistry()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateDeleteInput(context.Background(), test.objName, mappers)
+			if test.want == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorAs(t, test.want, &err)
+			}
+		})
+	}
+}

--- a/pkg/registry/apis/iam/resourcepermission/validate_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate_test.go
@@ -156,9 +156,10 @@ func TestValidateOnCreate(t *testing.T) {
 		},
 	}
 
+	mappers := NewMappersRegistry()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidateCreateAndUpdateInput(context.Background(), test.obj)
+			err := ValidateCreateAndUpdateInput(context.Background(), test.obj, mappers)
 			if test.want == nil {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/registry/apis/wireset.go
+++ b/pkg/registry/apis/wireset.go
@@ -28,7 +28,6 @@ import (
 
 // WireSetExts is a set of providers that can be overridden by enterprise implementations.
 var WireSetExts = wire.NewSet(
-	resourcepermission.ProvideMappersRegistry,
 	noopstorage.ProvideStorageBackend,
 	iam.ProvideNoopRoleApiInstaller,
 	iam.ProvideNoopGlobalRoleApiInstaller,
@@ -69,6 +68,9 @@ var WireSet = wire.NewSet(
 	// Provisioning
 	provisioning.RegisterDependencies,
 	provisioningExtras,
+
+	// Resource Permission
+	resourcepermission.ProvideMappersRegistry,
 
 	// Each must be added here *and* in the ServiceSink above
 	dashboardinternal.RegisterAPIService,

--- a/pkg/registry/apis/wireset.go
+++ b/pkg/registry/apis/wireset.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/externalgroupmapping"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/noopstorage"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
 	"github.com/grafana/grafana/pkg/registry/apis/ofrep"
 	"github.com/grafana/grafana/pkg/registry/apis/preferences"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning"
@@ -27,6 +28,7 @@ import (
 
 // WireSetExts is a set of providers that can be overridden by enterprise implementations.
 var WireSetExts = wire.NewSet(
+	resourcepermission.ProvideMappersRegistry,
 	noopstorage.ProvideStorageBackend,
 	iam.ProvideNoopRoleApiInstaller,
 	iam.ProvideNoopGlobalRoleApiInstaller,

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -58,6 +58,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/externalgroupmapping"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/noopstorage"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
 	"github.com/grafana/grafana/pkg/registry/apis/ofrep"
 	"github.com/grafana/grafana/pkg/registry/apis/preferences"
 	provisioning2 "github.com/grafana/grafana/pkg/registry/apis/provisioning"
@@ -914,7 +915,8 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	storageBackendImpl := noopstorage.ProvideStorageBackend()
 	noopTeamGroupsREST := externalgroupmapping.ProvideNoopTeamGroupsREST()
 	noopSearchREST := externalgroupmapping.ProvideNoopSearchREST()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller, tracingService, storageBackendImpl, noopTeamGroupsREST, noopSearchREST, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider)
+	mappersRegistry := resourcepermission.ProvideMappersRegistry()
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller, tracingService, storageBackendImpl, noopTeamGroupsREST, noopSearchREST, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -1613,7 +1615,8 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	storageBackendImpl := noopstorage.ProvideStorageBackend()
 	noopTeamGroupsREST := externalgroupmapping.ProvideNoopTeamGroupsREST()
 	noopSearchREST := externalgroupmapping.ProvideNoopSearchREST()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller, tracingService, storageBackendImpl, noopTeamGroupsREST, noopSearchREST, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider)
+	mappersRegistry := resourcepermission.ProvideMappersRegistry()
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, featureToggles, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller, tracingService, storageBackendImpl, noopTeamGroupsREST, noopSearchREST, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tests/apis/iam/resource_permissions_integration_test.go
+++ b/pkg/tests/apis/iam/resource_permissions_integration_test.go
@@ -209,6 +209,18 @@ func doResourcePermissionCRUDTests(t *testing.T, helper *apis.K8sTestHelper, cli
 		require.ErrorAs(t, err, &statusErr)
 		require.Equal(t, int32(404), statusErr.ErrStatus.Code)
 	})
+
+	t.Run("should reject delete for unknown group/resource type", func(t *testing.T) {
+		ctx := context.Background()
+
+		// Try to delete a resource permission with an unknown/unregistered group/resource
+		// This should be rejected by the admission validation
+		err := clients.rpAdmin.Resource.Delete(ctx, "unknown.group.app-resources-test", metav1.DeleteOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code, "delete of unknown group/resource should return 400 Bad Request")
+	})
 }
 
 func doResourcePermissionAuthzTests(t *testing.T, helper *apis.K8sTestHelper, clients *k8sTestClients, parentUID string) {

--- a/pkg/tests/apis/iam/resource_permissions_integration_test.go
+++ b/pkg/tests/apis/iam/resource_permissions_integration_test.go
@@ -209,18 +209,6 @@ func doResourcePermissionCRUDTests(t *testing.T, helper *apis.K8sTestHelper, cli
 		require.ErrorAs(t, err, &statusErr)
 		require.Equal(t, int32(404), statusErr.ErrStatus.Code)
 	})
-
-	t.Run("should reject delete for unknown group/resource type", func(t *testing.T) {
-		ctx := context.Background()
-
-		// Try to delete a resource permission with an unknown/unregistered group/resource
-		// This should be rejected by the admission validation
-		err := clients.rpAdmin.Resource.Delete(ctx, "unknown.group.app-resources-test", metav1.DeleteOptions{})
-		require.Error(t, err)
-		var statusErr *errors.StatusError
-		require.ErrorAs(t, err, &statusErr)
-		require.Equal(t, int32(400), statusErr.ErrStatus.Code, "delete of unknown group/resource should return 400 Bad Request")
-	})
 }
 
 func doResourcePermissionAuthzTests(t *testing.T, helper *apis.K8sTestHelper, clients *k8sTestClients, parentUID string) {


### PR DESCRIPTION

## Summary

- Rename `Mappers` to `MappersRegistry` for clarity
- Add `ProvideMappersRegistry` to `WireSetExts` so it is provided via Wire in OSS
- Add `*MappersRegistry` to `IdentityAccessManagementAPIBuilder` and thread it through `RegisterAPIService` and `NewAPIService`
- Pass `*MappersRegistry` to `ProvideStorageBackend` instead of inline `NewMappersRegistry()` calls
- Update `ValidateCreateAndUpdateInput` to accept `*MappersRegistry` and gate create/update on `IsEnabled` — ensures unknown or disabled group/resources are rejected at admission
- Create `ValidateDeleteInput` to gate delete on `IsEnabled`.

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/11356

## Test plan

- [x] Unit tests for `MappersRegistry` and `ValidateCreateAndUpdateInput` `ValidateDeleteInput` pass
- [x] IAM package compiles