### PR TITLE
Provisioning: Full Sync - react when folder name changes in metadata

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -229,6 +229,7 @@ const (
 	FullSyncPhaseFolderDeletions
 	FullSyncPhaseFolderCreations
 	FullSyncPhaseFileCreations
+	FullSyncPhaseOldFolderCleanup
 )
 
 func (p FullSyncPhase) String() string {
@@ -243,6 +244,8 @@ func (p FullSyncPhase) String() string {
 		return "folder_creations"
 	case FullSyncPhaseFileCreations:
 		return "file_creations"
+	case FullSyncPhaseOldFolderCleanup:
+		return "old_folder_cleanup"
 	default:
 		return "unknown"
 	}

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -22,9 +22,9 @@ type ResourceFileChange struct {
 	// The current value in the database -- only required for delete
 	Existing *provisioning.ResourceListItem
 
-	// OldFolderUID is set when a folder's _folder.json UID changed.
+	// FolderRenamed is set when a folder's _folder.json UID changed.
 	// The old folder needs cleanup after all children have been re-parented.
-	OldFolderUID string
+	FolderRenamed bool
 }
 
 // IsUpdatedFolder reports whether this change is an update to an existing folder.
@@ -246,7 +246,7 @@ func augmentChangesForUIDChanges(
 		}
 		if meta.Name != change.Existing.Name {
 			affectedFolders[change.Path] = true
-			change.OldFolderUID = change.Existing.Name
+			change.FolderRenamed = true
 		}
 	}
 	if len(affectedFolders) == 0 {

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -138,7 +138,15 @@ func Changes(
 			// The folder metadata file is not a resource itself.
 			// For new folders the parent directory creation handles it;
 			// for existing folders we compare hashes to detect metadata changes.
-			if folderMetadataEnabled && resources.IsFolderMetadataFile(file.Path) {
+			if resources.IsFolderMetadataFile(file.Path) {
+				if !folderMetadataEnabled {
+					logger.Debug("skipping folder metadata file - will be handled by parent directory change", "path", file.Path)
+					if err := keep.Add(file.Path); err != nil {
+						return nil, fmt.Errorf("failed to add path to keep folder metadata file: %w", err)
+					}
+					continue
+				}
+
 				logger.Debug("processing folder metadata file", "path", file.Path)
 				if err := keep.Add(file.Path); err != nil {
 					return nil, fmt.Errorf("failed to add path to keep folder metadata file: %w", err)

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type ResourceFileChange struct {
@@ -23,6 +25,13 @@ type ResourceFileChange struct {
 	// OldFolderUID is set when a folder's _folder.json UID changed.
 	// The old folder needs cleanup after all children have been re-parented.
 	OldFolderUID string
+}
+
+// IsUpdatedFolder reports whether this change is an update to an existing folder.
+func (c *ResourceFileChange) IsUpdatedFolder() bool {
+	return c.Action == repository.FileActionUpdated &&
+		safepath.IsDir(c.Path) &&
+		c.Existing != nil
 }
 
 // Compare reads the repository tree at ref, lists the current Grafana resources,
@@ -208,19 +217,32 @@ func augmentChangesForUIDChanges(
 	target *provisioning.ResourceList,
 	changes []ResourceFileChange,
 ) ([]ResourceFileChange, error) {
+	// Early return if no folder has metadata — nothing to augment.
+	hasMetadata := false
+	for _, item := range target.Items {
+		if item.Group == resources.FolderResource.Group && item.Hash != "" {
+			hasMetadata = true
+			break
+		}
+	}
+	if !hasMetadata {
+		return changes, nil
+	}
+
 	// 1. Find affected folders: folder updates where UID actually changed.
 	// Also annotate the folder change with OldFolderUID for deferred cleanup.
 	affectedFolders := make(map[string]bool)
 	for i := range changes {
 		change := &changes[i]
-		if change.Action != repository.FileActionUpdated ||
-			!safepath.IsDir(change.Path) ||
-			change.Existing == nil {
+		if !change.IsUpdatedFolder() {
 			continue
 		}
 		meta, _, err := resources.ReadFolderMetadata(ctx, repo, change.Path, ref)
 		if err != nil {
-			continue // not metadata-backed or read error — skip
+			if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+				continue // no _folder.json — not metadata-backed, skip
+			}
+			return nil, fmt.Errorf("read folder metadata for %s: %w", change.Path, err)
 		}
 		if meta.Name != change.Existing.Name {
 			affectedFolders[change.Path] = true
@@ -241,7 +263,7 @@ func augmentChangesForUIDChanges(
 	for i := range target.Items {
 		item := &target.Items[i]
 		path := item.Path
-		if item.Group == resources.FolderResource.Group && !strings.HasSuffix(path, "/") {
+		if item.Group == resources.FolderResource.Group && !safepath.IsDir(path) {
 			path += "/"
 		}
 		targetLookup[path] = item
@@ -250,7 +272,7 @@ func augmentChangesForUIDChanges(
 	// 3. Emit FileActionUpdated for direct children of affected folders
 	for _, file := range source {
 		path := file.Path
-		if !file.Blob && !strings.HasSuffix(path, "/") {
+		if !file.Blob && !safepath.IsDir(path) {
 			path += "/"
 		}
 		if resources.IsFolderMetadataFile(path) {
@@ -259,9 +281,6 @@ func augmentChangesForUIDChanges(
 
 		// Direct parent check
 		parentDir := safepath.Dir(path)
-		if !strings.HasSuffix(parentDir, "/") {
-			parentDir += "/"
-		}
 		if !affectedFolders[parentDir] {
 			continue
 		}

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -19,6 +19,10 @@ type ResourceFileChange struct {
 
 	// The current value in the database -- only required for delete
 	Existing *provisioning.ResourceListItem
+
+	// OldFolderUID is set when a folder's _folder.json UID changed.
+	// The old folder needs cleanup after all children have been re-parented.
+	OldFolderUID string
 }
 
 // Compare reads the repository tree at ref, lists the current Grafana resources,
@@ -38,6 +42,11 @@ func Compare(ctx context.Context, repo repository.Reader, repositoryResources re
 	changes, err := Changes(ctx, source, target)
 	if err != nil {
 		return nil, nil, fmt.Errorf("calculate changes: %w", err)
+	}
+
+	changes, err = augmentChangesForUIDChanges(ctx, repo, ref, source, target, changes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("augment changes for UID changes: %w", err)
 	}
 
 	if len(changes) > 0 {
@@ -184,5 +193,96 @@ func Changes(ctx context.Context, source []repository.FileTreeEntry, target *pro
 	// Deepest first (stable sort order)
 	safepath.SortByDepth(changes, func(c ResourceFileChange) string { return c.Path }, false)
 
+	return changes, nil
+}
+
+// augmentChangesForUIDChanges detects folder UID changes (new _folder.json metadata.name
+// differs from the existing Grafana folder name) and emits FileActionUpdated for direct
+// children of affected folders. This ensures children are re-parented during the normal
+// apply flow without scanning all resources.
+func augmentChangesForUIDChanges(
+	ctx context.Context,
+	repo repository.Reader,
+	ref string,
+	source []repository.FileTreeEntry,
+	target *provisioning.ResourceList,
+	changes []ResourceFileChange,
+) ([]ResourceFileChange, error) {
+	// 1. Find affected folders: folder updates where UID actually changed.
+	// Also annotate the folder change with OldFolderUID for deferred cleanup.
+	affectedFolders := make(map[string]bool)
+	for i := range changes {
+		change := &changes[i]
+		if change.Action != repository.FileActionUpdated ||
+			!safepath.IsDir(change.Path) ||
+			change.Existing == nil {
+			continue
+		}
+		meta, _, err := resources.ReadFolderMetadata(ctx, repo, change.Path, ref)
+		if err != nil {
+			continue // not metadata-backed or read error — skip
+		}
+		if meta.Name != change.Existing.Name {
+			affectedFolders[change.Path] = true
+			change.OldFolderUID = change.Existing.Name
+		}
+	}
+	if len(affectedFolders) == 0 {
+		return changes, nil
+	}
+
+	// 2. Build lookups
+	existingPaths := make(map[string]bool, len(changes))
+	for _, c := range changes {
+		existingPaths[c.Path] = true
+	}
+
+	targetLookup := make(map[string]*provisioning.ResourceListItem, len(target.Items))
+	for i := range target.Items {
+		item := &target.Items[i]
+		path := item.Path
+		if item.Group == resources.FolderResource.Group && !strings.HasSuffix(path, "/") {
+			path += "/"
+		}
+		targetLookup[path] = item
+	}
+
+	// 3. Emit FileActionUpdated for direct children of affected folders
+	for _, file := range source {
+		path := file.Path
+		if !file.Blob && !strings.HasSuffix(path, "/") {
+			path += "/"
+		}
+		if resources.IsFolderMetadataFile(path) {
+			continue
+		}
+
+		// Direct parent check
+		parentDir := safepath.Dir(path)
+		if !strings.HasSuffix(parentDir, "/") {
+			parentDir += "/"
+		}
+		if !affectedFolders[parentDir] {
+			continue
+		}
+		if existingPaths[path] {
+			continue // already in changes
+		}
+
+		existing, ok := targetLookup[path]
+		if !ok {
+			continue // new resource, not a re-parenting case
+		}
+
+		changes = append(changes, ResourceFileChange{
+			Action:   repository.FileActionUpdated,
+			Path:     path,
+			Existing: existing,
+		})
+		existingPaths[path] = true
+	}
+
+	// 4. Re-sort by depth (deepest first) since we appended new entries
+	safepath.SortByDepth(changes, func(c ResourceFileChange) string { return c.Path }, false)
 	return changes, nil
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -37,7 +37,13 @@ func (c *ResourceFileChange) IsUpdatedFolder() bool {
 // Compare reads the repository tree at ref, lists the current Grafana resources,
 // and delegates to Changes to produce the diff. It also returns the list of
 // folder paths that are missing a _folder.json metadata file.
-func Compare(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string) ([]ResourceFileChange, []string, error) {
+func Compare(
+	ctx context.Context,
+	repo repository.Reader,
+	repositoryResources resources.RepositoryResources,
+	ref string,
+	folderMetadataEnabled bool,
+) ([]ResourceFileChange, []string, error) {
 	target, err := repositoryResources.List(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error listing current: %w", err)
@@ -48,14 +54,16 @@ func Compare(ctx context.Context, repo repository.Reader, repositoryResources re
 		return nil, nil, fmt.Errorf("error reading tree: %w", err)
 	}
 
-	changes, err := Changes(ctx, source, target)
+	changes, err := Changes(ctx, source, target, folderMetadataEnabled)
 	if err != nil {
 		return nil, nil, fmt.Errorf("calculate changes: %w", err)
 	}
 
-	changes, err = augmentChangesForUIDChanges(ctx, repo, ref, source, target, changes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("augment changes for UID changes: %w", err)
+	if folderMetadataEnabled {
+		changes, err = augmentChangesForUIDChanges(ctx, repo, ref, source, target, changes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("augment changes for UID changes: %w", err)
+		}
 	}
 
 	if len(changes) > 0 {
@@ -72,7 +80,12 @@ func Compare(ctx context.Context, repo repository.Reader, repositoryResources re
 // Changes computes the diff between a repository source tree and the current Grafana state (target).
 //
 //nolint:gocyclo
-func Changes(ctx context.Context, source []repository.FileTreeEntry, target *provisioning.ResourceList) ([]ResourceFileChange, error) {
+func Changes(
+	ctx context.Context,
+	source []repository.FileTreeEntry,
+	target *provisioning.ResourceList,
+	folderMetadataEnabled bool,
+) ([]ResourceFileChange, error) {
 	logger := logging.FromContext(ctx)
 	lookup := make(map[string]*provisioning.ResourceListItem, len(target.Items))
 	for _, item := range target.Items {
@@ -125,7 +138,7 @@ func Changes(ctx context.Context, source []repository.FileTreeEntry, target *pro
 			// The folder metadata file is not a resource itself.
 			// For new folders the parent directory creation handles it;
 			// for existing folders we compare hashes to detect metadata changes.
-			if resources.IsFolderMetadataFile(file.Path) {
+			if folderMetadataEnabled && resources.IsFolderMetadataFile(file.Path) {
 				logger.Debug("processing folder metadata file", "path", file.Path)
 				if err := keep.Add(file.Path); err != nil {
 					return nil, fmt.Errorf("failed to add path to keep folder metadata file: %w", err)
@@ -217,18 +230,6 @@ func augmentChangesForUIDChanges(
 	target *provisioning.ResourceList,
 	changes []ResourceFileChange,
 ) ([]ResourceFileChange, error) {
-	// Early return if no folder has metadata — nothing to augment.
-	hasMetadata := false
-	for _, item := range target.Items {
-		if item.Group == resources.FolderResource.Group && item.Hash != "" {
-			hasMetadata = true
-			break
-		}
-	}
-	if !hasMetadata {
-		return changes, nil
-	}
-
 	// 1. Find affected folders: folder updates where UID actually changed.
 	// Also annotate the folder change with OldFolderUID for deferred cleanup.
 	affectedFolders := make(map[string]bool)

--- a/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
@@ -568,7 +568,7 @@ func TestChanges(t *testing.T) {
 }
 
 func TestChanges_FolderMetadataFlagDisabled(t *testing.T) {
-	t.Run("_folder.json treated as normal resource when flag off", func(t *testing.T) {
+	t.Run("_folder.json is kept but not treated as resource or metadata when flag off", func(t *testing.T) {
 		source := []repository.FileTreeEntry{
 			{Path: "my-folder/", Hash: "abc", Blob: false},
 			{Path: "my-folder/_folder.json", Hash: "def", Blob: true},
@@ -579,14 +579,18 @@ func TestChanges_FolderMetadataFlagDisabled(t *testing.T) {
 		changes, err := Changes(context.Background(), source, target, false)
 		require.NoError(t, err)
 
-		// With flag off, _folder.json is NOT intercepted as metadata —
-		// it passes through as a normal created resource.
+		// With flag off, _folder.json is added to keep trie (prevents parent
+		// folder deletion) but NOT emitted as a resource change or metadata update.
 		paths := make([]string, len(changes))
 		for i, c := range changes {
 			paths[i] = c.Path
 		}
-		require.Contains(t, paths, "my-folder/_folder.json",
-			"_folder.json should be treated as a normal resource when flag is off")
+		require.NotContains(t, paths, "my-folder/_folder.json",
+			"_folder.json should not appear as a change when flag is off")
+		require.Contains(t, paths, "my-folder/dashboard.json",
+			"dashboard should still be created")
+		require.Contains(t, paths, "my-folder/",
+			"folder should still be created")
 	})
 
 	t.Run("_folder.json hash change does not emit folder update when flag off", func(t *testing.T) {
@@ -714,7 +718,7 @@ func TestCompare_FolderMetadataFlagDisabled(t *testing.T) {
 		}
 
 		repoResources.On("List", mock.Anything).Return(target, nil)
-		repoResources.On("SetTree", mock.Anything).Return()
+		repoResources.On("SetTree", mock.Anything).Return().Maybe()
 		repo.On("ReadTree", mock.Anything, "ref").Return(source, nil)
 		// NOT mocking repo.Read — if augmentChangesForUIDChanges ran,
 		// it would call ReadFolderMetadata which calls repo.Read, and

--- a/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
@@ -567,6 +567,196 @@ func TestChanges(t *testing.T) {
 	})
 }
 
+func TestAugmentChangesForUIDChanges(t *testing.T) {
+	t.Run("emits children for UID change", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		// ReadFolderMetadata reads "my-folder/_folder.json" and returns a new UID
+		repo.On("Read", mock.Anything, "my-folder/_folder.json", "main").
+			Return(&repository.FileInfo{
+				Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"new-uid"},"spec":{"title":"My Folder"}}`),
+			}, nil)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "new-hash", Blob: true},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+			{Path: "my-folder/child-folder", Hash: "def", Blob: false},
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-uid"},
+				{Path: "my-folder/dashboard.json", Hash: "xyz", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+				{Path: "my-folder/child-folder", Hash: "def", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-folder-uid"},
+			},
+		}
+
+		changes := []ResourceFileChange{
+			{
+				Action:   repository.FileActionUpdated,
+				Path:     "my-folder/",
+				Existing: &provisioning.ResourceListItem{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-uid"},
+			},
+		}
+
+		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		// Should contain: the original folder update + dashboard + child folder
+		paths := make(map[string]bool)
+		for _, c := range result {
+			paths[c.Path] = true
+		}
+		require.True(t, paths["my-folder/"], "folder update should be present")
+		require.True(t, paths["my-folder/dashboard.json"], "direct child dashboard should be emitted")
+		require.True(t, paths["my-folder/child-folder/"], "direct child folder should be emitted")
+	})
+
+	t.Run("skips children for title-only change (UID same)", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		// ReadFolderMetadata returns the same UID as existing
+		repo.On("Read", mock.Anything, "my-folder/_folder.json", "main").
+			Return(&repository.FileInfo{
+				Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"same-uid"},"spec":{"title":"New Title"}}`),
+			}, nil)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "new-hash", Blob: true},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "same-uid"},
+				{Path: "my-folder/dashboard.json", Hash: "xyz", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+			},
+		}
+
+		changes := []ResourceFileChange{
+			{
+				Action:   repository.FileActionUpdated,
+				Path:     "my-folder/",
+				Existing: &provisioning.ResourceListItem{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "same-uid"},
+			},
+		}
+
+		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+		require.Len(t, result, 1, "only the original folder update — no children emitted")
+		require.Equal(t, "my-folder/", result[0].Path)
+	})
+
+	t.Run("only emits direct children, not grandchildren", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repo.On("Read", mock.Anything, "parent/_folder.json", "main").
+			Return(&repository.FileInfo{
+				Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"new-parent-uid"},"spec":{"title":"Parent"}}`),
+			}, nil)
+
+		source := []repository.FileTreeEntry{
+			{Path: "parent/", Hash: "abc", Blob: false},
+			{Path: "parent/_folder.json", Hash: "new-hash", Blob: true},
+			{Path: "parent/child/", Hash: "def", Blob: false},
+			{Path: "parent/child/grandchild.json", Hash: "ghi", Blob: true},
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "parent/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-parent-uid"},
+				{Path: "parent/child/", Hash: "def", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-uid"},
+				{Path: "parent/child/grandchild.json", Hash: "ghi", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "gc-1"},
+			},
+		}
+
+		changes := []ResourceFileChange{
+			{
+				Action:   repository.FileActionUpdated,
+				Path:     "parent/",
+				Existing: &provisioning.ResourceListItem{Path: "parent/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-parent-uid"},
+			},
+		}
+
+		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		paths := make(map[string]bool)
+		for _, c := range result {
+			paths[c.Path] = true
+		}
+		require.True(t, paths["parent/"], "folder update present")
+		require.True(t, paths["parent/child/"], "direct child folder emitted")
+		require.False(t, paths["parent/child/grandchild.json"], "grandchild should NOT be emitted")
+	})
+
+	t.Run("does not duplicate already-existing changes", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repo.On("Read", mock.Anything, "my-folder/_folder.json", "main").
+			Return(&repository.FileInfo{
+				Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"new-uid"},"spec":{"title":"My Folder"}}`),
+			}, nil)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "new-hash", Blob: true},
+			{Path: "my-folder/dashboard.json", Hash: "changed", Blob: true},
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-uid"},
+				{Path: "my-folder/dashboard.json", Hash: "original", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+			},
+		}
+
+		// dashboard.json is already in changes (hash changed independently)
+		changes := []ResourceFileChange{
+			{
+				Action:   repository.FileActionUpdated,
+				Path:     "my-folder/",
+				Existing: &provisioning.ResourceListItem{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-uid"},
+			},
+			{
+				Action:   repository.FileActionUpdated,
+				Path:     "my-folder/dashboard.json",
+				Existing: &provisioning.ResourceListItem{Path: "my-folder/dashboard.json", Hash: "original", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+			},
+		}
+
+		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		// Count dashboard entries — should be exactly 1 (no duplicate)
+		count := 0
+		for _, c := range result {
+			if c.Path == "my-folder/dashboard.json" {
+				count++
+			}
+		}
+		require.Equal(t, 1, count, "dashboard should appear only once, not duplicated")
+	})
+
+	t.Run("no-op when no folder updates", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+		}
+
+		target := &provisioning.ResourceList{}
+
+		changes := []ResourceFileChange{
+			{Action: repository.FileActionCreated, Path: "my-folder/"},
+			{Action: repository.FileActionCreated, Path: "my-folder/dashboard.json"},
+		}
+
+		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+		require.Equal(t, changes, result, "should return changes unchanged")
+	})
+}
+
 func TestCompare(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
@@ -24,7 +24,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes)
 	})
@@ -35,7 +35,7 @@ func TestChanges(t *testing.T) {
 		}
 		target := &provisioning.ResourceList{}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 		require.Equal(t, ResourceFileChange{
@@ -50,7 +50,7 @@ func TestChanges(t *testing.T) {
 				{Path: "", Resource: "dashboard", Group: "dashboard.grafana.app"},
 			},
 		}
-		_, err := Changes(context.Background(), source, target)
+		_, err := Changes(context.Background(), source, target, true)
 		require.EqualError(t, err, "empty path on a non folder")
 	})
 
@@ -62,7 +62,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes)
 	})
@@ -74,7 +74,7 @@ func TestChanges(t *testing.T) {
 		}
 
 		target := &provisioning.ResourceList{}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 
@@ -100,7 +100,7 @@ func TestChanges(t *testing.T) {
 				{Path: "other/", Resource: "folders"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes)
 	})
@@ -117,7 +117,7 @@ func TestChanges(t *testing.T) {
 				{Path: "alsocommon/", Resource: "folders"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 		require.Equal(t, ResourceFileChange{
@@ -140,7 +140,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 		require.Equal(t, ResourceFileChange{
@@ -171,7 +171,7 @@ func TestChanges(t *testing.T) {
 				{Path: "short/file.yml"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 
 		order := make([]string, len(changes))
@@ -203,7 +203,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 1)
 		require.Equal(t, ResourceFileChange{
@@ -228,7 +228,7 @@ func TestChanges(t *testing.T) {
 				{Path: "folder/", Resource: "folders"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes, "folder should be kept when it contains hidden files")
 	})
@@ -242,7 +242,7 @@ func TestChanges(t *testing.T) {
 				{Path: "folder/", Resource: "folders"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes, "folder should be kept when it contains invalid hidden paths")
 	})
@@ -256,7 +256,7 @@ func TestChanges(t *testing.T) {
 				{Path: "folder/", Resource: "folders"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes, "folder should be kept when it contains hidden folders")
 	})
@@ -270,7 +270,7 @@ func TestChanges(t *testing.T) {
 				{Path: "folder/", Resource: "folders"},
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes, "hidden file should not be unhidden")
 	})
@@ -285,7 +285,7 @@ func TestChanges(t *testing.T) {
 				Path:   "one/two/",
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Equal(t, expected, changes)
 	})
@@ -300,7 +300,7 @@ func TestChanges(t *testing.T) {
 				Path:   "one/two/",
 			},
 		}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Equal(t, expected, changes)
 	})
@@ -310,7 +310,7 @@ func TestChanges(t *testing.T) {
 		}
 
 		target := &provisioning.ResourceList{}
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes)
 	})
@@ -334,7 +334,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Equal(t, expected, changes, "Expected diff to correctly include nested folder contents")
 	})
@@ -349,7 +349,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty path on a non folder")
 		require.Nil(t, changes)
@@ -372,7 +372,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.Equal(t, "root/folder1/subfolder/", changes[0].Path)
@@ -395,7 +395,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Empty(t, changes, "Should handle folder paths with and without trailing slash")
 	})
@@ -410,7 +410,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 3)
 
@@ -432,7 +432,7 @@ func TestChanges(t *testing.T) {
 		}
 		target := &provisioning.ResourceList{}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		require.Len(t, changes, 3) // Only non-blob entries should create changes
 
@@ -460,7 +460,7 @@ func TestChanges(t *testing.T) {
 		}
 		target := &provisioning.ResourceList{}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		// Only the folder and the dashboard — _folder.json must not appear
 		require.Len(t, changes, 2)
@@ -485,7 +485,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 
 		var folderUpdates []ResourceFileChange
@@ -509,7 +509,7 @@ func TestChanges(t *testing.T) {
 			},
 		}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 
 		for _, c := range changes {
@@ -526,7 +526,7 @@ func TestChanges(t *testing.T) {
 		}
 		target := &provisioning.ResourceList{}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 
 		for _, c := range changes {
@@ -545,7 +545,7 @@ func TestChanges(t *testing.T) {
 		}
 		target := &provisioning.ResourceList{}
 
-		changes, err := Changes(context.Background(), source, target)
+		changes, err := Changes(context.Background(), source, target, true)
 		require.NoError(t, err)
 		// 2 folders and 1 file, so 3 changes in total
 		require.Len(t, changes, 3)
@@ -564,6 +564,171 @@ func TestChanges(t *testing.T) {
 			Action: repository.FileActionCreated,
 			Path:   "folder2/",
 		}, changes[2])
+	})
+}
+
+func TestChanges_FolderMetadataFlagDisabled(t *testing.T) {
+	t.Run("_folder.json treated as normal resource when flag off", func(t *testing.T) {
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "def", Blob: true},
+			{Path: "my-folder/dashboard.json", Hash: "ghi", Blob: true},
+		}
+		target := &provisioning.ResourceList{}
+
+		changes, err := Changes(context.Background(), source, target, false)
+		require.NoError(t, err)
+
+		// With flag off, _folder.json is NOT intercepted as metadata —
+		// it passes through as a normal created resource.
+		paths := make([]string, len(changes))
+		for i, c := range changes {
+			paths[i] = c.Path
+		}
+		require.Contains(t, paths, "my-folder/_folder.json",
+			"_folder.json should be treated as a normal resource when flag is off")
+	})
+
+	t.Run("_folder.json hash change does not emit folder update when flag off", func(t *testing.T) {
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "new-hash", Blob: true},
+		}
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "folder-uid"},
+			},
+		}
+
+		changes, err := Changes(context.Background(), source, target, false)
+		require.NoError(t, err)
+
+		// With flag off, no folder update should be emitted from metadata hash comparison.
+		for _, c := range changes {
+			if c.Path == "my-folder/" && c.Action == repository.FileActionUpdated {
+				t.Fatal("folder update should not be emitted when flag is off")
+			}
+		}
+	})
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupMocks      func(*repository.MockRepository, *resources.MockRepositoryResources)
+		expectedError   string
+		expectedChanges []ResourceFileChange
+		expectedMissing []string
+		description     string
+	}{
+		{
+			name:        "error listing current resources",
+			description: "Should return error when listing current resources fails",
+			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
+				repoResources.On("List", mock.Anything).Return(nil, fmt.Errorf("listing failed"))
+			},
+			expectedError: "error listing current: listing failed",
+		},
+		{
+			name:        "error reading tree",
+			description: "Should return error when reading tree fails",
+			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
+				repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
+				repo.On("ReadTree", mock.Anything, "current-ref").Return(nil, fmt.Errorf("read tree failed"))
+			},
+			expectedError: "error reading tree: read tree failed",
+		},
+		{
+			name:        "no changes between source and target",
+			description: "Should return empty changes when source and target are identical",
+			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
+				target := &provisioning.ResourceList{
+					Items: []provisioning.ResourceListItem{
+						{Path: "dashboard.json", Hash: "xyz"},
+					},
+				}
+				source := []repository.FileTreeEntry{
+					{Path: "dashboard.json", Hash: "xyz", Blob: true},
+				}
+
+				repoResources.On("List", mock.Anything).Return(target, nil)
+				repo.On("ReadTree", mock.Anything, "current-ref").Return(source, nil)
+			},
+			expectedChanges: []ResourceFileChange{},
+		},
+		{
+			name:        "compare function error",
+			description: "Should return error when comparing fails",
+			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
+				target := &provisioning.ResourceList{
+					Items: []provisioning.ResourceListItem{
+						// Empty path to trigger error
+						{Path: "", Hash: "xyz", Resource: "dashboard", Group: "dashboard.grafana.app"},
+					},
+				}
+				source := []repository.FileTreeEntry{
+					{Path: "dashboard.json", Hash: "xyz", Blob: true},
+				}
+				repoResources.On("List", mock.Anything).Return(target, nil)
+				repo.On("ReadTree", mock.Anything, "current-ref").Return(source, nil)
+			},
+			expectedError: "calculate changes: empty path on a non folder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := repository.NewMockRepository(t)
+			repoResources := resources.NewMockRepositoryResources(t)
+
+			tt.setupMocks(repo, repoResources)
+
+			changes, missing, err := Compare(context.Background(), repo, repoResources, "current-ref", true)
+
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError, tt.description)
+				require.Nil(t, changes)
+				require.Nil(t, missing)
+			} else {
+				require.NoError(t, err, tt.description)
+				require.Equal(t, tt.expectedChanges, changes, tt.description)
+				require.Equal(t, tt.expectedMissing, missing, tt.description)
+			}
+		})
+	}
+}
+
+func TestCompare_FolderMetadataFlagDisabled(t *testing.T) {
+	t.Run("augmentChangesForUIDChanges skipped when flag off", func(t *testing.T) {
+		repo := repository.NewMockRepository(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Hash: "abc", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "new-hash", Blob: true},
+		}
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-uid"},
+			},
+		}
+
+		repoResources.On("List", mock.Anything).Return(target, nil)
+		repoResources.On("SetTree", mock.Anything).Return()
+		repo.On("ReadTree", mock.Anything, "ref").Return(source, nil)
+		// NOT mocking repo.Read — if augmentChangesForUIDChanges ran,
+		// it would call ReadFolderMetadata which calls repo.Read, and
+		// the mock would panic on unexpected call.
+
+		changes, _, err := Compare(context.Background(), repo, repoResources, "ref", false)
+		require.NoError(t, err)
+
+		// No folder update should be emitted — the metadata processing is skipped.
+		for _, c := range changes {
+			if c.Path == "my-folder/" && c.Action == repository.FileActionUpdated {
+				t.Fatal("folder update should not be emitted when flag is off")
+			}
+		}
 	})
 }
 
