### PR TITLE
SQL Store: Allow registering migrator dialects from other packages

### DIFF
--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -125,6 +125,13 @@ var supportedDialects = map[string]dialectFunc{
 	Postgres + "WithHooks": NewPostgresDialect,
 }
 
+func RegisterDialect(driverName string, f dialectFunc) {
+	if _, has := supportedDialects[driverName]; has {
+		panic(fmt.Errorf("dialect %q already registered", driverName))
+	}
+	supportedDialects[driverName] = f
+}
+
 func NewDialect(driverName string) Dialect {
 	if fn, exist := supportedDialects[driverName]; exist {
 		return fn()


### PR DESCRIPTION
## What is this feature?

Adds `migrator.RegisterDialect(driverName string, f dialectFunc)`, so additional `migrator.Dialect` implementations can be registered for a database/sql driver name without editing the built-in supportedDialects map in `pkg/services/sqlstore/migrator/dialect.go`.
Duplicate registration for the same `driverName` fails fast with a panic (same idea as conflicting registration in `database/sql`).

## Why do we need this feature?

The migrator’s dialect registry is currently a closed set keyed by `engine.DriverName()`. If you run Grafana with a driver name that is not one of the built-ins, `NewDialect` panics at startup even when you could supply a correct `Dialect` implementation elsewhere (e.g. in a fork, a private module, or a build-tagged integration package).

This mirrors patterns already used in the codebase and ecosystem:

- `database/sql` driver registration
- `github.com/grafana/grafana/pkg/util/xorm/core.RegisterDialect` for xorm dialects

So downstream embedders can **extend** SQL/migration behavior by importing a package whose `init()` registers a dialect, instead of maintaining a permanent patch to core Grafana.

## Who is this feature for?

- Teams shipping **custom or downstream builds** of Grafana that use an alternate SQL backend or compatibility layer (still implementing `migrator.Dialect` and wiring the driver themselves).
- Integrators who want a **clean extension point** and smaller diffs vs upstream when experimenting with storage backends.

## Which issue(s) does this PR fix?

Fixes #120682 (partly)

### Special notes for your reviewer:
- Registration must run **before** `migrator.NewDialect` is called for that driver (typically from `init()` in an imported package, same as `sql.Register`).
- Upstream behavior for MySQL / PostgreSQL / SQLite is unchanged; this only adds an opt-in hook.
- Happy to add a small unit test that registers a minimal dialect and asserts `NewDialect` returns it, if you want that locked in.

### Please check that:
- [x] It works as expected from a user's perspective. (N/A — no end-user UI; library hook for embedders.)
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A)
- [ ] The docs are updated… (Optional: godoc on `RegisterDialect` is enough unless you want a short “embedding / custom SQL” note; this is not a user-facing Grafana feature.)
