### PR TITLE
IAM: Fix user StoreWrapper panic in multi-tenant deployments

### DIFF
--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -113,7 +114,8 @@ type IdentityAccessManagementAPIBuilder struct {
 
 	tracing tracing.Tracer
 
-	cfgProvider configprovider.ConfigProvider
+	cfgProvider    configprovider.ConfigProvider
+	settingService settingsvc.Service
 
 	apiConfig Config
 }

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -53,6 +53,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	teamservice "github.com/grafana/grafana/pkg/services/team"
 	legacyuser "github.com/grafana/grafana/pkg/services/user"
@@ -180,6 +181,7 @@ func NewAPIService(
 	authorizerDialConfigs map[schema.GroupResource]iamauthorizer.DialConfig,
 	tracingService tracing.Tracer,
 	mappers *resourcepermission.MappersRegistry,
+	settingService settingsvc.Service,
 ) *IdentityAccessManagementAPIBuilder {
 	store := legacy.NewLegacySQLStores(dbProvider)
 	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, mappers)
@@ -215,6 +217,7 @@ func NewAPIService(
 		globalRoleApiInstaller:     globalRoleApiInstaller,
 		apiConfig:                  Config{SingleOrganization: true},
 		teamLBACApiInstaller:       teamLBACApiInstaller,
+		settingService:             settingService,
 		authorizer: authorizer.AuthorizerFunc(
 			func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				user, ok := types.AuthInfoFrom(ctx)
@@ -545,7 +548,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateUsersAPIGroup(opts builder.AP
 		}
 	}
 
-	storage[userResource.StoragePath()] = storewrapper.New(userStore, user.NewStoreWrapper(b.cfgProvider), storewrapper.WithPreserveIdentity())
+	storage[userResource.StoragePath()] = storewrapper.New(userStore, user.NewStoreWrapper(b.cfgProvider, b.settingService), storewrapper.WithPreserveIdentity())
 
 	if b.dual != nil && b.unified != nil {
 		legacyTeamBindingSearchClient := teambinding.NewLegacyTeamBindingSearchClient(b.store, b.tracing)

--- a/pkg/registry/apis/iam/user/store_wrapper.go
+++ b/pkg/registry/apis/iam/user/store_wrapper.go
@@ -3,41 +3,85 @@ package user
 import (
 	"context"
 	"errors"
+	"strings"
 
 	claims "github.com/grafana/authlib/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 )
 
 // StoreWrapper filters users based on the hidden users configuration.
 // It does not enforce any write authorization — those are handled at the API level.
 type StoreWrapper struct {
-	cfgProvider configprovider.ConfigProvider
-	logger      log.Logger
+	cfgProvider    configprovider.ConfigProvider
+	settingService settingsvc.Service
+	logger         log.Logger
 }
 
 var _ storewrapper.ResourceStorageAuthorizer = (*StoreWrapper)(nil)
 
-func NewStoreWrapper(cfgProvider configprovider.ConfigProvider) *StoreWrapper {
+func NewStoreWrapper(cfgProvider configprovider.ConfigProvider, settingService settingsvc.Service) *StoreWrapper {
 	return &StoreWrapper{
-		cfgProvider: cfgProvider,
-		logger:      log.New("grafana-apiserver.users.storewrapper"),
+		cfgProvider:    cfgProvider,
+		settingService: settingService,
+		logger:         log.New("grafana-apiserver.users.storewrapper"),
 	}
+}
+
+// hiddenUsersSelector selects the hidden_users setting from the users section.
+var hiddenUsersSelector = metav1.LabelSelector{
+	MatchLabels: map[string]string{
+		"section": "users",
+		"key":     "hidden_users",
+	},
+}
+
+// getHiddenUsers returns the set of hidden user logins by querying either the
+// local ConfigProvider (single-tenant) or the remote setting.Service (multi-tenant).
+func (f *StoreWrapper) getHiddenUsers(ctx context.Context) (map[string]struct{}, error) {
+	if f.cfgProvider != nil {
+		cfg, err := f.cfgProvider.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return cfg.HiddenUsers, nil
+	}
+
+	if f.settingService != nil {
+		settings, err := f.settingService.List(ctx, hiddenUsersSelector)
+		if err != nil {
+			return nil, err
+		}
+		hidden := make(map[string]struct{})
+		for _, s := range settings {
+			for _, login := range strings.Split(s.Value, ",") {
+				login = strings.TrimSpace(login)
+				if login != "" {
+					hidden[login] = struct{}{}
+				}
+			}
+		}
+		return hidden, nil
+	}
+
+	return nil, errors.New("user store wrapper: neither cfgProvider nor settingService is configured")
 }
 
 // AfterGet returns NotFound if the user's login is in the hidden users list
 // and the requester is not the user themselves.
 func (f *StoreWrapper) AfterGet(ctx context.Context, obj runtime.Object) error {
-	cfg, err := f.cfgProvider.Get(ctx)
+	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
 	}
-	if len(cfg.HiddenUsers) == 0 {
+	if len(hiddenUsers) == 0 {
 		return nil
 	}
 
@@ -52,7 +96,7 @@ func (f *StoreWrapper) AfterGet(ctx context.Context, obj runtime.Object) error {
 	}
 
 	login := u.Spec.Login
-	if _, isHidden := cfg.HiddenUsers[login]; isHidden && login != authInfo.GetUsername() {
+	if _, isHidden := hiddenUsers[login]; isHidden && login != authInfo.GetUsername() {
 		return apierrors.NewNotFound(iamv0.UserResourceInfo.GroupResource(), u.Name)
 	}
 
@@ -61,11 +105,11 @@ func (f *StoreWrapper) AfterGet(ctx context.Context, obj runtime.Object) error {
 
 // FilterList removes hidden users from the list, except for the requester themselves.
 func (f *StoreWrapper) FilterList(ctx context.Context, list runtime.Object) (runtime.Object, error) {
-	cfg, err := f.cfgProvider.Get(ctx)
+	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(cfg.HiddenUsers) == 0 {
+	if len(hiddenUsers) == 0 {
 		return list, nil
 	}
 
@@ -82,7 +126,7 @@ func (f *StoreWrapper) FilterList(ctx context.Context, list runtime.Object) (run
 	requesterLogin := authInfo.GetUsername()
 	filtered := make([]iamv0.User, 0, len(userList.Items))
 	for _, u := range userList.Items {
-		if _, isHidden := cfg.HiddenUsers[u.Spec.Login]; !isHidden || u.Spec.Login == requesterLogin {
+		if _, isHidden := hiddenUsers[u.Spec.Login]; !isHidden || u.Spec.Login == requesterLogin {
 			filtered = append(filtered, u)
 		}
 	}
@@ -92,11 +136,11 @@ func (f *StoreWrapper) FilterList(ctx context.Context, list runtime.Object) (run
 
 // BeforeCreate returns Forbidden if the new user's login is in the hidden users list.
 func (f *StoreWrapper) BeforeCreate(ctx context.Context, obj runtime.Object) error {
-	cfg, err := f.cfgProvider.Get(ctx)
+	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
 	}
-	if len(cfg.HiddenUsers) == 0 {
+	if len(hiddenUsers) == 0 {
 		return nil
 	}
 
@@ -105,7 +149,7 @@ func (f *StoreWrapper) BeforeCreate(ctx context.Context, obj runtime.Object) err
 		return nil
 	}
 
-	if _, isHidden := cfg.HiddenUsers[u.Spec.Login]; isHidden {
+	if _, isHidden := hiddenUsers[u.Spec.Login]; isHidden {
 		f.logger.Info("blocked create for hidden user", "login", u.Spec.Login, "name", u.Name)
 		return apierrors.NewForbidden(iamv0.UserResourceInfo.GroupResource(), u.Name, errors.New("operation not permitted"))
 	}
@@ -115,11 +159,11 @@ func (f *StoreWrapper) BeforeCreate(ctx context.Context, obj runtime.Object) err
 
 // BeforeUpdate returns Forbidden if the target user (old object) or the new login is in the hidden users list.
 func (f *StoreWrapper) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	cfg, err := f.cfgProvider.Get(ctx)
+	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
 	}
-	if len(cfg.HiddenUsers) == 0 {
+	if len(hiddenUsers) == 0 {
 		return nil
 	}
 
@@ -128,7 +172,7 @@ func (f *StoreWrapper) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Obj
 		return nil
 	}
 
-	if _, isHidden := cfg.HiddenUsers[oldUser.Spec.Login]; isHidden {
+	if _, isHidden := hiddenUsers[oldUser.Spec.Login]; isHidden {
 		f.logger.Info("blocked update for hidden user", "login", oldUser.Spec.Login, "name", oldUser.Name)
 		return apierrors.NewForbidden(iamv0.UserResourceInfo.GroupResource(), oldUser.Name, errors.New("operation not permitted"))
 	}
@@ -139,7 +183,7 @@ func (f *StoreWrapper) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Obj
 		return nil
 	}
 
-	if _, isHidden := cfg.HiddenUsers[newUser.Spec.Login]; isHidden {
+	if _, isHidden := hiddenUsers[newUser.Spec.Login]; isHidden {
 		f.logger.Info("blocked update to hidden user login", "login", newUser.Spec.Login, "name", newUser.Name)
 		return apierrors.NewForbidden(iamv0.UserResourceInfo.GroupResource(), newUser.Name, errors.New("operation not permitted"))
 	}
@@ -149,11 +193,11 @@ func (f *StoreWrapper) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Obj
 
 // BeforeDelete returns Forbidden if the target user is in the hidden users list.
 func (f *StoreWrapper) BeforeDelete(ctx context.Context, obj runtime.Object) error {
-	cfg, err := f.cfgProvider.Get(ctx)
+	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
 	}
-	if len(cfg.HiddenUsers) == 0 {
+	if len(hiddenUsers) == 0 {
 		return nil
 	}
 
@@ -162,7 +206,7 @@ func (f *StoreWrapper) BeforeDelete(ctx context.Context, obj runtime.Object) err
 		return nil
 	}
 
-	if _, isHidden := cfg.HiddenUsers[u.Spec.Login]; isHidden {
+	if _, isHidden := hiddenUsers[u.Spec.Login]; isHidden {
 		f.logger.Info("blocked delete for hidden user", "login", u.Spec.Login, "name", u.Name)
 		return apierrors.NewForbidden(iamv0.UserResourceInfo.GroupResource(), u.Name, errors.New("operation not permitted"))
 	}

--- a/pkg/registry/apis/iam/user/store_wrapper_test.go
+++ b/pkg/registry/apis/iam/user/store_wrapper_test.go
@@ -1,0 +1,310 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	claims "github.com/grafana/authlib/types"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+)
+
+func TestStoreWrapper_SettingService_AfterGet(t *testing.T) {
+	tests := []struct {
+		name        string
+		settings    []*settingsvc.Setting
+		login       string
+		requester   string
+		expectError bool
+		isNotFound  bool
+	}{
+		{
+			name:        "no hidden users setting returns nil",
+			settings:    nil,
+			login:       "admin",
+			requester:   "viewer",
+			expectError: false,
+		},
+		{
+			name: "empty hidden_users value returns nil",
+			settings: []*settingsvc.Setting{
+				{Section: "users", Key: "hidden_users", Value: ""},
+			},
+			login:       "admin",
+			requester:   "viewer",
+			expectError: false,
+		},
+		{
+			name: "hidden user returns NotFound for other requester",
+			settings: []*settingsvc.Setting{
+				{Section: "users", Key: "hidden_users", Value: "admin"},
+			},
+			login:       "admin",
+			requester:   "viewer",
+			expectError: true,
+			isNotFound:  true,
+		},
+		{
+			name: "hidden user can see themselves",
+			settings: []*settingsvc.Setting{
+				{Section: "users", Key: "hidden_users", Value: "admin"},
+			},
+			login:       "admin",
+			requester:   "admin",
+			expectError: false,
+		},
+		{
+			name: "comma-separated hidden users",
+			settings: []*settingsvc.Setting{
+				{Section: "users", Key: "hidden_users", Value: "admin, servicebot"},
+			},
+			login:       "servicebot",
+			requester:   "viewer",
+			expectError: true,
+			isNotFound:  true,
+		},
+		{
+			name: "non-hidden user is allowed",
+			settings: []*settingsvc.Setting{
+				{Section: "users", Key: "hidden_users", Value: "admin"},
+			},
+			login:       "viewer",
+			requester:   "other",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sw := NewStoreWrapper(nil, &fakeSettingService{settings: tt.settings})
+			ctx := withAuthInfo(context.Background(), tt.requester)
+			user := &iamv0.User{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.login},
+				Spec:       iamv0.UserSpec{Login: tt.login},
+			}
+
+			err := sw.AfterGet(ctx, user)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.isNotFound {
+					assert.True(t, apierrors.IsNotFound(err))
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStoreWrapper_SettingService_FilterList(t *testing.T) {
+	sw := NewStoreWrapper(nil, &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: "users", Key: "hidden_users", Value: "hidden1, hidden2"},
+		},
+	})
+	ctx := withAuthInfo(context.Background(), "hidden1")
+
+	list := &iamv0.UserList{
+		Items: []iamv0.User{
+			{Spec: iamv0.UserSpec{Login: "visible"}},
+			{Spec: iamv0.UserSpec{Login: "hidden1"}}, // requester themselves
+			{Spec: iamv0.UserSpec{Login: "hidden2"}},
+			{Spec: iamv0.UserSpec{Login: "another"}},
+		},
+	}
+
+	result, err := sw.FilterList(ctx, list)
+	require.NoError(t, err)
+
+	userList := result.(*iamv0.UserList)
+	logins := make([]string, len(userList.Items))
+	for i, u := range userList.Items {
+		logins[i] = u.Spec.Login
+	}
+	assert.Equal(t, []string{"visible", "hidden1", "another"}, logins)
+}
+
+func TestStoreWrapper_SettingService_BeforeCreate(t *testing.T) {
+	sw := NewStoreWrapper(nil, &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: "users", Key: "hidden_users", Value: "admin"},
+		},
+	})
+	ctx := context.Background()
+
+	t.Run("blocked for hidden login", func(t *testing.T) {
+		err := sw.BeforeCreate(ctx, &iamv0.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "admin"},
+			Spec:       iamv0.UserSpec{Login: "admin"},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("allowed for non-hidden login", func(t *testing.T) {
+		err := sw.BeforeCreate(ctx, &iamv0.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "viewer"},
+			Spec:       iamv0.UserSpec{Login: "viewer"},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestStoreWrapper_SettingService_BeforeUpdate(t *testing.T) {
+	sw := NewStoreWrapper(nil, &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: "users", Key: "hidden_users", Value: "admin"},
+		},
+	})
+	ctx := context.Background()
+
+	t.Run("blocked when old user is hidden", func(t *testing.T) {
+		oldObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "admin"}, Spec: iamv0.UserSpec{Login: "admin"}}
+		newObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "admin"}, Spec: iamv0.UserSpec{Login: "newlogin"}}
+		err := sw.BeforeUpdate(ctx, oldObj, newObj)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("blocked when new login is hidden", func(t *testing.T) {
+		oldObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "viewer"}, Spec: iamv0.UserSpec{Login: "viewer"}}
+		newObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "viewer"}, Spec: iamv0.UserSpec{Login: "admin"}}
+		err := sw.BeforeUpdate(ctx, oldObj, newObj)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("allowed when neither is hidden", func(t *testing.T) {
+		oldObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "viewer"}, Spec: iamv0.UserSpec{Login: "viewer"}}
+		newObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "viewer"}, Spec: iamv0.UserSpec{Login: "editor"}}
+		err := sw.BeforeUpdate(ctx, oldObj, newObj)
+		require.NoError(t, err)
+	})
+}
+
+func TestStoreWrapper_SettingService_BeforeDelete(t *testing.T) {
+	sw := NewStoreWrapper(nil, &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: "users", Key: "hidden_users", Value: "admin"},
+		},
+	})
+	ctx := context.Background()
+
+	t.Run("blocked for hidden user", func(t *testing.T) {
+		err := sw.BeforeDelete(ctx, &iamv0.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "admin"},
+			Spec:       iamv0.UserSpec{Login: "admin"},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("allowed for non-hidden user", func(t *testing.T) {
+		err := sw.BeforeDelete(ctx, &iamv0.User{
+			ObjectMeta: metav1.ObjectMeta{Name: "viewer"},
+			Spec:       iamv0.UserSpec{Login: "viewer"},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestStoreWrapper_NilProviders(t *testing.T) {
+	sw := NewStoreWrapper(nil, nil)
+	ctx := withAuthInfo(context.Background(), "admin")
+
+	user := &iamv0.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin"},
+		Spec:       iamv0.UserSpec{Login: "admin"},
+	}
+
+	errMsg := "neither cfgProvider nor settingService is configured"
+
+	t.Run("AfterGet returns error", func(t *testing.T) {
+		err := sw.AfterGet(ctx, user)
+		require.ErrorContains(t, err, errMsg)
+	})
+
+	t.Run("FilterList returns error", func(t *testing.T) {
+		list := &iamv0.UserList{Items: []iamv0.User{*user}}
+		_, err := sw.FilterList(ctx, list)
+		require.ErrorContains(t, err, errMsg)
+	})
+
+	t.Run("BeforeCreate returns error", func(t *testing.T) {
+		require.ErrorContains(t, sw.BeforeCreate(ctx, user), errMsg)
+	})
+
+	t.Run("BeforeUpdate returns error", func(t *testing.T) {
+		require.ErrorContains(t, sw.BeforeUpdate(ctx, user, user), errMsg)
+	})
+
+	t.Run("BeforeDelete returns error", func(t *testing.T) {
+		require.ErrorContains(t, sw.BeforeDelete(ctx, user), errMsg)
+	})
+}
+
+func TestStoreWrapper_SettingService_Error(t *testing.T) {
+	sw := NewStoreWrapper(nil, &fakeSettingService{
+		err: assert.AnError,
+	})
+	ctx := context.Background()
+	user := &iamv0.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin"},
+		Spec:       iamv0.UserSpec{Login: "admin"},
+	}
+
+	t.Run("AfterGet propagates error", func(t *testing.T) {
+		require.ErrorIs(t, sw.AfterGet(ctx, user), assert.AnError)
+	})
+
+	t.Run("FilterList propagates error", func(t *testing.T) {
+		_, err := sw.FilterList(ctx, &iamv0.UserList{})
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("BeforeCreate propagates error", func(t *testing.T) {
+		require.ErrorIs(t, sw.BeforeCreate(ctx, user), assert.AnError)
+	})
+
+	t.Run("BeforeUpdate propagates error", func(t *testing.T) {
+		require.ErrorIs(t, sw.BeforeUpdate(ctx, user, user), assert.AnError)
+	})
+
+	t.Run("BeforeDelete propagates error", func(t *testing.T) {
+		require.ErrorIs(t, sw.BeforeDelete(ctx, user), assert.AnError)
+	})
+}
+
+// withAuthInfo adds a StaticRequester to the context so claims.AuthInfoFrom succeeds.
+func withAuthInfo(ctx context.Context, login string) context.Context {
+	return claims.WithAuthInfo(ctx, &identity.StaticRequester{
+		Type:  claims.TypeUser,
+		Login: login,
+	})
+}
+
+// fakeSettingService implements settingsvc.Service for testing.
+type fakeSettingService struct {
+	settings []*settingsvc.Setting
+	err      error
+}
+
+func (f *fakeSettingService) ListAsIni(_ context.Context, _ metav1.LabelSelector) (*ini.File, error) {
+	return nil, f.err
+}
+
+func (f *fakeSettingService) List(_ context.Context, _ metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	return f.settings, f.err
+}
+
+func (f *fakeSettingService) Describe(chan<- *prometheus.Desc) {}
+func (f *fakeSettingService) Collect(chan<- prometheus.Metric) {}


### PR DESCRIPTION
## Summary
- Adds `setting.Service` as an alternative config source in the user `StoreWrapper` for multi-tenant (MT) deployments where `ConfigProvider` is nil
- Introduces `getHiddenUsers` helper that routes between `ConfigProvider` (single-tenant) and `setting.Service` (multi-tenant), returning an error if neither is configured
- Adds `setting.Service` as a dependency to `NewAPIService` and wires it through the `IdentityAccessManagementAPIBuilder`

## Test plan
- [x] Unit tests added for all `StoreWrapper` methods using `setting.Service` (`AfterGet`, `FilterList`, `BeforeCreate`, `BeforeUpdate`, `BeforeDelete`)
- [x] Tests cover: hidden user filtering, comma-separated values, self-visibility, error propagation, nil-providers error
- [x] Verified existing code compiles (`go build ./pkg/registry/apis/iam/...`)
- [ ] Verify MT callers of `NewAPIService` pass the `setting.Service` parameter