@@ -755,90 +920,4 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, changes, result, "should return changes unchanged")
 	})
-}
-
-func TestCompare(t *testing.T) {
-	tests := []struct {
-		name            string
-		setupMocks      func(*repository.MockRepository, *resources.MockRepositoryResources)
-		expectedError   string
-		expectedChanges []ResourceFileChange
-		expectedMissing []string
-		description     string
-	}{
-		{
-			name:        "error listing current resources",
-			description: "Should return error when listing current resources fails",
-			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
-				repoResources.On("List", mock.Anything).Return(nil, fmt.Errorf("listing failed"))
-			},
-			expectedError: "error listing current: listing failed",
-		},
-		{
-			name:        "error reading tree",
-			description: "Should return error when reading tree fails",
-			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
-				repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
-				repo.On("ReadTree", mock.Anything, "current-ref").Return(nil, fmt.Errorf("read tree failed"))
-			},
-			expectedError: "error reading tree: read tree failed",
-		},
-		{
-			name:        "no changes between source and target",
-			description: "Should return empty changes when source and target are identical",
-			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
-				target := &provisioning.ResourceList{
-					Items: []provisioning.ResourceListItem{
-						{Path: "dashboard.json", Hash: "xyz"},
-					},
-				}
-				source := []repository.FileTreeEntry{
-					{Path: "dashboard.json", Hash: "xyz", Blob: true},
-				}
-
-				repoResources.On("List", mock.Anything).Return(target, nil)
-				repo.On("ReadTree", mock.Anything, "current-ref").Return(source, nil)
-			},
-			expectedChanges: []ResourceFileChange{},
-		},
-		{
-			name:        "compare function error",
-			description: "Should return error when comparing fails",
-			setupMocks: func(repo *repository.MockRepository, repoResources *resources.MockRepositoryResources) {
-				target := &provisioning.ResourceList{
-					Items: []provisioning.ResourceListItem{
-						// Empty path to trigger error
-						{Path: "", Hash: "xyz", Resource: "dashboard", Group: "dashboard.grafana.app"},
-					},
-				}
-				source := []repository.FileTreeEntry{
-					{Path: "dashboard.json", Hash: "xyz", Blob: true},
-				}
-				repoResources.On("List", mock.Anything).Return(target, nil)
-				repo.On("ReadTree", mock.Anything, "current-ref").Return(source, nil)
-			},
-			expectedError: "calculate changes: empty path on a non folder",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			repo := repository.NewMockRepository(t)
-			repoResources := resources.NewMockRepositoryResources(t)
-
-			tt.setupMocks(repo, repoResources)
-
-			changes, missing, err := Compare(context.Background(), repo, repoResources, "current-ref")
-
-			if tt.expectedError != "" {
-				require.EqualError(t, err, tt.expectedError, tt.description)
-				require.Nil(t, changes)
-				require.Nil(t, missing)
-			} else {
-				require.NoError(t, err, tt.description)
-				require.Equal(t, tt.expectedChanges, changes, tt.description)
-				require.Equal(t, tt.expectedMissing, missing, tt.description)
-			}
-		})
-	}
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/compare_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/compare_fn_mock.go
@@ -24,9 +24,9 @@ func (_m *MockCompareFn) EXPECT() *MockCompareFn_Expecter {
 	return &MockCompareFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repo, repositoryResources, ref
-func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string) ([]ResourceFileChange, []string, error) {
-	ret := _m.Called(ctx, repo, repositoryResources, ref)
+// Execute provides a mock function with given fields: ctx, repo, repositoryResources, ref, folderMetadataEnabled
+func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, error) {
+	ret := _m.Called(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
@@ -35,27 +35,27 @@ func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, re
 	var r0 []ResourceFileChange
 	var r1 []string
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string) ([]ResourceFileChange, []string, error)); ok {
-		return rf(ctx, repo, repositoryResources, ref)
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) ([]ResourceFileChange, []string, error)); ok {
+		return rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string) []ResourceFileChange); ok {
-		r0 = rf(ctx, repo, repositoryResources, ref)
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) []ResourceFileChange); ok {
+		r0 = rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ResourceFileChange)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, repository.Reader, resources.RepositoryResources, string) []string); ok {
-		r1 = rf(ctx, repo, repositoryResources, ref)
+	if rf, ok := ret.Get(1).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) []string); ok {
+		r1 = rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, repository.Reader, resources.RepositoryResources, string) error); ok {
-		r2 = rf(ctx, repo, repositoryResources, ref)
+	if rf, ok := ret.Get(2).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) error); ok {
+		r2 = rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -73,13 +73,14 @@ type MockCompareFn_Execute_Call struct {
 //   - repo repository.Reader
 //   - repositoryResources resources.RepositoryResources
 //   - ref string
-func (_e *MockCompareFn_Expecter) Execute(ctx interface{}, repo interface{}, repositoryResources interface{}, ref interface{}) *MockCompareFn_Execute_Call {
-	return &MockCompareFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, repositoryResources, ref)}
+//   - folderMetadataEnabled bool
+func (_e *MockCompareFn_Expecter) Execute(ctx interface{}, repo interface{}, repositoryResources interface{}, ref interface{}, folderMetadataEnabled interface{}) *MockCompareFn_Execute_Call {
+	return &MockCompareFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, repositoryResources, ref, folderMetadataEnabled)}
 }
 
