### PR TITLE
  Prometheus: Improve series limit input handling in metrics browser

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -14,10 +14,27 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+  const [localSeriesLimit, setLocalSeriesLimit] = useState<string | number>(
+    seriesLimit === undefined || isNaN(seriesLimit) ? '' : seriesLimit
+  );
+
+  useEffect(() => {
+    setLocalSeriesLimit(seriesLimit === undefined || isNaN(seriesLimit) ? '' : seriesLimit);
+  }, [seriesLimit]);
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
   }, [metrics, selectedMetric, metricSearchTerm]);
+
+  const handleSeriesLimitChange = (e: React.FormEvent<HTMLInputElement>) => {
+    setLocalSeriesLimit(e.currentTarget.value);
+  };
+
+  const handleSeriesLimitBlur = () => {
+    const value = String(localSeriesLimit).trim();
+    const limit = value === '' ? NaN : parseInt(value, 10);
+    setSeriesLimit(limit);
+  };
 
   return (
     <div>
@@ -51,12 +68,13 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={handleSeriesLimitChange}
+            onBlur={handleSeriesLimitBlur}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={localSeriesLimit}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>

--- a/packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts
+++ b/packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
-import { useDebounce } from 'react-use';
 
 import { TimeRange } from '@grafana/data';
 
@@ -30,7 +29,7 @@ export const useMetricsLabelsValues = (timeRange: TimeRange, languageProvider: P
   const [isLoadingLabelValues, setIsLoadingLabelValues] = useState(false);
 
   // Memoize the effective series limit to use the default when seriesLimit is empty
-  const effectiveLimit = useMemo(() => seriesLimit, [seriesLimit]);
+  const effectiveLimit = useMemo(() => (isNaN(seriesLimit) ? undefined : seriesLimit), [seriesLimit]);
 
   // We don't want to trigger fetching for small amount of time changes.
   // When MetricsBrowser re-renders for any reason we might receive a new timerange.
@@ -192,18 +191,14 @@ export const useMetricsLabelsValues = (timeRange: TimeRange, languageProvider: P
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // We use debounce here to prevent fetching data on every keystroke
-  // We also track the seriesLimit change to prevent fetching twice right after the initialization
-  useDebounce(
-    () => {
-      if (isInitializedRef.current && lastSeriesLimitRef.current !== seriesLimit) {
-        initialize(selectedMetric, selectedLabelValues);
-        lastSeriesLimitRef.current = seriesLimit;
-      }
-    },
-    300,
-    [seriesLimit]
-  );
+  // We use useEffect here to fetch data when the seriesLimit changes
+  // We track the seriesLimit change to prevent fetching twice right after the initialization
+  useEffect(() => {
+    if (isInitializedRef.current && !Object.is(lastSeriesLimitRef.current, seriesLimit)) {
+      initialize(selectedMetric, selectedLabelValues);
+      lastSeriesLimitRef.current = seriesLimit;
+    }
+  }, [seriesLimit, initialize, selectedMetric, selectedLabelValues]);
 
   // Handles metric selection changes.
   // If a metric selected it fetches the labels of that metric


### PR DESCRIPTION
 What is this feature?

  This PR improves the handling of the "series limit" input in the Prometheus metrics browser. It introduces a local state for the input field and changes
  the seriesLimit state update to occur on onBlur instead of onChange. This change ensures that data-fetching logic is only triggered when the user
  finishes entering their desired limit and moves focus away from the input field.

  Why do we need this feature?

  Previously, every keystroke in the series limit input field triggered a backend fetch request via onChange. This caused unnecessary network traffic and
  potentially degraded performance, especially when entering larger numbers. By switching to onBlur, we eliminate these redundant requests and provide a
  smoother user experience.

  Who is this feature for?

  Grafana users who use the Prometheus metrics browser and want a more responsive and reliable way to limit the number of series returned during metric
  discovery.

  Which issue(s) does this PR fix?:

  Fixes #[120727](https://github.com/grafana/grafana/issues/120727)

  Special notes for your reviewer:

  Please check that:
   - [x] It works as expected from a user's perspective: The input now only triggers a re-fetch when it loses focus (onBlur).
   - [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A)
   -  ] The docs are updated, and if this is a [notable improvement
     (https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our What's New
     (https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (N/A)

  Technical Notes:
   - MetricSelector.tsx: Added localSeriesLimit to decouple the input's visual state from the global seriesLimit until the user finishes typing.
   - useMetricsLabelsValues.ts: Improved the update logic to use Object.is for reliable change detection, specifically ensuring that transitioning from a
     number to NaN (and vice versa) correctly triggers or skips re-fetches as intended. This also removes the reliance on useDebounce from react-use for
     this specific interaction.
