### PR TITLE
Dashboard variables: Clean up outdated documentation code

### DIFF
--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -82,36 +82,6 @@ import {
 import { KeyedVariableIdentifier } from './types';
 import { cleanVariables } from './variablesReducer';
 
-// process flow queryVariable
-// thunk => processVariables
-//    adapter => setValueFromUrl
-//      thunk => setOptionFromUrl
-//        adapter => updateOptions
-//          thunk => updateQueryVariableOptions
-//            action => updateVariableOptions
-//            action => updateVariableTags
-//            thunk => validateVariableSelectionState
-//              adapter => setValue
-//                thunk => setOptionAsCurrent
-//                  action => setCurrentVariableValue
-//                  thunk => variableUpdated
-//                    adapter => updateOptions for dependent nodes
-//        adapter => setValue
-//          thunk => setOptionAsCurrent
-//            action => setCurrentVariableValue
-//            thunk => variableUpdated
-//              adapter => updateOptions for dependent nodes
-//    adapter => updateOptions
-//      thunk => updateQueryVariableOptions
-//        action => updateVariableOptions
-//        action => updateVariableTags
-//        thunk => validateVariableSelectionState
-//          adapter => setValue
-//            thunk => setOptionAsCurrent
-//              action => setCurrentVariableValue
-//              thunk => variableUpdated
-//                adapter => updateOptions for dependent nodes
-
 export const initDashboardTemplating = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
     let orderIndex = 0;


### PR DESCRIPTION
**What is this PR about?**
While working on another issue I found this documentation comment that was merged in 2020 (see #22434). I would like to remove it due to the following reasons:
- Documentation comment wasn't updated in 6 years but the rest of the file constantly changed (last commit in February 2026)
- It only covers query variables, not the full picture

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
