### PR TITLE
Provisioning: Full Sync - react when metadata is deleted

### DIFF
--- a/apps/provisioning/pkg/safepath/dir.go
+++ b/apps/provisioning/pkg/safepath/dir.go
@@ -38,6 +38,16 @@ func InDir(filePath, dir string) bool {
 	return strings.HasPrefix(filePath, dir)
 }
 
+// EnsureTrailingSlash returns the path with a trailing slash appended if it
+// doesn't already have one. This is useful for marking paths as directories.
+func EnsureTrailingSlash(filePath string) string {
+	if strings.HasSuffix(filePath, "/") {
+		return filePath
+	}
+
+	return filePath + "/"
+}
+
 // RelativeTo returns the relative path of the filePath to the given directory.
 // It handles cases where either filePath or dir have leading or trailing slashes.
 func RelativeTo(filePath, dir string) (string, error) {
@@ -62,14 +72,4 @@ func RelativeTo(filePath, dir string) (string, error) {
 	relativePath := strings.TrimPrefix(normalizedPath, normalizedDir)
 
 	return relativePath, nil
-}
-
-// NormalizeDirPath returns the normalized path of the given directory path,
-// by adding a trailing slash if it's missing.
-func NormalizeDirPath(p string) string {
-	if IsDir(p) && strings.HasSuffix(p, "/") {
-		return p
-	}
-
-	return p + "/"
 }

--- a/apps/provisioning/pkg/safepath/dir.go
+++ b/apps/provisioning/pkg/safepath/dir.go
@@ -41,7 +41,7 @@ func InDir(filePath, dir string) bool {
 // EnsureTrailingSlash returns the path with a trailing slash appended if it
 // doesn't already have one. This is useful for marking paths as directories.
 // To keep compatibility with the functions in this package, the "root" directory
-// "which can be represented as "" or "." or "/", is returned as "".
+// (which can be represented as "" or "." or "/") is returned as "".
 func EnsureTrailingSlash(filePath string) string {
 	if filePath == "" || filePath == "." || filePath == "/" {
 		return ""

--- a/apps/provisioning/pkg/safepath/dir.go
+++ b/apps/provisioning/pkg/safepath/dir.go
@@ -63,3 +63,13 @@ func RelativeTo(filePath, dir string) (string, error) {
 
 	return relativePath, nil
 }
+
+// NormalizeDirPath returns the normalized path of the given directory path,
+// by adding a trailing slash if it's missing.
+func NormalizeDirPath(p string) string {
+	if IsDir(p) && strings.HasSuffix(p, "/") {
+		return p
+	}
+
+	return p + "/"
+}

--- a/apps/provisioning/pkg/safepath/dir.go
+++ b/apps/provisioning/pkg/safepath/dir.go
@@ -40,7 +40,13 @@ func InDir(filePath, dir string) bool {
 
 // EnsureTrailingSlash returns the path with a trailing slash appended if it
 // doesn't already have one. This is useful for marking paths as directories.
+// To keep compatibility with the functions in this package, the "root" directory
+// "which can be represented as "" or "." or "/", is returned as "".
 func EnsureTrailingSlash(filePath string) string {
+	if filePath == "" || filePath == "." || filePath == "/" {
+		return ""
+	}
+
 	if strings.HasSuffix(filePath, "/") {
 		return filePath
 	}

--- a/apps/provisioning/pkg/safepath/dir_test.go
+++ b/apps/provisioning/pkg/safepath/dir_test.go
@@ -161,7 +161,6 @@ func TestInDir(t *testing.T) {
 	}
 }
 
-
 func TestEnsureTrailingSlash(t *testing.T) {
 	tests := []struct {
 		name string

--- a/apps/provisioning/pkg/safepath/dir_test.go
+++ b/apps/provisioning/pkg/safepath/dir_test.go
@@ -161,6 +161,48 @@ func TestInDir(t *testing.T) {
 	}
 }
 
+
+func TestEnsureTrailingSlash(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "empty path",
+			path: "",
+			want: "/",
+		},
+		{
+			name: "directory path with trailing slash",
+			path: "folder/",
+			want: "folder/",
+		},
+		{
+			name: "directory path without trailing slash",
+			path: "folder",
+			want: "folder/",
+		},
+		{
+			name: "nested directory path with trailing slash",
+			path: "folder/subfolder/",
+			want: "folder/subfolder/",
+		},
+		{
+			name: "nested directory path without trailing slash",
+			path: "folder/subfolder",
+			want: "folder/subfolder/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EnsureTrailingSlash(tt.path)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestRelativeTo(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -255,47 +297,6 @@ func TestRelativeTo(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tt.want, got)
 			}
-		})
-	}
-}
-
-func TestNormalizeDirPath(t *testing.T) {
-	tests := []struct {
-		name string
-		path string
-		want string
-	}{
-		{
-			name: "empty path",
-			path: "",
-			want: "/",
-		},
-		{
-			name: "directory path with trailing slash",
-			path: "folder/",
-			want: "folder/",
-		},
-		{
-			name: "directory path without trailing slash",
-			path: "folder",
-			want: "folder/",
-		},
-		{
-			name: "nested directory path with trailing slash",
-			path: "folder/subfolder/",
-			want: "folder/subfolder/",
-		},
-		{
-			name: "nested directory path without trailing slash",
-			path: "folder/subfolder",
-			want: "folder/subfolder/",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NormalizeDirPath(tt.path)
-			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/apps/provisioning/pkg/safepath/dir_test.go
+++ b/apps/provisioning/pkg/safepath/dir_test.go
@@ -261,9 +261,9 @@ func TestRelativeTo(t *testing.T) {
 
 func TestNormalizeDirPath(t *testing.T) {
 	tests := []struct {
-		name     string
-		path     string
-		want     string
+		name string
+		path string
+		want string
 	}{
 		{
 			name: "empty path",

--- a/apps/provisioning/pkg/safepath/dir_test.go
+++ b/apps/provisioning/pkg/safepath/dir_test.go
@@ -258,3 +258,44 @@ func TestRelativeTo(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeDirPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		want     string
+	}{
+		{
+			name: "empty path",
+			path: "",
+			want: "/",
+		},
+		{
+			name: "directory path with trailing slash",
+			path: "folder/",
+			want: "folder/",
+		},
+		{
+			name: "directory path without trailing slash",
+			path: "folder",
+			want: "folder/",
+		},
+		{
+			name: "nested directory path with trailing slash",
+			path: "folder/subfolder/",
+			want: "folder/subfolder/",
+		},
+		{
+			name: "nested directory path without trailing slash",
+			path: "folder/subfolder",
+			want: "folder/subfolder/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeDirPath(tt.path)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/apps/provisioning/pkg/safepath/dir_test.go
+++ b/apps/provisioning/pkg/safepath/dir_test.go
@@ -168,9 +168,19 @@ func TestEnsureTrailingSlash(t *testing.T) {
 		want string
 	}{
 		{
-			name: "empty path",
+			name: "root path version 1",
 			path: "",
-			want: "/",
+			want: "",
+		},
+		{
+			name: "root path version 2",
+			path: ".",
+			want: "",
+		},
+		{
+			name: "root path version 3",
+			path: "/",
+			want: "",
 		},
 		{
 			name: "directory path with trailing slash",

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -319,7 +319,7 @@ func detectDeletedFolderMetadata(
 	affectedFolders := make(map[string]bool)
 
 	for i := range target.Items {
-		item := target.Items[i]
+		item := &target.Items[i]
 
 		// Non-folder resources or resources without a metadata file already are not affected.
 		if item.Group != resources.FolderResource.Group || item.Hash == "" {
@@ -327,7 +327,7 @@ func detectDeletedFolderMetadata(
 		}
 
 		path := safepath.EnsureTrailingSlash(item.Path)
-		if path == "" || path == "/" {
+		if path == "" {
 			continue // root folder doesn't contain metadata and doesn't need to be renamed
 		}
 		if !sourceFolders[path] {
@@ -343,7 +343,7 @@ func detectDeletedFolderMetadata(
 		changes = append(changes, ResourceFileChange{
 			Action:        repository.FileActionUpdated,
 			Path:          path,
-			Existing:      &item,
+			Existing:      item,
 			FolderRenamed: true,
 		})
 		affectedFolders[path] = true
@@ -396,13 +396,13 @@ func emitDirectChildrenChanges(
 	pathsWithChanges, affectedFolders map[string]bool,
 	changes []ResourceFileChange,
 ) []ResourceFileChange {
-	existingByPath := make(map[string]provisioning.ResourceListItem, len(target.Items))
+	existingByPath := make(map[string]*provisioning.ResourceListItem, len(target.Items))
 	for _, item := range target.Items {
 		path := item.Path
 		if item.Group == resources.FolderResource.Group {
 			path = safepath.EnsureTrailingSlash(path)
 		}
-		existingByPath[path] = item
+		existingByPath[path] = &item
 	}
 
 	for _, file := range source {
@@ -436,7 +436,7 @@ func emitDirectChildrenChanges(
 		changes = append(changes, ResourceFileChange{
 			Action:   repository.FileActionUpdated,
 			Path:     path,
-			Existing: &existing,
+			Existing: existing,
 		})
 		pathsWithChanges[path] = true
 	}

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -283,7 +283,7 @@ func buildSourceMetadataIndex(source []repository.FileTreeEntry) (map[string]boo
 	foldersWithMetadata := make(map[string]bool)
 	for _, file := range source {
 		if !file.Blob {
-			path := safepath.NormalizeDirPath(file.Path)
+			path := safepath.EnsureTrailingSlash(file.Path)
 			sourceFolders[path] = true
 		} else if resources.IsFolderMetadataFile(file.Path) {
 			if parent := safepath.Dir(file.Path); parent != "" {
@@ -318,13 +318,15 @@ func detectDeletedFolderMetadata(
 	var changes []ResourceFileChange
 	affectedFolders := make(map[string]bool)
 
-	for _, item := range target.Items {
+	for i := range target.Items {
+		item := target.Items[i]
+
 		// Non-folder resources or resources without a metadata file already are not affected.
 		if item.Group != resources.FolderResource.Group || item.Hash == "" {
 			continue
 		}
 
-		path := safepath.NormalizeDirPath(item.Path)
+		path := safepath.EnsureTrailingSlash(item.Path)
 		if path == "" {
 			continue // root folder
 		}
@@ -378,7 +380,7 @@ func detectFolderUIDChanges(
 
 		// If the metadata file exists, check if the UID has changed.
 		if meta.Name != change.Existing.Name {
-			path := safepath.NormalizeDirPath(change.Path)
+			path := safepath.EnsureTrailingSlash(change.Path)
 			affectedFolders[path] = true
 			change.FolderRenamed = true
 		}
@@ -398,7 +400,7 @@ func emitDirectChildrenChanges(
 	for _, item := range target.Items {
 		path := item.Path
 		if item.Group == resources.FolderResource.Group {
-			path = safepath.NormalizeDirPath(path)
+			path = safepath.EnsureTrailingSlash(path)
 		}
 		existingByPath[path] = item
 	}
@@ -406,7 +408,7 @@ func emitDirectChildrenChanges(
 	for _, file := range source {
 		path := file.Path
 		if !file.Blob {
-			path = safepath.NormalizeDirPath(path)
+			path = safepath.EnsureTrailingSlash(path)
 		}
 
 		// Not emit update for metadata files.

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -397,12 +397,15 @@ func emitDirectChildrenChanges(
 	changes []ResourceFileChange,
 ) []ResourceFileChange {
 	existingByPath := make(map[string]*provisioning.ResourceListItem, len(target.Items))
-	for _, item := range target.Items {
+	for i := range target.Items {
+		item := &target.Items[i]
+
 		path := item.Path
 		if item.Group == resources.FolderResource.Group {
 			path = safepath.EnsureTrailingSlash(path)
 		}
-		existingByPath[path] = &item
+
+		existingByPath[path] = item
 	}
 
 	for _, file := range source {

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -22,8 +22,10 @@ type ResourceFileChange struct {
 	// The current value in the database -- only required for delete
 	Existing *provisioning.ResourceListItem
 
-	// FolderRenamed is set when a folder's _folder.json UID changed.
-	// The old folder needs cleanup after all children have been re-parented.
+	// FolderRenamed is set when folder metadata reconciliation changes the folder ID
+	// (for example, a UID change in _folder.json or reverting to a hash-based ID
+	// after _folder.json deletion). The old folder needs cleanup after children
+	// have been re-parented.
 	FolderRenamed bool
 }
 
@@ -60,9 +62,9 @@ func Compare(
 	}
 
 	if folderMetadataEnabled {
-		changes, err = augmentChangesForUIDChanges(ctx, repo, ref, source, target, changes)
+		changes, err = augmentChangesForFolderMetadata(ctx, repo, ref, source, target, changes)
 		if err != nil {
-			return nil, nil, fmt.Errorf("augment changes for UID changes: %w", err)
+			return nil, nil, fmt.Errorf("augment changes for folder metadata: %w", err)
 		}
 	}
 
@@ -226,11 +228,11 @@ func Changes(
 	return changes, nil
 }
 
-// augmentChangesForUIDChanges detects folder UID changes (new _folder.json metadata.name
-// differs from the existing Grafana folder name) and emits FileActionUpdated for direct
-// children of affected folders. This ensures children are re-parented during the normal
-// apply flow without scanning all resources.
-func augmentChangesForUIDChanges(
+// augmentChangesForFolderMetadata detects two categories of folder metadata changes:
+// (1) folders whose _folder.json was deleted, and (2) folders whose _folder.json UID
+// changed. In both cases, direct children are emitted as FileActionUpdated so they
+// are re-parented during the normal apply flow.
+func augmentChangesForFolderMetadata(
 	ctx context.Context,
 	repo repository.Reader,
 	ref string,
@@ -238,79 +240,204 @@ func augmentChangesForUIDChanges(
 	target *provisioning.ResourceList,
 	changes []ResourceFileChange,
 ) ([]ResourceFileChange, error) {
-	// 1. Find affected folders: folder updates where UID actually changed.
-	// Also annotate the folder change with OldFolderUID for deferred cleanup.
-	affectedFolders := make(map[string]bool)
-	for i := range changes {
-		change := &changes[i]
-		if !change.IsUpdatedFolder() {
-			continue
-		}
-		meta, _, err := resources.ReadFolderMetadata(ctx, repo, change.Path, ref)
-		if err != nil {
-			if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
-				continue // no _folder.json — not metadata-backed, skip
-			}
-			return nil, fmt.Errorf("read folder metadata for %s: %w", change.Path, err)
-		}
-		if meta.Name != change.Existing.Name {
-			affectedFolders[change.Path] = true
-			change.FolderRenamed = true
-		}
+	sourceFolders, foldersWithMetadata := buildSourceMetadataIndex(source)
+
+	pathsWithChanges := make(map[string]bool, len(changes))
+	for _, c := range changes {
+		pathsWithChanges[c.Path] = true
 	}
+
+	affectedFolders := make(map[string]bool)
+
+	// Detect folders whose _folder.json was deleted.
+	deletedChanges, deletedAffected := detectDeletedFolderMetadata(target, sourceFolders, foldersWithMetadata, pathsWithChanges)
+	for _, change := range deletedChanges {
+		pathsWithChanges[change.Path] = true
+	}
+	changes = append(changes, deletedChanges...)
+	affectedFolders = mergeAffectedFolders(affectedFolders, deletedAffected)
+
+	// Detect folders whose _folder.json UID changed.
+	var err error
+	uidAffected, err := detectFolderUIDChanges(ctx, repo, ref, changes)
+	if err != nil {
+		return nil, err
+	}
+	affectedFolders = mergeAffectedFolders(affectedFolders, uidAffected)
+
+	// No folders will be renamed, so we can return the changes as is.
 	if len(affectedFolders) == 0 {
 		return changes, nil
 	}
 
-	// 2. Build lookups
-	existingPaths := make(map[string]bool, len(changes))
-	for _, c := range changes {
-		existingPaths[c.Path] = true
-	}
+	// Emit children for re-parenting and re-sort by path depth.
+	changes = emitDirectChildrenChanges(source, target, pathsWithChanges, affectedFolders, changes)
+	safepath.SortByDepth(changes, func(c ResourceFileChange) string { return c.Path }, false)
+	return changes, nil
+}
 
-	targetLookup := make(map[string]*provisioning.ResourceListItem, len(target.Items))
-	for i := range target.Items {
-		item := &target.Items[i]
-		path := item.Path
-		if item.Group == resources.FolderResource.Group && !safepath.IsDir(path) {
-			path += "/"
+// buildSourceMetadataIndex performs a single pass over the source tree, returning
+// which directories exist and which contain a _folder.json metadata file.
+func buildSourceMetadataIndex(source []repository.FileTreeEntry) (map[string]bool, map[string]bool) {
+	sourceFolders := make(map[string]bool)
+	foldersWithMetadata := make(map[string]bool)
+	for _, file := range source {
+		if !file.Blob {
+			path := safepath.NormalizeDirPath(file.Path)
+			sourceFolders[path] = true
+		} else if resources.IsFolderMetadataFile(file.Path) {
+			if parent := safepath.Dir(file.Path); parent != "" {
+				foldersWithMetadata[parent] = true
+			}
 		}
-		targetLookup[path] = item
+	}
+	return sourceFolders, foldersWithMetadata
+}
+
+func mergeAffectedFolders(dst, src map[string]bool) map[string]bool {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]bool, len(src))
+	}
+	for path := range src {
+		dst[path] = true
+	}
+	return dst
+}
+
+// detectDeletedFolderMetadata finds folders in target that had metadata (non-empty Hash)
+// but whose _folder.json is now absent from source (while the directory still exists).
+// It emits FileActionUpdated with FolderRenamed=true.
+func detectDeletedFolderMetadata(
+	target *provisioning.ResourceList,
+	sourceFolders, foldersWithMetadata map[string]bool,
+	pathsWithChanges map[string]bool,
+) ([]ResourceFileChange, map[string]bool) {
+	var changes []ResourceFileChange
+	affectedFolders := make(map[string]bool)
+
+	for _, item := range target.Items {
+		// Non-folder resources or resources without a metadata file already are not affected.
+		if item.Group != resources.FolderResource.Group || item.Hash == "" {
+			continue
+		}
+		
+		path := safepath.NormalizeDirPath(item.Path)
+		if path == "" {
+			continue // root folder
+		}
+		if !sourceFolders[path] {
+			continue // entire folder deleted — handled by normal flow
+		}
+		if foldersWithMetadata[path] {
+			continue // metadata still exists
+		}
+		if pathsWithChanges[path] {
+			continue // this path is already marked for update
+		}
+
+		changes = append(changes, ResourceFileChange{
+			Action:        repository.FileActionUpdated,
+			Path:          path,
+			Existing:      &item,
+			FolderRenamed: true,
+		})
+		affectedFolders[path] = true
+	}
+	return changes, affectedFolders
+}
+
+// detectFolderUIDChanges iterates existing folder update changes, reads their
+// _folder.json and compares the UID. 
+// Returns a map of the folder paths that will be renamed.
+func detectFolderUIDChanges(
+	ctx context.Context,
+	repo repository.Reader,
+	ref string,
+	changes []ResourceFileChange,
+) (map[string]bool, error) {
+	affectedFolders := make(map[string]bool)
+	for i := range changes {
+		change := &changes[i]
+
+		// Skip if the folder was not marked as updated or if it was already marked for renaming.
+		if !change.IsUpdatedFolder() || change.FolderRenamed {
+			continue
+		}
+		
+		meta, _, err := resources.ReadFolderMetadata(ctx, repo, change.Path, ref)
+		if err != nil {
+			// Metadata file not found, meaning the folder has no metadata, skipping.
+			if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read folder metadata for %s: %w", change.Path, err)
+		}
+
+		// If the metadata file exists, check if the UID has changed.
+		if meta.Name != change.Existing.Name {
+			path := safepath.NormalizeDirPath(change.Path)
+			affectedFolders[path] = true
+			change.FolderRenamed = true
+		}
+	}
+	return affectedFolders, nil
+}
+
+// emitDirectChildrenChanges iterates the source tree and emits FileActionUpdated for
+// direct children of affected folders that exist in target but aren't already in changes.
+func emitDirectChildrenChanges(
+	source []repository.FileTreeEntry,
+	target *provisioning.ResourceList,
+	pathsWithChanges, affectedFolders map[string]bool,
+	changes []ResourceFileChange,
+) []ResourceFileChange {
+	existingByPath := make(map[string]provisioning.ResourceListItem, len(target.Items))
+	for _, item := range target.Items {
+		path := item.Path
+		if item.Group == resources.FolderResource.Group {
+			path = safepath.NormalizeDirPath(path)
+		}
+		existingByPath[path] = item
 	}
 
-	// 3. Emit FileActionUpdated for direct children of affected folders
 	for _, file := range source {
 		path := file.Path
-		if !file.Blob && !safepath.IsDir(path) {
-			path += "/"
+		if !file.Blob {
+			path = safepath.NormalizeDirPath(path)
 		}
+
+		// Not emit update for metadata files.
 		if resources.IsFolderMetadataFile(path) {
 			continue
 		}
 
-		// Direct parent check
 		parentDir := safepath.Dir(path)
+		// If the directory of given resource is not being renamed, skip
 		if !affectedFolders[parentDir] {
 			continue
 		}
-		if existingPaths[path] {
-			continue // already in changes
+		
+		// If the specific resource path has already been marked for update, skip
+		if pathsWithChanges[path] {
+			continue
 		}
 
-		existing, ok := targetLookup[path]
+		existing, ok := existingByPath[path]
+		// If the resource path doesn't exist in Grafana, it means it's new
+		// therefore it doesn't need to be updated.
 		if !ok {
-			continue // new resource, not a re-parenting case
+			continue
 		}
-
 		changes = append(changes, ResourceFileChange{
 			Action:   repository.FileActionUpdated,
 			Path:     path,
-			Existing: existing,
+			Existing: &existing,
 		})
-		existingPaths[path] = true
+		pathsWithChanges[path] = true
 	}
 
-	// 4. Re-sort by depth (deepest first) since we appended new entries
-	safepath.SortByDepth(changes, func(c ResourceFileChange) string { return c.Path }, false)
-	return changes, nil
+	return changes
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -327,8 +327,8 @@ func detectDeletedFolderMetadata(
 		}
 
 		path := safepath.EnsureTrailingSlash(item.Path)
-		if path == "" {
-			continue // root folder
+		if path == "" || path == "/" {
+			continue // root folder doesn't contain metadata and doesn't need to be renamed
 		}
 		if !sourceFolders[path] {
 			continue // entire folder deleted — handled by normal flow

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -323,7 +323,7 @@ func detectDeletedFolderMetadata(
 		if item.Group != resources.FolderResource.Group || item.Hash == "" {
 			continue
 		}
-		
+
 		path := safepath.NormalizeDirPath(item.Path)
 		if path == "" {
 			continue // root folder
@@ -350,7 +350,7 @@ func detectDeletedFolderMetadata(
 }
 
 // detectFolderUIDChanges iterates existing folder update changes, reads their
-// _folder.json and compares the UID. 
+// _folder.json and compares the UID.
 // Returns a map of the folder paths that will be renamed.
 func detectFolderUIDChanges(
 	ctx context.Context,
@@ -366,7 +366,7 @@ func detectFolderUIDChanges(
 		if !change.IsUpdatedFolder() || change.FolderRenamed {
 			continue
 		}
-		
+
 		meta, _, err := resources.ReadFolderMetadata(ctx, repo, change.Path, ref)
 		if err != nil {
 			// Metadata file not found, meaning the folder has no metadata, skipping.
@@ -419,7 +419,7 @@ func emitDirectChildrenChanges(
 		if !affectedFolders[parentDir] {
 			continue
 		}
-		
+
 		// If the specific resource path has already been marked for update, skip
 		if pathsWithChanges[path] {
 			continue

--- a/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
@@ -703,7 +703,7 @@ func TestCompare(t *testing.T) {
 }
 
 func TestCompare_FolderMetadataFlagDisabled(t *testing.T) {
-	t.Run("augmentChangesForUIDChanges skipped when flag off", func(t *testing.T) {
+	t.Run("augmentChangesForFolderMetadata skipped when flag off", func(t *testing.T) {
 		repo := repository.NewMockRepository(t)
 		repoResources := resources.NewMockRepositoryResources(t)
 
@@ -736,10 +736,11 @@ func TestCompare_FolderMetadataFlagDisabled(t *testing.T) {
 	})
 }
 
-func TestAugmentChangesForUIDChanges(t *testing.T) {
+func TestAugmentChangesForFolderMetadata(t *testing.T) {
+	// --- UID change subtests ---
+
 	t.Run("emits children for UID change", func(t *testing.T) {
 		repo := repository.NewMockReader(t)
-		// ReadFolderMetadata reads "my-folder/_folder.json" and returns a new UID
 		repo.On("Read", mock.Anything, "my-folder/_folder.json", "main").
 			Return(&repository.FileInfo{
 				Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"new-uid"},"spec":{"title":"My Folder"}}`),
@@ -768,10 +769,9 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
-		// Should contain: the original folder update + dashboard + child folder
 		paths := make(map[string]bool)
 		for _, c := range result {
 			paths[c.Path] = true
@@ -783,7 +783,6 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 
 	t.Run("skips children for title-only change (UID same)", func(t *testing.T) {
 		repo := repository.NewMockReader(t)
-		// ReadFolderMetadata returns the same UID as existing
 		repo.On("Read", mock.Anything, "my-folder/_folder.json", "main").
 			Return(&repository.FileInfo{
 				Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"same-uid"},"spec":{"title":"New Title"}}`),
@@ -810,13 +809,13 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Len(t, result, 1, "only the original folder update — no children emitted")
 		require.Equal(t, "my-folder/", result[0].Path)
 	})
 
-	t.Run("only emits direct children, not grandchildren", func(t *testing.T) {
+	t.Run("only emits direct children not grandchildren for UID change", func(t *testing.T) {
 		repo := repository.NewMockReader(t)
 		repo.On("Read", mock.Anything, "parent/_folder.json", "main").
 			Return(&repository.FileInfo{
@@ -833,7 +832,8 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 		target := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{Path: "parent/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "old-parent-uid"},
-				{Path: "parent/child/", Hash: "def", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-uid"},
+				// Hash empty: child never had _folder.json metadata
+				{Path: "parent/child/", Hash: "", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-uid"},
 				{Path: "parent/child/grandchild.json", Hash: "ghi", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "gc-1"},
 			},
 		}
@@ -846,7 +846,7 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		paths := make(map[string]bool)
@@ -858,7 +858,7 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 		require.False(t, paths["parent/child/grandchild.json"], "grandchild should NOT be emitted")
 	})
 
-	t.Run("does not duplicate already-existing changes", func(t *testing.T) {
+	t.Run("does not duplicate already-existing changes for UID change", func(t *testing.T) {
 		repo := repository.NewMockReader(t)
 		repo.On("Read", mock.Anything, "my-folder/_folder.json", "main").
 			Return(&repository.FileInfo{
@@ -892,10 +892,9 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
-		// Count dashboard entries — should be exactly 1 (no duplicate)
 		count := 0
 		for _, c := range result {
 			if c.Path == "my-folder/dashboard.json" {
@@ -920,8 +919,244 @@ func TestAugmentChangesForUIDChanges(t *testing.T) {
 			{Action: repository.FileActionCreated, Path: "my-folder/dashboard.json"},
 		}
 
-		result, err := augmentChangesForUIDChanges(context.Background(), repo, "main", source, target, changes)
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Equal(t, changes, result, "should return changes unchanged")
+	})
+
+	// --- Deleted metadata subtests ---
+
+	t.Run("emits folder update with FolderRenamed when _folder.json deleted", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Blob: false},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+			// No _folder.json — it was deleted
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}
+
+		changes := []ResourceFileChange{} // no changes from Changes()
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		require.Len(t, result, 1)
+		require.Equal(t, repository.FileActionUpdated, result[0].Action)
+		require.Equal(t, "my-folder/", result[0].Path)
+		require.True(t, result[0].FolderRenamed, "should mark FolderRenamed")
+		require.Equal(t, "stable-uid", result[0].Existing.Name)
+	})
+
+	t.Run("emits direct children of affected folder for deleted metadata", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Blob: false},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+			{Path: "my-folder/child/", Blob: false},
+			// No _folder.json
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid"},
+				{Path: "my-folder/dashboard.json", Hash: "xyz", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+				{Path: "my-folder/child/", Hash: "def", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-uid"},
+			},
+		}
+
+		changes := []ResourceFileChange{} // empty
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		require.Len(t, result, 3, "folder update + dashboard + child folder")
+		paths := make(map[string]bool)
+		for _, c := range result {
+			paths[c.Path] = true
+			require.Equal(t, repository.FileActionUpdated, c.Action)
+		}
+		require.True(t, paths["my-folder/"], "folder itself should be updated")
+		require.True(t, paths["my-folder/dashboard.json"], "direct child dashboard should be emitted")
+		require.True(t, paths["my-folder/child/"], "direct child folder should be emitted")
+	})
+
+	t.Run("normalizes source and target directory paths before emitting children", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder", Blob: false},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+			{Path: "my-folder/child", Blob: false},
+			// No _folder.json - metadata was deleted.
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid"},
+				{Path: "my-folder/dashboard.json", Hash: "xyz", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+				{Path: "my-folder/child", Hash: "def", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-uid"},
+			},
+		}
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, nil)
+		require.NoError(t, err)
+
+		paths := make(map[string]bool)
+		for _, c := range result {
+			paths[c.Path] = true
+		}
+		require.True(t, paths["my-folder/"], "folder update should be emitted with normalized path")
+		require.True(t, paths["my-folder/dashboard.json"], "direct child dashboard should be emitted")
+		require.True(t, paths["my-folder/child/"], "direct child folder should be emitted with normalized path")
+	})
+
+	t.Run("no-op when folder never had metadata (Hash empty)", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Blob: false},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "hash-uid"},
+			},
+		}
+
+		changes := []ResourceFileChange{}
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+		require.Empty(t, result, "no changes expected when folder never had metadata")
+	})
+
+	t.Run("no-op when _folder.json still exists", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Blob: false},
+			{Path: "my-folder/_folder.json", Hash: "some-hash", Blob: true},
+			{Path: "my-folder/dashboard.json", Hash: "xyz", Blob: true},
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "some-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}
+
+		changes := []ResourceFileChange{}
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+		require.Empty(t, result, "no changes expected when _folder.json still exists")
+	})
+
+	t.Run("no-op when folder directory gone from source", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			// Folder entirely removed from source
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}
+
+		changes := []ResourceFileChange{
+			{Action: repository.FileActionDeleted, Path: "my-folder/", Existing: &provisioning.ResourceListItem{
+				Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid",
+			}},
+		}
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+		require.Equal(t, changes, result, "no additional changes expected when folder is entirely deleted")
+	})
+
+	t.Run("does not duplicate already-existing changes for deleted metadata", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "my-folder/", Blob: false},
+			{Path: "my-folder/dashboard.json", Hash: "changed", Blob: true},
+			// No _folder.json — deleted
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "my-folder/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "stable-uid"},
+				{Path: "my-folder/dashboard.json", Hash: "original", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+			},
+		}
+
+		// dashboard.json already appears in changes (hash changed)
+		changes := []ResourceFileChange{
+			{
+				Action:   repository.FileActionUpdated,
+				Path:     "my-folder/dashboard.json",
+				Existing: &provisioning.ResourceListItem{Path: "my-folder/dashboard.json", Hash: "original", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "dash-1"},
+			},
+		}
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		folderCount := 0
+		dashCount := 0
+		for _, c := range result {
+			if c.Path == "my-folder/" {
+				folderCount++
+				require.True(t, c.FolderRenamed, "folder change should be marked FolderRenamed")
+			}
+			if c.Path == "my-folder/dashboard.json" {
+				dashCount++
+			}
+		}
+		require.Equal(t, 1, folderCount, "folder update should be added")
+		require.Equal(t, 1, dashCount, "dashboard should appear only once, not duplicated")
+	})
+
+	t.Run("only emits direct children not grandchildren for deleted metadata", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+
+		source := []repository.FileTreeEntry{
+			{Path: "parent/", Blob: false},
+			{Path: "parent/child/", Blob: false},
+			{Path: "parent/child/_folder.json", Hash: "child-meta", Blob: true}, // child still has metadata
+			{Path: "parent/child/gc.json", Hash: "ghi", Blob: true},
+			// No _folder.json in parent/ — metadata was deleted
+		}
+
+		target := &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "parent/", Hash: "old-hash", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "parent-uid"},
+				{Path: "parent/child/", Hash: "child-meta", Resource: resources.FolderResource.Resource, Group: resources.FolderResource.Group, Name: "child-uid"},
+				{Path: "parent/child/gc.json", Hash: "ghi", Resource: "dashboards", Group: "dashboard.grafana.app", Name: "gc-1"},
+			},
+		}
+
+		changes := []ResourceFileChange{}
+
+		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		require.NoError(t, err)
+
+		paths := make(map[string]bool)
+		for _, c := range result {
+			paths[c.Path] = true
+		}
+		require.True(t, paths["parent/"], "parent folder update should be present")
+		require.True(t, paths["parent/child/"], "direct child folder should be emitted")
+		require.False(t, paths["parent/child/gc.json"], "grandchild should NOT be emitted")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -763,3 +763,184 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 		})
 	})
 }
+
+// TestIntegrationProvisioning_FullSync_FolderMetadataDeletedReverts verifies that
+// deleting a _folder.json between syncs causes the folder to revert to hash-based UID
+// and directory-name title, and that child resources are re-parented accordingly.
+func TestIntegrationProvisioning_FullSync_FolderMetadataDeletedReverts(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("folder reverts to hash-based UID and directory-name title", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-deleted-revert"
+
+		// First sync: folder with _folder.json (stable UID + custom title).
+		writeToProvisioningPath(t, helper, "my-folder/_folder.json", folderMetadataJSON("stable-uid", "Custom Title"))
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "my-folder/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		helper.SyncAndWait(t, repo, nil)
+		requireFolderState(t, helper, "stable-uid", "Custom Title", "my-folder", repo)
+
+		// Delete _folder.json (keep the directory and dashboard).
+		require.NoError(t, os.Remove(filepath.Join(helper.ProvisioningPath, "my-folder/_folder.json")))
+
+		// Second sync — folder should revert.
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		require.NotEmpty(t, jobObj.Status.Warnings)
+
+		found := false
+		for _, w := range jobObj.Status.Warnings {
+			if strings.Contains(w, "missing folder metadata") && strings.Contains(w, "my-folder") {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected missing folder metadata warning for my-folder; warnings: %v", jobObj.Status.Warnings)
+		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonMissingFolderMetadata)
+
+		// Old stable-UID folder should be gone.
+		assertNoFolderByUID(t, helper, "stable-uid")
+
+		// New folder should exist with directory-name title and empty checksum.
+		newUID := findFolderUIDBySourcePath(t, helper, repo, "my-folder")
+		require.NotEqual(t, "stable-uid", newUID, "folder should have a new hash-based UID")
+		requireRepoFolderTitle(t, helper, repo, "my-folder", "my-folder") // title = directory name
+		requireRepoFolderChecksum(t, helper, repo, "my-folder", "")       // checksum cleared
+
+		// Dashboard re-parented to new UID.
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"my-folder/dashboard.json": newUID,
+		})
+	})
+
+	t.Run("nested: parent _folder.json deleted, child retains metadata", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-deleted-nested"
+
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-uid", "Parent"))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("child-uid", "Child"))
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "parent/child/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		helper.SyncAndWait(t, repo, nil)
+		requireFolderState(t, helper, "parent-uid", "Parent", "parent", repo)
+		requireFolderState(t, helper, "child-uid", "Child", "parent/child", "parent-uid")
+
+		// Delete ONLY parent's _folder.json.
+		require.NoError(t, os.Remove(filepath.Join(helper.ProvisioningPath, "parent/_folder.json")))
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		require.NotEmpty(t, jobObj.Status.Warnings)
+
+		hasParentWarning := false
+		hasChildWarning := false
+		for _, w := range jobObj.Status.Warnings {
+			if strings.Contains(w, "missing folder metadata") && strings.Contains(w, "parent") {
+				hasParentWarning = true
+			}
+			if strings.Contains(w, "missing folder metadata") && strings.Contains(w, "parent/child") {
+				hasChildWarning = true
+			}
+		}
+		require.True(t, hasParentWarning, "expected missing folder metadata warning for parent; warnings: %v", jobObj.Status.Warnings)
+		require.False(t, hasChildWarning, "did not expect missing folder metadata warning for parent/child; warnings: %v", jobObj.Status.Warnings)
+		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonMissingFolderMetadata)
+
+		// Old parent-uid should be gone.
+		assertNoFolderByUID(t, helper, "parent-uid")
+
+		// New hash-based parent with directory-name title.
+		newParentUID := findFolderUIDBySourcePath(t, helper, repo, "parent")
+		require.NotEqual(t, "parent-uid", newParentUID)
+
+		// Child should still have its stable UID but re-parented to new parent.
+		requireFolderState(t, helper, "child-uid", "Child", "parent/child", newParentUID)
+
+		// Dashboard still parented to child-uid.
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"parent/child/dashboard.json": "child-uid",
+		})
+	})
+
+	t.Run("nested: parent _folder.json deleted while child UID changes", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "full-sync-meta-deleted-child-uid-change"
+
+		writeToProvisioningPath(t, helper, "parent/_folder.json", folderMetadataJSON("parent-uid", "Parent"))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("child-old-uid", "Child"))
+		helper.CreateRepo(t, common.TestRepo{
+			Name:   repo,
+			Target: "folder",
+			Copies: map[string]string{
+				"../testdata/all-panels.json": "parent/child/dashboard.json",
+			},
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		helper.SyncAndWait(t, repo, nil)
+		requireFolderState(t, helper, "parent-uid", "Parent", "parent", repo)
+		requireFolderState(t, helper, "child-old-uid", "Child", "parent/child", "parent-uid")
+
+		require.NoError(t, os.Remove(filepath.Join(helper.ProvisioningPath, "parent/_folder.json")))
+		writeToProvisioningPath(t, helper, "parent/child/_folder.json", folderMetadataJSON("child-new-uid", "Child"))
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		require.NotEmpty(t, jobObj.Status.Warnings)
+
+		hasParentWarning := false
+		hasChildWarning := false
+		for _, w := range jobObj.Status.Warnings {
+			if strings.Contains(w, "missing folder metadata") && strings.Contains(w, "parent") {
+				hasParentWarning = true
+			}
+			if strings.Contains(w, "missing folder metadata") && strings.Contains(w, "parent/child") {
+				hasChildWarning = true
+			}
+		}
+		require.True(t, hasParentWarning, "expected missing folder metadata warning for parent; warnings: %v", jobObj.Status.Warnings)
+		require.False(t, hasChildWarning, "did not expect missing folder metadata warning for parent/child; warnings: %v", jobObj.Status.Warnings)
+		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonMissingFolderMetadata)
+
+		assertNoFolderByUID(t, helper, "parent-uid")
+		assertNoFolderByUID(t, helper, "child-old-uid")
+
+		newParentUID := findFolderUIDBySourcePath(t, helper, repo, "parent")
+		require.NotEqual(t, "parent-uid", newParentUID)
+
+		requireFolderState(t, helper, "child-new-uid", "Child", "parent/child", newParentUID)
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"parent/child/dashboard.json": "child-new-uid",
+		})
+	})
+}


### PR DESCRIPTION
## What

This PR teaches full sync to reconcile folder metadata deletion.

When a folder previously had a `_folder.json` and that file is deleted while the folder directory still exists, full sync now treats that as a real folder identity change:
- the folder reverts from the metadata-defined stable UID to the directory-derived/hash-based UID
- the old folder is cleaned up after children are re-parented
- direct child resources are emitted into the apply flow so they follow the parent change in the same sync
- the existing missing-metadata warning behavior is preserved

This brings `_folder.json` deletion in line with the other folder metadata reconciliation flows already handled in full sync.

## Why

Before this change, deleting `_folder.json` did not converge correctly during full sync.

Grafana could keep the old metadata-backed folder around, leave children attached to the wrong parent, or create duplicates on later syncs. The source of truth had changed, but full sync did not have an explicit compare/apply path for that transition.

This PR closes that gap and makes metadata deletion settle cleanly in one sync.

## Files changed

- `pkg/registry/apis/provisioning/jobs/sync/changes.go`
  - extends folder-metadata augmentation beyond UID changes
  - detects folders that lost `_folder.json` while still existing in source
  - marks those folders with `FolderRenamed` so the normal replacement flow handles cleanup and child re-parenting
  - emits direct child updates for affected folders so hierarchy changes are applied in the same run

- `apps/provisioning/pkg/safepath/dir.go`
  - adds `EnsureTrailingSlash`
  - this gives compare-time code a single canonical way to represent folder paths with trailing `/`
  - needed because source tree directories and managed folder paths are not always shaped identically, and the metadata augmentation logic relies on exact path-key matching

- `apps/provisioning/pkg/safepath/dir_test.go`
  - adds coverage for `EnsureTrailingSlash`

- `pkg/registry/apis/provisioning/jobs/sync/changes_test.go`
  - adds unit coverage for metadata deletion detection
  - covers direct-child emission, dedupe, no-op cases, and path normalization regressions

- `pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go`
  - adds enterprise integration coverage for full-sync behavior after `_folder.json` deletion
  - covers nested folders, warning behavior, UID replacement, re-parenting, and the mixed case where a parent loses metadata while a child UID changes in the same sync

## Testing

- `go test ./pkg/registry/apis/provisioning/jobs/sync/...`
- `go test -tags=enterprise ./pkg/tests/apis/provisioning/foldermetadata/...`
