### PR TITLE
docs: upgrade notes: add info about disabled APIs

### DIFF
--- a/docs/sources/upgrade-guide/upgrade-v13.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v13.0/index.md
@@ -38,3 +38,7 @@ To get the latest version of each installed plugin and increase the chance that 
 #### Upgrade to Grafana 13
 
 Finally you can continue your upgrade to Grafana 13.
+
+### Deprecated data source APIs disabled
+
+Data source APIs that refer to data sources using a numeric `id` have been deprecated since Grafana 9. In Grafana 13, they are disabled by default. If you require these APIs, you can re-enable them by enabling the `datasourceLegacyIdApi` feature flag.

--- a/docs/sources/upgrade-guide/upgrade-v13.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v13.0/index.md
@@ -42,3 +42,4 @@ Finally you can continue your upgrade to Grafana 13.
 ### Deprecated data source APIs disabled
 
 Data source APIs that refer to data sources using a numeric `id` have been deprecated since Grafana 9. In Grafana 13, they are disabled by default. If you require these APIs, you can re-enable them by enabling the `datasourceLegacyIdApi` feature flag.
+These deprecated APIs and the `datasourceLegacyIdApi` feature toggle will be removed in a future release.


### PR DESCRIPTION
add a note about APIs that will be disabled by default in Grafana 13.