### PR TITLE
adHoc: collapsible state

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -365,7 +365,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       supportsMultiValueOperators: Boolean(
         getDataSourceSrv().getInstanceSettings({ type: ds?.type })?.meta.multiValueFilterOperators
       ),
-      collapsible: config.featureToggles.dashboardAdHocAndGroupByWrapper,
+      collapsible: config.featureToggles.dashboardUnifiedDrilldownControls,
     };
     if (variable.spec.allowCustomValue !== undefined) {
       adhocVariableState.allowCustomValue = variable.spec.allowCustomValue;

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -178,7 +178,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       useQueriesAsFilterForOptions: true,
       drilldownRecommendationsEnabled: config.featureToggles.drilldownRecommendations,
       layout: 'combobox',
-      collapsible: config.featureToggles.dashboardAdHocAndGroupByWrapper,
+      collapsible: config.featureToggles.dashboardUnifiedDrilldownControls,
       supportsMultiValueOperators: Boolean(
         getDataSourceSrv().getInstanceSettings({ type: variable.datasource?.type })?.meta.multiValueFilterOperators
       ),


### PR DESCRIPTION
**What is this feature?**

Enables collapsible state for adhoc filter

before:
<img width="1343" height="141" alt="image" src="https://github.com/user-attachments/assets/29432d5c-0ad8-4596-9457-0ee1d50f4b64" />

<img width="1491" height="286" alt="image" src="https://github.com/user-attachments/assets/1529d934-7dd3-4154-8f6f-077da1d01229" />


after:
<img width="1343" height="106" alt="image" src="https://github.com/user-attachments/assets/9a7848f3-a902-4faf-b68b-e87d23ea4813" />
