### PR TITLE
Stars: Use StarToolbarButton in legacy DashNav and remove dead star code

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -896,26 +896,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     this.setState({ overlay: undefined });
   }
 
-  public async onStarDashboard(isStarred?: boolean) {
-    const { meta, uid } = this.state;
-    isStarred = isStarred ?? Boolean(meta.isStarred);
-    if (!uid) {
-      return;
-    }
-    try {
-      const result = await getDashboardSrv().starDashboard(uid, isStarred);
-
-      this.setState({
-        meta: {
-          ...meta,
-          isStarred: result,
-        },
-      });
-    } catch (err) {
-      console.error('Failed to star dashboard', err);
-    }
-  }
-
   public onOpenSettings = () => {
     locationService.partial({ editview: 'settings' });
   };

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationService, reportInteraction } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import {
   ButtonGroup,
   ModalsController,
@@ -20,16 +20,14 @@ import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/Na
 import config from 'app/core/config';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { useBusEvent } from 'app/core/hooks/useBusEvent';
-import { ID_PREFIX, setStarred } from 'app/core/reducers/navBarTree';
-import { removeNavIndex, updateNavIndex } from 'app/core/reducers/navModel';
 import AddPanelButton from 'app/features/dashboard/components/AddPanelButton/AddPanelButton';
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
-import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PublicDashboardBadgeLegacy } from 'app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
+import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 import { KioskMode } from 'app/types/dashboard';
 import { DashboardMetaChangedEvent, ShowModalReactEvent } from 'app/types/events';
 import { StoreState } from 'app/types/store';
@@ -45,15 +43,10 @@ import { DashNavTimeControls } from './DashNavTimeControls';
 import { ShareButton } from './ShareButton';
 
 const mapDispatchToProps = {
-  removeNavIndex,
-  setStarred,
   updateTimeZoneForSession,
-  updateNavIndex,
 };
 
-const mapStateToProps = (state: StoreState) => ({
-  navIndex: state.navIndex,
-});
+const mapStateToProps = (_state: StoreState) => ({});
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
@@ -127,38 +120,6 @@ export const DashNav = memo<Props>((props) => {
     }
   };
 
