### PR TITLE
Short URL: add unified storage migration phase timing logs

### DIFF
--- a/pkg/registry/apps/shorturl/migrator/migrator.go
+++ b/pkg/registry/apps/shorturl/migrator/migrator.go
@@ -49,154 +49,130 @@ func (m *shortURLMigrator) MigrateShortURLs(ctx context.Context, orgId int64, op
 
 	var lastID int64 = 0
 	limit := int64(1000)
-	fetchLimit := limit + 1
-	readCount := 0
-	convertedCount := 0
-	writtenCount := 0
+	count := 0
 	readDuration := time.Duration(0)
 	convertDuration := time.Duration(0)
 	writeDuration := time.Duration(0)
 
 	for {
 		readStart := time.Now()
-		rows, err := m.listShortURLs(ctx, orgId, lastID, fetchLimit)
-		if err != nil {
-			return err
-		}
-		batch, nextLastID, hasMore, err := readShortURLBatch(rows, limit)
-		readDuration += time.Since(readStart)
+		rows, err := m.listShortURLs(ctx, orgId, lastID, limit)
 		if err != nil {
 			return err
 		}
 
-		if len(batch) == 0 {
-			opts.Progress(readCount, fmt.Sprintf("finished reading legacy short URLs from legacy short_url table in %s (%d)", readDuration, readCount))
-			opts.Progress(convertedCount, fmt.Sprintf("finished converting legacy short URLs to unified storage format in %s (%d)", convertDuration, convertedCount))
-			opts.Progress(writtenCount, fmt.Sprintf("finished writing short URLs to unified storage in %s (%d)", writeDuration, writtenCount))
-			break
+		var id int64
+		var orgID int64
+		var uid, path string
+		var createdBy int64
+		var createdAt int64
+		var lastSeenAt int64
+
+		rawRows := make([]shortURLRow, 0, limit)
+		for rows.Next() {
+			err = rows.Scan(&id, &orgID, &uid, &path, &createdBy, &createdAt, &lastSeenAt)
+			if err != nil {
+				_ = rows.Close()
+				return err
+			}
+
+			lastID = id
+			rawRows = append(rawRows, shortURLRow{
+				uid:        uid,
+				path:       path,
+				createdBy:  createdBy,
+				createdAt:  createdAt,
+				lastSeenAt: lastSeenAt,
+			})
 		}
-		readCount += len(batch)
-		lastID = nextLastID
-		if !hasMore {
-			opts.Progress(readCount, fmt.Sprintf("finished reading legacy short URLs from legacy short_url table in %s (%d)", readDuration, readCount))
+
+		if err = rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+
+		_ = rows.Close()
+		readDuration += time.Since(readStart)
+
+		if len(rawRows) == 0 {
+			break
 		}
 
 		convertStart := time.Now()
-		chunk, err := buildBulkRequests(batch, opts.Namespace)
+		chunk := make([]*resourcepb.BulkRequest, 0, len(rawRows))
+		for _, row := range rawRows {
+			shortURL := &shorturlv1beta1.ShortURL{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: shorturlv1beta1.GroupVersion.String(),
+					Kind:       "ShortURL",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              row.uid,
+					Namespace:         opts.Namespace,
+					CreationTimestamp: metav1.NewTime(time.Unix(row.createdAt, 0)),
+				},
+				Spec: shorturlv1beta1.ShortURLSpec{
+					Path: row.path,
+				},
+				Status: shorturlv1beta1.ShortURLStatus{
+					LastSeenAt: row.lastSeenAt,
+				},
+			}
+
+			if row.createdBy > 0 {
+				shortURL.SetCreatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(row.createdBy, 10)))
+			}
+
+			body, err := json.Marshal(shortURL)
+			if err != nil {
+				return err
+			}
+
+			req := &resourcepb.BulkRequest{
+				Key: &resourcepb.ResourceKey{
+					Namespace: opts.Namespace,
+					Group:     shorturlv1beta1.APIGroup,
+					Resource:  "shorturls",
+					Name:      row.uid,
+				},
+				Value:  body,
+				Action: resourcepb.BulkRequest_ADDED,
+			}
+			chunk = append(chunk, req)
+		}
 		convertDuration += time.Since(convertStart)
-		if err != nil {
-			return err
-		}
-		convertedCount += len(chunk)
-		if !hasMore {
-			opts.Progress(convertedCount, fmt.Sprintf("finished converting legacy short URLs to unified storage format in %s (%d)", convertDuration, convertedCount))
-		}
 
 		writeStart := time.Now()
 		for _, req := range chunk {
+			count++
 			err = stream.Send(req)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					opts.Progress(writtenCount, fmt.Sprintf("stream EOF/cancelled. index=%d", writtenCount))
+					opts.Progress(count, fmt.Sprintf("stream EOF/cancelled. index=%d", count))
 				}
 				return err
 			}
