### PR TITLE
Provisioning: Handle file renames gracefully in CompareFiles

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -784,12 +784,30 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 				Action: repository.FileActionUpdated,
 			})
 		case protocol.FileStatusRenamed:
-			if f.Mode == 0o40000 {
-				continue
-			}
-
 			newPath, newErr := safepath.RelativeTo(f.Path, r.gitConfig.Path)
 			oldPath, oldErr := safepath.RelativeTo(f.OldPath, r.gitConfig.Path)
+
+			// Tree entries (directories) cannot be processed as file renames.
+			// Decompose into delete + create so folder bookkeeping still works.
+			if f.Mode == 0o40000 {
+				if oldErr == nil {
+					changes = append(changes, repository.VersionedFileChange{
+						Action:       repository.FileActionDeleted,
+						Path:         oldPath,
+						PreviousPath: oldPath,
+						Ref:          ref,
+						PreviousRef:  base,
+					})
+				}
+				if newErr == nil {
+					changes = append(changes, repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   newPath,
+						Ref:    ref,
+					})
+				}
+				continue
+			}
 
 			switch {
 			case newErr == nil && oldErr == nil:

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -784,6 +784,10 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 				Action: repository.FileActionUpdated,
 			})
 		case protocol.FileStatusRenamed:
+			if f.Mode == 0o40000 {
+				continue
+			}
+
 			newPath, newErr := safepath.RelativeTo(f.Path, r.gitConfig.Path)
 			oldPath, oldErr := safepath.RelativeTo(f.OldPath, r.gitConfig.Path)
 

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -724,9 +724,7 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 		return nil, fmt.Errorf("resolve ref: %w", err)
 	}
 
-	// Get commit hashes for base and ref
-	// Compare commits using nanogit (without rename detection for now)
-	files, err := r.client.CompareCommits(ctx, baseHash, refHash)
+	files, err := r.client.CompareCommits(ctx, baseHash, refHash, nanogit.WithRenameDetection())
 	if err != nil {
 		return nil, fmt.Errorf("compare commits: %w", err)
 	}
@@ -786,9 +784,33 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 				Action: repository.FileActionUpdated,
 			})
 		case protocol.FileStatusRenamed:
-			// Rename handling will be implemented in follow-up PR
-			// For now, let renames fall through to default (logged as unhandled)
-			fallthrough
+			newPath, newErr := safepath.RelativeTo(f.Path, r.gitConfig.Path)
+			oldPath, oldErr := safepath.RelativeTo(f.OldPath, r.gitConfig.Path)
+
+			switch {
+			case newErr == nil && oldErr == nil:
+				changes = append(changes, repository.VersionedFileChange{
+					Action:       repository.FileActionRenamed,
+					Path:         newPath,
+					PreviousPath: oldPath,
+					Ref:          ref,
+					PreviousRef:  base,
+				})
+			case newErr == nil:
+				changes = append(changes, repository.VersionedFileChange{
+					Action: repository.FileActionCreated,
+					Path:   newPath,
+					Ref:    ref,
+				})
+			case oldErr == nil:
+				changes = append(changes, repository.VersionedFileChange{
+					Action:       repository.FileActionDeleted,
+					Path:         oldPath,
+					PreviousPath: oldPath,
+					Ref:          ref,
+					PreviousRef:  base,
+				})
+			}
 		default:
 			logger.Error("ignore unhandled file", "file", f.Path, "status", string(f.Status))
 		}

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -3564,11 +3564,77 @@ func TestGitRepository_CompareFiles_Renamed(t *testing.T) {
 			wantChanges: []repository.VersionedFileChange{},
 		},
 		{
-			name: "tree entry rename is skipped",
+			name: "tree entry rename decomposes into delete + create",
 			files: []nanogit.CommitFile{
 				{
 					Path:    "configs/new-dir",
 					OldPath: "configs/old-dir",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o40000,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action:       repository.FileActionDeleted,
+					Path:         "old-dir",
+					PreviousPath: "old-dir",
+					Ref:          "feature",
+					PreviousRef:  "main",
+				},
+				{
+					Action: repository.FileActionCreated,
+					Path:   "new-dir",
+					Ref:    "feature",
+				},
+			},
+		},
+		{
+			name: "tree entry rename from outside to inside emits only create",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "configs/new-dir",
+					OldPath: "other/old-dir",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o40000,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action: repository.FileActionCreated,
+					Path:   "new-dir",
+					Ref:    "feature",
+				},
+			},
+		},
+		{
+			name: "tree entry rename from inside to outside emits only delete",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "other/new-dir",
+					OldPath: "configs/old-dir",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o40000,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action:       repository.FileActionDeleted,
+					Path:         "old-dir",
+					PreviousPath: "old-dir",
+					Ref:          "feature",
+					PreviousRef:  "main",
+				},
+			},
+		},
+		{
+			name: "tree entry rename both outside is skipped",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "other/new-dir",
+					OldPath: "other/old-dir",
 					Status:  protocol.FileStatusRenamed,
 					Mode:    0o40000,
 				},

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -3482,6 +3482,166 @@ func TestGitRepository_CompareFiles_EmptyBase(t *testing.T) {
 	require.Equal(t, hash.MustFromHex("0102030405060708090a0b0c0d0e0f1011121314"), refHash)
 }
 
