### PR TITLE
Alerting: Fix flaky test in policies list

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -250,7 +250,7 @@ function PolicyTreeTab() {
     });
     setManualDefaultExpanded(!isAllExpanded);
     clear();
-  }, [isAllExpanded, clear, visiblePolicies.length]);
+  }, [isAllExpanded, clear, visiblePolicies]);
 
   // Single-tree mode: show filters but no collapse/expand or create button
   if (!useMultiplePolicies) {

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { isEqual } from 'lodash';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSet } from 'react-use';
 
 import { GrafanaTheme2, UrlQueryMap } from '@grafana/data';
@@ -164,6 +165,9 @@ function PolicyTreeTab() {
   const [contactPointFilter, setContactPointFilter] = useState<string | undefined>();
   const [labelMatchersFilter, setLabelMatchersFilter] = useState<ObjectMatcher[]>([]);
 
+  const prevLabelMatchersRef = useRef<ObjectMatcher[]>([]);
+  const prevContactPointRef = useRef<string | undefined>(undefined);
+
   /**
    * Expand / collapse state
    * `defaultExpanded` is the baseline; `expandedOverrides` holds route IDs (hash-based) that are
@@ -181,6 +185,10 @@ function PolicyTreeTab() {
 
   const handleChangeContactPoint = useCallback(
     (value: string | undefined) => {
+      if (prevContactPointRef.current === value) {
+        return;
+      }
+      prevContactPointRef.current = value;
       if (value) {
         trackNotificationPoliciesFilterContactPoint();
       }
@@ -192,6 +200,10 @@ function PolicyTreeTab() {
 
   const handleChangeLabelMatchers = useCallback(
     (value: ObjectMatcher[]) => {
+      if (isEqual(prevLabelMatchersRef.current, value)) {
+        return;
+      }
+      prevLabelMatchersRef.current = value;
       if (value.length > 0) {
         trackNotificationPoliciesFilterMatchers();
       }


### PR DESCRIPTION
**Problem**
A 500ms useDebounce in NotificationPoliciesFilter fires after mount with unchanged values (empty `[]` matchers, undefined contact point), calling resetExpandState() and clobbering user-initiated expand/collapse state. This creates a timing-dependent race with React Testing Library's asyncWrapper macrotask boundary.

**Fix**
Added refs to track the previous values of both filter callbacks and skip resetExpandState() when the value hasn't meaningfully changed.