### PR TITLE
annotations: postgres store implementation

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1755,8 +1755,8 @@ max_annotations_to_keep =
 # Enable the App Platform annotations API
 enabled = false
 
-# Storage backend for annotations. Options: "sql" (default) or "grpc"
-store_backend = sql
+# Storage backend for annotations. Options: "legacy-sql" (default), "grpc", or "postgres"
+store_backend = legacy-sql
 
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 grpc_address = localhost:9090
@@ -1769,6 +1769,27 @@ grpc_tls_ca_file =
 
 # Skip TLS verification (insecure, for testing only, only used when grpc_use_tls = true)
 grpc_tls_skip_verify = false
+
+# PostgreSQL connection string (only used when store_backend = "postgres")
+postgres_connection_string =
+
+# Maximum number of connections in the Postgres pool (only used when store_backend = "postgres")
+postgres_max_connections = 10
+
+# Maximum number of idle connections in the Postgres pool (only used when store_backend = "postgres")
+postgres_max_idle_conns = 5
+
+# Maximum lifetime of a connection in the Postgres pool (only used when store_backend = "postgres")
+postgres_conn_max_lifetime = 1h
+
+# Retention TTL for annotations - old partitions will be dropped (only used when store_backend = "postgres")
+postgres_retention_ttl = 2160h
+
+# TTL for tag query cache (only used when store_backend = "postgres")
+postgres_tag_cache_ttl = 60s
+
+# Size of the tag query cache (only used when store_backend = "postgres")
+postgres_tag_cache_size = 1000
 
 #################################### Explore #############################
 [explore]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1758,6 +1758,9 @@ enabled = false
 # Storage backend for annotations. Options: "legacy-sql" (default), "grpc", or "postgres"
 store_backend = legacy-sql
 
+# Retention TTL for annotations - old data will be cleaned up
+retention_ttl = 2160h
+
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 grpc_address = localhost:9090
 
@@ -1781,9 +1784,6 @@ postgres_max_idle_conns = 5
 
 # Maximum lifetime of a connection in the Postgres pool (only used when store_backend = "postgres")
 postgres_conn_max_lifetime = 1h
-
-# Retention TTL for annotations - old partitions will be dropped (only used when store_backend = "postgres")
-postgres_retention_ttl = 2160h
 
 # TTL for tag query cache (only used when store_backend = "postgres")
 postgres_tag_cache_ttl = 60s

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1695,8 +1695,8 @@ default_datasource_uid =
 # Enable the App Platform annotations API
 ;enabled = false
 
-# Storage backend for annotations. Options: "sql" (default) or "grpc"
-;store_backend = sql
+# Storage backend for annotations. Options: "legacy-sql" (default), "grpc", or "postgres"
+;store_backend = legacy-sql
 
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 ;grpc_address = localhost:9090
@@ -1709,6 +1709,27 @@ default_datasource_uid =
 
 # Skip TLS verification (insecure, for testing only, only used when grpc_use_tls = true)
 ;grpc_tls_skip_verify = false
+
+# PostgreSQL connection string (only used when store_backend = "postgres")
+;postgres_connection_string =
+
+# Maximum number of connections in the Postgres pool (only used when store_backend = "postgres")
+;postgres_max_connections = 10
+
+# Maximum number of idle connections in the Postgres pool (only used when store_backend = "postgres")
+;postgres_max_idle_conns = 5
+
+# Maximum lifetime of a connection in the Postgres pool (only used when store_backend = "postgres")
+;postgres_conn_max_lifetime = 1h
+
+# Retention TTL for annotations - old partitions will be dropped (only used when store_backend = "postgres")
+;postgres_retention_ttl = 2160h
+
+# TTL for tag query cache (only used when store_backend = "postgres")
+;postgres_tag_cache_ttl = 60s
+
+# Size of the tag query cache (only used when store_backend = "postgres")
+;postgres_tag_cache_size = 1000
 
 #################################### Explore #############################
 [explore]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1698,6 +1698,9 @@ default_datasource_uid =
 # Storage backend for annotations. Options: "legacy-sql" (default), "grpc", or "postgres"
 ;store_backend = legacy-sql
 
+# Retention TTL for annotations - old data will be cleaned up
+;retention_ttl = 2160h
+
 # gRPC server address for remote annotation storage (only used when store_backend = "grpc")
 ;grpc_address = localhost:9090
 
@@ -1721,9 +1724,6 @@ default_datasource_uid =
 
 # Maximum lifetime of a connection in the Postgres pool (only used when store_backend = "postgres")
 ;postgres_conn_max_lifetime = 1h
-
-# Retention TTL for annotations - old partitions will be dropped (only used when store_backend = "postgres")
-;postgres_retention_ttl = 2160h
 
 # TTL for tag query cache (only used when store_backend = "postgres")
 ;postgres_tag_cache_ttl = 60s

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -1,6 +1,8 @@
 package annotation
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 
 	"github.com/grafana/grafana/pkg/services/annotations"
