### PR TITLE
fix: close leaked file handles in sqlutil and generate_datasources

### DIFF
--- a/pkg/services/publicdashboards/commands/generate_datasources/main.go
+++ b/pkg/services/publicdashboards/commands/generate_datasources/main.go
@@ -29,7 +29,9 @@ func main() {
 	tsFile, err := os.Create("./../../../../../public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SupportedPubdashDatasources.ts")
 	if err != nil {
 		fmt.Println(err)
+		return
 	}
+	defer tsFile.Close()
 	err = tsTemplate.Execute(tsFile, slugs)
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -93,6 +93,7 @@ func sqLite3TestDB() (*TestDB, error) {
 			return nil, err
 		}
 		sqliteDb = f.Name()
+
 		// Close the temp file handle immediately -- we only need the path.
 		// The database driver will open it with its own handle.
 		if err := f.Close(); err != nil {

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -92,8 +92,12 @@ func sqLite3TestDB() (*TestDB, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		sqliteDb = f.Name()
+		// Close the temp file handle immediately -- we only need the path.
+		// The database driver will open it with its own handle.
+		if err := f.Close(); err != nil {
+			return nil, err
+		}
 
 		ret.Cleanup = func() {
 			// remove db file if it exists


### PR DESCRIPTION
## Summary

Two leaked file handles found via static analysis of the control flow graph:

**1. `pkg/services/sqlstore/sqlutil/sqlutil.go`**

`os.CreateTemp()` returns a file handle, but only `f.Name()` was used to get the path. The file handle `f` was never closed, leaking the fd for the lifetime of the test process. The database driver opens the file with its own handle, so the original temp file handle is unnecessary after extracting the path.

**Fix:** Added `f.Close()` immediately after `f.Name()`.

**2. `pkg/services/publicdashboards/commands/generate_datasources/main.go`**

`os.Create()` opens a file for template output, but the handle was never closed. Without `Close()`, buffered data may not be flushed to disk, and the fd leaks until process exit.

**Fix:** Added `defer tsFile.Close()` and early return on create error.