### PR TITLE
Folders: Only add shared with me folder on first page of results

### DIFF
--- a/public/app/features/browse-dashboards/api/services.test.ts
+++ b/public/app/features/browse-dashboards/api/services.test.ts
@@ -245,6 +245,16 @@ describe('browse-dashboards services', () => {
         });
       });
 
+      it('does not add shared with me folder on subsequent pages', async () => {
+        const mockFolders = [{ uid: 'folder-1', name: 'Folder 1' }];
+        searchMock.mockResolvedValue(createSearchData(mockFolders));
+
+        const result = await listFolders(undefined, undefined, 2, PAGE_SIZE);
+
+        expect(result).toHaveLength(1);
+        expect(result.find((f) => f.uid === 'sharedwithme')).toBeUndefined();
+      });
+
       it('does not add shared with me folder when parentUID is provided', async () => {
         const mockFolders = [{ uid: 'folder-1', name: 'Folder 1' }];
         searchMock.mockResolvedValue(createSearchData(mockFolders));

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -36,7 +36,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
   // Add shared with me item statically to the array as it is not returned from the
   // API anymore. This also means we show it every time, whether it has children or not. This is the same as in folder
   // picker for now. In the future we could to additional request to see if there are any children in it.
-  if (!parentUID && config.sharedWithMeFolderUID) {
+  if (page === 1 && !parentUID && config.sharedWithMeFolderUID) {
     folders.unshift({
       kind: 'folder',
       name: t('browse-dashboards.shared-with-me', 'Shared with me'),


### PR DESCRIPTION
**What is this feature?**
Makes sure the virtual folder "Shared with me" is only added to the first page of results - otherwise it repeats every 50

**Why do we need this feature?**
To stop incorrect displays in pagination results when using `foldersAppPlatformAPI` feature toggle

**Who is this feature for?**
Folders users!