-func (_c *MockCompareFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string)) *MockCompareFn_Execute_Call {
+func (_c *MockCompareFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool)) *MockCompareFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(resources.RepositoryResources), args[3].(string))
+		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(resources.RepositoryResources), args[3].(string), args[4].(bool))
 	})
 	return _c
 }
@@ -89,7 +90,7 @@ func (_c *MockCompareFn_Execute_Call) Return(_a0 []ResourceFileChange, _a1 []str
 	return _c
 }
 
-func (_c *MockCompareFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, resources.RepositoryResources, string) ([]ResourceFileChange, []string, error)) *MockCompareFn_Execute_Call {
+func (_c *MockCompareFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) ([]ResourceFileChange, []string, error)) *MockCompareFn_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -9,13 +9,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
@@ -232,19 +230,6 @@ func applyChange(
 			return
 		}
 
-		// If the UID changed (_folder.json metadata.name was modified),
-		// re-parent children from the old folder to the new one and delete the old folder.
-		if change.Action == repository.FileActionUpdated && change.Existing != nil && change.Existing.Name != folder {
-			if err := reparentAndDeleteOldFolder(ensureFolderCtx, clients, repositoryResources, change.Existing.Name, folder); err != nil {
-				resultBuilder.WithError(fmt.Errorf("replace folder %s → %s: %w", change.Existing.Name, folder, err))
-				ensureFolderSpan.RecordError(err)
-				ensureFolderSpan.End()
-				progress.Record(ctx, resultBuilder.Build())
-
-				return
-			}
-		}
-
 		resultBuilder.WithName(folder)
 		progress.Record(ensureFolderCtx, resultBuilder.Build())
 		ensureFolderSpan.End()
