### PR TITLE
State Timeline: fix axis text color not updating on theme change

### DIFF
--- a/public/app/core/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/core/components/TimelineChart/TimelineChart.tsx
@@ -33,6 +33,7 @@ const propsToDiff = [
   'tooltip',
   'paginationRev',
   'annotationLanes',
+  'theme',
 ];
 
 export const TimelineChart = (props: TimelineProps) => {


### PR DESCRIPTION
Fixes #120721.

When switching between light and dark themes, the state timeline panel's axis text colors stayed stale until a page reload. Other panels like timeseries updated correctly.

The `TimelineChart` component was missing `'theme'` in its `propsToDiff` array, so `GraphNG` never detected the theme change and didn't rebuild the plot config. The `TimeSeries` component already includes `'theme'` for this reason.