### PR TITLE
CI: fix codeql-analysis missing permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,8 +21,7 @@ on:
   schedule:
     - cron: '0 4 * * 6'
 
-permissions:
-  security-events: write
+permissions: {}
 
 jobs:
   detect-changes:
@@ -53,7 +52,7 @@ jobs:
     if: github.repository == 'grafana/grafana'
     permissions:
       contents: read
-      # Required for github/codeql-action/analyze to upload SARIF (job-level permissions replace defaults; omitting this blocks upload).
+      # Upload SARIF to code scanning results
       security-events: write
 
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,6 +53,8 @@ jobs:
     if: github.repository == 'grafana/grafana'
     permissions:
       contents: read
+      # Required for github/codeql-action/analyze to upload SARIF (job-level permissions replace defaults; omitting this blocks upload).
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The check is currently failing on push to main: https://github.com/grafana/grafana/actions/runs/23341936948/job/67897444177