+func TestGitRepository_CompareFiles_Renamed(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       []nanogit.CommitFile
+		gitPath     string
+		wantChanges []repository.VersionedFileChange
+	}{
+		{
+			name: "rename within configured path",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "configs/new-name.yaml",
+					OldPath: "configs/old-name.yaml",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o100644,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action:       repository.FileActionRenamed,
+					Path:         "new-name.yaml",
+					PreviousPath: "old-name.yaml",
+					Ref:          "feature",
+					PreviousRef:  "main",
+				},
+			},
+		},
+		{
+			name: "rename from outside to inside configured path",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "configs/moved-in.yaml",
+					OldPath: "other/old-location.yaml",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o100644,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action: repository.FileActionCreated,
+					Path:   "moved-in.yaml",
+					Ref:    "feature",
+				},
+			},
+		},
+		{
+			name: "rename from inside to outside configured path",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "other/moved-out.yaml",
+					OldPath: "configs/was-here.yaml",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o100644,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action:       repository.FileActionDeleted,
+					Path:         "was-here.yaml",
+					PreviousPath: "was-here.yaml",
+					Ref:          "feature",
+					PreviousRef:  "main",
+				},
+			},
+		},
+		{
+			name: "rename both outside configured path is skipped",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "other/new.yaml",
+					OldPath: "other/old.yaml",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o100644,
+				},
+			},
+			gitPath:     "configs",
+			wantChanges: []repository.VersionedFileChange{},
+		},
+		{
+			name: "tree entry rename is passed through",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "configs/new-dir",
+					OldPath: "configs/old-dir",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o40000,
+				},
+			},
+			gitPath: "configs",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action:       repository.FileActionRenamed,
+					Path:         "new-dir",
+					PreviousPath: "old-dir",
+					Ref:          "feature",
+					PreviousRef:  "main",
+				},
+			},
+		},
+		{
+			name: "rename with no configured path",
+			files: []nanogit.CommitFile{
+				{
+					Path:    "new-name.yaml",
+					OldPath: "old-name.yaml",
+					Status:  protocol.FileStatusRenamed,
+					Mode:    0o100644,
+				},
+			},
+			gitPath: "",
+			wantChanges: []repository.VersionedFileChange{
+				{
+					Action:       repository.FileActionRenamed,
+					Path:         "new-name.yaml",
+					PreviousPath: "old-name.yaml",
+					Ref:          "feature",
+					PreviousRef:  "main",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mocks.FakeClient{}
+			mockClient.GetRefReturnsOnCall(0, nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: hash.Hash{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+			}, nil)
+			mockClient.GetRefReturnsOnCall(1, nanogit.Ref{
+				Name: "refs/heads/feature",
+				Hash: hash.Hash{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+			}, nil)
+			mockClient.CompareCommitsReturns(tt.files, nil)
+
+			gitRepo := &gitRepository{
+				client: mockClient,
+				gitConfig: RepositoryConfig{
+					Branch: "main",
+					Path:   tt.gitPath,
+				},
+				config: &provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+					},
+				},
+			}
+
+			changes, err := gitRepo.CompareFiles(context.Background(), "main", "feature")
+
+			require.NoError(t, err)
+			require.NotNil(t, changes)
+			require.Equal(t, tt.wantChanges, changes)
+		})
+	}
+}
+
 func TestGitRepository_EmptyRefHandling(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -3564,7 +3564,7 @@ func TestGitRepository_CompareFiles_Renamed(t *testing.T) {
 			wantChanges: []repository.VersionedFileChange{},
 		},
 		{
-			name: "tree entry rename is passed through",
+			name: "tree entry rename is skipped",
 			files: []nanogit.CommitFile{
 				{
 					Path:    "configs/new-dir",
@@ -3573,16 +3573,8 @@ func TestGitRepository_CompareFiles_Renamed(t *testing.T) {
 					Mode:    0o40000,
 				},
 			},
-			gitPath: "configs",
-			wantChanges: []repository.VersionedFileChange{
-				{
-					Action:       repository.FileActionRenamed,
-					Path:         "new-dir",
-					PreviousPath: "old-dir",
-					Ref:          "feature",
-					PreviousRef:  "main",
-				},
-			},
+			gitPath:     "configs",
+			wantChanges: []repository.VersionedFileChange{},
 		},
 		{
 			name: "rename with no configured path",

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -194,7 +194,7 @@ func applyIncrementalChanges(ctx context.Context, diff []repository.VersionedFil
 			resultBuilder.WithName(name).WithGVK(gvk)
 
 			if oldFolderName != "" {
-				affectedFolders[safepath.Dir(change.Path)] = oldFolderName
+				affectedFolders[safepath.Dir(change.PreviousPath)] = oldFolderName
 			}
 
 			renameSpan.End()

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1472,6 +1472,94 @@ func (h *GitExportHelper) GitReadFile(t *testing.T, ctx context.Context, repoNam
 	return data
 }
 
+// ExpectedDashboard describes the expected state of a single dashboard.
+type ExpectedDashboard struct {
+	Title      string
+	SourcePath string
+}
+
+// RequireDashboardCount asserts the total number of dashboards in the instance.
+func RequireDashboardCount(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, expected int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
+		}
+		assert.Len(c, list.Items, expected, "unexpected dashboard count")
+	}, WaitTimeoutDefault, WaitIntervalDefault, "expected %d dashboard(s)", expected)
+}
+
+// RequireDashboardTitle asserts that the dashboard with the given uid (K8s name)
+// has the expected title.
+func RequireDashboardTitle(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, uid, expectedTitle string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
+		}
+		for _, d := range list.Items {
+			if d.GetName() != uid {
+				continue
+			}
+			title, _, _ := unstructured.NestedString(d.Object, "spec", "title")
+			assert.Equal(c, expectedTitle, title, "dashboard %q title mismatch", uid)
+			return
+		}
+		c.Errorf("dashboard with uid %q not found", uid)
+	}, WaitTimeoutDefault, WaitIntervalDefault, "dashboard %q should have title %q", uid, expectedTitle)
+}
+
+// RequireDashboards lists dashboards once and asserts that exactly the expected
+// set exists with matching count, title, and grafana.app/sourcePath for each UID.
+func RequireDashboards(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, expected map[string]ExpectedDashboard) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
+		}
+		if !assert.Len(c, list.Items, len(expected), "unexpected dashboard count") {
+			return
+		}
+		for _, d := range list.Items {
+			uid := d.GetName()
+			exp, ok := expected[uid]
+			if !assert.True(c, ok, "unexpected dashboard %q", uid) {
+				continue
+			}
+			title, _, _ := unstructured.NestedString(d.Object, "spec", "title")
+			assert.Equal(c, exp.Title, title, "dashboard %q title mismatch", uid)
+			sp, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			assert.Equal(c, exp.SourcePath, sp, "dashboard %q sourcePath mismatch", uid)
+		}
+	}, WaitTimeoutDefault, WaitIntervalDefault, "dashboards should match expected state")
+}
+
+// RequireRepoFolders lists folders once and asserts that the set of
+// grafana.app/sourcePath values for folders managed by repoName matches exactly.
+func RequireRepoFolders(t *testing.T, folderClient *apis.K8sResourceClient, ctx context.Context, repoName string, expectedSourcePaths []string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := folderClient.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		var gotPaths []string
+		for _, f := range list.Items {
+			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if mgr != repoName {
+				continue
+			}
+			sp, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			gotPaths = append(gotPaths, sp)
+		}
+		assert.ElementsMatch(c, expectedSourcePaths, gotPaths, "folder sourcePaths mismatch for repo %q", repoName)
+	}, WaitTimeoutDefault, WaitIntervalDefault,
+		"folders for repo %q should have sourcePaths %v", repoName, expectedSourcePaths)
+}
+
 // FindCondition finds a condition by type in the conditions list
 func FindCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
 	for i := range conditions {

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
+// expectedDashboard describes the expected state of a single dashboard.
+type expectedDashboard struct {
+	Title      string
+	SourcePath string
+}
+
 // TestIntegrationProvisioning_IncrementalGitSync_Add verifies that incremental
 // sync imports a newly committed file without re-processing the full tree.
 func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
@@ -129,7 +135,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 
 // TestIntegrationProvisioning_IncrementalGitSync_Rename verifies that
 // incremental sync handles a file rename (git mv) without losing the dashboard.
-// The dashboard UID and title should be preserved after the rename.
 func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
@@ -143,8 +148,9 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
-	requireDashboardTitle(t, helper, ctx, "incr-dash-001", "Dashboard One")
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
+	})
 
 	_, err := local.Git("mv", "dashboard1.json", "renamed-dashboard1.json")
 	require.NoError(t, err)
