### PR TITLE
CI: Remove validate-dockerfile script

### DIFF
--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -55,8 +55,6 @@ jobs:
           echo "If there is a change in enterprise dependencies, please update pkg/extensions/main.go."
           exit 1
         fi
-    - name: Ensure Dockerfile contains submodule COPY commands
-      run: ./scripts/go-workspace/validate-dockerfile.sh
 
   check-wire:
     needs: detect-changes

--- a/scripts/go-workspace/main.go
+++ b/scripts/go-workspace/main.go
@@ -19,8 +19,6 @@ func main() {
 	switch os.Args[1] {
 	case "list-submodules":
 		err = listSubmodules()
-	case "validate-dockerfile":
-		err = validateDockerfile()
 	default:
 		printUsage()
 	}
@@ -61,41 +59,6 @@ func listSubmodules() error {
 		fmt.Printf("%s%s", p, *delimiter)
 	}
 
-	return nil
-}
-
-func validateDockerfile() error {
-	fs := flag.NewFlagSet("validate-dockerfile", flag.ExitOnError)
-	workPath := fs.String("path", "go.work", "Path to go.work")
-	dockerfilePath := fs.String("dockerfile-path", "Dockerfile", "Path to Dockerfile")
-	skip := fs.String("skip", "", "Skip submodules with this comment tag")
-	if err := fs.Parse(os.Args[2:]); err != nil {
-		return err
-	}
-
-	dockerFileRaw, err := os.ReadFile(*dockerfilePath)
-	if err != nil {
-		return err
-	}
-	dockerFile := string(dockerFileRaw)
-
-	workfile, err := parseGoWork(*workPath)
-	if err != nil {
-		return err
-	}
-
-	paths := getSubmodulePaths(workfile, *skip)
-	for _, p := range paths {
-		path := strings.TrimPrefix(p, "./")
-		if path == "" || path == "." {
-			continue
-		}
-		if !strings.Contains(dockerFile, path) {
-			return fmt.Errorf("the Dockerfile is missing `COPY %s/go.* %s` for the related module. Please add it and commit the change.", path, path)
-		}
-	}
-
-	fmt.Println("All submodules are included in the Dockerfile.")
 	return nil
 }
 

--- a/scripts/go-workspace/validate-dockerfile.sh
+++ b/scripts/go-workspace/validate-dockerfile.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
-go run scripts/go-workspace/main.go validate-dockerfile --path "${REPO_ROOT}/go.work" --dockerfile-path "${REPO_ROOT}/Dockerfile"


### PR DESCRIPTION
We already test the Dockerfile with `docker build` in PRs. The Dockerfile also copies all go.mod/go.sum in `apps` and `pkg` now without explicitly importing each one, so this script is unnecessary.