### PR TITLE
Provisioning: Add MockGrafanaLiveSrv for watch stream testing and fix useCallback stability

### DIFF
--- a/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
@@ -95,6 +95,9 @@ const createRepositoryJobsHandler = () =>
     HttpResponse.json({ spec: { action: 'pull' }, status: { state: 'success' } })
   );
 
+const listJobsHandler = () =>
+  http.get(`${BASE}/jobs`, () => HttpResponse.json({ items: [], metadata: { resourceVersion: '1' } }));
+
 const createConnectionHandler = (response = defaultConnection) =>
   http.post(`${BASE}/connections`, () => HttpResponse.json(response));
 
@@ -127,6 +130,7 @@ const handlers = [
   replaceRepositoryHandler(),
   testRepositoryHandler(),
   createRepositoryJobsHandler(),
+  listJobsHandler(),
   createConnectionHandler(),
   replaceConnectionHandler(),
   listConnectionsHandler(),

--- a/public/app/features/provisioning/Job/JobStatus.test.tsx
+++ b/public/app/features/provisioning/Job/JobStatus.test.tsx
@@ -14,40 +14,46 @@ setupProvisioningMswServer();
 const repositoryName = 'test-repo-abc123';
 const repositoryLabel = { 'provisioning.grafana.app/repository': repositoryName };
 
-function createJob(overrides: Partial<Job> = {}): Job {
-  const metadata = {
-    name: 'job-1',
-    uid: 'uid-1',
-    ...overrides.metadata,
-    labels: {
-      ...repositoryLabel,
-      ...overrides.metadata?.labels,
-    },
-  };
-  const spec = {
-    action: 'pull',
-    ...overrides.spec,
-  };
-  const status = {
-    state: 'working',
-    message: 'Pulling...',
-    progress: 30,
-    ...overrides.status,
-  };
+function createJob(overrides: Record<string, unknown> = {}): Job {
+  const {
+    metadata: metadataOverrides,
+    spec: specOverrides,
+    status: statusOverrides,
+    ...rest
+  } = overrides as Partial<Job>;
 
   return {
-    ...overrides,
-    metadata,
-    spec,
-    status,
-  };
+    ...rest,
+    metadata: {
+      name: 'job-1',
+      uid: 'uid-1',
+      ...metadataOverrides,
+      labels: {
+        ...repositoryLabel,
+        ...metadataOverrides?.labels,
+      },
+    },
+    spec: {
+      action: 'pull' as const,
+      ...specOverrides,
+    },
+    status: {
+      state: 'working' as const,
+      message: 'Pulling...',
+      progress: 30,
+      ...statusOverrides,
+    },
+  } as Job;
 }
 
-function createRepository(overrides: Partial<Repository> = {}): Repository {
+function createRepository(overrides: Record<string, unknown> = {}): Repository {
+  const { metadata: metadataOverrides, spec: specOverrides, ...rest } = overrides as Partial<Repository>;
+
   return {
+    ...rest,
     metadata: {
       name: repositoryName,
-      ...overrides.metadata,
+      ...metadataOverrides,
     },
     spec: {
       title: 'Test Repository',
@@ -58,10 +64,9 @@ function createRepository(overrides: Partial<Repository> = {}): Repository {
         url: 'https://github.com/test/repo',
         branch: 'main',
       },
-      ...overrides.spec,
+      ...specOverrides,
     },
-    ...overrides,
-  };
+  } as Repository;
 }
 
 function mockJobList(job: Job) {

--- a/public/app/features/provisioning/Job/JobStatus.test.tsx
+++ b/public/app/features/provisioning/Job/JobStatus.test.tsx
@@ -5,69 +5,12 @@ import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 import server from '@grafana/test-utils/server';
 import { Job, Repository } from 'app/api/clients/provisioning/v0alpha1';
 
+import { createJob, createRepository } from '../mocks/factories';
 import { getMockLiveSrv, setupProvisioningMswServer } from '../mocks/server';
 
 import { JobStatus } from './JobStatus';
 
 setupProvisioningMswServer();
-
-const repositoryName = 'test-repo-abc123';
-const repositoryLabel = { 'provisioning.grafana.app/repository': repositoryName };
-
-function createJob(overrides: Record<string, unknown> = {}): Job {
-  const {
-    metadata: metadataOverrides,
-    spec: specOverrides,
-    status: statusOverrides,
-    ...rest
-  } = overrides as Partial<Job>;
-
-  return {
-    ...rest,
-    metadata: {
-      name: 'job-1',
-      uid: 'uid-1',
-      ...metadataOverrides,
-      labels: {
-        ...repositoryLabel,
-        ...metadataOverrides?.labels,
-      },
-    },
-    spec: {
-      action: 'pull' as const,
-      ...specOverrides,
-    },
-    status: {
-      state: 'working' as const,
-      message: 'Pulling...',
-      progress: 30,
-      ...statusOverrides,
-    },
-  } as Job;
-}
-
-function createRepository(overrides: Record<string, unknown> = {}): Repository {
-  const { metadata: metadataOverrides, spec: specOverrides, ...rest } = overrides as Partial<Repository>;
-
-  return {
-    ...rest,
-    metadata: {
-      name: repositoryName,
-      ...metadataOverrides,
-    },
-    spec: {
-      title: 'Test Repository',
-      type: 'github',
-      sync: { target: 'folder', enabled: true },
-      workflows: [],
-      github: {
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-      },
-      ...specOverrides,
-    },
-  } as Repository;
-}
 
 function mockJobList(job: Job) {
   server.use(

--- a/public/app/features/provisioning/Job/JobStatus.test.tsx
+++ b/public/app/features/provisioning/Job/JobStatus.test.tsx
@@ -1,0 +1,215 @@
+import { HttpResponse, http } from 'msw';
+import { act, render, screen, waitFor } from 'test/test-utils';
+
+import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
+import server from '@grafana/test-utils/server';
+import { Job, Repository } from 'app/api/clients/provisioning/v0alpha1';
+
+import { getMockLiveSrv, setupProvisioningMswServer } from '../mocks/server';
+
+import { JobStatus } from './JobStatus';
+
+setupProvisioningMswServer();
+
+const repositoryName = 'test-repo-abc123';
+const repositoryLabel = { 'provisioning.grafana.app/repository': repositoryName };
+
+function createJob(overrides: Partial<Job> = {}): Job {
+  const metadata = {
+    name: 'job-1',
+    uid: 'uid-1',
+    ...overrides.metadata,
+    labels: {
+      ...repositoryLabel,
+      ...overrides.metadata?.labels,
+    },
+  };
+  const spec = {
+    action: 'pull',
+    ...overrides.spec,
+  };
+  const status = {
+    state: 'working',
+    message: 'Pulling...',
+    progress: 30,
+    ...overrides.status,
+  };
+
+  return {
+    ...overrides,
+    metadata,
+    spec,
+    status,
+  };
+}
+
+function createRepository(overrides: Partial<Repository> = {}): Repository {
+  return {
+    metadata: {
+      name: repositoryName,
+      ...overrides.metadata,
+    },
+    spec: {
+      title: 'Test Repository',
+      type: 'github',
+      sync: { target: 'folder', enabled: true },
+      workflows: [],
+      github: {
+        url: 'https://github.com/test/repo',
+        branch: 'main',
+      },
+      ...overrides.spec,
+    },
+    ...overrides,
+  };
+}
+
+function mockJobList(job: Job) {
+  server.use(
+    http.get(`${BASE}/jobs`, () =>
+      HttpResponse.json({
+        items: [job],
+        metadata: { resourceVersion: '1' },
+      })
+    )
+  );
+}
+
+function mockRepositoryLookup(repository: Repository = createRepository()) {
+  server.use(http.get(`${BASE}/repositories/:name`, () => HttpResponse.json(repository)));
+}
+
+function setupComponent(options?: { watch?: Job; onStatusChange?: jest.Mock }) {
+  const watch = options?.watch ?? createJob({ status: { state: 'pending' } });
+  const onStatusChange = options?.onStatusChange;
+
+  return render(<JobStatus watch={watch} jobType="sync" onStatusChange={onStatusChange} />);
+}
+
+describe('JobStatus', () => {
+  it('shows working progress while the job is running', async () => {
+    mockJobList(createJob());
+
+    setupComponent();
+
+    expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Progress Bar' })).toHaveAttribute('aria-valuenow', '30');
+  });
+
+  it('updates the UI when a watch event transitions the job to success', async () => {
+    const workingJob = createJob();
+    const successJob = createJob({
+      status: {
+        state: 'success',
+      },
+    });
+
+    mockJobList(workingJob);
+    mockRepositoryLookup();
+
+    setupComponent();
+
+    expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+
+    act(() => {
+      getMockLiveSrv().emitWatchEvent('jobs', { type: 'MODIFIED', object: successJob });
+    });
+
+    expect(await screen.findByText(/Your resources are now in your external storage/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View repository' })).toHaveAttribute(
+      'href',
+      'https://github.com/test/repo/tree/main'
+    );
+  });
+
+  it('calls onStatusChange when a watch event transitions the job to error', async () => {
+    const onStatusChange = jest.fn();
+    const workingJob = createJob();
+    const errorJob = createJob({
+      status: {
+        state: 'error',
+        message: 'Sync failed',
+      },
+    });
+
+    mockJobList(workingJob);
+
+    setupComponent({ onStatusChange });
+
+    expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+
+    act(() => {
+      getMockLiveSrv().emitWatchEvent('jobs', { type: 'MODIFIED', object: errorJob });
+    });
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({
+        status: 'error',
+        error: {
+          title: 'Error running job',
+          message: ['Sync failed'],
+        },
+        warning: undefined,
+        action: undefined,
+      });
+    });
+  });
+
+  it('calls onStatusChange for running and success state transitions', async () => {
+    const onStatusChange = jest.fn();
+    const workingJob = createJob();
+    const successJob = createJob({
+      status: {
+        state: 'success',
+      },
+    });
+
+    mockJobList(workingJob);
+    mockRepositoryLookup();
+
+    setupComponent({ onStatusChange });
+
+    expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({ status: 'running' });
+    });
+
+    act(() => {
+      getMockLiveSrv().emitWatchEvent('jobs', { type: 'MODIFIED', object: successJob });
+    });
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({ status: 'success' });
+    });
+  });
+
+  it('handles watch stream errors by marking the cached job as failed', async () => {
+    const onStatusChange = jest.fn();
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockJobList(createJob());
+
+    setupComponent({ onStatusChange });
+
+    expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+
+    act(() => {
+      getMockLiveSrv().emitWatchError('jobs', new Error('connection lost'));
+    });
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith({
+        status: 'error',
+        error: {
+          title: 'Error running job',
+          message: ['Error: connection lost'],
+        },
+        warning: undefined,
+        action: undefined,
+      });
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -3,13 +3,14 @@ import { screen } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
 import type { JSX } from 'react';
-import { render } from 'test/test-utils';
+import { act, render, waitFor } from 'test/test-utils';
 
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 import server from '@grafana/test-utils/server';
+import { Job, Repository } from 'app/api/clients/provisioning/v0alpha1';
 
 import { useCreateOrUpdateRepository } from '../hooks/useCreateOrUpdateRepository';
-import { setupProvisioningMswServer } from '../mocks/server';
+import { getMockLiveSrv, setupProvisioningMswServer } from '../mocks/server';
 
 import { ProvisioningWizard } from './ProvisioningWizard';
 import { StepStatusProvider } from './StepStatusContext';
@@ -169,6 +170,133 @@ function setupMockSubmitData() {
   return mockSubmitData;
 }
 
+const syncRepositoryName = 'test-repo-abc123';
+const syncRepositoryLabel = { 'provisioning.grafana.app/repository': syncRepositoryName };
+
+function createSyncJob(overrides: Partial<Job> = {}): Job {
+  const { metadata: metadataOverrides, spec: specOverrides, status: statusOverrides, ...rest } = overrides;
+  const metadata = {
+    name: 'sync-job-1',
+    uid: 'uid-1',
+    ...metadataOverrides,
+    labels: {
+      ...syncRepositoryLabel,
+      ...metadataOverrides?.labels,
+    },
+  };
+  const spec = {
+    action: 'pull',
+    ...specOverrides,
+  };
+  const status = {
+    state: 'pending',
+    ...statusOverrides,
+  };
+
+  return {
+    ...rest,
+    metadata,
+    spec,
+    status,
+  };
+}
+
+function createSyncRepository(overrides: Partial<Repository> = {}): Repository {
+  const { metadata: metadataOverrides, spec: specOverrides, status: statusOverrides, ...rest } = overrides;
+
+  return {
+    ...rest,
+    metadata: {
+      name: syncRepositoryName,
+      generation: 1,
+      ...metadataOverrides,
+    },
+    spec: {
+      title: 'Test Repository',
+      type: 'github',
+      sync: { target: 'folder', enabled: true },
+      workflows: [],
+      github: {
+        url: 'https://github.com/test/repo',
+        branch: 'main',
+      },
+      ...specOverrides,
+    },
+    status: {
+      observedGeneration: 1,
+      health: {
+        healthy: true,
+        checked: 1704067200000,
+        message: [],
+      },
+      ...statusOverrides,
+    },
+  };
+}
+
+function enableSynchronizationStep() {
+  server.use(
+    http.get(`${BASE}/stats`, () => HttpResponse.json({ instance: [{ group: 'dashboard.grafana.app', count: 1 }] })),
+    http.get(`${BASE}/repositories/:name/files/`, () =>
+      HttpResponse.json({ items: [{ name: 'test.json', path: 'test.json' }] })
+    )
+  );
+}
+
+function mockRepositoryList(repository: Repository = createSyncRepository()) {
+  server.use(
+    http.get(`${BASE}/repositories`, () =>
+      HttpResponse.json({
+        items: [repository],
+        metadata: { resourceVersion: '1' },
+      })
+    )
+  );
+}
+
+function mockSyncRepositoryLookup(repository: Repository = createSyncRepository()) {
+  server.use(http.get(`${BASE}/repositories/:name`, () => HttpResponse.json(repository)));
+}
+
+async function navigateToBootstrapStep(user: UserEvent) {
+  enableSynchronizationStep();
+
+  await fillConnectionForm(user, 'github', {
+    token: 'test-token',
+    url: 'https://github.com/test/repo',
+    branch: 'main',
+  });
+
+  await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
+  expect(await screen.findByRole('heading', { name: /3\. Choose what to synchronize/i })).toBeInTheDocument();
+}
+
+async function navigateToSynchronizationStep(user: UserEvent) {
+  await navigateToBootstrapStep(user);
+  await user.click(screen.getByRole('button', { name: /Synchronize with external storage/i }));
+  expect(await screen.findByRole('heading', { name: /4\. Synchronize with external storage/i })).toBeInTheDocument();
+}
+
+function setupWorkingJobHandlers() {
+  const createdJob = createSyncJob();
+  const workingJob = createSyncJob({
+    status: { state: 'working', message: 'Pulling...', progress: 30 },
+  });
+  server.use(
+    http.post(`${BASE}/repositories/:name/jobs`, () => HttpResponse.json(createdJob)),
+    http.get(`${BASE}/jobs`, () => HttpResponse.json({ items: [workingJob], metadata: { resourceVersion: '1' } }))
+  );
+  return { createdJob, workingJob };
+}
+
+async function beginSynchronization(user: UserEvent) {
+  await navigateToSynchronizationStep(user);
+  const finishButton = screen.getByRole('button', { name: /Choose additional settings/i });
+  await user.click(screen.getByRole('button', { name: /Begin synchronization/i }));
+  expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+  return { finishButton };
+}
+
 describe('ProvisioningWizard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -207,38 +335,6 @@ describe('ProvisioningWizard', () => {
 
       // Verify connection step
       expect(await screen.findByRole('heading', { name: /Configure repository/i })).toBeInTheDocument();
-    });
-
-    it('should progress through first 3 steps successfully', async () => {
-      // Override stats and files for this test via MSW
-      server.use(
-        http.get(`${BASE}/stats`, () =>
-          HttpResponse.json({ instance: [{ group: 'dashboard.grafana.app', count: 1 }] })
-        ),
-        http.get(`${BASE}/repositories/:name/files/`, () =>
-          HttpResponse.json({ items: [{ name: 'test.json', path: 'test.json' }] })
-        )
-      );
-
-      const { user } = setup(<ProvisioningWizard type="github" />);
-
-      await fillConnectionForm(user, 'github', {
-        token: 'test-token',
-        url: 'https://github.com/test/repo',
-      });
-
-      await user.click(screen.getByRole('button', { name: /Choose what to synchronize/i }));
-
-      expect(await screen.findByRole('heading', { name: /3\. Choose what to synchronize/i })).toBeInTheDocument();
-
-      expect(mockUseCreateOrUpdateRepository).toHaveBeenCalled();
-
-      await user.click(screen.getByRole('button', { name: /Synchronize with external storage/i }));
-
-      expect(
-        await screen.findByRole('heading', { name: /4\. Synchronize with external storage/i })
-      ).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Begin synchronization/i })).toBeInTheDocument();
     });
 
     it('should skip sync step when there are no resources', async () => {
@@ -391,6 +487,277 @@ describe('ProvisioningWizard', () => {
       // Should still be on connection step due to validation
       expect(screen.getByRole('heading', { name: /2\. Configure repository/i })).toBeInTheDocument();
       expect(screen.getByText(/Branch is required/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Repository Reconciliation', () => {
+    it('shows loading while waiting for reconciliation, then shows bootstrap content after a healthy watch event', async () => {
+      mockRepositoryList(
+        createSyncRepository({
+          status: {
+            observedGeneration: undefined,
+          },
+        })
+      );
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+
+      await navigateToBootstrapStep(user);
+
+      expect(screen.getByText('Loading resource information...')).toBeInTheDocument();
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('repositories', {
+          type: 'MODIFIED',
+          object: createSyncRepository(),
+        });
+      });
+
+      expect(await screen.findByText('Sync external storage to a new Grafana folder')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('Loading resource information...')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows an unhealthy repository error and clears it after retry plus a healthy watch event', async () => {
+      mockRepositoryList(
+        createSyncRepository({
+          status: {
+            observedGeneration: 1,
+            health: {
+              healthy: false,
+              checked: 1704067200000,
+              message: ['Connection failed'],
+            },
+          },
+        })
+      );
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+
+      await navigateToBootstrapStep(user);
+
+      expect(await screen.findByText('Repository status unhealthy')).toBeInTheDocument();
+
+      // Retry is rendered via Alert's buttonContent/onRemove, not as a standard named button
+      const retryButton = (await screen.findByText('Retry')).closest('button');
+      expect(retryButton).not.toBeNull();
+      await user.click(retryButton!);
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('repositories', {
+          type: 'MODIFIED',
+          object: createSyncRepository(),
+        });
+      });
+
+      expect(await screen.findByText('Sync external storage to a new Grafana folder')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('Repository status unhealthy')).not.toBeInTheDocument();
+      });
+    });
+
+    it('transitions from loading to unhealthy to healthy as repository watch events arrive', async () => {
+      mockRepositoryList(
+        createSyncRepository({
+          status: {
+            observedGeneration: undefined,
+          },
+        })
+      );
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+
+      await navigateToBootstrapStep(user);
+
+      expect(screen.getByText('Loading resource information...')).toBeInTheDocument();
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('repositories', {
+          type: 'MODIFIED',
+          object: createSyncRepository({
+            status: {
+              observedGeneration: 1,
+              health: {
+                healthy: false,
+                checked: 1704067200000,
+                message: ['Connection failed'],
+              },
+            },
+          }),
+        });
+      });
+
+      expect(await screen.findByText('Repository status unhealthy')).toBeInTheDocument();
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('repositories', {
+          type: 'MODIFIED',
+          object: createSyncRepository(),
+        });
+      });
+
+      expect(await screen.findByText('Sync external storage to a new Grafana folder')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText('Repository status unhealthy')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Synchronization Step', () => {
+    it('enables the finish button after the sync job succeeds via a watch event', async () => {
+      setupWorkingJobHandlers();
+      mockSyncRepositoryLookup();
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+      const { finishButton } = await beginSynchronization(user);
+      expect(finishButton).toBeDisabled();
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('jobs', {
+          type: 'MODIFIED',
+          object: createSyncJob({ status: { state: 'success' } }),
+        });
+      });
+
+      await waitFor(() => {
+        expect(finishButton).toBeEnabled();
+      });
+      expect(await screen.findByText(/Your resources are now in your external storage/i)).toBeInTheDocument();
+    });
+
+    it('enables the finish button and shows a warning alert when the sync job completes with warnings', async () => {
+      setupWorkingJobHandlers();
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+      const { finishButton } = await beginSynchronization(user);
+      expect(finishButton).toBeDisabled();
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('jobs', {
+          type: 'MODIFIED',
+          object: createSyncJob({ status: { state: 'warning', message: 'Completed with warnings' } }),
+        });
+      });
+
+      await waitFor(() => {
+        expect(finishButton).toBeEnabled();
+      });
+      expect(await screen.findByText('Job completed with warnings')).toBeInTheDocument();
+      expect(screen.getByText('Completed with warnings')).toBeInTheDocument();
+    });
+
+    it('shows an error alert and keeps the finish button disabled when the sync job fails', async () => {
+      setupWorkingJobHandlers();
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+      const { finishButton } = await beginSynchronization(user);
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('jobs', {
+          type: 'MODIFIED',
+          object: createSyncJob({ status: { state: 'error', message: 'Sync failed' } }),
+        });
+      });
+
+      expect(await screen.findByText('Error running job')).toBeInTheDocument();
+      expect(finishButton).toBeDisabled();
+    });
+
+    it('shows an error alert and keeps the finish button disabled when the jobs watch stream errors', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        setupWorkingJobHandlers();
+
+        const { user } = setup(<ProvisioningWizard type="github" />);
+        const { finishButton } = await beginSynchronization(user);
+
+        act(() => {
+          getMockLiveSrv().emitWatchError('jobs', new Error('connection lost'));
+        });
+
+        expect(await screen.findByText('Error running job')).toBeInTheDocument();
+        expect(screen.getByText('Error: connection lost')).toBeInTheDocument();
+        expect(finishButton).toBeDisabled();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
+    it('creates a new sync job when retry is clicked after a job error', async () => {
+      const createdJobs = [
+        createSyncJob(),
+        createSyncJob({
+          metadata: {
+            name: 'sync-job-2',
+            uid: 'uid-2',
+            labels: syncRepositoryLabel,
+          },
+        }),
+      ];
+      const jobLists = {
+        'metadata.name=sync-job-1': createSyncJob({
+          status: {
+            state: 'working',
+            message: 'Pulling...',
+            progress: 30,
+          },
+        }),
+        'metadata.name=sync-job-2': createSyncJob({
+          metadata: {
+            name: 'sync-job-2',
+            uid: 'uid-2',
+            labels: syncRepositoryLabel,
+          },
+          status: {
+            state: 'working',
+            message: 'Retrying...',
+            progress: 10,
+          },
+        }),
+      };
+      const errorJob = createSyncJob({
+        status: {
+          state: 'error',
+          message: 'Sync failed',
+        },
+      });
+
+      let createJobCalls = 0;
+      server.use(
+        http.post(`${BASE}/repositories/:name/jobs`, () => {
+          const job = createdJobs[Math.min(createJobCalls, createdJobs.length - 1)];
+          createJobCalls++;
+          return HttpResponse.json(job);
+        }),
+        http.get(`${BASE}/jobs`, ({ request }) => {
+          const fieldSelector = new URL(request.url).searchParams.get('fieldSelector') ?? 'metadata.name=sync-job-1';
+          return HttpResponse.json({
+            items: [jobLists[fieldSelector as keyof typeof jobLists]],
+            metadata: { resourceVersion: '1' },
+          });
+        })
+      );
+
+      const { user } = setup(<ProvisioningWizard type="github" />);
+      await navigateToSynchronizationStep(user);
+
+      await user.click(screen.getByRole('button', { name: /Begin synchronization/i }));
+      expect(await screen.findByText('Pulling...')).toBeInTheDocument();
+
+      act(() => {
+        getMockLiveSrv().emitWatchEvent('jobs', { type: 'MODIFIED', object: errorJob });
+      });
+
+      // Retry is rendered via Alert's buttonContent/onRemove, not as a standard named button
+      const retryButton = (await screen.findByText('Retry')).closest('button');
+      expect(retryButton).not.toBeNull();
+      await user.click(retryButton!);
+
+      await waitFor(() => {
+        expect(createJobCalls).toBe(2);
+      });
+      expect(await screen.findByText('Retrying...')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -173,36 +173,43 @@ function setupMockSubmitData() {
 const syncRepositoryName = 'test-repo-abc123';
 const syncRepositoryLabel = { 'provisioning.grafana.app/repository': syncRepositoryName };
 
-function createSyncJob(overrides: Partial<Job> = {}): Job {
-  const { metadata: metadataOverrides, spec: specOverrides, status: statusOverrides, ...rest } = overrides;
-  const metadata = {
-    name: 'sync-job-1',
-    uid: 'uid-1',
-    ...metadataOverrides,
-    labels: {
-      ...syncRepositoryLabel,
-      ...metadataOverrides?.labels,
-    },
-  };
-  const spec = {
-    action: 'pull',
-    ...specOverrides,
-  };
-  const status = {
-    state: 'pending',
-    ...statusOverrides,
-  };
+function createSyncJob(overrides: Record<string, unknown> = {}): Job {
+  const {
+    metadata: metadataOverrides,
+    spec: specOverrides,
+    status: statusOverrides,
+    ...rest
+  } = overrides as Partial<Job>;
 
   return {
     ...rest,
-    metadata,
-    spec,
-    status,
-  };
+    metadata: {
+      name: 'sync-job-1',
+      uid: 'uid-1',
+      ...metadataOverrides,
+      labels: {
+        ...syncRepositoryLabel,
+        ...metadataOverrides?.labels,
+      },
+    },
+    spec: {
+      action: 'pull' as const,
+      ...specOverrides,
+    },
+    status: {
+      state: 'pending' as const,
+      ...statusOverrides,
+    },
+  } as Job;
 }
 
-function createSyncRepository(overrides: Partial<Repository> = {}): Repository {
-  const { metadata: metadataOverrides, spec: specOverrides, status: statusOverrides, ...rest } = overrides;
+function createSyncRepository(overrides: Record<string, unknown> = {}): Repository {
+  const {
+    metadata: metadataOverrides,
+    spec: specOverrides,
+    status: statusOverrides,
+    ...rest
+  } = overrides as Partial<Repository>;
 
   return {
     ...rest,
@@ -231,7 +238,7 @@ function createSyncRepository(overrides: Partial<Repository> = {}): Repository {
       },
       ...statusOverrides,
     },
-  };
+  } as Repository;
 }
 
 function enableSynchronizationStep() {

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -7,9 +7,10 @@ import { act, render, waitFor } from 'test/test-utils';
 
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 import server from '@grafana/test-utils/server';
-import { Job, Repository } from 'app/api/clients/provisioning/v0alpha1';
+import { Repository } from 'app/api/clients/provisioning/v0alpha1';
 
 import { useCreateOrUpdateRepository } from '../hooks/useCreateOrUpdateRepository';
+import { createJob, createRepository } from '../mocks/factories';
 import { getMockLiveSrv, setupProvisioningMswServer } from '../mocks/server';
 
 import { ProvisioningWizard } from './ProvisioningWizard';
@@ -75,13 +76,7 @@ async function navigateToConnectionStep(
   }
 
   if (type !== 'local' && data?.url) {
-    const urlPlaceholders = {
-      github: 'https://github.com/owner/repository',
-      gitlab: 'https://gitlab.com/owner/repository',
-      bitbucket: 'https://bitbucket.org/owner/repository',
-      git: 'https://git.example.com/owner/repository.git',
-    };
-    await pasteIntoInput(user, screen.getByPlaceholderText(urlPlaceholders[type]), data.url);
+    await pasteIntoInput(user, screen.getByRole('textbox', { name: /Repository URL/i }), data.url);
   }
 
   if (type !== 'local') {
@@ -170,77 +165,6 @@ function setupMockSubmitData() {
   return mockSubmitData;
 }
 
-const syncRepositoryName = 'test-repo-abc123';
-const syncRepositoryLabel = { 'provisioning.grafana.app/repository': syncRepositoryName };
-
-function createSyncJob(overrides: Record<string, unknown> = {}): Job {
-  const {
-    metadata: metadataOverrides,
-    spec: specOverrides,
-    status: statusOverrides,
-    ...rest
-  } = overrides as Partial<Job>;
-
-  return {
-    ...rest,
-    metadata: {
-      name: 'sync-job-1',
-      uid: 'uid-1',
-      ...metadataOverrides,
-      labels: {
-        ...syncRepositoryLabel,
-        ...metadataOverrides?.labels,
-      },
-    },
-    spec: {
-      action: 'pull' as const,
-      ...specOverrides,
-    },
-    status: {
-      state: 'pending' as const,
-      ...statusOverrides,
-    },
-  } as Job;
-}
-
-function createSyncRepository(overrides: Record<string, unknown> = {}): Repository {
-  const {
-    metadata: metadataOverrides,
-    spec: specOverrides,
-    status: statusOverrides,
-    ...rest
-  } = overrides as Partial<Repository>;
-
-  return {
-    ...rest,
-    metadata: {
-      name: syncRepositoryName,
-      generation: 1,
-      ...metadataOverrides,
-    },
-    spec: {
-      title: 'Test Repository',
-      type: 'github',
-      sync: { target: 'folder', enabled: true },
-      workflows: [],
-      github: {
-        url: 'https://github.com/test/repo',
-        branch: 'main',
-      },
-      ...specOverrides,
-    },
-    status: {
-      observedGeneration: 1,
-      health: {
-        healthy: true,
-        checked: 1704067200000,
-        message: [],
-      },
-      ...statusOverrides,
-    },
-  } as Repository;
-}
-
 function enableSynchronizationStep() {
   server.use(
     http.get(`${BASE}/stats`, () => HttpResponse.json({ instance: [{ group: 'dashboard.grafana.app', count: 1 }] })),
@@ -250,7 +174,7 @@ function enableSynchronizationStep() {
   );
 }
 
-function mockRepositoryList(repository: Repository = createSyncRepository()) {
+function mockRepositoryList(repository: Repository = createRepository()) {
   server.use(
     http.get(`${BASE}/repositories`, () =>
       HttpResponse.json({
@@ -261,7 +185,7 @@ function mockRepositoryList(repository: Repository = createSyncRepository()) {
   );
 }
 
-function mockSyncRepositoryLookup(repository: Repository = createSyncRepository()) {
+function mockSyncRepositoryLookup(repository: Repository = createRepository()) {
   server.use(http.get(`${BASE}/repositories/:name`, () => HttpResponse.json(repository)));
 }
 
@@ -285,10 +209,8 @@ async function navigateToSynchronizationStep(user: UserEvent) {
 }
 
 function setupWorkingJobHandlers() {
-  const createdJob = createSyncJob();
-  const workingJob = createSyncJob({
-    status: { state: 'working', message: 'Pulling...', progress: 30 },
-  });
+  const createdJob = createJob({ status: { state: 'pending' } });
+  const workingJob = createJob();
   server.use(
     http.post(`${BASE}/repositories/:name/jobs`, () => HttpResponse.json(createdJob)),
     http.get(`${BASE}/jobs`, () => HttpResponse.json({ items: [workingJob], metadata: { resourceVersion: '1' } }))
@@ -479,7 +401,7 @@ describe('ProvisioningWizard', () => {
       await typeIntoTokenField(user, 'ghp_xxxxxxxxxxxxxxxxxxxx', 'test-token');
       await pasteIntoInput(
         user,
-        screen.getByPlaceholderText('https://github.com/owner/repository'),
+        screen.getByRole('textbox', { name: /Repository URL/i }),
         'https://github.com/test/repo'
       );
 
@@ -500,7 +422,7 @@ describe('ProvisioningWizard', () => {
   describe('Repository Reconciliation', () => {
     it('shows loading while waiting for reconciliation, then shows bootstrap content after a healthy watch event', async () => {
       mockRepositoryList(
-        createSyncRepository({
+        createRepository({
           status: {
             observedGeneration: undefined,
           },
@@ -516,7 +438,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('repositories', {
           type: 'MODIFIED',
-          object: createSyncRepository(),
+          object: createRepository(),
         });
       });
 
@@ -528,7 +450,7 @@ describe('ProvisioningWizard', () => {
 
     it('shows an unhealthy repository error and clears it after retry plus a healthy watch event', async () => {
       mockRepositoryList(
-        createSyncRepository({
+        createRepository({
           status: {
             observedGeneration: 1,
             health: {
@@ -554,7 +476,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('repositories', {
           type: 'MODIFIED',
-          object: createSyncRepository(),
+          object: createRepository(),
         });
       });
 
@@ -566,7 +488,7 @@ describe('ProvisioningWizard', () => {
 
     it('transitions from loading to unhealthy to healthy as repository watch events arrive', async () => {
       mockRepositoryList(
-        createSyncRepository({
+        createRepository({
           status: {
             observedGeneration: undefined,
           },
@@ -582,7 +504,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('repositories', {
           type: 'MODIFIED',
-          object: createSyncRepository({
+          object: createRepository({
             status: {
               observedGeneration: 1,
               health: {
@@ -600,7 +522,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('repositories', {
           type: 'MODIFIED',
-          object: createSyncRepository(),
+          object: createRepository(),
         });
       });
 
@@ -623,7 +545,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('jobs', {
           type: 'MODIFIED',
-          object: createSyncJob({ status: { state: 'success' } }),
+          object: createJob({ status: { state: 'success' } }),
         });
       });
 
@@ -643,7 +565,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('jobs', {
           type: 'MODIFIED',
-          object: createSyncJob({ status: { state: 'warning', message: 'Completed with warnings' } }),
+          object: createJob({ status: { state: 'warning', message: 'Completed with warnings' } }),
         });
       });
 
@@ -663,7 +585,7 @@ describe('ProvisioningWizard', () => {
       act(() => {
         getMockLiveSrv().emitWatchEvent('jobs', {
           type: 'MODIFIED',
-          object: createSyncJob({ status: { state: 'error', message: 'Sync failed' } }),
+          object: createJob({ status: { state: 'error', message: 'Sync failed' } }),
         });
       });
 
@@ -693,41 +615,21 @@ describe('ProvisioningWizard', () => {
 
     it('creates a new sync job when retry is clicked after a job error', async () => {
       const createdJobs = [
-        createSyncJob(),
-        createSyncJob({
-          metadata: {
-            name: 'sync-job-2',
-            uid: 'uid-2',
-            labels: syncRepositoryLabel,
-          },
+        createJob({ status: { state: 'pending' } }),
+        createJob({
+          metadata: { name: 'job-2', uid: 'uid-2' },
+          status: { state: 'pending' },
         }),
       ];
       const jobLists = {
-        'metadata.name=sync-job-1': createSyncJob({
-          status: {
-            state: 'working',
-            message: 'Pulling...',
-            progress: 30,
-          },
-        }),
-        'metadata.name=sync-job-2': createSyncJob({
-          metadata: {
-            name: 'sync-job-2',
-            uid: 'uid-2',
-            labels: syncRepositoryLabel,
-          },
-          status: {
-            state: 'working',
-            message: 'Retrying...',
-            progress: 10,
-          },
+        'metadata.name=job-1': createJob(),
+        'metadata.name=job-2': createJob({
+          metadata: { name: 'job-2', uid: 'uid-2' },
+          status: { state: 'working', message: 'Retrying...', progress: 10 },
         }),
       };
-      const errorJob = createSyncJob({
-        status: {
-          state: 'error',
-          message: 'Sync failed',
-        },
+      const errorJob = createJob({
+        status: { state: 'error', message: 'Sync failed' },
       });
 
       let createJobCalls = 0;
@@ -738,7 +640,7 @@ describe('ProvisioningWizard', () => {
           return HttpResponse.json(job);
         }),
         http.get(`${BASE}/jobs`, ({ request }) => {
-          const fieldSelector = new URL(request.url).searchParams.get('fieldSelector') ?? 'metadata.name=sync-job-1';
+          const fieldSelector = new URL(request.url).searchParams.get('fieldSelector') ?? 'metadata.name=job-1';
           return HttpResponse.json({
             items: [jobLists[fieldSelector as keyof typeof jobLists]],
             metadata: { resourceVersion: '1' },
@@ -841,7 +743,7 @@ describe('ProvisioningWizard', () => {
       await pasteIntoInput(user, screen.getByPlaceholderText('username'), 'test-user');
       await pasteIntoInput(
         user,
-        screen.getByPlaceholderText('https://bitbucket.org/owner/repository'),
+        screen.getByRole('textbox', { name: /Repository URL/i }),
         'https://bitbucket.org/test/repo'
       );
 
@@ -855,7 +757,7 @@ describe('ProvisioningWizard', () => {
       await pasteIntoInput(user, screen.getByPlaceholderText('username'), 'test-user');
       await pasteIntoInput(
         user,
-        screen.getByPlaceholderText('https://git.example.com/owner/repository.git'),
+        screen.getByRole('textbox', { name: /Repository URL/i }),
         'https://git.example.com/test/repo.git'
       );
 

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
@@ -81,17 +81,17 @@ export const SynchronizeStep = memo(function SynchronizeStep({
 
   const isButtonDisabled = hasError || !isHealthy;
 
-  const startSynchronization = async () => {
+  const startSynchronization = useCallback(async () => {
     const response = await createSyncJob(requiresMigration);
     if (response) {
       setJob(response);
     }
-  };
+  }, [createSyncJob, requiresMigration]);
 
-  const retryJob = () => {
+  const retryJob = useCallback(() => {
     setJob(undefined);
-    startSynchronization();
-  };
+    void startSynchronization();
+  }, [startSynchronization]);
 
   if (isLoading || healthStatusNotReady) {
     return (

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { t } from '@grafana/i18n';
 import { useCreateRepositoryJobsMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
@@ -12,67 +14,70 @@ export interface UseCreateSyncJobParams {
 export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJobParams) {
   const [createJob, { isLoading }] = useCreateRepositoryJobsMutation();
 
-  const createSyncJob = async (requiresMigration: boolean, options?: { skipStatusUpdates?: boolean }) => {
-    const { skipStatusUpdates = false } = options || {};
+  const createSyncJob = useCallback(
+    async (requiresMigration: boolean, options?: { skipStatusUpdates?: boolean }) => {
+      const { skipStatusUpdates = false } = options || {};
 
-    if (!repoName) {
-      if (!skipStatusUpdates) {
-        setStepStatusInfo?.({
-          status: 'error',
-          error: t('provisioning.sync-job.error-no-repository-name', 'No repository name provided'),
-        });
-      }
-      return null;
-    }
-
-    try {
-      if (!skipStatusUpdates) {
-        setStepStatusInfo?.({ status: 'running' });
-      }
-
-      const jobSpec = requiresMigration
-        ? {
-            action: 'migrate' as const,
-            migrate: {},
-          }
-        : {
-            action: 'pull' as const,
-            pull: {
-              incremental: false,
-            },
-          };
-
-      const response = await createJob({
-        name: repoName,
-        jobSpec,
-      }).unwrap();
-
-      if (!response?.metadata?.name) {
+      if (!repoName) {
         if (!skipStatusUpdates) {
           setStepStatusInfo?.({
             status: 'error',
-            error: t('provisioning.sync-job.error-no-job-id', 'Failed to start job'),
+            error: t('provisioning.sync-job.error-no-repository-name', 'No repository name provided'),
           });
         }
         return null;
       }
 
-      // Job status will be tracked by JobStatus component, keep status as 'running'
-      return response;
-    } catch (error) {
-      if (!skipStatusUpdates) {
-        const errorMessage = extractErrorMessage(error);
-        setStepStatusInfo?.({
-          status: 'error',
-          error: {
-            title: t('provisioning.sync-job.error-starting-job', 'Error starting job'),
-            message: errorMessage,
-          },
-        });
+      try {
+        if (!skipStatusUpdates) {
+          setStepStatusInfo?.({ status: 'running' });
+        }
+
+        const jobSpec = requiresMigration
+          ? {
+              action: 'migrate' as const,
+              migrate: {},
+            }
+          : {
+              action: 'pull' as const,
+              pull: {
+                incremental: false,
+              },
+            };
+
+        const response = await createJob({
+          name: repoName,
+          jobSpec,
+        }).unwrap();
+
+        if (!response?.metadata?.name) {
+          if (!skipStatusUpdates) {
+            setStepStatusInfo?.({
+              status: 'error',
+              error: t('provisioning.sync-job.error-no-job-id', 'Failed to start job'),
+            });
+          }
+          return null;
+        }
+
+        // Job status will be tracked by JobStatus component, keep status as 'running'
+        return response;
+      } catch (error) {
+        if (!skipStatusUpdates) {
+          const errorMessage = extractErrorMessage(error);
+          setStepStatusInfo?.({
+            status: 'error',
+            error: {
+              title: t('provisioning.sync-job.error-starting-job', 'Error starting job'),
+              message: errorMessage,
+            },
+          });
+        }
+        return null;
       }
-      return null;
-    }
-  };
+    },
+    [createJob, repoName, setStepStatusInfo]
+  );
 
   return {
     createSyncJob,

--- a/public/app/features/provisioning/mocks/factories.ts
+++ b/public/app/features/provisioning/mocks/factories.ts
@@ -1,0 +1,74 @@
+import { Job, Repository } from 'app/api/clients/provisioning/v0alpha1';
+
+const DEFAULT_REPOSITORY_NAME = 'test-repo-abc123';
+const DEFAULT_REPOSITORY_LABEL = { 'provisioning.grafana.app/repository': DEFAULT_REPOSITORY_NAME };
+
+export function createJob(overrides: Record<string, unknown> = {}): Job {
+  const {
+    metadata: metadataOverrides,
+    spec: specOverrides,
+    status: statusOverrides,
+    ...rest
+  } = overrides as Partial<Job>;
+
+  return {
+    ...rest,
+    metadata: {
+      name: 'job-1',
+      uid: 'uid-1',
+      ...metadataOverrides,
+      labels: {
+        ...DEFAULT_REPOSITORY_LABEL,
+        ...metadataOverrides?.labels,
+      },
+    },
+    spec: {
+      action: 'pull' as const,
+      ...specOverrides,
+    },
+    status: {
+      state: 'working' as const,
+      message: 'Pulling...',
+      progress: 30,
+      ...statusOverrides,
+    },
+  } as Job;
+}
+
+export function createRepository(overrides: Record<string, unknown> = {}): Repository {
+  const {
+    metadata: metadataOverrides,
+    spec: specOverrides,
+    status: statusOverrides,
+    ...rest
+  } = overrides as Partial<Repository>;
+
+  return {
+    ...rest,
+    metadata: {
+      name: DEFAULT_REPOSITORY_NAME,
+      generation: 1,
+      ...metadataOverrides,
+    },
+    spec: {
+      title: 'Test Repository',
+      type: 'github',
+      sync: { target: 'folder', enabled: true },
+      workflows: [],
+      github: {
+        url: 'https://github.com/test/repo',
+        branch: 'main',
+      },
+      ...specOverrides,
+    },
+    status: {
+      observedGeneration: 1,
+      health: {
+        healthy: true,
+        checked: 1704067200000,
+        message: [],
+      },
+      ...statusOverrides,
+    },
+  } as Repository;
+}

--- a/public/app/features/provisioning/mocks/server/MockGrafanaLiveSrv.ts
+++ b/public/app/features/provisioning/mocks/server/MockGrafanaLiveSrv.ts
@@ -9,9 +9,16 @@ import {
   LiveChannelEventType,
 } from '@grafana/data';
 import type { GrafanaLiveSrv, LiveDataStreamOptions } from '@grafana/runtime';
-import { ResourceEvent } from 'app/features/apiserver/types';
-
 type ProvisioningResource = 'jobs' | 'repositories' | 'connections';
+
+/**
+ * A loose version of ResourceEvent that accepts generated API types
+ * (where metadata, spec, etc. are optional) without requiring strict Resource<T>.
+ */
+interface WatchEvent {
+  type: 'ADDED' | 'DELETED' | 'MODIFIED';
+  object: Record<string, unknown>;
+}
 
 function addressToKey(address: LiveChannelAddress): string {
   return `${address.scope}/${address.stream}/${address.path}`;
@@ -52,7 +59,7 @@ export class MockGrafanaLiveSrv implements GrafanaLiveSrv {
    * Emit a watch event (ADDED, MODIFIED, DELETED) to all matching streams for the given resource.
    * The event is wrapped in a LiveChannelMessageEvent so it flows through the ScopedResourceClient.watch() pipe.
    */
-  emitWatchEvent<T>(resource: ProvisioningResource, event: ResourceEvent<T>): void {
+  emitWatchEvent(resource: ProvisioningResource, event: WatchEvent): void {
     const messageEvent: LiveChannelEvent = {
       type: LiveChannelEventType.Message,
       message: event,

--- a/public/app/features/provisioning/mocks/server/MockGrafanaLiveSrv.ts
+++ b/public/app/features/provisioning/mocks/server/MockGrafanaLiveSrv.ts
@@ -1,0 +1,97 @@
+import { Observable, NEVER, Subject } from 'rxjs';
+
+import {
+  type DataQueryResponse,
+  type LiveChannelAddress,
+  type LiveChannelEvent,
+  type LiveChannelPresenceStatus,
+  LiveChannelConnectionState,
+  LiveChannelEventType,
+} from '@grafana/data';
+import type { GrafanaLiveSrv, LiveDataStreamOptions } from '@grafana/runtime';
+import { ResourceEvent } from 'app/features/apiserver/types';
+
+type ProvisioningResource = 'jobs' | 'repositories' | 'connections';
+
+function addressToKey(address: LiveChannelAddress): string {
+  return `${address.scope}/${address.stream}/${address.path}`;
+}
+
+/**
+ * A mock GrafanaLiveSrv that uses RxJS Subjects for controllable streams.
+ * Tests can push events into specific channels via `emitWatchEvent` and `emitWatchError`.
+ */
+export class MockGrafanaLiveSrv implements GrafanaLiveSrv {
+  private streams = new Map<string, Subject<LiveChannelEvent>>();
+
+  getConnectionState(): Observable<boolean> {
+    return NEVER;
+  }
+
+  getStream<T>(address: LiveChannelAddress): Observable<LiveChannelEvent<T>> {
+    const key = addressToKey(address);
+    if (!this.streams.has(key)) {
+      this.streams.set(key, new Subject<LiveChannelEvent>());
+    }
+    return this.streams.get(key)!.asObservable() as Observable<LiveChannelEvent<T>>;
+  }
+
+  getDataStream(_options: LiveDataStreamOptions): Observable<DataQueryResponse> {
+    return NEVER;
+  }
+
+  getPresence(_address: LiveChannelAddress): Promise<LiveChannelPresenceStatus> {
+    return Promise.resolve({} as LiveChannelPresenceStatus);
+  }
+
+  publish(_address: LiveChannelAddress, _data: unknown): Promise<unknown> {
+    return Promise.resolve(undefined);
+  }
+
+  /**
+   * Emit a watch event (ADDED, MODIFIED, DELETED) to all matching streams for the given resource.
+   * The event is wrapped in a LiveChannelMessageEvent so it flows through the ScopedResourceClient.watch() pipe.
+   */
+  emitWatchEvent<T>(resource: ProvisioningResource, event: ResourceEvent<T>): void {
+    const messageEvent: LiveChannelEvent = {
+      type: LiveChannelEventType.Message,
+      message: event,
+    };
+
+    for (const [key, subject] of this.streams) {
+      if (key.includes(`/${resource}`)) {
+        subject.next(messageEvent);
+      }
+    }
+  }
+
+  /**
+   * Emit a watch error to all matching streams for the given resource.
+   * This triggers the error path in ScopedResourceClient.watch() which catches LiveChannelStatusEvents with errors.
+   */
+  emitWatchError(resource: ProvisioningResource, error: unknown): void {
+    const statusEvent: LiveChannelEvent = {
+      type: LiveChannelEventType.Status,
+      id: `watch/provisioning.grafana.app/${resource}`,
+      timestamp: Date.now(),
+      state: LiveChannelConnectionState.Disconnected,
+      error,
+    };
+
+    for (const [key, subject] of this.streams) {
+      if (key.includes(`/${resource}`)) {
+        subject.next(statusEvent);
+      }
+    }
+  }
+
+  /**
+   * Complete all subjects and clear the map. Call in afterEach to prevent cross-test leakage.
+   */
+  reset(): void {
+    for (const subject of this.streams.values()) {
+      subject.complete();
+    }
+    this.streams.clear();
+  }
+}

--- a/public/app/features/provisioning/mocks/server/MockGrafanaLiveSrv.ts
+++ b/public/app/features/provisioning/mocks/server/MockGrafanaLiveSrv.ts
@@ -66,7 +66,7 @@ export class MockGrafanaLiveSrv implements GrafanaLiveSrv {
     };
 
     for (const [key, subject] of this.streams) {
-      if (key.includes(`/${resource}`)) {
+      if (key.includes(`/v0alpha1/${resource}`)) {
         subject.next(messageEvent);
       }
     }
@@ -86,7 +86,7 @@ export class MockGrafanaLiveSrv implements GrafanaLiveSrv {
     };
 
     for (const [key, subject] of this.streams) {
-      if (key.includes(`/${resource}`)) {
+      if (key.includes(`/v0alpha1/${resource}`)) {
         subject.next(statusEvent);
       }
     }

--- a/public/app/features/provisioning/mocks/server/index.ts
+++ b/public/app/features/provisioning/mocks/server/index.ts
@@ -1,22 +1,36 @@
-import { NEVER } from 'rxjs';
-
 import { setBackendSrv, setGrafanaLiveSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
 
+import { MockGrafanaLiveSrv } from './MockGrafanaLiveSrv';
+
+export { MockGrafanaLiveSrv } from './MockGrafanaLiveSrv';
+
+let mockLiveSrv: MockGrafanaLiveSrv;
+
+/**
+ * Returns the current MockGrafanaLiveSrv instance.
+ * Use this to emit watch events or errors in tests:
+ *
+ * ```ts
+ * getMockLiveSrv().emitWatchEvent('jobs', { type: 'MODIFIED', object: job });
+ * getMockLiveSrv().emitWatchError('repositories', new Error('connection lost'));
+ * ```
+ */
+export function getMockLiveSrv(): MockGrafanaLiveSrv {
+  return mockLiveSrv;
+}
+
 export function setupProvisioningMswServer() {
   const server = setupMockServer();
 
+  mockLiveSrv = new MockGrafanaLiveSrv();
+
   setBackendSrv(backendSrv);
-  // Provide a minimal GrafanaLiveSrv mock so that onCacheEntryAdded watch
-  // subscriptions (triggered by RTK Query list endpoints with watch: true)
-  // don't crash when calling getGrafanaLiveSrv().getStream().
-  setGrafanaLiveSrv({
-    getConnectionState: () => NEVER,
-    getStream: () => NEVER,
-    getDataStream: () => NEVER,
-    getPresence: () => Promise.resolve({} as never),
-    publish: () => Promise.resolve(undefined),
+  setGrafanaLiveSrv(mockLiveSrv);
+
+  afterEach(() => {
+    mockLiveSrv.reset();
   });
 
   return server;

--- a/public/app/features/provisioning/mocks/server/index.ts
+++ b/public/app/features/provisioning/mocks/server/index.ts
@@ -6,6 +6,7 @@ import { MockGrafanaLiveSrv } from './MockGrafanaLiveSrv';
 
 export { MockGrafanaLiveSrv } from './MockGrafanaLiveSrv';
 
+// Module-level singleton is safe: Jest runs each test file in its own worker.
 let mockLiveSrv: MockGrafanaLiveSrv;
 
 /**


### PR DESCRIPTION
**What is this feature?**

- Add a controllable `MockGrafanaLiveSrv` test utility that lets provisioning tests emit watch events and errors via RxJS Subjects, enabling full integration testing of the watch data flow (RTK Query → `onCacheEntryAdded` → LiveChannel → UI). 
- Wrap `startSynchronization`, `retryJob`, and `createSyncJob` in `useCallback` to fix a render stability issue.

**Why do we need this feature?**

The existing test mock used `NEVER` (an Observable that never emits), making it impossible to test how UI components react to real-time watch updates — job status transitions, repository reconciliation lifecycle, and error/warning scenarios. The missing `useCallback` wrappers caused an infinite re-render loop when `JobContent`'s `useEffect` fired on every render due to unstable function references.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/984

**Special notes for your reviewer:**

- `MockGrafanaLiveSrv` implements `GrafanaLiveSrv` with RxJS Subjects keyed by channel address, with `emitWatchEvent()` and `emitWatchError()` helpers
- Added missing `listJobsHandler` to MSW handlers — without it, `onCacheEntryAdded` watch subscriptions never activated