@@ -154,8 +160,217 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
-	requireDashboardTitle(t, helper, ctx, "incr-dash-001", "Dashboard One")
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
+	})
+}
+
+// TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder verifies that
+// incremental sync handles moving a dashboard from root into a subfolder.
+func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-move-into-folder"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"dashboard1.json": dashboardJSON("move-in-001", "Dashboard One", 1),
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
+	})
+
+	require.NoError(t, local.CreateDirPath("team-a"))
+	_, err := local.Git("mv", "dashboard1.json", "team-a/dashboard1.json")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "move dashboard into team-a folder")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
+	})
+	requireRepoFolders(t, helper, ctx, repoName, []string{"team-a"})
+}
+
+// TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders verifies
+// that incremental sync handles moving a dashboard from one folder to another.
+func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-move-between"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"folder-a/dashboard1.json": dashboardJSON("move-btwn-001", "Dashboard Between", 1),
+		"folder-b/.keep":           {},
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
+	})
+
+	_, err := local.Git("mv", "folder-a/dashboard1.json", "folder-b/dashboard1.json")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "move dashboard from folder-a to folder-b")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
+	})
+	requireRepoFolders(t, helper, ctx, repoName, []string{"folder-a", "folder-b"})
+}
+
+// TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot verifies that
+// incremental sync handles moving a dashboard from a subfolder back to root.
+func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-move-to-root"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"team-x/dashboard1.json": dashboardJSON("move-root-001", "Dashboard Root", 1),
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
+	})
+
+	_, err := local.Git("mv", "team-x/dashboard1.json", "dashboard1.json")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "move dashboard from team-x to root")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
+	})
+}
+
+// TestIntegrationProvisioning_IncrementalGitSync_RenameFolder verifies that
+// renaming an entire folder (git mv folderA folderB) preserves all dashboards
+// inside it. Git reports individual file renames for each file in the folder.
+func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-rename-folder"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"old-team/dashboard1.json": dashboardJSON("ren-fold-001", "Folder Dash One", 1),
+		"old-team/dashboard2.json": dashboardJSON("ren-fold-002", "Folder Dash Two", 1),
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
+		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
+	})
+	requireRepoFolders(t, helper, ctx, repoName, []string{"old-team"})
+
+	_, err := local.Git("mv", "old-team", "new-team")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "rename folder old-team to new-team")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
+		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
+	})
+	requireRepoFolders(t, helper, ctx, repoName, []string{"new-team"})
+}
+
+// TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard verifies
+// that incremental sync handles moving a dashboard between nested folder levels.
+func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-move-nested"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"parent/child-a/dashboard1.json": dashboardJSON("nested-001", "Nested Dashboard", 1),
+		"parent/child-b/.keep":           {},
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
+	})
+
+	_, err := local.Git("mv", "parent/child-a/dashboard1.json", "parent/child-b/dashboard1.json")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "move dashboard from child-a to child-b")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
+	})
+	requireRepoFolders(t, helper, ctx, repoName, []string{"parent", "parent/child-b"})
+}
+
+// TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder verifies
+// that renaming a nested folder preserves all dashboards inside it.
+func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-rename-nested"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"parent/old-child/dashboard1.json": dashboardJSON("ren-nest-001", "Nested Rename Dash", 1),
+		"parent/sibling/dashboard2.json":   dashboardJSON("ren-nest-002", "Sibling Dash", 1),
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
+		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
+	})
+
+	_, err := local.Git("mv", "parent/old-child", "parent/new-child")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "rename nested folder old-child to new-child")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
+		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
+	})
+	requireRepoFolders(t, helper, ctx, repoName, []string{"parent", "parent/new-child", "parent/sibling"})
 }
 
 // requireDashboardCount asserts the total number of dashboards in the instance.
