### PR TITLE
SchemaV2: correctly serialise natural and case-insensitive sort modes

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
@@ -47,6 +47,10 @@ describe('transformToV2TypesUtils', () => {
       expect(transformSortVariableToEnum(2)).toBe('alphabeticalDesc');
       expect(transformSortVariableToEnum(3)).toBe('numericalAsc');
       expect(transformSortVariableToEnum(4)).toBe('numericalDesc');
+      expect(transformSortVariableToEnum(5)).toBe('alphabeticalCaseInsensitiveAsc');
+      expect(transformSortVariableToEnum(6)).toBe('alphabeticalCaseInsensitiveDesc');
+      expect(transformSortVariableToEnum(7)).toBe('naturalAsc');
+      expect(transformSortVariableToEnum(8)).toBe('naturalDesc');
       expect(transformSortVariableToEnum(undefined)).toBe(defaultVariableSort());
     });
   });

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -73,6 +73,14 @@ export function transformSortVariableToEnum(sort?: VariableSortV1): VariableSort
       return 'numericalAsc';
     case 4:
       return 'numericalDesc';
+    case 5:
+      return 'alphabeticalCaseInsensitiveAsc';
+    case 6:
+      return 'alphabeticalCaseInsensitiveDesc';
+    case 7:
+      return 'naturalAsc';
+    case 8:
+      return 'naturalDesc';
     default:
       return defaultVariableSort();
   }


### PR DESCRIPTION
**What is this feature?**

The Natural and Alphabetical (case-insensitive) dashboard variable sort modes are incorrectly serialised as "disabled". This patch adds the missing cases in `transformSortVariableToEnum()`, and the corresponding test cases in `transformToV2TypesUtils.test.ts`.

The bug is straightforward to verify manually:
* Create a dashboard in v2 format
* Add a dashboard variable sorted by Natural
* Save and reload the dashboard
* Inspect the variable and observe that sorting is disabled, with the value "disabled" in the dashboard source.

**Who is this feature for?**

Dashboard editors

