### PR TITLE
fix: disable migrations when target is not all or core

### DIFF
--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -1,6 +1,7 @@
 package setting
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -78,15 +79,8 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	// Set indexer config for unified storage
 	section := cfg.Raw.Section("unified_storage")
 	cfg.DisableDataMigrations = section.Key("disable_data_migrations").MustBool(false)
-	if !cfg.DisableDataMigrations && cfg.UnifiedStorageType() == "unified" {
-		// Helper log to find instances running migrations in the future
-		cfg.Logger.Info("Unified migration configs enforced")
-		cfg.enforceMigrationToUnifiedConfigs()
-	} else {
-		// Helper log to find instances disabling migration
-		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations)
-	}
-	cfg.EnableSearch = section.Key("enable_search").MustBool(false)
+	cfg.EnableSearch = section.Key("enable_search").MustBool(true)
+	cfg.applyMigrationEnforcements()
 	cfg.EnableSearchClient = section.Key("enable_search_client").MustBool(false)
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
 	cfg.IndexPath = section.Key("index_path").String()
@@ -138,11 +132,20 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MinFileIndexBuildVersion = section.Key("min_file_index_build_version").MustString("")
 }
 
-// enforceMigrationToUnifiedConfigs enforces configurations required to run migrated resources in mode 5
-// All migrated resources in MigratedUnifiedResources are set to mode 5 and unified search is enabled
-func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
+// applyMigrationEnforcements enforces unified storage migration configs when migrations should run,
+// or disables local search when a remote search server is configured.
+func (cfg *Cfg) applyMigrationEnforcements() {
+	if !cfg.ShouldRunMigrations() {
+		cfg.Logger.Info("Unified migration configs enforcement disabled", "storage_type", cfg.UnifiedStorageType(), "disable_data_migrations", cfg.DisableDataMigrations, "target", cfg.Target)
+		if cfg.shouldProxySearchRemotely() {
+			cfg.EnableSearch = false
+		}
+		return
+	}
+
+	cfg.Logger.Info("Unified migration configs enforced", "storage_type", cfg.UnifiedStorageType(), "target", cfg.Target)
+
 	section := cfg.Raw.Section("unified_storage")
-	cfg.EnableSearch = section.Key("enable_search").MustBool(true)
 	if !cfg.EnableSearch {
 		cfg.Logger.Info("Enforcing enable_search for unified storage")
 		section.Key("enable_search").SetValue("true")
@@ -166,6 +169,27 @@ func (cfg *Cfg) enforceMigrationToUnifiedConfigs() {
 			AutoMigrationThreshold: resourceCfg.AutoMigrationThreshold,
 		}
 	}
+}
+
+func isTargetEligibleForMigrations(targets []string) bool {
+	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
+}
+
+// shouldProxySearchRemotely reports whether local search should be disabled in
+// favor of a remote search server. This is true when a search_server_address is
+// configured and the current target is not a dedicated search-server (which
+// needs local indexing to serve search RPCs).
+func (cfg *Cfg) shouldProxySearchRemotely() bool {
+	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
+	return apiserverCfg.Key("search_server_address").MustString("") != "" &&
+		!slices.Contains(cfg.Target, "search-server")
+}
+
+// ShouldRunMigrations reports whether data migrations to unified storage should run.
+func (cfg *Cfg) ShouldRunMigrations() bool {
+	return !cfg.DisableDataMigrations &&
+		cfg.UnifiedStorageType() == "unified" &&
+		isTargetEligibleForMigrations(cfg.Target)
 }
 
 // UnifiedStorageType returns the configured storage type without creating or mutating keys.

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -96,3 +96,143 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 1, cfg.IndexMinCount)
 	})
 }
