### PR TITLE
Chore: Bump nanogit to v0.13.0

### DIFF
--- a/apps/iam/go.sum
+++ b/apps/iam/go.sum
@@ -844,8 +844,8 @@ github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000 h1:/5LKSYgLm
 github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000/go.mod h1:/ZklAgE1i4f3Z8uriXwESmCr1VLF8lBGaJspuaGuf78=
 github.com/grafana/loki/v3 v3.5.11 h1:cIO1FYgg0o2aj8zIpXz6kFOUxW0AWU3Yk/AZqtwbzoI=
 github.com/grafana/loki/v3 v3.5.11/go.mod h1:vT/ZnjX2++rBwKSdsjzNELU+66PWkop5KetzeALZH5Y=
-github.com/grafana/nanogit v0.12.0 h1:ckBI+uPwrq4iMMQgjgKxx66jC4Q7q9mMcBKDHzesXnI=
-github.com/grafana/nanogit v0.12.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
+github.com/grafana/nanogit v0.13.0 h1:E1YV8YYLOxoZTl6J7KqsReQ90Ww1lVfmd6kqhhUWYfA=
+github.com/grafana/nanogit v0.13.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20250911094103-5456b6e45604 h1:aXfUhVN/Ewfpbko2CCtL65cIiGgwStOo4lWH2b6gw2U=

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/grafana-app-sdk/logging v0.51.4
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
-	github.com/grafana/nanogit v0.12.0
+	github.com/grafana/nanogit v0.13.0
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -101,8 +101,8 @@ github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6 h1:TJd
 github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6/go.mod h1:6ZLwJmNc+7dWXQ+NRBV09HZbg/XZ6yN7kWFf7w301Lo=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6/go.mod h1:BpUYFztGINSLZmkzcS9dSHdNwBZAb8w1KD5unG1oNeg=
-github.com/grafana/nanogit v0.12.0 h1:ckBI+uPwrq4iMMQgjgKxx66jC4Q7q9mMcBKDHzesXnI=
-github.com/grafana/nanogit v0.12.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
+github.com/grafana/nanogit v0.13.0 h1:E1YV8YYLOxoZTl6J7KqsReQ90Ww1lVfmd6kqhhUWYfA=
+github.com/grafana/nanogit v0.13.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/grafana/grafana-plugin-sdk-go v0.290.1 // @grafana/plugins-platform-backend
 	github.com/grafana/loki/pkg/push v0.0.0-20250823105456-332df2b20000 // @grafana/alerting-backend
 	github.com/grafana/loki/v3 v3.5.11 // @grafana/observability-logs
-	github.com/grafana/nanogit v0.12.0 // indirect; @grafana/grafana-git-ui-sync-team
+	github.com/grafana/nanogit v0.13.0 // indirect; @grafana/grafana-git-ui-sync-team
 	github.com/grafana/nanogit/gittest v0.10.2 // @grafana/grafana-git-ui-sync-team
 	github.com/grafana/otel-profiling-go v0.5.1 // @grafana/grafana-backend-group
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // @grafana/observability-traces-and-profiling

--- a/go.sum
+++ b/go.sum
@@ -1656,8 +1656,8 @@ github.com/grafana/loki/v3 v3.5.11 h1:cIO1FYgg0o2aj8zIpXz6kFOUxW0AWU3Yk/AZqtwbzo
 github.com/grafana/loki/v3 v3.5.11/go.mod h1:vT/ZnjX2++rBwKSdsjzNELU+66PWkop5KetzeALZH5Y=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOmOr//QEn9J1MtC4R4CPR9/IbUd8hZrbWKo=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86/go.mod h1:h60o12SZn/ua/j0B6iKAZezA4eDaGsIuPO70eOaJ6WE=
-github.com/grafana/nanogit v0.12.0 h1:ckBI+uPwrq4iMMQgjgKxx66jC4Q7q9mMcBKDHzesXnI=
-github.com/grafana/nanogit v0.12.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
+github.com/grafana/nanogit v0.13.0 h1:E1YV8YYLOxoZTl6J7KqsReQ90Ww1lVfmd6kqhhUWYfA=
+github.com/grafana/nanogit v0.13.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
 github.com/grafana/nanogit/gittest v0.10.2 h1:2+e/zvmBCjpTN/8AeHS7OIjEI6FnzqyNs5RmiJYcJdY=
 github.com/grafana/nanogit/gittest v0.10.2/go.mod h1:qewV4AZOErVbxBMYLj9yAv5ITs/VOc+t/Ko/2w3pSfo=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=


### PR DESCRIPTION
## Summary

- Bumps nanogit dependency from v0.12.0 to v0.13.0 across:
  - `go.mod` / `go.sum`
  - `apps/iam/go.sum`
  - `apps/provisioning/go.mod` / `apps/provisioning/go.sum`

## What's new in nanogit v0.13.0

The key improvement is the addition of `Type` and `OldType` fields to the `CommitFile` struct ([nanogit PR #252](https://github.com/grafana/nanogit/pull/252)).

**Before (v0.12.0):**
```go
// Had to write helper functions to distinguish files from directories
func isTreeEntry(mode uint32) bool {
    return mode&0040000 != 0
}
```

**After (v0.13.0):**
```go
// CommitFile now includes explicit Git object types
type CommitFile struct {
    // ... existing fields ...
    Type    protocol.ObjectType // blob (file) or tree (directory) in head commit
    OldType protocol.ObjectType // blob or tree in base commit
}

// Usage in CompareCommits is now straightforward
if file.Type == protocol.ObjectTypeTree {
    // handle directory
}
```

## Benefits

- **Cleaner code**: No need for custom helper functions to parse file modes
- **More explicit**: Object types are directly accessible on `CommitFile`
- **Complete coverage**: Type information is populated for all file change scenarios (added, modified, deleted, renamed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)