### PR TITLE
RBAC: Improve test coverage for SearchUsersPermissions endpoint

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -588,17 +588,17 @@ func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 	listAllPerms := map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:*"}}
 	listSomePerms := map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:id:2"}}
 	tests := []struct {
-		name             string
-		siuPermissions   map[string][]string
-		searchOption     accesscontrol.SearchOptions
-		ramRoles         map[string]*accesscontrol.RoleDTO    // BasicRole => RBAC BasicRole
-		storedPerms      map[int64][]accesscontrol.Permission // UserID => Permissions
-		storedRoles      map[int64][]string                   // UserID => Roles
-		want             map[int64][]accesscontrol.Permission
-		wantErr          bool
+		name           string
+		siuPermissions map[string][]string
+		searchOption   accesscontrol.SearchOptions
+		ramRoles       map[string]*accesscontrol.RoleDTO    // BasicRole => RBAC BasicRole
+		storedPerms    map[int64][]accesscontrol.Permission // UserID => Permissions
+		storedRoles    map[int64][]string                   // UserID => Roles
+		want           map[int64][]accesscontrol.Permission
+		wantErr        bool
 		// Error injection fields - explicitly control which store methods return errors
-		injectSearchErr  bool // When true, SearchUsersPermissions returns an error
-		injectBasicErr   bool // When true, GetUsersBasicRoles returns an error
+		injectSearchErr bool // When true, SearchUsersPermissions returns an error
+		injectBasicErr  bool // When true, GetUsersBasicRoles returns an error
 	}{
 		{
 			name:           "ram only",
@@ -831,9 +831,9 @@ func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 		},
 		// error handling
 		{
-			name:            "store.SearchUsersPermissions error is propagated",
-			siuPermissions:  listAllPerms,
-			searchOption:    searchOption,
+			name:           "store.SearchUsersPermissions error is propagated",
+			siuPermissions: listAllPerms,
+			searchOption:   searchOption,
 			storedRoles: map[int64][]string{
 				1: {string(identity.RoleEditor)},
 			},

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -588,14 +588,17 @@ func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 	listAllPerms := map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:*"}}
 	listSomePerms := map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:id:2"}}
 	tests := []struct {
-		name           string
-		siuPermissions map[string][]string
-		searchOption   accesscontrol.SearchOptions
-		ramRoles       map[string]*accesscontrol.RoleDTO    // BasicRole => RBAC BasicRole
-		storedPerms    map[int64][]accesscontrol.Permission // UserID => Permissions
-		storedRoles    map[int64][]string                   // UserID => Roles
-		want           map[int64][]accesscontrol.Permission
-		wantErr        bool
+		name             string
+		siuPermissions   map[string][]string
+		searchOption     accesscontrol.SearchOptions
+		ramRoles         map[string]*accesscontrol.RoleDTO    // BasicRole => RBAC BasicRole
+		storedPerms      map[int64][]accesscontrol.Permission // UserID => Permissions
+		storedRoles      map[int64][]string                   // UserID => Roles
+		want             map[int64][]accesscontrol.Permission
+		wantErr          bool
+		// Error injection fields - explicitly control which store methods return errors
+		injectSearchErr  bool // When true, SearchUsersPermissions returns an error
+		injectBasicErr   bool // When true, GetUsersBasicRoles returns an error
 	}{
 		{
 			name:           "ram only",
@@ -773,16 +776,96 @@ func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 				1: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}, {Action: accesscontrol.ActionTeamsRead, Scope: "teams:*"}},
 			},
 		},
