### PR TITLE
A11y: Add aria-live to notification list for screen reader announcements

### DIFF
--- a/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
@@ -44,8 +44,7 @@ describe('AppNotificationList', () => {
 
     const liveRegion = container.querySelector('[aria-live="polite"]');
     expect(liveRegion).toBeInTheDocument();
-    expect(liveRegion).toHaveTextContent(expectedInfoMessage);
-    expect(liveRegion).toHaveClass('sr-only');
+    expect(liveRegion).toHaveAttribute('aria-label', expect.stringContaining(expectedInfoMessage));
   });
 
   describe('Error notifications', () => {
@@ -53,7 +52,7 @@ describe('AppNotificationList', () => {
       renderWithContext(undefined, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
     });
 
     it('should hide error notifications in kiosk mode on dashboard page', async () => {
@@ -67,7 +66,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/alerting');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
     });
 
     it('should hide error notifications in kiosk mode on home dashboard', async () => {
@@ -81,7 +80,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
     });
   });
 
@@ -90,21 +89,21 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertSuccess, expectedSuccessMessage);
 
-      expect((await screen.findAllByText(expectedSuccessMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedSuccessMessage)).toBeInTheDocument();
     });
 
     it('should always show warning notifications in kiosk mode on dashboard', async () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertWarning, expectedWarningMessage);
 
-      expect((await screen.findAllByText(expectedWarningMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedWarningMessage)).toBeInTheDocument();
     });
 
     it('should always show info notifications in kiosk mode on dashboard', async () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertInfo, expectedInfoMessage);
 
-      expect((await screen.findAllByText(expectedInfoMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedInfoMessage)).toBeInTheDocument();
     });
   });
 
@@ -156,7 +155,7 @@ describe('AppNotificationList', () => {
       renderWithContext(undefined, '/d/test-uid/test-slug');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
     });
 
     it('should hide error in kiosk mode on dashboard page with uid and slug', async () => {
@@ -170,7 +169,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/dashboard/db/test-dashboard');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
+      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
     });
   });
 });

--- a/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
@@ -38,6 +38,12 @@ const sendTestNotification = async (type: (typeof AppEvents)[keyof typeof AppEve
 };
 
 describe('AppNotificationList', () => {
+  it('should have aria-live attribute for screen reader announcements', () => {
+    const { container } = renderWithContext();
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+  });
+
   describe('Error notifications', () => {
     it('should show error notifications when not in kiosk mode', async () => {
       renderWithContext(undefined, '/d/test-dashboard');

--- a/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
@@ -38,10 +38,14 @@ const sendTestNotification = async (type: (typeof AppEvents)[keyof typeof AppEve
 };
 
 describe('AppNotificationList', () => {
-  it('should have aria-live attribute for screen reader announcements', () => {
+  it('should announce notifications to screen readers via live region', async () => {
     const { container } = renderWithContext();
+    await sendTestNotification(AppEvents.alertInfo, expectedInfoMessage);
+
     const liveRegion = container.querySelector('[aria-live="polite"]');
     expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion).toHaveTextContent(expectedInfoMessage);
+    expect(liveRegion).toHaveClass('sr-only');
   });
 
   describe('Error notifications', () => {
@@ -49,7 +53,7 @@ describe('AppNotificationList', () => {
       renderWithContext(undefined, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
     });
 
     it('should hide error notifications in kiosk mode on dashboard page', async () => {
@@ -63,7 +67,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/alerting');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
     });
 
     it('should hide error notifications in kiosk mode on home dashboard', async () => {
@@ -77,7 +81,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
     });
   });
 
@@ -86,21 +90,21 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertSuccess, expectedSuccessMessage);
 
-      expect(await screen.findByText(expectedSuccessMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedSuccessMessage)).length).toBeGreaterThan(0);
     });
 
     it('should always show warning notifications in kiosk mode on dashboard', async () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertWarning, expectedWarningMessage);
 
-      expect(await screen.findByText(expectedWarningMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedWarningMessage)).length).toBeGreaterThan(0);
     });
 
     it('should always show info notifications in kiosk mode on dashboard', async () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertInfo, expectedInfoMessage);
 
-      expect(await screen.findByText(expectedInfoMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedInfoMessage)).length).toBeGreaterThan(0);
     });
   });
 
@@ -152,7 +156,7 @@ describe('AppNotificationList', () => {
       renderWithContext(undefined, '/d/test-uid/test-slug');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
     });
 
     it('should hide error in kiosk mode on dashboard page with uid and slug', async () => {
@@ -166,7 +170,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/dashboard/db/test-dashboard');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect((await screen.findAllByText(expectedErrorMessage)).length).toBeGreaterThan(0);
     });
   });
 });

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -84,8 +84,13 @@ export function AppNotificationList() {
     dispatch(hideAppNotification(id));
   };
 
+  const liveRegionMessage = appNotifications.map((n) => n.title).join('. ');
+
   return (
-    <div className={styles.wrapper} aria-live="polite">
+    <div className={styles.wrapper}>
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveRegionMessage}
+      </div>
       <Stack direction="column">
         {appNotifications.map((appNotification, index) => {
           return (

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -84,13 +84,11 @@ export function AppNotificationList() {
     dispatch(hideAppNotification(id));
   };
 
-  const liveRegionMessage = appNotifications.map((n) => n.title).join('. ');
+  const liveRegionMessage = appNotifications.map((n) => [n.title, n.text].filter(Boolean).join('. ')).join('. ');
 
   return (
     <div className={styles.wrapper}>
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {liveRegionMessage}
-      </div>
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
       <Stack direction="column">
         {appNotifications.map((appNotification, index) => {
           return (

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -85,7 +85,7 @@ export function AppNotificationList() {
   };
 
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} aria-live="polite">
       <Stack direction="column">
         {appNotifications.map((appNotification, index) => {
           return (

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -88,7 +88,7 @@ export function AppNotificationList() {
 
   return (
     <div className={styles.wrapper}>
-      <div className="sr-only" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
+      <div className="sr-only" role="log" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
       <Stack direction="column">
         {appNotifications.map((appNotification, index) => {
           return (

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -88,7 +88,7 @@ export function AppNotificationList() {
 
   return (
     <div className={styles.wrapper}>
-      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
+      <div className="sr-only" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
       <Stack direction="column">
         {appNotifications.map((appNotification, index) => {
           return (


### PR DESCRIPTION
## Summary
- Adds a visually-hidden `aria-live="polite"` live region inside `AppNotificationList` so screen readers announce dynamically added notifications
- Uses `aria-label` (not text content) to avoid duplicating notification text in the DOM, which would break Playwright's strict-mode `getByText` queries
- The existing `role="status"` on individual `Alert` components doesn't trigger announcements when freshly mounted — only when content changes within an already-present live region

Fixes #118640

## Test plan
- [ ] Verify notifications are announced by a screen reader (VoiceOver/NVDA) when they appear
- [ ] Existing unit tests pass with updated assertions
- [ ] E2E tests no longer fail with strict mode violations on `getByText('Dashboard saved')`