### PR TITLE
Unified Storage: defer search index build from module init to starting()

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -61,6 +61,7 @@ type SearchServer interface {
 	// Deprecated: clients should use grpc.health.v1.Health with modules.SearchServer service name instead
 	resourcepb.DiagnosticsServer //nolint:staticcheck
 	ResourceServerStopper
+	Init(ctx context.Context) error
 }
 
 type ResourceServerStopper interface {
@@ -299,8 +300,10 @@ type ResourceServerOptions struct {
 	QuotasConfig QuotasConfig
 }
 
-// NewSearchServer creates a standalone search server.
-func NewSearchServer(opts ResourceServerOptions) (SearchServer, error) {
+// NewUninitializedSearchServer creates a standalone search server without calling Init.
+// The caller must call Init on the returned server before it handles requests.
+// This is useful when initialization must be deferred (e.g., until a ring reaches Running state).
+func NewUninitializedSearchServer(opts ResourceServerOptions) (SearchServer, error) {
 	if opts.Backend == nil {
 		return nil, fmt.Errorf("missing backend implementation")
 	}
@@ -321,16 +324,27 @@ func NewSearchServer(opts ResourceServerOptions) (SearchServer, error) {
 	}
 	searchServer.backendDiagnostics = opts.Diagnostics
 
-	// Initialize the search server
-	ctx := context.Background()
-	if err := searchServer.Init(ctx); err != nil {
+	return searchServer, nil
+}
+
+// NewSearchServer creates a standalone search server and initializes it immediately.
+func NewSearchServer(opts ResourceServerOptions) (SearchServer, error) {
+	searchServer, err := NewUninitializedSearchServer(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := searchServer.Init(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to initialize search server: %w", err)
 	}
 
 	return searchServer, nil
 }
 
-func NewResourceServer(opts ResourceServerOptions) (*server, error) {
+// NewUninitializedResourceServer creates a resource server without calling Init.
+// The caller must call Init on the returned server before it handles requests.
+// This is useful when initialization must be deferred (e.g., until a ring reaches Running state).
+func NewUninitializedResourceServer(opts ResourceServerOptions) (*server, error) {
 	if opts.Backend == nil {
 		return nil, fmt.Errorf("missing Backend implementation")
 	}
@@ -412,8 +426,16 @@ func NewResourceServer(opts ResourceServerOptions) (*server, error) {
 		}
 	}
 
-	err = s.Init(ctx)
+	return s, nil
+}
+
+func NewResourceServer(opts ResourceServerOptions) (*server, error) {
+	s, err := NewUninitializedResourceServer(opts)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := s.Init(s.ctx); err != nil {
 		s.log.Error("resource server init failed", "error", err)
 		return nil, err
 	}

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -47,8 +47,9 @@ type ServerOptions struct {
 	DisableStorageServices bool
 }
 
-// NewResourceServer creates a new ResourceServer with support for both storage and search capabilities.
-func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
+// NewUninitializedResourceServer creates a new ResourceServer without calling Init.
+// The caller must call Init on the returned server before it handles requests.
+func NewUninitializedResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 	if opts.DisableStorageServices {
 		return nil, fmt.Errorf("cannot create ResourceServer with storage services disabled")
 	}
@@ -68,11 +69,24 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return resource.NewResourceServer(*resourceOpts)
+	return resource.NewUninitializedResourceServer(*resourceOpts)
 }
 
-// NewSearchServer creates a new SearchServer with only search capabilities enabled.
-func NewSearchServer(opts ServerOptions) (resource.SearchServer, error) {
+// NewResourceServer creates a new ResourceServer with support for both storage and search capabilities.
+func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
+	server, err := NewUninitializedResourceServer(opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := server.Init(context.Background()); err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
+// NewUninitializedSearchServer creates a new SearchServer without calling Init.
+// The caller must call Init on the returned server before it handles requests.
+func NewUninitializedSearchServer(opts ServerOptions) (resource.SearchServer, error) {
 	opts.DisableStorageServices = true
 	resourceOpts, err := buildResourceServerOptions(&opts,
 		withBlobConfig,
@@ -83,7 +97,7 @@ func NewSearchServer(opts ServerOptions) (resource.SearchServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return resource.NewSearchServer(*resourceOpts)
+	return resource.NewUninitializedSearchServer(*resourceOpts)
 }
 
 type buildResourceServerOpts func(*ServerOptions, *resource.ResourceServerOptions) error

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -331,19 +331,22 @@ func (s *service) starting(ctx context.Context) error {
 			return fmt.Errorf("error switching to JOINING in the ring: %s", err)
 		}
 		s.log.Info("resource server is JOINING in the ring")
-
-		if err := s.ringLifecycler.ChangeState(ctx, ring.ACTIVE); err != nil {
-			return fmt.Errorf("error switching to ACTIVE in the ring: %s", err)
-		}
-		s.log.Info("resource server is ACTIVE in the ring")
 	}
 
-	// Initialize the server (builds search indexes) after the ring is Running,
-	// so that OwnsIndex checks work correctly with sharding enabled.
+	// Initialize the server (builds search indexes) while in JOINING state.
+	// The ring is Running so OwnsIndex checks work, but this instance won't
+	// receive ring-routed queries until it switches to ACTIVE below.
 	if s.uninitializedSearchServer != nil {
 		if err := s.uninitializedSearchServer.Init(ctx); err != nil {
 			return fmt.Errorf("failed to initialize server: %w", err)
 		}
+	}
+
+	if s.cfg.EnableSharding {
+		if err := s.ringLifecycler.ChangeState(ctx, ring.ACTIVE); err != nil {
+			return fmt.Errorf("error switching to ACTIVE in the ring: %s", err)
+		}
+		s.log.Info("resource server is ACTIVE in the ring")
 	}
 
 	return nil

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -69,6 +69,10 @@ type service struct {
 	ringLifecycler   *ring.BasicLifecycler // Ring state for sharding
 	searchStandalone bool
 	authenticator    interceptors.AuthenticatorFunc
+
+	// uninitializedSearchServer holds the server created during module init, whose Init() is
+	// deferred to starting() so the ring is Running when search indexes are built.
+	uninitializedSearchServer resource.SearchServer
 }
 
 // ProvideSearchGRPCService provides a gRPC service that only serves search requests.
@@ -334,6 +338,14 @@ func (s *service) starting(ctx context.Context) error {
 		s.log.Info("resource server is ACTIVE in the ring")
 	}
 
+	// Initialize the server (builds search indexes) after the ring is Running,
+	// so that OwnsIndex checks work correctly with sharding enabled.
+	if s.uninitializedSearchServer != nil {
+		if err := s.uninitializedSearchServer.Init(ctx); err != nil {
+			return fmt.Errorf("failed to initialize server: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -468,18 +480,20 @@ func toLifecyclerConfig(cfg *setting.Cfg, logger log.Logger) (ring.BasicLifecycl
 
 func (s *service) createAndRegisterServer(provider grpcserver.Provider, opts ServerOptions) error {
 	if s.searchStandalone {
-		server, err := NewSearchServer(opts)
+		server, err := NewUninitializedSearchServer(opts)
 		if err != nil {
 			return err
 		}
 		s.serverStopper = server
+		s.uninitializedSearchServer = server
 		return s.registerSearchServer(provider, server)
 	}
-	server, err := NewResourceServer(opts)
+	server, err := NewUninitializedResourceServer(opts)
 	if err != nil {
 		return err
 	}
 	s.serverStopper = server
+	s.uninitializedSearchServer = server
 	s.registerUnifiedResourceServer(provider, server)
 	return nil
 }


### PR DESCRIPTION
## Summary

- On search-api pod restart, `buildIndexes()` runs during dskit module init, before the ring service has started. The ring is in `New` state, so `OwnsIndex` returns an error for every tenant. The fail-open fallback then builds indexes for ALL tenants instead of only the owned shard, causing a CPU spike on every pod restart.
- Move the `Init()` call (which triggers `buildIndexes`) from the server constructors to the `starting()` lifecycle callback, where the ring is guaranteed to be `Running`.
- Switch to `ACTIVE` only after initial indexing completes, so other ring members don't route queries to this instance before its indexes are ready. The instance stays in `JOINING` during indexing — `JOINING` is included in `searchOwnerRead` op, so `OwnsIndex` checks still work correctly.

**Changes:**
- Add `NewUninitializedSearchServer` / `NewUninitializedResourceServer` in resource and sql packages that create servers without calling `Init`
- Refactor existing constructors to delegate to the uninitialized variants + immediate `Init`
- Add `Init(ctx context.Context) error` to the `SearchServer` interface
- In `service.starting()`: wait for `JOINING` → build indexes → switch to `ACTIVE`
- Remove unused `sql.NewSearchServer`

**Safety:**
- `server.Init()` has `sync.Once` guard — safe if called multiple times
- gRPC handlers registered during module init don't need indexes — only need the server object
- dskit health checks report `NOT_SERVING` until `starting()` completes, so no traffic arrives before indexes are built
- Non-sharded path works correctly: `OwnsIndex` returns `true` when `searchRing == nil`
- All existing callers of `NewSearchServer`/`NewResourceServer` are unchanged — they still Init immediately

Fixes: grafana/search-and-storage-team#713

## Test plan

- [x] Existing tests pass: `go test ./pkg/storage/unified/resource/...` and `go test ./pkg/storage/unified/sql/...`
- [x] With sharding enabled, the warn log `"failed to check index ownership, building index"` with `error="ring is not Running: New"` should no longer appear on startup
- [x] Non-sharded path: verify Init still runs in `starting()` when `EnableSharding == false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)