### PR TITLE
Implement K8s IAM integration for user permissions and enhance SearchUsersPermissions functionality

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -96,6 +96,18 @@ type SearchOptions struct {
 	RolePrefixes []string
 }
 
+// GetActionFilter returns a function that checks if an action matches the given search options.
+// When ActionPrefix is set, the action must start with that prefix.
+// When Action is set, the action must match exactly.
+func GetActionFilter(options SearchOptions) func(action string) bool {
+	return func(action string) bool {
+		if options.ActionPrefix != "" {
+			return strings.HasPrefix(action, options.ActionPrefix)
+		}
+		return action == options.Action
+	}
+}
+
 // Wildcards computes the wildcard scopes that include the scope
 func (s *SearchOptions) Wildcards() []string {
 	if s.wildcards != nil {

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -71,7 +71,7 @@ func ProvideService(
 		lock,
 	)
 
-	api.NewAccessControlAPI(routeRegister, accessControl, service, userService).RegisterAPIEndpoints()
+	api.NewAccessControlAPI(routeRegister, accessControl, service, userService, features, nil, actionResolver).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
 		return nil, err
 	}
@@ -620,16 +620,6 @@ func (s *Service) DeclarePluginRoles(ctx context.Context, ID, name string, regs 
 	return nil
 }
 
-func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bool {
-	return func(action string) bool {
-		if options.ActionPrefix != "" {
-			return strings.HasPrefix(action, options.ActionPrefix)
-		} else {
-			return action == options.Action
-		}
-	}
-}
-
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
 func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester, options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
 	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.SearchUsersPermissions")
@@ -732,7 +722,7 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Reque
 
 	if len(options.ActionSets) > 0 {
 		for id, perms := range res {
-			res[id] = s.actionResolver.ExpandActionSetsWithFilter(perms, GetActionFilter(options))
+			res[id] = s.actionResolver.ExpandActionSetsWithFilter(perms, accesscontrol.GetActionFilter(options))
 		}
 	}
 
@@ -795,7 +785,7 @@ func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, search
 	permissions = append(permissions, dbPermissions[searchOptions.UserID]...)
 
 	if len(searchOptions.ActionSets) != 0 {
-		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, GetActionFilter(searchOptions))
+		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, accesscontrol.GetActionFilter(searchOptions))
 	}
 
 	key, err := accesscontrol.GetSearchPermissionCacheKey(s.log, &user.SignedInUser{UserID: searchOptions.UserID, OrgID: orgID}, searchOptions)

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -2,6 +2,7 @@ package actest
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -28,7 +29,40 @@ func (f FakeService) GetUserPermissions(ctx context.Context, user identity.Reque
 }
 
 func (f FakeService) SearchUsersPermissions(ctx context.Context, user identity.Requester, options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
-	return f.ExpectedUsersPermissions, f.ExpectedErr
+	if f.ExpectedErr != nil {
+		return nil, f.ExpectedErr
+	}
+
+	// Filter permissions based on SearchOptions
+	result := make(map[int64][]accesscontrol.Permission)
+	for userID, perms := range f.ExpectedUsersPermissions {
+		// Filter by UserID if specified
+		if options.UserID > 0 && userID != options.UserID {
+			continue
+		}
+
+		var filtered []accesscontrol.Permission
+		for _, p := range perms {
+			// Filter by Action or ActionPrefix
+			if options.Action != "" && p.Action != options.Action {
+				continue
+			}
+			if options.ActionPrefix != "" && !strings.HasPrefix(p.Action, options.ActionPrefix) {
+				continue
+			}
+			// Filter by Scope
+			if options.Scope != "" && p.Scope != options.Scope {
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+
+		if len(filtered) > 0 {
+			result[userID] = filtered
+		}
+	}
+
+	return result, nil
 }
 
 func (f FakeService) SearchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {

--- a/pkg/services/accesscontrol/api/api.go
+++ b/pkg/services/accesscontrol/api/api.go
@@ -16,19 +16,37 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/middleware/requestmeta"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
+// Ensure the package-level interface is satisfied by the upstream type at compile time.
+var _ restConfigProvider = (apiserver.DirectRestConfigProvider)(nil)
+
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/accesscontrol/api")
 
-func NewAccessControlAPI(router routing.RouteRegister, accesscontrol ac.AccessControl, service ac.Service, userSvc user.Service) *AccessControlAPI {
-	return &AccessControlAPI{
+func NewAccessControlAPI(
+	router routing.RouteRegister,
+	accesscontrol ac.AccessControl,
+	service ac.Service,
+	userSvc user.Service,
+	features featuremgmt.FeatureToggles,
+	restConfigProvider restConfigProvider,
+	actionResolver ac.ActionResolver,
+) *AccessControlAPI {
+	api := &AccessControlAPI{
 		RouteRegister: router,
 		Service:       service,
 		userSvc:       userSvc,
 		AccessControl: accesscontrol,
+		features:      features,
 	}
+
+	api.k8sResolver = newK8sPermissionResolver(restConfigProvider, userSvc, actionResolver)
+
+	return api
 }
 
 type AccessControlAPI struct {
@@ -36,6 +54,8 @@ type AccessControlAPI struct {
 	AccessControl ac.AccessControl
 	RouteRegister routing.RouteRegister
 	userSvc       user.Service
+	features      featuremgmt.FeatureToggles
+	k8sResolver   *k8sPermissionResolver
 }
 
 func (api *AccessControlAPI) RegisterAPIEndpoints() {
@@ -110,7 +130,21 @@ func (api *AccessControlAPI) searchUsersPermissions(c *contextmodel.ReqContext) 
 		return response.JSON(http.StatusBadRequest, "at least one search option must be provided")
 	}
 
-	// Compute metadata
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	// Use K8s path when FlagKubernetesAuthzRolesAndRoleBindingsRedirect is enabled
+	if api.features != nil && api.features.IsEnabled(ctx, featuremgmt.FlagKubernetesAuthzRolesAndRoleBindingsRedirect) && api.k8sResolver != nil {
+		k8sResult, err := api.k8sResolver.SearchUsersPermissions(ctx, c.Namespace, c, searchOptions)
+		if err != nil {
+			return response.Error(http.StatusInternalServerError, "could not get user permissions from k8s", err)
+		}
+		permsByAction := map[int64]map[string][]string{}
+		for userID, userPerms := range k8sResult {
+			permsByAction[userID] = ac.Reduce(userPerms)
+		}
+		return response.JSON(http.StatusOK, permsByAction)
+	}
+
+	// Legacy SQL-based path
 	permissions, err := api.Service.SearchUsersPermissions(ctx, c.SignedInUser, searchOptions)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "could not get org user permissions", err)

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -3,21 +3,57 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/infra/log"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
+
+// buildFakeK8sResolver creates a k8sPermissionResolver backed by a dynamicfake client.
+// Each user ID in perms is assigned UID "uid-{id}". When fail is true the resolver has no
+// clients, causing SearchUsersPermissions to return an error.
+func buildFakeK8sResolver(t *testing.T, perms map[int64][]ac.Permission, fail bool, userSvc user.Service) *k8sPermissionResolver {
+	t.Helper()
+	if fail {
+		return &k8sPermissionResolver{log: log.New("test")}
+	}
+
+	const ns = "default"
+	var objects []runtime.Object
+	for id, ps := range perms {
+		uid := fmt.Sprintf("uid-%d", id)
+		objects = append(objects, makeUser(uid, ns, ""))
+		if len(ps) > 0 {
+			roleName := fmt.Sprintf("role-%s", uid)
+			objects = append(objects, makeRole(roleName, ns, ps...))
+			objects = append(objects, makeRoleBinding(
+				fmt.Sprintf("user-%s", uid), ns, uid,
+				roleRef(iamv0.RoleBindingSpecRoleRefKindRole, roleName),
+			))
+		}
+	}
+
+	return &k8sPermissionResolver{
+		dynamicClient: newFakeDynamic(t, objects...),
+		userService:   userSvc,
+		log:           log.New("test"),
+	}
+}
 
 func TestAPI_getUserActions(t *testing.T) {
 	type testCase struct {
@@ -42,7 +78,7 @@ func TestAPI_getUserActions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			acSvc := actest.FakeService{ExpectedPermissions: tt.permissions}
-			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{})
+			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{}, nil, nil, nil)
 			api.RegisterAPIEndpoints()
 
 			server := webtest.NewServer(t, api.RouteRegister)
@@ -95,7 +131,7 @@ func TestAPI_getUserPermissions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			acSvc := actest.FakeService{ExpectedPermissions: tt.permissions}
-			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{})
+			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{}, nil, nil, nil)
 			api.RegisterAPIEndpoints()
 
 			server := webtest.NewServer(t, api.RouteRegister)
@@ -130,8 +166,8 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 		desc           string
 		permissions    map[int64][]ac.Permission
 		filters        string
-		expectedOutput map[int64]map[string][]string
 		expectedCode   int
+		expectedOutput map[int64]map[string][]string
 		serviceErr     error
 	}
 
@@ -205,7 +241,6 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 			expectedCode: http.StatusOK,
 			expectedOutput: map[int64]map[string][]string{
 				1: {"dashboards:read": {"dashboards:*"}},
-				2: {"dashboards:write": {"dashboards:*"}},
 			},
 		},
 		{
@@ -218,11 +253,10 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 			expectedCode: http.StatusOK,
 			expectedOutput: map[int64]map[string][]string{
 				1: {"teams:read": {"teams:id:1"}},
-				2: {"teams:read": {"teams:id:2"}},
 			},
 		},
 		{
-			desc:         "Should return 500 when service returns error",
+			desc:         "Should return 500 when backend returns error",
 			filters:      "?actionPrefix=users:",
 			serviceErr:   errors.New("database connection failed"),
 			expectedCode: http.StatusInternalServerError,
@@ -242,40 +276,310 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 			expectedOutput: map[int64]map[string][]string{3: {"users:read": {"users:*"}}},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			acSvc := actest.FakeService{
-				ExpectedUsersPermissions: tt.permissions,
-				ExpectedErr:              tt.serviceErr,
-			}
 
-			accessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
-			mockUserSvc := usertest.NewMockService(t)
-			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "user_2_uid"}).Return(&user.User{ID: 2}, nil).Maybe()
-			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "non_existent_uid"}).Return(nil, user.ErrUserNotFound).Maybe()
-			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "sa_abc123"}).Return(&user.User{ID: 3, IsServiceAccount: true}, nil).Maybe()
-			api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc)
-			api.RegisterAPIEndpoints()
+	// setupUserSvc builds a mock user service with all UID/ID lookups needed by both paths.
+	setupUserSvc := func(t *testing.T) *usertest.MockService {
+		t.Helper()
+		mockUserSvc := usertest.NewMockService(t)
+		// UID lookups used by ComputeUserID (both paths)
+		mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "user_2_uid"}).Return(&user.User{ID: 2}, nil).Maybe()
+		mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "non_existent_uid"}).Return(nil, user.ErrUserNotFound).Maybe()
+		mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "sa_abc123"}).Return(&user.User{ID: 3, IsServiceAccount: true}, nil).Maybe()
+		// ID→UID and UID→ID used by the K8s path
+		for _, id := range []int64{1, 2, 3} {
+			uid := fmt.Sprintf("uid-%d", id)
+			mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: id}).Return(&user.User{ID: id, UID: uid}, nil).Maybe()
+			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: uid}).Return(&user.User{ID: id}, nil).Maybe()
+		}
+		return mockUserSvc
+	}
 