@@ -311,6 +296,7 @@ func applyChanges(
 	// 2. Folder deletions
 	// 3. Folder creations (must happen before file creations)
 	// 4. File creations (must happen after folder creations)
+	// 5. Old folder deletions (must happen after all children have been re-parented)
 	var fileDeletions []ResourceFileChange
 	var folderDeletions []ResourceFileChange
 	var folderCreations []ResourceFileChange
@@ -358,6 +344,21 @@ func applyChanges(
 		}
 	}
 
+	// Collect old folder UIDs that need deletion after children have been re-parented.
+	// OldFolderUID is set by augmentChangesForUIDChanges when a _folder.json UID changed.
+	// We track the path to sort by depth (deepest first) so child folders are deleted
+	// before their parents.
+	type oldFolder struct {
+		Path string
+		UID  string
+	}
+	var oldFolders []oldFolder
+	for _, change := range folderCreations {
+		if change.OldFolderUID != "" {
+			oldFolders = append(oldFolders, oldFolder{Path: change.Path, UID: change.OldFolderUID})
+		}
+	}
+
 	if len(folderCreations) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderCreations, func() error {
 			return applyFoldersSerially(ctx, folderCreations, clients, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
@@ -371,6 +372,22 @@ func applyChanges(
 			return applyResourcesInParallel(ctx, fileCreations, clients, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
 		}, metrics); err != nil {
 			return err
+		}
+	}
+
+	// Delete old folders after all children (folders + files) have been re-parented.
+	// Deepest first so child folders are deleted before their parents.
+	safepath.SortByDepth(oldFolders, func(f oldFolder) string { return f.Path }, false)
+	for _, old := range oldFolders {
+		if ctx.Err() != nil {
+			break
+		}
+		if err := repositoryResources.RemoveFolder(ctx, old.UID); err != nil {
+			progress.Record(ctx, jobs.NewFolderResult(old.Path).
+				WithAction(repository.FileActionDeleted).
+				WithName(old.UID).
+				WithError(fmt.Errorf("delete old folder %s after UID change: %w", old.UID, err)).
+				Build())
 		}
 	}
 
@@ -467,48 +484,6 @@ func wrapWithTimeout(ctx context.Context, timeout time.Duration, fn func(context
 	defer cancel()
 
 	fn(timeoutCtx)
-}
-
-// reparentAndDeleteOldFolder re-parents children from the old folder to the new one,
-// then deletes the old folder. Used when _folder.json UID changes.
-func reparentAndDeleteOldFolder(
-	ctx context.Context,
-	clients resources.ResourceClients,
-	repositoryResources resources.RepositoryResources,
-	oldUID, newUID string,
-) error {
-	// Re-parent children: iterate all resource types that support the folder annotation.
-	for _, gvr := range resources.SupportedProvisioningResources {
-		client, _, err := clients.ForResource(ctx, gvr)
-		if err != nil {
-			return fmt.Errorf("get client for %s: %w", gvr.Resource, err)
-		}
-
-		if err := resources.ForEach(ctx, client, func(item *unstructured.Unstructured) error {
-			meta, err := utils.MetaAccessor(item)
-			if err != nil {
-				return fmt.Errorf("get meta for %s/%s: %w", item.GetKind(), item.GetName(), err)
-			}
-			if meta.GetFolder() != oldUID {
-				return nil
-			}
-
-			meta.SetFolder(newUID)
-			if _, err := client.Update(ctx, item, metav1.UpdateOptions{}); err != nil {
-				return fmt.Errorf("re-parent %s/%s: %w", item.GetKind(), item.GetName(), err)
-			}
-			return nil
-		}); err != nil {
-			return fmt.Errorf("re-parent children: %w", err)
-		}
-	}
-
-	// Delete the old folder.
-	if err := repositoryResources.RemoveFolder(ctx, oldUID); err != nil {
-		return fmt.Errorf("delete old folder %s: %w", oldUID, err)
-	}
-
-	return nil
 }
 
 // checkQuotaBeforeSync checks if the repository is over quota and if the sync would exceed the quota limit.

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -344,21 +344,6 @@ func applyChanges(
 		}
 	}
 
-	// Collect old folder UIDs that need deletion after children have been re-parented.
-	// OldFolderUID is set by augmentChangesForUIDChanges when a _folder.json UID changed.
-	// We track the path to sort by depth (deepest first) so child folders are deleted
-	// before their parents.
-	type oldFolder struct {
-		Path string
-		UID  string
-	}
-	var oldFolders []oldFolder
-	for _, change := range folderCreations {
-		if change.OldFolderUID != "" {
-			oldFolders = append(oldFolders, oldFolder{Path: change.Path, UID: change.OldFolderUID})
-		}
-	}
-
 	if len(folderCreations) > 0 {
 		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderCreations, func() error {
 			return applyFoldersSerially(ctx, folderCreations, clients, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
@@ -375,19 +360,40 @@ func applyChanges(
 		}
 	}
 
-	// Delete old folders after all children (folders + files) have been re-parented.
-	// Deepest first so child folders are deleted before their parents.
-	safepath.SortByDepth(oldFolders, func(f oldFolder) string { return f.Path }, false)
-	for _, old := range oldFolders {
-		if ctx.Err() != nil {
-			break
+	// Collect and delete old folders after all children have been re-parented.
+	type oldFolder struct {
+		Path string
+		UID  string
+	}
+	var oldFolders []oldFolder
+	for _, change := range folderCreations {
+		if change.OldFolderUID != "" {
+			oldFolders = append(oldFolders, oldFolder{Path: change.Path, UID: change.OldFolderUID})
 		}
-		if err := repositoryResources.RemoveFolder(ctx, old.UID); err != nil {
-			progress.Record(ctx, jobs.NewFolderResult(old.Path).
-				WithAction(repository.FileActionDeleted).
-				WithName(old.UID).
-				WithError(fmt.Errorf("delete old folder %s after UID change: %w", old.UID, err)).
-				Build())
+	}
+
+	if len(oldFolders) > 0 {
+		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseOldFolderCleanup, func() error {
+			safepath.SortByDepth(oldFolders, func(f oldFolder) string { return f.Path }, false)
+			for _, old := range oldFolders {
+				if ctx.Err() != nil {
+					break
+				}
+				// Skip if the replacement folder failed to be created.
+				if progress.HasDirPathFailedCreation(old.Path) {
+					continue
+				}
+				resultBuilder := jobs.NewFolderResult(old.Path).
+					WithAction(repository.FileActionDeleted).
+					WithName(old.UID)
+				if err := repositoryResources.RemoveFolder(ctx, old.UID); err != nil {
+					resultBuilder.WithError(fmt.Errorf("delete old folder %s after UID change: %w", old.UID, err))
+				}
+				progress.Record(ctx, resultBuilder.Build())
+			}
+			return nil
+		}, metrics); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -379,6 +379,11 @@ func applyChanges(
 				if ctx.Err() != nil {
 					break
 				}
+
+				if err := progress.TooManyErrors(); err != nil {
+					return err
+				}
+
 				// Skip if the replacement folder failed to be created.
 				if progress.HasDirPathFailedCreation(old.Path) {
 					skipCtx, skipSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.skip_renamed_folder_deletion")
@@ -389,7 +394,7 @@ func applyChanges(
 					skipSpan.End()
 					continue
 				}
-				
+
 				resultBuilder := jobs.NewFolderResult(old.Path).
 					WithAction(repository.FileActionDeleted).
 					WithName(old.UID)

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -367,8 +367,8 @@ func applyChanges(
 	}
 	var oldFolders []oldFolder
 	for _, change := range folderCreations {
-		if change.OldFolderUID != "" {
-			oldFolders = append(oldFolders, oldFolder{Path: change.Path, UID: change.OldFolderUID})
+		if change.FolderRenamed {
+			oldFolders = append(oldFolders, oldFolder{Path: change.Path, UID: change.Existing.Name})
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -64,7 +64,7 @@ func FullSync(
 	var changes []ResourceFileChange
 	var missingFolderMetadata []string
 	err := instrumentedFullSyncPhase(jobs.FullSyncPhaseCompare, func() (err error) {
-		changes, missingFolderMetadata, err = compare(compareCtx, repo, repositoryResources, currentRef)
+		changes, missingFolderMetadata, err = compare(compareCtx, repo, repositoryResources, currentRef, folderMetadataEnabled)
 		return
 	}, metrics)
 	compareSpan.End()

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -381,8 +381,15 @@ func applyChanges(
 				}
 				// Skip if the replacement folder failed to be created.
 				if progress.HasDirPathFailedCreation(old.Path) {
+					skipCtx, skipSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.skip_renamed_folder_deletion")
+					progress.Record(skipCtx, jobs.NewPathOnlyResult(old.Path).
+						WithError(fmt.Errorf("old folder was not deleted because the replacement folder could not be created")).
+						AsSkipped().
+						Build())
+					skipSpan.End()
 					continue
 				}
+				
 				resultBuilder := jobs.NewFolderResult(old.Path).
 					WithAction(repository.FileActionDeleted).
 					WithName(old.UID)

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -9,11 +9,13 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
@@ -214,6 +216,12 @@ func applyChange(
 		ensureFolderCtx, ensureFolderSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.ensure_folder_exists")
 		resultBuilder := jobs.NewFolderResult(change.Path).WithAction(change.Action)
 
+		// For updated folders, remove the old UID from the tree so EnsureFolderPathExist
+		// doesn't skip it. This handles both title changes (hash mismatch) and UID changes.
+		if change.Action == repository.FileActionUpdated && change.Existing != nil {
+			repositoryResources.RemoveFolderFromTree(change.Existing.Name)
+		}
+
 		folder, err := repositoryResources.EnsureFolderPathExist(ensureFolderCtx, change.Path)
 		if err != nil {
 			resultBuilder.WithError(fmt.Errorf("ensuring folder exists at path %s: %w", change.Path, err))
@@ -222,6 +230,19 @@ func applyChange(
 			progress.Record(ctx, resultBuilder.Build())
 
 			return
+		}
+
+		// If the UID changed (_folder.json metadata.name was modified),
+		// re-parent children from the old folder to the new one and delete the old folder.
+		if change.Action == repository.FileActionUpdated && change.Existing != nil && change.Existing.Name != folder {
+			if err := reparentAndDeleteOldFolder(ensureFolderCtx, clients, repositoryResources, change.Existing.Name, folder); err != nil {
+				resultBuilder.WithError(fmt.Errorf("replace folder %s → %s: %w", change.Existing.Name, folder, err))
+				ensureFolderSpan.RecordError(err)
+				ensureFolderSpan.End()
+				progress.Record(ctx, resultBuilder.Build())
+
+				return
+			}
 		}
 
 		resultBuilder.WithName(folder)
@@ -446,6 +467,48 @@ func wrapWithTimeout(ctx context.Context, timeout time.Duration, fn func(context
 	defer cancel()
 
 	fn(timeoutCtx)
+}
+
+// reparentAndDeleteOldFolder re-parents children from the old folder to the new one,
+// then deletes the old folder. Used when _folder.json UID changes.
+func reparentAndDeleteOldFolder(
+	ctx context.Context,
+	clients resources.ResourceClients,
+	repositoryResources resources.RepositoryResources,
+	oldUID, newUID string,
+) error {
+	// Re-parent children: iterate all resource types that support the folder annotation.
+	for _, gvr := range resources.SupportedProvisioningResources {
+		client, _, err := clients.ForResource(ctx, gvr)
+		if err != nil {
+			return fmt.Errorf("get client for %s: %w", gvr.Resource, err)
+		}
+
+		if err := resources.ForEach(ctx, client, func(item *unstructured.Unstructured) error {
+			meta, err := utils.MetaAccessor(item)
+			if err != nil {
+				return fmt.Errorf("get meta for %s/%s: %w", item.GetKind(), item.GetName(), err)
+			}
+			if meta.GetFolder() != oldUID {
+				return nil
+			}
+
+			meta.SetFolder(newUID)
+			if _, err := client.Update(ctx, item, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("re-parent %s/%s: %w", item.GetKind(), item.GetName(), err)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("re-parent children: %w", err)
+		}
+	}
+
+	// Delete the old folder.
+	if err := repositoryResources.RemoveFolder(ctx, oldUID); err != nil {
+		return fmt.Errorf("delete old folder %s: %w", oldUID, err)
+	}
+
+	return nil
 }
 
 // checkQuotaBeforeSync checks if the repository is over quota and if the sync would exceed the quota limit.

--- a/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
@@ -411,7 +411,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 			tt.setupMocks(repo, repoResources, clients, progress, dynamicClient)
 
-			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil)
+			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil)
 			progress.On("SetTotal", mock.Anything, len(tt.changes)).Return()
 			progress.On("TooManyErrors").Return(nil).Maybe()
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -1258,3 +1258,186 @@ func TestFullSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
 	require.NoError(t, err)
 }
+
+func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
+	// Verify that old folder UIDs are deleted AFTER folder creations and file creations.
+	// The ordering must be: folder phase -> file phase -> old folder deletion.
+	repoResources := resources.NewMockRepositoryResources(t)
+	clients := resources.NewMockResourceClients(t)
+	progress := jobs.NewMockJobProgressRecorder(t)
+	tracer := tracing.NewNoopTracerService()
+	metrics := jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry())
+
+	// Track call ordering. With maxSyncWorkers=1 all phases are sequential,
+	// so no mutex is needed.
+	var callOrder []string
+	recordCall := func(name string) {
+		callOrder = append(callOrder, name)
+	}
+
+	changes := []ResourceFileChange{
+		{
+			// Folder creation with OldFolderUID — triggers deferred deletion
+			Action:       repository.FileActionUpdated,
+			Path:         "myfolder/",
+			OldFolderUID: "old-uid-123",
+			Existing:     &provisioning.ResourceListItem{Name: "old-uid-123"},
+		},
+		{
+			// A file creation that needs to happen before old folder cleanup
+			Action: repository.FileActionCreated,
+			Path:   "myfolder/dashboard.json",
+		},
+	}
+
+	progress.On("SetTotal", mock.Anything, 2).Return()
+	progress.On("TooManyErrors").Return(nil)
+	progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
+
+	// Folder phase: updated folder triggers RemoveFolderFromTree then EnsureFolderPathExist
+	repoResources.On("RemoveFolderFromTree", "old-uid-123").Run(func(args mock.Arguments) {
+		recordCall("RemoveFolderFromTree")
+	}).Return()
+
+	repoResources.On("EnsureFolderPathExist", mock.Anything, "myfolder/").Run(func(args mock.Arguments) {
+		recordCall("EnsureFolderPathExist")
+	}).Return("new-uid-456", nil)
+
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Path() == "myfolder/" && r.Action() == repository.FileActionUpdated
+	})).Return()
+
+	// File phase: dashboard creation
+	repoResources.On("WriteResourceFromFile", mock.Anything, "myfolder/dashboard.json", "").Run(func(args mock.Arguments) {
+		recordCall("WriteResourceFromFile")
+	}).Return("dash-1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
+
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Path() == "myfolder/dashboard.json"
+	})).Return()
+
+	// Old folder deletion phase
+	repoResources.On("RemoveFolder", mock.Anything, "old-uid-123").Run(func(args mock.Arguments) {
+		recordCall("RemoveFolder")
+	}).Return(nil)
+
+	err := applyChanges(
+		context.Background(), changes, clients, repoResources, progress, tracer, 1, metrics,
+		quotas.NewInMemoryQuotaTracker(0, 0), true,
+	)
+	require.NoError(t, err)
+
+	// Verify ordering: folder phase -> file phase -> old folder deletion
+	require.Equal(t, []string{
+		"RemoveFolderFromTree",  // folder phase: clear old entry from tree
+		"EnsureFolderPathExist", // folder phase: create/update folder
+		"WriteResourceFromFile", // file phase: create dashboard
+		"RemoveFolder",          // deferred: delete old folder after re-parenting
+	}, callOrder)
+}
+
+func TestApplyChanges_OldFolderDeletion_DeepestFirst(t *testing.T) {
+	// When multiple folders have OldFolderUID, deeper paths must be deleted first.
+	repoResources := resources.NewMockRepositoryResources(t)
+	clients := resources.NewMockResourceClients(t)
+	progress := jobs.NewMockJobProgressRecorder(t)
+	tracer := tracing.NewNoopTracerService()
+	metrics := jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry())
+
+	// Track deletion order. Old folder deletion is sequential, so no mutex needed.
+	var deletionOrder []string
+
+	changes := []ResourceFileChange{
+		{
+			Action:       repository.FileActionUpdated,
+			Path:         "parent/",
+			OldFolderUID: "old-parent-uid",
+			Existing:     &provisioning.ResourceListItem{Name: "old-parent-uid"},
+		},
+		{
+			Action:       repository.FileActionUpdated,
+			Path:         "parent/child/",
+			OldFolderUID: "old-child-uid",
+			Existing:     &provisioning.ResourceListItem{Name: "old-child-uid"},
+		},
+	}
+
+	progress.On("SetTotal", mock.Anything, 2).Return()
+	progress.On("TooManyErrors").Return(nil)
+	progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
+
+	// Folder phase mocks
+	repoResources.On("RemoveFolderFromTree", mock.Anything).Return()
+	repoResources.On("EnsureFolderPathExist", mock.Anything, mock.Anything).Return("new-uid", nil)
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Action() == repository.FileActionUpdated
+	})).Return()
+
+	// Old folder deletion mocks — record the order
+	repoResources.On("RemoveFolder", mock.Anything, mock.MatchedBy(func(uid string) bool {
+		return uid == "old-parent-uid" || uid == "old-child-uid"
+	})).Run(func(args mock.Arguments) {
+		deletionOrder = append(deletionOrder, args.Get(1).(string))
+	}).Return(nil)
+
+	err := applyChanges(
+		context.Background(), changes, clients, repoResources, progress, tracer, 1, metrics,
+		quotas.NewInMemoryQuotaTracker(0, 0), true,
+	)
+	require.NoError(t, err)
+
+	// Deeper path ("parent/child/") must be deleted before shallower ("parent/")
+	require.Equal(t, []string{"old-child-uid", "old-parent-uid"}, deletionOrder)
+}
+
+func TestApplyChanges_OldFolderDeletion_ErrorContinues(t *testing.T) {
+	// When RemoveFolder fails, the error is recorded in progress but applyChanges does NOT fail.
+	repoResources := resources.NewMockRepositoryResources(t)
+	clients := resources.NewMockResourceClients(t)
+	progress := jobs.NewMockJobProgressRecorder(t)
+	tracer := tracing.NewNoopTracerService()
+	metrics := jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry())
+
+	changes := []ResourceFileChange{
+		{
+			Action:       repository.FileActionUpdated,
+			Path:         "broken/",
+			OldFolderUID: "old-broken-uid",
+			Existing:     &provisioning.ResourceListItem{Name: "old-broken-uid"},
+		},
+	}
+
+	progress.On("SetTotal", mock.Anything, 1).Return()
+	progress.On("TooManyErrors").Return(nil)
+	progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
+
+	// Folder phase
+	repoResources.On("RemoveFolderFromTree", "old-broken-uid").Return()
+	repoResources.On("EnsureFolderPathExist", mock.Anything, "broken/").Return("new-broken-uid", nil)
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Path() == "broken/" && r.Action() == repository.FileActionUpdated && r.Error() == nil
+	})).Return()
+
+	// RemoveFolder fails
+	repoResources.On("RemoveFolder", mock.Anything, "old-broken-uid").Return(errors.New("folder in use"))
+
+	// Expect progress records the error for the old folder deletion
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Path() == "broken/" &&
+			r.Action() == repository.FileActionDeleted &&
+			r.Name() == "old-broken-uid" &&
+			r.Error() != nil &&
+			r.Error().Error() == "delete old folder old-broken-uid after UID change: folder in use"
+	})).Return()
+
+	err := applyChanges(
+		context.Background(), changes, clients, repoResources, progress, tracer, 1, metrics,
+		quotas.NewInMemoryQuotaTracker(0, 0), true,
+	)
+
+	// applyChanges must NOT return an error even though RemoveFolder failed
+	require.NoError(t, err)
+
+	// Verify RemoveFolder was actually called
+	repoResources.AssertCalled(t, "RemoveFolder", mock.Anything, "old-broken-uid")
+}

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -1280,7 +1280,7 @@ func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
 			// Folder creation with OldFolderUID — triggers deferred deletion
 			Action:       repository.FileActionUpdated,
 			Path:         "myfolder/",
