### PR TITLE
Flaky Test: Library Elements Delete Fix

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -77,14 +77,20 @@ func syncFieldsWithModel(libraryElement *model.LibraryElement) error {
 	return nil
 }
 
-func (l *LibraryElementService) GetLibraryElement(c context.Context, signedInUser identity.Requester, session *db.Session, uid string) (model.LibraryElementWithMeta, error) {
+// getLibraryElementRow fetches a single library element row from the database using the
+// provided transaction session. It intentionally does NOT call folderService.Get — callers
+// that need folder metadata (e.g. for display) should use GetLibraryElement instead.
+//
+// This separation exists because folderService.Get opens its own database connection. Calling
+// it inside a WithTransactionalDbSession callback can cause SQLite "database is locked" errors
+// (or deadlocks on small connection pools) because the outer transaction already holds the
+// write lock. DeleteLibraryElement uses this helper so the transaction stays clean.
+func (l *LibraryElementService) getLibraryElementRow(session *db.Session, signedInUser identity.Requester, uid string) (model.LibraryElementWithMeta, error) {
 	elements := make([]model.LibraryElementWithMeta, 0)
 	sql := selectLibraryElementDTOWithMeta +
 		getFromLibraryElementDTOWithMeta(l.SQLStore.GetDialect()) +
 		" WHERE le.uid=? AND le.org_id=?"
-	sess := session.SQL(sql, uid, signedInUser.GetOrgID())
-	err := sess.Find(&elements)
-	if err != nil {
+	if err := session.SQL(sql, uid, signedInUser.GetOrgID()).Find(&elements); err != nil {
 		return model.LibraryElementWithMeta{}, err
 	}
 	if len(elements) == 0 {
@@ -93,21 +99,34 @@ func (l *LibraryElementService) GetLibraryElement(c context.Context, signedInUse
 	if len(elements) > 1 {
 		return model.LibraryElementWithMeta{}, fmt.Errorf("found %d elements, while expecting at most one", len(elements))
 	}
+	return elements[0], nil
+}
 
-	// get the folder title
+// GetLibraryElement fetches a library element by UID and enriches it with the folder title.
+// Do NOT call this from inside a WithTransactionalDbSession callback — the folderService.Get
+// call it makes opens a new database connection, which can deadlock against the open
+// transaction (especially on SQLite). Use getLibraryElementRow instead for transactional paths.
+func (l *LibraryElementService) GetLibraryElement(c context.Context, signedInUser identity.Requester, session *db.Session, uid string) (model.LibraryElementWithMeta, error) {
+	element, err := l.getLibraryElementRow(session, signedInUser, uid)
+	if err != nil {
+		return model.LibraryElementWithMeta{}, err
+	}
+
+	// Enrich with the folder title. folderService.Get opens its own DB connection so this
+	// must not be called inside an active transaction (see getLibraryElementRow above).
 	f, err := l.folderService.Get(c, &folder.GetFolderQuery{
-		OrgID:        elements[0].OrgID,
-		UID:          &elements[0].FolderUID,
+		OrgID:        element.OrgID,
+		UID:          &element.FolderUID,
 		SignedInUser: signedInUser,
 	})
 	if err == nil {
-		elements[0].FolderName = f.Title
+		element.FolderName = f.Title
 	} else {
 		// default to General if we cannot find the folder
-		elements[0].FolderName = "General"
+		element.FolderName = "General"
 	}
 
-	return elements[0], nil
+	return element, nil
 }
 
 // createLibraryElement adds a library element.
@@ -234,7 +253,11 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 func (l *LibraryElementService) DeleteLibraryElement(c context.Context, signedInUser identity.Requester, uid string) (int64, error) {
 	var elementID int64
 	err := l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
-		element, err := l.GetLibraryElement(c, signedInUser, session, uid)
+		// Use getLibraryElementRow (not GetLibraryElement) to avoid calling folderService.Get
+		// inside the transaction. folderService.Get opens its own DB connection; doing so
+		// while holding a write lock causes "database is locked" errors on SQLite and can
+		// deadlock on small connection pools. Folder metadata is not needed for deletion.
+		element, err := l.getLibraryElementRow(session, signedInUser, uid)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -125,6 +125,11 @@ func TestIntegrationLibraryElementPermissions(t *testing.T) {
 	})
 
 	t.Run("delete", func(t *testing.T) {
+		// Guard: if earlier subtests failed to create or correctly move the panel, uid will
+		// be empty or the element will be in an unexpected state. Catching that here prevents
+		// the delete from getting a 404/500 that looks like a delete-specific bug.
+		require.NotEmpty(t, uid, "uid must be set by the 'create' subtest before delete can run")
+
 		t.Run("When viewer tries to delete library panel, it should fail", func(t *testing.T) {
 			deleteLibraryElement(t, grafanaListedAddr, "viewer", "viewer", uid, http.StatusForbidden)
 		})
@@ -328,6 +333,8 @@ func revokeFolderPermissions(t *testing.T, grafanaListedAddr, folderUID string, 
 }
 
 func makeHTTPRequest(t *testing.T, method, url string, body interface{}, expectedStatus int) []byte {
+	t.Helper()
+
 	var req *http.Request
 	var err error
 
@@ -346,12 +353,17 @@ func makeHTTPRequest(t *testing.T, method, url string, body interface{}, expecte
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	// nolint:errcheck
-	defer resp.Body.Close()
-	require.Equal(t, expectedStatus, resp.StatusCode)
+	defer resp.Body.Close() // nolint:errcheck
 
+	// Read the body before asserting the status code so the response text is
+	// visible in the failure message. Previously the body was read after the
+	// require.Equal, which meant a status mismatch always showed an empty body.
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
+
+	require.Equal(t, expectedStatus, resp.StatusCode,
+		"%s %s: unexpected status code; response body: %s", method, url, string(respBody))
+
 	return respBody
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This fixes a small issue in Library Elements API found by this flaky test: https://github.com/grafana/grafana/actions/runs/23251514199/job/67594870081

The fix extracts the folder metadata lookup (folderService.Get) out of the delete transaction into a new private helper getLibraryElementRow, which performs only the raw database query needed for deletion. This prevents a second
  database connection from being opened while the transaction holds the SQLite write lock, eliminating the intermittent "database is locked" 500 error.

**Why do we need this feature?**
folderService.Get is called inside a WithTransactionalDbSession callback in DeleteLibraryElement, opening a second database connection while the transaction holds the SQLite write lock, causing intermittent "database is locked" errors
that surface as HTTP 500.

**Who is this feature for?**
Grafana / Library Elements users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/120712

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
