### PR TITLE
refactor: share pruner history limits

### DIFF
--- a/pkg/storage/unified/resource/pruner_history_limits.go
+++ b/pkg/storage/unified/resource/pruner_history_limits.go
@@ -1,0 +1,13 @@
+package resource
+
+// customPrunerHistoryLimits defines resource-specific history limits.
+// The key format is "group/resource".
+var customPrunerHistoryLimits = map[string]int{
+	"plugins.grafana.app/plugins": 3,
+}
+
+// LookupCustomPrunerHistoryLimit returns a resource-specific history limit when one is configured.
+func LookupCustomPrunerHistoryLimit(group, resource string) (int, bool) {
+	limit, ok := customPrunerHistoryLimits[group+"/"+resource]
+	return limit, ok
+}

--- a/pkg/storage/unified/resource/pruner_history_limits_test.go
+++ b/pkg/storage/unified/resource/pruner_history_limits_test.go
@@ -1,0 +1,40 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupCustomPrunerHistoryLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		group    string
+		resource string
+		expected int
+		ok       bool
+	}{
+		{
+			name:     "returns custom limit for plugins",
+			group:    "plugins.grafana.app",
+			resource: "plugins",
+			expected: 3,
+			ok:       true,
+		},
+		{
+			name:     "returns not found for other resources",
+			group:    "dashboard.grafana.app",
+			resource: "dashboards",
+			expected: 0,
+			ok:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			limit, ok := LookupCustomPrunerHistoryLimit(tc.group, tc.resource)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.expected, limit)
+		})
+	}
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -41,12 +41,6 @@ const (
 	clusterScopeNamespace             = "__cluster__"
 )
 
-// customPrunerHistoryLimits defines resource-specific history limits.
-// The key format is "group/resource".
-var customPrunerHistoryLimits = map[string]int{
-	"plugins.grafana.app/plugins": 3,
-}
-
 type GarbageCollectionConfig struct {
 	Enabled          bool
 	DryRun           bool
@@ -628,8 +622,7 @@ func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName 
 }
 
 func (b *kvStorageBackend) prunerHistoryLimit(group, resource string) int {
-	key := fmt.Sprintf("%s/%s", group, resource)
-	if limit, ok := customPrunerHistoryLimits[key]; ok {
+	if limit, ok := LookupCustomPrunerHistoryLimit(group, resource); ok {
 		return limit
 	}
 	return defaultEventPruningLimit

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -51,12 +51,6 @@ const defaultWatchBufferSize = 100 // number of events to buffer in the watch st
 const defaultPrunerHistoryLimit = 20
 const defaultGarbageCollectionBatchWait = 1 * time.Second
 
-// customPrunerHistoryLimits defines resource-specific history limits.
-// The key format is "group/resource".
-var customPrunerHistoryLimits = map[string]int64{
-	"plugins.grafana.app/plugins": 3,
-}
-
 type GarbageCollectionConfig struct {
 	Enabled          bool
 	Interval         time.Duration // how often the process runs
@@ -541,10 +535,9 @@ func (b *backend) garbageCollectionCutoffTimestamp(group, resourceName string, d
 	return defaultCutoff
 }
 
-func (b *backend) prunerHistoryLimit(group, resource string) int64 {
-	key := fmt.Sprintf("%s/%s", group, resource)
-	if limit, ok := customPrunerHistoryLimits[key]; ok {
-		return limit
+func (b *backend) prunerHistoryLimit(group, resourceName string) int64 {
+	if limit, ok := resource.LookupCustomPrunerHistoryLimit(group, resourceName); ok {
+		return int64(limit)
 	}
 	return defaultPrunerHistoryLimit
 }


### PR DESCRIPTION
Both SQL and KVSQL currently keep their own `customPrunerHistoryLimits` maps even though they contain the same entries. This change moves the custom limit definitions into a single helper in `pkg/storage/unified/resource` so both backends read the same source of truth while keeping their existing default limits and return types.

## Summary
- move the custom pruner history limit map into a shared resource helper
- update SQL and KVSQL to use the shared lookup
- add a table test for the shared lookup

## Testing
- `go test ./pkg/storage/unified/resource -run 'TestLookupCustomPrunerHistoryLimit|TestKvStorageBackend_prunerHistoryLimit'`\n- `go test ./pkg/storage/unified/sql -run TestBackend_prunerHistoryLimit`