### PR TITLE
IAM: Fix NULL column scan error in legacy user list query

### DIFF
--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -174,12 +174,22 @@ func (s *legacySQLStore) queryUsers(ctx context.Context, sql *legacysql.LegacyDa
 		var lastID int64
 		for rows.Next() {
 			u := common.UserWithRole{}
-			err = rows.Scan(&u.OrgID, &u.ID, &u.UID, &u.Login, &u.Email, &u.Name,
+			var name, email, role stdsql.NullString
+			err = rows.Scan(&u.OrgID, &u.ID, &u.UID, &u.Login, &email, &name,
 				&u.Created, &u.Updated, &u.IsServiceAccount, &u.IsDisabled, &u.IsAdmin, &u.EmailVerified,
-				&u.IsProvisioned, &u.LastSeenAt, &u.Role,
+				&u.IsProvisioned, &u.LastSeenAt, &role,
 			)
 			if err != nil {
 				return res, err
+			}
+			if name.Valid {
+				u.Name = name.String
+			}
+			if email.Valid {
+				u.Email = email.String
+			}
+			if role.Valid {
+				u.Role = role.String
 			}
 
 			lastID = u.ID


### PR DESCRIPTION
## Summary
- Fix `sql: Scan error on column index 5, name "name": converting NULL to string is unsupported` in the IAM user list query
- Use `sql.NullString` intermediaries for nullable columns (`name`, `email`, `role`) when scanning rows, matching the existing pattern used in `team.go`

## Test plan
- [x] `go test ./pkg/tests/apis/iam/... -run TestIntegrationUsers -count=1 -timeout 300s` passes
- [ ] Verify against a database with NULL name/email columns (e.g., users created via OAuth providers)