### PR TITLE
Chore: Evict `react-awesome-query-builder` from initial chunks

### DIFF
--- a/packages/grafana-sql/src/types.ts
+++ b/packages/grafana-sql/src/types.ts
@@ -1,4 +1,4 @@
-import { JsonTree } from '@react-awesome-query-builder/ui';
+import type { JsonTree } from '@react-awesome-query-builder/ui';
 
 import {
   DataFrame,

--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -1,4 +1,4 @@
-import { BooleanFieldSettings } from '@react-awesome-query-builder/ui';
+import type { BooleanFieldSettings } from '@react-awesome-query-builder/ui';
 
 import {
   FieldConfigPropertyItem,

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { uniqueId } from 'lodash';
-import { FC, useCallback, useState } from 'react';
+import { FC, Suspense, lazy, useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import {
@@ -18,7 +18,6 @@ import { ClassicConditions } from 'app/features/expressions/components/ClassicCo
 import { Math } from 'app/features/expressions/components/Math';
 import { Reduce } from 'app/features/expressions/components/Reduce';
 import { Resample } from 'app/features/expressions/components/Resample';
-import { SqlExpr } from 'app/features/expressions/components/SqlExpressions/SqlExpr';
 import { Threshold } from 'app/features/expressions/components/Threshold';
 import {
   ExpressionQuery,
@@ -37,6 +36,12 @@ import { AlertStateTag } from '../rules/AlertStateTag';
 
 import { ExpressionStatusIndicator } from './ExpressionStatusIndicator';
 import { formatLabels, formatSeriesValue, getSeriesLabels, getSeriesName, getSeriesValue, isEmptySeries } from './util';
+
+const SqlExpr = lazy(() =>
+  import('app/features/expressions/components/SqlExpressions/SqlExpr').then((module) => ({
+    default: module.SqlExpr,
+  }))
+);
 
 interface ExpressionProps {
   isAlertCondition?: boolean;
@@ -132,13 +137,15 @@ export const Expression: FC<ExpressionProps> = ({
 
         case ExpressionQueryType.sql:
           return (
-            <SqlExpr
-              onChange={(query) => onChangeQuery(query)}
-              query={query}
-              refIds={availableRefIds}
-              alerting
-              queries={[]}
-            />
+            <Suspense fallback={null}>
+              <SqlExpr
+                onChange={(query) => onChangeQuery(query)}
+                query={query}
+                refIds={availableRefIds}
+                alerting
+                queries={[]}
+              />
+            </Suspense>
           );
 
         default:

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useRef } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useRef } from 'react';
 
 import { DataSourceApi, FeatureState, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
@@ -10,7 +10,6 @@ import { ExpressionTypeDropdown } from './components/ExpressionTypeDropdown';
 import { Math } from './components/Math';
 import { Reduce } from './components/Reduce';
 import { Resample } from './components/Resample';
-import { SqlExpr } from './components/SqlExpressions/SqlExpr';
 import { Threshold } from './components/Threshold';
 import { ExpressionQuery, ExpressionQueryType, expressionTypes } from './types';
 import { getDefaults } from './utils/expressionTypes';
@@ -18,6 +17,11 @@ import { getDefaults } from './utils/expressionTypes';
 export type ExpressionQueryEditorProps = QueryEditorProps<DataSourceApi<ExpressionQuery>, ExpressionQuery>;
 
 const labelWidth = 15;
+const SqlExpr = lazy(() =>
+  import('./components/SqlExpressions/SqlExpr').then((module) => ({
+    default: module.SqlExpr,
+  }))
+);
 
 type NonClassicExpressionType = Exclude<ExpressionQueryType, ExpressionQueryType.classic>;
 type ExpressionTypeConfigStorage = Partial<Record<NonClassicExpressionType, string>>;
@@ -131,14 +135,16 @@ export function ExpressionQueryEditor(props: ExpressionQueryEditorProps) {
 
       case ExpressionQueryType.sql:
         return (
-          <SqlExpr
-            onChange={onChange}
-            query={query}
-            refIds={refIds}
-            queries={queries}
-            metadata={props}
-            onRunQuery={onRunQuery}
-          />
+          <Suspense fallback={null}>
+            <SqlExpr
+              onChange={onChange}
+              query={query}
+              refIds={refIds}
+              queries={queries}
+              metadata={props}
+              onRunQuery={onRunQuery}
+            />
+          </Suspense>
         );
     }
   };

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -5,8 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { CompletionItemKind } from '@grafana/plugin-ui';
-import type { LanguageDefinition, TableIdentifier } from '@grafana/plugin-ui';
+import { CompletionItemKind, type LanguageDefinition, type TableIdentifier } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { formatSQL } from '@grafana/sql';

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -5,7 +5,8 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { CompletionItemKind, LanguageDefinition, SQLEditor, TableIdentifier } from '@grafana/plugin-ui';
+import { CompletionItemKind } from '@grafana/plugin-ui';
+import type { LanguageDefinition, TableIdentifier } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { formatSQL } from '@grafana/sql';
@@ -33,6 +34,11 @@ const GenAISuggestionsDrawer = lazy(() =>
 const GenAIExplanationDrawer = lazy(() =>
   import('./GenAI/GenAIExplanationDrawer').then((module) => ({
     default: module.GenAIExplanationDrawer,
+  }))
+);
+const SQLEditor = lazy(() =>
+  import('@grafana/plugin-ui').then((module) => ({
+    default: module.SQLEditor,
   }))
 );
 
@@ -249,19 +255,21 @@ LIMIT
       <div className={styles.editorContainer}>
         <AutoSizer>
           {({ width, height }) => (
-            <SQLEditor
-              query={query.expression || initialQuery}
-              onChange={onEditorChange}
-              language={EDITOR_LANGUAGE_DEFINITION}
-              width={width}
-              height={height - EDITOR_BORDER_ADJUSTMENT - toolboxMeasure.height}
-            >
-              {({ formatQuery }) => (
-                <div ref={toolboxRef}>
-                  <QueryToolbox query={query} onFormatCode={formatQuery} />
-                </div>
-              )}
-            </SQLEditor>
+            <Suspense fallback={null}>
+              <SQLEditor
+                query={query.expression || initialQuery}
+                onChange={onEditorChange}
+                language={EDITOR_LANGUAGE_DEFINITION}
+                width={width}
+                height={height - EDITOR_BORDER_ADJUSTMENT - toolboxMeasure.height}
+              >
+                {({ formatQuery }) => (
+                  <div ref={toolboxRef}>
+                    <QueryToolbox query={query} onFormatCode={formatQuery} />
+                  </div>
+                )}
+              </SQLEditor>
+            </Suspense>
           )}
         </AutoSizer>
       </div>

--- a/public/app/features/expressions/utils/metaSqlExpr.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.ts
@@ -3,8 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDefaultTimeRange, DataFrameView } from '@grafana/data';
 import { QueryFormat, SQLQuery, SQLSelectableValue } from '@grafana/plugin-ui';
 import { DataQuery } from '@grafana/schema';
-import { mapFieldsToTypes } from 'app/plugins/datasource/mysql/fields';
-import { quoteIdentifierIfNecessary } from 'app/plugins/datasource/mysql/sqlUtil';
 
 import { dataSource } from '../ExpressionDatasource';
 
@@ -34,6 +32,87 @@ export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuer
   });
 
   return mapFieldsToTypes(fields);
+}
+
+type RAQBFieldType = 'boolean' | 'text' | 'number' | 'date' | 'datetime' | 'time';
+
+function mapFieldsToTypes(columns: SQLSelectableValue[]) {
+  const fields: SQLSelectableValue[] = [];
+
+  for (const col of columns) {
+    const type = col.type?.toUpperCase() ?? '';
+    let raqbFieldType: RAQBFieldType = 'text';
+
+    switch (type) {
+      case 'BOOLEAN':
+      case 'BOOL':
+        raqbFieldType = 'boolean';
+        break;
+      case 'FLOAT':
+      case 'FLOAT64':
+      case 'INT':
+      case 'INTEGER':
+      case 'INT64':
+      case 'NUMERIC':
+      case 'BIGNUMERIC':
+        raqbFieldType = 'number';
+        break;
+      case 'DATE':
+        raqbFieldType = 'date';
+        break;
+      case 'DATETIME':
+      case 'TIMESTAMP':
+        raqbFieldType = 'datetime';
+        break;
+      case 'TIME':
+        raqbFieldType = 'time';
+        break;
+    }
+
+    fields.push({ ...col, raqbFieldType, icon: mapColumnTypeToIcon(type) });
+  }
+
+  return fields;
+}
+
+function mapColumnTypeToIcon(type: string) {
+  switch (type) {
+    case 'TIME':
+    case 'DATETIME':
+    case 'TIMESTAMP':
+      return 'clock-nine';
+    case 'BOOLEAN':
+      return 'toggle-off';
+    case 'INTEGER':
+    case 'FLOAT':
+    case 'FLOAT64':
+    case 'INT':
+    case 'SMALLINT':
+    case 'BIGINT':
+    case 'TINYINT':
+    case 'BYTEINT':
+    case 'INT64':
+    case 'NUMERIC':
+    case 'DECIMAL':
+      return 'calculator-alt';
+    case 'CHAR':
+    case 'VARCHAR':
+    case 'STRING':
+    case 'BYTES':
+    case 'TEXT':
+    case 'TINYTEXT':
+    case 'MEDIUMTEXT':
+    case 'LONGTEXT':
+      return 'text';
+    case 'GEOGRAPHY':
+      return 'map';
+    default:
+      return undefined;
+  }
+}
+
+function quoteIdentifierIfNecessary(value: string) {
+  return /^[a-zA-Z_][a-zA-Z0-9_$]*$/g.test(value) ? value : `\`${value}\``;
 }
 
 // based off https://github.com/grafana/grafana/blob/main/pkg/expr/sql/parser_allow.go


### PR DESCRIPTION
previously: https://github.com/grafana/grafana/pull/120652

alternative to https://github.com/grafana/grafana/pull/120644 (which didn't work correctly when loading sql query editors).

**this removes ~800KB from the blocking path**. iiuc, each sql query DS is in its own package and already bundles a copy of `react-awesome-query-builder`, so they were not benefiting from a shared dependency extraction anyways, much less an eagerly loaded one.

before
---
<img width="2532" height="1431" alt="Screenshot_20260319_012840" src="https://github.com/user-attachments/assets/4a87a886-1803-472c-b2b9-0b7187d39539" />
<img width="3840" height="2160" alt="Screenshot_20260319_015612" src="https://github.com/user-attachments/assets/5d210b9e-1282-4db8-8c4e-06bd27bf0f54" />

after
---
<img width="2532" height="1431" alt="Screenshot_20260319_012718" src="https://github.com/user-attachments/assets/e95e5192-2585-418c-9ca6-567933b8bdf2" />
<img width="3840" height="2160" alt="Screenshot_20260319_015257" src="https://github.com/user-attachments/assets/6d4992bf-4367-4dde-bc8e-da7be194f559" />