@@ -190,4 +405,53 @@ func requireDashboardTitle(t *testing.T, h *gitTestHelper, ctx context.Context, 
 		}
 		c.Errorf("dashboard with uid %q not found", uid)
 	}, waitTimeoutDefault, waitIntervalDefault, "dashboard %q should have title %q", uid, expectedTitle)
+}
+
+// requireDashboards lists dashboards once and asserts that exactly the expected
+// set exists with matching title and grafana.app/sourcePath for each UID.
+func requireDashboards(t *testing.T, h *gitTestHelper, ctx context.Context, expected map[string]expectedDashboard) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := h.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
+		}
+		if !assert.Len(c, list.Items, len(expected), "unexpected dashboard count") {
+			return
+		}
+		for _, d := range list.Items {
+			uid := d.GetName()
+			exp, ok := expected[uid]
+			if !assert.True(c, ok, "unexpected dashboard %q", uid) {
+				continue
+			}
+			title, _, _ := unstructured.NestedString(d.Object, "spec", "title")
+			assert.Equal(c, exp.Title, title, "dashboard %q title mismatch", uid)
+			sp, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			assert.Equal(c, exp.SourcePath, sp, "dashboard %q sourcePath mismatch", uid)
+		}
+	}, waitTimeoutDefault, waitIntervalDefault, "dashboards should match expected state")
+}
+
+// requireRepoFolders lists folders once and asserts that the set of
+// grafana.app/sourcePath values for folders managed by repoName matches exactly.
+func requireRepoFolders(t *testing.T, h *gitTestHelper, ctx context.Context, repoName string, expectedSourcePaths []string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		list, err := h.FoldersV1.Resource.List(ctx, metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		var gotPaths []string
+		for _, f := range list.Items {
+			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if mgr != repoName {
+				continue
+			}
+			sp, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+			gotPaths = append(gotPaths, sp)
+		}
+		assert.ElementsMatch(c, expectedSourcePaths, gotPaths, "folder sourcePaths mismatch for repo %q", repoName)
+	}, waitTimeoutDefault, waitIntervalDefault,
+		"folders for repo %q should have sourcePaths %v", repoName, expectedSourcePaths)
 }

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -213,7 +213,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"folder-a"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"folder-a", "folder-b"})
 
 	_, err := local.Git("mv", "folder-a/dashboard1.json", "folder-b/dashboard1.json")
 	require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/child-a"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/child-a", "parent/child-b"})
 
 	_, err := local.Git("mv", "parent/child-a/dashboard1.json", "parent/child-b/dashboard1.json")
 	require.NoError(t, err)

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -8,16 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
-
-// expectedDashboard describes the expected state of a single dashboard.
-type expectedDashboard struct {
-	Title      string
-	SourcePath string
-}
 
 // TestIntegrationProvisioning_IncrementalGitSync_Add verifies that incremental
 // sync imports a newly committed file without re-processing the full tree.
