### PR TITLE
Suggested Dashboards: `dashvalidator` Remove flaky timing-based performance tests

### DIFF
--- a/apps/dashvalidator/pkg/validator/benchmark_test.go
+++ b/apps/dashvalidator/pkg/validator/benchmark_test.go
@@ -3,8 +3,6 @@ package validator
 import (
 	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // promQLPool contains realistic PromQL expressions sourced from real Grafana dashboards.

--- a/apps/dashvalidator/pkg/validator/benchmark_test.go
+++ b/apps/dashvalidator/pkg/validator/benchmark_test.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -202,40 +201,6 @@ func buildDashboardJSONWithRows(flatPanels, rows, panelsPerRow, queriesPerPanel 
 		"uid":     "benchmark-rows-uid",
 		"version": 1,
 	}
-}
-
-// TestPerformanceBaseline_ExtractQueries asserts that query extraction for a large
-// dashboard completes within a generous threshold. Uses 5ms to account for slow CI
-// machines, GC pauses, and noisy neighbors. Our benchmarks show ~94µs for 800 queries
-// on fast hardware — this test only catches catastrophic regressions (e.g., O(n²)).
-// For precise measurements, use the benchmarks with `go test -bench=`.
-func TestPerformanceBaseline_ExtractQueries(t *testing.T) {
-	dashboard := buildDashboardJSON(200, 4)
-
-	start := time.Now()
-	queries, err := extractQueriesFromDashboard(dashboard)
-	elapsed := time.Since(start)
-
-	assert.NoError(t, err)
-	assert.Len(t, queries, 800)
-	assert.Less(t, elapsed, 5*time.Millisecond,
-		"extractQueriesFromDashboard took %v, expected < 5ms", elapsed)
-}
-
-// TestPerformanceBaseline_GroupQueries asserts that query grouping completes within
-// a generous threshold. Same rationale as TestPerformanceBaseline_ExtractQueries.
-func TestPerformanceBaseline_GroupQueries(t *testing.T) {
-	dashboard := buildDashboardJSON(100, 4)
-	queries, err := extractQueriesFromDashboard(dashboard)
-	assert.NoError(t, err)
-
-	start := time.Now()
-	grouped := groupQueriesByDatasource(queries, concreteUID, dashboard)
-	elapsed := time.Since(start)
-
-	assert.NotEmpty(t, grouped)
-	assert.Less(t, elapsed, 5*time.Millisecond,
-		"groupQueriesByDatasource took %v, expected < 5ms", elapsed)
 }
 
 // BenchmarkGroupQueriesByDatasource measures the second pipeline stage:


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The tests `TestPerformanceBaseline_ExtractQueries` and `TestPerformanceBaseline_GroupQueries` asserted that in-memory operations finish within 5ms, causing flaky [CI](https://github.com/grafana/grafana/actions/runs/23300664561/job/67760567809?pr=120606#step:8:51) failures (e.g. 5.5ms) despite the code being fast (~94µs).

Wall-clock assertions in Go tests are unreliable due to GC, scheduling, and CPU variability, especially in CI. The Go team recommends using benchmarks (testing.B) with `benchstat` instead.

These tests were redundant. Existing benchmarks already cover the same code paths. Performance regressions can be detected with:

`go test -bench=. -count=10 ./apps/dashvalidator/pkg/validator/... ` and comparing via benchstat.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
