### PR TITLE
CODEOWNERS: add grafana-operator-experience-squad to scope E2E helpers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -430,6 +430,8 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/cloud-plugins-suite/ @grafana/partner-datasources
 /e2e-playwright/dashboard-new-layouts/ @grafana/dashboards-squad
 /e2e-playwright/dashboard-cujs/ @grafana/dashboards-squad
+/e2e-playwright/dashboard-cujs/scope-*.spec.ts @grafana/dashboards-squad @grafana/grafana-operator-experience-squad
+/e2e-playwright/utils/scope* @grafana/grafana-operator-experience-squad
 /e2e-playwright/dashboards-search-suite/ @grafana/dashboards-squad
 /e2e-playwright/dashboards/cujs/ @grafana/dashboards-squad
 /e2e-playwright/dashboards/DashboardForConditionalRendering.json @grafana/dashboards-squad


### PR DESCRIPTION
## Summary

- `e2e-playwright/utils/scope*` (scope-helpers.ts, scopes.ts) had no CODEOWNERS entry — adds `@grafana/grafana-operator-experience-squad` as owner
- `e2e-playwright/dashboard-cujs/scope-*.spec.ts` was covered only by the broad `dashboard-cujs/` rule (`@grafana/dashboards-squad`) — adds `@grafana/grafana-operator-experience-squad` as co-owner since these tests cover scopes feature behavior

The more specific rules override the broader directory rule per CODEOWNERS precedence, so `scope-*.spec.ts` files will now request reviews from both squads. The `utils/scope*` files were previously unowned.

Follows from merged fix in #120724.

## Test plan

- [x] No code changes — CODEOWNERS only
- [x] Verified team name matches existing entries (`@grafana/grafana-operator-experience-squad`)
- [x] More specific rules placed after broader `dashboard-cujs/` rule so CODEOWNERS precedence applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)