-			OldFolderUID: "old-uid-123",
+			FolderRenamed: true,
 			Existing:     &provisioning.ResourceListItem{Name: "old-uid-123"},
 		},
 		{
@@ -1359,14 +1359,14 @@ func TestApplyChanges_OldFolderDeletion_DeepestFirst(t *testing.T) {
 		{
 			Action:       repository.FileActionUpdated,
 			Path:         "parent/",
-			OldFolderUID: "old-parent-uid",
+			FolderRenamed: true,
 			Existing:     &provisioning.ResourceListItem{Name: "old-parent-uid"},
 		},
 		{
-			Action:       repository.FileActionUpdated,
-			Path:         "parent/child/",
-			OldFolderUID: "old-child-uid",
-			Existing:     &provisioning.ResourceListItem{Name: "old-child-uid"},
+			Action:        repository.FileActionUpdated,
+			Path:          "parent/child/",
+			FolderRenamed: true,
+			Existing:      &provisioning.ResourceListItem{Name: "old-child-uid"},
 		},
 	}
 
@@ -1413,10 +1413,10 @@ func TestApplyChanges_OldFolderDeletion_ErrorContinues(t *testing.T) {
 
 	changes := []ResourceFileChange{
 		{
-			Action:       repository.FileActionUpdated,
-			Path:         "broken/",
-			OldFolderUID: "old-broken-uid",
-			Existing:     &provisioning.ResourceListItem{Name: "old-broken-uid"},
+			Action:        repository.FileActionUpdated,
+			Path:          "broken/",
+			FolderRenamed: true,
+			Existing:      &provisioning.ResourceListItem{Name: "old-broken-uid"},
 		},
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -44,7 +44,7 @@ func TestFullSync_ContextCancelled(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{{}}, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{{}}, nil, nil)
 	progress.On("SetTotal", mock.Anything, 1).Return()
 
 	err := FullSync(ctx, repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
@@ -64,7 +64,7 @@ func TestFullSync_Error(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("some error"))
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("some error"))
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
 	require.EqualError(t, err, "compare changes: some error")
@@ -83,7 +83,7 @@ func TestFullSync_NoChanges(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil)
 	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
@@ -109,7 +109,7 @@ func TestFullSync_SuccessfulFolderCreation(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil)
 	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 	repoResources.On("EnsureFolderExists", mock.Anything, resources.Folder{
 		ID:    "test-repo",
@@ -172,7 +172,7 @@ func TestFullSync_FolderCreationFailedWithInstanceTarget(t *testing.T) {
 
 	// No folder creation should be attempted with instance target
 	// But we should still test the error path for completeness
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil, fmt.Errorf("compare error"))
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
@@ -806,7 +806,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 			compareFn := NewMockCompareFn(t)
 
 			tt.setupMocks(repo, repoResources, clients, progress, compareFn)
-			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil)
+			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil)
 			repo.On("Config").Return(&provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -1113,7 +1113,7 @@ func TestFullSync_QuotaTrackerSkipsCreationsAtLimit(t *testing.T) {
 		{Action: repository.FileActionCreated, Path: "dashboards/c.json"},
 	}
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil)
 	progress.On("SetTotal", mock.Anything, 3).Return()
 	progress.On("TooManyErrors").Return(nil)
 
@@ -1159,7 +1159,7 @@ func TestFullSync_QuotaTrackerAllowsUpdatesRegardlessOfQuota(t *testing.T) {
 		{Action: repository.FileActionUpdated, Path: "dashboards/existing.json"},
 	}
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil)
 	progress.On("SetTotal", mock.Anything, 1).Return()
 	progress.On("TooManyErrors").Return(nil)
 	progress.On("HasDirPathFailedCreation", "dashboards/existing.json").Return(false)
@@ -1196,7 +1196,7 @@ func TestFullSync_MissingFolderMetadata_FlagEnabled(t *testing.T) {
 		{Action: repository.FileActionCreated, Path: "myfolder/dashboard.json"},
 	}
 	// Compare returns the missing folder metadata list directly
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(changes, []string{"myfolder/"}, nil)
 
 	// Expect a warning record for the missing folder metadata with action derived from changes
@@ -1241,7 +1241,7 @@ func TestFullSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 		{Action: repository.FileActionCreated, Path: "myfolder/dashboard.json"},
 	}
 	// Compare always returns missing list, even when flag is disabled
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(changes, []string{"myfolder/"}, nil)
 
 	progress.On("SetTotal", mock.Anything, 1).Return()

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -1321,6 +1321,14 @@ func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
 		recordCall("RemoveFolder")
 	}).Return(nil)
 
