### PR TITLE
Auth: Add disable_forgot_password config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -638,6 +638,10 @@ token_rotation_interval_minutes = 10
 # Set to true to disable (hide) the login form, useful if you use OAuth
 disable_login_form = false
 
+# Set to true to hide the "Forgot your password?" link on the login page.
+# Useful when using LDAP or other external authentication where Grafana cannot reset the password.
+disable_forgot_password = false
+
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt.
 disable_signout_menu = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -628,6 +628,10 @@
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
 
+# Set to true to hide the "Forgot your password?" link on the login page, defaults to false
+# Useful when using LDAP or other external authentication where Grafana cannot reset the password.
+;disable_forgot_password = false
+
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt, defaults to false
 ;disable_signout_menu = false
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -382,6 +382,7 @@ export interface AuthSettings {
   GenericOAuthSkipOrgRoleSync?: boolean;
 
   disableLogin?: boolean;
+  disableForgotPassword?: boolean;
   passwordlessEnabled?: boolean;
   basicAuthStrongPasswordPolicy?: boolean;
   disableSignoutMenu?: boolean;

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -32,6 +32,7 @@ type FrontendSettingsAuthDTO struct {
 	OktaSkipOrgRoleSync bool `json:"OktaSkipOrgRoleSync"`
 
 	DisableLogin                  bool `json:"disableLogin"`
+	DisableForgotPassword         bool `json:"disableForgotPassword"`
 	BasicAuthStrongPasswordPolicy bool `json:"basicAuthStrongPasswordPolicy"`
 	PasswordlessEnabled           bool `json:"passwordlessEnabled"`
 	DisableSignoutMenu            bool `json:"disableSignoutMenu"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -407,6 +407,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		GitLabSkipOrgRoleSync:         parseSkipOrgRoleSyncEnabled(oauthProviders[social.GitlabProviderName]),
 		OktaSkipOrgRoleSync:           parseSkipOrgRoleSyncEnabled(oauthProviders[social.OktaProviderName]),
 		DisableLogin:                  hs.Cfg.DisableLogin,
+		DisableForgotPassword:         hs.Cfg.DisableForgotPassword,
 		BasicAuthStrongPasswordPolicy: hs.Cfg.BasicAuthStrongPasswordPolicy,
 		DisableSignoutMenu:            hs.Cfg.DisableSignoutMenu,
 	}

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (hs *HTTPServer) SendResetPasswordEmail(c *contextmodel.ReqContext) response.Response {
-	if hs.Cfg.DisableLoginForm || hs.Cfg.DisableLogin {
+	if hs.Cfg.DisableLoginForm || hs.Cfg.DisableLogin || hs.Cfg.DisableForgotPassword {
 		return response.Error(http.StatusUnauthorized, "Not allowed to reset password when login form is disabled", nil)
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -280,6 +280,7 @@ type Cfg struct {
 	DisableLogin                  bool
 	AdminEmail                    string
 	DisableLoginForm              bool
+	DisableForgotPassword         bool
 	SignoutRedirectUrl            string
 	IDResponseHeaderEnabled       bool
 	IDResponseHeaderPrefix        string
@@ -1907,6 +1908,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	}
 
 	cfg.DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
+	cfg.DisableForgotPassword = auth.Key("disable_forgot_password").MustBool(false)
 	cfg.DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
 
 	// Deprecated

--- a/public/app/core/components/Login/LoginPage.test.tsx
+++ b/public/app/core/components/Login/LoginPage.test.tsx
@@ -17,6 +17,7 @@ jest.mock('@grafana/runtime', () => ({
     ...jest.requireActual('@grafana/runtime').config,
     auth: {
       disableLogin: false,
+      disableForgotPassword: false,
     },
     loginError: false,
     buildInfo: {

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -60,7 +60,7 @@ const LoginPage = () => {
                     isLoggingIn={isLoggingIn}
                   >
                     <Stack justifyContent="flex-end">
-                      {!config.auth.disableLogin && (
+                      {!config.auth.disableLogin && !config.auth.disableForgotPassword && (
                         <LinkButton
                           className={styles.forgottenPassword}
                           fill="text"


### PR DESCRIPTION
## Summary

- Adds a new `disable_forgot_password` setting under `[auth]` in `grafana.ini` to allow hiding the "Forgot your password?" link on the login page
- Guards the password reset API endpoint (`/api/user/password/send-reset-email`) when the setting is enabled
- Useful for environments using mixed authentication (e.g., Basic Auth + LDAP) where the password reset link confuses LDAP users

Closes #113075

## Details

When Grafana is configured with both basic authentication and LDAP, the "Forgot your password?" link is visible to all users, including LDAP users who cannot reset their passwords through Grafana. This causes user confusion and unnecessary support overhead.

This PR adds a dedicated `disable_forgot_password` configuration option (defaulting to `false`) that:
1. Hides the "Forgot your password?" link on the login page
2. Blocks the password reset email API endpoint
3. Is independent of `disable_login` and `disable_login_form` so administrators can keep the login form visible while hiding only the password reset link

### Configuration

```ini
[auth]
disable_forgot_password = true
```

### Files changed

| File | Change |
|------|--------|
| `pkg/setting/setting.go` | New `DisableForgotPassword` config field |
| `pkg/api/dtos/frontend_settings.go` | Add to `FrontendSettingsAuthDTO` |
| `pkg/api/frontendsettings.go` | Wire setting to frontend |
| `pkg/api/password.go` | Guard password reset endpoint |
| `packages/grafana-data/src/types/config.ts` | TypeScript type for auth settings |
| `public/app/core/components/Login/LoginPage.tsx` | Conditionally hide forgot password link |
| `public/app/core/components/Login/LoginPage.test.tsx` | Add setting to test mock |
| `conf/defaults.ini` | Document new setting with default |
| `conf/sample.ini` | Document new setting as commented example |

## Test plan

- [ ] Set `disable_forgot_password = false` (default) — verify "Forgot your password?" link is visible on login page
- [ ] Set `disable_forgot_password = true` — verify the link is hidden
- [ ] With `disable_forgot_password = true`, POST to `/api/user/password/send-reset-email` — verify it returns 401
- [ ] Verify existing `disable_login` behavior is unchanged
- [ ] Run `yarn jest --no-watch public/app/core/components/Login/LoginPage.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)