### PR TITLE
Dashboards: Add default layout selector to Empty Dashboard page

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1030,7 +1030,7 @@ export interface FeatureToggles {
   */
   alertingJiraIntegration?: boolean;
   /**
-  *
+  * 
   * @default true
   */
   alertingUseNewSimplifiedRoutingHashAlgorithm?: boolean;

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -414,6 +414,11 @@ export interface FeatureToggles {
   */
   dashboardNewLayouts?: boolean;
   /**
+  * Enables default layout selector in dashboard settings
+  * @default false
+  */
+  dashboardDefaultLayoutSelector?: boolean;
+  /**
   * Enables the assistant prompt popover on panel click in dashboard view mode
   * @default false
   */
@@ -1025,7 +1030,7 @@ export interface FeatureToggles {
   */
   alertingJiraIntegration?: boolean;
   /**
-  * 
+  *
   * @default true
   */
   alertingUseNewSimplifiedRoutingHashAlgorithm?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -633,6 +633,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "dashboardDefaultLayoutSelector",
+			Description:  "Enables default layout selector in dashboard settings",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaDashboardsSquad,
+			Expression:   "false",
+		},
+		{
 			Name:         "dashboardAssistantPopover",
 			Description:  "Enables the assistant prompt popover on panel click in dashboard view mode",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -78,6 +78,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-12,annotationsClustering,experimental,@grafana/dataviz-squad,false,false,true
 2023-11-13,dashboardScene,GA,@grafana/dashboards-squad,false,false,true
 2024-10-23,dashboardNewLayouts,preview,@grafana/dashboards-squad,false,false,false
+2026-03-19,dashboardDefaultLayoutSelector,experimental,@grafana/dashboards-squad,false,false,true
 2026-03-10,dashboardAssistantPopover,experimental,@grafana/dashboards-squad,false,false,true
 2025-08-29,dashboardUndoRedo,experimental,@grafana/dashboards-squad,false,false,true
 2025-10-10,unlimitedLayoutsNesting,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1368,6 +1368,20 @@
     },
     {
       "metadata": {
+        "name": "dashboardDefaultLayoutSelector",
+        "resourceVersion": "1773923636566",
+        "creationTimestamp": "2026-03-19T12:33:56Z"
+      },
+      "spec": {
+        "description": "Enables default layout selector in dashboard settings",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboardDisableSchemaValidationV1",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-04-11T16:52:46Z"

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -134,7 +134,7 @@ export interface DashboardSceneState extends SceneObjectState {
   id?: number | undefined;
 
   /** Dashboard-specific preferences **/
-  preferences: DashboardScenePreferences;
+  preferences?: DashboardScenePreferences;
 
   /** The title */
   title: string;
@@ -1298,7 +1298,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Undefined if default layout is not set in preferences
    */
   getDefaultLayout() {
-    if (this.state.preferences.defaultLayoutTemplate) {
+    if (this.state.preferences?.defaultLayoutTemplate) {
       return this.state.preferences.defaultLayoutTemplate.clone();
     }
     return undefined;

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -125,9 +125,16 @@ type CopiedPanelStyles = {
   styles: PanelStyles;
 };
 
+export interface DashboardScenePreferences {
+  defaultLayoutTemplate?: DashboardLayoutManager;
+}
+
 export interface DashboardSceneState extends SceneObjectState {
   /** @deprecated */
   id?: number | undefined;
+
+  /** Dashboard-specific preferences **/
+  preferences: DashboardScenePreferences;
 
   /** The title */
   title: string;
@@ -227,11 +234,13 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       meta: {},
       editable: true,
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),
-      body: state.body ?? DefaultGridLayoutManager.fromVizPanels([]),
+      body:
+        state.body ?? state.preferences?.defaultLayoutTemplate?.clone() ?? DefaultGridLayoutManager.fromVizPanels([]),
       links: state.links ?? [],
       ...state,
       editPane: new DashboardEditPane(),
       layoutOrchestrator: new DashboardLayoutOrchestrator(),
+      preferences: state.preferences ?? {},
     });
 
     this.serializer =
@@ -1282,6 +1291,30 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   private hasVariableErrors(): boolean {
     return Boolean(this.state.$variables?.state.variables.find((v) => Boolean(v.state.error)));
+  }
+
+  /**
+   * Default layout used for new Tab and Row containers
+   * Undefined if default layout is not set in preferences
+   */
+  getDefaultLayout() {
+    if (this.state.preferences.defaultLayoutTemplate) {
+      return this.state.preferences.defaultLayoutTemplate.clone();
+    }
+    return undefined;
+  }
+
+  getDefaultLayoutType() {
+    return this.state.preferences?.defaultLayoutTemplate?.descriptor?.id;
+  }
+
+  updateDefaultLayoutTemplate(template: DashboardLayoutManager) {
+    this.setState({
+      preferences: {
+        ...this.state.preferences,
+        defaultLayoutTemplate: template.clone(),
+      },
+    });
   }
 }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -8,10 +8,12 @@ import {
   SceneObjectState,
   VizPanel,
   SceneGridItemLike,
+  useSceneObjectState,
 } from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty';
 
 import { dashboardEditActions, NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
 import { serializeAutoGridLayout } from '../../serialization/layoutSerializers/AutoGridLayoutSerializer';
@@ -22,6 +24,7 @@ import {
   getDashboardSceneFor,
   getGridItemKeyForPanelId,
   getVizPanelKeyForPanelId,
+  useDashboard,
 } from '../../utils/utils';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { clearClipboard, getAutoGridItemFromClipboard } from '../layouts-shared/paste';
@@ -437,6 +440,15 @@ export class AutoGridLayoutManager
 }
 
 function AutoGridLayoutManagerRenderer({ model }: SceneComponentProps<AutoGridLayoutManager>) {
+  const dashboard = useDashboard(model);
+  const { children } = useSceneObjectState(model.state.layout, { shouldActivateOrKeepAlive: true });
+
+  if (model.parent === dashboard && children.length === 0) {
+    return (
+      <DashboardEmpty dashboard={dashboard} canCreate={!!dashboard.state.meta.canEdit} key="dashboard-empty-state" />
+    );
+  }
+
   return <model.state.layout.Component model={model.state.layout} />;
 }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -131,7 +131,7 @@ export class RowsLayoutManager
   }
 
   public addNewRow(row?: RowItem): RowItem {
-    const newRow = row ?? new RowItem({});
+    const newRow = row ?? new RowItem({ layout: getDashboardSceneFor(this).getDefaultLayout() });
     const existingNames = new Set(this.state.rows.map((row) => row.state.title).filter((title) => title !== undefined));
 
     const newTitle = generateUniqueTitle(newRow.state.title, existingNames);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -195,7 +195,7 @@ export class TabsLayoutManager
   }
 
   public addNewTab(tab?: TabItem) {
-    const newTab = tab ?? new TabItem({});
+    const newTab = tab ?? new TabItem({ layout: getDashboardSceneFor(this).getDefaultLayout() });
     const existingNames = new Set(
       this.getTabsIncludingRepeats()
         .map((tab) => tab.state.title)

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -9,6 +9,7 @@ import {
   defaultTimeSettingsSpec,
   GroupByVariableKind,
   Spec as DashboardV2Spec,
+  defaultGridLayoutKind,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
@@ -157,6 +158,14 @@ export async function buildNewDashboardSaveModelV2(
 
   if (urlFolderUid && data.metadata.annotations) {
     data.metadata.annotations[AnnoKeyFolder] = urlFolderUid;
+  }
+
+  // Initialize default preferences to be same as the default layout
+  if (config.featureToggles.dashboardDefaultLayoutSelector) {
+    data.spec.preferences = {
+      ...data.spec.preferences,
+      defaultLayoutTemplate: defaultGridLayoutKind(),
+    };
   }
 
   return data;

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -182,6 +182,13 @@ export function transformSaveModelSchemaV2ToScene(
     .get(dashboard.layout.kind)
     .deserialize(dashboard.layout, dashboard.elements, dashboard.preload);
 
+  let templateLayoutManager: DashboardLayoutManager | undefined = undefined;
+  if (config.featureToggles.dashboardDefaultLayoutSelector && dashboard.preferences?.defaultLayoutTemplate) {
+    templateLayoutManager = layoutDeserializerRegistry
+      .get(dashboard.preferences.defaultLayoutTemplate.kind)
+      .deserialize(dashboard.preferences.defaultLayoutTemplate, {}, false);
+  }
+
   // Create profiler once and reuse to avoid duplicate metadata setting
   const dashboardProfiler = getDashboardSceneProfilerWithMetadata(metadata.name, dashboard.title);
 
@@ -207,6 +214,9 @@ export function transformSaveModelSchemaV2ToScene(
   const dashboardScene = new DashboardScene(
     {
       id: deprecatedId ? parseInt(deprecatedId, 10) : undefined,
+      preferences: {
+        defaultLayoutTemplate: templateLayoutManager,
+      },
       description: dashboard.description,
       editable: dashboard.editable,
       preload: dashboard.preload,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -214,9 +214,11 @@ export function transformSaveModelSchemaV2ToScene(
   const dashboardScene = new DashboardScene(
     {
       id: deprecatedId ? parseInt(deprecatedId, 10) : undefined,
-      preferences: {
-        defaultLayoutTemplate: templateLayoutManager,
-      },
+      preferences: templateLayoutManager
+        ? {
+            defaultLayoutTemplate: templateLayoutManager,
+          }
+        : undefined,
       description: dashboard.description,
       editable: dashboard.editable,
       preload: dashboard.preload,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -53,6 +53,7 @@ import {
   defaultTimeSettingsSpec,
   defaultDashboardLinkType,
   defaultDashboardLink,
+  DashboardPreferences,
 } from '../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene, DashboardSceneState } from '../scene/DashboardScene';
@@ -90,9 +91,20 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
 
   const timeSettingsDefaults = defaultTimeSettingsSpec();
 
+  let preferences: DashboardPreferences = {};
+
+  if (config.featureToggles.dashboardDefaultLayoutSelector && sceneDash.preferences.defaultLayoutTemplate) {
+    const template = sceneDash.preferences.defaultLayoutTemplate;
+    const serialized = template.serialize();
+    if (serialized.kind === 'AutoGridLayout' || serialized.kind === 'GridLayout') {
+      preferences.defaultLayoutTemplate = serialized;
+    }
+  }
+
   const dashboardSchemaV2: DeepPartial<DashboardV2Spec> = {
     //dashboard settings
     title: sceneDash.title,
+    preferences,
     description: sceneDash.description || undefined,
     cursorSync: getCursorSync(sceneDash),
     liveNow: getLiveNow(sceneDash),

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -91,13 +91,15 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
 
   const timeSettingsDefaults = defaultTimeSettingsSpec();
 
-  let preferences: DashboardPreferences = {};
+  let preferences: DashboardPreferences | undefined = undefined;
 
-  if (config.featureToggles.dashboardDefaultLayoutSelector && sceneDash.preferences.defaultLayoutTemplate) {
+  if (config.featureToggles.dashboardDefaultLayoutSelector && sceneDash.preferences?.defaultLayoutTemplate) {
     const template = sceneDash.preferences.defaultLayoutTemplate;
     const serialized = template.serialize();
     if (serialized.kind === 'AutoGridLayout' || serialized.kind === 'GridLayout') {
-      preferences.defaultLayoutTemplate = serialized;
+      preferences = {
+        defaultLayoutTemplate: serialized,
+      };
     }
   }
 

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -28,6 +28,8 @@ import { ProvisioningAwareFolderPicker } from 'app/features/provisioning/compone
 import { updateNavModel } from '../pages/utils';
 import { DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
+import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../utils/utils';
 
@@ -111,6 +113,14 @@ export class GeneralSettingsEditView
 
   public onEditableChange = (value: boolean) => {
     this._dashboard.setState({ editable: value });
+  };
+
+  public onDefaultGridChange = (value: string) => {
+    if (value === AutoGridLayoutManager.descriptor.id) {
+      this._dashboard.updateDefaultLayoutTemplate(AutoGridLayoutManager.createEmpty());
+    } else if (value === DefaultGridLayoutManager.descriptor.id) {
+      this._dashboard.updateDefaultLayoutTemplate(DefaultGridLayoutManager.createEmpty());
+    }
   };
 
   public onTimeZoneChange = (value: TimeZone) => {
@@ -216,6 +226,19 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
     },
   ];
 
+  const DEFAULT_GRID_OPTIONS = [
+    {
+      label: t('dashboard-scene.general-settings-edit-view.default_grid_options.label.auto', 'Auto grid'),
+      value: AutoGridLayoutManager.descriptor.id,
+    },
+    {
+      label: t('dashboard-scene.general-settings-edit-view.default_grid_options.label.custom', 'Custom grid'),
+      value: DefaultGridLayoutManager.descriptor.id,
+    },
+  ];
+
+  const defaultGrid = dashboard.getDefaultLayoutType();
+
   const GRAPH_TOOLTIP_OPTIONS = [
     {
       value: 0,
@@ -315,6 +338,23 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
           >
             <RadioButtonGroup value={editable} options={EDITABLE_OPTIONS} onChange={model.onEditableChange} />
           </Field>
+
+          {config.featureToggles.dashboardDefaultLayoutSelector && (
+            <Field
+              noMargin
+              label={t('dashboard-settings.general.default-grid-label', 'Default grid')}
+              description={t(
+                'dashboard-settings.general.default-grid-description',
+                'Select layout type to be used for new rows and tabs'
+              )}
+            >
+              <RadioButtonGroup
+                value={defaultGrid}
+                options={DEFAULT_GRID_OPTIONS}
+                onChange={model.onDefaultGridChange}
+              />
+            </Field>
+          )}
         </Box>
 
         <TimePickerSettings

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -4,11 +4,13 @@ import { useSearchParams } from 'react-router-dom-v5-compat';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Button, useStyles2, Text, Box, Stack, TextLink, Icon } from '@grafana/ui';
+import { Button, useStyles2, Text, Box, Stack, TextLink, Icon, FilterPill, Tooltip } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { AutoGridLayoutManager } from 'app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager';
+import { DefaultGridLayoutManager } from 'app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager';
 
 import { BasicProvisionedDashboardsEmptyPage } from '../DashboardLibrary/BasicProvisionedDashboardsEmptyPage';
 import { SuggestedDashboards } from '../DashboardLibrary/SuggestedDashboards';
@@ -98,16 +100,31 @@ interface NewLayoutEmptyProps {
 }
 
 const NewLayoutEmpty = ({ dashboard, styles, dashboardLibraryDatasourceUid }: NewLayoutEmptyProps) => {
-  const { uid, isEditing, editPane } = dashboard.state;
+  const { uid, isEditing, editPane, body } = dashboard.useState();
   const isEditingNewDashboard = isEditing && !uid;
+  const isAutoGrid = body instanceof AutoGridLayoutManager;
 
   // open the edit pane when the dashboard is new and in editing mode
   // will only happen when the default empty state is shown (not overridden by extension point)
   useEffect(() => {
-    if (isEditingNewDashboard) {
+    if (isEditingNewDashboard && editPane.state.openPane !== 'add') {
       editPane.openPane('add');
     }
   }, [isEditingNewDashboard, editPane]);
+
+  const onSelectAutoGrid = () => {
+    dashboard.switchLayout(AutoGridLayoutManager.createEmpty());
+    if (config.featureToggles.dashboardDefaultLayoutSelector) {
+      dashboard.updateDefaultLayoutTemplate(AutoGridLayoutManager.createEmpty());
+    }
+  };
+
+  const onSelectCustomGrid = () => {
+    dashboard.switchLayout(DefaultGridLayoutManager.createEmpty());
+    if (config.featureToggles.dashboardDefaultLayoutSelector) {
+      dashboard.updateDefaultLayoutTemplate(DefaultGridLayoutManager.createEmpty());
+    }
+  };
 
   return (
     <Stack alignItems="stretch" justifyContent="center" gap={4} direction="column">
@@ -123,6 +140,46 @@ const NewLayoutEmpty = ({ dashboard, styles, dashboardLibraryDatasourceUid }: Ne
             <Trans i18nKey="dashboard.empty.description">Add a panel to visualize your data</Trans>
           </Text>
         </Box>
+        {config.featureToggles.dashboardDefaultLayoutSelector && (
+          <>
+            <Box marginTop={3} paddingX={4} display="flex" justifyContent="center" alignItems="center" gap={1}>
+              <Text element="p" textAlignment="center" color="secondary">
+                <Trans i18nKey="dashboard.empty.select-layout-header">Select layout</Trans>
+              </Text>
+              <Tooltip
+                content={
+                  <Trans i18nKey="dashboard.empty.layout-default-hint">
+                    The selected layout will also be used as the default for all new tabs and rows. You can change this
+                    later in Dashboard Settings &gt; General.
+                  </Trans>
+                }
+              >
+                <Icon name="info-circle" size="sm" />
+              </Tooltip>
+            </Box>
+            <Box marginTop={1} display="flex" justifyContent="center">
+              <Stack gap={1}>
+                <FilterPill
+                  label={t('dashboard.empty.auto-grid', 'Auto grid')}
+                  selected={isAutoGrid}
+                  onClick={onSelectAutoGrid}
+                />
+                <FilterPill
+                  label={t('dashboard.empty.custom-grid', 'Custom grid')}
+                  selected={!isAutoGrid}
+                  onClick={onSelectCustomGrid}
+                />
+              </Stack>
+            </Box>
+            <Box marginTop={1} paddingX={4}>
+              <Text element="p" textAlignment="center" color="secondary">
+                {isAutoGrid
+                  ? t('dashboard.empty.auto-grid-description', 'Panels resize to fit and form uniform grids')
+                  : t('dashboard.empty.custom-grid-description', 'Position and size each panel individually')}
+              </Text>
+            </Box>
+          </>
+        )}
       </Box>
       <DashboardExtensionsComponents dashboardLibraryDatasourceUid={dashboardLibraryDatasourceUid} />
     </Stack>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5564,10 +5564,16 @@
       "add-visualization-body": "Select a data source and then query and visualize your data with charts, stats and tables or create lists, markdowns and other widgets.",
       "add-visualization-button": "Add visualization",
       "add-visualization-header": "Start your new dashboard by adding a visualization",
+      "auto-grid": "Auto grid",
+      "auto-grid-description": "Panels resize to fit and form uniform grids",
+      "custom-grid": "Custom grid",
+      "custom-grid-description": "Position and size each panel individually",
       "description": "Add a panel to visualize your data",
       "import-a-dashboard-body": "Import dashboards from files or <2>grafana.com</2>.",
       "import-a-dashboard-header": "Import a dashboard",
       "import-dashboard-button": "Import dashboard",
+      "layout-default-hint": "The selected layout will also be used as the default for all new tabs and rows. You can change this later in Dashboard Settings > General.",
+      "select-layout-header": "Select layout",
       "show-less-dashboards": "Show less",
       "show-more-dashboards": "Show more",
       "start-with-suggested-dashboards": "Start with a pre-made dashboard from your data source",
@@ -6889,6 +6895,12 @@
       "sql-transformation-description": "Manipulate your data using MySQL-like syntax"
     },
     "general-settings-edit-view": {
+      "default_grid_options": {
+        "label": {
+          "auto": "Auto grid",
+          "custom": "Custom grid"
+        }
+      },
       "editable_options": {
         "label": {
           "editable": "Editable",
@@ -7631,6 +7643,8 @@
     "general": {
       "auto-refresh-description": "Define the auto refresh intervals that should be available in the auto refresh list. Use the format '5s' for seconds, '1m' for minutes, '1h' for hours, and '1d' for days (e.g.: '5s,10s,30s,1m,5m,15m,30m,1h,2h,1d').",
       "auto-refresh-label": "Auto refresh",
+      "default-grid-description": "Select layout type to be used for new rows and tabs",
+      "default-grid-label": "Default grid",
       "description-label": "Description",
       "editable-description": "Set to read-only to disable all editing. Reload the dashboard for changes to take effect",
       "editable-label": "Editable",


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/111794

Depends on https://github.com/grafana/grafana/pull/120750

Frontend changes extracted from https://github.com/grafana/grafana/pull/120408.