+	// Successful old folder deletion also records progress
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Path() == "myfolder/" &&
+			r.Action() == repository.FileActionDeleted &&
+			r.Name() == "old-uid-123" &&
+			r.Error() == nil
+	})).Return()
+
 	err := applyChanges(
 		context.Background(), changes, clients, repoResources, progress, tracer, 1, metrics,
 		quotas.NewInMemoryQuotaTracker(0, 0), true,
@@ -1379,6 +1387,11 @@ func TestApplyChanges_OldFolderDeletion_DeepestFirst(t *testing.T) {
 	})).Run(func(args mock.Arguments) {
 		deletionOrder = append(deletionOrder, args.Get(1).(string))
 	}).Return(nil)
+
+	// Successful old folder deletions also record progress
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Action() == repository.FileActionDeleted && r.Error() == nil
+	})).Return()
 
 	err := applyChanges(
 		context.Background(), changes, clients, repoResources, progress, tracer, 1, metrics,

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -1278,10 +1278,10 @@ func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
 	changes := []ResourceFileChange{
 		{
 			// Folder creation with OldFolderUID — triggers deferred deletion
-			Action:       repository.FileActionUpdated,
-			Path:         "myfolder/",
+			Action:        repository.FileActionUpdated,
+			Path:          "myfolder/",
 			FolderRenamed: true,
-			Existing:     &provisioning.ResourceListItem{Name: "old-uid-123"},
+			Existing:      &provisioning.ResourceListItem{Name: "old-uid-123"},
 		},
 		{
 			// A file creation that needs to happen before old folder cleanup
@@ -1357,10 +1357,10 @@ func TestApplyChanges_OldFolderDeletion_DeepestFirst(t *testing.T) {
 
 	changes := []ResourceFileChange{
 		{
-			Action:       repository.FileActionUpdated,
-			Path:         "parent/",
+			Action:        repository.FileActionUpdated,
+			Path:          "parent/",
 			FolderRenamed: true,
-			Existing:     &provisioning.ResourceListItem{Name: "old-parent-uid"},
+			Existing:      &provisioning.ResourceListItem{Name: "old-parent-uid"},
 		},
 		{
 			Action:        repository.FileActionUpdated,

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -17,7 +17,7 @@ import (
 type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error
 
 //go:generate mockery --name CompareFn --structname MockCompareFn --inpackage --filename compare_fn_mock.go --with-expecter
-type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string) ([]ResourceFileChange, []string, error)
+type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, error)
 
 //go:generate mockery --name IncrementalSyncFn --structname MockIncrementalSyncFn --inpackage --filename incremental_sync_fn_mock.go --with-expecter
 type IncrementalSyncFn func(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -124,6 +124,7 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 			}
 		}
 
+		f.ParentID = parent
 		if err := fm.EnsureFolderExists(ctx, f, parent); err != nil {
 			return &PathCreationError{
 				Path: f.Path,
@@ -178,6 +179,14 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			source.Checksum = folder.MetadataHash
 			meta.SetSourceProperties(source)
 			needsUpdate = true
+		}
+
+		if folder.ParentID != "" {
+			currentParent := meta.GetFolder()
+			if currentParent != folder.ParentID {
+				meta.SetFolder(folder.ParentID)
+				needsUpdate = true
+			}
 		}
 
 		if needsUpdate {
@@ -292,6 +301,7 @@ func (fm *FolderManager) CreateFolderWithUID(ctx context.Context, folderPath, st
 	// Build the leaf folder struct but replace the hash-derived ID with the stable UID.
 	leaf := ParseFolder(folderPath, cfg.GetName())
 	leaf.ID = stableUID
+	leaf.ParentID = parentFolderID
 
 	return fm.EnsureFolderExists(ctx, leaf, parentFolderID)
 }

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -181,12 +181,10 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			needsUpdate = true
 		}
 
-		if folder.ParentID != "" {
-			currentParent := meta.GetFolder()
-			if currentParent != folder.ParentID {
-				meta.SetFolder(folder.ParentID)
-				needsUpdate = true
-			}
+		currentParent := meta.GetFolder()
+		if currentParent != folder.ParentID {
+			meta.SetFolder(folder.ParentID)
+			needsUpdate = true
 		}
 
 		if needsUpdate {

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -1345,16 +1345,21 @@ func TestEnsureFolderExists_ParentUpdate(t *testing.T) {
 		require.Empty(t, client.updateCalls, "should not update when parent matches")
 	})
 
-	t.Run("skips parent check when ParentID empty", func(t *testing.T) {
+	t.Run("updates parent when ParentID empty and current parent is non-empty", func(t *testing.T) {
 		config := newTestRepoConfig("test-repo")
 		rw := repository.NewMockReaderWriter(t)
 		rw.On("Config").Return(config)
 
 		tree := NewEmptyFolderTree()
 
+		var updatedObj *unstructured.Unstructured
 		client := &fakeDynamicResourceClient{
 			getFn: func(name string) (*unstructured.Unstructured, error) {
 				return managedFolderWithParent(name, "Same Title", config.Name, "some-parent"), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj
+				return obj, nil
 			},
 		}
 
@@ -1363,11 +1368,41 @@ func TestEnsureFolderExists_ParentUpdate(t *testing.T) {
 			ID:    "folder-uid",
 			Title: "Same Title",
 			Path:  "my-folder",
-			// ParentID is empty — root folder, no parent comparison
+			// ParentID is empty — moving to root
 		}, "")
 
 		require.NoError(t, err)
-		require.Empty(t, client.updateCalls, "should not update when ParentID is empty")
+		require.Equal(t, []string{"folder-uid"}, client.updateCalls, "should update to clear parent annotation when moving to root")
+		require.NotNil(t, updatedObj)
+
+		parentAnnotation, _, _ := unstructured.NestedString(updatedObj.Object, "metadata", "annotations", "grafana.app/folder")
+		require.Empty(t, parentAnnotation, "parent annotation should be cleared")
+	})
+
+	t.Run("skips update when both ParentID and current parent are empty", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				// Existing folder also has no parent (root)
+				return managedFolderWithParent(name, "Same Title", config.Name, ""), nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "folder-uid",
+			Title: "Same Title",
+			Path:  "my-folder",
+			// ParentID is empty — root folder, same as existing
+		}, "")
+
+		require.NoError(t, err)
+		require.Empty(t, client.updateCalls, "should not update when both ParentID and current parent are empty")
 	})
 }
 

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -1251,6 +1251,126 @@ func TestEnsureFolderExists_MetadataHashUpdate(t *testing.T) {
 	})
 }
 
+func TestEnsureFolderExists_ParentUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	newTestRepoConfig := func(name string) *provisioning.Repository {
+		return &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{Target: provisioning.SyncTargetTypeFolder},
+			},
+		}
+	}
+
+	managedFolderWithParent := func(name, title, managerIdentity, parent string) *unstructured.Unstructured {
+		annotations := map[string]interface{}{
+			"grafana.app/managerId": managerIdentity,
+		}
+		if parent != "" {
+			annotations["grafana.app/folder"] = parent
+		}
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "folder.grafana.app/v1beta1",
+				"kind":       "Folder",
+				"metadata": map[string]interface{}{
+					"name":        name,
+					"namespace":   "default",
+					"annotations": annotations,
+				},
+				"spec": map[string]interface{}{
+					"title": title,
+				},
+			},
+		}
+	}
+
+	t.Run("updates parent when ParentID differs", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		var updatedObj *unstructured.Unstructured
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithParent(name, "Same Title", config.Name, "old-parent-uid"), nil
+			},
+			updateFn: func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				updatedObj = obj
+				return obj, nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:       "folder-uid",
+			Title:    "Same Title",
+			Path:     "my-folder",
+			ParentID: "new-parent-uid",
+		}, "new-parent-uid")
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"folder-uid"}, client.updateCalls, "should update to fix parent annotation")
+		require.NotNil(t, updatedObj)
+
+		parentAnnotation, _, _ := unstructured.NestedString(updatedObj.Object, "metadata", "annotations", "grafana.app/folder")
+		require.Equal(t, "new-parent-uid", parentAnnotation)
+	})
+
+	t.Run("skips parent update when ParentID matches", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithParent(name, "Same Title", config.Name, "same-parent"), nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:       "folder-uid",
+			Title:    "Same Title",
+			Path:     "my-folder",
+			ParentID: "same-parent",
+		}, "same-parent")
+
+		require.NoError(t, err)
+		require.Empty(t, client.updateCalls, "should not update when parent matches")
+	})
+
+	t.Run("skips parent check when ParentID empty", func(t *testing.T) {
+		config := newTestRepoConfig("test-repo")
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Config").Return(config)
+
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolderWithParent(name, "Same Title", config.Name, "some-parent"), nil
+			},
+		}
+
+		fm := NewFolderManager(rw, client, tree)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "folder-uid",
+			Title: "Same Title",
+			Path:  "my-folder",
+			// ParentID is empty — root folder, no parent comparison
+		}, "")
+
+		require.NoError(t, err)
+		require.Empty(t, client.updateCalls, "should not update when ParentID is empty")
+	})
+}
+
 func TestEnsureFolderPathExist_MetadataErrors(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/registry/apis/provisioning/resources/id.go
+++ b/pkg/registry/apis/provisioning/resources/id.go
@@ -104,6 +104,9 @@ type Folder struct {
 	// MetadataHash is the hash of the _folder.json file content.
 	// Empty when folder metadata is disabled or no _folder.json exists.
 	MetadataHash string
+	// ParentID is the UID of this folder's parent folder.
+	// Set during EnsureFolderPathExist's walk and used to detect stale parent annotations.
+	ParentID string
 }
 
 func ParseFolder(dirPath, repositoryName string) Folder {

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -111,6 +111,8 @@ func (t *folderTree) Add(folder Folder, parent string) {
 	defer t.mu.Unlock()
 	_, exists := t.tree[folder.ID]
 	t.tree[folder.ID] = parent
+	// Ensure the parent folder is set
+	folder.ParentID = parent
 	t.folders[folder.ID] = folder
 	if !exists {
 		t.count++
@@ -191,6 +193,7 @@ func (t *folderTree) AddUnstructured(item *unstructured.Unstructured) error {
 	folder := Folder{
 		Title: meta.FindTitle(item.GetName()),
 		ID:    item.GetName(),
+		ParentID: meta.GetFolder(),
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -214,6 +217,7 @@ func NewFolderTreeFromResourceList(resources *provisioning.ResourceList) FolderT
 			ID:           rf.Name,
 			Path:         rf.Path,
 			MetadataHash: rf.Hash,
+			ParentID:     rf.Folder,
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -191,8 +191,8 @@ func (t *folderTree) AddUnstructured(item *unstructured.Unstructured) error {
 	}
 
 	folder := Folder{
-		Title: meta.FindTitle(item.GetName()),
-		ID:    item.GetName(),
+		Title:    meta.FindTitle(item.GetName()),
+		ID:       item.GetName(),
 		ParentID: meta.GetFolder(),
 	}
 	t.mu.Lock()

--- a/pkg/registry/apis/provisioning/resources/tree_test.go
+++ b/pkg/registry/apis/provisioning/resources/tree_test.go
@@ -291,4 +291,54 @@ func TestNewFolderTreeFromResourceList_MetadataHash(t *testing.T) {
 		require.True(t, ok)
 		assert.Empty(t, got.MetadataHash)
 	})
+
+	t.Run("populates ParentID from ResourceListItem.Folder", func(t *testing.T) {
+		rl := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{
+					Name:   "parent-uid",
+					Title:  "Parent",
+					Path:   "parent",
+					Group:  folders.GROUP,
+					Folder: "",
+				},
+				{
+					Name:   "child-uid",
+					Title:  "Child",
+					Path:   "parent/child",
+					Group:  folders.GROUP,
+					Folder: "parent-uid",
+				},
+			},
+		}
+
+		tree := NewFolderTreeFromResourceList(rl)
+
+		parent, ok := tree.Get("parent-uid")
+		require.True(t, ok)
+		assert.Empty(t, parent.ParentID, "root folder should have empty ParentID")
+
+		child, ok := tree.Get("child-uid")
+		require.True(t, ok)
+		assert.Equal(t, "parent-uid", child.ParentID)
+	})
+}
+
+func TestFolderTree_Add_SetsParentID(t *testing.T) {
+	tree := NewEmptyFolderTree()
+
+	f := Folder{ID: "child", Title: "Child", Path: "child/"}
+	tree.Add(f, "parent-uid")
+
+	got, ok := tree.Get("child")
+	require.True(t, ok)
+	assert.Equal(t, "parent-uid", got.ParentID, "Add should set ParentID to parent")
+
+	// Root folder
+	root := Folder{ID: "root", Title: "Root", Path: "root/"}
+	tree.Add(root, "")
+
+	gotRoot, ok := tree.Get("root")
+	require.True(t, ok)
+	assert.Empty(t, gotRoot.ParentID, "root folder should have empty ParentID")
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
@@ -207,6 +207,88 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_MetaToPlainPare
 	})
 }
 
