### PR TITLE
A11y(#118639): fix "Skip to main content" link only working on first activation

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -99,6 +99,22 @@ describe('AppChrome', () => {
     expect(await screen.findByRole('button', { name: 'Main menu' })).toHaveFocus();
   });
 
+  it('should move focus to main content on every skip link activation', async () => {
+    setup(<Page navId="child1">Children</Page>);
+    const skipLink = await screen.findByRole('link', { name: 'Skip to main content' });
+    const mainContent = document.getElementById('pageContent')!;
+
+    await userEvent.click(skipLink);
+    expect(mainContent).toHaveFocus();
+
+    // Tab away, then activate the skip link a second time
+    await userEvent.tab();
+    expect(mainContent).not.toHaveFocus();
+
+    await userEvent.click(skipLink);
+    expect(mainContent).toHaveFocus();
+  });
+
   it('should not render a skip link if the page is chromeless', async () => {
     const { context } = setup(<Page navId="child1">Children</Page>);
     act(() => {

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -92,7 +92,14 @@ export function AppChrome({ children }: Props) {
     >
       {!state.chromeless && (
         <>
-          <LinkButton className={styles.skipLink} href="#pageContent">
+          <LinkButton
+            className={styles.skipLink}
+            href="#pageContent"
+            onClick={(e) => {
+              e.preventDefault();
+              document.getElementById('pageContent')?.focus();
+            }}
+          >
             <Trans i18nKey="app-chrome.skip-content-button">Skip to main content</Trans>
           </LinkButton>
           {menuDockedAndOpen && (
@@ -133,6 +140,7 @@ export function AppChrome({ children }: Props) {
               [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen,
             })}
             id="pageContent"
+            tabIndex={-1}
           >
             {children}
           </main>


### PR DESCRIPTION
Fixes #118639

## Summary

- Added `tabIndex={-1}` to `<main id="pageContent">` — makes it programmatically focusable. Without this, calling `.focus()` on the element is a no-op since `<main>` is not natively interactive.
- Added `onClick` handler on the skip link that calls `e.preventDefault()` and `document.getElementById('pageContent')?.focus()` directly — prevents the URL hash from accumulating `#pageContent`. On a SPA, once `#pageContent` is in the URL, subsequent clicks on `href="#pageContent"` are treated as no-ops by the browser (no navigation occurs).

## Test plan

- [ ] Open Grafana, tab to "Skip to main content" link, press Enter — focus moves to main content
- [ ] Shift+Tab back to the top, tab to the skip link again, press Enter — focus moves to main content a second time (previously broken)
- [ ] Verify no focus outline appears on `<main>` (`:focus-visible` is not triggered by programmatic focus)
- [ ] All `AppChrome` tests pass: `yarn jest --no-watch AppChrome.test`