### PR TITLE
SQLStore: Fix service account cross-org login code migration execution

### DIFF
--- a/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
+++ b/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
@@ -1,8 +1,6 @@
 package usermig
 
 import (
-	"fmt"
-
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/util/xorm"
 )
@@ -31,12 +29,21 @@ func (p *ServiceAccountsSameLoginCrossOrgs) SQL(dialect migrator.Dialect) string
 }
 
 func (p *ServiceAccountsSameLoginCrossOrgs) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
-	p.sess = sess
 	p.dialect = mg.Dialect
-	var err error
+	q := `
+		UPDATE ` + p.dialect.Quote("user") + `
+		SET login = 'sa-' || CAST(org_id AS TEXT) || '-' ||
+			CASE
+				WHEN SUBSTR(login, 1, 3) = 'sa-' THEN SUBSTR(login, 4)
+				ELSE login
+			END
+		WHERE login IS NOT NULL
+		  AND is_service_account = 1
+		  AND login NOT LIKE 'sa-' || CAST(org_id AS TEXT) || '-%';
+	`
 	switch p.dialect.DriverName() {
 	case migrator.Postgres:
-		_, err = p.sess.Exec(`
+		q = `
             UPDATE "user"
             SET login = 'sa-' || org_id::text || '-' ||
                 CASE
@@ -46,9 +53,9 @@ func (p *ServiceAccountsSameLoginCrossOrgs) Exec(sess *xorm.Session, mg *migrato
             WHERE login IS NOT NULL
               AND is_service_account = true
               AND login NOT LIKE 'sa-' || org_id::text || '-%';
-        `)
+        `
 	case migrator.MySQL:
-		_, err = p.sess.Exec(`
+		q = `
             UPDATE user
             SET login = CONCAT('sa-', CAST(org_id AS CHAR), '-',
                 CASE
@@ -59,23 +66,11 @@ func (p *ServiceAccountsSameLoginCrossOrgs) Exec(sess *xorm.Session, mg *migrato
             WHERE login IS NOT NULL
               AND is_service_account = 1
               AND login NOT LIKE CONCAT('sa-', org_id, '-%');
-        `)
-	case migrator.SQLite:
-		_, err = p.sess.Exec(`
-            UPDATE ` + p.dialect.Quote("user") + `
-            SET login = 'sa-' || CAST(org_id AS TEXT) || '-' ||
-                CASE
-                    WHEN SUBSTR(login, 1, 3) = 'sa-' THEN SUBSTR(login, 4)
-                    ELSE login
-                END
-            WHERE login IS NOT NULL
-              AND is_service_account = 1
-              AND login NOT LIKE 'sa-' || CAST(org_id AS TEXT) || '-%';
-        `)
-
+        `
 	default:
-		return fmt.Errorf("dialect not supported: %s", p.dialect)
+		// nop
 	}
+	_, err := p.sess.Exec(q)
 	return err
 }
 
@@ -89,12 +84,21 @@ func (p *ServiceAccountsDeduplicateOrgInLogin) SQL(dialect migrator.Dialect) str
 
 func (p *ServiceAccountsDeduplicateOrgInLogin) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	dialect := mg.Dialect
-	var err error
-
-	// var logins []Login
+	q := `
+		UPDATE ` + dialect.Quote("user") + ` AS u
+		SET login = 'sa-' || CAST(u.org_id AS TEXT) || SUBSTRING(u.login, LENGTH('sa-'||CAST(u.org_id AS TEXT)||'-'||CAST(u.org_id AS TEXT))+1)
+		WHERE u.login IS NOT NULL
+			AND u.is_service_account = 1
+			AND u.login LIKE 'sa-'||CAST(u.org_id AS TEXT)||'-'||CAST(u.org_id AS TEXT)||'-%'
+			AND NOT EXISTS (
+				SELECT 1
+				FROM  ` + dialect.Quote("user") + `AS u2
+				WHERE u2.login = 'sa-' || CAST(u.org_id AS TEXT) || SUBSTRING(u.login, LENGTH('sa-'||CAST(u.org_id AS TEXT)||'-'||CAST(u.org_id AS TEXT))+1)
+			);;
+	`
 	switch dialect.DriverName() {
 	case migrator.Postgres:
-		_, err = sess.Exec(`
+		q = `
             UPDATE "user" AS u
             SET login = 'sa-' || org_id::text || SUBSTRING(login FROM LENGTH('sa-' || org_id::text || '-' || org_id::text)+1)
             WHERE login IS NOT NULL
@@ -105,9 +109,9 @@ func (p *ServiceAccountsDeduplicateOrgInLogin) Exec(sess *xorm.Session, mg *migr
                 FROM "user" AS u2
                 WHERE u2.login = 'sa-' || u.org_id::text || SUBSTRING(u.login FROM LENGTH('sa-' || u.org_id::text || '-' || u.org_id::text)+1)
             );;
-        `)
+        `
 	case migrator.MySQL:
-		_, err = sess.Exec(`
+		q = `
             UPDATE user AS u
             LEFT JOIN user AS u2 ON u2.login = CONCAT('sa-', u.org_id, SUBSTRING(u.login, LENGTH(CONCAT('sa-', u.org_id, '-', u.org_id))+1))
             SET u.login = CONCAT('sa-', u.org_id, SUBSTRING(u.login, LENGTH(CONCAT('sa-', u.org_id, '-', u.org_id))+1))
@@ -115,23 +119,10 @@ func (p *ServiceAccountsDeduplicateOrgInLogin) Exec(sess *xorm.Session, mg *migr
                 AND u.is_service_account = 1
                 AND u.login LIKE CONCAT('sa-', u.org_id, '-', u.org_id, '-%')
                 AND u2.login IS NULL;
-        `)
-	case migrator.SQLite:
-		_, err = sess.Exec(`
-            UPDATE ` + dialect.Quote("user") + ` AS u
-            SET login = 'sa-' || CAST(u.org_id AS TEXT) || SUBSTRING(u.login, LENGTH('sa-'||CAST(u.org_id AS TEXT)||'-'||CAST(u.org_id AS TEXT))+1)
-            WHERE u.login IS NOT NULL
-                AND u.is_service_account = 1
-                AND u.login LIKE 'sa-'||CAST(u.org_id AS TEXT)||'-'||CAST(u.org_id AS TEXT)||'-%'
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM  ` + dialect.Quote("user") + `AS u2
-                    WHERE u2.login = 'sa-' || CAST(u.org_id AS TEXT) || SUBSTRING(u.login, LENGTH('sa-'||CAST(u.org_id AS TEXT)||'-'||CAST(u.org_id AS TEXT))+1)
-                );;
-        `)
+        `
 	default:
-		return fmt.Errorf("dialect not supported: %s", dialect)
+		// nop
 	}
-
+	_, err := sess.Exec(q)
 	return err
 }


### PR DESCRIPTION
> This PR no requires CHANGELOG entry because PR is only about refactoring - NOP for business-logic

This change fixes the ServiceMigration / code migration ServiceAccountsSameLoginCrossOrgs in pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go.
- **Exec must use the `xorm.Session` passed in by the migrator** (sess), not a struct field. The session is created and supplied by the sqlstore migrator (`migrator.Migrator` → `CodeMigration.Exec(sess, mg)`); this package does not own session lifecycle, so relying on `p.sess` is incorrect and can be nil or stale.
- **Dialect-specific SQL stays behind an explicit switch on `mg.Dialect.DriverName()`, with the default branch keeping the portable query built with `dialect.Quote(...)`** and generic constructs. That way anything that is not the Postgres/MySQL specialized branches still runs a dialect-aware baseline instead of assuming this file “knows” every driver Grafana might ever use.

(Aligns the first migration with the same pattern as ServiceAccountsDeduplicateOrgInLogin in the same file, which already uses sess.Exec(q).)

## Why do we need this feature?

Code migrations receive the active DB session from the migrator; using a different session reference breaks the contract of CodeMigration and is fragile. Separately, usermig does not control which dialect is registered at runtime—only Postgres/MySQL get hand-tuned SQL; **all other drivers must fall through to the quoted, portable statement**. This makes the migration correct and easier to reason about for maintainers and for any environment that plugs in another SQL backend via the same migrator interfaces.

## Who is this feature for?

Operators and developers running Grafana migrations against supported databases, and anyone extending the sqlstore/migrator stack while keeping migrations safe.

## Which issue(s) does this PR fix?:

Fixes #120682 (partly)

## Special notes for your reviewer:

Please check that:
- [x] It works as expected from a user's perspective. (migrations only — no UI change)
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (N/A unless you want a one-line release note — optional for an internal migration fix)

## Additional context

- The migrator invokes `CodeMigration.Exec(sess, mg)` with the live session; **sess is the only session that should be used for `Exec(q)`** in this handler.
- The **default branch of the dialect switch is intentional**: it is not “SQLite-only,” **it is “every driver that is not covered by the Postgres/MySQL-specific statements**”, using the query built from `Dialect` metadata first.