### PR TITLE
ShortURL: Validate target URL to always be relative

### DIFF
--- a/apps/shorturl/go.mod
+++ b/apps/shorturl/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/grafana/grafana-app-sdk v0.51.4
 	github.com/grafana/grafana-app-sdk/logging v0.51.4
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
+	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/apiserver v0.35.1
 	k8s.io/klog/v2 v2.130.1

--- a/apps/shorturl/pkg/app/app.go
+++ b/apps/shorturl/pkg/app/app.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"path"
 	"strings"
 	"time"
 
@@ -22,52 +20,6 @@ import (
 	shorturlv1beta1 "github.com/grafana/grafana/apps/shorturl/pkg/apis/shorturl/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
-
-// Local error definitions to avoid importing the main shorturls package
-var (
-	ErrShortURLAbsolutePath = fmt.Errorf("path should be relative")
-	ErrShortURLInvalidPath  = fmt.Errorf("invalid short URL path")
-)
-
-// validateRelativePath checks that a short URL path is a safe relative path
-// that will not redirect to an external domain.
-func validateRelativePath(rawPath string) error {
-	p := strings.TrimSpace(rawPath)
-
-	// IMPORTANT: This logic is duplicated in pkg/services/shorturls/models.go — keep both in sync.
-	// Reject path traversal (forward and backslash variants)
-	if strings.Contains(p, "../") || strings.Contains(p, `..\`) {
-		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
-	}
-
-	// Reject protocol-relative URLs (//evil.com) before the general absolute path check
-	if strings.HasPrefix(p, "//") {
-		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
-	}
-
-	// Reject backslash-based paths that browsers may interpret as URLs
-	if strings.HasPrefix(p, `\`) {
-		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
-	}
-
-	// Reject URLs containing a scheme (e.g. http://evil.com)
-	if strings.Contains(p, "://") {
-		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
-	}
-
-	// Parse as URL and reject if it has a scheme (catches scheme:... patterns like javascript:alert(1))
-	parsed, err := url.Parse(p)
-	if err == nil && parsed.Scheme != "" {
-		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
-	}
-
-	// Reject absolute filesystem paths (starts with /)
-	if path.IsAbs(p) {
-		return fmt.Errorf("%w: %s", ErrShortURLAbsolutePath, p)
-	}
-
-	return nil
-}
 
 func New(cfg app.Config) (app.App, error) {
 	cfg.KubeConfig.APIPath = "apis"

--- a/apps/shorturl/pkg/app/app.go
+++ b/apps/shorturl/pkg/app/app.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 	"time"
@@ -27,6 +28,45 @@ var (
 	ErrShortURLAbsolutePath = fmt.Errorf("path should be relative")
 	ErrShortURLInvalidPath  = fmt.Errorf("invalid short URL path")
 )
+
+// validateRelativePath checks that a short URL path is a safe relative path
+// that will not redirect to an external domain.
+func validateRelativePath(rawPath string) error {
+	p := strings.TrimSpace(rawPath)
+
+	// Reject path traversal
+	if strings.Contains(p, "../") {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject protocol-relative URLs (//evil.com) before the general absolute path check
+	if strings.HasPrefix(p, "//") {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject backslash-based paths that browsers may interpret as URLs
+	if strings.HasPrefix(p, `\`) {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject URLs containing a scheme (e.g. http://evil.com)
+	if strings.Contains(p, "://") {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Parse as URL and reject if it has a scheme (catches scheme:... patterns like javascript:alert(1))
+	parsed, err := url.Parse(p)
+	if err == nil && parsed.Scheme != "" {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject absolute filesystem paths (starts with /)
+	if path.IsAbs(p) {
+		return fmt.Errorf("%w: %s", ErrShortURLAbsolutePath, p)
+	}
+
+	return nil
+}
 
 func New(cfg app.Config) (app.App, error) {
 	cfg.KubeConfig.APIPath = "apis"
@@ -58,14 +98,7 @@ func New(cfg app.Config) (app.App, error) {
 							return fmt.Errorf("expected ShortURL object, got %T", req.Object)
 						}
 
-						relPath := strings.TrimSpace(shortURL.Spec.Path)
-						if path.IsAbs(relPath) {
-							return fmt.Errorf("%w: %s", ErrShortURLAbsolutePath, relPath)
-						}
-						if strings.Contains(relPath, "../") {
-							return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, relPath)
-						}
-						return nil
+						return validateRelativePath(shortURL.Spec.Path)
 					},
 				},
 				CustomRoutes: simple.AppCustomRouteHandlers{
@@ -73,7 +106,7 @@ func New(cfg app.Config) (app.App, error) {
 						Method: "GET",
 						Path:   "goto",
 					}: func(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-						url, _, found := strings.Cut(req.URL.Path, "/apis/") // This will be settings.AppURL
+						appURL, _, found := strings.Cut(req.URL.Path, "/apis/") // This will be settings.AppURL
 						if !found {
 							return fmt.Errorf("unable to parse request URL")
 						}
@@ -85,6 +118,11 @@ func New(cfg app.Config) (app.App, error) {
 						info, err := client.Get(ctx, id)
 						if err != nil {
 							return err
+						}
+
+						// Safety net: validate the stored path before redirecting
+						if err := validateRelativePath(info.Spec.Path); err != nil {
+							return fmt.Errorf("stored short URL has invalid path: %w", err)
 						}
 
 						// Update lastSeenAt in the background
@@ -103,13 +141,13 @@ func New(cfg app.Config) (app.App, error) {
 							}
 						}()
 
-						url = url + "/" + info.Spec.Path
+						redirectURL := appURL + "/" + info.Spec.Path
 						if req.URL.Query().Get("redirect") == "false" { // helpful for testing
 							return json.NewEncoder(w).Encode(shorturlv1beta1.GetGotoResponse{
-								Url: url,
+								Url: redirectURL,
 							})
 						}
-						w.Header().Add("Location", url)
+						w.Header().Add("Location", redirectURL)
 						w.WriteHeader(http.StatusFound)
 						return nil
 					},

--- a/apps/shorturl/pkg/app/app.go
+++ b/apps/shorturl/pkg/app/app.go
@@ -34,8 +34,9 @@ var (
 func validateRelativePath(rawPath string) error {
 	p := strings.TrimSpace(rawPath)
 
-	// Reject path traversal
-	if strings.Contains(p, "../") {
+	// IMPORTANT: This logic is duplicated in pkg/services/shorturls/models.go — keep both in sync.
+	// Reject path traversal (forward and backslash variants)
+	if strings.Contains(p, "../") || strings.Contains(p, `..\`) {
 		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
 	}
 

--- a/apps/shorturl/pkg/app/validate.go
+++ b/apps/shorturl/pkg/app/validate.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// Local error definitions to avoid importing the main shorturls package
+var (
+	ErrShortURLAbsolutePath = fmt.Errorf("path should be relative")
+	ErrShortURLInvalidPath  = fmt.Errorf("invalid short URL path")
+)
+
+// validateRelativePath checks that a short URL path is a safe relative path
+// that will not redirect to an external domain.
+func validateRelativePath(rawPath string) error {
+	p := strings.TrimSpace(rawPath)
+
+	// IMPORTANT: This logic is duplicated in pkg/services/shorturls/models.go — keep both in sync.
+	// Reject path traversal (forward and backslash variants)
+	if strings.Contains(p, "../") || strings.Contains(p, `..\`) {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject protocol-relative URLs (//evil.com) before the general absolute path check
+	if strings.HasPrefix(p, "//") {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject backslash-based paths that browsers may interpret as URLs
+	if strings.HasPrefix(p, `\`) {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject URLs containing a scheme (e.g. http://evil.com)
+	if strings.Contains(p, "://") {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Parse as URL and reject if it has a scheme (catches scheme:... patterns like javascript:alert(1))
+	parsed, err := url.Parse(p)
+	if err == nil && parsed.Scheme != "" {
+		return fmt.Errorf("%w: %s", ErrShortURLInvalidPath, p)
+	}
+
+	// Reject absolute filesystem paths (starts with /)
+	if path.IsAbs(p) {
+		return fmt.Errorf("%w: %s", ErrShortURLAbsolutePath, p)
+	}
+
+	return nil
+}

--- a/apps/shorturl/pkg/app/validate_test.go
+++ b/apps/shorturl/pkg/app/validate_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRelativePath(t *testing.T) {
+	validPaths := []string{
+		"d/TxKARsmGz/new-dashboard?orgId=1",
+		"mock/path?test=true",
+		"d/abc123/my-dashboard",
+		"explore?left=...",
+		"alerting/list",
+	}
+
+	for _, p := range validPaths {
+		t.Run("valid: "+p, func(t *testing.T) {
+			err := validateRelativePath(p)
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		err := validateRelativePath("/absolute/path")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLAbsolutePath))
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		err := validateRelativePath("path/../etc/passwd")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLInvalidPath))
+	})
+
+	t.Run("rejects protocol-relative URL", func(t *testing.T) {
+		err := validateRelativePath("//evil.com/path")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLInvalidPath))
+	})
+
+	t.Run("rejects backslash prefix", func(t *testing.T) {
+		err := validateRelativePath(`\evil.com`)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLInvalidPath))
+	})
+
+	t.Run("rejects http:// URL", func(t *testing.T) {
+		err := validateRelativePath("http://evil.com")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLInvalidPath))
+	})
+
+	t.Run("rejects https:// URL", func(t *testing.T) {
+		err := validateRelativePath("https://evil.com/path")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLInvalidPath))
+	})
+
+	t.Run("rejects javascript: scheme", func(t *testing.T) {
+		err := validateRelativePath("javascript:alert(1)")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrShortURLInvalidPath))
+	})
+}

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,8 +213,12 @@ func (sk8s *shortURLK8sHandler) getKubernetesRedirectFromShortURL(c *contextmode
 	// Ensure the redirect URL is relative to this server by checking it has no scheme
 	// or its host matches what we expect. Since the goto handler constructs the URL
 	// as appURL + "/" + path, we just need to verify it's not pointing externally.
-	appParsed, _ := url.Parse(sk8s.cfg.AppURL)
-	if parsedURL.Host != "" && appParsed != nil && parsedURL.Host != appParsed.Host {
+	appParsed, appParseErr := url.Parse(sk8s.cfg.AppURL)
+	if appParseErr != nil || appParsed.Host == "" {
+		c.JsonApiErr(500, "invalid app URL configuration", appParseErr)
+		return
+	}
+	if parsedURL.Host != "" && !strings.EqualFold(parsedURL.Host, appParsed.Host) {
 		c.Logger.Error("Short URL redirect points to external host, refusing", "url", value.Url)
 		c.Redirect(sk8s.cfg.AppURL, http.StatusFound)
 		return

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,6 +88,13 @@ func (hs *HTTPServer) redirectFromShortURL(c *contextmodel.ReqContext) {
 	// Failure to update LastSeenAt should still allow to redirect
 	if err := hs.ShortURLService.UpdateLastSeenAt(c.Req.Context(), shortURL); err != nil {
 		hs.log.Error("Failed to update short URL last seen at", "error", err)
+	}
+
+	// Safety net: validate stored path before redirecting to prevent open redirects
+	if err := shorturls.ValidateRelativePath(shortURL.Path); err != nil {
+		hs.log.Error("Short URL has invalid path, refusing to redirect", "path", shortURL.Path, "err", err)
+		c.Redirect(hs.Cfg.AppURL, http.StatusFound)
+		return
 	}
 
 	hs.log.Debug("Redirecting short URL", "path", shortURL.Path)
@@ -190,6 +198,24 @@ func (sk8s *shortURLK8sHandler) getKubernetesRedirectFromShortURL(c *contextmode
 	}
 	if value.Url == "" {
 		c.JsonApiErr(500, "invalid", fmt.Errorf("expected url"))
+		return
+	}
+
+	// Safety net: validate the redirect URL is not an open redirect.
+	// The URL from the goto subresource is already an absolute URL (appURL + path),
+	// so we parse it and validate the path component.
+	parsedURL, parseErr := url.Parse(value.Url)
+	if parseErr != nil {
+		c.JsonApiErr(500, "invalid redirect URL", parseErr)
+		return
+	}
+	// Ensure the redirect URL is relative to this server by checking it has no scheme
+	// or its host matches what we expect. Since the goto handler constructs the URL
+	// as appURL + "/" + path, we just need to verify it's not pointing externally.
+	appParsed, _ := url.Parse(sk8s.cfg.AppURL)
+	if parsedURL.Host != "" && appParsed != nil && parsedURL.Host != appParsed.Host {
+		c.Logger.Error("Short URL redirect points to external host, refusing", "url", value.Url)
+		c.Redirect(sk8s.cfg.AppURL, http.StatusFound)
 		return
 	}
 

--- a/pkg/services/shorturls/models.go
+++ b/pkg/services/shorturls/models.go
@@ -31,11 +31,12 @@ type ShortUrl struct {
 // ValidateRelativePath checks that a short URL path is a safe relative path
 // that will not redirect to an external domain. It returns an appropriate error
 // if the path is invalid, or nil if the path is safe.
+// IMPORTANT: This logic is duplicated in apps/shorturl/pkg/app/app.go — keep both in sync.
 func ValidateRelativePath(rawPath string) error {
 	p := strings.TrimSpace(rawPath)
 
-	// Reject path traversal
-	if strings.Contains(p, "../") {
+	// Reject path traversal (forward and backslash variants)
+	if strings.Contains(p, "../") || strings.Contains(p, `..\`) {
 		return ErrShortURLInvalidPath.Errorf("path cannot contain '../': %s", p)
 	}
 

--- a/pkg/services/shorturls/models.go
+++ b/pkg/services/shorturls/models.go
@@ -1,6 +1,9 @@
 package shorturls
 
 import (
+	"net/url"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
@@ -23,6 +26,46 @@ type ShortUrl struct {
 	CreatedBy  int64  `json:"-"`
 	CreatedAt  int64  `json:"-"`
 	LastSeenAt int64  `json:"lastSeenAt"`
+}
+
+// ValidateRelativePath checks that a short URL path is a safe relative path
+// that will not redirect to an external domain. It returns an appropriate error
+// if the path is invalid, or nil if the path is safe.
+func ValidateRelativePath(rawPath string) error {
+	p := strings.TrimSpace(rawPath)
+
+	// Reject path traversal
+	if strings.Contains(p, "../") {
+		return ErrShortURLInvalidPath.Errorf("path cannot contain '../': %s", p)
+	}
+
+	// Reject protocol-relative URLs (//evil.com) before the general absolute path check
+	if strings.HasPrefix(p, "//") {
+		return ErrShortURLInvalidPath.Errorf("path cannot start with '//': %s", p)
+	}
+
+	// Reject backslash-based paths that browsers may interpret as URLs (\\evil.com, \evil.com)
+	if strings.HasPrefix(p, `\`) {
+		return ErrShortURLInvalidPath.Errorf("path cannot start with backslash: %s", p)
+	}
+
+	// Reject URLs containing a scheme (e.g. http://evil.com)
+	if strings.Contains(p, "://") {
+		return ErrShortURLInvalidPath.Errorf("path cannot contain a URL scheme: %s", p)
+	}
+
+	// Parse as URL and reject if it has a scheme (catches scheme:... patterns like javascript:alert(1))
+	parsed, err := url.Parse(p)
+	if err == nil && parsed.Scheme != "" {
+		return ErrShortURLInvalidPath.Errorf("path cannot contain a URL scheme: %s", p)
+	}
+
+	// Reject absolute filesystem paths (starts with /)
+	if path.IsAbs(p) {
+		return ErrShortURLAbsolutePath.Errorf("expected relative path: %s", p)
+	}
+
+	return nil
 }
 
 type DeleteShortUrlCommand struct {

--- a/pkg/services/shorturls/models_test.go
+++ b/pkg/services/shorturls/models_test.go
@@ -95,4 +95,15 @@ func TestValidateRelativePath(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, ErrShortURLAbsolutePath.Is(err))
 	})
+
+	t.Run("accepts empty string", func(t *testing.T) {
+		err := ValidateRelativePath("")
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects backslash path traversal", func(t *testing.T) {
+		err := ValidateRelativePath(`path..\etc\passwd`)
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
 }

--- a/pkg/services/shorturls/models_test.go
+++ b/pkg/services/shorturls/models_test.go
@@ -1,0 +1,98 @@
+package shorturls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRelativePath(t *testing.T) {
+	validPaths := []string{
+		"d/TxKARsmGz/new-dashboard?orgId=1",
+		"mock/path?test=true",
+		"d/abc123/my-dashboard",
+		"explore?left=...",
+		"alerting/list",
+		"connections/datasources",
+	}
+
+	for _, p := range validPaths {
+		t.Run("valid: "+p, func(t *testing.T) {
+			err := ValidateRelativePath(p)
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("rejects absolute path starting with /", func(t *testing.T) {
+		err := ValidateRelativePath("/absolute/path")
+		require.Error(t, err)
+		require.True(t, ErrShortURLAbsolutePath.Is(err))
+	})
+
+	t.Run("rejects path traversal with ../", func(t *testing.T) {
+		err := ValidateRelativePath("path/../etc/passwd")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects path traversal starting with ../", func(t *testing.T) {
+		err := ValidateRelativePath("../etc/passwd")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects protocol-relative URL //", func(t *testing.T) {
+		err := ValidateRelativePath("//evil.com/path")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects backslash prefix", func(t *testing.T) {
+		err := ValidateRelativePath(`\evil.com`)
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects double backslash prefix", func(t *testing.T) {
+		err := ValidateRelativePath(`\\evil.com`)
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects http:// URL", func(t *testing.T) {
+		err := ValidateRelativePath("http://evil.com")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects https:// URL", func(t *testing.T) {
+		err := ValidateRelativePath("https://evil.com/path")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects javascript: scheme", func(t *testing.T) {
+		err := ValidateRelativePath("javascript:alert(1)")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects URL with scheme in the middle", func(t *testing.T) {
+		err := ValidateRelativePath("foo://bar")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("trims whitespace before validation", func(t *testing.T) {
+		err := ValidateRelativePath("  //evil.com  ")
+		require.Error(t, err)
+		require.True(t, ErrShortURLInvalidPath.Is(err))
+	})
+
+	t.Run("rejects whitespace-padded absolute path", func(t *testing.T) {
+		err := ValidateRelativePath("  /absolute  ")
+		require.Error(t, err)
+		require.True(t, ErrShortURLAbsolutePath.Is(err))
+	})
+}

--- a/pkg/services/shorturls/shorturlimpl/shorturl.go
+++ b/pkg/services/shorturls/shorturlimpl/shorturl.go
@@ -3,7 +3,6 @@ package shorturlimpl
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -43,11 +42,8 @@ func (s ShortURLService) List(ctx context.Context, orgID int64) ([]*shorturls.Sh
 func (s ShortURLService) CreateShortURL(ctx context.Context, user identity.Requester, cmd *dtos.CreateShortURLCmd) (*shorturls.ShortUrl, error) {
 	relPath := strings.TrimSpace(cmd.Path)
 
-	if path.IsAbs(relPath) {
-		return nil, shorturls.ErrShortURLAbsolutePath.Errorf("expected relative path: %s", relPath)
-	}
-	if strings.Contains(relPath, "../") {
-		return nil, shorturls.ErrShortURLInvalidPath.Errorf("path cannot contain '../': %s", relPath)
+	if err := shorturls.ValidateRelativePath(relPath); err != nil {
+		return nil, err
 	}
 
 	uid := cmd.UID

--- a/pkg/services/shorturls/shorturlimpl/shorturl_test.go
+++ b/pkg/services/shorturls/shorturlimpl/shorturl_test.go
@@ -124,6 +124,38 @@ func TestIntegrationShortURLService(t *testing.T) {
 		newShortURL, err = service.CreateShortURL(ctx, user, cmd3)
 		require.ErrorIs(t, err, shorturls.ErrShortURLInvalidPath)
 		require.Nil(t, newShortURL)
+
+		// Protocol-relative URL (open redirect)
+		cmd4 := &dtos.CreateShortURLCmd{
+			Path: "//evil.com/path",
+		}
+		newShortURL, err = service.CreateShortURL(ctx, user, cmd4)
+		require.ErrorIs(t, err, shorturls.ErrShortURLInvalidPath)
+		require.Nil(t, newShortURL)
+
+		// Full URL with scheme (open redirect)
+		cmd5 := &dtos.CreateShortURLCmd{
+			Path: "https://evil.com/path",
+		}
+		newShortURL, err = service.CreateShortURL(ctx, user, cmd5)
+		require.ErrorIs(t, err, shorturls.ErrShortURLInvalidPath)
+		require.Nil(t, newShortURL)
+
+		// Backslash-based URL (open redirect)
+		cmd6 := &dtos.CreateShortURLCmd{
+			Path: `\\evil.com`,
+		}
+		newShortURL, err = service.CreateShortURL(ctx, user, cmd6)
+		require.ErrorIs(t, err, shorturls.ErrShortURLInvalidPath)
+		require.Nil(t, newShortURL)
+
+		// javascript: scheme
+		cmd7 := &dtos.CreateShortURLCmd{
+			Path: "javascript:alert(1)",
+		}
+		newShortURL, err = service.CreateShortURL(ctx, user, cmd7)
+		require.ErrorIs(t, err, shorturls.ErrShortURLInvalidPath)
+		require.Nil(t, newShortURL)
 	})
 
 	t.Run("The same URL will generate different entries", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Fixes open redirect vulnerability** in short URLs (grafana/grafana-enterprise#10848) where attackers could create short URLs redirecting to external domains
- Adds comprehensive `ValidateRelativePath()` that rejects protocol-relative URLs (`//evil.com`), backslash paths (`\evil.com`), scheme-based URLs (`http://`, `javascript:`), path traversal (`../`), and absolute paths
- Applies validation at two layers for defense-in-depth: at creation time (reject bad paths) and before redirecting (safety net for pre-existing malicious entries in the DB)

## Changes
- `pkg/services/shorturls/models.go` — New exported `ValidateRelativePath()` function
- `pkg/services/shorturls/shorturlimpl/shorturl.go` — Use centralized validation in `CreateShortURL`
- `apps/shorturl/pkg/app/app.go` — Updated K8s admission validator + safety-net in goto handler
- `pkg/api/short_url.go` — Safety-net validation in both legacy and K8s redirect handlers
- New test files with 35+ test cases covering all attack vectors

## Test plan
- [x] `go test ./pkg/services/shorturls/...` — all pass
- [x] `go test ./apps/shorturl/pkg/app/...` — all pass
- [x] `go build ./pkg/api/...` — compiles cleanly
- [ ] Manual test: attempt to create short URL with `//evil.com` path → should be rejected
- [ ] Manual test: attempt to create short URL with `http://evil.com` path → should be rejected
- [ ] Manual test: valid relative paths still work as expected

Fixes https://github.com/grafana/grafana-enterprise/issues/10848