### PR TITLE
CI: Remove profiled mode from SQLite integration tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -48,7 +48,6 @@ jobs:
         # We don't need more than this since it has to wait for the other tests.
         shard: [
           1/4, 2/4, 3/4, 4/4,
-          profiled,
         ]
       fail-fast: false
 
@@ -64,74 +63,13 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Run tests
-        if: matrix.shard != 'profiled'
         env:
           SHARD: ${{ matrix.shard }}
           CGO_ENABLED: 0
-          SKIP_PACKAGES: |-
-            pkg/tests/apis/folder
-            pkg/tests/apis/dashboard
         run: |
           set -euo pipefail
-          # Build regex pattern like: pkg1$|pkg2$|pkg3$
-          SKIP_PATTERN=$(echo "$SKIP_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d - | grep -Ev "($SKIP_PATTERN)")"
+          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d -)"
           go test -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
-      - name: Run profiled tests
-        id: run-profiled-tests
-        if: matrix.shard == 'profiled'
-        env:
-          CGO_ENABLED: 0
-          PROFILED_PACKAGES: |-
-            pkg/tests/apis/folder
-            pkg/tests/apis/dashboard
-        run: |
-          set -euo pipefail
-          # Build regex pattern line: pkg1$|pkg2$|pkg3$
-          PROFILE_PATTERN=$(echo "$PROFILED_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | grep -E "($PROFILE_PATTERN)")"
-          if [ ${#PACKAGES[@]} -eq 0 ]; then
-            echo "⚠️  No profiled packages found"
-            exit 0
-          fi
-          mkdir -p profiles
-          EXIT_CODE=0
-          # Run each profiled package sequentially
-          for full_pkg in "${PACKAGES[@]}"; do
-            # Build valid file name
-            pkg_name=$(basename "$full_pkg" | tr '/' '_' | tr '.' '_')
-            echo "📦 Running $full_pkg"
-            set +e
-            go test -timeout=8m -run '^TestIntegration' \
-              -outputdir=profiles \
-              -cpuprofile="cpu_${pkg_name}.prof" \
-              -memprofile="mem_${pkg_name}.prof" \
-              -trace="trace_${pkg_name}.out" \
-              "$full_pkg" 2>&1 | tee "profiles/test_${pkg_name}.log"
-            TEST_EXIT=$?
-            set -e
-            if [ $TEST_EXIT -ne 0 ]; then
-              echo "❌ $full_pkg failed with exit code $TEST_EXIT"
-              EXIT_CODE=1
-            else
-              echo "✅ $full_pkg passed"
-            fi
-          done
-          # Set output for artifact upload
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "upload_artifacts=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "upload_artifacts=false" >> "$GITHUB_OUTPUT"
-          fi
-          exit $EXIT_CODE
-      - name: Output test profiles and traces
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v4
-        if: matrix.shard == 'profiled' && !cancelled() && steps.run-profiled-tests.outputs.upload_artifacts == 'true'
-        with:
-          name: integration-test-profiles-sqlite-${{ github.run_number }}
-          path: profiles/
-          retention-days: 7
-          if-no-files-found: ignore
 
   mysql:
     # Run this workflow only for PRs from forks
@@ -246,7 +184,6 @@ jobs:
            5/16,  6/16,  7/16,  8/16,
            9/16, 10/16, 11/16, 12/16,
           13/16, 14/16, 15/16, 16/16,
-          profiled,
         ]
       fail-fast: false
 
@@ -269,74 +206,13 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Run tests
-        if: matrix.shard != 'profiled'
         env:
           SHARD: ${{ matrix.shard }}
           CGO_ENABLED: 0
-          SKIP_PACKAGES: |-
-            pkg/tests/apis/folder
-            pkg/tests/apis/dashboard
         run: |
           set -euo pipefail
-          # Build regex pattern like: pkg1$|pkg2$|pkg3$
-          SKIP_PATTERN=$(echo "$SKIP_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d - | grep -Ev "($SKIP_PATTERN)")"
+          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d -)"
           go test -tags=enterprise -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
-      - name: Run profiled tests
-        id: run-profiled-tests
-        if: matrix.shard == 'profiled'
-        env:
-          CGO_ENABLED: 0
-          PROFILED_PACKAGES: |-
-            pkg/tests/apis/folder
-            pkg/tests/apis/dashboard
-        run: |
-          set -euo pipefail
-          # Build regex pattern line: pkg1$|pkg2$|pkg3$
-          PROFILE_PATTERN=$(echo "$PROFILED_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
-          readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | grep -E "($PROFILE_PATTERN)")"
-          if [ ${#PACKAGES[@]} -eq 0 ]; then
-            echo "⚠️  No profiled packages found"
-            exit 0
-          fi
-          mkdir -p profiles
-          EXIT_CODE=0
-          # Run each profiled package sequentially
-          for full_pkg in "${PACKAGES[@]}"; do
-            # Build valid file name
-            pkg_name=$(basename "$full_pkg" | tr '/' '_' | tr '.' '_')
-            echo "📦 Running $full_pkg"
-            set +e
-            go test -tags=enterprise -timeout=8m -run '^TestIntegration' \
-              -outputdir=profiles \
-              -cpuprofile="cpu_${pkg_name}.prof" \
-              -memprofile="mem_${pkg_name}.prof" \
-              -trace="trace_${pkg_name}.out" \
-              "$full_pkg" 2>&1 | tee "profiles/test_${pkg_name}.log"
-            TEST_EXIT=$?
-            set -e
-            if [ $TEST_EXIT -ne 0 ]; then
-              echo "❌ $full_pkg failed with exit code $TEST_EXIT"
-              EXIT_CODE=1
-            else
-              echo "✅ $full_pkg passed"
-            fi
-          done
-          # Set output for artifact upload
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "upload_artifacts=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "upload_artifacts=false" >> "$GITHUB_OUTPUT"
-          fi
-          exit $EXIT_CODE
-      - name: Output test profiles and traces
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v4
-        if: matrix.shard == 'profiled' && !cancelled() && steps.run-profiled-tests.outputs.upload_artifacts == 'true'
-        with:
-          name: integration-test-profiles-sqlite-${{ github.run_number }}
-          path: profiles/
-          retention-days: 7
-          if-no-files-found: ignore
 
   mysql-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)


### PR DESCRIPTION
## Summary
- Remove the `profiled` shard from both OSS SQLite (4+1 → 4 shards) and Enterprise SQLite (16+1 → 16 shards) integration test matrices
- Remove the `SKIP_PACKAGES` / `grep -Ev` logic that excluded `pkg/tests/apis/folder` and `pkg/tests/apis/dashboard` from regular shards
- Delete the "Run profiled tests" and "Output test profiles and traces" steps from both jobs

These packages now run in normal shards like every other integration test package. The profiled mode added complexity (skip lists, separate step with CPU/memory/trace profiling, artifact upload) but the profiling data was only uploaded on test failures, making it a rarely-used debugging aid.

## Test plan
- [x] CI passes — the previously-profiled packages (`pkg/tests/apis/folder`, `pkg/tests/apis/dashboard`) should appear in normal shard output
- [x] Verify no packages are lost: `pkgs-with-tests-named.sh -b TestIntegration` still includes both packages, and they are no longer filtered out