### PR TITLE
Alerting: Return rule title from historian notification counting API.

### DIFF
--- a/apps/alerting/historian/kinds/v0alpha1/notification.cue
+++ b/apps/alerting/historian/kinds/v0alpha1/notification.cue
@@ -94,6 +94,9 @@ import (
 	error?:            string
 	ruleUID?:          string
 
+	// RuleTitle is returned if grouping by ruleUID.
+	ruleTitle?: string
+
 	// Count is the number of notification attempts in the time period. Set for counts queries.
 	count: int
 

--- a/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian/v0alpha1/createnotificationquery_response_types_gen.go
@@ -114,6 +114,8 @@ type CreateNotificationqueryNotificationCount struct {
 	Outcome          *CreateNotificationqueryNotificationOutcome `json:"outcome,omitempty"`
 	Error            *string                                     `json:"error,omitempty"`
 	RuleUID          *string                                     `json:"ruleUID,omitempty"`
+	// RuleTitle is returned if grouping by ruleUID.
+	RuleTitle *string `json:"ruleTitle,omitempty"`
 	// Count is the number of notification attempts in the time period. Set for counts queries.
 	Count int64 `json:"count"`
 	// Values is the list of (timestamp, count) pairs in the time series. Set for range_counts queries.

--- a/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
+++ b/apps/alerting/historian/pkg/apis/alertinghistorian_manifest.go
@@ -452,6 +452,12 @@ var appManifestData = app.ManifestData{
 										Type: []string{"string"},
 									},
 								},
+								"ruleTitle": {
+									SchemaProps: spec.SchemaProps{
+										Type:        []string{"string"},
+										Description: "RuleTitle is returned if grouping by ruleUID.",
+									},
+								},
 								"ruleUID": {
 									SchemaProps: spec.SchemaProps{
 										Type: []string{"string"},

--- a/apps/alerting/historian/pkg/app/notification/lokireader.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader.go
@@ -258,6 +258,7 @@ func buildMetricsRangeQuery(logqlInner string, step time.Duration, groupBy Query
 	}
 	if groupBy.RuleUID {
 		labels = append(labels, "rule_uids")
+		labels = append(labels, "groupLabels_alertname")
 	}
 	sumBy := ""
 	if len(labels) > 0 {
@@ -466,6 +467,9 @@ func parseCountLabels(m map[string]string) (Count, error) {
 		// Store the raw comma-separated rule_uids string temporarily in the RuleUID
 		// field. The explodeRuleUIDCounts function will split and reaggregate later.
 		entry.RuleUID = &v
+	}
+	if v, ok := m["groupLabels_alertname"]; ok && v != "" {
+		entry.RuleTitle = &v
 	}
 	return entry, nil
 }

--- a/apps/alerting/historian/pkg/app/notification/lokireader_test.go
+++ b/apps/alerting/historian/pkg/app/notification/lokireader_test.go
@@ -1133,7 +1133,7 @@ func TestBuildMetricsQuery(t *testing.T) {
 			to:         now,
 			limit:      100,
 			groupBy:    QueryGroupBy{RuleUID: true},
-			expected:   fmt.Sprintf(`sum by (rule_uids) (count_over_time({foo="bar"} | json[%ds]))`, rangeSeconds),
+			expected:   fmt.Sprintf(`sum by (rule_uids,groupLabels_alertname) (count_over_time({foo="bar"} | json[%ds]))`, rangeSeconds),
 		},
 		{
 			name:       "group by ruleUID and receiver omits topk",
@@ -1142,7 +1142,7 @@ func TestBuildMetricsQuery(t *testing.T) {
 			to:         now,
 			limit:      50,
 			groupBy:    QueryGroupBy{Receiver: true, RuleUID: true},
-			expected:   fmt.Sprintf(`sum by (receiver,rule_uids) (count_over_time({foo="bar"} | json[%ds]))`, rangeSeconds),
+			expected:   fmt.Sprintf(`sum by (receiver,rule_uids,groupLabels_alertname) (count_over_time({foo="bar"} | json[%ds]))`, rangeSeconds),
 		},
 	}
 
@@ -1224,6 +1224,22 @@ func TestParseCount(t *testing.T) {
 			want: Count{Count: 15, RuleUID: stringPtr("ruleA,ruleB")},
 		},
 		{
+			name: "with groupLabels_alertname populates ruleTitle",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"rule_uids": "ruleA", "groupLabels_alertname": "HighCPU"},
+				Value:  makeValue("8"),
+			},
+			want: Count{Count: 8, RuleUID: stringPtr("ruleA"), RuleTitle: stringPtr("HighCPU")},
+		},
+		{
+			name: "empty groupLabels_alertname does not set ruleTitle",
+			sample: lokiclient.MetricSample{
+				Metric: map[string]string{"rule_uids": "ruleA", "groupLabels_alertname": ""},
+				Value:  makeValue("3"),
+			},
+			want: Count{Count: 3, RuleUID: stringPtr("ruleA")},
+		},
+		{
 			name: "non-integer count",
 			sample: lokiclient.MetricSample{
 				Metric: map[string]string{},
@@ -1258,6 +1274,7 @@ func TestParseCount(t *testing.T) {
 			assert.Equal(t, tt.want.Outcome, got.Outcome)
 			assert.Equal(t, tt.want.Error, got.Error)
 			assert.Equal(t, tt.want.RuleUID, got.RuleUID)
+			assert.Equal(t, tt.want.RuleTitle, got.RuleTitle)
 		})
 	}
 }
@@ -1403,7 +1420,7 @@ func TestBuildMetricsRangeQuery(t *testing.T) {
 			logqlInner: `{foo="bar"} | json`,
 			step:       step,
 			groupBy:    QueryGroupBy{RuleUID: true},
-			expected:   `sum by (rule_uids) (count_over_time({foo="bar"} | json[60s]))`,
+			expected:   `sum by (rule_uids,groupLabels_alertname) (count_over_time({foo="bar"} | json[60s]))`,
 		},
 	}
 

--- a/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/historian.alerting/v0alpha1/endpoints.gen.ts
@@ -629,6 +629,8 @@ export type CreateNotificationqueryNotificationCount = {
   integrationIndex?: number;
   outcome?: CreateNotificationqueryNotificationOutcome;
   receiver?: string;
+  /** RuleTitle is returned if grouping by ruleUID. */
+  ruleTitle?: string;
   ruleUID?: string;
   status?: CreateNotificationqueryNotificationStatus;
   /** Values is the list of (timestamp, count) pairs in the time series. Set for range_counts queries. */

--- a/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/historian.alerting.grafana.app-v0alpha1.json
@@ -1155,6 +1155,10 @@
           "receiver": {
             "type": "string"
           },
+          "ruleTitle": {
+            "description": "RuleTitle is returned if grouping by ruleUID.",
+            "type": "string"
+          },
           "ruleUID": {
             "type": "string"
           },

--- a/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/historian.alerting.grafana.app-v0alpha1.json
@@ -1252,6 +1252,10 @@
           "receiver": {
             "type": "string"
           },
+          "ruleTitle": {
+            "description": "RuleTitle is returned if grouping by ruleUID.",
+            "type": "string"
+          },
           "ruleUID": {
             "type": "string"
           },


### PR DESCRIPTION
Returns the rule title from groupLabels['alertname'] if it exists, to save the
client having to lookup the rule name all the time. Note that it will still be
necessary to lookup the rule title if alertname is not used for grouping, but
this avoids the lookup in the common case.
