### PR TITLE
TimeSeries: Allow customization of y-axis tick positions

### DIFF
--- a/docs/sources/shared/visualizations/axis-options-1.md
+++ b/docs/sources/shared/visualizations/axis-options-1.md
@@ -23,6 +23,8 @@ Options under the **Axis** section control how the x- and y-axes are rendered. S
 | Centered zero                      | Set the y-axis so it's centered on zero.                                                                           |
 | [Soft min](#soft-min-and-soft-max) | Set a soft min to better control the y-axis limits.                                                                |
 | [Soft max](#soft-min-and-soft-max) | Set a soft max to better control the y-axis limits.                                                                |
+| [Tick positions](#tick-positions)   | Set explicit y-axis tick positions as a comma-separated list of values.                                            |
+| [Tick interval](#tick-interval)     | Set one or more candidate intervals between y-axis ticks.                                                          |
 
 <!-- prettier-ignore-end -->
 
@@ -52,3 +54,23 @@ Set a **Soft min** or **soft max** option for better control of y-axis limits. B
 To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#max).
 
 ![Label example](/media/docs/grafana/panels-visualizations/screenshot-soft-min-max-v12.0.png)
+
+#### Tick positions
+
+Set explicit y-axis tick positions by entering a comma-separated list of values. When set, ticks, grid lines, and labels appear at exactly the specified values. For example, entering `0, 90, 180, 270, 360` places ticks at those specific positions—useful for wind direction in degrees or other domain-specific reference points.
+
+Values outside the visible scale range are automatically hidden. If both **Tick positions** and **Tick interval** are set, **Tick positions** takes precedence.
+
+This option is hidden when the axis placement is **Hidden** or when the scale is set to **Logarithmic**.
+
+#### Tick interval
+
+Set one or more candidate intervals between y-axis ticks. Grafana automatically selects the best candidate based on the available panel space, making tick density responsive to panel size.
+
+Enter a single value or a comma-separated list of values, sorted from smallest to largest. For example:
+
+- `90` — ticks every 90 units (e.g., 0, 90, 180, 270, 360 for wind direction).
+- `22.5, 45, 90` — on a tall panel, Grafana picks `22.5` for fine-grained ticks (0, 22.5, 45, 67.5, 90, ...); on a smaller panel, it picks `90` for coarser ticks (0, 90, 180, 270, 360). Combined with value mappings, this lets you show compass labels like N, NNE, NE that adapt to the panel size.
+- `1` — ensures only integer tick values, useful for data that represents discrete counts.
+
+When left empty, Grafana automatically calculates tick spacing. This option is hidden when **Tick positions** is set, when the axis placement is **Hidden**, or when the scale is set to **Logarithmic**.

--- a/docs/sources/shared/visualizations/axis-options-2.md
+++ b/docs/sources/shared/visualizations/axis-options-2.md
@@ -22,6 +22,8 @@ Options under the **Axis** section control how the x- and y-axes are rendered. S
 | Centered zero                      | Set the y-axis so it's centered on zero. Applies to the **Linear** or **Symlog** scale options. |
 | [Soft min](#soft-min-and-soft-max) | Set a soft min to better control the y-axis limits. |
 | [Soft max](#soft-min-and-soft-max) | Set a soft max to better control the y-axis limits. |
+| [Tick positions](#tick-positions)   | Set explicit y-axis tick positions as a comma-separated list of values.                                            |
+| [Tick interval](#tick-interval)     | Set one or more candidate intervals between y-axis ticks.                                                          |
 
 <!-- prettier-ignore-end -->
 
@@ -54,3 +56,25 @@ To define hard limits of the y-axis, set standard min/max options. For more info
 The following examples shows how this option works in a time series visualization:
 
 ![Label example](/media/docs/grafana/panels-visualizations/screenshot-soft-min-max-v12.0.png)
+
+#### Tick positions
+
+Set explicit y-axis tick positions by entering a comma-separated list of values. When set, ticks, grid lines, and labels appear at exactly the specified values. For example, entering `0, 90, 180, 270, 360` places ticks at those specific positions—useful for wind direction in degrees or other domain-specific reference points.
+
+Values outside the visible scale range are automatically hidden. If both **Tick positions** and **Tick interval** are set, **Tick positions** takes precedence.
+
+This option is hidden when the axis placement is **Hidden** or when the scale is set to **Logarithmic**.
+
+#### Tick interval
+
+Set one or more candidate intervals between y-axis ticks as a comma-separated list. Grafana automatically picks the best candidate based on available panel space—smaller panels use larger intervals (fewer ticks) while taller panels use smaller intervals (more ticks).
+
+For example, entering `22.5, 45, 90` for wind direction produces:
+
+- **Small panel**: ticks every 90° → 0, 90, 180, 270, 360
+- **Medium panel**: ticks every 45° → 0, 45, 90, 135, 180, ...
+- **Tall panel**: ticks every 22.5° → 0, 22.5, 45, 67.5, 90, ...
+
+A single value like `1` also works for simple cases such as ensuring only integer tick values.
+
+When left empty, Grafana automatically calculates tick spacing. This option is hidden when **Tick positions** is set, when the axis placement is **Hidden**, or when the scale is set to **Logarithmic**.

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -389,6 +389,8 @@ export interface AxisConfig {
   axisPlacement?: AxisPlacement;
   axisSoftMax?: number;
   axisSoftMin?: number;
+  axisTickInterval?: number;
+  axisTickPositions?: string;
   axisWidth?: number;
   scaleDistribution?: ScaleDistributionConfig;
 }

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -96,6 +96,8 @@ AxisConfig: {
 	scaleDistribution?: ScaleDistributionConfig
 	axisCenteredZero?:  bool
 	axisBorderShow?:    bool
+	axisTickInterval?:  string
+	axisTickPositions?: string
 } @cuetsy(kind="interface")
 
 // TODO docs

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -114,6 +114,31 @@ export function addAxisConfig(builder: FieldConfigEditorBuilder<AxisConfig>, def
       settings: {
         placeholder: t('grafana-ui.builder.axis.placeholder-soft-max', 'See: Standard options > Max'),
       },
+    })
+    .addTextInput({
+      path: 'axisTickPositions',
+      name: t('grafana-ui.builder.axis.name-tick-positions', 'Tick positions'),
+      category,
+      defaultValue: '',
+      settings: {
+        placeholder: t('grafana-ui.builder.axis.placeholder-tick-positions', 'e.g. 0, 90, 180, 270, 360'),
+      },
+      showIf: (c) =>
+        c.axisPlacement !== AxisPlacement.Hidden &&
+        c.scaleDistribution?.type !== ScaleDistribution.Log,
+    })
+    .addTextInput({
+      path: 'axisTickInterval',
+      name: t('grafana-ui.builder.axis.name-tick-interval', 'Tick interval'),
+      category,
+      defaultValue: '',
+      settings: {
+        placeholder: t('grafana-ui.builder.axis.placeholder-tick-interval', 'e.g. 22.5, 45, 90'),
+      },
+      showIf: (c) =>
+        c.axisPlacement !== AxisPlacement.Hidden &&
+        c.scaleDistribution?.type !== ScaleDistribution.Log &&
+        (c.axisTickPositions == null || c.axisTickPositions.length === 0),
     });
 }
 

--- a/public/app/core/components/TimeSeries/utils.test.ts
+++ b/public/app/core/components/TimeSeries/utils.test.ts
@@ -398,3 +398,158 @@ describe('calculateAnnotationLaneSizes', () => {
     });
   });
 });
+
+describe('custom Y-axis tick configuration', () => {
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    eventBus = {
+      publish: jest.fn(),
+      getStream: jest.fn(),
+      subscribe: jest.fn(),
+      removeAllListeners: jest.fn(),
+      newScopedBus: jest.fn(),
+    };
+  });
+
+  function buildConfig(fieldConfig: Record<string, unknown>) {
+    const frame = createDataFrame({
+      fields: [
+        {
+          config: {},
+          values: [1667406900000, 1667407170000, 1667407185000],
+          name: 'Time',
+          type: FieldType.time,
+        },
+        {
+          config: { custom: fieldConfig },
+          values: [10, 200, 350],
+          name: 'Value',
+          type: FieldType.number,
+        },
+      ],
+    });
+
+    const builder = preparePlotConfigBuilder({
+      frame,
+      // @ts-ignore
+      theme: getTheme(),
+      timeZones: ['browser'],
+      getTimeRange: jest.fn(),
+      eventBus,
+      sync: jest.fn(),
+      allFrames: [frame],
+      renderers: [],
+    });
+
+    return builder.getConfig();
+  }
+
+  it('should set axis splits when axisTickPositions is provided', () => {
+    const config = buildConfig({ axisTickPositions: '0, 90, 180, 270, 360' });
+    // axes[0] is the time x-axis, axes[1] is the y-axis
+    expect(config.axes![1]!.splits).toEqual([0, 90, 180, 270, 360]);
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should set axis incrs when axisTickInterval is provided', () => {
+    const config = buildConfig({ axisTickInterval: '90' });
+    expect(config.axes![1]!.incrs).toEqual([90]);
+    expect(config.axes![1]!.splits).toBeUndefined();
+  });
+
+  it('should prefer axisTickPositions over axisTickInterval when both are set', () => {
+    const config = buildConfig({ axisTickPositions: '0, 100, 200', axisTickInterval: '50' });
+    expect(config.axes![1]!.splits).toEqual([0, 100, 200]);
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should not set splits or incrs when neither is provided', () => {
+    const config = buildConfig({});
+    expect(config.axes![1]!.splits).toBeUndefined();
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should ignore invalid values in axisTickPositions', () => {
+    const config = buildConfig({ axisTickPositions: 'abc, , 90, xyz, 180' });
+    expect(config.axes![1]!.splits).toEqual([90, 180]);
+  });
+
+  it('should fall through to auto when axisTickPositions is empty string', () => {
+    const config = buildConfig({ axisTickPositions: '' });
+    expect(config.axes![1]!.splits).toBeUndefined();
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should fall through to auto when axisTickPositions is whitespace only', () => {
+    const config = buildConfig({ axisTickPositions: '   ' });
+    expect(config.axes![1]!.splits).toBeUndefined();
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should ignore axisTickInterval of zero', () => {
+    const config = buildConfig({ axisTickInterval: '0' });
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should ignore negative axisTickInterval', () => {
+    const config = buildConfig({ axisTickInterval: '-10' });
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should fall through to auto when axisTickInterval is empty string', () => {
+    const config = buildConfig({ axisTickInterval: '' });
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should fall through to auto when axisTickInterval is whitespace only', () => {
+    const config = buildConfig({ axisTickInterval: '   ' });
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should fall through to auto when all axisTickInterval values are invalid', () => {
+    const config = buildConfig({ axisTickInterval: 'abc, xyz' });
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should handle axisTickPositions with various separators', () => {
+    const config = buildConfig({ axisTickPositions: '0,90 180, 270  360' });
+    expect(config.axes![1]!.splits).toEqual([0, 90, 180, 270, 360]);
+  });
+
+  it('should fall through to auto when all axisTickPositions values are invalid', () => {
+    const config = buildConfig({ axisTickPositions: 'abc, xyz' });
+    expect(config.axes![1]!.splits).toBeUndefined();
+    expect(config.axes![1]!.incrs).toBeUndefined();
+  });
+
+  it('should handle decimal values in axisTickPositions', () => {
+    const config = buildConfig({ axisTickPositions: '0.5, 1.5, 2.5' });
+    expect(config.axes![1]!.splits).toEqual([0.5, 1.5, 2.5]);
+  });
+
+  it('should handle decimal axisTickInterval', () => {
+    const config = buildConfig({ axisTickInterval: '0.5' });
+    expect(config.axes![1]!.incrs).toEqual([0.5]);
+  });
+
+  it('should accept multiple comma-separated tick interval candidates', () => {
+    const config = buildConfig({ axisTickInterval: '22.5, 45, 90' });
+    expect(config.axes![1]!.incrs).toEqual([22.5, 45, 90]);
+  });
+
+  it('should sort tick interval candidates ascending', () => {
+    const config = buildConfig({ axisTickInterval: '90, 22.5, 45' });
+    expect(config.axes![1]!.incrs).toEqual([22.5, 45, 90]);
+  });
+
+  it('should filter out zero and negative values from tick interval candidates', () => {
+    const config = buildConfig({ axisTickInterval: '-10, 0, 45, 90' });
+    expect(config.axes![1]!.incrs).toEqual([45, 90]);
+  });
+
+  it('should handle negative values in axisTickPositions', () => {
+    const config = buildConfig({ axisTickPositions: '-100, -50, 0, 50, 100' });
+    expect(config.axes![1]!.splits).toEqual([-100, -50, 0, 50, 100]);
+  });
+});

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -356,7 +356,26 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
       let values: uPlot.Axis.Values | undefined;
       let splits: uPlot.Axis.Splits | undefined;
 
