### PR TITLE
Search: Respect serve_from_sub_path in command palette URLs

### DIFF
--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -179,8 +179,8 @@ describe('toDashboardResults', () => {
 
       server.use(
         getCustomSearchHandler([
-          { name: 'folder1', title: 'Folder 1', resource: 'folders' },
-          { name: 'dashboard1', title: 'Dashboard 1', resource: 'dashboards', folder: 'folder1' },
+          { name: 'folder1', title: 'Folder 1', resource: 'folder' },
+          { name: 'dashboard1', title: 'Dashboard 1', resource: 'dashboard', folder: 'folder1' },
         ])
       );
 
@@ -197,8 +197,8 @@ describe('toDashboardResults', () => {
 
       server.use(
         getCustomSearchHandler([
-          { name: 'folder1', title: 'Folder 1', resource: 'folders' },
-          { name: 'dashboard1', title: 'Dashboard 1', resource: 'dashboards', folder: 'folder1' },
+          { name: 'folder1', title: 'Folder 1', resource: 'folder' },
+          { name: 'dashboard1', title: 'Dashboard 1', resource: 'dashboard', folder: 'folder1' },
         ])
       );
 

--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -1,4 +1,4 @@
-import { setBackendSrv } from '@grafana/runtime';
+import { config, setBackendSrv } from '@grafana/runtime';
 import { getCustomSearchHandler } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -165,5 +165,49 @@ describe('toDashboardResults', () => {
     const results = toDashboardResults(mockResponse, '-errors_today');
 
     expect(results.meta?.custom?.sortBy).toBe('errors_today');
+  });
+
+  describe('respects appSubUrl in search result URLs', () => {
+    const originalAppSubUrl = config.appSubUrl;
+
+    afterEach(() => {
+      config.appSubUrl = originalAppSubUrl;
+    });
+
+    it('should prepend appSubUrl to folder and dashboard URLs in locationInfo', async () => {
+      config.appSubUrl = '/grafana';
+
+      server.use(
+        getCustomSearchHandler([
+          { name: 'folder1', title: 'Folder 1', resource: 'folders' },
+          { name: 'dashboard1', title: 'Dashboard 1', resource: 'dashboards', folder: 'folder1' },
+        ])
+      );
+
+      const searcher = new UnifiedSearcher(mockFallbackSearcher);
+      const response = await searcher.search({ query: 'test', limit: 50 });
+
+      const locationInfo = response.view.dataFrame.meta?.custom?.locationInfo;
+      expect(locationInfo?.general.url).toBe('/grafana/dashboards');
+      expect(locationInfo?.folder1.url).toBe('/grafana/dashboards/f/folder1');
+    });
+
+    it('should work with empty appSubUrl', async () => {
+      config.appSubUrl = '';
+
+      server.use(
+        getCustomSearchHandler([
+          { name: 'folder1', title: 'Folder 1', resource: 'folders' },
+          { name: 'dashboard1', title: 'Dashboard 1', resource: 'dashboards', folder: 'folder1' },
+        ])
+      );
+
+      const searcher = new UnifiedSearcher(mockFallbackSearcher);
+      const response = await searcher.search({ query: 'test', limit: 50 });
+
+      const locationInfo = response.view.dataFrame.meta?.custom?.locationInfo;
+      expect(locationInfo?.general.url).toBe('/dashboards');
+      expect(locationInfo?.folder1.url).toBe('/dashboards/f/folder1');
+    });
   });
 });

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -460,7 +460,7 @@ async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
         general: {
           kind: 'folder',
           name: 'Dashboards',
-          url: '/dashboards',
+          url: `${config.appSubUrl}/dashboards`,
         }, // share location info with everyone
         sharedwithme: {
           kind: 'sharedwithme',
@@ -482,8 +482,8 @@ async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
 
 function toURL(resource: string, name: string, title: string): string {
   if (resource === 'folders') {
-    return `/dashboards/f/${name}`;
+    return `${config.appSubUrl}/dashboards/f/${name}`;
   }
   const slug = kbn.slugifyForUrl(title);
-  return `/d/${name}/${slug}`;
+  return `${config.appSubUrl}/d/${name}/${slug}`;
 }


### PR DESCRIPTION
Fixes #120715

When `serve_from_sub_path` is enabled with a custom `root_url`, the command palette search generates URLs without the configured subpath prefix, causing navigation to fail.

The `toURL()` helper in the unified search service builds absolute paths like `/d/{uid}/{slug}` without prepending `config.appSubUrl`. The hardcoded `/dashboards` URL in `loadLocationInfo()` has the same issue.

This is a regression in 12.4.x where the unified searcher became the default code path for search results.