+
+func TestApplyMigrationEnforcements(t *testing.T) {
+	newCfg := func(t *testing.T) *Cfg {
+		t.Helper()
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+		cfg.UnifiedStorage = make(map[string]UnifiedStorageConfig)
+		return cfg
+	}
+
+	enableMigrations := func(cfg *Cfg) {
+		cfg.Target = []string{"all"}
+		cfg.DisableDataMigrations = false
+		// storage_type defaults to "unified", no need to set it
+	}
+
+	disableMigrations := func(cfg *Cfg) {
+		cfg.DisableDataMigrations = true
+	}
+
+	t.Run("enforces EnableSearch when migrations run and search is disabled", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+		cfg.EnableSearch = false
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+
+	t.Run("keeps EnableSearch true when migrations run", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+		cfg.EnableSearch = true
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+
+	t.Run("enforces mode 5 for default-enabled migrated resources", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+
+		cfg.applyMigrationEnforcements()
+
+		for resource, enabledByDefault := range MigratedUnifiedResources {
+			if !enabledByDefault {
+				continue
+			}
+			resourceCfg, exists := cfg.UnifiedStorage[resource]
+			assert.True(t, exists, resource)
+			assert.Equal(t, rest.DualWriterMode(5), resourceCfg.DualWriterMode, resource)
+			assert.True(t, resourceCfg.EnableMigration, resource)
+		}
+	})
+
+	t.Run("skips resources with migration explicitly disabled", func(t *testing.T) {
+		cfg := newCfg(t)
+		enableMigrations(cfg)
+		cfg.UnifiedStorage[DashboardResource] = UnifiedStorageConfig{
+			DualWriterMode:  1,
+			EnableMigration: false,
+		}
+
+		cfg.applyMigrationEnforcements()
+
+		resourceCfg := cfg.UnifiedStorage[DashboardResource]
+		assert.Equal(t, rest.DualWriterMode(1), resourceCfg.DualWriterMode)
+		assert.False(t, resourceCfg.EnableMigration)
+	})
+
+	t.Run("disables local search when migrations disabled and shouldProxySearchRemotely", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.EnableSearch = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
+
+		cfg.applyMigrationEnforcements()
+
+		assert.False(t, cfg.EnableSearch)
+	})
+
+	t.Run("keeps local search on search-server target even with search_server_address set", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.Target = []string{"search-server"}
+		cfg.EnableSearch = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+
+	t.Run("disables local search on storage-server target with search_server_address set", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.Target = []string{"storage-server"}
+		cfg.EnableSearch = true
+		cfg.Raw.Section("grafana-apiserver").Key("search_server_address").SetValue("localhost:10000")
+
+		cfg.applyMigrationEnforcements()
+
+		assert.False(t, cfg.EnableSearch)
+	})
+
+	t.Run("keeps local search when migrations disabled and no search_server_address", func(t *testing.T) {
+		cfg := newCfg(t)
+		disableMigrations(cfg)
+		cfg.EnableSearch = true
+
+		cfg.applyMigrationEnforcements()
+
+		assert.True(t, cfg.EnableSearch)
+	})
+}
+
+func TestIsTargetEligibleForMigrations(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected bool
+	}{
+		{name: "all target", targets: []string{"all"}, expected: true},
+		{name: "core target", targets: []string{"core"}, expected: true},
+		{name: "all among multiple targets", targets: []string{"storage-server", "all"}, expected: true},
+		{name: "core among multiple targets", targets: []string{"storage-server", "core"}, expected: true},
+		{name: "storage-server only", targets: []string{"storage-server"}, expected: false},
+		{name: "empty targets", targets: []string{}, expected: false},
+		{name: "other target", targets: []string{"search-server-distributor"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTargetEligibleForMigrations(tt.targets))
+		})
+	}
+}

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -50,18 +49,8 @@ func ProvideUnifiedStorageMigrationService(
 	}
 }
 
