### PR TITLE
Dashboard: Fix broken K8S_V2_DASHBOARD_API_CONFIG imports

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/codePaneUtils.ts
+++ b/public/app/features/dashboard-scene/edit-pane/codePaneUtils.ts
@@ -3,7 +3,7 @@ import { sceneUtils } from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
 import { DashboardWithAccessInfo } from '../../dashboard/api/types';
-import { K8S_V2_DASHBOARD_API_CONFIG } from '../../dashboard/api/v2';
+import { getK8sV2DashboardApiConfig } from '../../dashboard/api/v2';
 import { DashboardScene } from '../scene/DashboardScene';
 import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
@@ -23,7 +23,7 @@ export function applyJsonToDashboard(
     const { meta } = dashboard.state;
 
     const dto: DashboardWithAccessInfo<DashboardV2Spec> = {
-      apiVersion: K8S_V2_DASHBOARD_API_CONFIG.version,
+      apiVersion: getK8sV2DashboardApiConfig().version,
       kind: 'DashboardWithAccessInfo',
       metadata: {
         name: dashboard.state.uid ?? '',

--- a/public/app/features/dashboard-scene/v2schema/dashboardSchemaFetcher.ts
+++ b/public/app/features/dashboard-scene/v2schema/dashboardSchemaFetcher.ts
@@ -1,5 +1,5 @@
 import { getBackendSrv } from '@grafana/runtime';
-import { K8S_V2_DASHBOARD_API_CONFIG } from 'app/features/dashboard/api/v2';
+import { getK8sV2DashboardApiConfig } from 'app/features/dashboard/api/v2';
 
 interface OpenAPISchema {
   components?: {
@@ -52,7 +52,7 @@ export async function fetchDashboardSchema(): Promise<JSONSchema> {
 }
 
 async function doFetchSchema(): Promise<JSONSchema> {
-  const { group, version } = K8S_V2_DASHBOARD_API_CONFIG;
+  const { group, version } = getK8sV2DashboardApiConfig();
   const endpoint = getOpenAPIEndpoint(group, version);
   const schemaKey = getDashboardSpecSchemaKey(version);
 


### PR DESCRIPTION
#120511 renamed `K8S_V2_DASHBOARD_API_CONFIG` to `getK8sV2DashboardApiConfig()` but missed two call sites breaking typecheck on main.
This updates them