@@ -9,11 +11,22 @@ import (
 
 // Config holds the store backend configuration for the annotation app.
 type Config struct {
-	StoreBackend      string
+	StoreBackend string
+
+	// gRPC store configuration
 	GRPCAddress       string
 	GRPCUseTLS        bool
 	GRPCTLSCAFile     string
 	GRPCTLSSkipVerify bool
+
+	// Postgres store configuration
+	PostgresConnectionString string
+	PostgresMaxConnections   int
+	PostgresMaxIdleConns     int
+	PostgresConnMaxLifetime  time.Duration
+	PostgresRetentionTTL     time.Duration
+	PostgresTagCacheTTL      time.Duration
+	PostgresTagCacheSize     int
 
 	// CleanupSettings configures annotation pruning for the SQL backend's LifecycleManager.
 	// Zero value (all limits unset) disables cleanup. Not used by memory or gRPC backends.
@@ -22,11 +35,22 @@ type Config struct {
 
 func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	// TODO: add cleanup flags when the SQL backend is supported in MT.
-	flags.StringVar(&c.StoreBackend, "annotation.store-backend", "memory", "Annotation store backend: memory, grpc")
+	flags.StringVar(&c.StoreBackend, "annotation.store-backend", "memory", "Annotation store backend: memory, grpc, postgres, legacy-sql")
+
+	// gRPC flags
 	flags.StringVar(&c.GRPCAddress, "annotation.grpc-address", "", "gRPC server address for the annotation store")
 	flags.BoolVar(&c.GRPCUseTLS, "annotation.grpc-use-tls", false, "Enable TLS for the annotation gRPC connection")
 	flags.StringVar(&c.GRPCTLSCAFile, "annotation.grpc-tls-ca-file", "", "CA certificate file for the annotation gRPC connection")
 	flags.BoolVar(&c.GRPCTLSSkipVerify, "annotation.grpc-tls-skip-verify", false, "Skip TLS verification for the annotation gRPC connection (insecure)")
+
+	// Postgres flags
+	flags.StringVar(&c.PostgresConnectionString, "annotation.postgres-connection-string", "", "PostgreSQL connection string for annotation store")
+	flags.IntVar(&c.PostgresMaxConnections, "annotation.postgres-max-connections", defaultMaxConnections, "Maximum number of connections in the Postgres pool")
+	flags.IntVar(&c.PostgresMaxIdleConns, "annotation.postgres-max-idle-conns", defaultMaxIdleConns, "Maximum number of idle connections in the Postgres pool")
+	flags.DurationVar(&c.PostgresConnMaxLifetime, "annotation.postgres-conn-max-lifetime", defaultConnMaxLifetime, "Maximum lifetime of a connection in the Postgres pool")
+	flags.DurationVar(&c.PostgresRetentionTTL, "annotation.postgres-retention-ttl", defaultRetentionTTL, "Retention TTL for annotations (old partitions will be dropped)")
+	flags.DurationVar(&c.PostgresTagCacheTTL, "annotation.postgres-tag-cache-ttl", defaultTagCacheTTL, "TTL for tag query cache")
+	flags.IntVar(&c.PostgresTagCacheSize, "annotation.postgres-tag-cache-size", defaultTagCacheSize, "Size of the tag query cache")
 }
 
 func newConfigFromSettings(cfg *setting.Cfg) Config {
@@ -36,6 +60,15 @@ func newConfigFromSettings(cfg *setting.Cfg) Config {
 		GRPCUseTLS:        cfg.AnnotationAppPlatform.GRPCUseTLS,
 		GRPCTLSCAFile:     cfg.AnnotationAppPlatform.GRPCTLSCAFile,
 		GRPCTLSSkipVerify: cfg.AnnotationAppPlatform.GRPCTLSSkipVerify,
+
+		PostgresConnectionString: cfg.AnnotationAppPlatform.PostgresConnectionString,
+		PostgresMaxConnections:   cfg.AnnotationAppPlatform.PostgresMaxConnections,
+		PostgresMaxIdleConns:     cfg.AnnotationAppPlatform.PostgresMaxIdleConns,
+		PostgresConnMaxLifetime:  cfg.AnnotationAppPlatform.PostgresConnMaxLifetime,
+		PostgresRetentionTTL:     cfg.AnnotationAppPlatform.PostgresRetentionTTL,
+		PostgresTagCacheTTL:      cfg.AnnotationAppPlatform.PostgresTagCacheTTL,
+		PostgresTagCacheSize:     cfg.AnnotationAppPlatform.PostgresTagCacheSize,
+
 		CleanupSettings: annotations.CleanupSettings{
 			Alerting:  cfg.AlertingAnnotationCleanupSetting,
 			API:       cfg.APIAnnotationCleanupSettings,

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -9,9 +9,20 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+const (
+	// cleanupInterval is how often the background cleanup runs
+	cleanupInterval = 24 * time.Hour
+	// defaultRetentionTTL is the default retention period for annotations
+	// TODO: determine appropriate default TTL
+	defaultRetentionTTL = 90 * 24 * time.Hour
+)
+
 // Config holds the store backend configuration for the annotation app.
 type Config struct {
 	StoreBackend string
+
+	// General lifecycle configuration
+	RetentionTTL time.Duration
 
 	// gRPC store configuration
 	GRPCAddress       string
@@ -24,7 +35,6 @@ type Config struct {
 	PostgresMaxConnections   int
 	PostgresMaxIdleConns     int
 	PostgresConnMaxLifetime  time.Duration
-	PostgresRetentionTTL     time.Duration
 	PostgresTagCacheTTL      time.Duration
 	PostgresTagCacheSize     int
 
@@ -37,6 +47,9 @@ func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	// TODO: add cleanup flags when the SQL backend is supported in MT.
 	flags.StringVar(&c.StoreBackend, "annotation.store-backend", "memory", "Annotation store backend: memory, grpc, postgres, legacy-sql")
 
+	// General lifecycle flags
+	flags.DurationVar(&c.RetentionTTL, "annotation.retention-ttl", defaultRetentionTTL, "Retention TTL for annotations (old data will be cleaned up)")
+
 	// gRPC flags
 	flags.StringVar(&c.GRPCAddress, "annotation.grpc-address", "", "gRPC server address for the annotation store")
 	flags.BoolVar(&c.GRPCUseTLS, "annotation.grpc-use-tls", false, "Enable TLS for the annotation gRPC connection")
@@ -48,14 +61,20 @@ func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&c.PostgresMaxConnections, "annotation.postgres-max-connections", defaultMaxConnections, "Maximum number of connections in the Postgres pool")
 	flags.IntVar(&c.PostgresMaxIdleConns, "annotation.postgres-max-idle-conns", defaultMaxIdleConns, "Maximum number of idle connections in the Postgres pool")
 	flags.DurationVar(&c.PostgresConnMaxLifetime, "annotation.postgres-conn-max-lifetime", defaultConnMaxLifetime, "Maximum lifetime of a connection in the Postgres pool")
-	flags.DurationVar(&c.PostgresRetentionTTL, "annotation.postgres-retention-ttl", defaultRetentionTTL, "Retention TTL for annotations (old partitions will be dropped)")
 	flags.DurationVar(&c.PostgresTagCacheTTL, "annotation.postgres-tag-cache-ttl", defaultTagCacheTTL, "TTL for tag query cache")
 	flags.IntVar(&c.PostgresTagCacheSize, "annotation.postgres-tag-cache-size", defaultTagCacheSize, "Size of the tag query cache")
 }
 
 func newConfigFromSettings(cfg *setting.Cfg) Config {
+	retentionTTL := cfg.AnnotationAppPlatform.RetentionTTL
+	if retentionTTL == 0 {
+		retentionTTL = defaultRetentionTTL
+	}
+
 	return Config{
-		StoreBackend:      cfg.AnnotationAppPlatform.StoreBackend,
+		StoreBackend: cfg.AnnotationAppPlatform.StoreBackend,
+		RetentionTTL: retentionTTL,
+
 		GRPCAddress:       cfg.AnnotationAppPlatform.GRPCAddress,
 		GRPCUseTLS:        cfg.AnnotationAppPlatform.GRPCUseTLS,
 		GRPCTLSCAFile:     cfg.AnnotationAppPlatform.GRPCTLSCAFile,
@@ -65,7 +84,6 @@ func newConfigFromSettings(cfg *setting.Cfg) Config {
 		PostgresMaxConnections:   cfg.AnnotationAppPlatform.PostgresMaxConnections,
 		PostgresMaxIdleConns:     cfg.AnnotationAppPlatform.PostgresMaxIdleConns,
 		PostgresConnMaxLifetime:  cfg.AnnotationAppPlatform.PostgresConnMaxLifetime,
-		PostgresRetentionTTL:     cfg.AnnotationAppPlatform.PostgresRetentionTTL,
 		PostgresTagCacheTTL:      cfg.AnnotationAppPlatform.PostgresTagCacheTTL,
 		PostgresTagCacheSize:     cfg.AnnotationAppPlatform.PostgresTagCacheSize,
 

--- a/pkg/registry/apps/annotation/migrations/00001_initial_schema.sql
+++ b/pkg/registry/apps/annotation/migrations/00001_initial_schema.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Create partitioned annotations table
+-- This table uses PostgreSQL declarative partitioning (available in PG 10+)
+-- Partitions are created on-demand at runtime based on the time column
+CREATE TABLE IF NOT EXISTS annotations (
+  namespace VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  time BIGINT NOT NULL,
+  time_end BIGINT,
+  dashboard_uid VARCHAR(40),
+  panel_id BIGINT,
+  text TEXT NOT NULL,
+  tags TEXT[],
+  scopes TEXT[],
+  created_by VARCHAR(255),
+  created_at BIGINT NOT NULL,
+  PRIMARY KEY (namespace, name, time),
+  CHECK (time_end IS NULL OR time_end >= time)
+) PARTITION BY RANGE (time);
+
+-- +goose Down
+-- Drop the partitioned table (will cascade to all partitions)
+DROP TABLE IF EXISTS annotations CASCADE;

--- a/pkg/registry/apps/annotation/migrations/00001_initial_schema.sql
+++ b/pkg/registry/apps/annotation/migrations/00001_initial_schema.sql
@@ -1,7 +1,5 @@
 -- +goose Up
 -- Create partitioned annotations table
--- This table uses PostgreSQL declarative partitioning (available in PG 10+)
--- Partitions are created on-demand at runtime based on the time column
 CREATE TABLE IF NOT EXISTS annotations (
   namespace VARCHAR(255) NOT NULL,
   name VARCHAR(255) NOT NULL,

--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -1,0 +1,65 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Cleanup implements the LifecycleManager interface
+// It removes old partitions that are beyond the retention TTL
+// TODO: figure out where this needs to be called from (e.g., background goroutine in the store, or an external cron job)
+func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {
+	// Calculate cutoff timestamp
+	cutoff := time.Now().Add(-s.config.RetentionTTL)
+	cutoffMs := cutoff.UnixMilli()
+
+	// Calculate the cutoff partition name
+	cutoffPartition := getPartitionName(cutoffMs)
+
+	// Get all existing partitions
+	partitions, err := listPartitions(ctx, s.pool)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list partitions: %w", err)
+	}
+
+	var totalDeleted int64
+
+	// Iterate through partitions and drop those older than cutoff
+	for _, partition := range partitions {
+		// Skip if partition is newer than or equal to cutoff
+		if partition.Name >= cutoffPartition {
+			continue
+		}
+
+		// Don't drop partitions less than 24 hours old even if they're past TTL
+		if partition.EndTime > time.Now().Add(-24*time.Hour).UnixMilli() {
+			continue
+		}
+
+		// Count rows to be deleted
+		var count int64
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", partition.Name)
+		if err := s.pool.QueryRow(ctx, countQuery).Scan(&count); err != nil {
+			// Log error but continue with other partitions since this is just for metrics
+			s.logger.Warn("Failed to count rows in partition", "partition", partition.Name, "err", err)
+			count = 0
+		}
+
+		// Detach partition first to avoid locking the main table during deletion
+		detachQuery := fmt.Sprintf("ALTER TABLE annotations DETACH PARTITION %s", partition.Name)
+		if _, err := s.pool.Exec(ctx, detachQuery); err != nil {
+			return totalDeleted, fmt.Errorf("failed to detach partition %s: %w", partition.Name, err)
+		}
+
+		// Drop the detached partition
+		dropQuery := fmt.Sprintf("DROP TABLE %s", partition.Name)
+		if _, err := s.pool.Exec(ctx, dropQuery); err != nil {
+			return totalDeleted, fmt.Errorf("failed to drop partition %s: %w", partition.Name, err)
+		}
+
+		totalDeleted += count
+	}
+
+	return totalDeleted, nil
+}

--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 const (
@@ -55,7 +57,7 @@ func (s *PostgreSQLStore) runCleanup(ctx context.Context) {
 // It removes old partitions that are beyond the retention TTL
 func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {
 	// Calculate cutoff timestamp and corresponding partition name
-	cutoff := time.Now().Add(-s.config.RetentionTTL)
+	cutoff := time.Now().UTC().Add(-s.config.RetentionTTL)
 	cutoffMs := cutoff.UnixMilli()
 	cutoffPartition := getPartitionName(cutoffMs)
 
@@ -75,13 +77,15 @@ func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {
 		}
 
 		// Don't drop partitions less than 24 hours old even if they're past TTL
-		if partition.EndTime > time.Now().Add(-24*time.Hour).UnixMilli() {
+		if partition.EndTime > time.Now().UTC().Add(-24*time.Hour).UnixMilli() {
 			continue
 		}
 
+		partitionIdent := pgx.Identifier{partition.Name}.Sanitize()
+
 		// Count rows to be deleted
 		var count int64
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", partition.Name)
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", partitionIdent)
 		if err := s.pool.QueryRow(ctx, countQuery).Scan(&count); err != nil {
 			// Log error but continue with other partitions since this is just for metrics
 			s.logger.Warn("Failed to count rows in partition", "partition", partition.Name, "err", err)
@@ -89,13 +93,13 @@ func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {
 		}
 
 		// Detach partition first to avoid locking the main table during deletion
-		detachQuery := fmt.Sprintf("ALTER TABLE annotations DETACH PARTITION %s", partition.Name)
+		detachQuery := fmt.Sprintf("ALTER TABLE annotations DETACH PARTITION %s", partitionIdent)
 		if _, err := s.pool.Exec(ctx, detachQuery); err != nil {
 			return totalDeleted, fmt.Errorf("failed to detach partition %s: %w", partition.Name, err)
 		}
 
 		// Drop the detached partition
-		dropQuery := fmt.Sprintf("DROP TABLE %s", partition.Name)
+		dropQuery := fmt.Sprintf("DROP TABLE %s", partitionIdent)
 		if _, err := s.pool.Exec(ctx, dropQuery); err != nil {
 			return totalDeleted, fmt.Errorf("failed to drop partition %s: %w", partition.Name, err)
 		}

--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -6,9 +6,53 @@ import (
 	"time"
 )
 
+const (
+	// cleanupInterval is how often the background cleanup runs to drop old partitions
+	cleanupInterval = 24 * time.Hour
+)
+
+// startCleanup starts a background goroutine that periodically runs cleanup
+func (s *PostgreSQLStore) startCleanup(parentCtx context.Context) {
+	ctx, cancel := context.WithCancel(parentCtx)
+	s.cleanupCancel = cancel
+
+	go func() {
+		ticker := time.NewTicker(cleanupInterval)
+		defer ticker.Stop()
+
+		s.logger.Info("Starting partition cleanup loop", "interval", cleanupInterval, "retention", s.config.RetentionTTL)
+
+		// Run immediately on startup
+		s.runCleanup(ctx)
+
+		for {
+			select {
+			case <-ticker.C:
+				s.runCleanup(ctx)
+			case <-ctx.Done():
+				s.logger.Info("Stopping partition cleanup loop")
+				return
+			}
+		}
+	}()
+}
+
+// runCleanup executes cleanup with timeout and logging
+func (s *PostgreSQLStore) runCleanup(ctx context.Context) {
+	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	deleted, err := s.Cleanup(cleanupCtx)
+	if err != nil {
+		s.logger.Error("Partition cleanup failed", "error", err, "duration", time.Since(start))
+	} else if deleted > 0 {
+		s.logger.Info("Partition cleanup completed", "rows_deleted", deleted, "duration", time.Since(start))
+	}
+}
+
 // Cleanup implements the LifecycleManager interface
 // It removes old partitions that are beyond the retention TTL
-// TODO: figure out where this needs to be called from (e.g., background goroutine in the store, or an external cron job)
 func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {
 	// Calculate cutoff timestamp
 	cutoff := time.Now().Add(-s.config.RetentionTTL)

--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -8,51 +8,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-const (
-	// cleanupInterval is how often the background cleanup runs to drop old partitions
-	cleanupInterval = 24 * time.Hour
-)
-
-// startCleanup starts a background goroutine that periodically runs cleanup
-func (s *PostgreSQLStore) startCleanup(parentCtx context.Context) {
-	ctx, cancel := context.WithCancel(parentCtx)
-	s.cleanupCancel = cancel
-
-	s.cleanupWg.Go(func() {
-		ticker := time.NewTicker(cleanupInterval)
-		defer ticker.Stop()
-
-		s.logger.Info("Starting partition cleanup loop", "interval", cleanupInterval, "retention", s.config.RetentionTTL)
-
-		// Run immediately on startup
-		s.runCleanup(ctx)
-
-		for {
-			select {
-			case <-ticker.C:
-				s.runCleanup(ctx)
-			case <-ctx.Done():
-				s.logger.Info("Stopping partition cleanup loop")
-				return
-			}
-		}
-	})
-}
-
-func (s *PostgreSQLStore) runCleanup(ctx context.Context) {
-	// Set a 5-minute timeout for the cleanup. This should be plenty given we're simply dropping entire partitions.
-	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
-	start := time.Now()
-	deleted, err := s.Cleanup(cleanupCtx)
-	if err != nil {
-		s.logger.Error("Partition cleanup failed", "error", err, "duration", time.Since(start))
-	} else if deleted > 0 {
-		s.logger.Info("Partition cleanup completed", "rows_deleted", deleted, "duration", time.Since(start))
-	}
-}
-
 // Cleanup implements the LifecycleManager interface
 // It removes old partitions that are beyond the retention TTL
 func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {

--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -16,7 +16,7 @@ func (s *PostgreSQLStore) startCleanup(parentCtx context.Context) {
 	ctx, cancel := context.WithCancel(parentCtx)
 	s.cleanupCancel = cancel
 
-	go func() {
+	s.cleanupWg.Go(func() {
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 
@@ -34,7 +34,7 @@ func (s *PostgreSQLStore) startCleanup(parentCtx context.Context) {
 				return
 			}
 		}
-	}()
+	})
 }
 
 func (s *PostgreSQLStore) runCleanup(ctx context.Context) {

--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -37,8 +37,8 @@ func (s *PostgreSQLStore) startCleanup(parentCtx context.Context) {
 	}()
 }
 
-// runCleanup executes cleanup with timeout and logging
 func (s *PostgreSQLStore) runCleanup(ctx context.Context) {
+	// Set a 5-minute timeout for the cleanup. This should be plenty given we're simply dropping entire partitions.
 	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -54,11 +54,9 @@ func (s *PostgreSQLStore) runCleanup(ctx context.Context) {
 // Cleanup implements the LifecycleManager interface
 // It removes old partitions that are beyond the retention TTL
 func (s *PostgreSQLStore) Cleanup(ctx context.Context) (int64, error) {
-	// Calculate cutoff timestamp
+	// Calculate cutoff timestamp and corresponding partition name
 	cutoff := time.Now().Add(-s.config.RetentionTTL)
 	cutoffMs := cutoff.UnixMilli()
-
-	// Calculate the cutoff partition name
 	cutoffPartition := getPartitionName(cutoffMs)
 
 	// Get all existing partitions

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -1,0 +1,434 @@
+package annotation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Common errors
+var (
+	ErrNotFound = errors.New("annotation not found")
+)
+
+// Default configuration values
+const (
+	defaultMaxConnections  = 10
+	defaultMaxIdleConns    = 5
+	defaultConnMaxLifetime = time.Hour
+	defaultRetentionTTL    = 90 * 24 * time.Hour // TODO: determine appropriate default TTL
+	defaultTagCacheTTL     = 60 * time.Second
+	defaultTagCacheSize    = 1000
+)
+
+// PostgreSQLStoreConfig contains configuration for the PostgreSQL store
+type PostgreSQLStoreConfig struct {
+	ConnectionString string
+	MaxConnections   int
+	MaxIdleConns     int
+	ConnMaxLifetime  time.Duration
+	RetentionTTL     time.Duration
+	TagCacheTTL      time.Duration
+	TagCacheSize     int
+}
+
+// PostgreSQLStore implements the Store interface using PostgreSQL as the backend
+type PostgreSQLStore struct {
+	pool     *pgxpool.Pool
+	config   PostgreSQLStoreConfig
+	tagCache *tagCache
+	logger   log.Logger
+}
+
+var _ Store = (*PostgreSQLStore)(nil)
+var _ TagProvider = (*PostgreSQLStore)(nil)
+var _ LifecycleManager = (*PostgreSQLStore)(nil)
+
+// NewPostgreSQLStore creates a new PostgreSQL-backed annotation store
+func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*PostgreSQLStore, error) {
+	// Set defaults
+	if cfg.MaxConnections == 0 {
+		cfg.MaxConnections = defaultMaxConnections
+	}
+	if cfg.MaxIdleConns == 0 {
+		cfg.MaxIdleConns = defaultMaxIdleConns
+	}
+	if cfg.ConnMaxLifetime == 0 {
+		cfg.ConnMaxLifetime = defaultConnMaxLifetime
+	}
+	if cfg.RetentionTTL == 0 {
+		cfg.RetentionTTL = defaultRetentionTTL
+	}
+	if cfg.TagCacheTTL == 0 {
+		cfg.TagCacheTTL = defaultTagCacheTTL
+	}
+	if cfg.TagCacheSize == 0 {
+		cfg.TagCacheSize = defaultTagCacheSize
+	}
+
+	// Configure connection pool
+	poolConfig, err := pgxpool.ParseConfig(cfg.ConnectionString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	poolConfig.MaxConns = int32(cfg.MaxConnections)
+	poolConfig.MinConns = int32(cfg.MaxIdleConns)
+	poolConfig.MaxConnLifetime = cfg.ConnMaxLifetime
+
+	// Create connection pool
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection pool: %w", err)
+	}
+
+	// Test connection
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	// Run database migrations
+	if err := runMigrations(ctx, pool); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	// Initialize tag cache
+	// NOTE: We currently do _not_ invalidate the tag cache and rely on TTL expiration to keep things simple,
+	// but we could consider more aggressive invalidation on writes if we find the cache is too stale in practice.
+	// The current default TTL is 60 seconds.
+	cache, err := newTagCache(cfg.TagCacheSize, cfg.TagCacheTTL)
+	if err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to create tag cache: %w", err)
+	}
+
+	return &PostgreSQLStore{
+		pool:     pool,
+		config:   cfg,
+		tagCache: cache,
+		logger:   log.New("postgres.annotation.store"),
+	}, nil
+}
+
+// Close closes the database connection pool
+func (s *PostgreSQLStore) Close() {
+	if s.pool != nil {
+		s.pool.Close()
+	}
+}
+
+// Get retrieves a single annotation by namespace and name
+func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*annotationV0.Annotation, error) {
+	query := `
+		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
+		       text, tags, scopes, created_by, created_at
+		FROM annotations
+		WHERE namespace = $1 AND name = $2
+		LIMIT 1
+	`
+
+	row := s.pool.QueryRow(ctx, query, namespace, name)
+
+	var (
+		ns, n, text       string
+		timeMs, createdAt int64
+		timeEnd           *int64
+		dashboardUID      *string
+		panelID           *int64
+		tags, scopes      []string
+		createdBy         *string
+	)
+
+	err := row.Scan(&ns, &n, &timeMs, &timeEnd, &dashboardUID, &panelID,
+		&text, &tags, &scopes, &createdBy, &createdAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to scan annotation: %w", err)
+	}
+
+	return rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt), nil
+}
+
+// Create creates a new annotation
+func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	// Ensure partition exists for this timestamp
+	if err := ensurePartition(ctx, s.pool, anno.Spec.Time); err != nil {
+		return nil, fmt.Errorf("failed to ensure partition: %w", err)
+	}
+
+	// Extract values
+	namespace := anno.Namespace
+	name := anno.Name
+	timeMs := anno.Spec.Time
+	timeEnd := anno.Spec.TimeEnd
+	dashboardUID := anno.Spec.DashboardUID
+	panelID := anno.Spec.PanelID
+	text := anno.Spec.Text
+	tags := anno.Spec.Tags
+	scopes := anno.Spec.Scopes
+	createdBy := anno.GetCreatedBy()
+	createdAt := time.Now().UnixMilli()
+
+	query := `
+		INSERT INTO annotations
+		(namespace, name, time, time_end, dashboard_uid, panel_id, text, tags, scopes, created_by, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`
+
+	_, err := s.pool.Exec(ctx, query,
+		namespace, name, timeMs, timeEnd, dashboardUID, panelID,
+		text, pq.Array(tags), pq.Array(scopes), createdBy, createdAt,
+	)
+	if err != nil {
+		// Check for unique constraint violation
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, fmt.Errorf("annotation with name %q already exists: %w", name, err)
+		}
+		return nil, fmt.Errorf("failed to insert annotation: %w", err)
+	}
+
+	return anno, nil
+}
+
+// Update updates an existing annotation (only mutable fields: text, tags, scopes)
+func (s *PostgreSQLStore) Update(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	query := `
+		UPDATE annotations
+		SET text = $1, tags = $2, scopes = $3
+		WHERE namespace = $4 AND name = $5
+	`
+
+	result, err := s.pool.Exec(ctx, query,
+		anno.Spec.Text,
+		pq.Array(anno.Spec.Tags),
+		pq.Array(anno.Spec.Scopes),
+		anno.Namespace,
+		anno.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update annotation: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return nil, ErrNotFound
+	}
+
+	return anno, nil
+}
+
+// Delete deletes an annotation
+func (s *PostgreSQLStore) Delete(ctx context.Context, namespace, name string) error {
+	query := `DELETE FROM annotations WHERE namespace = $1 AND name = $2`
+
+	result, err := s.pool.Exec(ctx, query, namespace, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete annotation: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// List lists annotations based on the provided options
+func (s *PostgreSQLStore) List(ctx context.Context, namespace string, opts ListOptions) (*AnnotationList, error) {
+	// Decode continue token and validate limit
+	offset := int64(0)
+	if opts.Continue != "" {
+		token, err := decodeContinueToken(opts.Continue)
+		if err != nil {
+			return nil, err
+		}
+		if token.Limit != opts.Limit {
+			return nil, fmt.Errorf("continue token limit does not match the request limit")
+		}
+		offset = token.Offset
+	}
+
+	// Build query
+	limit := opts.Limit
+	if limit == 0 {
+		limit = 100 // default limit
+	}
+	query, args := buildListQuery(namespace, opts, offset, limit)
+
+	// Execute query (query will request limit + 1 to detect if there are more results for pagination)
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query annotations: %w", err)
+	}
+	defer rows.Close()
+
+	var results []annotationV0.Annotation
+	for rows.Next() {
+		var (
+			ns, n, text       string
+			timeMs, createdAt int64
+			timeEnd           *int64
+			dashboardUID      *string
+			panelID           *int64
+			tags, scopes      []string
+			createdBy         *string
+		)
+
+		err := rows.Scan(&ns, &n, &timeMs, &timeEnd, &dashboardUID, &panelID,
+			&text, &tags, &scopes, &createdBy, &createdAt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan annotation row: %w", err)
+		}
+
+		results = append(results, *rowToAnnotation(ns, n, timeMs, timeEnd, dashboardUID, panelID, text, tags, scopes, createdBy, createdAt))
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating annotation rows: %w", err)
+	}
+
+	// Handle pagination
+	var continueToken string
+	if int64(len(results)) > limit {
+		// More results available
+		results = results[:limit]
+		continueToken = encodeContinueToken(offset+limit, limit)
+	}
+
+	return &AnnotationList{
+		Items:    results,
+		Continue: continueToken,
+	}, nil
+}
+
+// buildListQuery constructs the SQL query and arguments for List
+func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (string, []interface{}) {
+	var conditions []string
+	var args []interface{}
+	argNum := 1
+
+	// Namespace is always required
+	conditions = append(conditions, fmt.Sprintf("namespace = $%d", argNum))
+	args = append(args, namespace)
+	argNum++
+
+	// Time range filters
+	if opts.To > 0 {
+		conditions = append(conditions, fmt.Sprintf("time <= $%d", argNum))
+		args = append(args, opts.To)
+		argNum++
+	}
+
+	if opts.From > 0 {
+		// Range overlap: annotation's time_end is NULL (point) OR time_end >= from
+		conditions = append(conditions, fmt.Sprintf("(time_end IS NULL OR time_end >= $%d)", argNum))
+		args = append(args, opts.From)
+		argNum++
+	}
+
+	// Dashboard filter
+	if opts.DashboardUID != "" {
+		conditions = append(conditions, fmt.Sprintf("dashboard_uid = $%d", argNum))
+		args = append(args, opts.DashboardUID)
+		argNum++
+	}
+
+	// Panel filter
+	if opts.PanelID != 0 {
+		conditions = append(conditions, fmt.Sprintf("panel_id = $%d", argNum))
+		args = append(args, opts.PanelID)
+		argNum++
+	}
+
+	// CreatedBy filter
+	if opts.CreatedBy != "" {
+		conditions = append(conditions, fmt.Sprintf("created_by = $%d", argNum))
+		args = append(args, opts.CreatedBy)
+		argNum++
+	}
+
+	// Tags filter
+	if len(opts.Tags) > 0 {
+		if opts.TagsMatchAny {
+			// Overlaps operator: tags && $N
+			conditions = append(conditions, fmt.Sprintf("tags && $%d", argNum))
+		} else {
+			// Contains operator: tags @> $N
+			conditions = append(conditions, fmt.Sprintf("tags @> $%d", argNum))
+		}
+		args = append(args, pq.Array(opts.Tags))
+		argNum++
+	}
+
+	// Scopes filter
+	if len(opts.Scopes) > 0 {
+		if opts.ScopesMatchAny {
+			conditions = append(conditions, fmt.Sprintf("scopes && $%d", argNum))
+		} else {
+			conditions = append(conditions, fmt.Sprintf("scopes @> $%d", argNum))
+		}
+		args = append(args, pq.Array(opts.Scopes))
+		argNum++
+	}
+
+	// Construct query
+	query := `
+		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
+		       text, tags, scopes, created_by, created_at
+		FROM annotations
+		WHERE ` + strings.Join(conditions, " AND ") + `
+		ORDER BY time DESC, name
+	`
+
+	// Add pagination
+	query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
+	args = append(args, limit+1, offset) // Request one extra to detect more results
+
+	return query, args
+}
+
+// rowToAnnotation converts database row values to an Annotation object
+func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
+	dashboardUID *string, panelID *int64, text string, tags, scopes []string,
+	createdBy *string, createdAt int64) *annotationV0.Annotation {
+
+	anno := &annotationV0.Annotation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: annotationV0.AnnotationSpec{
+			Time:         timeMs,
+			TimeEnd:      timeEnd,
+			DashboardUID: dashboardUID,
+			PanelID:      panelID,
+			Text:         text,
+			Tags:         tags,
+			Scopes:       scopes,
+		},
+	}
+
+	// Set createdBy if present
+	if createdBy != nil && *createdBy != "" {
+		anno.SetCreatedBy(*createdBy)
+	}
+
+	// Set creation timestamp
+	anno.CreationTimestamp = metav1.NewTime(time.UnixMilli(createdAt))
+
+	return anno
+}

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -93,8 +93,10 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
+	logger := log.New("postgres.annotation.store")
+
 	// Run database migrations
-	if err := runMigrations(ctx, pool); err != nil {
+	if err := runMigrations(ctx, pool, logger); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
@@ -113,7 +115,7 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 		pool:     pool,
 		config:   cfg,
 		tagCache: cache,
-		logger:   log.New("postgres.annotation.store"),
+		logger:   logger,
 	}
 
 	// Start background cleanup
@@ -169,7 +171,7 @@ func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*ann
 // Create creates a new annotation
 func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
 	// Ensure partition exists for this timestamp
-	if err := ensurePartition(ctx, s.pool, anno.Spec.Time); err != nil {
+	if err := ensurePartition(ctx, s.pool, s.logger, anno.Spec.Time); err != nil {
 		return nil, fmt.Errorf("failed to ensure partition: %w", err)
 	}
 
@@ -407,7 +409,6 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 	dashboardUID *string, panelID *int64, text string, tags, scopes []string,
 	createdBy *string, createdAt int64) *annotationV0.Annotation {
-
 	anno := &annotationV0.Annotation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
@@ -46,6 +47,7 @@ type PostgreSQLStore struct {
 	tagCache      *tagCache
 	logger        log.Logger
 	cleanupCancel context.CancelFunc
+	cleanupWg     sync.WaitGroup
 }
 
 var _ Store = (*PostgreSQLStore)(nil)
@@ -128,6 +130,7 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 func (s *PostgreSQLStore) Close() {
 	if s.cleanupCancel != nil {
 		s.cleanupCancel()
+		s.cleanupWg.Wait()
 	}
 	if s.pool != nil {
 		s.pool.Close()

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -44,10 +44,11 @@ type PostgreSQLStoreConfig struct {
 
 // PostgreSQLStore implements the Store interface using PostgreSQL as the backend
 type PostgreSQLStore struct {
-	pool     *pgxpool.Pool
-	config   PostgreSQLStoreConfig
-	tagCache *tagCache
-	logger   log.Logger
+	pool          *pgxpool.Pool
+	config        PostgreSQLStoreConfig
+	tagCache      *tagCache
+	logger        log.Logger
+	cleanupCancel context.CancelFunc
 }
 
 var _ Store = (*PostgreSQLStore)(nil)
@@ -114,16 +115,24 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 		return nil, fmt.Errorf("failed to create tag cache: %w", err)
 	}
 
-	return &PostgreSQLStore{
+	store := &PostgreSQLStore{
 		pool:     pool,
 		config:   cfg,
 		tagCache: cache,
 		logger:   log.New("postgres.annotation.store"),
-	}, nil
+	}
+
+	// Start background cleanup
+	store.startCleanup(ctx)
+
+	return store, nil
 }
 
-// Close closes the database connection pool
+// Close closes the database connection pool and stops background cleanup
 func (s *PostgreSQLStore) Close() {
+	if s.cleanupCancel != nil {
+		s.cleanupCancel()
+	}
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -16,12 +16,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Common errors
 var (
 	ErrNotFound = errors.New("annotation not found")
 )
 
-// Default configuration values
 const (
 	defaultMaxConnections  = 10
 	defaultMaxIdleConns    = 5
@@ -31,7 +29,6 @@ const (
 	defaultTagCacheSize    = 1000
 )
 
-// PostgreSQLStoreConfig contains configuration for the PostgreSQL store
 type PostgreSQLStoreConfig struct {
 	ConnectionString string
 	MaxConnections   int
@@ -57,7 +54,6 @@ var _ LifecycleManager = (*PostgreSQLStore)(nil)
 
 // NewPostgreSQLStore creates a new PostgreSQL-backed annotation store
 func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*PostgreSQLStore, error) {
-	// Set defaults
 	if cfg.MaxConnections == 0 {
 		cfg.MaxConnections = defaultMaxConnections
 	}
@@ -77,7 +73,7 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 		cfg.TagCacheSize = defaultTagCacheSize
 	}
 
-	// Configure connection pool
+	// Create connection pool
 	poolConfig, err := pgxpool.ParseConfig(cfg.ConnectionString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
@@ -87,13 +83,11 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 	poolConfig.MinConns = int32(cfg.MaxIdleConns)
 	poolConfig.MaxConnLifetime = cfg.ConnMaxLifetime
 
-	// Create connection pool
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection pool: %w", err)
 	}
 
-	// Test connection
 	if err := pool.Ping(ctx); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
@@ -179,7 +173,6 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 		return nil, fmt.Errorf("failed to ensure partition: %w", err)
 	}
 
-	// Extract values
 	namespace := anno.Namespace
 	name := anno.Name
 	timeMs := anno.Spec.Time
@@ -278,7 +271,7 @@ func (s *PostgreSQLStore) List(ctx context.Context, namespace string, opts ListO
 	}
 	query, args := buildListQuery(namespace, opts, offset, limit)
 
-	// Execute query (query will request limit + 1 to detect if there are more results for pagination)
+	// Execute query
 	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query annotations: %w", err)
@@ -325,9 +318,9 @@ func (s *PostgreSQLStore) List(ctx context.Context, namespace string, opts ListO
 }
 
 // buildListQuery constructs the SQL query and arguments for List
-func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (string, []interface{}) {
+func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (string, []any) {
 	var conditions []string
-	var args []interface{}
+	var args []any
 	argNum := 1
 
 	// Namespace is always required
@@ -405,7 +398,7 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 
 	// Add pagination
 	query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
-	args = append(args, limit+1, offset) // Request one extra to detect more results
+	args = append(args, limit+1, offset) // Request one extra to detect more results for pagination
 
 	return query, args
 }

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
@@ -25,7 +24,6 @@ const (
 	defaultMaxConnections  = 10
 	defaultMaxIdleConns    = 5
 	defaultConnMaxLifetime = time.Hour
-	defaultRetentionTTL    = 90 * 24 * time.Hour // TODO: determine appropriate default TTL
 	defaultTagCacheTTL     = 60 * time.Second
 	defaultTagCacheSize    = 1000
 )
@@ -42,12 +40,10 @@ type PostgreSQLStoreConfig struct {
 
 // PostgreSQLStore implements the Store interface using PostgreSQL as the backend
 type PostgreSQLStore struct {
-	pool          *pgxpool.Pool
-	config        PostgreSQLStoreConfig
-	tagCache      *tagCache
-	logger        log.Logger
-	cleanupCancel context.CancelFunc
-	cleanupWg     sync.WaitGroup
+	pool     *pgxpool.Pool
+	config   PostgreSQLStoreConfig
+	tagCache *tagCache
+	logger   log.Logger
 }
 
 var _ Store = (*PostgreSQLStore)(nil)
@@ -64,9 +60,6 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 	}
 	if cfg.ConnMaxLifetime == 0 {
 		cfg.ConnMaxLifetime = defaultConnMaxLifetime
-	}
-	if cfg.RetentionTTL == 0 {
-		cfg.RetentionTTL = defaultRetentionTTL
 	}
 	if cfg.TagCacheTTL == 0 {
 		cfg.TagCacheTTL = defaultTagCacheTTL
@@ -120,18 +113,11 @@ func NewPostgreSQLStore(ctx context.Context, cfg PostgreSQLStoreConfig) (*Postgr
 		logger:   logger,
 	}
 
-	// Start background cleanup
-	store.startCleanup(ctx)
-
 	return store, nil
 }
 
-// Close closes the database connection pool and stops background cleanup
+// Close closes the database connection pool
 func (s *PostgreSQLStore) Close() {
-	if s.cleanupCancel != nil {
-		s.cleanupCancel()
-		s.cleanupWg.Wait()
-	}
 	if s.pool != nil {
 		s.pool.Close()
 	}
@@ -445,7 +431,7 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 
 func (s *PostgreSQLStore) validateAnnotation(anno *annotationV0.Annotation) error {
 	now := time.Now().UTC()
-	// TODO: determine appropriate bounds and maybe make configurable
+	// TODO: determine appropriate future bound and maybe make configurable
 	maxFuture := now.Add(7 * 24 * time.Hour).UnixMilli()
 	maxPast := now.Add(-s.config.RetentionTTL).UnixMilli()
 

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -173,6 +173,10 @@ func (s *PostgreSQLStore) Get(ctx context.Context, namespace, name string) (*ann
 
 // Create creates a new annotation
 func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	if err := s.validateAnnotation(anno); err != nil {
+		return nil, err
+	}
+
 	// Ensure partition exists for this timestamp
 	if err := ensurePartition(ctx, s.pool, s.logger, anno.Spec.Time); err != nil {
 		return nil, fmt.Errorf("failed to ensure partition: %w", err)
@@ -188,7 +192,7 @@ func (s *PostgreSQLStore) Create(ctx context.Context, anno *annotationV0.Annotat
 	tags := anno.Spec.Tags
 	scopes := anno.Spec.Scopes
 	createdBy := anno.GetCreatedBy()
-	createdAt := time.Now().UnixMilli()
+	createdAt := time.Now().UTC().UnixMilli()
 
 	query := `
 		INSERT INTO annotations
@@ -437,4 +441,30 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 	anno.CreationTimestamp = metav1.NewTime(time.UnixMilli(createdAt))
 
 	return anno
+}
+
+func (s *PostgreSQLStore) validateAnnotation(anno *annotationV0.Annotation) error {
+	now := time.Now().UTC()
+	// TODO: determine appropriate bounds and maybe make configurable
+	maxFuture := now.Add(7 * 24 * time.Hour).UnixMilli()
+	maxPast := now.Add(-s.config.RetentionTTL).UnixMilli()
+
+	if anno.Spec.Time > maxFuture {
+		return fmt.Errorf("annotation time cannot be more than 1 week in the future")
+	}
+	if anno.Spec.Time < maxPast {
+		return fmt.Errorf("annotation time cannot be older than retention TTL (%v)", s.config.RetentionTTL)
+	}
+
+	// If timeEnd is set, validate it's after time and within future bounds
+	if anno.Spec.TimeEnd != nil {
+		if *anno.Spec.TimeEnd < anno.Spec.Time {
+			return fmt.Errorf("annotation timeEnd must be after time")
+		}
+		if *anno.Spec.TimeEnd > maxFuture {
+			return fmt.Errorf("annotation timeEnd cannot be more than 1 week in the future")
+		}
+	}
+
+	return nil
 }

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -1,0 +1,193 @@
+package annotation
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+)
+
+//go:embed migrations/*.sql
+var embedMigrations embed.FS
+
+// PartitionInfo contains metadata about a partition
+type PartitionInfo struct {
+	Name       string
+	StartTime  int64
+	EndTime    int64
+	ParentName string
+}
+
+const (
+	createPartitionSQL = `
+CREATE TABLE IF NOT EXISTS %s
+PARTITION OF annotations
+FOR VALUES FROM (%d) TO (%d);
+`
+
+	// Index templates for partitions
+	createBRINIndexSQL      = `CREATE INDEX IF NOT EXISTS %s ON %s USING BRIN (time);`
+	createTimeIndexSQL      = `CREATE INDEX IF NOT EXISTS %s ON %s (namespace, time);`
+	createDashboardIndexSQL = `CREATE INDEX IF NOT EXISTS %s ON %s (namespace, dashboard_uid, panel_id, time);`
+	createTimeEndIndexSQL   = `CREATE INDEX IF NOT EXISTS %s ON %s (namespace, time_end) WHERE time_end IS NOT NULL;`
+	createTagsIndexSQL      = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (tags);`
+	createScopesIndexSQL    = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (scopes);`
+
+	listPartitionsSQL = `
+SELECT
+    child.relname AS partition_name,
+    pg_get_expr(child.relpartbound, child.oid) AS partition_bounds
+FROM pg_inherits
+JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class child ON pg_inherits.inhrelid = child.oid
+WHERE parent.relname = 'annotations'
+ORDER BY child.relname;
+`
+)
+
+// getPartitionName calculates the partition name for a given timestamp
+// Returns partition name in format: annotations_YYYYwWW (e.g., annotations_2025w10)
+func getPartitionName(ts int64) string {
+	t := time.UnixMilli(ts)
+	year, week := t.ISOWeek()
+	return fmt.Sprintf("annotations_%dw%02d", year, week)
+}
+
+// getPartitionBounds calculates the start and end timestamps for the week containing ts
+// Uses ISO 8601 week definition (Monday is first day of week)
+func getPartitionBounds(ts int64) (start, end int64) {
+	t := time.UnixMilli(ts).UTC()
+
+	// Get the weekday (0=Sunday, 1=Monday, etc.)
+	weekday := int(t.Weekday())
+	if weekday == 0 {
+		weekday = 7 // Sunday is 7 in ISO
+	}
+
+	// Start of week is Monday (subtract days since Monday)
+	weekStart := t.AddDate(0, 0, -weekday+1).Truncate(24 * time.Hour)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	return weekStart.UnixMilli(), weekEnd.UnixMilli()
+}
+
+// ensurePartition creates a partition for the given timestamp if it doesn't exist
+// TODO: can we pre-create partitions for the next N weeks in a background job instead of creating on-demand during inserts?
+func ensurePartition(ctx context.Context, pool *pgxpool.Pool, ts int64) error {
+	partitionName := getPartitionName(ts)
+	start, end := getPartitionBounds(ts)
+
+	// Begin transaction for partition creation
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Create partition
+	createPartition := fmt.Sprintf(createPartitionSQL, partitionName, start, end)
+	if _, err := tx.Exec(ctx, createPartition); err != nil {
+		// Check if error is "already exists" - this is OK due to concurrent inserts
+		if !isAlreadyExistsError(err) {
+			return fmt.Errorf("failed to create partition %s: %w", partitionName, err)
+		}
+	}
+
+	// Create indices on the new partition
+	indices := []string{
+		fmt.Sprintf(createBRINIndexSQL, fmt.Sprintf("idx_time_%s", partitionName), partitionName),
+		fmt.Sprintf(createTimeIndexSQL, fmt.Sprintf("idx_ns_time_%s", partitionName), partitionName),
+		fmt.Sprintf(createDashboardIndexSQL, fmt.Sprintf("idx_dashboard_%s", partitionName), partitionName),
+		fmt.Sprintf(createTimeEndIndexSQL, fmt.Sprintf("idx_time_end_%s", partitionName), partitionName),
+		fmt.Sprintf(createTagsIndexSQL, fmt.Sprintf("idx_tags_%s", partitionName), partitionName),
+		fmt.Sprintf(createScopesIndexSQL, fmt.Sprintf("idx_scopes_%s", partitionName), partitionName),
+	}
+
+	for _, indexSQL := range indices {
+		if _, err := tx.Exec(ctx, indexSQL); err != nil {
+			// Index creation errors are OK if they already exist
+			if !isAlreadyExistsError(err) {
+				return fmt.Errorf("failed to create index: %w", err)
+			}
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+// listPartitions returns all existing partitions with their metadata
+func listPartitions(ctx context.Context, pool *pgxpool.Pool) ([]PartitionInfo, error) {
+	rows, err := pool.Query(ctx, listPartitionsSQL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query partitions: %w", err)
+	}
+	defer rows.Close()
+
+	var partitions []PartitionInfo
+	for rows.Next() {
+		var name, bounds string
+		if err := rows.Scan(&name, &bounds); err != nil {
+			return nil, fmt.Errorf("failed to scan partition row: %w", err)
+		}
+
+		var start, end int64
+		if _, err := fmt.Sscanf(bounds, "FOR VALUES FROM (%d) TO (%d)", &start, &end); err != nil {
+			return nil, fmt.Errorf("failed to parse partition bounds %q: %w", bounds, err)
+		}
+
+		partitions = append(partitions, PartitionInfo{
+			Name:       name,
+			StartTime:  start,
+			EndTime:    end,
+			ParentName: "annotations",
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating partition rows: %w", err)
+	}
+
+	return partitions, nil
+}
+
+// runMigrations executes database migrations using goose
+func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	// Get underlying *sql.DB from pgxpool for goose
+	// Note: This creates a new *sql.DB from the pool config, which is safe
+	// because goose operations are short-lived
+	db := stdlib.OpenDBFromPool(pool)
+	defer db.Close()
+
+	// Configure goose to use embedded migrations
+	goose.SetBaseFS(embedMigrations)
+
+	if err := goose.SetDialect("postgres"); err != nil {
+		return fmt.Errorf("failed to set goose dialect: %w", err)
+	}
+
+	// Run all pending migrations
+	if err := goose.UpContext(ctx, db, "migrations"); err != nil {
+		return fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	return nil
+}
+
+// isAlreadyExistsError checks if the error is a "relation already exists" error
+func isAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Check for pgx error code "42P07" (duplicate_table)
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "42P07" // duplicate_table
+	}
+	return false
+}

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
@@ -79,7 +80,7 @@ func getPartitionBounds(ts int64) (start, end int64) {
 
 // ensurePartition creates a partition for the given timestamp if it doesn't exist
 // TODO: should we pre-create partitions for the next N weeks in a background job instead of creating on-demand during inserts?
-func ensurePartition(ctx context.Context, pool *pgxpool.Pool, ts int64) error {
+func ensurePartition(ctx context.Context, pool *pgxpool.Pool, logger log.Logger, ts int64) error {
 	partitionName := getPartitionName(ts)
 	start, end := getPartitionBounds(ts)
 
@@ -88,7 +89,11 @@ func ensurePartition(ctx context.Context, pool *pgxpool.Pool, ts int64) error {
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	defer tx.Rollback(ctx)
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			logger.Error("failed to rollback transaction", "error", err)
+		}
+	}()
 
 	// Create partition
 	createPartition := fmt.Sprintf(createPartitionSQL, partitionName, start, end)
@@ -157,10 +162,14 @@ func listPartitions(ctx context.Context, pool *pgxpool.Pool) ([]PartitionInfo, e
 }
 
 // runMigrations executes database migrations using goose
-func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger log.Logger) error {
 	// goose operates on *sql.DB, so we need to create one from our pgxpool
 	db := stdlib.OpenDBFromPool(pool)
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			logger.Error("failed to close database connection", "error", err)
+		}
+	}()
 
 	// Configure goose to use embedded migrations
 	goose.SetBaseFS(embedMigrations)

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -78,7 +78,7 @@ func getPartitionBounds(ts int64) (start, end int64) {
 }
 
 // ensurePartition creates a partition for the given timestamp if it doesn't exist
-// TODO: can we pre-create partitions for the next N weeks in a background job instead of creating on-demand during inserts?
+// TODO: should we pre-create partitions for the next N weeks in a background job instead of creating on-demand during inserts?
 func ensurePartition(ctx context.Context, pool *pgxpool.Pool, ts int64) error {
 	partitionName := getPartitionName(ts)
 	start, end := getPartitionBounds(ts)
@@ -93,7 +93,7 @@ func ensurePartition(ctx context.Context, pool *pgxpool.Pool, ts int64) error {
 	// Create partition
 	createPartition := fmt.Sprintf(createPartitionSQL, partitionName, start, end)
 	if _, err := tx.Exec(ctx, createPartition); err != nil {
-		// Check if error is "already exists" - this is OK due to concurrent inserts
+		// Check if error is "already exists", which is fine since we just want to ensure it exists
 		if !isAlreadyExistsError(err) {
 			return fmt.Errorf("failed to create partition %s: %w", partitionName, err)
 		}
@@ -158,9 +158,7 @@ func listPartitions(ctx context.Context, pool *pgxpool.Pool) ([]PartitionInfo, e
 
 // runMigrations executes database migrations using goose
 func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-	// Get underlying *sql.DB from pgxpool for goose
-	// Note: This creates a new *sql.DB from the pool config, which is safe
-	// because goose operations are short-lived
+	// goose operates on *sql.DB, so we need to create one from our pgxpool
 	db := stdlib.OpenDBFromPool(pool)
 	defer db.Close()
 
@@ -187,7 +185,7 @@ func isAlreadyExistsError(err error) bool {
 	// Check for pgx error code "42P07" (duplicate_table)
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
-		return pgErr.Code == "42P07" // duplicate_table
+		return pgErr.Code == "42P07"
 	}
 	return false
 }

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -55,7 +55,7 @@ ORDER BY child.relname;
 // getPartitionName calculates the partition name for a given timestamp
 // Returns partition name in format: annotations_YYYYwWW (e.g., annotations_2025w10)
 func getPartitionName(ts int64) string {
-	t := time.UnixMilli(ts)
+	t := time.UnixMilli(ts).UTC()
 	year, week := t.ISOWeek()
 	return fmt.Sprintf("annotations_%dw%02d", year, week)
 }

--- a/pkg/registry/apps/annotation/postgres_schema_test.go
+++ b/pkg/registry/apps/annotation/postgres_schema_test.go
@@ -1,0 +1,103 @@
+package annotation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPartitionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		ts       int64
+		expected string
+	}{
+		{
+			name:     "regular week",
+			ts:       time.Date(2025, 3, 12, 15, 30, 0, 0, time.UTC).UnixMilli(),
+			expected: "annotations_2025w11",
+		},
+		{
+			name:     "year boundary",
+			ts:       time.Date(2025, 12, 29, 12, 0, 0, 0, time.UTC).UnixMilli(),
+			expected: "annotations_2026w01", // ISO week 1 of 2026
+		},
+		{
+			name:     "week 53",
+			ts:       time.Date(2020, 12, 28, 12, 0, 0, 0, time.UTC).UnixMilli(),
+			expected: "annotations_2020w53",
+		},
+		{
+			name:     "first day of year in previous year's week",
+			ts:       time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+			expected: "annotations_2020w53", // Jan 1, 2021 is a Friday in 2020's week 53
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPartitionName(tt.ts)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetPartitionBounds(t *testing.T) {
+	tests := []struct {
+		name           string
+		ts             int64
+		expectedStart  time.Time
+		expectedEndSub time.Duration // Duration from start to end
+	}{
+		{
+			name:           "mid-week Wednesday",
+			ts:             time.Date(2025, 3, 12, 15, 30, 0, 0, time.UTC).UnixMilli(),
+			expectedStart:  time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC), // Monday
+			expectedEndSub: 7 * 24 * time.Hour,
+		},
+		{
+			name:           "Monday at midnight",
+			ts:             time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC).UnixMilli(),
+			expectedStart:  time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC),
+			expectedEndSub: 7 * 24 * time.Hour,
+		},
+		{
+			name:           "Sunday end of week",
+			ts:             time.Date(2025, 3, 16, 23, 59, 59, 0, time.UTC).UnixMilli(),
+			expectedStart:  time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC), // Previous Monday
+			expectedEndSub: 7 * 24 * time.Hour,
+		},
+		{
+			name:           "year boundary spanning week",
+			ts:             time.Date(2025, 12, 29, 12, 0, 0, 0, time.UTC).UnixMilli(), // Monday in week spanning 2025-2026
+			expectedStart:  time.Date(2025, 12, 29, 0, 0, 0, 0, time.UTC),
+			expectedEndSub: 7 * 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := getPartitionBounds(tt.ts)
+
+			actualStart := time.UnixMilli(start).UTC()
+			actualEnd := time.UnixMilli(end).UTC()
+
+			// Verify start matches expected
+			assert.Equal(t, tt.expectedStart, actualStart)
+
+			// Verify start is Monday at midnight
+			assert.Equal(t, time.Monday, actualStart.Weekday())
+			assert.Equal(t, 0, actualStart.Hour())
+			assert.Equal(t, 0, actualStart.Minute())
+			assert.Equal(t, 0, actualStart.Second())
+
+			// Verify end is exactly 7 days later
+			assert.Equal(t, tt.expectedEndSub, actualEnd.Sub(actualStart))
+
+			// Verify timestamp is within bounds
+			assert.GreaterOrEqual(t, tt.ts, start)
+			assert.Less(t, tt.ts, end)
+		})
+	}
+}

--- a/pkg/registry/apps/annotation/postgres_tags.go
+++ b/pkg/registry/apps/annotation/postgres_tags.go
@@ -1,0 +1,134 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// tagCache is a simple LRU cache with TTL for tag queries
+type tagCache struct {
+	cache *lru.Cache[string, *cachedTagResult]
+	ttl   time.Duration
+	mu    sync.RWMutex
+}
+
+// cachedTagResult holds cached tag results with expiration time
+type cachedTagResult struct {
+	tags      []Tag
+	expiresAt time.Time
+}
+
+// newTagCache creates a new tag cache
+func newTagCache(size int, ttl time.Duration) (*tagCache, error) {
+	cache, err := lru.New[string, *cachedTagResult](size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
+	}
+
+	return &tagCache{
+		cache: cache,
+		ttl:   ttl,
+	}, nil
+}
+
+// get retrieves tags from cache if valid
+func (c *tagCache) get(key string) ([]Tag, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cached, ok := c.cache.Get(key)
+	if !ok {
+		return nil, false
+	}
+
+	// Check if expired
+	if time.Now().After(cached.expiresAt) {
+		return nil, false
+	}
+
+	return cached.tags, true
+}
+
+// set stores tags in cache with TTL
+func (c *tagCache) set(key string, tags []Tag) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache.Add(key, &cachedTagResult{
+		tags:      tags,
+		expiresAt: time.Now().Add(c.ttl),
+	})
+}
+
+// cacheKey generates a cache key for tag queries
+func tagCacheKey(namespace, prefix string, limit int) string {
+	return fmt.Sprintf("%s:%s:%d", namespace, prefix, limit)
+}
+
+// ListTags implements the TagProvider interface
+func (s *PostgreSQLStore) ListTags(ctx context.Context, namespace string, opts TagListOptions) ([]Tag, error) {
+	// Try cache first
+	cacheKey := tagCacheKey(namespace, opts.Prefix, opts.Limit)
+	if cached, ok := s.tagCache.get(cacheKey); ok {
+		return cached, nil
+	}
+
+	// Build query
+	query := `
+		SELECT tag, COUNT(*) as count
+		FROM annotations, unnest(tags) as tag
+		WHERE namespace = $1
+	`
+
+	args := []any{namespace}
+	argNum := 2
+
+	// Add prefix filter if specified
+	if opts.Prefix != "" {
+		query += fmt.Sprintf(" AND tag LIKE $%d", argNum)
+		args = append(args, opts.Prefix+"%")
+		argNum++
+	}
+
+	query += `
+		GROUP BY tag
+		ORDER BY count DESC, tag
+	`
+
+	// Add limit
+	limit := opts.Limit
+	if limit == 0 {
+		limit = 100 // default
+	}
+	query += fmt.Sprintf(" LIMIT $%d", argNum)
+	args = append(args, limit)
+
+	// Execute query
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query tags: %w", err)
+	}
+	defer rows.Close()
+
+	var tags []Tag
+	for rows.Next() {
+		var tag Tag
+		if err := rows.Scan(&tag.Name, &tag.Count); err != nil {
+			return nil, fmt.Errorf("failed to scan tag row: %w", err)
+		}
+		tags = append(tags, tag)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating tag rows: %w", err)
+	}
+
+	// Store in cache
+	s.tagCache.set(cacheKey, tags)
+
+	return tags, nil
+}

--- a/pkg/registry/apps/annotation/postgres_tags.go
+++ b/pkg/registry/apps/annotation/postgres_tags.go
@@ -9,7 +9,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-// tagCache is a simple LRU cache with TTL for tag queries
+// tagCache is an LRU cache with TTL for tag queries
 type tagCache struct {
 	cache *lru.Cache[string, *cachedTagResult]
 	ttl   time.Duration
@@ -69,7 +69,8 @@ func tagCacheKey(namespace, prefix string, limit int) string {
 	return fmt.Sprintf("%s:%s:%d", namespace, prefix, limit)
 }
 
-// ListTags implements the TagProvider interface
+// ListTags implements the TagProvider interface.
+// We use a cache here because tag queries can be expensive, and they don't change frequently.
 func (s *PostgreSQLStore) ListTags(ctx context.Context, namespace string, opts TagListOptions) ([]Tag, error) {
 	// Try cache first
 	cacheKey := tagCacheKey(namespace, opts.Prefix, opts.Limit)

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -80,12 +80,16 @@ func NewAppInstaller(
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gRPC store: %w", err)
 		}
-	case "sql":
-		// sql is the default, but we allow explicitly specifying it for clarity
-		fallthrough
-	default:
+	case "postgres":
+		store, err = newPostgresStore(context.Background(), cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Postgres store: %w", err)
+		}
+	case "legacy-sql":
 		// Layer 1→2: Wrap old annotations.Repository with sqlAdapter (implements Store interface)
 		store = NewSQLAdapter(service, cleaner, cfg.CleanupSettings)
+	default:
+		return nil, fmt.Errorf("unknown store backend: %s (valid options: memory, grpc, postgres, legacy-sql)", cfg.StoreBackend)
 	}
 
 	installer.k8sAdapter = &k8sRESTAdapter{
@@ -166,6 +170,24 @@ func loadTLSConfig(cfg Config) (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+func newPostgresStore(ctx context.Context, cfg Config) (Store, error) {
+	if cfg.PostgresConnectionString == "" {
+		return nil, fmt.Errorf("postgres connection string is required")
+	}
+
+	pgCfg := PostgreSQLStoreConfig{
+		ConnectionString: cfg.PostgresConnectionString,
+		MaxConnections:   cfg.PostgresMaxConnections,
+		MaxIdleConns:     cfg.PostgresMaxIdleConns,
+		ConnMaxLifetime:  cfg.PostgresConnMaxLifetime,
+		RetentionTTL:     cfg.PostgresRetentionTTL,
+		TagCacheTTL:      cfg.PostgresTagCacheTTL,
+		TagCacheSize:     cfg.PostgresTagCacheSize,
+	}
+
+	return NewPostgreSQLStore(ctx, pgCfg)
 }
 
 func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -262,7 +262,13 @@ func (s *k8sRESTAdapter) New() runtime.Object {
 	return annotationV0.AnnotationKind().ZeroValue()
 }
 
-func (s *k8sRESTAdapter) Destroy() {}
+func (s *k8sRESTAdapter) Destroy() {
+	// Call Close() on the PostgreSQL store to cleanup connection pool and background goroutines
+	// TODO: add Close() to the Store interface so we can do proper cleanup for other store types
+	if pg, ok := s.store.(*PostgreSQLStore); ok {
+		pg.Close()
+	}
+}
 
 func (s *k8sRESTAdapter) NamespaceScoped() bool {
 	return true // namespace == org

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -86,10 +86,11 @@ func NewAppInstaller(
 			return nil, fmt.Errorf("failed to create Postgres store: %w", err)
 		}
 	case "legacy-sql":
+		// legacy-sql is the default, but we allow explicitly specifying it for clarity
+		fallthrough
+	default:
 		// Layer 1→2: Wrap old annotations.Repository with sqlAdapter (implements Store interface)
 		store = NewSQLAdapter(service, cleaner, cfg.CleanupSettings)
-	default:
-		return nil, fmt.Errorf("unknown store backend: %s (valid options: memory, grpc, postgres, legacy-sql)", cfg.StoreBackend)
 	}
 
 	installer.k8sAdapter = &k8sRESTAdapter{

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	authtypes "github.com/grafana/authlib/types"
 	"google.golang.org/grpc"
@@ -32,6 +34,7 @@ import (
 	annotationapp "github.com/grafana/grafana/apps/annotation/pkg/app"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apiserverrest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
 	"github.com/grafana/grafana/pkg/setting"
@@ -45,7 +48,10 @@ var (
 
 type AppInstaller struct {
 	appsdkapiserver.AppInstaller
-	k8sAdapter *k8sRESTAdapter
+	k8sAdapter    *k8sRESTAdapter
+	cleanupCancel context.CancelFunc
+	cleanupWg     sync.WaitGroup
+	logger        log.Logger
 }
 
 // RegisterAppInstaller is the wire entry point for the ST server.
@@ -68,7 +74,9 @@ func NewAppInstaller(
 	cleaner annotations.Cleaner,
 	accessClient authtypes.AccessClient,
 ) (*AppInstaller, error) {
-	installer := &AppInstaller{}
+	installer := &AppInstaller{
+		logger: log.New("annotation.app"),
+	}
 
 	var store Store
 	var err error
@@ -93,9 +101,15 @@ func NewAppInstaller(
 		store = NewSQLAdapter(service, cleaner, cfg.CleanupSettings)
 	}
 
+	// Start background cleanup if the store supports lifecycle management
+	if lifecycleMgr, ok := store.(LifecycleManager); ok {
+		installer.startCleanup(context.Background(), lifecycleMgr, cfg.RetentionTTL)
+	}
+
 	installer.k8sAdapter = &k8sRESTAdapter{
 		store:        store,
 		accessClient: accessClient,
+		installer:    installer,
 	}
 
 	// Create the tags handler
@@ -183,12 +197,56 @@ func newPostgresStore(ctx context.Context, cfg Config) (Store, error) {
 		MaxConnections:   cfg.PostgresMaxConnections,
 		MaxIdleConns:     cfg.PostgresMaxIdleConns,
 		ConnMaxLifetime:  cfg.PostgresConnMaxLifetime,
-		RetentionTTL:     cfg.PostgresRetentionTTL,
+		RetentionTTL:     cfg.RetentionTTL,
 		TagCacheTTL:      cfg.PostgresTagCacheTTL,
 		TagCacheSize:     cfg.PostgresTagCacheSize,
 	}
 
 	return NewPostgreSQLStore(ctx, pgCfg)
+}
+
+// startCleanup starts a background goroutine that periodically runs cleanup on the store
+func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr LifecycleManager, retentionTTL time.Duration) {
+	ctx, cancel := context.WithCancel(parentCtx)
+	a.cleanupCancel = cancel
+
+	a.cleanupWg.Add(1)
+	go func() {
+		defer a.cleanupWg.Done()
+
+		ticker := time.NewTicker(cleanupInterval)
+		defer ticker.Stop()
+
+		a.logger.Info("Starting annotation cleanup loop", "interval", cleanupInterval, "retention", retentionTTL)
+
+		// Run immediately on startup
+		a.runCleanup(ctx, lifecycleMgr)
+
+		for {
+			select {
+			case <-ticker.C:
+				a.runCleanup(ctx, lifecycleMgr)
+			case <-ctx.Done():
+				a.logger.Info("Stopping annotation cleanup loop")
+				return
+			}
+		}
+	}()
+}
+
+// runCleanup executes the cleanup operation with a timeout
+func (a *AppInstaller) runCleanup(ctx context.Context, lifecycleMgr LifecycleManager) {
+	// Set a 5-minute timeout for the cleanup
+	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	deleted, err := lifecycleMgr.Cleanup(cleanupCtx)
+	if err != nil {
+		a.logger.Error("Annotation cleanup failed", "error", err, "duration", time.Since(start))
+	} else if deleted > 0 {
+		a.logger.Info("Annotation cleanup completed", "rows_deleted", deleted, "duration", time.Since(start))
+	}
 }
 
 func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {
@@ -257,6 +315,7 @@ type k8sRESTAdapter struct {
 	store          Store
 	tableConverter rest.TableConvertor
 	accessClient   authtypes.AccessClient
+	installer      *AppInstaller
 }
 
 func (s *k8sRESTAdapter) New() runtime.Object {
@@ -264,7 +323,13 @@ func (s *k8sRESTAdapter) New() runtime.Object {
 }
 
 func (s *k8sRESTAdapter) Destroy() {
-	// Call Close() on the PostgreSQL store to cleanup connection pool and background goroutines
+	// Stop background cleanup goroutines
+	if s.installer != nil && s.installer.cleanupCancel != nil {
+		s.installer.cleanupCancel()
+		s.installer.cleanupWg.Wait()
+	}
+
+	// Call Close() on the PostgreSQL store to cleanup connection pool
 	// TODO: add Close() to the Store interface so we can do proper cleanup for other store types
 	if pg, ok := s.store.(*PostgreSQLStore); ok {
 		pg.Close()

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -7,7 +7,10 @@ import (
 	authtypes "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -107,5 +110,158 @@ func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
 		// When both are provided, name takes priority
 		assert.Equal(t, "my-special-name", result.Name,
 			"expected name to match the provided name, not the generateName")
+	})
+}
+
+func TestK8sRESTAdapter_TenantIsolation(t *testing.T) {
+	store := NewMemoryStore()
+	adapter := &k8sRESTAdapter{
+		store:        store,
+		accessClient: authtypes.FixedAccessClient(true),
+	}
+
+	// Create annotations in different namespaces (tenants)
+	namespace1 := "org-1"
+	namespace2 := "org-2"
+
+	ctx1 := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), namespace1)
+	ctx2 := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 2), namespace2)
+
+	t.Run("annotations are isolated by namespace", func(t *testing.T) {
+		// Create annotation in namespace1
+		anno1 := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "anno-1",
+				Namespace: namespace1,
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "annotation in org 1",
+				Time: 12345,
+			},
+		}
+		_, err := adapter.Create(ctx1, anno1, nil, nil)
+		require.NoError(t, err)
+
+		// Create annotation in namespace2
+		anno2 := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "anno-2",
+				Namespace: namespace2,
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "annotation in org 2",
+				Time: 12346,
+			},
+		}
+		_, err = adapter.Create(ctx2, anno2, nil, nil)
+		require.NoError(t, err)
+
+		// List from namespace1 should only see anno1
+		list1, err := adapter.List(ctx1, &metainternalversion.ListOptions{})
+		require.NoError(t, err)
+		annoList1 := list1.(*annotationV0.AnnotationList)
+		assert.Len(t, annoList1.Items, 1)
+		assert.Equal(t, "anno-1", annoList1.Items[0].Name)
+		assert.Equal(t, namespace1, annoList1.Items[0].Namespace)
+
+		// List from namespace2 should only see anno2
+		list2, err := adapter.List(ctx2, &metainternalversion.ListOptions{})
+		require.NoError(t, err)
+		annoList2 := list2.(*annotationV0.AnnotationList)
+		assert.Len(t, annoList2.Items, 1)
+		assert.Equal(t, "anno-2", annoList2.Items[0].Name)
+		assert.Equal(t, namespace2, annoList2.Items[0].Namespace)
+	})
+
+	t.Run("get fails when accessing annotation from different namespace", func(t *testing.T) {
+		// Create annotation in namespace1
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cross-ns-test",
+				Namespace: namespace1,
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "test annotation",
+				Time: 12347,
+			},
+		}
+		_, err := adapter.Create(ctx1, anno, nil, nil)
+		require.NoError(t, err)
+
+		// Try to get from namespace1 (should succeed)
+		retrieved1, err := adapter.Get(ctx1, "cross-ns-test", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "cross-ns-test", retrieved1.(*annotationV0.Annotation).Name)
+
+		// Try to get from namespace2 (should fail - not found)
+		_, err = adapter.Get(ctx2, "cross-ns-test", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("update enforces namespace consistency", func(t *testing.T) {
+		// Create annotation in namespace1
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "update-test",
+				Namespace: namespace1,
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "original text",
+				Time: 12348,
+			},
+		}
+		_, err := adapter.Create(ctx1, anno, nil, nil)
+		require.NoError(t, err)
+
+		// Try to update with mismatched namespace in body
+		updatedAnno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "update-test",
+				Namespace: namespace2, // Wrong namespace!
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "updated text",
+				Time: 12348,
+			},
+		}
+
+		// Update should fail due to namespace mismatch
+		_, _, err = adapter.Update(ctx1, "update-test", rest.DefaultUpdatedObjectInfo(updatedAnno), nil, nil, false, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace")
+	})
+
+	t.Run("delete is isolated by namespace", func(t *testing.T) {
+		// Create annotation in namespace1
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "delete-test",
+				Namespace: namespace1,
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "to be deleted",
+				Time: 12349,
+			},
+		}
+		_, err := adapter.Create(ctx1, anno, nil, nil)
+		require.NoError(t, err)
+
+		// Try to delete from namespace2 (should fail)
+		_, _, err = adapter.Delete(ctx2, "delete-test", nil, nil)
+		require.Error(t, err)
+
+		// Verify annotation still exists in namespace1
+		retrieved, err := adapter.Get(ctx1, "delete-test", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "delete-test", retrieved.(*annotationV0.Annotation).Name)
+
+		// Delete from namespace1 (should succeed)
+		_, _, err = adapter.Delete(ctx1, "delete-test", nil, nil)
+		require.NoError(t, err)
+
+		// Verify it's gone
+		_, err = adapter.Get(ctx1, "delete-test", nil)
+		require.Error(t, err)
 	})
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1004,22 +1004,40 @@ type AnnotationCleanupSettings struct {
 
 type AnnotationAppPlatformSettings struct {
 	Enabled           bool
-	StoreBackend      string // "sql" (default) or "grpc"
+	StoreBackend      string // "legacy-sql" (default), "grpc", or "postgres"
 	GRPCAddress       string // gRPC server address (e.g., "localhost:9090")
 	GRPCUseTLS        bool   // Enable TLS for gRPC connection (default: false)
 	GRPCTLSCAFile     string // Path to CA certificate file (optional)
 	GRPCTLSSkipVerify bool   // Skip TLS verification (insecure, for testing)
+
+	// Postgres store configuration
+	PostgresConnectionString string        // PostgreSQL connection string
+	PostgresMaxConnections   int           // Maximum number of connections in the pool
+	PostgresMaxIdleConns     int           // Maximum number of idle connections
+	PostgresConnMaxLifetime  time.Duration // Maximum lifetime of a connection
+	PostgresRetentionTTL     time.Duration // Retention TTL for annotations
+	PostgresTagCacheTTL      time.Duration // TTL for tag query cache
+	PostgresTagCacheSize     int           // Size of the tag query cache
 }
 
 func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSettings {
 	appPlatformSection := cfg.Section("annotations.app_platform")
 	return AnnotationAppPlatformSettings{
 		Enabled:           appPlatformSection.Key("enabled").MustBool(false),
-		StoreBackend:      appPlatformSection.Key("store_backend").MustString("sql"),
+		StoreBackend:      appPlatformSection.Key("store_backend").MustString("legacy-sql"),
 		GRPCAddress:       appPlatformSection.Key("grpc_address").MustString("localhost:9090"),
 		GRPCUseTLS:        appPlatformSection.Key("grpc_use_tls").MustBool(false),
 		GRPCTLSCAFile:     appPlatformSection.Key("grpc_tls_ca_file").MustString(""),
 		GRPCTLSSkipVerify: appPlatformSection.Key("grpc_tls_skip_verify").MustBool(false),
+
+		// Postgres configuration
+		PostgresConnectionString: appPlatformSection.Key("postgres_connection_string").MustString(""),
+		PostgresMaxConnections:   appPlatformSection.Key("postgres_max_connections").MustInt(10),
+		PostgresMaxIdleConns:     appPlatformSection.Key("postgres_max_idle_conns").MustInt(5),
+		PostgresConnMaxLifetime:  appPlatformSection.Key("postgres_conn_max_lifetime").MustDuration(time.Hour),
+		PostgresRetentionTTL:     appPlatformSection.Key("postgres_retention_ttl").MustDuration(2160 * time.Hour),
+		PostgresTagCacheTTL:      appPlatformSection.Key("postgres_tag_cache_ttl").MustDuration(60 * time.Second),
+		PostgresTagCacheSize:     appPlatformSection.Key("postgres_tag_cache_size").MustInt(1000),
 	}
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1003,8 +1003,10 @@ type AnnotationCleanupSettings struct {
 }
 
 type AnnotationAppPlatformSettings struct {
-	Enabled           bool
-	StoreBackend      string // "legacy-sql" (default), "grpc", or "postgres"
+	Enabled      bool
+	StoreBackend string        // "legacy-sql" (default), "grpc", or "postgres"
+	RetentionTTL time.Duration // Retention TTL for annotations
+
 	GRPCAddress       string // gRPC server address (e.g., "localhost:9090")
 	GRPCUseTLS        bool   // Enable TLS for gRPC connection (default: false)
 	GRPCTLSCAFile     string // Path to CA certificate file (optional)
@@ -1015,7 +1017,6 @@ type AnnotationAppPlatformSettings struct {
 	PostgresMaxConnections   int           // Maximum number of connections in the pool
 	PostgresMaxIdleConns     int           // Maximum number of idle connections
 	PostgresConnMaxLifetime  time.Duration // Maximum lifetime of a connection
-	PostgresRetentionTTL     time.Duration // Retention TTL for annotations
 	PostgresTagCacheTTL      time.Duration // TTL for tag query cache
 	PostgresTagCacheSize     int           // Size of the tag query cache
 }
@@ -1023,8 +1024,10 @@ type AnnotationAppPlatformSettings struct {
 func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSettings {
 	appPlatformSection := cfg.Section("annotations.app_platform")
 	return AnnotationAppPlatformSettings{
-		Enabled:           appPlatformSection.Key("enabled").MustBool(false),
-		StoreBackend:      appPlatformSection.Key("store_backend").MustString("legacy-sql"),
+		Enabled:      appPlatformSection.Key("enabled").MustBool(false),
+		StoreBackend: appPlatformSection.Key("store_backend").MustString("legacy-sql"),
+		RetentionTTL: appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
+
 		GRPCAddress:       appPlatformSection.Key("grpc_address").MustString("localhost:9090"),
 		GRPCUseTLS:        appPlatformSection.Key("grpc_use_tls").MustBool(false),
 		GRPCTLSCAFile:     appPlatformSection.Key("grpc_tls_ca_file").MustString(""),
@@ -1035,7 +1038,6 @@ func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSetti
 		PostgresMaxConnections:   appPlatformSection.Key("postgres_max_connections").MustInt(10),
 		PostgresMaxIdleConns:     appPlatformSection.Key("postgres_max_idle_conns").MustInt(5),
 		PostgresConnMaxLifetime:  appPlatformSection.Key("postgres_conn_max_lifetime").MustDuration(time.Hour),
-		PostgresRetentionTTL:     appPlatformSection.Key("postgres_retention_ttl").MustDuration(2160 * time.Hour),
 		PostgresTagCacheTTL:      appPlatformSection.Key("postgres_tag_cache_ttl").MustDuration(60 * time.Second),
 		PostgresTagCacheSize:     appPlatformSection.Key("postgres_tag_cache_size").MustInt(1000),
 	}


### PR DESCRIPTION
This PR creates a PostgreSQL store implementation for the annotations app platform API. Key changes include:
- Weekly time-based partitioning with configurable retention TTL
- Schema migrations using `github.com/pressly/goose/v3`
- Tags and scopes stored as de-normalized arrays with GIN indexes to enable efficient array containment queries
- Caching for tag queries (defaulting to 60s TTL)

_Note: I'd like to add some integration tests to cover this. Debating whether to add them in this PR or as a follow-on as the diff is already >1k lines._