+func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_RootToNested(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+	const repo = "folder-move-root-to-nested"
+
+	// Root-level folder with metadata + a target nested parent.
+	writeToProvisioningPath(t, helper, "myfolder/_folder.json", folderMetadataJSON("my-uid", "My Folder"))
+	writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-uid", "Parent"))
+
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo,
+		Target: "folder",
+		Copies: map[string]string{
+			"../testdata/all-panels.json": "myfolder/dashboard.json",
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	helper.SyncAndWait(t, repo, nil)
+
+	requireFolderState(t, helper, "my-uid", "My Folder", "myfolder", repo)
+	requireFolderState(t, helper, "parent-uid", "Parent", "parent", repo)
+	requireDashboardParents(t, helper, repo, map[string]string{
+		"myfolder/dashboard.json": "my-uid",
+	})
+
+	// Move root-level folder into nested parent.
+	moveInProvisioningPath(t, helper, "myfolder", "parent/myfolder")
+	helper.SyncAndWait(t, repo, nil)
+
+	// Folder should preserve UID but now be nested under parent.
+	requireFolderState(t, helper, "my-uid", "My Folder", "parent/myfolder", "parent-uid")
+	requireFolderState(t, helper, "parent-uid", "Parent", "parent", repo)
+	assertNoFolderAtPath(t, helper, repo, "myfolder")
+	requireDashboardParents(t, helper, repo, map[string]string{
+		"parent/myfolder/dashboard.json": "my-uid",
+	})
+}
+
+func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedToRoot(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+	const repo = "folder-move-nested-to-root"
+
+	// Nested folder with metadata.
+	writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-uid", "Parent"))
+	writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("child-uid", "Child"))
+
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo,
+		Target: "folder",
+		Copies: map[string]string{
+			"../testdata/all-panels.json": "parent/child/dashboard.json",
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	helper.SyncAndWait(t, repo, nil)
+
+	requireFolderState(t, helper, "parent-uid", "Parent", "parent", repo)
+	requireFolderState(t, helper, "child-uid", "Child", "parent/child", "parent-uid")
+	requireDashboardParents(t, helper, repo, map[string]string{
+		"parent/child/dashboard.json": "child-uid",
+	})
+
+	// Move nested folder to root level.
+	moveInProvisioningPath(t, helper, "parent/child", "child")
+	helper.SyncAndWait(t, repo, nil)
+
+	// Child should preserve UID but now be at root (parent = repo).
+	requireFolderState(t, helper, "child-uid", "Child", "child", repo)
+	requireFolderState(t, helper, "parent-uid", "Parent", "parent", repo)
+	assertNoFolderAtPath(t, helper, repo, "parent/child")
+	requireDashboardParents(t, helper, repo, map[string]string{
+		"child/dashboard.json": "child-uid",
+	})
+}
+
 func folderMetadataJSON(uid, title string) []byte {
 	folder := map[string]any{
 		"apiVersion": "folder.grafana.app/v1beta1",

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
@@ -327,3 +327,12 @@ func assertNoFolderAtPath(t *testing.T, helper *common.ProvisioningTestHelper, r
 	}, 30*time.Second, 100*time.Millisecond,
 		"folder at path %q should be absent for repo %q", sourcePath, repoName)
 }
+
+func assertNoFolderByUID(t *testing.T, helper *common.ProvisioningTestHelper, folderUID string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := helper.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
+		assert.Error(c, err, "folder %q should no longer exist", folderUID)
+	}, 30*time.Second, 100*time.Millisecond,
+		"folder %q should be deleted", folderUID)
+}

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -332,7 +333,12 @@ func assertNoFolderByUID(t *testing.T, helper *common.ProvisioningTestHelper, fo
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, err := helper.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
-		assert.Error(c, err, "folder %q should no longer exist", folderUID)
+		if err == nil {
+			c.Errorf("folder %q still exists, expected NotFound", folderUID)
+			return
+		}
+		assert.True(c, apierrors.IsNotFound(err),
+			"expected NotFound error for folder %q, got: %v", folderUID, err)
 	}, 30*time.Second, 100*time.Millisecond,
 		"folder %q should be deleted", folderUID)
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -628,6 +628,11 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 			}
 			c.Errorf("folder not found")
 		}, 30*time.Second, 100*time.Millisecond)
