### PR TITLE
Fix: increase PBKDF2 salt to 128 bits for FIPS 140-3 compliance with lazy migration

### DIFF
--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -394,7 +394,7 @@ func newCreateOrgUser(sql *legacysql.LegacyDatabaseHelper, cmd *CreateOrgUserCom
 func (s *legacySQLStore) CreateUser(ctx context.Context, ns claims.NamespaceInfo, cmd CreateUserCommand) (*CreateUserResult, error) {
 	cmd.OrgID = ns.OrgID
 
-	salt, err := util.GetRandomString(10)
+	salt, err := util.GeneratePasswordSalt()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
+	"fmt"
 	"net/mail"
 	"strconv"
 
 	"go.opentelemetry.io/otel/trace"
 
 	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -22,13 +24,14 @@ var _ authn.ProxyClient = new(Grafana)
 var _ authn.PasswordClient = new(Grafana)
 
 func ProvideGrafana(cfg *setting.Cfg, userService user.Service, tracer trace.Tracer) *Grafana {
-	return &Grafana{cfg, userService, tracer}
+	return &Grafana{cfg: cfg, userService: userService, tracer: tracer, log: log.New("authn.grafana")}
 }
 
 type Grafana struct {
 	cfg         *setting.Cfg
 	userService user.Service
 	tracer      trace.Tracer
+	log         log.Logger
 }
 
 func (c *Grafana) String() string {
@@ -111,8 +114,38 @@ func (c *Grafana) AuthenticatePassword(ctx context.Context, r *authn.Request, us
 	// user was found so set auth module in req metadata
 	r.SetMeta(authn.MetaKeyAuthModule, "grafana")
 
-	if ok := comparePassword(password, usr.Salt, string(usr.Password)); !ok {
+	ok, err := comparePassword(password, usr.Salt, string(usr.Password))
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
 		return nil, errInvalidPassword.Errorf("invalid password")
+	}
+
+	// After successful legacy password verification, upgrade to a FIPS-compliant salt
+	// if the stored salt is shorter than 16 bytes (32 hex chars).
+	// See: GitHub issue #120561, comment by xnox
+	if len(usr.Salt) < 32 {
+		newSalt, err := util.GeneratePasswordSalt()
+		if err != nil {
+			c.log.Warn("failed to generate password salt during migration", "userID", usr.ID, "error", err)
+		} else {
+			newSaltCopy := newSalt
+			newPassword := user.Password(password)
+			if err := c.userService.Update(ctx, &user.UpdateUserCommand{
+				UserID:   usr.ID,
+				Salt:     &newSaltCopy,
+				Password: &newPassword,
+			}); err != nil {
+				// Log but don't fail login — migration is best-effort
+				c.log.Warn(
+					"failed to upgrade password salt to FIPS-compliant length",
+					"userID", usr.ID,
+					"error", err,
+				)
+			}
+		}
 	}
 
 	return &authn.Identity{
@@ -124,8 +157,24 @@ func (c *Grafana) AuthenticatePassword(ctx context.Context, r *authn.Request, us
 	}, nil
 }
 
-func comparePassword(password, salt, hash string) bool {
-	// It is ok to ignore the error here because util.EncodePassword can never return a error
-	hashedPassword, _ := util.EncodePassword(password, salt)
-	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) == 1
+func comparePassword(password, salt, hash string) (bool, error) {
+	if salt == "" {
+		return false, nil
+	}
+
+	// Step 1: Try standard PBKDF2 (FIPS-compliant path).
+	// This will fail on FIPS systems if salt < 16 bytes.
+	hashedPassword, err := util.EncodePassword(password, salt)
+	if err != nil {
+		// Step 2: Salt is too short for FIPS module.
+		// Fall back to pure-Go PBKDF2 which bypasses FIPS enforcement.
+		// This is intentional and approved for legacy migration only.
+		// See: GitHub issue #120561, comment by xnox
+		hashedPassword, err = util.EncodePasswordLegacy(password, salt)
+		if err != nil {
+			return false, fmt.Errorf("password comparison failed: %w", err)
+		}
+	}
+
+	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) == 1, nil
 }

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -166,7 +167,8 @@ func TestGrafana_AuthenticatePassword(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			hashed, _ := util.EncodePassword("password", "salt")
+			hashed, err := util.EncodePassword("password", "salt")
+			assert.NoError(t, err)
 			userService := &usertest.FakeUserService{
 				ExpectedUser: &user.User{ID: 1, Password: user.Password(hashed), Salt: "salt"},
 			}
@@ -182,4 +184,110 @@ func TestGrafana_AuthenticatePassword(t *testing.T) {
 			assert.EqualValues(t, tt.expectedIdentity, identity)
 		})
 	}
+}
+
+func TestComparePassword_LegacySalt(t *testing.T) {
+	password := "password"
+	salt := "salt123456" // legacy short salt
+	hash, err := util.EncodePasswordLegacy(password, salt)
+	assert.NoError(t, err)
+
+	ok, err := comparePassword(password, salt, hash)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = comparePassword("wrong", salt, hash)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestComparePassword_CompliantSalt(t *testing.T) {
+	password := "password"
+	salt, err := util.GeneratePasswordSalt()
+	assert.NoError(t, err)
+
+	hash, err := util.EncodePassword(password, salt)
+	assert.NoError(t, err)
+
+	ok, err := comparePassword(password, salt, hash)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = comparePassword("wrong", salt, hash)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAuthenticatePassword_MigrationBoundarySaltLength(t *testing.T) {
+	t.Run("salt length 31 triggers migration update", func(t *testing.T) {
+		password := "password"
+		salt := "1234567890123456789012345678901" // 31 chars
+		hash, err := util.EncodePassword(password, salt)
+		assert.NoError(t, err)
+
+		updateCalled := 0
+		userService := &usertest.FakeUserService{
+			ExpectedUser: &user.User{ID: 1, Password: user.Password(hash), Salt: salt},
+			UpdateFn: func(ctx context.Context, cmd *user.UpdateUserCommand) error {
+				updateCalled++
+				assert.Equal(t, int64(1), cmd.UserID)
+				assert.NotNil(t, cmd.Salt)
+				assert.NotNil(t, cmd.Password)
+				return nil
+			},
+		}
+
+		c := ProvideGrafana(setting.NewCfg(), userService, tracing.InitializeTracerForTest())
+		identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, "user", password)
+		assert.NoError(t, err)
+		assert.NotNil(t, identity)
+		assert.Equal(t, 1, updateCalled)
+	})
+
+	t.Run("salt length 32 does not trigger migration update", func(t *testing.T) {
+		password := "password"
+		salt := "12345678901234567890123456789012" // 32 chars
+		hash, err := util.EncodePassword(password, salt)
+		assert.NoError(t, err)
+
+		updateCalled := 0
+		userService := &usertest.FakeUserService{
+			ExpectedUser: &user.User{ID: 1, Password: user.Password(hash), Salt: salt},
+			UpdateFn: func(ctx context.Context, cmd *user.UpdateUserCommand) error {
+				updateCalled++
+				return nil
+			},
+		}
+
+		c := ProvideGrafana(setting.NewCfg(), userService, tracing.InitializeTracerForTest())
+		identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, "user", password)
+		assert.NoError(t, err)
+		assert.NotNil(t, identity)
+		assert.Equal(t, 0, updateCalled)
+	})
+}
+
+func TestComparePassword_EmptySalt(t *testing.T) {
+	ok, err := comparePassword("password", "", "anything")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAuthenticatePassword_MigrationUpdateErrorDoesNotFailLogin(t *testing.T) {
+	password := "password"
+	salt := "1234567890" // legacy short salt triggers migration
+	hash, err := util.EncodePasswordLegacy(password, salt)
+	assert.NoError(t, err)
+
+	userService := &usertest.FakeUserService{
+		ExpectedUser: &user.User{ID: 1, Password: user.Password(hash), Salt: salt},
+		UpdateFn: func(ctx context.Context, cmd *user.UpdateUserCommand) error {
+			return errors.New("db unavailable")
+		},
+	}
+
+	c := ProvideGrafana(setting.NewCfg(), userService, tracing.InitializeTracerForTest())
+	identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, "user", password)
+	assert.NoError(t, err)
+	assert.NotNil(t, identity)
 }

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -73,7 +73,7 @@ func (ss *SQLStore) createUser(ctx context.Context, sess *DBSession, args user.C
 		LastSeenAt: time.Now().AddDate(-10, 0, 0),
 	}
 
-	salt, err := util.GetRandomString(10)
+	salt, err := util.GeneratePasswordSalt()
 	if err != nil {
 		return usr, err
 	}

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -90,6 +90,9 @@ type UpdateUserCommand struct {
 	IsDisabled     *bool `json:"-"`
 	EmailVerified  *bool `json:"-"`
 	IsGrafanaAdmin *bool `json:"-"`
+	// If Salt is included it will be used when hashing Password.
+	// Intended for legacy password rehash migrations only.
+	Salt *string `json:"-"`
 	// If password is included it will be validated, hashed and updated for user.
 	Password *Password `json:"-"`
 	// If old password is included it will be validated against users current password.

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -152,7 +152,7 @@ func (s *LegacyService) Create(ctx context.Context, cmd *user.CreateUserCommand)
 		IsProvisioned:    cmd.IsProvisioned,
 	}
 
-	salt, err := util.GetRandomString(10)
+	salt, err := util.GeneratePasswordSalt()
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +273,10 @@ func (s *LegacyService) Update(ctx context.Context, cmd *user.UpdateUserCommand)
 	usr, err := s.store.GetByID(ctx, cmd.UserID)
 	if err != nil {
 		return err
+	}
+
+	if cmd.Salt != nil {
+		usr.Salt = *cmd.Salt
 	}
 
 	if cmd.OldPassword != nil {
@@ -459,7 +463,7 @@ func (s *LegacyService) CreateServiceAccount(ctx context.Context, cmd *user.Crea
 		IsServiceAccount: true,
 	}
 
-	salt, err := util.GetRandomString(10)
+	salt, err := util.GeneratePasswordSalt()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -253,6 +253,7 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 		q := sess.ID(cmd.UserID).Where(ss.notServiceAccountFilter())
 
 		setOptional(cmd.OrgID, func(v int64) { usr.OrgID = v })
+		setOptional(cmd.Salt, func(v string) { usr.Salt = v })
 		setOptional(cmd.Password, func(v user.Password) { usr.Password = v })
 		setOptional(cmd.IsDisabled, func(v bool) {
 			q = q.UseBool("is_disabled")

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -143,7 +143,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		require.Equal(t, result.Email, "usertest@test.com")
 		require.Equal(t, string(result.Password), "")
 		require.Len(t, result.Rands, 10)
-		require.Len(t, result.Salt, 10)
+		require.Len(t, result.Salt, 32)
 		require.False(t, result.IsDisabled)
 
 		result, err = userStore.GetByID(context.Background(), usr.ID)
@@ -152,7 +152,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		require.Equal(t, result.Email, "usertest@test.com")
 		require.Equal(t, string(result.Password), "")
 		require.Len(t, result.Rands, 10)
-		require.Len(t, result.Salt, 10)
+		require.Len(t, result.Salt, 32)
 		require.False(t, result.IsDisabled)
 
 		t.Run("Get User by email case insensitive", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 			require.Equal(t, result.Email, "usertest@test.com")
 			require.Equal(t, string(result.Password), "")
 			require.Len(t, result.Rands, 10)
-			require.Len(t, result.Salt, 10)
+			require.Len(t, result.Salt, 32)
 			require.False(t, result.IsDisabled)
 		})
 
@@ -174,7 +174,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 			require.Equal(t, result.Email, "usertest@test.com")
 			require.Equal(t, string(result.Password), "")
 			require.Len(t, result.Rands, 10)
-			require.Len(t, result.Salt, 10)
+			require.Len(t, result.Salt, 32)
 			require.False(t, result.IsDisabled)
 
 			result, err = userStore.GetByID(context.Background(), usr.ID)
@@ -183,7 +183,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 			require.Equal(t, result.Email, "usertest@test.com")
 			require.Equal(t, string(result.Password), "")
 			require.Len(t, result.Rands, 10)
-			require.Len(t, result.Salt, 10)
+			require.Len(t, result.Salt, 32)
 			require.False(t, result.IsDisabled)
 		})
 	})

