### PR TITLE
OpenFeature: Fix namespace fallback for unauthenticated requests

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -167,6 +167,8 @@ func (h *ContextHandler) setRequestContext(ctx context.Context) context.Context 
 	ns := "default"
 	if id != nil {
 		ns = id.Namespace
+	} else if h.cfg.StackID != "" {
+		ns = "stacks-" + h.cfg.StackID
 	}
 	evalCtx := openfeature.NewEvaluationContext(ns, map[string]any{
 		"namespace": ns,


### PR DESCRIPTION
Flag evaluations via `openfeature.TransactionContext(ctx)` rely on the namespace being set by `ContextHandler.setRequestContext`, which derives it from the authenticated identity. 
When auth hasn't run yet or doesn't produce a namespaced identity, it fell back to `default` namespace causing the features service to reject requests.

Observed on `reportRenderBinding` and `react19`, both evaluated in paths where a namespaced identity isn't guaranteed.

The fix is to sall back to "stacks-" + cfg.StackID when id is nil and StackID is set.