### PR TITLE
Add contents: read when using actions/checkout in a job

### DIFF
--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -7,6 +7,8 @@ jobs:
   gen-swagger:
     name: Alerting Swagger spec generation cron job
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.event.workflow_run.head_repository.fork == false && github.repository == 'grafana/grafana' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
       actions: read
     steps:

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -153,6 +153,8 @@ jobs:
     if: always()
     name: All steps completed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,6 +51,8 @@ jobs:
     runs-on: ubuntu-x64-large-io
     continue-on-error: true # doesn't block PRs from being merged if this fails
     if: github.repository == 'grafana/grafana'
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -313,6 +313,8 @@ jobs:
     if: needs.detect-changes.outputs.changed-frontend-dependencies == 'true'
     runs-on: ubuntu-x64-small
     name: Validate yarn install
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/pr-codeql-analysis-javascript.yml
+++ b/.github/workflows/pr-codeql-analysis-javascript.yml
@@ -17,6 +17,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/pr-codeql-analysis-python.yml
+++ b/.github/workflows/pr-codeql-analysis-python.yml
@@ -15,6 +15,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -141,6 +141,8 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-x64-large
     name: "Decoupled plugin tests"
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
       with:
@@ -157,6 +159,8 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-x64-large
     name: "Packages unit tests"
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
       with:
@@ -185,6 +189,8 @@ jobs:
 
     name: All frontend unit tests complete
     runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -202,6 +208,8 @@ jobs:
     if: needs.detect-changes.outputs.devenv-changed == 'true'
     runs-on: ubuntu-x64-large
     name: "Devenv frontend-service build"
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -31,6 +31,8 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     name: Go Workspace Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/pr-k8s-codegen-check.yml
+++ b/.github/workflows/pr-k8s-codegen-check.yml
@@ -16,6 +16,8 @@ jobs:
   check:
     name: K8s Codegen Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-x64-large
     continue-on-error: true
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   trivy-scan:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       # renovate: datasource=github-releases depName=trivy packageName=aquasecurity/trivy
       TRIVY_VERSION: 'v0.69.2'


### PR DESCRIPTION
This will allow workflows to `checkout` a private fork / mirror when running in that context. Because `grafana/grafana` is open source, it doesn't require `contents: read` to check out.