--- a/pkg/util/encoding.go
+++ b/pkg/util/encoding.go
@@ -7,9 +7,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"mime/quotedprintable"
 	"strings"
+
+	legacypbkdf2 "golang.org/x/crypto/pbkdf2"
 )
 
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -54,6 +57,35 @@ func EncodePassword(password string, salt string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return hex.EncodeToString(newPasswd), nil
+}
+
+// GeneratePasswordSalt generates a FIPS-compliant 16-byte
+// random salt encoded as a hex string for DB storage.
+// Uses crypto/rand to meet NIST SP 800-132 §5.1 requirements.
+func GeneratePasswordSalt() (string, error) {
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("failed to generate salt: %w", err)
+	}
+	return hex.EncodeToString(salt), nil
+}
+
+// EncodePasswordLegacy encodes a password using the pure-Go
+// PBKDF2 implementation from golang.org/x/crypto/pbkdf2.
+// This bypasses FIPS enforcement and is used ONLY to verify
+// passwords hashed with legacy short salts (< 16 bytes).
+// After successful verification, the caller must re-hash the
+// password with EncodePassword and a new compliant salt.
+// See: GitHub issue #120561
+func EncodePasswordLegacy(password string, salt string) (string, error) {
+	newPasswd := legacypbkdf2.Key(
+		[]byte(password),
+		[]byte(salt),
+		10000,
+		50,
+		sha256.New,
+	)
 	return hex.EncodeToString(newPasswd), nil
 }
 

