### PR TITLE
Tracing: Add mTLS support to OTLP exporter

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1900,6 +1900,12 @@ propagation =
 # Toggles the insecure communication setting, defaults to `true`.
 # When set to `false`, the OTLP client will use TLS credentials with the default system cert pool for communication.
 insecure =
+# Path to the CA certificate for verifying the OTLP server's certificate. If empty, the system cert pool is used.
+ca_cert =
+# Path to the client certificate for mTLS authentication with the OTLP server. Must be set together with client_key.
+client_cert =
+# Path to the client private key for mTLS authentication with the OTLP server. Must be set together with client_cert.
+client_key =
 
 #################################### External Image Storage ##############
 [external_image_storage]

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -2,11 +2,14 @@ package tracing
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"math"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -177,7 +180,11 @@ func (ots *TracingService) initOTLPTracerProvider() (*tracesdk.TracerProvider, e
 	if ots.cfg.Insecure {
 		opts = append(opts, otlptracegrpc.WithInsecure())
 	} else {
-		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(nil)))
+		tlsCfg, err := ots.buildTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config for OTLP exporter: %w", err)
+		}
+		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsCfg)))
 	}
 
 	client := otlptracegrpc.NewClient(opts...)
@@ -192,6 +199,32 @@ func (ots *TracingService) initOTLPTracerProvider() (*tracesdk.TracerProvider, e
 	}
 
 	return initTracerProvider(exp, ots.cfg.ServiceName, ots.cfg.ServiceVersion, sampler, ots.cfg.CustomAttribs...)
+}
+
+func (ots *TracingService) buildTLSConfig() (*tls.Config, error) {
+	tlsCfg := &tls.Config{}
+
+	if ots.cfg.CACert != "" {
+		caPEM, err := os.ReadFile(ots.cfg.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA certificate %q: %w", ots.cfg.CACert, err)
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %q", ots.cfg.CACert)
+		}
+		tlsCfg.RootCAs = certPool
+	}
+
+	if ots.cfg.ClientCert != "" && ots.cfg.ClientKey != "" {
+		cert, err := tls.LoadX509KeyPair(ots.cfg.ClientCert, ots.cfg.ClientKey)
+		if err != nil {
+			return nil, fmt.Errorf("loading client certificate/key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsCfg, nil
 }
 
 func (ots *TracingService) initSampler() (tracesdk.Sampler, error) {

--- a/pkg/infra/tracing/tracing_config.go
+++ b/pkg/infra/tracing/tracing_config.go
@@ -27,6 +27,11 @@ type TracingConfig struct {
 
 	ProfilingIntegration bool
 	Insecure             bool
+
+	// TLS certificate paths for mTLS with the OTLP exporter.
+	CACert     string
+	ClientCert string
+	ClientKey  string
 }
 
 func ProvideTracingConfig(cfgProvider configprovider.ConfigProvider) (*TracingConfig, error) {
@@ -138,6 +143,9 @@ func ParseTracingConfig(cfg *setting.Cfg) (*TracingConfig, error) {
 	}
 	tc.Propagation = section.Key("propagation").MustString("")
 	tc.Insecure = section.Key("insecure").MustBool(true)
+	tc.CACert = section.Key("ca_cert").MustString("")
+	tc.ClientCert = section.Key("client_cert").MustString("")
+	tc.ClientKey = section.Key("client_key").MustString("")
 	return tc, nil
 }
 

--- a/pkg/infra/tracing/tracing_config_test.go
+++ b/pkg/infra/tracing/tracing_config_test.go
@@ -69,6 +69,10 @@ func TestTracingConfig(t *testing.T) {
 		ExpectedSampler           string
 		ExpectedSamplerParam      float64
 		ExpectedSamplingServerURL string
+
+		ExpectedCACert     string
+		ExpectedClientCert string
+		ExpectedClientKey  string
 	}{
 		{
 			Name:             "default config uses noop exporter",
@@ -177,6 +181,24 @@ func TestTracingConfig(t *testing.T) {
 			ExpectedSamplerParam:      0.5,
 			ExpectedSamplingServerURL: "http://example.com:5778/sampling",
 		},
+		{
+			Name: "OTLP mTLS config is parsed",
+			Cfg: `
+			[tracing.opentelemetry.otlp]
+			address = otlp.example.com:4317
+			insecure = false
+			ca_cert = /etc/ssl/ca.pem
+			client_cert = /etc/ssl/client.crt
+			client_key = /etc/ssl/client.key
+			`,
+			ExpectedExporter:   otlpExporter,
+			ExpectedAddress:    "otlp.example.com:4317",
+			ExpectedInsecure:   false,
+			ExpectedAttrs:      []attribute.KeyValue{},
+			ExpectedCACert:     "/etc/ssl/ca.pem",
+			ExpectedClientCert: "/etc/ssl/client.crt",
+			ExpectedClientKey:  "/etc/ssl/client.key",
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			// export environment variables
@@ -200,6 +222,9 @@ func TestTracingConfig(t *testing.T) {
 			assert.Equal(t, test.ExpectedPropagator, tracingConfig.Propagation)
 			assert.Equal(t, test.ExpectedAttrs, tracingConfig.CustomAttribs)
 			assert.Equal(t, test.ExpectedInsecure, tracingConfig.Insecure)
+			assert.Equal(t, test.ExpectedCACert, tracingConfig.CACert)
+			assert.Equal(t, test.ExpectedClientCert, tracingConfig.ClientCert)
+			assert.Equal(t, test.ExpectedClientKey, tracingConfig.ClientKey)
 
 			if test.ExpectedSampler != "" {
 				assert.Equal(t, test.ExpectedSampler, tracingConfig.Sampler)


### PR DESCRIPTION
## Summary
  - Add `ca_cert`, `client_cert`, and `client_key` configuration options to `[tracing.opentelemetry.otlp]` to enable mTLS connections to OTLP collectors that require client
  certificate authentication
  - When `insecure = false`, a custom `*tls.Config` is now built from these paths instead of always using the system cert pool
  - If no cert paths are provided, behavior is unchanged (system cert pool with no client identity)

  ### Configuration example
  ```ini
  [tracing.opentelemetry.otlp]
  address = otelgateway.example.com:4317
  insecure = false
  ca_cert = /etc/ssl/ca.pem
  client_cert = /etc/ssl/client.crt
  client_key = /etc/ssl/client.key

  Test plan

  - All existing tracing config tests pass
  - New OTLP_mTLS_config_is_parsed test verifies config field parsing
  - go vet clean, no regressions
  - Manual test with an OTLP collector requiring mTLS