-  const onStarDashboard = () => {
-    DashboardInteractions.toolbarFavoritesClick();
-    const dashboardSrv = getDashboardSrv();
-    const { dashboard, navIndex, removeNavIndex, setStarred, updateNavIndex } = props;
-
-    dashboardSrv.starDashboard(dashboard.uid, Boolean(dashboard.meta.isStarred)).then((newState) => {
-      setStarred({ id: dashboard.uid, title: dashboard.title, url: dashboard.meta.url ?? '', isStarred: newState });
-      const starredNavItem = navIndex['starred'];
-      if (newState) {
-        starredNavItem.children?.push({
-          id: ID_PREFIX + dashboard.uid,
-          text: dashboard.title,
-          url: dashboard.meta.url ?? '',
-          parentItem: starredNavItem,
-        });
-        reportInteraction('grafana_dashboards_star_dashboard', {
-          origin: 'dashnav',
-          status: newState ? 'starred' : 'unstarred',
-        });
-      } else {
-        removeNavIndex(ID_PREFIX + dashboard.uid);
-        const indexToRemove = starredNavItem.children?.findIndex((element) => element.id === ID_PREFIX + dashboard.uid);
-        if (indexToRemove) {
-          starredNavItem.children?.splice(indexToRemove, 1);
-        }
-      }
-      updateNavIndex(starredNavItem);
-      dashboard.meta.isStarred = newState;
-      forceUpdate();
-    });
-  };
-
   const onOpenSettings = () => {
     DashboardInteractions.toolbarSettingsClick();
     locationService.partial({ editview: 'settings' });
@@ -193,25 +154,21 @@ export const DashNav = memo<Props>((props) => {
     const isDevEnv = config.buildInfo.env === 'development';
 
     const { dashboard, kioskMode } = props;
-    const { canStar, isStarred } = dashboard.meta;
+    const { canStar } = dashboard.meta;
     const buttons: ReactNode[] = [];
 
     if (kioskMode || isPlaylistRunning()) {
       return [];
     }
 
-    if (canStar) {
-      let desc = isStarred
-        ? t('dashboard.toolbar.unmark-favorite', 'Unmark as favorite')
-        : t('dashboard.toolbar.mark-favorite', 'Mark as favorite');
+    if (canStar && dashboard.uid) {
       buttons.push(
-        <DashNavButton
-          tooltip={desc}
-          icon={isStarred ? 'favorite' : 'star'}
-          iconType={isStarred ? 'mono' : 'default'}
-          iconSize="lg"
-          onClick={onStarDashboard}
+        <StarToolbarButton
           key="button-star"
+          group="dashboard.grafana.app"
+          kind="Dashboard"
+          title={dashboard.title}
+          id={dashboard.uid}
         />
       );
     }

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -30,7 +30,6 @@ import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 import { KioskMode } from 'app/types/dashboard';
 import { DashboardMetaChangedEvent, ShowModalReactEvent } from 'app/types/events';
-import { StoreState } from 'app/types/store';
 
 import {
   DynamicDashNavButtonModel,
@@ -46,9 +45,7 @@ const mapDispatchToProps = {
   updateTimeZoneForSession,
 };
 
-const mapStateToProps = (_state: StoreState) => ({});
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
+const connector = connect(null, mapDispatchToProps);
 
 export interface OwnProps {
   dashboard: DashboardModel;

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -158,6 +158,7 @@ export const DashNav = memo<Props>((props) => {
       return [];
     }
 
+    // uid check narrows the type for StarToolbarButton's required `id` prop
     if (canStar && dashboard.uid) {
       buttons.push(
         <StarToolbarButton

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -1,9 +1,7 @@
-import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { BackendSrvRequest } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
-import { getBackendSrv } from 'app/core/services/backend_srv';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardMeta } from 'app/types/dashboard';
 
@@ -70,32 +68,6 @@ export class DashboardSrv {
       folderUid: data.folderUid,
       dashboard: data.dashboard.getSaveModelClone(),
       showErrorAlert: requestOptions?.showErrorAlert,
-    });
-  }
-
-  starDashboard(dashboardUid: string, isStarred: boolean) {
-    const backendSrv = getBackendSrv();
-
-    const request = {
-      showSuccessAlert: false,
-      url: '/api/user/stars/dashboard/uid/' + dashboardUid,
-      method: isStarred ? 'DELETE' : 'POST',
-    };
-
-    return backendSrv.request(request).then(() => {
-      const newIsStarred = !isStarred;
-
-      if (this.dashboard?.uid === dashboardUid) {
-        this.dashboard.meta.isStarred = newIsStarred;
-      }
-
-      const message = newIsStarred
-        ? t('notifications.starred-dashboard', 'Dashboard starred')
-        : t('notifications.unstarred-dashboard', 'Dashboard unstarred');
-
-      appEvents.emit(AppEvents.alertSuccess, [message]);
-
-      return newIsStarred;
     });
   }
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6323,7 +6323,6 @@
         "label": "Exit edit",
         "tooltip": "Exits edit mode and discards unsaved changes"
       },
-      "mark-favorite": "Mark as favorite",
       "more-save-options": "More save options",
       "new": {
         "back-to-dashboard": "Back to dashboard",
@@ -6393,8 +6392,7 @@
       "star-added": "Added to starred",
       "star-remove-error": "Failed to remove from starred",
       "star-removed": "Removed from starred",
-      "unlink-library-panel": "Unlink library panel",
-      "unmark-favorite": "Unmark as favorite"
+      "unlink-library-panel": "Unlink library panel"
     },
     "transformation-editor": {
       "input-data": "Input data",
@@ -12213,12 +12211,10 @@
       "description": "Notifications you have received will appear here",
       "title": "You're all caught up!"
     },
-    "starred-dashboard": "Dashboard starred",
     "stored-notifications": {
       "dismiss-notifications": "Dismiss notifications",
       "title-alert": "This page displays past errors and warnings. Once dismissed, they cannot be retrieved."
-    },
-    "unstarred-dashboard": "Dashboard unstarred"
+    }
   },
   "oauth": {
     "form": {


### PR DESCRIPTION
**What is this feature?**

Replaces the star button in the legacy `DashNav` with the shared `StarToolbarButton` component (already used by the scene path), and removes dead star-related code from `DashboardScene` and `DashboardSrv`.

**Why do we need this feature?**

When `kubernetesDashboards` is enabled, the K8s DTO endpoint does not return `isStarred` in `DashboardAccess`, so `meta.isStarred` is always `undefined`. This caused the legacy `DashNav` star button to always show "Mark as favorite" even for already-starred dashboards. `StarToolbarButton` queries star state independently via `useStarredItems()`, so it works correctly regardless of how the dashboard was loaded.

