### PR TITLE
Add tenant deleter for unified storage backend

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -682,6 +682,9 @@ type Cfg struct {
 	TenantApiServerAddress        string
 	TenantWatcherAllowInsecureTLS bool
 	TenantWatcherCAFile           string
+	EnableTenantDeleter           bool
+	TenantDeleterDryRun           bool
+	TenantDeleterInterval         time.Duration
 
 	// Secrets Management
 	SecretsManagement SecretsManagerSettings

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -182,6 +182,11 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.TenantWatcherAllowInsecureTLS = section.Key("tenant_watcher_allow_insecure_tls").MustBool(false)
 	cfg.TenantWatcherCAFile = section.Key("tenant_watcher_ca_file").String()
 
+	// tenant deleter
+	cfg.EnableTenantDeleter = section.Key("tenant_deleter_enabled").MustBool(false)
+	cfg.TenantDeleterDryRun = section.Key("tenant_deleter_dry_run").MustBool(true)
+	cfg.TenantDeleterInterval = section.Key("tenant_deleter_interval").MustDuration(1 * time.Hour)
+
 	// garbage collection
 	cfg.EnableGarbageCollection = section.Key("garbage_collection_enabled").MustBool(false)
 	cfg.GarbageCollectionDryRun = section.Key("garbage_collection_dry_run").MustBool(true)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -98,6 +98,10 @@ type kvStorageBackend struct {
 	// nil if tenant watching is not configured.
 	tenantWatcher *TenantWatcher
 
+	// tenantDeleter periodically deletes data for expired pending-delete tenants.
+	// nil if tenant deletion is not configured.
+	tenantDeleter *TenantDeleter
+
 	searchLookback time.Duration
 }
 
@@ -135,6 +139,9 @@ type KVBackendOptions struct {
 
 	// TenantWatcherConfig, if set, enables watching Tenant CRDs for pending-delete state.
 	TenantWatcherConfig *TenantWatcherConfig
+
+	// TenantDeleterConfig, if set, enables periodic deletion of expired pending-delete tenant data.
+	TenantDeleterConfig *TenantDeleterConfig
 
 	// SearchLookback is the duration subtracted from sinceRv in calls to ListModifiedSince.
 	// This guards against concurrent writes that commit slightly out-of-order. 0 means no lookback.
@@ -225,6 +232,13 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		backend.tenantWatcher = tw
 	}
 
+	// Optionally start the tenant deleter.
+	if opts.TenantDeleterConfig != nil {
+		td := NewTenantDeleter(backend.dataStore, newPendingDeleteStore(backend.kv), *opts.TenantDeleterConfig)
+		td.Start(ctx)
+		backend.tenantDeleter = td
+	}
+
 	// Start the cleanup background job.
 	go backend.runCleanups(ctx)
 
@@ -249,6 +263,9 @@ func (k *kvStorageBackend) IsHealthy(ctx context.Context, _ *resourcepb.HealthCh
 func (k *kvStorageBackend) Stop() {
 	if k.tenantWatcher != nil {
 		k.tenantWatcher.Stop()
+	}
+	if k.tenantDeleter != nil {
+		k.tenantDeleter.Stop()
 	}
 }
 

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -1,0 +1,180 @@
+package resource
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// TenantDeleterConfig holds configuration for the TenantDeleter.
+type TenantDeleterConfig struct {
+	Enabled  bool
+	DryRun   bool
+	Interval time.Duration
+	Log      log.Logger
+}
+
+// NewTenantDeleterConfig creates a TenantDeleterConfig from Grafana settings and returns nil
+// when tenant deleter is not enabled.
+func NewTenantDeleterConfig(cfg *setting.Cfg) *TenantDeleterConfig {
+	if cfg == nil || !cfg.EnableTenantDeleter {
+		return nil
+	}
+
+	interval := cfg.TenantDeleterInterval
+	if interval <= 0 {
+		interval = 1 * time.Hour
+	}
+
+	return &TenantDeleterConfig{
+		Enabled:  true,
+		DryRun:   cfg.TenantDeleterDryRun,
+		Interval: interval,
+		Log:      log.New("tenant-deleter"),
+	}
+}
+
+// TenantDeleter periodically checks the pending-delete store and removes
+// expired tenant data from the data store.
+type TenantDeleter struct {
+	log                log.Logger
+	pendingDeleteStore *PendingDeleteStore
+	dataStore          *dataStore
+	cfg                TenantDeleterConfig
+	stopCh             chan struct{}
+}
+
+// NewTenantDeleter creates a new TenantDeleter. It does NOT start the background goroutine.
+func NewTenantDeleter(ds *dataStore, pds *PendingDeleteStore, cfg TenantDeleterConfig) *TenantDeleter {
+	return &TenantDeleter{
+		log:                cfg.Log,
+		pendingDeleteStore: pds,
+		dataStore:          ds,
+		cfg:                cfg,
+		stopCh:             make(chan struct{}),
+	}
+}
+
+// Start launches the background deletion loop. It applies an initial jitter
+// before the first tick to avoid thundering herd.
+func (td *TenantDeleter) Start(ctx context.Context) {
+	go func() {
+		jitter := time.Duration(rand.Int64N(int64(td.cfg.Interval)))
+		select {
+		case <-time.After(jitter):
+		case <-ctx.Done():
+			return
+		case <-td.stopCh:
+			return
+		}
+
+		ticker := time.NewTicker(td.cfg.Interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-td.stopCh:
+				return
+			case <-ticker.C:
+				td.runDeletionPass(ctx)
+			}
+		}
+	}()
+}
+
+// Stop signals the background goroutine to exit.
+func (td *TenantDeleter) Stop() {
+	close(td.stopCh)
+}
+
+// runDeletionPass iterates all pending-delete records and deletes data for
+// tenants whose deletion time has passed.
+func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
+	for key, err := range td.pendingDeleteStore.kv.Keys(ctx, pendingDeleteSection, ListOptions{}) {
+		if err != nil {
+			td.log.Error("failed to list pending delete records", "error", err)
+			return
+		}
+
+		tenantName := key
+
+		record, err := td.pendingDeleteStore.Get(ctx, tenantName)
+		if err != nil {
+			td.log.Warn("failed to get pending delete record", "tenant", tenantName, "error", err)
+			continue
+		}
+
+		deleteAfter, err := time.Parse(time.RFC3339, record.DeleteAfter)
+		if err != nil {
+			td.log.Warn("failed to parse delete-after time", "tenant", tenantName, "value", record.DeleteAfter)
+			continue
+		}
+
+		if time.Now().UTC().Before(deleteAfter) {
+			// Not yet expired; skip.
+			continue
+		}
+
+		if err := td.deleteTenant(ctx, tenantName); err != nil {
+			td.log.Error("failed to delete tenant data", "tenant", tenantName, "error", err)
+		}
+	}
+}
+
+// deleteTenant removes all resource data for the given tenant from the data
+// store, then removes its pending-delete record.
+func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string) error {
+	td.log.Info("tenant data deletion", "tenant", tenantName, "dry_run", td.cfg.DryRun)
+
+	groupResources, err := td.dataStore.getGroupResources(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, gr := range groupResources {
+		listKey := ListRequestKey{
+			Group:     gr.Group,
+			Resource:  gr.Resource,
+			Namespace: tenantName,
+		}
+
+		prefix := listKey.Prefix()
+		var keys []string
+		for k, err := range td.dataStore.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: prefix,
+			EndKey:   PrefixRangeEnd(prefix),
+		}) {
+			if err != nil {
+				return err
+			}
+			keys = append(keys, k)
+		}
+
+		if td.cfg.DryRun {
+			td.log.Info("dry run: would delete tenant resources",
+				"tenant", tenantName,
+				"group", gr.Group,
+				"resource", gr.Resource,
+				"count", len(keys),
+			)
+			continue
+		}
+
+		if len(keys) > 0 {
+			if err := td.dataStore.kv.BatchDelete(ctx, dataSection, keys); err != nil {
+				return err
+			}
+		}
+	}
+
+	if td.cfg.DryRun {
+		return nil
+	}
+
+	return td.pendingDeleteStore.Delete(ctx, tenantName)
+}

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -95,6 +95,12 @@ func (td *TenantDeleter) Stop() {
 // runDeletionPass iterates all pending-delete records and deletes data for
 // tenants whose deletion time has passed.
 func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
+	groupResources, err := td.dataStore.getGroupResources(ctx)
+	if err != nil {
+		td.log.Error("failed to list group resources", "error", err)
+		return
+	}
+
 	for key, err := range td.pendingDeleteStore.kv.Keys(ctx, pendingDeleteSection, ListOptions{}) {
 		if err != nil {
 			td.log.Error("failed to list pending delete records", "error", err)
@@ -120,7 +126,7 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 			continue
 		}
 
-		if err := td.deleteTenant(ctx, tenantName); err != nil {
+		if err := td.deleteTenant(ctx, tenantName, groupResources); err != nil {
 			td.log.Error("failed to delete tenant data", "tenant", tenantName, "error", err)
 		}
 	}
@@ -128,13 +134,8 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 
 // deleteTenant removes all resource data for the given tenant from the data
 // store, then removes its pending-delete record.
-func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string) error {
+func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, groupResources []GroupResource) error {
 	td.log.Info("tenant data deletion", "tenant", tenantName, "dry_run", td.cfg.DryRun)
-
-	groupResources, err := td.dataStore.getGroupResources(ctx)
-	if err != nil {
-		return err
-	}
 
 	for _, gr := range groupResources {
 		listKey := ListRequestKey{

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -190,7 +190,10 @@ func TestDeleteTenant_MultipleGroupResources(t *testing.T) {
 		DeleteAfter: pastTime(),
 	}))
 
-	err := td.deleteTenant(t.Context(), "tenant-1")
+	groupResources, err := ds.getGroupResources(t.Context())
+	require.NoError(t, err)
+
+	err = td.deleteTenant(t.Context(), "tenant-1", groupResources)
 	require.NoError(t, err)
 
 	// Both group/resource pairs should be gone.

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -1,0 +1,217 @@
+package resource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore, *PendingDeleteStore) {
+	t.Helper()
+	kv := setupBadgerKV(t)
+	ds := newDataStore(kv)
+	pds := newPendingDeleteStore(kv)
+	cfg := TenantDeleterConfig{
+		Enabled:  true,
+		DryRun:   dryRun,
+		Interval: time.Hour,
+		Log:      log.NewNopLogger(),
+	}
+	td := NewTenantDeleter(ds, pds, cfg)
+	return td, ds, pds
+}
+
+func pastTime() string {
+	return time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+}
+
+func futureTime() string {
+	return time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+}
+
+// TestRunDeletionPass_SkipsNotExpired verifies that a tenant with a future
+// deletion time is not deleted.
+func TestRunDeletionPass_SkipsNotExpired(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: futureTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// Data should still be present.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 1, count, "resource should still exist for non-expired tenant")
+
+	// Pending delete record should still be there.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.NoError(t, err)
+}
+
+// TestRunDeletionPass_DeletesExpired verifies that all resource keys for an
+// expired tenant are removed, and the pending-delete record is also removed.
+func TestRunDeletionPass_DeletesExpired(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash2", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// All data keys for tenant-1 should be gone.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 0, count, "resources should have been deleted for expired tenant")
+
+	// Pending delete record should be gone.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestRunDeletionPass_PreservesOtherTenants verifies that only the expired
+// tenant's data is removed, leaving other tenants' data intact.
+func TestRunDeletionPass_PreservesOtherTenants(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	// tenant-1 is expired; tenant-2 is not.
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-2", "apps", "dashboards", "dash2", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-2", PendingDeleteRecord{
+		DeleteAfter: futureTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// tenant-1 data gone.
+	listKey1 := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix1 := listKey1.Prefix()
+	var count1 int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix1,
+		EndKey:   PrefixRangeEnd(prefix1),
+	}) {
+		require.NoError(t, err)
+		count1++
+	}
+	assert.Equal(t, 0, count1, "tenant-1 resources should have been deleted")
+
+	// tenant-2 data intact.
+	listKey2 := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-2"}
+	prefix2 := listKey2.Prefix()
+	var count2 int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix2,
+		EndKey:   PrefixRangeEnd(prefix2),
+	}) {
+		require.NoError(t, err)
+		count2++
+	}
+	assert.Equal(t, 1, count2, "tenant-2 resources should remain")
+
+	// tenant-1 pending delete record gone; tenant-2 record still exists.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	_, err = pds.Get(t.Context(), "tenant-2")
+	assert.NoError(t, err)
+}
+
+// TestRunDeletionPass_DryRun verifies that dry-run mode does not delete any
+// data or remove the pending-delete record.
+func TestRunDeletionPass_DryRun(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, true /* dryRun */)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// Data should still be present.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 1, count, "data should not be deleted in dry-run mode")
+
+	// Pending delete record should still exist.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.NoError(t, err)
+}
+
+// TestDeleteTenant_MultipleGroupResources verifies that deleteTenant removes
+// data across multiple group/resource pairs.
+func TestDeleteTenant_MultipleGroupResources(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-1", "core", "pods", "pod1", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	err := td.deleteTenant(t.Context(), "tenant-1")
+	require.NoError(t, err)
+
+	// Both group/resource pairs should be gone.
+	for _, gr := range []struct{ group, resource string }{
+		{"apps", "dashboards"},
+		{"core", "pods"},
+	} {
+		listKey := ListRequestKey{Group: gr.group, Resource: gr.resource, Namespace: "tenant-1"}
+		prefix := listKey.Prefix()
+		var count int
+		for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+			StartKey: prefix,
+			EndKey:   PrefixRangeEnd(prefix),
+		}) {
+			require.NoError(t, err)
+			count++
+		}
+		assert.Equal(t, 0, count, "resources for %s/%s should have been deleted", gr.group, gr.resource)
+	}
+
+	// Pending delete record should also be removed.
+	_, err = pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+}

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -145,6 +145,7 @@ func NewStorageBackend(
 		DBKeepAlive:          eDB,
 		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
 		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
+		TenantDeleterConfig:  resource.NewTenantDeleterConfig(cfg),
 		GarbageCollection: resource.GarbageCollectionConfig{
 			Enabled:          cfg.EnableGarbageCollection,
 			DryRun:           cfg.GarbageCollectionDryRun,


### PR DESCRIPTION
Implements a background service that periodically deletes resource data for tenants marked as pending-delete after their expiration time has passed.

Key changes:
- Add TenantDeleter component that runs a periodic deletion pass over expired pending-delete tenants
- Fetch group resources once per deletion pass for efficiency instead of per-tenant
- Add configuration options: `EnableTenantDeleter`, `TenantDeleterDryRun`, `TenantDeleterInterval`
- Integrate tenant deleter into KVStorageBackend initialization and lifecycle management
- Include comprehensive test coverage for deletion behavior, expiration checks, multi-tenant isolation, and dry-run mode