### PR TITLE
Add tenant deleter for periodic cleanup of expired tenant data

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -683,6 +683,9 @@ type Cfg struct {
 	TenantApiServerAddress        string
 	TenantWatcherAllowInsecureTLS bool
 	TenantWatcherCAFile           string
+	EnableTenantDeleter           bool
+	TenantDeleterDryRun           bool
+	TenantDeleterInterval         time.Duration
 
 	// Secrets Management
 	SecretsManagement SecretsManagerSettings

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -190,6 +190,11 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.TenantWatcherAllowInsecureTLS = section.Key("tenant_watcher_allow_insecure_tls").MustBool(false)
 	cfg.TenantWatcherCAFile = section.Key("tenant_watcher_ca_file").String()
 
+	// tenant deleter
+	cfg.EnableTenantDeleter = section.Key("tenant_deleter_enabled").MustBool(false)
+	cfg.TenantDeleterDryRun = section.Key("tenant_deleter_dry_run").MustBool(true)
+	cfg.TenantDeleterInterval = section.Key("tenant_deleter_interval").MustDuration(1 * time.Hour)
+
 	// garbage collection
 	cfg.EnableGarbageCollection = section.Key("garbage_collection_enabled").MustBool(false)
 	cfg.GarbageCollectionDryRun = section.Key("garbage_collection_dry_run").MustBool(true)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -106,6 +106,10 @@ type kvStorageBackend struct {
 	// nil if tenant watching is not configured.
 	tenantWatcher *TenantWatcher
 
+	// tenantDeleter periodically deletes data for expired pending-delete tenants.
+	// nil if tenant deletion is not configured.
+	tenantDeleter *TenantDeleter
+
 	searchLookback time.Duration
 }
 
@@ -143,6 +147,9 @@ type KVBackendOptions struct {
 
 	// TenantWatcherConfig, if set, enables watching Tenant CRDs for pending-delete state.
 	TenantWatcherConfig *TenantWatcherConfig
+
+	// TenantDeleterConfig, if set, enables periodic deletion of expired pending-delete tenant data.
+	TenantDeleterConfig *TenantDeleterConfig
 
 	// SearchLookback is the duration subtracted from sinceRv in calls to ListModifiedSince.
 	// This guards against concurrent writes that commit slightly out-of-order. 0 means no lookback.
@@ -238,6 +245,13 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		backend.tenantWatcher = tw
 	}
 
+	// Optionally start the tenant deleter.
+	if opts.TenantDeleterConfig != nil {
+		td := NewTenantDeleter(backend.dataStore, newPendingDeleteStore(backend.kv), *opts.TenantDeleterConfig)
+		td.Start(ctx)
+		backend.tenantDeleter = td
+	}
+
 	// Start the cleanup background job.
 	go backend.runCleanups(ctx)
 
@@ -262,6 +276,9 @@ func (k *kvStorageBackend) IsHealthy(ctx context.Context, _ *resourcepb.HealthCh
 func (k *kvStorageBackend) Stop() {
 	if k.tenantWatcher != nil {
 		k.tenantWatcher.Stop()
+	}
+	if k.tenantDeleter != nil {
+		k.tenantDeleter.Stop()
 	}
 }
 

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -1,0 +1,180 @@
+package resource
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// TenantDeleterConfig holds configuration for the TenantDeleter.
+type TenantDeleterConfig struct {
+	Enabled  bool
+	DryRun   bool
+	Interval time.Duration
+	Log      log.Logger
+}
+
+// NewTenantDeleterConfig creates a TenantDeleterConfig from Grafana settings and returns nil
+// when tenant deleter is not enabled.
+func NewTenantDeleterConfig(cfg *setting.Cfg) *TenantDeleterConfig {
+	if cfg == nil || !cfg.EnableTenantDeleter {
+		return nil
+	}
+
+	interval := cfg.TenantDeleterInterval
+	if interval <= 0 {
+		interval = 1 * time.Hour
+	}
+
+	return &TenantDeleterConfig{
+		Enabled:  true,
+		DryRun:   cfg.TenantDeleterDryRun,
+		Interval: interval,
+		Log:      log.New("tenant-deleter"),
+	}
+}
+
+// TenantDeleter periodically checks the pending-delete store and removes
+// expired tenant data from the data store.
+type TenantDeleter struct {
+	log                log.Logger
+	pendingDeleteStore *PendingDeleteStore
+	dataStore          *dataStore
+	cfg                TenantDeleterConfig
+	stopCh             chan struct{}
+}
+
+// NewTenantDeleter creates a new TenantDeleter. It does NOT start the background goroutine.
+func NewTenantDeleter(ds *dataStore, pds *PendingDeleteStore, cfg TenantDeleterConfig) *TenantDeleter {
+	return &TenantDeleter{
+		log:                cfg.Log,
+		pendingDeleteStore: pds,
+		dataStore:          ds,
+		cfg:                cfg,
+		stopCh:             make(chan struct{}),
+	}
+}
+
+// Start launches the background deletion loop. It applies an initial jitter
+// before the first tick to avoid thundering herd.
+func (td *TenantDeleter) Start(ctx context.Context) {
+	go func() {
+		jitter := time.Duration(rand.Int64N(int64(td.cfg.Interval)))
+		select {
+		case <-time.After(jitter):
+		case <-ctx.Done():
+			return
+		case <-td.stopCh:
+			return
+		}
+
+		ticker := time.NewTicker(td.cfg.Interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-td.stopCh:
+				return
+			case <-ticker.C:
+				td.runDeletionPass(ctx)
+			}
+		}
+	}()
+}
+
+// Stop signals the background goroutine to exit.
+func (td *TenantDeleter) Stop() {
+	close(td.stopCh)
+}
+
+// runDeletionPass iterates all pending-delete records and deletes data for
+// tenants whose deletion time has passed.
+func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
+	for key, err := range td.pendingDeleteStore.kv.Keys(ctx, pendingDeleteSection, ListOptions{}) {
+		if err != nil {
+			td.log.Error("failed to list pending delete records", "error", err)
+			return
+		}
+
+		tenantName := key
+
+		record, err := td.pendingDeleteStore.Get(ctx, tenantName)
+		if err != nil {
+			td.log.Warn("failed to get pending delete record", "tenant", tenantName, "error", err)
+			continue
+		}
+
+		deleteAfter, err := time.Parse(time.RFC3339, record.DeleteAfter)
+		if err != nil {
+			td.log.Warn("failed to parse delete-after time", "tenant", tenantName, "value", record.DeleteAfter)
+			continue
+		}
+
+		if time.Now().UTC().Before(deleteAfter) {
+			// Not yet expired; skip.
+			continue
+		}
+
+		if err := td.deleteTenant(ctx, tenantName); err != nil {
+			td.log.Error("failed to delete tenant data", "tenant", tenantName, "error", err)
+		}
+	}
+}
+
+// deleteTenant removes all resource data for the given tenant from the data
+// store, then removes its pending-delete record.
+func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string) error {
+	td.log.Info("tenant data deletion", "tenant", tenantName, "dry_run", td.cfg.DryRun)
+
+	groupResources, err := td.dataStore.getGroupResources(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, gr := range groupResources {
+		listKey := ListRequestKey{
+			Group:     gr.Group,
+			Resource:  gr.Resource,
+			Namespace: tenantName,
+		}
+
+		prefix := listKey.Prefix()
+		var keys []string
+		for k, err := range td.dataStore.kv.Keys(ctx, dataSection, ListOptions{
+			StartKey: prefix,
+			EndKey:   PrefixRangeEnd(prefix),
+		}) {
+			if err != nil {
+				return err
+			}
+			keys = append(keys, k)
+		}
+
+		if td.cfg.DryRun {
+			td.log.Info("dry run: would delete tenant resources",
+				"tenant", tenantName,
+				"group", gr.Group,
+				"resource", gr.Resource,
+				"count", len(keys),
+			)
+			continue
+		}
+
+		if len(keys) > 0 {
+			if err := td.dataStore.kv.BatchDelete(ctx, dataSection, keys); err != nil {
+				return err
+			}
+		}
+	}
+
+	if td.cfg.DryRun {
+		return nil
+	}
+
+	return td.pendingDeleteStore.Delete(ctx, tenantName)
+}

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -11,7 +11,6 @@ import (
 
 // TenantDeleterConfig holds configuration for the TenantDeleter.
 type TenantDeleterConfig struct {
-	Enabled  bool
 	DryRun   bool
 	Interval time.Duration
 	Log      log.Logger
@@ -30,7 +29,6 @@ func NewTenantDeleterConfig(cfg *setting.Cfg) *TenantDeleterConfig {
 	}
 
 	return &TenantDeleterConfig{
-		Enabled:  true,
 		DryRun:   cfg.TenantDeleterDryRun,
 		Interval: interval,
 		Log:      log.New("tenant-deleter"),

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -95,6 +95,12 @@ func (td *TenantDeleter) Stop() {
 // runDeletionPass iterates all pending-delete records and deletes data for
 // tenants whose deletion time has passed.
 func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
+	groupResources, err := td.dataStore.getGroupResources(ctx)
+	if err != nil {
+		td.log.Error("failed to list group resources", "error", err)
+		return
+	}
+
 	for key, err := range td.pendingDeleteStore.kv.Keys(ctx, pendingDeleteSection, ListOptions{}) {
 		if err != nil {
 			td.log.Error("failed to list pending delete records", "error", err)
@@ -120,7 +126,7 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 			continue
 		}
 
-		if err := td.deleteTenant(ctx, tenantName); err != nil {
+		if err := td.deleteTenant(ctx, tenantName, groupResources); err != nil {
 			td.log.Error("failed to delete tenant data", "tenant", tenantName, "error", err)
 		}
 	}
@@ -128,13 +134,8 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 
 // deleteTenant removes all resource data for the given tenant from the data
 // store, then removes its pending-delete record.
-func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string) error {
+func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, groupResources []GroupResource) error {
 	td.log.Info("tenant data deletion", "tenant", tenantName, "dry_run", td.cfg.DryRun)
-
-	groupResources, err := td.dataStore.getGroupResources(ctx)
-	if err != nil {
-		return err
-	}
 
 	for _, gr := range groupResources {
 		listKey := ListRequestKey{

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -145,7 +145,7 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 		}
 
 		prefix := listKey.Prefix()
-		var keys []string
+		var keys []DataKey
 		for k, err := range td.dataStore.kv.Keys(ctx, dataSection, ListOptions{
 			StartKey: prefix,
 			EndKey:   PrefixRangeEnd(prefix),
@@ -153,7 +153,11 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 			if err != nil {
 				return err
 			}
-			keys = append(keys, k)
+			dk, err := ParseKey(k)
+			if err != nil {
+				return err
+			}
+			keys = append(keys, dk)
 		}
 
 		if td.cfg.DryRun {
@@ -166,10 +170,8 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 			continue
 		}
 
-		if len(keys) > 0 {
-			if err := td.dataStore.kv.BatchDelete(ctx, dataSection, keys); err != nil {
-				return err
-			}
+		if err := td.dataStore.batchDelete(ctx, keys); err != nil {
+			return err
 		}
 	}
 
@@ -177,5 +179,6 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 		return nil
 	}
 
+	// we delete the pending-delete record at the end to ensure idempotency
 	return td.pendingDeleteStore.Delete(ctx, tenantName)
 }

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -126,6 +126,8 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 			continue
 		}
 
+		// TODO add check to verify with GCOM that tenant is deleted
+
 		if err := td.deleteTenant(ctx, tenantName, groupResources); err != nil {
 			td.log.Error("failed to delete tenant data", "tenant", tenantName, "error", err)
 		}

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -69,6 +69,8 @@ func (td *TenantDeleter) Start(ctx context.Context) {
 			return
 		}
 
+		td.runDeletionPass(ctx)
+
 		ticker := time.NewTicker(td.cfg.Interval)
 		defer ticker.Stop()
 

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -1,6 +1,11 @@
 package resource
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"iter"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -8,6 +13,46 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// failOnceBatchDeleteKV wraps a KV and makes BatchDelete fail on the Nth call,
+// then succeed on all subsequent calls. This simulates a transient failure
+// partway through a deletion pass.
+type failOnceBatchDeleteKV struct {
+	KV
+	batchDeleteCalls atomic.Int32
+	failOnCall       int32
+}
+
+func (f *failOnceBatchDeleteKV) BatchDelete(ctx context.Context, section string, keys []string) error {
+	call := f.batchDeleteCalls.Add(1)
+	if call == f.failOnCall {
+		return fmt.Errorf("injected BatchDelete failure")
+	}
+	return f.KV.BatchDelete(ctx, section, keys)
+}
+
+// Delegate all other methods to the wrapped KV.
+func (f *failOnceBatchDeleteKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
+	return f.KV.Keys(ctx, section, opt)
+}
+func (f *failOnceBatchDeleteKV) Get(ctx context.Context, section string, key string) (io.ReadCloser, error) {
+	return f.KV.Get(ctx, section, key)
+}
+func (f *failOnceBatchDeleteKV) BatchGet(ctx context.Context, section string, keys []string) iter.Seq2[KeyValue, error] {
+	return f.KV.BatchGet(ctx, section, keys)
+}
+func (f *failOnceBatchDeleteKV) Save(ctx context.Context, section string, key string) (io.WriteCloser, error) {
+	return f.KV.Save(ctx, section, key)
+}
+func (f *failOnceBatchDeleteKV) Delete(ctx context.Context, section string, key string) error {
+	return f.KV.Delete(ctx, section, key)
+}
+func (f *failOnceBatchDeleteKV) UnixTimestamp(ctx context.Context) (int64, error) {
+	return f.KV.UnixTimestamp(ctx)
+}
+func (f *failOnceBatchDeleteKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
+	return f.KV.Batch(ctx, section, ops)
+}
 
 func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore, *PendingDeleteStore) {
 	t.Helper()
@@ -176,6 +221,154 @@ func TestRunDeletionPass_DryRun(t *testing.T) {
 	// Pending delete record should still exist.
 	_, err := pds.Get(t.Context(), "tenant-1")
 	assert.NoError(t, err)
+}
+
+// TestRunDeletionPass_NoDataCleansUpRecord verifies that an expired tenant
+// with no resource data still has its pending-delete record removed.
+func TestRunDeletionPass_NoDataCleansUpRecord(t *testing.T) {
+	td, _, pds := newTestTenantDeleter(t, false)
+
+	// No resources saved — only a pending-delete record.
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// Pending delete record should be removed.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestRunDeletionPass_IdempotentRerun verifies that running a deletion pass
+// twice is safe — the second pass is a no-op.
+func TestRunDeletionPass_IdempotentRerun(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash2", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	// First pass deletes everything.
+	td.runDeletionPass(t.Context())
+
+	_, err := pds.Get(t.Context(), "tenant-1")
+	require.ErrorIs(t, err, ErrNotFound)
+
+	// Second pass should be a no-op (no record, no data).
+	td.runDeletionPass(t.Context())
+
+	// Verify data is still gone.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 0, count, "data should remain deleted after second pass")
+}
+
+// TestRunDeletionPass_IdempotentAfterPartialFailure uses a KV wrapper that
+// fails BatchDelete on the first call, so the first deletion pass deletes one
+// group/resource ("apps/dashboards") but fails on the second ("core/pods").
+// The pending-delete record must survive. A second pass (with no more injected
+// failures) should clean up the remaining data and remove the record.
+func TestRunDeletionPass_IdempotentAfterPartialFailure(t *testing.T) {
+	realKV := setupBadgerKV(t)
+	faultyKV := &failOnceBatchDeleteKV{KV: realKV, failOnCall: 2}
+
+	ds := newDataStore(faultyKV)
+	pds := newPendingDeleteStore(realKV)
+	cfg := TenantDeleterConfig{
+		Enabled:  true,
+		DryRun:   false,
+		Interval: time.Hour,
+		Log:      log.NewNopLogger(),
+	}
+	td := NewTenantDeleter(ds, pds, cfg)
+
+	// Create data across two group/resources.
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-1", "core", "pods", "pod1", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	// First pass: BatchDelete #1 (dashboards) succeeds, #2 (pods) fails.
+	td.runDeletionPass(t.Context())
+
+	// Dashboards should be deleted.
+	dashPrefix := (&ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}).Prefix()
+	var dashCount int
+	for _, err := range realKV.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: dashPrefix, EndKey: PrefixRangeEnd(dashPrefix),
+	}) {
+		require.NoError(t, err)
+		dashCount++
+	}
+	assert.Equal(t, 0, dashCount, "dashboards should have been deleted in the first pass")
+
+	// Pods should still exist (BatchDelete failed for this group).
+	podPrefix := (&ListRequestKey{Group: "core", Resource: "pods", Namespace: "tenant-1"}).Prefix()
+	var podCount int
+	for _, err := range realKV.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: podPrefix, EndKey: PrefixRangeEnd(podPrefix),
+	}) {
+		require.NoError(t, err)
+		podCount++
+	}
+	assert.Equal(t, 1, podCount, "pods should survive the failed first pass")
+
+	// Pending-delete record must still exist (deleteTenant returned an error).
+	_, err := pds.Get(t.Context(), "tenant-1")
+	require.NoError(t, err, "pending-delete record should survive after partial failure")
+
+	// Second pass: no more injected failures — should finish the job.
+	td.runDeletionPass(t.Context())
+
+	podCount = 0
+	for _, err := range realKV.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: podPrefix, EndKey: PrefixRangeEnd(podPrefix),
+	}) {
+		require.NoError(t, err)
+		podCount++
+	}
+	assert.Equal(t, 0, podCount, "pods should be deleted after retry pass")
+
+	_, err = pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound, "pending-delete record should be removed after retry")
+}
+
+// TestRunDeletionPass_DataWithoutPendingRecord verifies that tenant data is
+// untouched when there is no pending-delete record for that tenant.
+func TestRunDeletionPass_DataWithoutPendingRecord(t *testing.T) {
+	td, ds, _ := newTestTenantDeleter(t, false)
+
+	// Save data but do NOT create a pending-delete record.
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+	td.runDeletionPass(t.Context())
+
+	// Data should be untouched.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 1, count, "data should not be deleted without a pending-delete record")
 }
 
 // TestDeleteTenant_MultipleGroupResources verifies that deleteTenant removes

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -190,7 +190,10 @@ func TestDeleteTenant_MultipleGroupResources(t *testing.T) {
 		DeleteAfter: pastTime(),
 	}))
 