-			server := webtest.NewServer(t, api.RouteRegister)
-			url := "/api/access-control/users/permissions/search" + tt.filters
+	runCase := func(t *testing.T, tt testCase, expectedCode int, expectedOutput map[int64]map[string][]string, api *AccessControlAPI, namespace string) {
+		t.Helper()
+		server := webtest.NewServer(t, api.RouteRegister)
+		req := server.NewGetRequest("/api/access-control/users/permissions/search" + tt.filters)
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			OrgID:       1,
+			Namespace:   namespace,
+			Permissions: map[int64]map[string][]string{},
+		})
+		res, err := server.Send(req)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.NoError(t, err)
+		require.Equal(t, expectedCode, res.StatusCode)
+		if expectedCode == http.StatusOK {
+			var output map[int64]map[string][]string
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+			require.Equal(t, expectedOutput, output)
+		}
+	}
 
-			req := server.NewGetRequest(url)
-			webtest.RequestWithSignedInUser(req, &user.SignedInUser{
-				OrgID:       1,
-				Permissions: map[int64]map[string][]string{},
+	t.Run("legacy", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.desc, func(t *testing.T) {
+				acSvc := actest.FakeService{ExpectedUsersPermissions: tt.permissions, ExpectedErr: tt.serviceErr}
+				api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{ExpectedEvaluate: true}, acSvc, setupUserSvc(t), nil, nil, nil)
+				api.RegisterAPIEndpoints()
+				runCase(t, tt, tt.expectedCode, tt.expectedOutput, api, "")
 			})
-			res, err := server.Send(req)
-			defer func() { require.NoError(t, res.Body.Close()) }()
-			require.NoError(t, err)
-			require.Equal(t, tt.expectedCode, res.StatusCode)
+		}
+	})
 