@@ -34,7 +28,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(dashboardJSON("incr-dash-002", "Dashboard Two", 1))))
 	_, err := local.Git("add", ".")
@@ -45,7 +39,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboardCount(t, helper, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Update verifies that
@@ -63,7 +57,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
 	_, err := local.Git("add", ".")
@@ -74,8 +68,8 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
-	requireDashboardTitle(t, helper, ctx, "incr-dash-001", "Dashboard One Updated")
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "incr-dash-001", "Dashboard One Updated")
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Delete verifies that
@@ -94,7 +88,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
 	require.NoError(t, err)
@@ -104,7 +98,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, err := helper.DashboardsV1.Resource.Get(ctx, "incr-dash-002", metav1.GetOptions{})
@@ -127,10 +121,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Rename verifies that
@@ -148,7 +142,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
 
@@ -160,7 +154,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
 	})
 }
@@ -180,7 +174,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
 
@@ -193,10 +187,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
 	})
-	requireRepoFolders(t, helper, ctx, repoName, []string{"team-a"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"team-a"})
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders verifies
@@ -215,7 +209,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
 
@@ -227,10 +221,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
 	})
-	requireRepoFolders(t, helper, ctx, repoName, []string{"folder-a", "folder-b"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"folder-b"})
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot verifies that
@@ -248,7 +242,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
 