-			writtenCount++
 		}
 		writeDuration += time.Since(writeStart)
 
-		if !hasMore {
-			opts.Progress(writtenCount, fmt.Sprintf("finished writing short URLs to unified storage in %s (%d)", writeDuration, writtenCount))
+		if int64(len(rawRows)) < limit {
 			break
 		}
 	}
 
-	opts.Progress(-2, fmt.Sprintf("finished short URLs... (%d)", writtenCount))
+	opts.Progress(count, fmt.Sprintf("finished reading legacy short URLs from legacy short_url table in %s (%d)", readDuration, count))
+	opts.Progress(count, fmt.Sprintf("finished converting legacy short URLs to unified storage format in %s (%d)", convertDuration, count))
+	opts.Progress(count, fmt.Sprintf("finished writing short URLs to unified storage in %s (%d)", writeDuration, count))
+	opts.Progress(-2, fmt.Sprintf("finished short URLs... (%d)", count))
 	return nil
 }
 
 type shortURLRow struct {
-	id         int64
 	uid        string
 	path       string
 	createdBy  int64
 	createdAt  int64
 	lastSeenAt int64
-}
-
-func readShortURLBatch(rows *sql.Rows, limit int64) ([]shortURLRow, int64, bool, error) {
-	if rows == nil {
-		return nil, 0, false, nil
-	}
-	defer func() {
-		_ = rows.Close()
-	}()
-
-	batch := make([]shortURLRow, 0, limit+1)
-	for rows.Next() {
-		var row shortURLRow
-		var orgID int64
-		if err := rows.Scan(&row.id, &orgID, &row.uid, &row.path, &row.createdBy, &row.createdAt, &row.lastSeenAt); err != nil {
-			return nil, 0, false, err
-		}
-		batch = append(batch, row)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, 0, false, err
-	}
-	if len(batch) == 0 {
-		return nil, 0, false, nil
-	}
-	if int64(len(batch)) > limit {
-		return batch[:limit], batch[limit-1].id, true, nil
-	}
-	return batch, batch[len(batch)-1].id, false, nil
-}
-
-func buildBulkRequests(batch []shortURLRow, namespace string) ([]*resourcepb.BulkRequest, error) {
-	chunk := make([]*resourcepb.BulkRequest, 0, len(batch))
-	for _, row := range batch {
-		shortURL := &shorturlv1beta1.ShortURL{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: shorturlv1beta1.GroupVersion.String(),
-				Kind:       "ShortURL",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              row.uid,
-				Namespace:         namespace,
-				CreationTimestamp: metav1.NewTime(time.Unix(row.createdAt, 0)),
-			},
-			Spec: shorturlv1beta1.ShortURLSpec{
-				Path: row.path,
-			},
-			Status: shorturlv1beta1.ShortURLStatus{
-				LastSeenAt: row.lastSeenAt,
-			},
-		}
-
-		if row.createdBy > 0 {
-			shortURL.SetCreatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(row.createdBy, 10)))
-		}
-
-		body, err := json.Marshal(shortURL)
-		if err != nil {
-			return nil, err
-		}
-
-		req := &resourcepb.BulkRequest{
-			Key: &resourcepb.ResourceKey{
-				Namespace: namespace,
-				Group:     shorturlv1beta1.APIGroup,
-				Resource:  "shorturls",
-				Name:      row.uid,
-			},
-			Value:  body,
-			Action: resourcepb.BulkRequest_ADDED,
-		}
-		chunk = append(chunk, req)
-	}
-	return chunk, nil
 }
 
 func (m *shortURLMigrator) listShortURLs(ctx context.Context, orgID int64, lastID int64, limit int64) (*sql.Rows, error) {

--- a/pkg/registry/apps/shorturl/migrator/migrator.go
+++ b/pkg/registry/apps/shorturl/migrator/migrator.go
@@ -34,7 +34,8 @@ type ShortURLMigrator interface {
 
 // shortURLMigrator handles migrating short URLs from legacy SQL storage.
 type shortURLMigrator struct {
-	sql legacysql.LegacyDatabaseProvider
+	sql             legacysql.LegacyDatabaseProvider
+	listShortURLsFn func(context.Context, int64, int64, int64) (*sql.Rows, error)
 }
 
 // ProvideShortURLMigrator creates a shortURLMigrator for use in wire DI.
@@ -48,106 +49,161 @@ func (m *shortURLMigrator) MigrateShortURLs(ctx context.Context, orgId int64, op
 
 	var lastID int64 = 0
 	limit := int64(1000)
-	count := 0
+	fetchLimit := limit + 1
+	readCount := 0
+	convertedCount := 0
+	writtenCount := 0
+	readDuration := time.Duration(0)
+	convertDuration := time.Duration(0)
+	writeDuration := time.Duration(0)
 
 	for {
-		rows, err := m.ListShortURLs(ctx, orgId, lastID, limit)
+		readStart := time.Now()
+		rows, err := m.listShortURLs(ctx, orgId, lastID, fetchLimit)
+		if err != nil {
+			return err
+		}
+		batch, nextLastID, hasMore, err := readShortURLBatch(rows, limit)
+		readDuration += time.Since(readStart)
 		if err != nil {
 			return err
 		}
 
-		var id int64
-		var orgID int64
-		var uid, path string
-		var createdBy int64
-		var createdAt int64
-		var lastSeenAt int64
-
-		// We buffer them in memory so we can close the DB cursor before sending
-		// to the potentially slow gRPC stream.
-		chunk := make([]*resourcepb.BulkRequest, 0, limit)
-
-		for rows.Next() {
-			err = rows.Scan(&id, &orgID, &uid, &path, &createdBy, &createdAt, &lastSeenAt)
-			if err != nil {
-				_ = rows.Close()
-				return err
-			}
-
-			lastID = id // Keep track of the highest ID in this batch
-
-			shortURL := &shorturlv1beta1.ShortURL{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: shorturlv1beta1.GroupVersion.String(),
-					Kind:       "ShortURL",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              uid,
-					Namespace:         opts.Namespace,
-					CreationTimestamp: metav1.NewTime(time.Unix(createdAt, 0)),
-				},
-				Spec: shorturlv1beta1.ShortURLSpec{
-					Path: path,
-				},
-				Status: shorturlv1beta1.ShortURLStatus{
-					LastSeenAt: lastSeenAt,
-				},
-			}
-
-			if createdBy > 0 {
-				shortURL.SetCreatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(createdBy, 10)))
-			}
-
-			body, err := json.Marshal(shortURL)
-			if err != nil {
-				_ = rows.Close()
-				return err
-			}
-
-			req := &resourcepb.BulkRequest{
-				Key: &resourcepb.ResourceKey{
-					Namespace: opts.Namespace,
-					Group:     shorturlv1beta1.APIGroup,
-					Resource:  "shorturls",
-					Name:      uid,
-				},
-				Value:  body,
-				Action: resourcepb.BulkRequest_ADDED,
-			}
-			chunk = append(chunk, req)
+		if len(batch) == 0 {
+			opts.Progress(readCount, fmt.Sprintf("finished reading legacy short URLs from legacy short_url table in %s (%d)", readDuration, readCount))
+			opts.Progress(convertedCount, fmt.Sprintf("finished converting legacy short URLs to unified storage format in %s (%d)", convertDuration, convertedCount))
+			opts.Progress(writtenCount, fmt.Sprintf("finished writing short URLs to unified storage in %s (%d)", writeDuration, writtenCount))
+			break
+		}
+		readCount += len(batch)
+		lastID = nextLastID
+		if !hasMore {
+			opts.Progress(readCount, fmt.Sprintf("finished reading legacy short URLs from legacy short_url table in %s (%d)", readDuration, readCount))
 		}
 
-		if err = rows.Err(); err != nil {
-			_ = rows.Close()
+		convertStart := time.Now()
+		chunk, err := buildBulkRequests(batch, opts.Namespace)
+		convertDuration += time.Since(convertStart)
+		if err != nil {
 			return err
 		}
-
-		_ = rows.Close() // Close the db connection for this chunk
-
-		if len(chunk) == 0 {
-			break // No more rows found
+		convertedCount += len(chunk)
+		if !hasMore {
+			opts.Progress(convertedCount, fmt.Sprintf("finished converting legacy short URLs to unified storage format in %s (%d)", convertDuration, convertedCount))
 		}
 
+		writeStart := time.Now()
 		for _, req := range chunk {
-			count++
-
 			err = stream.Send(req)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					opts.Progress(count, fmt.Sprintf("stream EOF/cancelled. index=%d", count))
+					opts.Progress(writtenCount, fmt.Sprintf("stream EOF/cancelled. index=%d", writtenCount))
 				}
 				return err
 			}
+			writtenCount++
 		}
+		writeDuration += time.Since(writeStart)
 
-		if int64(len(chunk)) < limit {
-			// If we read less than the limit, we're at the end of the results.
+		if !hasMore {
+			opts.Progress(writtenCount, fmt.Sprintf("finished writing short URLs to unified storage in %s (%d)", writeDuration, writtenCount))
 			break
 		}
 	}
 
-	opts.Progress(-2, fmt.Sprintf("finished short URLs... (%d)", count))
+	opts.Progress(-2, fmt.Sprintf("finished short URLs... (%d)", writtenCount))
 	return nil
+}
+
+type shortURLRow struct {
+	id         int64
+	uid        string
+	path       string
+	createdBy  int64
+	createdAt  int64
+	lastSeenAt int64
+}
+
+func readShortURLBatch(rows *sql.Rows, limit int64) ([]shortURLRow, int64, bool, error) {
+	if rows == nil {
+		return nil, 0, false, nil
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	batch := make([]shortURLRow, 0, limit+1)
+	for rows.Next() {
+		var row shortURLRow
+		var orgID int64
+		if err := rows.Scan(&row.id, &orgID, &row.uid, &row.path, &row.createdBy, &row.createdAt, &row.lastSeenAt); err != nil {
+			return nil, 0, false, err
+		}
+		batch = append(batch, row)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, false, err
+	}
+	if len(batch) == 0 {
+		return nil, 0, false, nil
+	}
+	if int64(len(batch)) > limit {
+		return batch[:limit], batch[limit-1].id, true, nil
+	}
+	return batch, batch[len(batch)-1].id, false, nil
+}
+
+func buildBulkRequests(batch []shortURLRow, namespace string) ([]*resourcepb.BulkRequest, error) {
+	chunk := make([]*resourcepb.BulkRequest, 0, len(batch))
+	for _, row := range batch {
+		shortURL := &shorturlv1beta1.ShortURL{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: shorturlv1beta1.GroupVersion.String(),
+				Kind:       "ShortURL",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              row.uid,
+				Namespace:         namespace,
+				CreationTimestamp: metav1.NewTime(time.Unix(row.createdAt, 0)),
+			},
+			Spec: shorturlv1beta1.ShortURLSpec{
+				Path: row.path,
+			},
+			Status: shorturlv1beta1.ShortURLStatus{
+				LastSeenAt: row.lastSeenAt,
+			},
+		}
+
+		if row.createdBy > 0 {
+			shortURL.SetCreatedBy(claims.NewTypeID(claims.TypeUser, strconv.FormatInt(row.createdBy, 10)))
+		}
+
+		body, err := json.Marshal(shortURL)
+		if err != nil {
+			return nil, err
+		}
+
+		req := &resourcepb.BulkRequest{
+			Key: &resourcepb.ResourceKey{
+				Namespace: namespace,
+				Group:     shorturlv1beta1.APIGroup,
+				Resource:  "shorturls",
+				Name:      row.uid,
+			},
+			Value:  body,
+			Action: resourcepb.BulkRequest_ADDED,
+		}
+		chunk = append(chunk, req)
+	}
+	return chunk, nil
+}
+
+func (m *shortURLMigrator) listShortURLs(ctx context.Context, orgID int64, lastID int64, limit int64) (*sql.Rows, error) {
+	if m.listShortURLsFn != nil {
+		return m.listShortURLsFn(ctx, orgID, lastID, limit)
+	}
+	return m.ListShortURLs(ctx, orgID, lastID, limit)
 }
 
 func (m *shortURLMigrator) ListShortURLs(ctx context.Context, orgID int64, lastID int64, limit int64) (*sql.Rows, error) {

--- a/pkg/registry/apps/shorturl/migrator/migrator_test.go
+++ b/pkg/registry/apps/shorturl/migrator/migrator_test.go
@@ -1,10 +1,19 @@
 package migrator
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
 	"testing"
 	"text/template"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/migrations"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
 )
@@ -59,4 +68,131 @@ func TestShortURLQueries(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestMigrateShortURLs_ProgressTimingLogs(t *testing.T) {
+	tests := []struct {
+		name                 string
+		totalRows            int
+		expectedLastIDs      []int64
+		expectedProgressRows int
+	}{
+		{
+			name:                 "single batch",
+			totalRows:            2,
+			expectedLastIDs:      []int64{0},
+			expectedProgressRows: 2,
+		},
+		{
+			name:                 "multiple batches",
+			totalRows:            1001,
+			expectedLastIDs:      []int64{0, 1000},
+			expectedProgressRows: 1001,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = db.Close()
+			})
+
+			records := makeShortURLRows(tc.totalRows)
+			for _, lastID := range tc.expectedLastIDs {
+				query := fmt.Sprintf("SELECT %d", lastID)
+				mock.ExpectQuery(query).WillReturnRows(newShortURLSQLRows(recordsAfter(records, lastID)))
+			}
+
+			var observedLastIDs []int64
+			m := &shortURLMigrator{
+				listShortURLsFn: func(_ context.Context, orgID int64, lastID int64, limit int64) (*sql.Rows, error) {
+					require.Equal(t, int64(1), orgID)
+					require.Equal(t, int64(1001), limit)
+					observedLastIDs = append(observedLastIDs, lastID)
+					return db.Query(fmt.Sprintf("SELECT %d", lastID))
+				},
+			}
+
+			stream := &capturingBulkProcessClient{}
+			var progress []progressEvent
+			err = m.MigrateShortURLs(context.Background(), 1, migrations.MigrateOptions{
+				Namespace: "default",
+				Progress: func(count int, msg string) {
+					progress = append(progress, progressEvent{count: count, msg: msg})
+				},
+			}, stream)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedLastIDs, observedLastIDs)
+			require.Len(t, stream.requests, tc.totalRows)
+
+			require.Len(t, progress, 5)
+			require.Equal(t, -1, progress[0].count)
+			require.Equal(t, tc.expectedProgressRows, progress[1].count)
+			require.Equal(t, tc.expectedProgressRows, progress[2].count)
+			require.Equal(t, tc.expectedProgressRows, progress[3].count)
+			require.Equal(t, -2, progress[4].count)
+
+			require.Equal(t, "migrating short URLs...", progress[0].msg)
+			require.Contains(t, progress[1].msg, "finished reading legacy short URLs from legacy short_url table in ")
+			require.Contains(t, progress[2].msg, "finished converting legacy short URLs to unified storage format in ")
+			require.Contains(t, progress[3].msg, "finished writing short URLs to unified storage in ")
+			require.Equal(t, fmt.Sprintf("finished short URLs... (%d)", tc.totalRows), progress[4].msg)
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+type progressEvent struct {
+	count int
+	msg   string
+}
+
+type capturingBulkProcessClient struct {
+	grpc.ClientStream
+	requests []*resourcepb.BulkRequest
+}
+
+func (c *capturingBulkProcessClient) Send(req *resourcepb.BulkRequest) error {
+	c.requests = append(c.requests, req)
+	return nil
+}
+
+func (c *capturingBulkProcessClient) CloseAndRecv() (*resourcepb.BulkResponse, error) {
+	return &resourcepb.BulkResponse{}, nil
+}
+
+func makeShortURLRows(total int) []shortURLRow {
+	rows := make([]shortURLRow, 0, total)
+	for i := 1; i <= total; i++ {
+		rows = append(rows, shortURLRow{
+			id:         int64(i),
+			uid:        fmt.Sprintf("uid-%04d", i),
+			path:       fmt.Sprintf("/d/%04d", i),
+			createdBy:  42,
+			createdAt:  1710000000 + int64(i),
+			lastSeenAt: 1710001000 + int64(i),
+		})
+	}
+	return rows
+}
+
+func recordsAfter(rows []shortURLRow, lastID int64) []shortURLRow {
+	result := make([]shortURLRow, 0, len(rows))
+	for _, row := range rows {
+		if row.id > lastID {
+			result = append(result, row)
+		}
+	}
+	return result
+}
+
+func newShortURLSQLRows(rows []shortURLRow) *sqlmock.Rows {
+	sqlRows := sqlmock.NewRows([]string{"id", "org_id", "uid", "path", "created_by", "created_at", "last_seen_at"})
+	for _, row := range rows {
+		sqlRows.AddRow(row.id, int64(1), row.uid, row.path, row.createdBy, row.createdAt, row.lastSeenAt)
+	}
+	return sqlRows
 }

--- a/pkg/registry/apps/shorturl/migrator/migrator_test.go
+++ b/pkg/registry/apps/shorturl/migrator/migrator_test.go
@@ -102,14 +102,14 @@ func TestMigrateShortURLs_ProgressTimingLogs(t *testing.T) {
 			records := makeShortURLRows(tc.totalRows)
 			for _, lastID := range tc.expectedLastIDs {
 				query := fmt.Sprintf("SELECT %d", lastID)
-				mock.ExpectQuery(query).WillReturnRows(newShortURLSQLRows(recordsAfter(records, lastID)))
+				mock.ExpectQuery(query).WillReturnRows(newShortURLSQLRows(recordsAfter(records, lastID, 1000)))
 			}
 
 			var observedLastIDs []int64
 			m := &shortURLMigrator{
 				listShortURLsFn: func(_ context.Context, orgID int64, lastID int64, limit int64) (*sql.Rows, error) {
 					require.Equal(t, int64(1), orgID)
-					require.Equal(t, int64(1001), limit)
+					require.Equal(t, int64(1000), limit)
 					observedLastIDs = append(observedLastIDs, lastID)
 					return db.Query(fmt.Sprintf("SELECT %d", lastID))
 				},
@@ -164,32 +164,42 @@ func (c *capturingBulkProcessClient) CloseAndRecv() (*resourcepb.BulkResponse, e
 	return &resourcepb.BulkResponse{}, nil
 }
 
-func makeShortURLRows(total int) []shortURLRow {
-	rows := make([]shortURLRow, 0, total)
+type testShortURLRow struct {
+	id int64
+	shortURLRow
+}
+
+func makeShortURLRows(total int) []testShortURLRow {
+	rows := make([]testShortURLRow, 0, total)
 	for i := 1; i <= total; i++ {
-		rows = append(rows, shortURLRow{
-			id:         int64(i),
-			uid:        fmt.Sprintf("uid-%04d", i),
-			path:       fmt.Sprintf("/d/%04d", i),
-			createdBy:  42,
-			createdAt:  1710000000 + int64(i),
-			lastSeenAt: 1710001000 + int64(i),
+		rows = append(rows, testShortURLRow{
+			id: int64(i),
+			shortURLRow: shortURLRow{
+				uid:        fmt.Sprintf("uid-%04d", i),
+				path:       fmt.Sprintf("/d/%04d", i),
+				createdBy:  42,
+				createdAt:  1710000000 + int64(i),
+				lastSeenAt: 1710001000 + int64(i),
+			},
 		})
 	}
 	return rows
 }
 
-func recordsAfter(rows []shortURLRow, lastID int64) []shortURLRow {
-	result := make([]shortURLRow, 0, len(rows))
+func recordsAfter(rows []testShortURLRow, lastID int64, limit int) []testShortURLRow {
+	result := make([]testShortURLRow, 0, len(rows))
 	for _, row := range rows {
 		if row.id > lastID {
 			result = append(result, row)
+		}
+		if len(result) == limit {
+			break
 		}
 	}
 	return result
 }
 
-func newShortURLSQLRows(rows []shortURLRow) *sqlmock.Rows {
+func newShortURLSQLRows(rows []testShortURLRow) *sqlmock.Rows {
 	sqlRows := sqlmock.NewRows([]string{"id", "org_id", "uid", "path", "created_by", "created_at", "last_seen_at"})
 	for _, row := range rows {
 		sqlRows.AddRow(row.id, int64(1), row.uid, row.path, row.createdBy, row.createdAt, row.lastSeenAt)


### PR DESCRIPTION
Short URL unified storage migration currently logs overall progress, but not how long the legacy read, conversion, and bulk write phases take. This change adds explicit timing log lines for each phase so we can see where time is spent while the migration holds the legacy `short_url` table lock. The migrator now reads one extra row per batch so it can detect the final batch cleanly and emit each phase-complete log exactly once, and the test covers both single-batch and multi-batch runs.

## Testing
- `go test ./pkg/registry/apps/shorturl/migrator`