-			if tt.expectedCode == http.StatusOK {
-				var output map[int64]map[string][]string
-				err := json.NewDecoder(res.Body).Decode(&output)
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedOutput, output)
-			}
+	t.Run("k8s", func(t *testing.T) {
+		for _, tt := range tests {
+			t.Run(tt.desc, func(t *testing.T) {
+				userSvc := setupUserSvc(t)
+				features := featuremgmt.WithFeatures(featuremgmt.FlagKubernetesAuthzRolesAndRoleBindingsRedirect, true)
+				// acSvc should not be called on the K8s path for non-error cases
+				api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{ExpectedEvaluate: true}, actest.FakeService{}, userSvc, features, &fakeRestConfigProvider{}, nil)
+				api.k8sResolver = buildFakeK8sResolver(t, tt.permissions, tt.serviceErr != nil, userSvc)
+				api.RegisterAPIEndpoints()
+
+				runCase(t, tt, tt.expectedCode, tt.expectedOutput, api, "default")
+			})
+		}
+	})
+}
+
+func TestAccessControlAPI_searchUsersPermissions_FeatureFlag(t *testing.T) {
+	legacyPerms := map[int64][]ac.Permission{
+		1: {{Action: "dashboards:read", Scope: "dashboards:*"}},
+	}
+
+	// mockUserSvc maps user ID 1 to UID "user-uid-1".
+	mockUserSvc := usertest.NewMockService(t)
+	mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).
+		Return(&user.User{ID: 1, UID: "user-uid-1"}, nil).Maybe()
+	mockUserSvc.On("GetByUID", mock.Anything, mock.Anything).
+		Return(nil, user.ErrUserNotFound).Maybe()
+
+	t.Run("flag OFF uses legacy path", func(t *testing.T) {
+		acSvc := actest.FakeService{ExpectedUsersPermissions: legacyPerms}
+		accessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
+		api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc, nil, nil, nil)
+		api.RegisterAPIEndpoints()
+
+		server := webtest.NewServer(t, api.RouteRegister)
+		req := server.NewGetRequest("/api/access-control/users/permissions/search?namespacedId=user:1")
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			OrgID:       1,
+			Permissions: map[int64]map[string][]string{},
+		})
+		res, err := server.Send(req)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		var output map[int64]map[string][]string
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+		require.Equal(t, map[string][]string{"dashboards:read": {"dashboards:*"}}, output[1])
+	})
+
+	t.Run("flag ON uses K8s path", func(t *testing.T) {
+		// Build a fake resolver with user "user-uid-1" having folders:read.
+		// (Different from the legacy dashboards:read to prove the K8s path is taken.)
+		const ns = "default"
+		fakeDyn := newFakeDynamic(t,
+			makeUser("user-uid-1", ns, ""),
+			makeRole("role-user-uid-1", ns, ac.Permission{Action: "folders:read", Scope: "folders:*"}),
+			makeRoleBinding("user-user-uid-1", ns, "user-uid-1",
+				roleRef(iamv0.RoleBindingSpecRoleRefKindRole, "role-user-uid-1"),
+			),
+		)
+		resolver := &k8sPermissionResolver{
+			dynamicClient: fakeDyn,
+			userService:   mockUserSvc,
+			log:           log.New("test"),
+		}
+
+		acSvc := actest.FakeService{ExpectedUsersPermissions: legacyPerms}
+		accessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
+		features := featuremgmt.WithFeatures(featuremgmt.FlagKubernetesAuthzRolesAndRoleBindingsRedirect, true)
+		api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc, features, &fakeRestConfigProvider{}, nil)
+		api.k8sResolver = resolver
+		api.RegisterAPIEndpoints()
+
+		server := webtest.NewServer(t, api.RouteRegister)
+		req := server.NewGetRequest("/api/access-control/users/permissions/search?namespacedId=user:1")
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			OrgID:       1,
+			Namespace:   "default",
+			Permissions: map[int64]map[string][]string{},
+		})
+		res, err := server.Send(req)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		var output map[int64]map[string][]string
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+		// K8s path returns folders:read, not the legacy dashboards:read.
+		require.Equal(t, map[string][]string{"folders:read": {"folders:*"}}, output[1])
+	})
+
+	t.Run("flag ON returns error when K8s resolver fails", func(t *testing.T) {
+		// Resolver with no clients → SearchUsersPermissions returns error.
+		failResolver := &k8sPermissionResolver{log: log.New("test")}
+
+		acSvc := actest.FakeService{ExpectedUsersPermissions: legacyPerms}
+		accessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
+		features := featuremgmt.WithFeatures(featuremgmt.FlagKubernetesAuthzRolesAndRoleBindingsRedirect, true)
+		api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc, features, &fakeRestConfigProvider{}, nil)
+		api.k8sResolver = failResolver
+		api.RegisterAPIEndpoints()
+
+		server := webtest.NewServer(t, api.RouteRegister)
+		req := server.NewGetRequest("/api/access-control/users/permissions/search?namespacedId=user:1")
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			OrgID:       1,
+			Namespace:   "default",
+			Permissions: map[int64]map[string][]string{},
+		})
+		res, err := server.Send(req)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	})
+
+	t.Run("flag ON without provider uses legacy path", func(t *testing.T) {
+		acSvc := actest.FakeService{ExpectedUsersPermissions: legacyPerms}
+		accessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
+		features := featuremgmt.WithFeatures(featuremgmt.FlagKubernetesAuthzRolesAndRoleBindingsRedirect, true)
+
+		// No provider means no K8s resolver; OSS wiring should continue to use legacy path.
+		api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc, features, nil, nil)
+		api.RegisterAPIEndpoints()
+
+		server := webtest.NewServer(t, api.RouteRegister)
+		req := server.NewGetRequest("/api/access-control/users/permissions/search?namespacedId=user:1")
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			OrgID:       1,
+			Permissions: map[int64]map[string][]string{},
+		})
+		res, err := server.Send(req)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		var output map[int64]map[string][]string
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+		require.Equal(t, map[string][]string{"dashboards:read": {"dashboards:*"}}, output[1])
+	})
+}
+
+func TestAccessControlAPI_searchUsersPermissions_LegacyAndK8sParity(t *testing.T) {
+	type parityCase struct {
+		name        string
+		filters     string
+		permissions map[int64][]ac.Permission
+		expected    map[int64]map[string][]string
+	}
+
+	cases := []parityCase{
+		{
+			name:    "action prefix",
+			filters: "?actionPrefix=users:",
+			permissions: map[int64][]ac.Permission{
+				1: {{Action: "users:read", Scope: "users:*"}},
+				2: {{Action: "dashboards:read", Scope: "dashboards:*"}},
+			},
+			expected: map[int64]map[string][]string{
+				1: {"users:read": {"users:*"}},
+			},
+		},
+		{
+			name:    "exact action and reduction",
+			filters: "?action=dashboards:read",
+			permissions: map[int64][]ac.Permission{
+				1: {
+					{Action: "dashboards:read", Scope: "dashboards:*"},
+					{Action: "dashboards:read", Scope: "dashboards:id:1"},
+				},
+			},
+			expected: map[int64]map[string][]string{
+				1: {"dashboards:read": {"dashboards:*"}},
+			},
+		},
+		{
+			name:    "scope",
+			filters: "?actionPrefix=teams:&scope=teams:id:1",
+			permissions: map[int64][]ac.Permission{
+				1: {{Action: "teams:read", Scope: "teams:id:1"}},
+				2: {{Action: "teams:read", Scope: "teams:id:2"}},
+			},
+			expected: map[int64]map[string][]string{
+				1: {"teams:read": {"teams:id:1"}},
+			},
+		},
+	}
+
+	run := func(t *testing.T, api *AccessControlAPI, filters string, namespace string) (int, map[int64]map[string][]string) {
+		t.Helper()
+		server := webtest.NewServer(t, api.RouteRegister)
+		req := server.NewGetRequest("/api/access-control/users/permissions/search" + filters)
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			OrgID:       1,
+			Namespace:   namespace,
+			Permissions: map[int64]map[string][]string{},
+		})
+
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+
+		if res.StatusCode != http.StatusOK {
+			return res.StatusCode, nil
+		}
+		var output map[int64]map[string][]string
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+		return res.StatusCode, output
+	}
+
+	setupUserSvc := func(t *testing.T) *usertest.MockService {
+		t.Helper()
+		mockUserSvc := usertest.NewMockService(t)
+		for _, id := range []int64{1, 2, 3} {
+			uid := fmt.Sprintf("uid-%d", id)
+			mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: id}).Return(&user.User{ID: id, UID: uid}, nil).Maybe()
+			mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: uid}).Return(&user.User{ID: id}, nil).Maybe()
+		}
+		return mockUserSvc
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := NewAccessControlAPI(
+				routing.NewRouteRegister(),
+				actest.FakeAccessControl{ExpectedEvaluate: true},
+				actest.FakeService{ExpectedUsersPermissions: tc.permissions},
+				setupUserSvc(t),
+				nil,
+				nil,
+				nil,
+			)
+			legacy.RegisterAPIEndpoints()
+
+			userSvc := setupUserSvc(t)
+			k8s := NewAccessControlAPI(
+				routing.NewRouteRegister(),
+				actest.FakeAccessControl{ExpectedEvaluate: true},
+				actest.FakeService{},
+				userSvc,
+				featuremgmt.WithFeatures(featuremgmt.FlagKubernetesAuthzRolesAndRoleBindingsRedirect, true),
+				&fakeRestConfigProvider{},
+				nil,
+			)
+			k8s.k8sResolver = buildFakeK8sResolver(t, tc.permissions, false, userSvc)
+			k8s.RegisterAPIEndpoints()
+
+			legacyCode, legacyOut := run(t, legacy, tc.filters, "")
+			k8sCode, k8sOut := run(t, k8s, tc.filters, "default")
+
+			require.Equal(t, http.StatusOK, legacyCode)
+			require.Equal(t, http.StatusOK, k8sCode)
+			require.Equal(t, tc.expected, legacyOut)
+			require.Equal(t, tc.expected, k8sOut)
+			require.Equal(t, legacyOut, k8sOut)
 		})
 	}
 }