@@ -260,7 +254,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
 }
@@ -282,11 +276,11 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
 	})
-	requireRepoFolders(t, helper, ctx, repoName, []string{"old-team"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 	_, err := local.Git("mv", "old-team", "new-team")
 	require.NoError(t, err)
@@ -296,11 +290,11 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
 	})
-	requireRepoFolders(t, helper, ctx, repoName, []string{"new-team"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"new-team"})
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard verifies
@@ -319,7 +313,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
 
@@ -331,10 +325,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
 	})
-	requireRepoFolders(t, helper, ctx, repoName, []string{"parent", "parent/child-b"})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/child-b"})
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder verifies
@@ -353,7 +347,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
 	})
@@ -366,92 +360,9 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	require.NoError(t, err)
 
 	helper.syncAndWaitIncremental(t, repoName)
-	requireDashboards(t, helper, ctx, map[string]expectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
 	})
-	requireRepoFolders(t, helper, ctx, repoName, []string{"parent", "parent/new-child", "parent/sibling"})
-}
-
-// requireDashboardCount asserts the total number of dashboards in the instance.
-func requireDashboardCount(t *testing.T, h *gitTestHelper, ctx context.Context, expected int) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list dashboards") {
-			return
-		}
-		assert.Len(c, list.Items, expected, "unexpected dashboard count")
-	}, waitTimeoutDefault, waitIntervalDefault, "expected %d dashboard(s)", expected)
-}
-
-// requireDashboardTitle asserts that the dashboard with the given uid (K8s name)
-// has the expected title. Classic dashboards store their full JSON under spec,
-// so the title lives at spec.title.
-func requireDashboardTitle(t *testing.T, h *gitTestHelper, ctx context.Context, uid, expectedTitle string) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list dashboards") {
-			return
-		}
-		for _, d := range list.Items {
-			if d.GetName() != uid {
-				continue
-			}
-			title, _, _ := unstructured.NestedString(d.Object, "spec", "title")
-			assert.Equal(c, expectedTitle, title, "dashboard %q title mismatch", uid)
-			return
-		}
-		c.Errorf("dashboard with uid %q not found", uid)
-	}, waitTimeoutDefault, waitIntervalDefault, "dashboard %q should have title %q", uid, expectedTitle)
-}
-
-// requireDashboards lists dashboards once and asserts that exactly the expected
-// set exists with matching title and grafana.app/sourcePath for each UID.
-func requireDashboards(t *testing.T, h *gitTestHelper, ctx context.Context, expected map[string]expectedDashboard) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list dashboards") {
-			return
-		}
-		if !assert.Len(c, list.Items, len(expected), "unexpected dashboard count") {
-			return
-		}
-		for _, d := range list.Items {
-			uid := d.GetName()
-			exp, ok := expected[uid]
-			if !assert.True(c, ok, "unexpected dashboard %q", uid) {
-				continue
-			}
-			title, _, _ := unstructured.NestedString(d.Object, "spec", "title")
-			assert.Equal(c, exp.Title, title, "dashboard %q title mismatch", uid)
-			sp, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/sourcePath")
-			assert.Equal(c, exp.SourcePath, sp, "dashboard %q sourcePath mismatch", uid)
-		}
-	}, waitTimeoutDefault, waitIntervalDefault, "dashboards should match expected state")
-}
-
-// requireRepoFolders lists folders once and asserts that the set of
-// grafana.app/sourcePath values for folders managed by repoName matches exactly.
-func requireRepoFolders(t *testing.T, h *gitTestHelper, ctx context.Context, repoName string, expectedSourcePaths []string) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.FoldersV1.Resource.List(ctx, metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list folders") {
-			return
-		}
-		var gotPaths []string
-		for _, f := range list.Items {
-			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-			if mgr != repoName {
-				continue
-			}
-			sp, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
-			gotPaths = append(gotPaths, sp)
-		}
-		assert.ElementsMatch(c, expectedSourcePaths, gotPaths, "folder sourcePaths mismatch for repo %q", repoName)
-	}, waitTimeoutDefault, waitIntervalDefault,
-		"folders for repo %q should have sourcePaths %v", repoName, expectedSourcePaths)
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/new-child", "parent/sibling"})
 }

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -177,6 +177,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{})
 
 	require.NoError(t, local.CreateDirPath("team-a"))
 	_, err := local.Git("mv", "dashboard1.json", "team-a/dashboard1.json")