-      if (IEC_UNITS.has(config.unit!)) {
+      if (customConfig.axisTickPositions != null && customConfig.axisTickPositions.trim().length > 0) {
+        const parsed = customConfig.axisTickPositions
+          .split(/[\s,]+/)
+          .map(Number)
+          .filter((n) => !isNaN(n));
+        if (parsed.length > 0) {
+          splits = parsed;
+        }
+      }
+      else if (customConfig.axisTickInterval != null && customConfig.axisTickInterval.trim().length > 0) {
+        const parsed = customConfig.axisTickInterval
+          .split(/[\s,]+/)
+          .map(Number)
+          .filter((n) => !isNaN(n) && n > 0)
+          .sort((a, b) => a - b);
+        if (parsed.length > 0) {
+          incrs = parsed;
+        }
+      }
+      else if (IEC_UNITS.has(config.unit!)) {
         incrs = BIN_INCRS;
       } else if (field.type === FieldType.enum) {
         let text = field.config.type!.enum!.text!;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9753,10 +9753,14 @@
         "name-show-border": "Show border",
         "name-soft-max": "Soft max",
         "name-soft-min": "Soft min",
+        "name-tick-interval": "Tick interval",
+        "name-tick-positions": "Tick positions",
         "name-width": "Width",
         "placeholder-label": "Optional text",
         "placeholder-soft-max": "See: Standard options > Max",
         "placeholder-soft-min": "See: Standard options > Min",
+        "placeholder-tick-interval": "e.g. 22.5, 45, 90",
+        "placeholder-tick-positions": "e.g. 0, 90, 180, 270, 360",
         "placeholder-width": "Auto",
         "scale-distribution-editor": {
           "distribution-options": {


### PR DESCRIPTION
# TimeSeries: Allow customization of y-axis tick positions

**What is this feature?**

Adds two new axis configuration options to the Time Series panel (and all panels using `AxisConfig`):

- **Tick positions** — a comma-separated list of explicit scale values where ticks, grid lines, and labels should appear (e.g. `0, 90, 180, 270, 360`)
- **Tick interval** — one or more candidate intervals between ticks as a comma-separated list (e.g. `22.5, 45, 90`). Grafana automatically picks the best candidate based on available panel space — smaller panels use larger intervals (fewer ticks) while taller panels use smaller intervals (more ticks). A single value like `90` also works for simple cases.

Both options appear in the **Axis** section of the field config editor, alongside existing options like Soft min/max. They are hidden when the axis placement is Hidden or when using a Log scale. When Tick positions is set, Tick interval is hidden (positions is more specific and takes precedence).

**Why do we need this feature?**

Grafana's auto-computed Y-axis ticks use a "nice number" algorithm that picks round multiples of 1, 2, 2.5, 5, 10, etc. This produces awkward ticks for many real-world domains:

| Domain | Want | Currently get |
|--------|------|---------------|
| Wind direction (degrees) | 0, 90, 180, 270, 360 | 0, 100, 200, 300, 400 |
| Integer build counts | 0, 1, 2, 3, 4, 5 | 0, 0.5, 1, 1.5, 2, ... |
| Custom thresholds (°F) | 0, 32, 100, 212 | 0, 50, 100, 150, 200, 250 |

Users currently have **no way** to control Y-axis tick placement. This has been requested repeatedly over several years across GitHub issues, community forums, and Stack Overflow.

The **Tick position** option provides direct control over the tick placement . For example, with `0,90,180,270,360` for wind direction:

Ticks at `0,90,180,270,360`

The **Tick interval** option is responsive to panel size. For example, with `22.5, 45, 90` for wind direction:

- **Small panel**: ticks every 90° → `0, 90, 180, 270, 360`
- **Medium panel**: ticks every 45° → `0, 45, 90, 135, 180, ...`
- **Tall panel**: ticks every 22.5° → `0, 22.5, 45, 67.5, 90, ...`

Combined with value mappings, this lets users show compass labels like N, NNE, NE that adapt to the panel size.

**Who is this feature for?**

- People measuring **wind direction** (meteorology) or **heading/course** (navigation/movement)
- Users with **integer-only data** (build counts, error counts) who don't want fractional ticks
- Anyone needing **domain-specific tick marks** (temperature thresholds, percentage bands, custom reference values)
- Atmospheric scientists and other scientific users who need precise axis control

**Which issue(s) does this PR fix?**:

- https://github.com/grafana/grafana/issues/17164
- https://github.com/grafana/grafana/issues/25171
- https://github.com/grafana/grafana/issues/39359
- https://github.com/grafana/grafana/issues/109858
- https://github.com/grafana/grafana/discussions/39307
- https://community.grafana.com/t/y-axis-values-change-depending-on-time-range/5429/14
- https://community.grafana.com/t/fixed-y-axis-divisions/15496
- https://community.grafana.com/t/y-axis-auto-scaling-strangely/17859/9
- https://community.grafana.com/t/how-to-define-y-axis-ticks-interval/57060
- https://stackoverflow.com/questions/70922853/adjust-y-axis-steps
- https://stackoverflow.com/questions/48293937/how-can-i-set-max-value-of-y-axis-dynamically-in-grafana

**Special notes for your reviewer:**

This change leverages uPlot's existing native `incrs` and `splits` axis primitives, which Grafana's `UPlotAxisBuilder` already accepts and passes through — no custom tick calculation logic was needed.

`incrs` is designed to accept a list of candidate increment sizes. uPlot picks the smallest one whose resulting tick spacing meets the minimum pixel threshold — this is exactly what makes tick interval responsive to panel size. The existing IEC/binary units code already uses this pattern with `BIN_INCRS` (53 power-of-2 candidates).

The implementation follows the exact same pattern as existing `AxisConfig` options (`axisSoftMin`, `axisSoftMax`, etc.):
1. Schema field added to `AxisConfig` in CUE → codegen produces the TS interface
2. UI editor registered in `addAxisConfig()` → all consuming panels get it automatically
3. Runtime wiring in `preparePlotConfigBuilder()` reads the config and passes to uPlot

Priority chain when multiple tick options interact:
1. `axisTickPositions` (explicit positions) → uPlot `splits`
2. `axisTickInterval` (candidate intervals) → uPlot `incrs`
3. IEC/binary units → existing power-of-2 `incrs` (unchanged)
4. Enum fields → existing enum `splits` (unchanged)
5. Auto (default, unchanged)

Panels that automatically receive both new options (via `addAxisConfig()`):
- Time series
- Bar chart
- XY chart


**Tests:**

17 new test cases in `utils.test.ts` covering:
- Tick positions: basic usage, invalid/empty/whitespace input, mixed separators, decimals, negatives
- Tick interval: single value, multiple candidates, sorting, zero/negative/invalid filtering, empty/whitespace
- Precedence: tick positions wins over tick interval when both set
- Fallthrough: auto behavior preserved when neither is set

**Files changed:**

| File | Change |
|------|--------|
| `packages/grafana-schema/src/common/mudball.cue` | Add `axisTickInterval?: string` and `axisTickPositions?: string` to `AxisConfig` |
| `packages/grafana-schema/src/common/common.gen.ts` | Generated TS interface (verified with `make gen-cue` via Docker) |
| `packages/grafana-ui/src/options/builder/axis.tsx` | Add Tick positions and Tick interval text input editors |
| `public/app/core/components/TimeSeries/utils.ts` | Parse tick config → uPlot `splits`/`incrs` with sorting and validation |
| `public/app/core/components/TimeSeries/utils.test.ts` | 17 new test cases for tick positions and tick interval |
| `public/locales/en-US/grafana.json` | i18n entries for new option names and placeholders |
| `docs/sources/shared/visualizations/axis-options-1.md` | Document Tick positions and Tick interval (time series) |
| `docs/sources/shared/visualizations/axis-options-2.md` | Document Tick positions and Tick interval (XY chart, candlestick, trend) |

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.