### PR TITLE
Alerting: Use notification_settings.policy in import wizard 

### DIFF
--- a/public/app/features/alerting/unified/api/convertToGMAApi.ts
+++ b/public/app/features/alerting/unified/api/convertToGMAApi.ts
@@ -22,6 +22,8 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
         targetDatasourceUID?: string;
         /** Extra labels to add to all imported rules (format: key=value,key2=value2) */
         extraLabels?: string;
+        /** JSON-encoded notification settings applied to all imported alerting rules */
+        notificationSettings?: string;
       }
     >({
       query: ({
@@ -32,6 +34,7 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
         dataSourceUID,
         targetDatasourceUID,
         extraLabels,
+        notificationSettings,
       }) => ({
         url: `/api/convert/prometheus/config/v1/rules`,
         method: 'POST',
@@ -44,6 +47,7 @@ export const convertToGMAApi = alertingApi.injectEndpoints({
           ...(targetFolderUID ? { 'X-Grafana-Alerting-Folder-UID': targetFolderUID } : {}),
           ...(targetDatasourceUID ? { 'X-Grafana-Alerting-Target-Datasource-UID': targetDatasourceUID } : {}),
           ...(extraLabels ? { 'X-Grafana-Alerting-Extra-Labels': extraLabels } : {}),
+          ...(notificationSettings ? { 'X-Grafana-Alerting-Notification-Settings': notificationSettings } : {}),
         },
       }),
     }),

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -5,7 +5,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { Alert, Box, Button, CodeEditor, Icon, Modal, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -42,7 +42,13 @@ import { Step1Content, useStep1Validation } from './steps/Step1AlertmanagerResou
 import { Step2Content, useStep2Validation } from './steps/Step2AlertRules';
 import { DryRunValidationResult } from './types';
 import { useExtraConfigState } from './useExtraConfigState';
-import { filterRulerRulesConfig, useDryRunNotifications, useImportNotifications, useImportRules } from './useImport';
+import {
+  buildRoutingParams,
+  filterRulerRulesConfig,
+  useDryRunNotifications,
+  useImportNotifications,
+  useImportRules,
+} from './useImport';
 import { getRoutingTreeLabel } from './useRoutingTrees';
 
 export interface ImportFormValues {
@@ -294,20 +300,25 @@ function ImportWizardContent() {
           rulesPayload = filteredConfig;
         }
 
-        // Add routing tree label to all imported rules
-        const extraLabels = values.selectedRoutingTree
-          ? `${MERGE_MATCHERS_LABEL_NAME}=${values.selectedRoutingTree}`
-          : undefined;
-
-        await importRules({
+        const baseParams = {
           dataSourceUID: values.rulesDatasourceUID,
           targetFolderUID: values.targetFolder?.uid,
           pauseAlertingRules: values.pauseAlertingRules,
           pauseRecordingRules: values.pauseRecordingRules,
           payload: rulesPayload,
           targetDatasourceUID: values.targetDatasourceUID,
-          extraLabels,
-        });
+        };
+
+        const { notificationSettings, extraLabels } = buildRoutingParams(
+          values.selectedRoutingTree,
+          Boolean(config.featureToggles.alertingPolicyRoutingSettings)
+        );
+
+        if (notificationSettings !== undefined) {
+          await importRules({ ...baseParams, notificationSettings });
+        } else {
+          await importRules({ ...baseParams, extraLabels });
+        }
       }
 
       setImportStatus('success');

--- a/public/app/features/alerting/unified/components/import-to-gma/useImport.test.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/useImport.test.ts
@@ -1,0 +1,57 @@
+import { buildRoutingParams } from './useImport';
+
+describe('buildRoutingParams', () => {
+  describe('when policy routing is enabled (feature flag ON)', () => {
+    const usePolicyRouting = true;
+
+    it('should return notificationSettings with policy when a routing tree is selected', () => {
+      const result = buildRoutingParams('my-policy', usePolicyRouting);
+
+      expect(result).toEqual({
+        notificationSettings: JSON.stringify({ policy: 'my-policy' }),
+      });
+      expect(result).not.toHaveProperty('extraLabels');
+    });
+
+    it('should fall back to extraLabels=undefined when no routing tree is selected', () => {
+      const result = buildRoutingParams(undefined, usePolicyRouting);
+
+      expect(result).toEqual({ extraLabels: undefined });
+      expect(result).not.toHaveProperty('notificationSettings');
+    });
+
+    it('should fall back to extraLabels=undefined for empty string routing tree', () => {
+      const result = buildRoutingParams('', usePolicyRouting);
+
+      expect(result).toEqual({ extraLabels: undefined });
+      expect(result).not.toHaveProperty('notificationSettings');
+    });
+  });
+
+  describe('when policy routing is disabled (feature flag OFF)', () => {
+    const usePolicyRouting = false;
+
+    it('should return extraLabels with the legacy label when a routing tree is selected', () => {
+      const result = buildRoutingParams('my-policy', usePolicyRouting);
+
+      expect(result).toEqual({
+        extraLabels: '__grafana_managed_route__=my-policy',
+      });
+      expect(result).not.toHaveProperty('notificationSettings');
+    });
+
+    it('should return extraLabels=undefined when no routing tree is selected', () => {
+      const result = buildRoutingParams(undefined, usePolicyRouting);
+
+      expect(result).toEqual({ extraLabels: undefined });
+      expect(result).not.toHaveProperty('notificationSettings');
+    });
+
+    it('should return extraLabels=undefined for empty string routing tree', () => {
+      const result = buildRoutingParams('', usePolicyRouting);
+
+      expect(result).toEqual({ extraLabels: undefined });
+      expect(result).not.toHaveProperty('notificationSettings');
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/import-to-gma/useImport.ts
+++ b/public/app/features/alerting/unified/components/import-to-gma/useImport.ts
@@ -7,6 +7,7 @@ import { fetchAlertManagerConfig } from '../../api/alertmanager';
 import { convertToGMAApi } from '../../api/convertToGMAApi';
 import { stringifyErrorLike } from '../../utils/misc';
 
+import { MERGE_MATCHERS_LABEL_NAME } from './Wizard/constants';
 import type { ConvertAlertmanagerResponse, DryRunValidationResult } from './types';
 
 interface ParsedAlertmanagerYaml {
@@ -88,15 +89,38 @@ async function resolveAlertmanagerConfig(params: NotificationsSourceParams): Pro
   throw new Error('Invalid import source configuration');
 }
 
-interface MigrateRulesParams {
+interface MigrateRulesBaseParams {
   dataSourceUID: string;
   targetFolderUID?: string;
   pauseAlertingRules: boolean;
   pauseRecordingRules: boolean;
   payload: RulerRulesConfigDTO;
   targetDatasourceUID?: string;
-  /** Extra labels to add to all imported rules (format: key=value,key2=value2) */
-  extraLabels?: string;
+}
+
+/**
+ * Policy routing via notification_settings.policy (new) and label-based routing via extraLabels (legacy)
+ * are mutually exclusive — only one mechanism should be used per import.
+ */
+type MigrateRulesParams = MigrateRulesBaseParams &
+  ({ extraLabels?: string; notificationSettings?: never } | { extraLabels?: never; notificationSettings?: string });
+
+/**
+ * Build the routing-specific params for rule import.
+ * When the `alertingPolicyRoutingSettings` feature flag is ON and a routing tree is selected,
+ * uses the new `notification_settings.policy` mechanism; otherwise falls back to `extraLabels`.
+ */
+export function buildRoutingParams(
+  selectedRoutingTree: string | undefined,
+  usePolicyRouting: boolean
+): Pick<MigrateRulesParams, 'extraLabels' | 'notificationSettings'> {
+  if (usePolicyRouting && selectedRoutingTree) {
+    return { notificationSettings: JSON.stringify({ policy: selectedRoutingTree }) };
+  }
+
+  return {
+    extraLabels: selectedRoutingTree ? `${MERGE_MATCHERS_LABEL_NAME}=${selectedRoutingTree}` : undefined,
+  };
 }
 
 /**
@@ -138,6 +162,7 @@ export function useImportRules() {
         payload,
         targetDatasourceUID,
         extraLabels,
+        notificationSettings,
       } = params;
 
       await convert({
@@ -148,6 +173,7 @@ export function useImportRules() {
         payload,
         targetDatasourceUID,
         extraLabels,
+        notificationSettings,
       }).unwrap();
     },
     [convert]


### PR DESCRIPTION
**What is this feature?**

When the `alertingPolicyRoutingSettings` feature flag is enabled, the import wizard (Step 2 — alert rules) now uses the new `notification_settings.policy` mechanism instead of the legacy `__grafana_managed_route__` extra label to assign imported rules to a notification policy.

This aligns the import wizard with the changes introduced in #120610 for the rule editor.

### Changes

- **`convertToGMAApi.ts`**: Added `notificationSettings` parameter to the `convertToGMA` mutation, sent via the `X-Grafana-Alerting-Notification-Settings` HTTP header.
- **`useImport.ts`**: Extracted `buildRoutingParams` pure function that returns either `notificationSettings` (new) or `extraLabels` (legacy) based on the feature flag. Enforced mutual exclusivity at the type level via `MigrateRulesParams`.
- **`ImportToGMA.tsx`**: Updated `handleConfirmImport` to use `buildRoutingParams` and branch the `importRules` call accordingly.
- **`useImport.test.ts`**: Added unit tests covering all branches (FF ON/OFF × routing tree selected/undefined/empty).

### Behavior

| Feature flag | Routing tree selected | Mechanism used |
|---|---|---|
| `alertingPolicyRoutingSettings` ON | Yes | `X-Grafana-Alerting-Notification-Settings: {"policy":"<name>"}` |
| `alertingPolicyRoutingSettings` ON | No | No routing params sent |
| OFF (or missing) | Yes | `X-Grafana-Alerting-Extra-Labels: __grafana_managed_route__=<name>` |
| OFF (or missing) | No | No routing params sent |

No backend changes needed , the convert API already supports the `X-Grafana-Alerting-Notification-Settings` header.


**Why do we need this feature?**

We should use notification settings if it's available

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/alerting-squad/issues/1478

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
