### PR TITLE
Delegate unified SQL getEngine to xorm.NewEngine (stop duplicating supported DB types in getEngine)

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/db_engine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db_engine.go
@@ -10,19 +10,14 @@ import (
 )
 
 func getEngine(config *sqlstore.DatabaseConfig) (*xorm.Engine, error) {
-	switch config.Type {
-	case dbTypeMySQL, dbTypePostgres, dbTypeSQLite:
-		engine, err := xorm.NewEngine(config.Type, config.ConnectionString)
-		if err != nil {
-			return nil, fmt.Errorf("open database: %w", err)
-		}
-
-		engine.SetMaxOpenConns(config.MaxOpenConn)
-		engine.SetMaxIdleConns(config.MaxIdleConn)
-		engine.SetConnMaxLifetime(time.Duration(config.ConnMaxLifetime) * time.Second)
-
-		return engine, nil
-	default:
-		return nil, fmt.Errorf("unsupported database type: %s", config.Type)
+	engine, err := xorm.NewEngine(config.Type, config.ConnectionString)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
 	}
+
+	engine.SetMaxOpenConns(config.MaxOpenConn)
+	engine.SetMaxIdleConns(config.MaxIdleConn)
+	engine.SetConnMaxLifetime(time.Duration(config.ConnMaxLifetime) * time.Second)
+
+	return engine, nil
 }


### PR DESCRIPTION
## TL;DR;

> Removes a redundant switch on DB type in the unified resource SQL `getEngine` and relies on `xorm.NewEngine` (and existing `sqlstore` config validation) so driver support stays aligned with `pkg/util/xorm` and matches how the core `sqlstore` opens engines.

## What is this feature?

`getEngine` in `pkg/storage/unified/sql/db/dbimpl/db_engine.go` no longer uses a local `switch` that only allows `mysql`, `postgres`, and `sqlite3`. It always builds the engine with `xorm.NewEngine(config.Type, config.ConnectionString)` and applies the same pool settings as before. Unsupported drivers still fail, but validation comes from Grafana’s forked `xorm` (`unsupported driver name` / dialect errors) instead of a second, hard-coded list in this package.

## Why do we need this feature?

- **Single source of truth**: Supported SQL backends are already determined by driver/dialect registration in `pkg/util/xorm` and by connection-string handling in `sqlstore` (`NewDatabaseConfig` / `buildConnectionString`). The extra allowlist in `getEngine` duplicated that policy without adding real safety for supported types.
- **Consistency with core sqlstore**: The main Grafana DB path uses `xorm.NewEngine` directly on `DatabaseConfig`; the unified resource SQL path should follow the same pattern instead of maintaining a parallel type list.
- **Correct behavior for registered drivers**: Grafana’s xorm registers multiple driver names for the same backend (e.g. `postgres` and `pgx`). A fixed three-way switch is easy to drift from xorm’s actual registrations and can block valid combinations that already work elsewhere.
- **Cleaner extension point for custom builds**: Custom or experimental SQL drivers can be wired by registering them with xorm’s `core` APIs without having to patch this `switch` again—while **upstream** behavior for standard configs is unchanged because unsupported types still fail when opening the engine or when building the connection string in `sqlstore`.


## Who is this feature for?

Operators and developers who run Grafana with the unified resource SQL store using the same `[database]` configuration as the core server, and maintainers who want less duplicated “supported DB” logic between `sqlstore` and the resource DB layer.

## Which issue(s) does this PR fix?

Fixes #120682 (partly)

## Special notes for your reviewer:

### Please check that:

- [x] It works as expected from a user's perspective. (No user-visible change for supported MySQL / Postgres / SQLite setups.)
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — internal refactor.)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (N/A unless you want a tiny “internal” note; not required for this refactor.)

## Additional context

- Error messages for truly unknown database.type values may now originate from `sqlstore.NewDatabaseConfig` / `buildConnectionString` or from `xorm.NewEngine` instead of unsupported database type from `getEngine`; existing tests that only assert substring "unknown" should still pass.
- No change to which databases Grafana officially supports; this only removes redundant layering in the resource DB provider.