### PR TITLE
Elasticsearch: Gate variable field mapping UI behind `multiPropsVariables` flag

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -13,6 +13,16 @@ jest.mock('./components/QueryEditor', () => ({
   ElasticQueryEditorProps: {},
 }));
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    featureToggles: {
+      multiPropsVariables: true,
+    },
+  },
+}));
+
 describe('ElasticsearchVariableEditor', () => {
   const defaultProps: ElasticQueryEditorProps = {
     query: {
@@ -223,5 +233,17 @@ describe('ElasticsearchVariableEditor', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ query: 'updated lucene query', meta: { textField: 'name', valueField: 'id' } })
     );
+  });
+
+  it('should not render field mapping when multiPropsVariables feature flag is disabled', () => {
+    const { config } = jest.requireMock('@grafana/runtime');
+    config.featureToggles.multiPropsVariables = false;
+
+    render(<ElasticsearchVariableEditor {...defaultProps} />);
+
+    expect(screen.queryByText('Value Field')).not.toBeInTheDocument();
+    expect(screen.queryByText('Text Field')).not.toBeInTheDocument();
+
+    config.featureToggles.multiPropsVariables = true;
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { DataQueryRequest, dateTime, Field } from '@grafana/data';
 import { EditorRows, EditorRow, EditorField } from '@grafana/plugin-ui';
+import { config } from '@grafana/runtime';
 import { Combobox, ComboboxOption, Text } from '@grafana/ui';
 
 import { ElasticsearchVariableQuery, migrateVariableQuery, refId } from './ElasticsearchVariableUtils';
@@ -29,7 +30,9 @@ export const ElasticsearchVariableEditor = (props: ElasticsearchVariableQueryEdi
   return (
     <>
       <QueryEditor {...props} query={query} onChange={handleQueryChange} />
-      <FieldMapping datasource={props.datasource} query={query} onChange={props.onChange} />
+      {config.featureToggles.multiPropsVariables && (
+        <FieldMapping datasource={props.datasource} query={query} onChange={props.onChange} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
The `FieldMapping` component (`textField`/`valueField` selectors) in the Elasticsearch variable editor was rendering unconditionally. This PR gates it behind `config.featureToggles.multiPropsVariables` to match the intent of the flag across other variable editors.