### PR TITLE
Prometheus: Fetch new labels onBlur instead of onChange for series limit input

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -14,6 +14,7 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+  const [localSeriesLimit, setLocalSeriesLimit] = useState(seriesLimit);
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -51,12 +52,13 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setLocalSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onBlur={() => setSeriesLimit(localSeriesLimit)}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={localSeriesLimit}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>

--- a/packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts
+++ b/packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts
@@ -192,18 +192,14 @@ export const useMetricsLabelsValues = (timeRange: TimeRange, languageProvider: P
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // We use debounce here to prevent fetching data on every keystroke
-  // We also track the seriesLimit change to prevent fetching twice right after the initialization
-  useDebounce(
-    () => {
-      if (isInitializedRef.current && lastSeriesLimitRef.current !== seriesLimit) {
-        initialize(selectedMetric, selectedLabelValues);
-        lastSeriesLimitRef.current = seriesLimit;
-      }
-    },
-    300,
-    [seriesLimit]
-  );
+  // Fetch new data when seriesLimit changes (triggered onBlur from the input)
+  useEffect(() => {
+    if (isInitializedRef.current && lastSeriesLimitRef.current !== seriesLimit) {
+      initialize(selectedMetric, selectedLabelValues);
+      lastSeriesLimitRef.current = seriesLimit;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seriesLimit]);
 
   // Handles metric selection changes.
   // If a metric selected it fetches the labels of that metric

--- a/packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts
+++ b/packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
-import { useDebounce } from 'react-use';
 
 import { TimeRange } from '@grafana/data';
 


### PR DESCRIPTION
**What is this pull request about?**

The metrics browser fires backend fetch requests on every keystroke in the
series limit input due to using `onChange`. This PR changes the behavior to
only fetch onBlur, preventing unnecessary API calls while the user is still typing.

**Changes:**
- `MetricSelector.tsx`: Added local state for the input value. `onChange` updates
  local state only; `setSeriesLimit` (which triggers fetching) is called on `onBlur`.
- `useMetricsLabelsValues.ts`: Replaced `useDebounce` with `useEffect` since the
  limit now only changes on blur (a single discrete event). Removed unused
  `useDebounce` import.

Fixes #120727

**How to test:**
1. Open Explore → Prometheus → Code → Metrics browser
2. Open DevTools Network tab, filter by `api/v1`
3. Type in the Series limit input — no requests should fire
4. Click outside (blur) — one batch of requests fires

**Checklist:**
- [x] Tests pass (`yarn jest --no-watch packages/grafana-prometheus/src/components/metrics-browser/`)