--- a/pkg/services/accesscontrol/api/k8s_adapter.go
+++ b/pkg/services/accesscontrol/api/k8s_adapter.go
@@ -1,0 +1,510 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/user"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// restConfigProvider is a minimal interface for obtaining a per-request K8s client config.
+// It matches the relevant subset of apiserver.DirectRestConfigProvider.
+type restConfigProvider interface {
+	GetDirectRestConfig(c *contextmodel.ReqContext) *rest.Config
+}
+
+// k8sPermissionResolver resolves user permissions by calling the K8s IAM APIs.
+// This is used when FlagKubernetesAuthzRolesAndRoleBindingsRedirect is enabled.
+type k8sPermissionResolver struct {
+	restConfigProvider restConfigProvider
+	// dynamicClient is used in tests to inject a fake client. In production it is nil and
+	// getDynamicClient creates a real client from restConfigProvider on each call.
+	dynamicClient  dynamic.Interface
+	userService    user.Service
+	actionResolver ac.ActionResolver
+	log            log.Logger
+}
+
+// newK8sPermissionResolver creates a new K8s permission resolver.
+// Returns nil if restConfigProvider is nil (K8s APIs not available).
+func newK8sPermissionResolver(
+	restConfigProvider restConfigProvider,
+	userService user.Service,
+	actionResolver ac.ActionResolver,
+) *k8sPermissionResolver {
+	if restConfigProvider == nil {
+		return nil
+	}
+	return &k8sPermissionResolver{
+		restConfigProvider: restConfigProvider,
+		userService:        userService,
+		actionResolver:     actionResolver,
+		log:                log.New("accesscontrol.k8s_resolver"),
+	}
+}
+
+func (r *k8sPermissionResolver) getDynamicClient(c *contextmodel.ReqContext) (dynamic.Interface, error) {
+	if r.dynamicClient != nil {
+		return r.dynamicClient, nil
+	}
+	restConfig := r.getRestConfig(c)
+	if restConfig == nil {
+		return nil, fmt.Errorf("rest config not available")
+	}
+	return dynamic.NewForConfig(restConfig)
+}
+
+func (r *k8sPermissionResolver) getRestConfig(c *contextmodel.ReqContext) *rest.Config {
+	if r.restConfigProvider == nil {
+		return nil
+	}
+	return r.restConfigProvider.GetDirectRestConfig(c)
+}
+
+// SearchUsersPermissions returns all users' permissions by querying K8s IAM APIs.
+// This mirrors the behaviour of Service.SearchUsersPermissions but uses K8s APIs instead of SQL.
+func (r *k8sPermissionResolver) SearchUsersPermissions(
+	ctx context.Context,
+	namespace string,
+	c *contextmodel.ReqContext,
+	options ac.SearchOptions,
+) (map[int64][]ac.Permission, error) {
+	if r.restConfigProvider == nil && r.dynamicClient == nil {
+		return nil, fmt.Errorf("rest config provider not available")
+	}
+
+	// Resolve action sets if an action resolver is available.
+	if r.actionResolver != nil {
+		options.ActionSets = r.actionResolver.ResolveAction(options.Action)
+		options.ActionSets = append(options.ActionSets, r.actionResolver.ResolveActionPrefix(options.ActionPrefix)...)
+	}
+
+	if options.UserID > 0 {
+		return r.searchSingleUserPermissions(ctx, namespace, c, options.UserID, options)
+	}
+
+	result, err := r.searchAllUsersPermissions(ctx, namespace, c, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// Expand action sets in the result if needed.
+	if r.actionResolver != nil && len(options.ActionSets) > 0 {
+		for id, perms := range result {
+			result[id] = r.actionResolver.ExpandActionSetsWithFilter(perms, ac.GetActionFilter(options))
+		}
+	}
+
+	return result, nil
+}
+
+func (r *k8sPermissionResolver) searchSingleUserPermissions(
+	ctx context.Context,
+	namespace string,
+	c *contextmodel.ReqContext,
+	userID int64,
+	options ac.SearchOptions,
+) (map[int64][]ac.Permission, error) {
+	if r.userService == nil {
+		return nil, fmt.Errorf("user service not available")
+	}
+
+	u, err := r.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	dynClient, err := r.getDynamicClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	roleCache := make(map[string][]ac.Permission)
+	perms, err := r.getUserPermissions(ctx, dynClient, namespace, u.UID, c, options, roleCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user permissions: %w", err)
+	}
+
+	return map[int64][]ac.Permission{userID: perms}, nil
+}
+
+func (r *k8sPermissionResolver) searchAllUsersPermissions(
+	ctx context.Context,
+	namespace string,
+	c *contextmodel.ReqContext,
+	options ac.SearchOptions,
+) (map[int64][]ac.Permission, error) {
+	dynClient, err := r.getDynamicClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := r.listAllUsers(ctx, dynClient, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+
+	roleBindings, err := r.listAllRoleBindings(ctx, dynClient, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list role bindings: %w", err)
+	}
+
+	// Build subject→roleRefs index from all role bindings.
+	subjectRoles := make(map[string][]iamv0.RoleBindingspecRoleRef)
+	for _, binding := range roleBindings {
+		key := fmt.Sprintf("%s:%s", binding.Spec.Subject.Kind, binding.Spec.Subject.Name)
+		subjectRoles[key] = append(subjectRoles[key], binding.Spec.RoleRefs...)
+	}
+
+	// Shared cache for role permissions to avoid duplicate K8s calls.
+	roleCache := make(map[string][]ac.Permission)
+	result := make(map[int64][]ac.Permission)
+
+	for _, userObj := range users {
+		userUID := userObj.GetName()
+		userKey := fmt.Sprintf("%s:%s", iamv0.RoleBindingSpecSubjectKindUser, userUID)
+
+		perms, err := r.buildUserPermissions(ctx, dynClient, namespace, userObj, userKey, subjectRoles, roleCache, c, options)
+		if err != nil {
+			r.log.Warn("Failed to build permissions for user", "uid", userUID, "error", err)
+			continue
+		}
+
+		if len(perms) > 0 {
+			userID := r.getUserIDFromUID(ctx, userUID)
+			if userID > 0 {
+				result[userID] = perms
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// listAllUsers fetches every user in the namespace, following K8s pagination tokens.
+func (r *k8sPermissionResolver) listAllUsers(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace string,
+) ([]*iamv0.User, error) {
+	resource := dynClient.Resource(iamv0.UserResourceInfo.GroupVersionResource()).Namespace(namespace)
+	var items []*iamv0.User
+	continueToken := ""
+	for {
+		list, err := resource.List(ctx, metav1.ListOptions{Continue: continueToken})
+		if err != nil {
+			return nil, err
+		}
+		for i := range list.Items {
+			var u iamv0.User
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &u); err != nil {
+				r.log.Warn("Failed to parse user object", "error", err)
+				continue
+			}
+			items = append(items, &u)
+		}
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+	return items, nil
+}
+
+// listAllRoleBindings fetches every role binding in the namespace, following K8s pagination tokens.
+func (r *k8sPermissionResolver) listAllRoleBindings(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace string,
+) ([]iamv0.RoleBinding, error) {
+	resource := dynClient.Resource(iamv0.RoleBindingInfo.GroupVersionResource()).Namespace(namespace)
+	var bindings []iamv0.RoleBinding
+	continueToken := ""
+	for {
+		list, err := resource.List(ctx, metav1.ListOptions{Continue: continueToken})
+		if err != nil {
+			return nil, err
+		}
+		for i := range list.Items {
+			var binding iamv0.RoleBinding
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &binding); err != nil {
+				r.log.Warn("Failed to parse role binding", "error", err)
+				continue
+			}
+			bindings = append(bindings, binding)
+		}
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+	return bindings, nil
+}
+
+// getUserPermissions returns the full permission list for a single user identified by their Grafana UID.
+func (r *k8sPermissionResolver) getUserPermissions(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace string,
+	userUID string,
+	c *contextmodel.ReqContext,
+	options ac.SearchOptions,
+	roleCache map[string][]ac.Permission,
+) ([]ac.Permission, error) {
+	var perms []ac.Permission
+
+	// Permissions from the user's explicit role binding.
+	bindingName := fmt.Sprintf("user-%s", userUID)
+	bindingResource := dynClient.Resource(iamv0.RoleBindingInfo.GroupVersionResource()).Namespace(namespace)
+	if bindingObj, err := bindingResource.Get(ctx, bindingName, metav1.GetOptions{}); err == nil {
+		var binding iamv0.RoleBinding
+		if convErr := runtime.DefaultUnstructuredConverter.FromUnstructured(bindingObj.Object, &binding); convErr == nil {
+			for _, roleRef := range binding.Spec.RoleRefs {
+				rolePerms, err := r.getRolePermissions(ctx, dynClient, namespace, roleRef.Name, string(roleRef.Kind), roleCache)
+				if err != nil {
+					r.log.Warn("Failed to get role permissions", "role", roleRef.Name, "error", err)
+					continue
+				}
+				perms = append(perms, rolePerms...)
+			}
+		}
+	}
+
+	// Permissions from the user's basic org role (Viewer / Editor / Admin).
+	userResource := dynClient.Resource(iamv0.UserResourceInfo.GroupVersionResource()).Namespace(namespace)
+	if userObj, err := userResource.Get(ctx, userUID, metav1.GetOptions{}); err == nil {
+		var u iamv0.User
+		if convErr := runtime.DefaultUnstructuredConverter.FromUnstructured(userObj.Object, &u); convErr == nil && u.Spec.Role != "" {
+			basicPerms, err := r.getBasicRolePermissions(ctx, dynClient, namespace, u.Spec.Role, roleCache)
+			if err == nil {
+				perms = append(perms, basicPerms...)
+			}
+		}
+	}
+
+	// Direct resource permissions (e.g. folder/dashboard-level grants).
+	directPerms, _ := r.getDirectResourcePermissions(c, namespace, userUID)
+	perms = append(perms, directPerms...)
+
+	return r.filterPermissions(perms, options), nil
+}
+
+// buildUserPermissions builds the filtered permission list for a user during a multi-user scan.
+// It reuses the shared roleCache to avoid redundant K8s calls for the same role.
+func (r *k8sPermissionResolver) buildUserPermissions(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace string,
+	userObj *iamv0.User,
+	userKey string,
+	subjectRoles map[string][]iamv0.RoleBindingspecRoleRef,
+	roleCache map[string][]ac.Permission,
+	c *contextmodel.ReqContext,
+	options ac.SearchOptions,
+) ([]ac.Permission, error) {
+	var perms []ac.Permission
+
+	// Permissions from explicitly assigned roles.
+	for _, roleRef := range subjectRoles[userKey] {
+		rolePerms, err := r.getRolePermissions(ctx, dynClient, namespace, roleRef.Name, string(roleRef.Kind), roleCache)
+		if err != nil {
+			r.log.Warn("Failed to get role permissions", "role", roleRef.Name, "error", err)
+			continue
+		}
+		perms = append(perms, rolePerms...)
+	}
+
+	// Permissions from the basic org role (also cached).
+	if userObj.Spec.Role != "" {
+		basicPerms, err := r.getBasicRolePermissions(ctx, dynClient, namespace, userObj.Spec.Role, roleCache)
+		if err == nil {
+			perms = append(perms, basicPerms...)
+		}
+	}
+
+	// Direct resource permissions.
+	userUID := userObj.GetName()
+	directPerms, _ := r.getDirectResourcePermissions(c, namespace, userUID)
+	perms = append(perms, directPerms...)
+
+	return r.filterPermissions(perms, options), nil
+}
+
+// getRolePermissions fetches permissions for a named role. Results are cached by "kind:name".
+func (r *k8sPermissionResolver) getRolePermissions(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace string,
+	roleName string,
+	roleKind string,
+	roleCache map[string][]ac.Permission,
+) ([]ac.Permission, error) {
+	cacheKey := fmt.Sprintf("%s:%s", roleKind, roleName)
+	if cached, ok := roleCache[cacheKey]; ok {
+		return cached, nil
+	}
+
+	var perms []ac.Permission
+
+	switch roleKind {
+	case string(iamv0.RoleBindingSpecRoleRefKindRole):
+		obj, err := dynClient.Resource(iamv0.RoleInfo.GroupVersionResource()).Namespace(namespace).Get(ctx, roleName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		var role iamv0.Role
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &role); err != nil {
+			return nil, err
+		}
+		for _, p := range role.Spec.Permissions {
+			perms = append(perms, ac.Permission{Action: p.Action, Scope: p.Scope})
+		}
+
+	case string(iamv0.RoleBindingSpecRoleRefKindGlobalRole):
+		obj, err := dynClient.Resource(iamv0.GlobalRoleInfo.GroupVersionResource()).Get(ctx, roleName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		var globalRole iamv0.GlobalRole
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &globalRole); err != nil {
+			return nil, err
+		}
+		for _, p := range globalRole.Spec.Permissions {
+			perms = append(perms, ac.Permission{Action: p.Action, Scope: p.Scope})
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown role kind: %s", roleKind)
+	}
+
+	roleCache[cacheKey] = perms
+	return perms, nil
+}
+
+// getBasicRolePermissions fetches permissions for the GlobalRole that corresponds to an org role
+// (e.g. "Viewer" → "basic_viewer"). Results are cached via roleCache.
+func (r *k8sPermissionResolver) getBasicRolePermissions(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace string,
+	orgRole string,
+	roleCache map[string][]ac.Permission,
+) ([]ac.Permission, error) {
+	basicRoleName := fmt.Sprintf("basic_%s", strings.ToLower(orgRole))
+	return r.getRolePermissions(ctx, dynClient, namespace, basicRoleName, string(iamv0.RoleBindingSpecRoleRefKindGlobalRole), roleCache)
+}
+
+// getDirectResourcePermissions fetches direct resource permissions (folder/dashboard-level grants)
+// via the resourcepermissions/search subresource. Returns empty without error when the rest
+// config provider is not available or the subresource is unreachable.
+func (r *k8sPermissionResolver) getDirectResourcePermissions(
+	c *contextmodel.ReqContext,
+	namespace string,
+	userUID string,
+) ([]ac.Permission, error) {
+	if userUID == "" {
+		return nil, nil
+	}
+	if c == nil || c.Context == nil || c.Req == nil {
+		if r.log != nil {
+			r.log.Debug("Skipping direct resource permissions: request context unavailable", "namespace", namespace, "userUID", userUID)
+		}
+		return nil, nil
+	}
+
+	restConfig := r.getRestConfig(c)
+	if restConfig == nil {
+		if r.log != nil {
+			r.log.Debug("Skipping direct resource permissions: rest config unavailable", "namespace", namespace, "userUID", userUID)
+		}
+		return nil, nil
+	}
+
+	cfg := dynamic.ConfigFor(restConfig)
+	cfg.GroupVersion = &iamv0.SchemeGroupVersion
+	client, err := rest.RESTClientFor(cfg)
+	if err != nil {
+		if r.log != nil {
+			r.log.Debug("Skipping direct resource permissions: could not build REST client", "namespace", namespace, "userUID", userUID, "error", err)
+		}
+		return nil, nil
+	}
+
+	raw, err := client.Get().
+		AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", namespace, "resourcepermissions", "search").
+		Param("userUID", userUID).
+		Do(c.Req.Context()).
+		Raw()
+	if err != nil {
+		if r.log != nil {
+			r.log.Debug("Skipping direct resource permissions: subresource call failed", "namespace", namespace, "userUID", userUID, "error", err)
+		}
+		return nil, nil
+	}
+
+	var result iamv0.PermissionsSearchResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		if r.log != nil {
+			r.log.Debug("Skipping direct resource permissions: invalid response payload", "namespace", namespace, "userUID", userUID, "error", err)
+		}
+		return nil, nil
+	}
+
+	perms := make([]ac.Permission, 0, len(result.Permissions))
+	for _, p := range result.Permissions {
+		perms = append(perms, ac.Permission{Action: p.Action, Scope: p.Scope})
+	}
+	return perms, nil
+}
+
+// getUserIDFromUID converts a Grafana user UID to its numeric ID via the user service.
+func (r *k8sPermissionResolver) getUserIDFromUID(ctx context.Context, uid string) int64 {
+	if r.userService == nil {
+		if r.log != nil {
+			r.log.Warn("user service not available for UID lookup", "uid", uid)
+		}
+		return 0
+	}
+
+	u, err := r.userService.GetByUID(ctx, &user.GetUserByUIDQuery{UID: uid})
+	if err != nil {
+		if r.log != nil {
+			r.log.Debug("Failed to get user by UID", "uid", uid, "error", err)
+		}
+		return 0
+	}
+
+	return u.ID
+}
+
+// filterPermissions applies SearchOptions filters (action, actionPrefix, scope) to a permission list.
+func (r *k8sPermissionResolver) filterPermissions(perms []ac.Permission, options ac.SearchOptions) []ac.Permission {
+	if options.Action == "" && options.ActionPrefix == "" && options.Scope == "" {
+		return perms
+	}
+
+	var filtered []ac.Permission
+	for _, p := range perms {
+		if options.Action != "" && p.Action != options.Action {
+			continue
+		}
+		if options.ActionPrefix != "" && !strings.HasPrefix(p.Action, options.ActionPrefix) {
+			continue
+		}
+		if options.Scope != "" && p.Scope != options.Scope {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}

--- a/pkg/services/accesscontrol/api/k8s_adapter_test.go
+++ b/pkg/services/accesscontrol/api/k8s_adapter_test.go
@@ -1,0 +1,405 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientrest "k8s.io/client-go/rest"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// newIAMScheme registers all IAM types needed by the dynamic fake client.
+func newIAMScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, iamv0.AddToScheme(scheme))
+	require.NoError(t, iamv0.AddGlobalRoleKnownTypes(scheme))
+	return scheme
+}
+
+// newFakeDynamic creates a dynamicfake client pre-populated with the given objects.
+// GlobalRole is cluster-scoped and requires an explicit list-kind mapping.
+func newFakeDynamic(t *testing.T, objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := newIAMScheme(t)
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			iamv0.GlobalRoleInfo.GroupVersionResource(): "GlobalRoleList",
+		},
+		objects...,
+	)
+}
+
+// makeUser creates an IAM User with the given name (Grafana UID) and org role.
+func makeUser(name, namespace, orgRole string) *iamv0.User {
+	u := &iamv0.User{}
+	u.TypeMeta = metav1.TypeMeta{APIVersion: iamv0.SchemeGroupVersion.String(), Kind: "User"}
+	u.ObjectMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
+	u.Spec.Role = orgRole
+	return u
+}
+
+// makeRole creates a namespaced Role with the given permissions.
+func makeRole(name, namespace string, perms ...accesscontrol.Permission) *iamv0.Role {
+	role := &iamv0.Role{}
+	role.TypeMeta = metav1.TypeMeta{APIVersion: iamv0.SchemeGroupVersion.String(), Kind: "Role"}
+	role.ObjectMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
+	for _, p := range perms {
+		role.Spec.Permissions = append(role.Spec.Permissions, iamv0.RolespecPermission{Action: p.Action, Scope: p.Scope})
+	}
+	return role
+}
+
+// makeGlobalRole creates a cluster-scoped GlobalRole with the given permissions.
+func makeGlobalRole(name string, perms ...accesscontrol.Permission) *iamv0.GlobalRole {
+	gr := &iamv0.GlobalRole{}
+	gr.TypeMeta = metav1.TypeMeta{APIVersion: iamv0.SchemeGroupVersion.String(), Kind: "GlobalRole"}
+	gr.ObjectMeta = metav1.ObjectMeta{Name: name}
+	for _, p := range perms {
+		gr.Spec.Permissions = append(gr.Spec.Permissions, iamv0.GlobalRolespecPermission{Action: p.Action, Scope: p.Scope})
+	}
+	return gr
+}
+
+// makeRoleBinding creates a RoleBinding for a user subject pointing at one or more roles.
+func makeRoleBinding(name, namespace, userUID string, roleRefs ...iamv0.RoleBindingspecRoleRef) *iamv0.RoleBinding {
+	rb := &iamv0.RoleBinding{}
+	rb.TypeMeta = metav1.TypeMeta{APIVersion: iamv0.SchemeGroupVersion.String(), Kind: "RoleBinding"}
+	rb.ObjectMeta = metav1.ObjectMeta{Name: name, Namespace: namespace}
+	rb.Spec.Subject = iamv0.RoleBindingspecSubject{
+		Kind: iamv0.RoleBindingSpecSubjectKindUser,
+		Name: userUID,
+	}
+	rb.Spec.RoleRefs = roleRefs
+	return rb
+}
+
+func roleRef(kind iamv0.RoleBindingSpecRoleRefKind, name string) iamv0.RoleBindingspecRoleRef {
+	return iamv0.RoleBindingspecRoleRef{Kind: kind, Name: name}
+}
+
+// Test that newK8sPermissionResolver returns nil when restConfigProvider is nil.
+func TestNewK8sPermissionResolver_NilProvider(t *testing.T) {
+	resolver := newK8sPermissionResolver(nil, nil, nil)
+	assert.Nil(t, resolver)
+}
+
+// Test that newK8sPermissionResolver creates a resolver when provider is available.
+func TestNewK8sPermissionResolver_WithProvider(t *testing.T) {
+	provider := &fakeRestConfigProvider{}
+	userSvc := &usertest.FakeUserService{}
+	resolver := newK8sPermissionResolver(provider, userSvc, nil)
+	assert.NotNil(t, resolver)
+	assert.Equal(t, provider, resolver.restConfigProvider)
+	assert.Equal(t, userSvc, resolver.userService)
+	assert.Nil(t, resolver.dynamicClient)
+}
+
+// Test SearchUsersPermissions when neither dynamic client nor rest config provider is available.
+func TestK8sPermissionResolver_SearchUsersPermissions_NoProvider(t *testing.T) {
+	resolver := &k8sPermissionResolver{log: log.New("test")}
+
+	ctx := context.Background()
+	caller := &contextmodel.ReqContext{}
+	options := accesscontrol.SearchOptions{}
+
+	_, err := resolver.SearchUsersPermissions(ctx, "default", caller, options)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rest config provider not available")
+}
+
+// Test SearchUsersPermissions with a single user query.
+func TestK8sPermissionResolver_SearchUsersPermissions_SingleUser(t *testing.T) {
+	const ns = "default"
+
+	// Set up K8s objects for user 1 (UID "test-user-uid").
+	fakeDyn := newFakeDynamic(t,
+		makeUser("test-user-uid", ns, ""),
+		makeRole("custom-role", ns,
+			accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:*"},
+		),
+		makeRoleBinding("user-test-user-uid", ns, "test-user-uid",
+			roleRef(iamv0.RoleBindingSpecRoleRefKindRole, "custom-role"),
+		),
+	)
+
+	mockUserSvc := usertest.NewMockService(t)
+	mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).
+		Return(&user.User{ID: 1, UID: "test-user-uid"}, nil)
+
+	resolver := &k8sPermissionResolver{
+		dynamicClient: fakeDyn,
+		userService:   mockUserSvc,
+		log:           log.New("test"),
+	}
+
+	result, err := resolver.SearchUsersPermissions(context.Background(), ns, &contextmodel.ReqContext{},
+		accesscontrol.SearchOptions{UserID: 1})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	perms, ok := result[1]
+	require.True(t, ok, "expected permissions for user 1")
+	require.Len(t, perms, 1)
+	assert.Equal(t, "dashboards:read", perms[0].Action)
+}
+
+// Test SearchUsersPermissions with the multi-user (all users) path.
+func TestK8sPermissionResolver_SearchUsersPermissions_AllUsers(t *testing.T) {
+	const ns = "default"
+
+	// User 1 has dashboards:read via a custom role.
+	// User 2 has no role binding → no permissions.
+	fakeDyn := newFakeDynamic(t,
+		makeUser("uid-user-1", ns, ""),
+		makeUser("uid-user-2", ns, ""),
+		makeRole("custom-role", ns,
+			accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:*"},
+		),
+		makeRoleBinding("user-uid-user-1", ns, "uid-user-1",
+			roleRef(iamv0.RoleBindingSpecRoleRefKindRole, "custom-role"),
+		),
+	)
+
+	mockUserSvc := usertest.NewMockService(t)
+	mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "uid-user-1"}).
+		Return(&user.User{ID: 10, UID: "uid-user-1"}, nil).Maybe()
+	mockUserSvc.On("GetByUID", mock.Anything, &user.GetUserByUIDQuery{UID: "uid-user-2"}).
+		Return(&user.User{ID: 20, UID: "uid-user-2"}, nil).Maybe()
+
+	resolver := &k8sPermissionResolver{
+		dynamicClient: fakeDyn,
+		userService:   mockUserSvc,
+		log:           log.New("test"),
+	}
+
+	result, err := resolver.SearchUsersPermissions(context.Background(), ns, &contextmodel.ReqContext{},
+		accesscontrol.SearchOptions{ActionPrefix: "dashboards:"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// User 10 (uid-user-1) should have dashboards:read.
+	perms10, ok := result[10]
+	require.True(t, ok, "expected permissions for user 10")
+	require.Len(t, perms10, 1)
+	assert.Equal(t, "dashboards:read", perms10[0].Action)
+
+	// User 20 (uid-user-2) has no permissions → not in result.
+	_, ok = result[20]
+	assert.False(t, ok, "user 20 should not appear in result")
+}
+
+// Test that basic org role permissions are fetched via GlobalRole and cached.
+func TestK8sPermissionResolver_BasicRolePermissions(t *testing.T) {
+	const ns = "default"
+
+	fakeDyn := newFakeDynamic(t,
+		makeUser("viewer-uid", ns, "Viewer"),
+		makeGlobalRole("basic_viewer",
+			accesscontrol.Permission{Action: "dashboards:read", Scope: "dashboards:*"},
+		),
+	)
+
+	mockUserSvc := usertest.NewMockService(t)
+	mockUserSvc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(5)}).
+		Return(&user.User{ID: 5, UID: "viewer-uid"}, nil)
+
+	resolver := &k8sPermissionResolver{
+		dynamicClient: fakeDyn,
+		userService:   mockUserSvc,
+		log:           log.New("test"),
+	}
+
+	result, err := resolver.SearchUsersPermissions(context.Background(), ns, &contextmodel.ReqContext{},
+		accesscontrol.SearchOptions{UserID: 5})
+	require.NoError(t, err)
+
+	perms, ok := result[5]
+	require.True(t, ok)
+	require.Len(t, perms, 1)
+	assert.Equal(t, "dashboards:read", perms[0].Action)
+}
+
+// Test filterPermissions with various options.
+func TestK8sPermissionResolver_FilterPermissions(t *testing.T) {
+	resolver := &k8sPermissionResolver{}
+
+	perms := []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:*"},
+		{Action: "dashboards:write", Scope: "dashboards:*"},
+		{Action: "folders:read", Scope: "folders:*"},
+		{Action: "users:read", Scope: "users:*"},
+	}
+
+	tests := []struct {
+		name     string
+		options  accesscontrol.SearchOptions
+		expected []accesscontrol.Permission
+	}{
+		{
+			name:     "no filters",
+			options:  accesscontrol.SearchOptions{},
+			expected: perms,
+		},
+		{
+			name:     "action filter",
+			options:  accesscontrol.SearchOptions{Action: "dashboards:read"},
+			expected: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:*"}},
+		},
+		{
+			name:    "action prefix filter",
+			options: accesscontrol.SearchOptions{ActionPrefix: "dashboards:"},
+			expected: []accesscontrol.Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+				{Action: "dashboards:write", Scope: "dashboards:*"},
+			},
+		},
+		{
+			name:     "scope filter",
+			options:  accesscontrol.SearchOptions{Scope: "users:*"},
+			expected: []accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolver.filterPermissions(perms, tt.options)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Test GetActionFilter in the base accesscontrol package.
+func TestGetActionFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		options accesscontrol.SearchOptions
+		action  string
+		want    bool
+	}{
+		{
+			name:    "exact match",
+			options: accesscontrol.SearchOptions{Action: "dashboards:read"},
+			action:  "dashboards:read",
+			want:    true,
+		},
+		{
+			name:    "exact mismatch",
+			options: accesscontrol.SearchOptions{Action: "dashboards:read"},
+			action:  "dashboards:write",
+			want:    false,
+		},
+		{
+			name:    "prefix match",
+			options: accesscontrol.SearchOptions{ActionPrefix: "dashboards:"},
+			action:  "dashboards:write",
+			want:    true,
+		},
+		{
+			name:    "prefix mismatch",
+			options: accesscontrol.SearchOptions{ActionPrefix: "dashboards:"},
+			action:  "folders:read",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := accesscontrol.GetActionFilter(tt.options)
+			got := filter(tt.action)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Test getUserIDFromUID with user service.
+func TestK8sPermissionResolver_GetUserIDFromUID(t *testing.T) {
+	tests := []struct {
+		name       string
+		userSvc    user.Service
+		uid        string
+		expectedID int64
+	}{
+		{
+			name: "successful lookup",
+			userSvc: &usertest.FakeUserService{
+				ExpectedUser: &user.User{ID: 42, UID: "test-uid"},
+			},
+			uid:        "test-uid",
+			expectedID: 42,
+		},
+		{
+			name:       "nil user service",
+			userSvc:    nil,
+			uid:        "test-uid",
+			expectedID: 0,
+		},
+		{
+			name: "user not found",
+			userSvc: &usertest.FakeUserService{
+				ExpectedError: user.ErrUserNotFound,
+			},
+			uid:        "unknown-uid",
+			expectedID: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &k8sPermissionResolver{
+				userService: tt.userSvc,
+				log:         log.New("test"),
+			}
+
+			id := resolver.getUserIDFromUID(context.Background(), tt.uid)
+			assert.Equal(t, tt.expectedID, id)
+		})
+	}
+}
+
+func TestK8sPermissionResolver_GetDirectResourcePermissions_GracefulFailures(t *testing.T) {
+	t.Run("nil request context", func(t *testing.T) {
+		resolver := &k8sPermissionResolver{
+			restConfigProvider: &fakeRestConfigProvider{},
+			log:                log.New("test"),
+		}
+
+		perms, err := resolver.getDirectResourcePermissions(nil, "default", "uid-1")
+		require.NoError(t, err)
+		require.Empty(t, perms)
+	})
+
+	t.Run("subresource unreachable", func(t *testing.T) {
+		resolver := &k8sPermissionResolver{
+			restConfigProvider: &fakeRestConfigProvider{},
+			log:                log.New("test"),
+		}
+		c := &contextmodel.ReqContext{Context: &web.Context{Req: httptest.NewRequest("GET", "/", nil)}}
+
+		perms, err := resolver.getDirectResourcePermissions(c, "default", "uid-1")
+		require.NoError(t, err)
+		require.Empty(t, perms)
+	})
+}
+
+// fakeRestConfigProvider implements DirectRestConfigProvider for testing.
+type fakeRestConfigProvider struct{}
+
+func (f *fakeRestConfigProvider) GetDirectRestConfig(_ *contextmodel.ReqContext) *clientrest.Config {
+	return &clientrest.Config{Host: "http://localhost"}
+}


### PR DESCRIPTION
- Added a new k8sPermissionResolver to handle user permissions via K8s IAM APIs.
- Updated AccessControlAPI to utilize the new resolver when Kubernetes feature flag is enabled.
- Refactored GetActionFilter function to improve clarity and maintainability.
- Enhanced test coverage for SearchUsersPermissions, including K8s-specific scenarios.
- Introduced new tests for k8sPermissionResolver to ensure correct behavior with user permissions.

This commit improves the overall access control mechanism by integrating Kubernetes IAM capabilities, allowing for more flexible permission management.