### PR TITLE
Storage: Add `sqltemplate.RegisterDialect` for additional database drivers

### DIFF
--- a/pkg/storage/unified/sql/sqltemplate/dialect.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect.go
@@ -3,6 +3,7 @@ package sqltemplate
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -13,19 +14,28 @@ var (
 	ErrInvalidRowLockingClause = errors.New("invalid row-locking clause")
 )
 
+var supportedDialects = map[string]Dialect{
+	"mysql":    MySQL,
+	"postgres": PostgreSQL,
+	"pgx":      PostgreSQL,
+	"sqlite":   SQLite,
+	"sqlite3":  SQLite,
+}
+
+func RegisterDialect(driverName string, d Dialect) {
+	if _, has := supportedDialects[driverName]; has {
+		panic(fmt.Errorf("dialect %q already registerd", driverName))
+	}
+	supportedDialects[driverName] = d
+}
+
 // DialectForDriver returns a predefined Dialect for the given driver name, or
 // nil if no Dialect is known for that driver.
 func DialectForDriver(driverName string) Dialect {
-	switch strings.ToLower(driverName) {
-	case "mysql":
-		return MySQL
-	case "postgres", "pgx":
-		return PostgreSQL
-	case "sqlite", "sqlite3":
-		return SQLite
-	default:
-		return nil
+	if d, has := supportedDialects[driverName]; has {
+		return d
 	}
+	panic(fmt.Errorf("unknown dialect %q", driverName))
 }
 
 // Dialect should be added to the data types passed to SQL templates to


### PR DESCRIPTION
## What is this feature?

Adds `sqltemplate.RegisterDialect(driverName string, d Dialect)`, which lets callers associate a database/sql driver name with a `sqltemplate.Dialect` implementation. Built-in mappings (`mysql`, `postgres` / `pgx`, `sqlite` / `sqlite3`) are unchanged. Registering the same driver name as an existing built-in (or previously registered) entry panics to avoid accidental overrides.

## Why do we need this feature?

Unified SQL storage (resource API SQL backend, RV manager, secret metadata stores, legacy IAM/dashboard SQL helpers, etc.) picks a dialect with `DialectForDriver(db.DriverName())`. That map is fixed in core; any unknown driver name currently fails at runtime with a panic. In practice, that blocks:

- **Alternate or wrapped drivers** that report a different `DriverName()` but still use the same SQL dialect as Postgres/MySQL/SQLite (proxies, shims, vendor-specific client libraries).
- **Downstream forks or custom builds** that need to plug in an extra driver without maintaining a permanent patch to `sqltemplate` every rebase.

This mirrors the idea of extensibility at the dialect layer already present elsewhere in the codebase (e.g. xorm’s RegisterDialect), but scoped to the unified sqltemplate package used by the newer SQL paths.

## Who is this feature for?

Operators and integrators who run Grafana against a **non-standard `database/sql` driver name** while still using SQL compatible with one of the supported dialects, and anyone maintaining a **custom build** who wants a supported extension point instead of editing the built-in dialect map.

## Which issue(s) does this PR fix?

Fixes #120682 (partly)

## Special notes for your reviewer:

Please check that:

- [x] It works as expected from a user's perspective. (N/A for end users unless they use a custom driver — behavior for supported drivers is unchanged.)
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — small API extension, no toggle.)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (Optional: a one-line note in developer-facing docs if you have a “unified SQL / sqltemplate” section; likely not What’s New material.)

## Additional reviewer context

- Registration must happen **before** any code path calls DialectForDriver for that driver (typically init() in the same binary that registers the driver).
- Consider a **small unit test**: register a fake driver name with an existing dialect, assert `DialectForDriver` returns it, and assert duplicate registration panics (or use `t.Run` + `recover` pattern).
- Minor: panic message has a typo — **“registerd” → “registered”** (worth fixing in the same PR).