+
+		// Verify the dashboard's parent folder annotation points to the new UID.
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"my-folder/dashboard.json": "new-uid",
+		})
 	})
 
 	t.Run("UID change deletes old folder and re-parents child folder", func(t *testing.T) {
@@ -714,6 +719,47 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 		// Dashboard re-parented to new child.
 		requireDashboardParents(t, helper, repo, map[string]string{
 			"parent/child/dashboard.json": "c-new",
+		})
+	})
+
+	t.Run("UID change on root-level folder re-parents dashboard", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "uid-change-root-level"
+
+		// First sync: root-level folder with original UID.
+		// The folder's parent is the repository folder (Target: "folder").
+		writeToProvisioningPath(t, helper, "root-folder/_folder.json", folderMetadataJSON("root-old-uid", "Root Folder"))
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "root-folder/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+		requireFolderState(t, helper, "root-old-uid", "Root Folder", "root-folder", repo)
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"root-folder/dashboard.json": "root-old-uid",
+		})
+
+		// Change UID in _folder.json.
+		writeToProvisioningPath(t, helper, "root-folder/_folder.json", folderMetadataJSON("root-new-uid", "Root Folder"))
+
+		helper.SyncAndWait(t, repo, nil)
+
+		// Old folder should be gone.
+		assertNoFolderByUID(t, helper, "root-old-uid")
+
+		// New folder should exist with repo as parent (folder-target repo).
+		requireFolderState(t, helper, "root-new-uid", "Root Folder", "root-folder", repo)
+
+		// Dashboard re-parented to new UID.
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"root-folder/dashboard.json": "root-new-uid",
 		})
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -570,3 +570,63 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataReconciliation(t *testin
 		requireRepoFolderChecksum(t, helper, repo, "my-folder", sha1Hex(metadataContent))
 	})
 }
+
+// TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange verifies that
+// full sync handles UID changes in _folder.json by replacing the folder and re-parenting children.
+func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("UID change replaces folder and re-parents dashboard", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-uid-change"
+
+		// First sync: folder with original UID.
+		originalContent := folderMetadataJSON("original-uid", "My Folder")
+		writeToProvisioningPath(t, helper, "my-folder/_folder.json", originalContent)
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "my-folder/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+		requireRepoFolderTitle(t, helper, repo, "my-folder", "My Folder")
+
+		// Change UID in _folder.json, keep title the same.
+		updatedContent := folderMetadataJSON("new-uid", "My Folder")
+		writeToProvisioningPath(t, helper, "my-folder/_folder.json", updatedContent)
+
+		// Second sync: should replace folder (new UID) and re-parent the dashboard.
+		helper.SyncAndWait(t, repo, nil)
+
+		// New folder should exist with correct title and checksum.
+		requireRepoFolderTitle(t, helper, repo, "my-folder", "My Folder")
+		requireRepoFolderChecksum(t, helper, repo, "my-folder", sha1Hex(updatedContent))
+
+		// Verify the folder UID is the new one by checking the folder name.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			list, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+			if !assert.NoError(c, err) {
+				return
+			}
+			for _, f := range list.Items {
+				mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+				if mgr != repo {
+					continue
+				}
+				srcPath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+				if srcPath != "my-folder" {
+					continue
+				}
+				assert.Equal(c, "new-uid", f.GetName(), "folder should have new UID")
+				return
+			}
+			c.Errorf("folder not found")
+		}, 30*time.Second, 100*time.Millisecond)
+	})
+}

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -629,4 +629,91 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 			c.Errorf("folder not found")
 		}, 30*time.Second, 100*time.Millisecond)
 	})
+
+	t.Run("UID change deletes old folder and re-parents child folder", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "uid-change-child-folder"
+
+		// First sync: parent with original UID, child folder + dashboard inside.
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-old-uid", "Parent"))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("child-uid", "Child"))
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "parent/child/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+		requireFolderState(t, helper, "parent-old-uid", "Parent", "parent", repo)
+		requireFolderState(t, helper, "child-uid", "Child", "parent/child", "parent-old-uid")
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"parent/child/dashboard.json": "child-uid",
+		})
+
+		// Change parent UID only.
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-new-uid", "Parent"))
+
+		helper.SyncAndWait(t, repo, nil)
+
+		// Old folder should be gone.
+		assertNoFolderByUID(t, helper, "parent-old-uid")
+
+		// New parent folder should exist with correct state.
+		requireFolderState(t, helper, "parent-new-uid", "Parent", "parent", repo)
+
+		// Child folder should be re-parented to new parent UID.
+		requireFolderState(t, helper, "child-uid", "Child", "parent/child", "parent-new-uid")
+
+		// Dashboard should still be parented to child (unchanged).
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"parent/child/dashboard.json": "child-uid",
+		})
+	})
+
+	t.Run("nested UID changes — both parent and child UIDs change", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "uid-change-nested"
+
+		// First sync: parent + child each with original UIDs.
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("p-old", "Parent"))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("c-old", "Child"))
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "parent/child/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+
+		helper.SyncAndWait(t, repo, nil)
+		requireFolderState(t, helper, "p-old", "Parent", "parent", repo)
+		requireFolderState(t, helper, "c-old", "Child", "parent/child", "p-old")
+
+		// Change both UIDs.
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("p-new", "Parent"))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("c-new", "Child"))
+
+		helper.SyncAndWait(t, repo, nil)
+
+		// Both old UIDs should be gone.
+		assertNoFolderByUID(t, helper, "p-old")
+		assertNoFolderByUID(t, helper, "c-old")
+
+		// New parent under repo root, new child under new parent.
+		requireFolderState(t, helper, "p-new", "Parent", "parent", repo)
+		requireFolderState(t, helper, "c-new", "Child", "parent/child", "p-new")
+
+		// Dashboard re-parented to new child.
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"parent/child/dashboard.json": "c-new",
+		})
+	})
 }


### PR DESCRIPTION
## What is this feature?

When a user changes the `metadata.name` (UID) in `_folder.json` and triggers a full sync, Grafana now detects the UID change, creates the folder with the new UID, re-parents all direct children (child folders and dashboards), and deletes the old folder.

Part of https://github.com/grafana/git-ui-sync-project/issues/936

## Why do we need this?

Changing a folder's UID in `_folder.json` is a valid user action (e.g. to adopt a more meaningful identifier). Without this change, the sync would create a new folder but leave children orphaned under the old UID, and the old folder would linger.

## How it works

### Detection (`jobs/sync/changes.go`)

A new `augmentChangesForUIDChanges` step runs after `Changes()` inside `Compare()`. For each folder update (detected via P2's hash comparison), it reads `_folder.json` and compares the new `metadata.name` against the existing Grafana folder name. When the UID actually changed:

- Sets `OldFolderUID` on the folder change (used later for cleanup)
- Emits `FileActionUpdated` for **direct children only** — grandchildren are unaffected since they point to their own (unchanged) parent

### Re-parenting

Child folders and dashboards are re-parented through the existing apply flow, no special re-parenting logic needed:

- **Child folders**: `EnsureFolderExists` now checks `folder.ParentID` against the stored `grafana.app/folder` annotation. When they differ, it updates the parent — this is the new parent annotation check added to the UPDATE path.
- **Dashboards**: `WriteResourceFromFile` → `EnsureFolderPathExist` resolves the new parent UID naturally.

A new `ParentID` field on the `Folder` struct tracks the parent UID throughout path walks, tree operations, and folder creation.

### Old folder cleanup (`jobs/sync/full.go`)

Old folders are deleted in a **new phase 5** that runs after all folder and file processing is complete. This ensures all children have been re-parented before the old folder is removed. Old folders are deleted deepest-first (children before parents) to avoid "folder not empty" errors. If a deletion fails, the error is recorded but the sync continues.

### Phase ordering

1. File deletions (parallel)
2. Folder deletions (serial, deepest first)
3. Folder creations (serial, deepest first) — creates new UIDs, re-parents child folders
4. File creations (parallel) — re-parents dashboards
5. **NEW**: Old folder cleanup (serial, deepest first) — deletes old UIDs

## Changes

| File | Change |
|------|--------|
| `resources/id.go` | Added `ParentID string` to `Folder` |
| `resources/folders.go` | Set `ParentID` in walk + `CreateFolderWithUID`; parent annotation check in `EnsureFolderExists` UPDATE path |
| `resources/tree.go` | Set `ParentID` in `Add`, `AddUnstructured`, `NewFolderTreeFromResourceList` |
| `jobs/sync/changes.go` | Added `OldFolderUID` to `ResourceFileChange`; added `augmentChangesForUIDChanges`; called from `Compare()` |
| `jobs/sync/full.go` | Added deferred old-folder cleanup phase; removed previous UID change handling and unused imports |
| Integration + unit test files | See test plan below |

## Test plan

- [x] `TestEnsureFolderExists_ParentUpdate` — parent differs/matches/empty (3 subtests)
- [x] `TestFolderTree_Add_SetsParentID` — verifies Add populates ParentID
- [x] `TestNewFolderTreeFromResourceList/populates_ParentID` — verifies tree from resource list
- [x] `TestAugmentChangesForUIDChanges` — emits children, skips title-only, excludes grandchildren, no duplicates, no-op (5 subtests)
- [x] `TestApplyChanges_DefersOldFolderDeletion` — verifies phase ordering
- [x] `TestApplyChanges_OldFolderDeletion_DeepestFirst` — deeper paths deleted first
- [x] `TestApplyChanges_OldFolderDeletion_ErrorContinues` — errors recorded but sync continues
- [x] Integration: `UID change replaces folder and re-parents dashboard` (existing, still passes)
- [x] Integration: `UID change deletes old folder and re-parents child folder`
- [x] Integration: `nested UID changes — both parent and child UIDs change`