### PR TITLE
fix(unified-storage): settle non-rvmanager create races

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -811,6 +811,12 @@ func (k *kvStorageBackend) validateCreateWrite(ctx context.Context, key *resourc
 	return k.waitForConcurrentCreateSettlement(ctx, key, namespace, dataKey)
 }
 
+// waitForConcurrentCreateSettlement handles the non-rvManager create race where
+// our write is currently the latest version, but its immediate predecessor is
+// also a create. In that case the predecessor may be a transient loser that is
+// about to delete itself, or it may be the real winner that will persist an
+// event. We briefly poll until one of those outcomes becomes observable before
+// deciding whether to keep or delete our write.
 func (k *kvStorageBackend) waitForConcurrentCreateSettlement(ctx context.Context, key *resourcepb.ResourceKey, namespace string, dataKey DataKey) error {
 	ticker := time.NewTicker(concurrentCreateSettleDelay)
 	defer ticker.Stop()

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -38,6 +38,8 @@ const (
 	defaultEventPruningInterval       = 5 * time.Minute
 	defaultSearchLookback             = 1 * time.Second
 	defaultGarbageCollectionBatchWait = 1 * time.Second
+	concurrentCreateSettleDelay       = 5 * time.Millisecond
+	concurrentCreateSettleTimeout     = 250 * time.Millisecond
 )
 
 type GarbageCollectionConfig struct {
@@ -742,31 +744,8 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 			return 0, fmt.Errorf("optimistic locking failed: resource was modified concurrently (expected previous RV %d, found %d)", event.PreviousRV, prevKey.ResourceVersion)
 		}
 	} else if event.Type == resourcepb.WatchEvent_ADDED {
-		// Create operations: verify our write is the latest version
-		latestKey, prevKey, err := k.dataStore.GetLatestAndPredecessor(ctx, ListRequestKey{
-			Group:     event.Key.Group,
-			Resource:  event.Key.Resource,
-			Namespace: namespace,
-			Name:      event.Key.Name,
-		})
-		if err != nil {
-			// If we can't read the latest version, clean up what we wrote
-			_ = k.dataStore.Delete(ctx, dataKey)
-			return 0, fmt.Errorf("failed to check latest version: %w", err)
-		}
-
-		// Check if the RV we just wrote is the latest. If not, a concurrent create with higher RV happened
-		if latestKey.ResourceVersion != dataKey.ResourceVersion {
-			// Delete the data we just wrote since it's not the latest
-			_ = k.dataStore.Delete(ctx, dataKey)
-			return 0, fmt.Errorf("optimistic locking failed: concurrent create detected")
-		}
-
-		// Verify that the immediate predecessor is not a create
-		if prevKey.Action == DataActionCreated {
-			// Another concurrent create happened - delete our write and return error
-			_ = k.dataStore.Delete(ctx, dataKey)
-			return 0, fmt.Errorf("optimistic locking failed: concurrent create detected")
+		if err := k.validateCreateWrite(ctx, event.Key, namespace, dataKey); err != nil {
+			return 0, err
 		}
 	}
 
@@ -797,6 +776,97 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 	k.notifier.Publish(eventData)
 
 	return rv, nil
+}
+
+func (k *kvStorageBackend) validateCreateWrite(ctx context.Context, key *resourcepb.ResourceKey, namespace string, dataKey DataKey) error {
+	latestKey, prevKey, err := k.dataStore.GetLatestAndPredecessor(ctx, ListRequestKey{
+		Group:     key.Group,
+		Resource:  key.Resource,
+		Namespace: namespace,
+		Name:      key.Name,
+	})
+	if err != nil {
+		// If we can't read the latest version, clean up what we wrote
+		_ = k.dataStore.Delete(ctx, dataKey)
+		return fmt.Errorf("failed to check latest version: %w", err)
+	}
+
+	// Check if the RV we just wrote is the latest. If not, a concurrent create with higher RV happened
+	if latestKey.ResourceVersion != dataKey.ResourceVersion {
+		// Delete the data we just wrote since it's not the latest
+		_ = k.dataStore.Delete(ctx, dataKey)
+		return fmt.Errorf("optimistic locking failed: concurrent create detected")
+	}
+
+	if prevKey.Action != DataActionCreated {
+		return nil
+	}
+
+	if k.rvManager != nil {
+		// Preserve the existing behavior for rvManager-backed writes.
+		_ = k.dataStore.Delete(ctx, dataKey)
+		return fmt.Errorf("optimistic locking failed: concurrent create detected")
+	}
+
+	return k.waitForConcurrentCreateSettlement(ctx, key, namespace, dataKey)
+}
+
+func (k *kvStorageBackend) waitForConcurrentCreateSettlement(ctx context.Context, key *resourcepb.ResourceKey, namespace string, dataKey DataKey) error {
+	ticker := time.NewTicker(concurrentCreateSettleDelay)
+	defer ticker.Stop()
+
+	timeout := time.NewTimer(concurrentCreateSettleTimeout)
+	defer timeout.Stop()
+
+	for {
+		latestKey, prevKey, err := k.dataStore.GetLatestAndPredecessor(ctx, ListRequestKey{
+			Group:     key.Group,
+			Resource:  key.Resource,
+			Namespace: namespace,
+			Name:      key.Name,
+		})
+		if err != nil {
+			_ = k.dataStore.Delete(ctx, dataKey)
+			return fmt.Errorf("failed to check latest version: %w", err)
+		}
+
+		if latestKey.ResourceVersion != dataKey.ResourceVersion {
+			_ = k.dataStore.Delete(ctx, dataKey)
+			return fmt.Errorf("optimistic locking failed: concurrent create detected")
+		}
+
+		if prevKey.Action != DataActionCreated {
+			return nil
+		}
+
+		_, err = k.eventStore.Get(ctx, EventKey{
+			Namespace:       prevKey.Namespace,
+			Group:           prevKey.Group,
+			Resource:        prevKey.Resource,
+			Name:            prevKey.Name,
+			ResourceVersion: prevKey.ResourceVersion,
+			Action:          prevKey.Action,
+			Folder:          prevKey.Folder,
+		})
+		if err == nil {
+			_ = k.dataStore.Delete(ctx, dataKey)
+			return ErrResourceAlreadyExists
+		}
+		if !errors.Is(err, ErrNotFound) {
+			_ = k.dataStore.Delete(ctx, dataKey)
+			return fmt.Errorf("failed to check predecessor event: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			_ = k.dataStore.Delete(ctx, dataKey)
+			return fmt.Errorf("failed to validate concurrent create: %w", ctx.Err())
+		case <-timeout.C:
+			_ = k.dataStore.Delete(ctx, dataKey)
+			return fmt.Errorf("failed to validate concurrent create: predecessor create did not settle")
+		case <-ticker.C:
+		}
+	}
 }
 
 func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) *BackendReadResponse {

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -510,6 +511,228 @@ func TestKvStorageBackend_WriteEvent_ResourceAlreadyExists(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, int64(0), rv2)
 	require.ErrorIs(t, err, ErrResourceAlreadyExists)
+}
+
+func TestKvStorageBackend_validateCreateWrite_WaitsForTransientPredecessorToDisappear(t *testing.T) {
+	testCases := []struct {
+		name    string
+		backend func(*testing.T) *kvStorageBackend
+	}{
+		{
+			name: "badger",
+			backend: func(t *testing.T) *kvStorageBackend {
+				return setupTestStorageBackend(t)
+			},
+		},
+		{
+			name: "sqlkv",
+			backend: func(t *testing.T) *kvStorageBackend {
+				return setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := tc.backend(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			key := &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "apps",
+				Resource:  "resources",
+				Name:      "settling-create",
+			}
+
+			prevKey := DataKey{
+				Namespace:       key.Namespace,
+				Group:           key.Group,
+				Resource:        key.Resource,
+				Name:            key.Name,
+				ResourceVersion: 1,
+				Action:          DataActionCreated,
+			}
+			dataKey := DataKey{
+				Namespace:       key.Namespace,
+				Group:           key.Group,
+				Resource:        key.Resource,
+				Name:            key.Name,
+				ResourceVersion: 2,
+				Action:          DataActionCreated,
+			}
+
+			require.NoError(t, backend.dataStore.Save(ctx, prevKey, strings.NewReader("predecessor")))
+			require.NoError(t, backend.dataStore.Save(ctx, dataKey, strings.NewReader("winner")))
+
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				_ = backend.dataStore.Delete(context.Background(), prevKey)
+			}()
+
+			err := backend.validateCreateWrite(ctx, key, key.Namespace, dataKey)
+			require.NoError(t, err)
+
+			reader, err := backend.dataStore.Get(ctx, dataKey)
+			require.NoError(t, err)
+			require.NoError(t, reader.Close())
+		})
+	}
+}
+
+func TestKvStorageBackend_validateCreateWrite_DeletesOurWriteWhenPredecessorEventAppears(t *testing.T) {
+	testCases := []struct {
+		name    string
+		backend func(*testing.T) *kvStorageBackend
+	}{
+		{
+			name: "badger",
+			backend: func(t *testing.T) *kvStorageBackend {
+				return setupTestStorageBackend(t)
+			},
+		},
+		{
+			name: "sqlkv",
+			backend: func(t *testing.T) *kvStorageBackend {
+				return setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := tc.backend(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			key := &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "apps",
+				Resource:  "resources",
+				Name:      "settling-create-with-event",
+			}
+
+			prevKey := DataKey{
+				Namespace:       key.Namespace,
+				Group:           key.Group,
+				Resource:        key.Resource,
+				Name:            key.Name,
+				ResourceVersion: 1,
+				Action:          DataActionCreated,
+			}
+			dataKey := DataKey{
+				Namespace:       key.Namespace,
+				Group:           key.Group,
+				Resource:        key.Resource,
+				Name:            key.Name,
+				ResourceVersion: 2,
+				Action:          DataActionCreated,
+			}
+
+			require.NoError(t, backend.dataStore.Save(ctx, prevKey, strings.NewReader("predecessor")))
+			require.NoError(t, backend.dataStore.Save(ctx, dataKey, strings.NewReader("winner")))
+
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				_ = backend.eventStore.Save(context.Background(), Event{
+					Namespace:       key.Namespace,
+					Group:           key.Group,
+					Resource:        key.Resource,
+					Name:            key.Name,
+					ResourceVersion: prevKey.ResourceVersion,
+					Action:          DataActionCreated,
+				})
+			}()
+
+			err := backend.validateCreateWrite(ctx, key, key.Namespace, dataKey)
+			require.ErrorIs(t, err, ErrResourceAlreadyExists)
+
+			_, err = backend.dataStore.Get(ctx, dataKey)
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	}
+}
+
+func TestKvStorageBackend_WriteEvent_ConcurrentCreatesSameName(t *testing.T) {
+	backend := setupTestStorageBackend(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const (
+		iterations  = 10
+		concurrency = 4
+	)
+
+	for i := range iterations {
+		name := fmt.Sprintf("concurrent-create-%d", i)
+
+		type writeResult struct {
+			rv  int64
+			err error
+		}
+
+		results := make(chan writeResult, concurrency)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+
+		for j := range concurrency {
+			obj, err := createTestObjectWithName(name, appsNamespace, fmt.Sprintf("value-%d-%d", i, j))
+			require.NoError(t, err)
+
+			metaAccessor, err := utils.MetaAccessor(obj)
+			require.NoError(t, err)
+
+			event := WriteEvent{
+				Type: resourcepb.WatchEvent_ADDED,
+				Key: &resourcepb.ResourceKey{
+					Namespace: appsNamespace.Namespace,
+					Group:     appsNamespace.Group,
+					Resource:  appsNamespace.Resource,
+					Name:      name,
+				},
+				Value:      objectToJSONBytes(t, obj),
+				Object:     metaAccessor,
+				ObjectOld:  metaAccessor,
+				PreviousRV: 0,
+			}
+
+			wg.Go(func() {
+				<-start
+				rv, err := backend.WriteEvent(ctx, event)
+				results <- writeResult{rv: rv, err: err}
+			})
+		}
+
+		close(start)
+		wg.Wait()
+		close(results)
+
+		successes := 0
+		for result := range results {
+			if result.err == nil {
+				successes++
+				require.Greater(t, result.rv, int64(0))
+				continue
+			}
+
+			require.True(t,
+				errors.Is(result.err, ErrResourceAlreadyExists) || strings.Contains(result.err.Error(), "concurrent create"),
+				"unexpected concurrent create error: %v", result.err)
+		}
+
+		require.Equal(t, 1, successes, "expected exactly one create to succeed for %s", name)
+
+		response := backend.ReadResource(ctx, &resourcepb.ReadRequest{
+			Key: &resourcepb.ResourceKey{
+				Namespace: appsNamespace.Namespace,
+				Group:     appsNamespace.Group,
+				Resource:  appsNamespace.Resource,
+				Name:      name,
+			},
+		})
+		require.Nil(t, response.Error, "resource should remain readable after concurrent creates for %s", name)
+		require.NotEmpty(t, response.Value)
+	}
 }
 
 func TestKvStorageBackend_ReadResource_Success(t *testing.T) {


### PR DESCRIPTION
Concurrent creates without RvManager can lose all writes because the create-side post-write validation immediately deletes the highest-RV write when its predecessor is still a transient create. This change keeps the fix intentionally narrow: in the non-RvManager path, the backend now briefly waits for a predecessor create to either persist its event or disappear before deciding whether to keep or delete the current write.

Changes:
- add a small settlement loop for non-RvManager create validation instead of immediately treating any predecessor create as a hard conflict
- preserve the existing rvManager behavior and keep the broader optimistic concurrency design unchanged
- add deterministic settle-path tests for badger and sqlkv
- add a concurrent same-name create regression through WriteEvent

Tests:
- `go test ./pkg/storage/unified/resource -run 'TestKvStorageBackend_(validateCreateWrite_WaitsForTransientPredecessorToDisappear|validateCreateWrite_DeletesOurWriteWhenPredecessorEventAppears|WriteEvent_ConcurrentCreatesSameName|WriteEvent_ResourceAlreadyExists)$'`
- `go test ./pkg/storage/unified/resource -run 'TestKvStorageBackend_'`