+		//canView visibility filtering
+		{
+			name:           "canView with wildcard scope returns all users",
+			siuPermissions: map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:*"}},
+			searchOption:   searchOption,
+			storedPerms: map[int64][]accesscontrol.Permission{
+				1: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}},
+				2: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}},
+				3: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:3"}},
+			},
+			storedRoles: map[int64][]string{
+				1: {string(identity.RoleEditor)},
+				2: {string(identity.RoleEditor)},
+				3: {string(identity.RoleEditor)},
+			},
+			want: map[int64][]accesscontrol.Permission{
+				1: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}},
+				2: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}},
+				3: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:3"}},
+			},
+		},
+		{
+			name:           "canView with no scope returns empty",
+			siuPermissions: map[string][]string{}, // No permissions at all
+			searchOption:   searchOption,
+			storedPerms: map[int64][]accesscontrol.Permission{
+				1: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}},
+				2: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}},
+			},
+			storedRoles: map[int64][]string{
+				1: {string(identity.RoleEditor)},
+				2: {string(identity.RoleEditor)},
+			},
+			want: map[int64][]accesscontrol.Permission{},
+		},
+		{
+			name:           "canView with specific scope returns only that user",
+			siuPermissions: map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:id:2"}},
+			searchOption:   searchOption,
+			storedPerms: map[int64][]accesscontrol.Permission{
+				1: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}},
+				2: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}},
+				3: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:3"}},
+			},
+			storedRoles: map[int64][]string{
+				1: {string(identity.RoleEditor)},
+				2: {string(identity.RoleEditor)},
+				3: {string(identity.RoleEditor)},
+			},
+			want: map[int64][]accesscontrol.Permission{
+				2: {{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}},
+			},
+		},
+		// error handling
+		{
+			name:            "store.SearchUsersPermissions error is propagated",
+			siuPermissions:  listAllPerms,
+			searchOption:    searchOption,
+			storedRoles: map[int64][]string{
+				1: {string(identity.RoleEditor)},
+			},
+			wantErr:         true,
+			injectSearchErr: true, // Explicitly inject error from SearchUsersPermissions
+		},
+		{
+			name:           "store.GetUsersBasicRoles error is propagated",
+			siuPermissions: listAllPerms,
+			searchOption:   searchOption,
+			wantErr:        true,
+			injectBasicErr: true, // Explicitly inject error from GetUsersBasicRoles
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ac := setupTestEnv(t, true)
 
 			ac.roles = tt.ramRoles
-			ac.store = actest.FakeStore{
+			store := actest.FakeStore{
 				ExpectedUsersPermissions: tt.storedPerms,
 				ExpectedUsersRoles:       tt.storedRoles,
 			}
+
+			// Explicit error injection based on test configuration
+			if tt.injectSearchErr {
+				store.ExpectedErr = assert.AnError
+			}
+			if tt.injectBasicErr {
+				store.ExpectedErr = assert.AnError
+			}
+			ac.store = store
 
 			siu := &user.SignedInUser{OrgID: 2, Permissions: map[int64]map[string][]string{2: tt.siuPermissions}}
 			got, err := ac.SearchUsersPermissions(ctx, siu, tt.searchOption)
@@ -801,6 +884,98 @@ func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIntegrationService_SearchUsersPermissions_SingleUserPath verifies that when UserID is set,
+// the SearchUsersPermissions method delegates to SearchUserPermissions (single-user cached path)
+func TestIntegrationService_SearchUsersPermissions_SingleUserPath(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	ac := setupTestEnv(t, true)
+
+	// Set up data for user 1 - use the FakeStore to provide permissions
+	// The single-user path delegates to searchUserPermissions which uses the store
+	ac.roles = map[string]*accesscontrol.RoleDTO{}
+	ac.store = actest.FakeStore{
+		ExpectedUsersPermissions: map[int64][]accesscontrol.Permission{
+			1: {
+				{Action: accesscontrol.ActionTeamsRead, Scope: "teams:*"},
+				{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:1"},
+			},
+		},
+		ExpectedUsersRoles: map[int64][]string{
+			1: {string(identity.RoleEditor)},
+		},
+	}
+
+	// Call with UserID set - should use the single-user cached path
+	opts := accesscontrol.SearchOptions{
+		UserID:       1,
+		ActionPrefix: "teams",
+	}
+	siu := &user.SignedInUser{OrgID: 2, Permissions: map[int64]map[string][]string{2: {
+		accesscontrol.ActionUsersPermissionsRead: {"users:*"},
+	}}}
+
+	got, err := ac.SearchUsersPermissions(ctx, siu, opts)
+	require.NoError(t, err)
+
+	// Should return exactly one user (user 1) with their permissions
+	require.Len(t, got, 1)
+	require.Contains(t, got, int64(1))
+	// The service returns stored permissions from FakeStore
+	require.ElementsMatch(t, got[1], []accesscontrol.Permission{
+		{Action: accesscontrol.ActionTeamsRead, Scope: "teams:*"},
+		{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:1"},
+	})
+}
+
+// TestIntegrationService_SearchUsersPermissions_ActionSets verifies action set expansion works
+func TestIntegrationService_SearchUsersPermissions_ActionSets(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	ac := setupTestEnv(t, true)
+
+	// Set up action sets
+	actionSetSvc := resourcepermissions.NewActionSetService()
+	actionSetSvc.StoreActionSet(resourcepermissions.GetActionSetName("dashboards", "view"), []string{"dashboards:read"})
+	actionSetSvc.StoreActionSet(resourcepermissions.GetActionSetName("dashboards", "edit"), []string{"dashboards:read", "dashboards:write"})
+	ac.actionResolver = actionSetSvc
+
+	ac.roles = map[string]*accesscontrol.RoleDTO{}
+	ac.store = actest.FakeStore{
+		ExpectedUsersPermissions: map[int64][]accesscontrol.Permission{
+			1: {
+				{Action: "dashboards:view", Scope: "dashboards:uid:d1"},
+				{Action: "dashboards:edit", Scope: "dashboards:uid:d2"},
+			},
+		},
+		ExpectedUsersRoles: map[int64][]string{
+			1: {string(identity.RoleEditor)},
+		},
+	}
+
+	opts := accesscontrol.SearchOptions{
+		Action: "dashboards:read",
+	}
+	siu := &user.SignedInUser{OrgID: 2, Permissions: map[int64]map[string][]string{2: {
+		accesscontrol.ActionUsersPermissionsRead: {"users:*"},
+	}}}
+
+	got, err := ac.SearchUsersPermissions(ctx, siu, opts)
+	require.NoError(t, err)
+
+	// Should have expanded action sets to include dashboards:read
+	require.Len(t, got, 1)
+	require.Contains(t, got, int64(1))
+
+	// Both view and edit grant dashboards:read, so we should see both scopes
+	require.ElementsMatch(t, got[1], []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:uid:d1"},
+		{Action: "dashboards:read", Scope: "dashboards:uid:d2"},
+	})
 }
 
 func TestIntegrationService_SearchUserPermissions(t *testing.T) {

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -132,7 +132,6 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 		filters        string
 		expectedOutput map[int64]map[string][]string
 		expectedCode   int
-		accessAllowed  bool // For authorization tests
 		serviceErr     error
 	}
 

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -131,6 +132,8 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 		filters        string
 		expectedOutput map[int64]map[string][]string
 		expectedCode   int
+		accessAllowed  bool // For authorization tests
+		serviceErr     error
 	}
 
 	tests := []testCase{
@@ -183,14 +186,75 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 				2: {"users:read": {"users:id:2"}},
 			},
 		},
+		{
+			desc:         "Should return 500 for invalid namespacedId format",
+			filters:      "?namespacedId=invalid_format",
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			desc:         "Should return 500 for unsupported identity type",
+			filters:      "?namespacedId=team:1",
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			desc:    "Should accept exact action filter",
+			filters: "?action=dashboards:read",
+			permissions: map[int64][]ac.Permission{
+				1: {{Action: "dashboards:read", Scope: "dashboards:*"}},
+				2: {{Action: "dashboards:write", Scope: "dashboards:*"}},
+			},
+			expectedCode: http.StatusOK,
+			expectedOutput: map[int64]map[string][]string{
+				1: {"dashboards:read": {"dashboards:*"}},
+				2: {"dashboards:write": {"dashboards:*"}},
+			},
+		},
+		{
+			desc:    "Should accept scope filter",
+			filters: "?actionPrefix=teams:&scope=teams:id:1",
+			permissions: map[int64][]ac.Permission{
+				1: {{Action: "teams:read", Scope: "teams:id:1"}},
+				2: {{Action: "teams:read", Scope: "teams:id:2"}},
+			},
+			expectedCode: http.StatusOK,
+			expectedOutput: map[int64]map[string][]string{
+				1: {"teams:read": {"teams:id:1"}},
+				2: {"teams:read": {"teams:id:2"}},
+			},
+		},
+		{
+			desc:         "Should return 500 when service returns error",
+			filters:      "?actionPrefix=users:",
+			serviceErr:   errors.New("database connection failed"),
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			desc:           "Should return empty map when no users match",
+			filters:        "?actionPrefix=nonexistent:",
+			permissions:    map[int64][]ac.Permission{},
+			expectedCode:   http.StatusOK,
+			expectedOutput: map[int64]map[string][]string{},
+		},
+		{
+			desc:           "Should resolve service-account UID",
+			filters:        "?namespacedId=service-account:sa_abc123",
+			permissions:    map[int64][]ac.Permission{3: {{Action: "users:read", Scope: "users:*"}}},
+			expectedCode:   http.StatusOK,
+			expectedOutput: map[int64]map[string][]string{3: {"users:read": {"users:*"}}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			acSvc := actest.FakeService{ExpectedUsersPermissions: tt.permissions}
-			accessControl := actest.FakeAccessControl{ExpectedEvaluate: true} // Always allow access to the endpoint
+			acSvc := actest.FakeService{
+				ExpectedUsersPermissions: tt.permissions,
+				ExpectedErr:              tt.serviceErr,
+			}
+
+			accessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
 			mockUserSvc := usertest.NewMockService(t)
 			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "user_2_uid"}).Return(&user.User{ID: 2}, nil).Maybe()
 			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "non_existent_uid"}).Return(nil, user.ErrUserNotFound).Maybe()
+			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "sa_abc123"}).Return(&user.User{ID: 3, IsServiceAccount: true}, nil).Maybe()
 			api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc)
 			api.RegisterAPIEndpoints()
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the `GET /api/access-control/users/permissions/search` endpoint to establish a regression safety net before implementing the K8s API migration feature.
## Changes
### API handler tests (`api_test.go`)
- 7 new test cases for input validation, error handling, query parameters, UID resolution
### Service tests (`service_test.go`)
- 5 new table-driven tests for `canView` filtering and error propagation
- 2 new test functions for single-user path and action sets
## Test Verification
```bash
go test ./pkg/services/accesscontrol/api/...
go test ./pkg/services/accesscontrol/acimpl/...