### PR TITLE
Tempo: sort search dropdown values alphabetically

### DIFF
--- a/public/app/plugins/datasource/tempo/language_provider.test.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.test.ts
@@ -295,6 +295,34 @@ describe('Language_provider', () => {
     });
   });
 
+  describe('getOptionsV2', () => {
+    it('returns tag values sorted alphabetically', async () => {
+      const datasource: TempoDatasource = {
+        instanceSettings: {
+          jsonData: {},
+        },
+        metadataRequest: jest.fn().mockResolvedValue({
+          tagValues: [
+            { type: 'string', value: 'zebra' },
+            { type: 'string', value: 'apple' },
+            { type: 'string', value: 'monkey' },
+          ],
+        }),
+        search: {
+          filters: [],
+        },
+      } as unknown as TempoDatasource;
+
+      const lp = new TempoLanguageProvider(datasource);
+
+      await expect(lp.getOptionsV2({ tag: 'resource.service.name' })).resolves.toEqual([
+        { type: 'string', value: 'apple', label: 'apple' },
+        { type: 'string', value: 'monkey', label: 'monkey' },
+        { type: 'string', value: 'zebra', label: 'zebra' },
+      ]);
+    });
+  });
+
   const setup = (tagsV2?: Scope[]) => {
     const datasource: TempoDatasource = {
       search: {

--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -20,6 +20,7 @@ export const TAGS_LIMIT = 5000;
 
 // Limit maximum options in select dropdowns
 export const OPTIONS_LIMIT = 1000;
+const optionLabelCollator = new Intl.Collator(undefined, { sensitivity: 'base' });
 
 interface GetOptionsV2 {
   tag: string;
@@ -171,7 +172,7 @@ export default class TempoLanguageProvider extends LanguageProvider {
         }
       });
     }
-    return options;
+    return options.sort((a, b) => optionLabelCollator.compare(a.label ?? '', b.label ?? ''));
   }
 
   getTimeRangeForTags = (timeRangeForTags: number, range: TimeRange) => {


### PR DESCRIPTION
**What is this feature?**

This updates Tempo search so the Service Name, Span Name, and Status dropdown values are shown in alphabetical order.

**Why do we need this feature?**

The current dropdown values are shown in backend response order, which makes them harder to scan and less consistent for users searching traces. Sorting them before they reach the UI gives the search fields a predictable order without changing the search flow itself.

**Who is this feature for?**

Users working with Tempo trace search filters in Grafana.

**Which issue(s) does this PR fix?**:

Fixes #120728

**Special notes for your reviewer:**

The change is scoped to `TempoLanguageProvider.getOptionsV2()` so the ordering is applied before the dropdown values are rendered.

Verification:
- `node .yarn/releases/yarn-4.11.0.cjs workspace @grafana-plugins/tempo exec jest language_provider.test.ts SearchTraceQLEditor/SearchField.test.tsx --runInBand`
- `node .yarn/releases/yarn-4.11.0.cjs eslint public/app/plugins/datasource/tempo/language_provider.ts public/app/plugins/datasource/tempo/language_provider.test.ts`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.