-func isTargetEligibleForMigrations(targets []string) bool {
-	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
-}
-
-func (p *UnifiedStorageMigrationServiceImpl) shouldRunMigrations() bool {
-	return !p.cfg.DisableDataMigrations &&
-		p.cfg.UnifiedStorageType() == "unified" &&
-		isTargetEligibleForMigrations(p.cfg.Target)
-}
-
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
-	if !p.shouldRunMigrations() {
+	if !p.cfg.ShouldRunMigrations() {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
 		logger.Info("Data migrations are disabled, skipping",
 			"disableDataMigrations", p.cfg.DisableDataMigrations,

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -49,11 +50,24 @@ func ProvideUnifiedStorageMigrationService(
 	}
 }
 
+func isTargetEligibleForMigrations(targets []string) bool {
+	return slices.Contains(targets, "all") || slices.Contains(targets, "core")
+}
+
+func (p *UnifiedStorageMigrationServiceImpl) shouldRunMigrations() bool {
+	return !p.cfg.DisableDataMigrations &&
+		p.cfg.UnifiedStorageType() == "unified" &&
+		isTargetEligibleForMigrations(p.cfg.Target)
+}
+
 func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
-	// skip migrations if disabled in config
-	if p.cfg.DisableDataMigrations {
+	if !p.shouldRunMigrations() {
 		metrics.MUnifiedStorageMigrationStatus.Set(1)
-		logger.Info("Data migrations are disabled, skipping")
+		logger.Info("Data migrations are disabled, skipping",
+			"disableDataMigrations", p.cfg.DisableDataMigrations,
+			"unifiedStorageType", p.cfg.UnifiedStorageType(),
+			"target", p.cfg.Target,
+		)
 		return nil
 	}
 

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -65,28 +64,6 @@ func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, float64(1), testutil.ToFloat64(metrics.MUnifiedStorageMigrationStatus))
 			migrator.AssertNotCalled(t, "Migrate")
-		})
-	}
-}
-
-func TestIsTargetEligibleForMigrations(t *testing.T) {
-	tests := []struct {
-		name     string
-		targets  []string
-		expected bool
-	}{
-		{name: "all target", targets: []string{"all"}, expected: true},
-		{name: "core target", targets: []string{"core"}, expected: true},
-		{name: "all among multiple targets", targets: []string{"storage-server", "all"}, expected: true},
-		{name: "core among multiple targets", targets: []string{"storage-server", "core"}, expected: true},
-		{name: "storage-server only", targets: []string{"storage-server"}, expected: false},
-		{name: "empty targets", targets: []string{}, expected: false},
-		{name: "other target", targets: []string{"search-server-distributor"}, expected: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isTargetEligibleForMigrations(tt.targets))
 		})
 	}
 }

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -1,0 +1,92 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgFunc func(cfg *setting.Cfg)
+	}{
+		{
+			name: "storage type is unified-grpc",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("grafana-apiserver").Key("storage_type").SetValue("unified-grpc")
+			},
+		},
+		{
+			name: "storage type is unified-kv-grpc",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("grafana-apiserver").Key("storage_type").SetValue("unified-kv-grpc")
+			},
+		},
+		{
+			name: "data migrations disabled",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.DisableDataMigrations = true
+			},
+		},
+		{
+			name: "target is not all or core",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Target = []string{"storage-server"}
+			},
+		},
+		{
+			name: "target is empty",
+			cfgFunc: func(cfg *setting.Cfg) {
+				cfg.Target = []string{}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			tt.cfgFunc(cfg)
+
+			migrator := NewMockUnifiedMigrator(t)
+
+			svc := &UnifiedStorageMigrationServiceImpl{
+				cfg:      cfg,
+				migrator: migrator,
+			}
+
+			err := svc.Run(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, float64(1), testutil.ToFloat64(metrics.MUnifiedStorageMigrationStatus))
+			migrator.AssertNotCalled(t, "Migrate")
+		})
+	}
+}
+
+func TestIsTargetEligibleForMigrations(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected bool
+	}{
+		{name: "all target", targets: []string{"all"}, expected: true},
+		{name: "core target", targets: []string{"core"}, expected: true},
+		{name: "all among multiple targets", targets: []string{"storage-server", "all"}, expected: true},
+		{name: "core among multiple targets", targets: []string{"storage-server", "core"}, expected: true},
+		{name: "storage-server only", targets: []string{"storage-server"}, expected: false},
+		{name: "empty targets", targets: []string{}, expected: false},
+		{name: "other target", targets: []string{"search-server-distributor"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTargetEligibleForMigrations(tt.targets))
+		})
+	}
+}


### PR DESCRIPTION
- **fix: disable migrations when target is not all or core (#119903)**
- **fix: limit migration config enforcements to specific targets (#120328)**