@@ -212,6 +213,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"folder-a"})
 
 	_, err := local.Git("mv", "folder-a/dashboard1.json", "folder-b/dashboard1.json")
 	require.NoError(t, err)
@@ -245,6 +247,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"team-x"})
 
 	_, err := local.Git("mv", "team-x/dashboard1.json", "dashboard1.json")
 	require.NoError(t, err)
@@ -257,6 +260,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{})
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_RenameFolder verifies that
@@ -316,6 +320,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/child-a"})
 
 	_, err := local.Git("mv", "parent/child-a/dashboard1.json", "parent/child-b/dashboard1.json")
 	require.NoError(t, err)
@@ -351,6 +356,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
 	})
+	common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/old-child", "parent/sibling"})
 
 	_, err := local.Git("mv", "parent/old-child", "parent/new-child")
 	require.NoError(t, err)

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -127,6 +127,37 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 	requireDashboardCount(t, helper, ctx, 1)
 }
 
+// TestIntegrationProvisioning_IncrementalGitSync_Rename verifies that
+// incremental sync handles a file rename (git mv) without losing the dashboard.
+// The dashboard UID and title should be preserved after the rename.
+func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafanaWithGitServer(t)
+	ctx := context.Background()
+
+	const repoName = "git-incremental-rename"
+
+	_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
+	}, "write", "branch")
+
+	helper.syncAndWait(t, repoName)
+	requireDashboardCount(t, helper, ctx, 1)
+	requireDashboardTitle(t, helper, ctx, "incr-dash-001", "Dashboard One")
+
+	_, err := local.Git("mv", "dashboard1.json", "renamed-dashboard1.json")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "rename dashboard1")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.syncAndWaitIncremental(t, repoName)
+	requireDashboardCount(t, helper, ctx, 1)
+	requireDashboardTitle(t, helper, ctx, "incr-dash-001", "Dashboard One")
+}
+
 // requireDashboardCount asserts the total number of dashboards in the instance.
 func requireDashboardCount(t *testing.T, h *gitTestHelper, ctx context.Context, expected int) {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -29,8 +30,8 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
-	requireDashboardTitle(t, helper, ctx, "name-change-full-001", "Dashboard One")
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-full-001", "Dashboard One")
 
 	// Change the metadata.name (uid) in the same file path.
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("name-change-full-002", "Dashboard One Renamed", 2))))
@@ -59,7 +60,7 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 		assert.NoError(c, err, "old dashboard should still exist (orphaned)")
 	}, waitTimeoutDefault, waitIntervalDefault, "old dashboard should remain orphaned")
 
-	requireDashboardCount(t, helper, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange verifies
@@ -79,8 +80,8 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	}, "write", "branch")
 
 	helper.syncAndWait(t, repoName)