--- a/pkg/util/encoding_test.go
+++ b/pkg/util/encoding_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/hex"
 	"math"
 	"strings"
 	"testing"
@@ -33,6 +34,56 @@ func TestEncodePassword(t *testing.T) {
 		"e59c568621e57756495a468f47c74e07c911b037084dd464bb2ed72410970dc849cabd71b48c394faf08a5405dae53741ce9",
 		encodedPassword,
 	)
+}
+
+func TestGeneratePasswordSalt_CompliantOutput(t *testing.T) {
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		salt, err := GeneratePasswordSalt()
+		require.NoError(t, err)
+		require.Len(t, salt, 32)
+
+		decoded, err := hex.DecodeString(salt)
+		require.NoError(t, err)
+		require.Len(t, decoded, 16)
+
+		_, exists := seen[salt]
+		require.False(t, exists, "salt must be unique")
+		seen[salt] = struct{}{}
+	}
+}
+
+func TestEncodePassword_WithCompliantSalt(t *testing.T) {
+	salt, err := GeneratePasswordSalt()
+	require.NoError(t, err)
+
+	encodedPassword, err := EncodePassword("iamgod", salt)
+	require.NoError(t, err)
+	require.NotEmpty(t, encodedPassword)
+
+	_, err = hex.DecodeString(encodedPassword)
+	require.NoError(t, err)
+}
+
+func TestEncodePasswordLegacy_WorksWithLegacyShortSalt(t *testing.T) {
+	encodedPassword, err := EncodePasswordLegacy("iamgod", "pepper")
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"e59c568621e57756495a468f47c74e07c911b037084dd464bb2ed72410970dc849cabd71b48c394faf08a5405dae53741ce9",
+		encodedPassword,
+	)
+}
+
+func TestGeneratePasswordSalt_UniqueAcrossMany(t *testing.T) {
+	seen := make(map[string]struct{}, 1000)
+	for i := 0; i < 1000; i++ {
+		salt, err := GeneratePasswordSalt()
+		require.NoError(t, err)
+		_, exists := seen[salt]
+		require.False(t, exists, "salt must be unique")
+		seen[salt] = struct{}{}
+	}
 }
 
 func TestDecodeQuotedPrintable(t *testing.T) {


### PR DESCRIPTION
Fixes #120561

## What this PR does

Fixes Grafana's PBKDF2 salt generation to meet FIPS 140-3 / NIST SP 800-132 §5.1 requirements, which mandate a minimum of 128 bits (16 bytes) of randomly generated salt. Implements a transparent lazy migration for existing users so no forced password reset is required.

## Root cause

Grafana generates PBKDF2 salts using `util.GetRandomString(n)` which draws from a 62-character alphabet (A-Z, a-z, 0-9). Because the alphabet is smaller than 256, each character carries only ~5.95 bits of entropy — not 8. So the effective entropy of current salts is:

| Callsite | Salt | Actual entropy |
|---|---|---|
| `EncodePassword()` — password hashing | `GetRandomString(10)` | ~59.5 bits |
| `Encrypt()` — legacy encryption | `GetRandomString(8)` | ~47.6 bits |

FIPS 140-3 compliant OpenSSL modules (RHEL 9, Chainguard 3.4) now enforce the 128-bit minimum at runtime, causing either a panic or — more dangerously — a silent lockout of all users because `comparePassword` discarded the error from
`EncodePassword` with `_`.

## Fix approach

Confirmed by issue reporter @xnox (OpenSSL/BoringSSL/AWS-LC maintainer) in issue comments.

**New users:** Generate salt using `crypto/rand` (16 raw bytes, hex encoded) via new `GeneratePasswordSalt()` helper. This meets NIST SP 800-132 §5.1 and is FIPS-compliant.

**Existing users (lazy migration):**
1. Attempt verification using standard `crypto/pbkdf2` (FIPS path)
2. If salt is too short and FIPS module rejects it, fall back to
   `golang.org/x/crypto/pbkdf2` (pure-Go, bypasses FIPS enforcement)
   — this approach is explicitly approved by @xnox
3. On successful legacy verification, immediately re-hash with a
   new compliant salt and update the DB transparently
4. Migration failures are logged as warnings but never block login

**Silent failure fix:** `comparePassword` now returns `(bool, error)`
and handles errors explicitly. Added empty salt guard.

## Changes

- `pkg/util/encoding.go` — add `GeneratePasswordSalt()` and
  `EncodePasswordLegacy()`
- `pkg/services/authn/clients/grafana.go` — fix `comparePassword`,
  implement lazy migration with structured logging
- `pkg/services/user/userimpl/legacy_user.go` — use
  `GeneratePasswordSalt()` for new users and service accounts
- `pkg/services/sqlstore/user.go` — same for deprecated sqlstore path
- `pkg/registry/apis/iam/legacy/user.go` — same for legacy IAM path
- `pkg/services/user/model.go` — add `Salt` field to
  `UpdateUserCommand` for lazy migration DB update
- `pkg/services/user/userimpl/store.go` — wire `Salt` field into
  DB update using existing `setOptional` pattern

## What this PR does NOT change

The AES-GCM nonce/IV length issue (`gcmSaltLength = 8` in encryption paths) was raised by @xnox in the issue comments but is explicitly a separate concern. @xnox recommended using `crypto/cipher.NewGCMWithRandomNonce`. That will be addressed in a follow-up issue and PR.

## Test coverage

- `TestGeneratePasswordSalt` — generates 100 salts, asserts
  each is 32 hex chars, all unique, all valid hex
- `TestEncodePasswordLegacy` — verifies pure-Go path produces
  correct hash for known input
- `TestComparePassword_LegacySalt` — correct/wrong password
  against legacy short salt
- `TestComparePassword_CompliantSalt` — correct/wrong password
  against new compliant salt
- `TestAuthenticatePassword_MigrationBoundarySaltLength` —
  salt length 31 triggers migration, length 32 does not
- `TestComparePassword_EmptySalt` — returns false, no panic
- `TestMigrationUpdateErrorDoesNotFailLogin` — DB update failure
  during migration does not block login

All existing tests pass.

## How to test manually

**Non-FIPS environment (verify no regression):**
1. Log in with an existing user → works normally
2. Create a new user → salt in DB is now 32 hex chars
3. Log in with the new user → works normally

**FIPS environment (verify fix):**
1. Build with go-openssl toolchain on RHEL 9 or Chainguard FIPS
2. Log in with an existing user (short salt in DB)
3. Login succeeds — no panic, no lockout
4. Check DB — user's salt is now upgraded to 32 hex chars
5. Log in again — now uses FIPS-compliant path directly

## Checklist
- [x] Tests added
- [x] No existing tests broken
- [x] Inline comments explain the why, not the what
- [x] Lazy migration is best-effort and never blocks login
- [x] AES-GCM nonce fix explicitly deferred to follow-up
- [x] Fix approach confirmed by original reporter @xnox