-	err := td.deleteTenant(t.Context(), "tenant-1")
+	groupResources, err := ds.getGroupResources(t.Context())
+	require.NoError(t, err)
+
+	err = td.deleteTenant(t.Context(), "tenant-1", groupResources)
 	require.NoError(t, err)
 
 	// Both group/resource pairs should be gone.

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -60,7 +60,6 @@ func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore
 	ds := newDataStore(kv)
 	pds := newPendingDeleteStore(kv)
 	cfg := TenantDeleterConfig{
-		Enabled:  true,
 		DryRun:   dryRun,
 		Interval: time.Hour,
 		Log:      log.NewNopLogger(),
@@ -287,7 +286,6 @@ func TestRunDeletionPass_IdempotentAfterPartialFailure(t *testing.T) {
 	ds := newDataStore(faultyKV)
 	pds := newPendingDeleteStore(realKV)
 	cfg := TenantDeleterConfig{
-		Enabled:  true,
 		DryRun:   false,
 		Interval: time.Hour,
 		Log:      log.NewNopLogger(),

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -1,0 +1,217 @@
+package resource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore, *PendingDeleteStore) {
+	t.Helper()
+	kv := setupBadgerKV(t)
+	ds := newDataStore(kv)
+	pds := newPendingDeleteStore(kv)
+	cfg := TenantDeleterConfig{
+		Enabled:  true,
+		DryRun:   dryRun,
+		Interval: time.Hour,
+		Log:      log.NewNopLogger(),
+	}
+	td := NewTenantDeleter(ds, pds, cfg)
+	return td, ds, pds
+}
+
+func pastTime() string {
+	return time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+}
+
+func futureTime() string {
+	return time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+}
+
+// TestRunDeletionPass_SkipsNotExpired verifies that a tenant with a future
+// deletion time is not deleted.
+func TestRunDeletionPass_SkipsNotExpired(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: futureTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// Data should still be present.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 1, count, "resource should still exist for non-expired tenant")
+
+	// Pending delete record should still be there.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.NoError(t, err)
+}
+
+// TestRunDeletionPass_DeletesExpired verifies that all resource keys for an
+// expired tenant are removed, and the pending-delete record is also removed.
+func TestRunDeletionPass_DeletesExpired(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash2", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// All data keys for tenant-1 should be gone.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 0, count, "resources should have been deleted for expired tenant")
+
+	// Pending delete record should be gone.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestRunDeletionPass_PreservesOtherTenants verifies that only the expired
+// tenant's data is removed, leaving other tenants' data intact.
+func TestRunDeletionPass_PreservesOtherTenants(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	// tenant-1 is expired; tenant-2 is not.
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-2", "apps", "dashboards", "dash2", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-2", PendingDeleteRecord{
+		DeleteAfter: futureTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// tenant-1 data gone.
+	listKey1 := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix1 := listKey1.Prefix()
+	var count1 int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix1,
+		EndKey:   PrefixRangeEnd(prefix1),
+	}) {
+		require.NoError(t, err)
+		count1++
+	}
+	assert.Equal(t, 0, count1, "tenant-1 resources should have been deleted")
+
+	// tenant-2 data intact.
+	listKey2 := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-2"}
+	prefix2 := listKey2.Prefix()
+	var count2 int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix2,
+		EndKey:   PrefixRangeEnd(prefix2),
+	}) {
+		require.NoError(t, err)
+		count2++
+	}
+	assert.Equal(t, 1, count2, "tenant-2 resources should remain")
+
+	// tenant-1 pending delete record gone; tenant-2 record still exists.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	_, err = pds.Get(t.Context(), "tenant-2")
+	assert.NoError(t, err)
+}
+
+// TestRunDeletionPass_DryRun verifies that dry-run mode does not delete any
+// data or remove the pending-delete record.
+func TestRunDeletionPass_DryRun(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, true /* dryRun */)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	td.runDeletionPass(t.Context())
+
+	// Data should still be present.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: "tenant-1"}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+		StartKey: prefix,
+		EndKey:   PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 1, count, "data should not be deleted in dry-run mode")
+
+	// Pending delete record should still exist.
+	_, err := pds.Get(t.Context(), "tenant-1")
+	assert.NoError(t, err)
+}
+
+// TestDeleteTenant_MultipleGroupResources verifies that deleteTenant removes
+// data across multiple group/resource pairs.
+func TestDeleteTenant_MultipleGroupResources(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+
+	saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+	saveTestResource(t, ds, "tenant-1", "core", "pods", "pod1", 101, nil)
+
+	require.NoError(t, pds.Upsert(t.Context(), "tenant-1", PendingDeleteRecord{
+		DeleteAfter: pastTime(),
+	}))
+
+	err := td.deleteTenant(t.Context(), "tenant-1")
+	require.NoError(t, err)
+
+	// Both group/resource pairs should be gone.
+	for _, gr := range []struct{ group, resource string }{
+		{"apps", "dashboards"},
+		{"core", "pods"},
+	} {
+		listKey := ListRequestKey{Group: gr.group, Resource: gr.resource, Namespace: "tenant-1"}
+		prefix := listKey.Prefix()
+		var count int
+		for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{
+			StartKey: prefix,
+			EndKey:   PrefixRangeEnd(prefix),
+		}) {
+			require.NoError(t, err)
+			count++
+		}
+		assert.Equal(t, 0, count, "resources for %s/%s should have been deleted", gr.group, gr.resource)
+	}
+
+	// Pending delete record should also be removed.
+	_, err = pds.Get(t.Context(), "tenant-1")
+	assert.ErrorIs(t, err, ErrNotFound)
+}

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -155,6 +155,7 @@ func NewStorageBackend(
 		DBKeepAlive:          eDB,
 		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
 		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
+		TenantDeleterConfig:  resource.NewTenantDeleterConfig(cfg),
 		GarbageCollection: resource.GarbageCollectionConfig{
 			Enabled:          cfg.EnableGarbageCollection,
 			DryRun:           cfg.GarbageCollectionDryRun,


### PR DESCRIPTION
Implements a background service that periodically deletes resource data for tenants marked for deletion after their expiration time has passed. This complements the existing tenant watcher by actually removing data from the unified storage backend once the grace period has elapsed.

Key changes:
- Add `TenantDeleter` service that runs on a configurable interval to identify and remove expired pending-delete tenant data
- Add configuration flags: `enable_tenant_deleter`, `tenant_deleter_dry_run`, and `tenant_deleter_interval`
- Implement dry-run mode to preview deletions without modifying data
- Add comprehensive test suite covering expiration logic, multi-tenant scenarios, and dry-run behavior
- Only present on the kv storage backend
- This will only run on dev in `dry-run` mode for now. Added a TODO about double checking the deletion with gcom before doing the delete.