-	requireDashboardCount(t, helper, ctx, 1)
-	requireDashboardTitle(t, helper, ctx, "name-change-incr-001", "Dashboard One")
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
 
 	// Change the metadata.name (uid) in the same file path.
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("name-change-incr-002", "Dashboard One Renamed", 2))))
@@ -110,5 +111,5 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		assert.NoError(c, err, "old dashboard should still exist (orphaned)")
 	}, waitTimeoutDefault, waitIntervalDefault, "old dashboard should remain orphaned")
 
-	requireDashboardCount(t, helper, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }


### PR DESCRIPTION
## Summary

When users reorganize dashboards in a Git repository using `git mv` (renaming files, moving files between folders, or renaming entire folders), incremental sync now detects these as renames instead of treating them as separate delete + create operations.

**Scope:** This PR handles **file-level renames only**. Tree (directory) rename entries emitted by `CompareCommits` (mode `0o40000`) are decomposed into delete + create pairs for backwards compatibility — the downstream `RenameResourceFile` only handles resource files and would fail on bare directory paths. Individual file renames within renamed directories are already reported as separate entries and cover the actual resource movements.

### What changed

- **Enable rename detection** in `CompareFiles` by passing `nanogit.WithRenameDetection()` to `CompareCommits`, connecting the nanogit v0.12.0 rename support ([nanogit#243](https://github.com/grafana/nanogit/pull/243), [nanogit#245](https://github.com/grafana/nanogit/pull/245)) to the existing downstream `RenameResourceFile` handler.

- **Map `FileStatusRenamed` to the correct action** based on path boundaries relative to the repository's configured path:
  | Old path | New path | Resulting action |
  |----------|----------|-----------------|
  | Inside configured path | Inside configured path | `FileActionRenamed` (with `PreviousPath`) |
  | Outside | Inside | `FileActionCreated` (moved into managed directory) |
  | Inside | Outside | `FileActionDeleted` (moved out of managed directory) |
  | Outside | Outside | Skipped |

- **Decompose tree entry renames into delete + create** — for backwards compatibility, directory rename entries (mode `0o40000`) are converted to a `FileActionDeleted` for the old path and a `FileActionCreated` for the new path. This preserves folder bookkeeping through the existing incremental sync path without requiring changes to `RenameResourceFile`, which only handles resource files.

- **Fix orphaned folder cleanup** — the rename case in `applyIncrementalChanges` was tracking the *new* folder path for orphan cleanup instead of the *old* one. Source folders that became empty after a rename were never checked and never cleaned up.

- **Move test helpers to common package** — `RequireDashboards`, `RequireRepoFolders`, `RequireDashboardCount`, and `RequireDashboardTitle` are now shared in the common test package for reuse across test suites.

### How it flows

```
git mv old.json new.json
    → nanogit CompareCommits (with rename detection)
    → FileStatusRenamed with OldPath + Path
    → CompareFiles maps to FileActionRenamed (files) or delete+create (directories)
    → applyIncrementalChanges calls RenameResourceFile for files
    → dashboard is deleted at old path and recreated at new path (UID preserved)
    → old folder cleaned up if now empty in git
```

Ref: https://github.com/grafana/git-ui-sync-project/issues/990

## Test plan

### Unit tests (`repository_test.go`)
- [x] Rename within configured path → `FileActionRenamed` with both paths
- [x] Rename from outside to inside → `FileActionCreated`
- [x] Rename from inside to outside → `FileActionDeleted`
- [x] Both paths outside configured path → no change emitted
- [x] Tree entry rename (both inside) → decomposed into `FileActionDeleted` + `FileActionCreated`
- [x] Tree entry rename from outside to inside → only `FileActionCreated`
- [x] Tree entry rename from inside to outside → only `FileActionDeleted`
- [x] Tree entry rename both outside → skipped
- [x] Rename with no configured path → `FileActionRenamed`

### Integration tests (`incremental_test.go`)
- [x] Simple file rename at root (`git mv a.json b.json`)
- [x] Move dashboard from root into a folder
- [x] Move dashboard between folders
- [x] Move dashboard from folder back to root
- [x] Rename entire folder (2 dashboards inside)
- [x] Move dashboard between nested sibling folders
- [x] Rename a nested folder while sibling folder is untouched

All tests verify dashboard count, title, `grafana.app/sourcePath` annotation, and managed folder state (before and after the operation).