### PR TITLE
Dashboard search: accept singular and plural type filters

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
@@ -671,8 +671,8 @@ export type SearchDashboardsAndFoldersApiResponse = /** status 200 undefined */ 
 export type SearchDashboardsAndFoldersApiArg = {
   /** user query string */
   query?: string;
-  /** search dashboards or folders.  When empty, this will search both */
-  type?: 'folder' | 'dashboard';
+  /** search dashboards or folders.  When empty, this will search both. Supports singular and plural resource names. */
+  type?: 'folder' | 'folders' | 'dashboard' | 'dashboards';
   /** search/list within a folder (not recursive) */
   folder?: string;
   /** count distinct terms for selected fields */

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
@@ -1525,10 +1525,10 @@
           {
             "name": "type",
             "in": "query",
-            "description": "search dashboards or folders.  When empty, this will search both",
+            "description": "search dashboards or folders.  When empty, this will search both. Supports singular and plural resource names.",
             "schema": {
               "type": "string",
-              "enum": ["folder", "dashboard"]
+              "enum": ["folder", "folders", "dashboard", "dashboards"]
             }
           },
           {

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -92,9 +92,9 @@ func (s *SearchHandler) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) *
 									ParameterProps: spec3.ParameterProps{
 										Name:        "type",
 										In:          "query",
-										Description: "search dashboards or folders.  When empty, this will search both",
+										Description: "search dashboards or folders.  When empty, this will search both. Supports singular and plural resource names.",
 										Required:    false,
-										Schema:      spec.StringProperty().WithEnum("folder", "dashboard"),
+										Schema:      spec.StringProperty().WithEnum("folder", "folders", "dashboard", "dashboards"),
 									},
 								},
 								{
@@ -477,7 +477,7 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 	}
 
 	// A search request can include multiple types, we need to acces the slice directly.
-	types := queryParams["type"]
+	types := normalizeSearchTypes(queryParams["type"])
 	hasDash := len(types) == 0 || slices.Contains(types, "dashboard")
 	hasFolder := len(types) == 0 || slices.Contains(types, "folder")
 	// If both types are present, we need to search both dashboards and folders, by default is nothing is set we also search both.
@@ -646,6 +646,25 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		})
 	}
 	return searchRequest, nil
+}
+
+func normalizeSearchTypes(types []string) []string {
+	if len(types) == 0 {
+		return types
+	}
+
+	normalized := make([]string, 0, len(types))
+	for _, t := range types {
+		switch t {
+		case "dashboards":
+			t = "dashboard"
+		case "folders":
+			t = "folder"
+		}
+		normalized = append(normalized, t)
+	}
+
+	return normalized
 }
 
 func (s *SearchHandler) write(w http.ResponseWriter, obj any) {

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -900,6 +900,18 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Fields:  defaultFields,
 			},
 		},
+		"type dashboards only": {
+			queryString: "type=dashboards",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{Key: dashboardKey},
+				Query:   "",
+				Limit:   50,
+				Offset:  0,
+				Page:    1,
+				Explain: false,
+				Fields:  defaultFields,
+			},
+		},
 		"type folder only": {
 			queryString: "type=folder",
 			expected: &resourcepb.ResourceSearchRequest{
@@ -912,8 +924,33 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Fields:  defaultFields,
 			},
 		},
+		"type folders only": {
+			queryString: "type=folders",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{Key: folderKey},
+				Query:   "",
+				Limit:   50,
+				Offset:  0,
+				Page:    1,
+				Explain: false,
+				Fields:  defaultFields,
+			},
+		},
 		"both types should include federated": {
 			queryString: "type=dashboard&type=folder",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options:   &resourcepb.ListOptions{Key: dashboardKey},
+				Query:     "",
+				Limit:     50,
+				Offset:    0,
+				Page:      1,
+				Explain:   false,
+				Fields:    defaultFields,
+				Federated: []*resourcepb.ResourceKey{folderKey},
+			},
+		},
+		"both plural types should include federated": {
+			queryString: "type=dashboards&type=folders",
 			expected: &resourcepb.ResourceSearchRequest{
 				Options:   &resourcepb.ListOptions{Key: dashboardKey},
 				Query:     "",

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -1619,12 +1619,14 @@
           {
             "name": "type",
             "in": "query",
-            "description": "search dashboards or folders.  When empty, this will search both",
+            "description": "search dashboards or folders.  When empty, this will search both. Supports singular and plural resource names.",
             "schema": {
               "type": "string",
               "enum": [
                 "folder",
-                "dashboard"
+                "folders",
+                "dashboard",
+                "dashboards"
               ]
             }
           },


### PR DESCRIPTION
Dashboard search currently accepts `type=folder` and `type=dashboard`, but the search results themselves expose plural resource names like `folders`. This change makes the `type` query param accept both singular kind names and plural resource names so callers can migrate gradually without changing search behavior. The OpenAPI schema and generated RTK Query type are updated with the same aliases so the API contract stays consistent end to end.

## Testing
- `go test ./pkg/registry/apis/dashboard -run TestConvertHttpSearchRequestToResourceSearchRequest`