### PR TITLE
feat(prometheus): add Query with Assistant button to Prometheus query

### DIFF
--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@floating-ui/react": "0.27.18",
+    "@grafana/assistant": "^0.1.24",
     "@grafana/data": "13.0.0-pre",
     "@grafana/e2e-selectors": "13.0.0-pre",
     "@grafana/i18n": "13.0.0-pre",

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@floating-ui/react": "0.27.18",
-    "@grafana/assistant": "^0.1.24",
+    "@grafana/assistant": "0.1.24",
     "@grafana/data": "13.0.0-pre",
     "@grafana/e2e-selectors": "13.0.0-pre",
     "@grafana/i18n": "13.0.0-pre",

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -99,7 +99,7 @@ export class PrometheusDatasource
   defaultEditor?: QueryEditorMode;
 
   constructor(
-    instanceSettings: DataSourceInstanceSettings<PromOptions>,
+    public readonly instanceSettings: DataSourceInstanceSettings<PromOptions>,
     private readonly templateSrv: TemplateSrv = getTemplateSrv(),
     languageProvider?: PrometheusLanguageProviderInterface
   ) {

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { cloneDeep, defaultsDeep } from 'lodash';
 
 import { CoreApp, PluginMeta, PluginType } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { PromQueryEditorProps } from '../../components/types';
 import { PrometheusDatasource } from '../../datasource';
@@ -30,6 +31,10 @@ jest.mock('@grafana/runtime', () => {
     reportInteraction: jest.fn(),
   };
 });
+
+jest.mock('@grafana/assistant', () => ({
+  QueryWithAssistantButton: () => <div data-testid="query-with-assistant-button" />,
+}));
 
 const defaultQuery = {
   refId: 'A',
@@ -82,6 +87,36 @@ const defaultProps = {
 };
 
 describe('PromQueryEditorSelector', () => {
+  beforeEach(() => {
+    config.featureToggles.queryWithAssistant = true;
+  });
+
+  it('shows the assistant button when feature toggle is enabled and app is Explore', async () => {
+    renderWithProps({}, { app: CoreApp.Explore });
+    expect(await screen.findByTestId('query-with-assistant-button')).toBeInTheDocument();
+  });
+
+  it('shows the assistant button when feature toggle is enabled and app is Dashboard', async () => {
+    renderWithProps({}, { app: CoreApp.Dashboard });
+    expect(await screen.findByTestId('query-with-assistant-button')).toBeInTheDocument();
+  });
+
+  it('shows the assistant button when feature toggle is enabled and app is PanelEditor', async () => {
+    renderWithProps({}, { app: CoreApp.PanelEditor });
+    expect(await screen.findByTestId('query-with-assistant-button')).toBeInTheDocument();
+  });
+
+  it('does not show the assistant button for UnifiedAlerting', async () => {
+    renderWithProps({}, { app: CoreApp.UnifiedAlerting });
+    expect(screen.queryByTestId('query-with-assistant-button')).not.toBeInTheDocument();
+  });
+
+  it('does not show the assistant button when feature toggle is disabled', async () => {
+    config.featureToggles.queryWithAssistant = false;
+    renderWithProps({}, { app: CoreApp.Explore });
+    expect(screen.queryByTestId('query-with-assistant-button')).not.toBeInTheDocument();
+  });
+
   it('shows code editor if expr and nothing else', async () => {
     // We opt for showing code editor for queries created before this feature was added
     render(<PromQueryEditorSelector {...defaultProps} />);

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -2,11 +2,12 @@
 import { isEqual } from 'lodash';
 import { memo, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 
+import { QueryWithAssistantButton } from '@grafana/assistant';
 import { CoreApp, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { EditorHeader, EditorRows, FlexItem } from '@grafana/plugin-ui';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Button, ConfirmModal, Space } from '@grafana/ui';
 
 import { PromQueryEditorProps } from '../../components/types';
@@ -32,6 +33,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
     data,
     app,
     onAddQuery,
+    datasource,
     datasource: { defaultEditor },
     queries,
   } = props;
@@ -44,6 +46,10 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
   const query = getQueryWithDefaults(props.query, app, defaultEditor);
   // This should be filled in from the defaults by now.
   const editorMode = query.editorMode!;
+
+  const showAssistant =
+    config.featureToggles.queryWithAssistant &&
+    (app === CoreApp.Explore || app === CoreApp.Dashboard || app === CoreApp.PanelEditor);
 
   const onEditorModeChange = useCallback(
     (newMetricEditorMode: QueryEditorMode) => {
@@ -118,6 +124,15 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         onAddQuery={onAddQuery}
       />
       <EditorHeader>
+        {showAssistant && (
+          <QueryWithAssistantButton
+            currentQuery={query}
+            queries={queries ?? [query]}
+            dataSourceInstanceSettings={datasource.instanceSettings}
+            datasourceApi={null}
+            app={app}
+          />
+        )}
         {!query.expr && (
           <Button
             data-testid={selectors.components.QueryBuilder.queryPatterns}

--- a/public/app/features/query/components/QueryActionAssistantButton.tsx
+++ b/public/app/features/query/components/QueryActionAssistantButton.tsx
@@ -37,9 +37,9 @@ export function QueryActionAssistantButton<TQuery extends DataQuery = DataQuery>
     return null;
   }
 
-  // Only show for loki and prometheus datasources
+  // Only show for loki datasource — prometheus has its own button inside the query editor
   const pluginId = dataSourceInstanceSettings.type;
-  if (pluginId !== 'loki' && pluginId !== 'prometheus') {
+  if (pluginId !== 'loki') {
     return null;
   }
   const origin = `grafana/query-editor/${pluginId}/${app ?? CoreApp.Unknown}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,6 +3817,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:11.13.5"
     "@floating-ui/react": "npm:0.27.18"
+    "@grafana/assistant": "npm:^0.1.24"
     "@grafana/data": "npm:13.0.0-pre"
     "@grafana/e2e-selectors": "npm:13.0.0-pre"
     "@grafana/i18n": "npm:13.0.0-pre"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,7 +3817,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:11.13.5"
     "@floating-ui/react": "npm:0.27.18"
-    "@grafana/assistant": "npm:^0.1.24"
+    "@grafana/assistant": "npm:0.1.24"
     "@grafana/data": "npm:13.0.0-pre"
     "@grafana/e2e-selectors": "npm:13.0.0-pre"
     "@grafana/i18n": "npm:13.0.0-pre"


### PR DESCRIPTION

**What is this feature?**
Adds a "Query with Assistant" button to the Prometheus query editor, matching the existing behavior in the Tempo query editor. The button appears in the editor header when the queryWithAssistant feature toggle is enabled and the user is in Explore, Dashboard, or Panel Editor contexts. The generic header-level button for Prometheus is removed since the editor now has its own.

**Why do we need this feature?**

Users working with Prometheus metrics often need help constructing or understanding PromQL queries. By surfacing the Grafana Assistant directly inside the Prometheus query editor, users can get AI-assisted query help without leaving their current context — the same experience already available to Tempo users.

**Who is this feature for?**
Grafana users (Cloud and OSS) who use Prometheus as a data source and want AI-assisted help writing or understanding PromQL queries in Explore, dashboards, or the panel editor.

Which issue(s) does this PR fix?

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
