### PR TITLE
Alerting: Support all label matcher operators on /api/v1/rules/history

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_history.go
+++ b/pkg/services/ngalert/api/api_ruler_history.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/alertmanager/pkg/labels"
+
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -67,11 +69,22 @@ func ParseHistoryQuery(orgID int64, user identity.Requester, query url.Values) (
 		}
 	}
 
-	labels := make(map[string]string)
+	var matchers labels.Matchers
 	for k, v := range query {
 		if strings.HasPrefix(k, labelQueryPrefix) {
-			labels[k[len(labelQueryPrefix):]] = v[0]
+			m, err := labels.NewMatcher(labels.MatchEqual, k[len(labelQueryPrefix):], v[0])
+			if err != nil {
+				return models.HistoryQuery{}, fmt.Errorf("invalid label filter %q: %w", k, err)
+			}
+			matchers = append(matchers, m)
 		}
+	}
+	for _, s := range query["matchers"] {
+		parsed, err := labels.ParseMatchers(s)
+		if err != nil {
+			return models.HistoryQuery{}, fmt.Errorf("invalid matchers: %w", err)
+		}
+		matchers = append(matchers, parsed...)
 	}
 
 	return models.HistoryQuery{
@@ -85,6 +98,6 @@ func ParseHistoryQuery(orgID int64, user identity.Requester, query url.Values) (
 		From:         time.Unix(from, 0),
 		To:           time.Unix(to, 0),
 		Limit:        limit,
-		Labels:       labels,
+		Labels:       matchers,
 	}, nil
 }

--- a/pkg/services/ngalert/api/api_ruler_history.go
+++ b/pkg/services/ngalert/api/api_ruler_history.go
@@ -72,7 +72,7 @@ func ParseHistoryQuery(orgID int64, user identity.Requester, query url.Values) (
 	var matchers labels.Matchers
 	for k, v := range query {
 		if strings.HasPrefix(k, labelQueryPrefix) {
-			m, err := labels.NewMatcher(labels.MatchEqual, k[len(labelQueryPrefix):], v[0])
+			m, err := labels.ParseMatcher(k[len(labelQueryPrefix):] + "=" + v[0])
 			if err != nil {
 				return models.HistoryQuery{}, fmt.Errorf("invalid label filter %q: %w", k, err)
 			}

--- a/pkg/services/ngalert/api/api_ruler_history_test.go
+++ b/pkg/services/ngalert/api/api_ruler_history_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -31,6 +34,12 @@ func TestRouteQueryStateHistory(t *testing.T) {
 		{"valid states", "previous=Normal&current=Alerting", http.StatusOK},
 		{"invalid previous", "previous=InvalidState", http.StatusBadRequest},
 		{"invalid current", "current=InvalidState", http.StatusBadRequest},
+		{"valid matchers equality", `matchers={severity="critical"}`, http.StatusOK},
+		{"valid matchers regex", `matchers={severity=~"crit.*"}`, http.StatusOK},
+		{"valid matchers not-equal", `matchers={env!="prod"}`, http.StatusOK},
+		{"valid matchers not-regex", `matchers={env!~"prod.*"}`, http.StatusOK},
+		{"invalid matchers regex", `matchers={severity=~"[invalid"}`, http.StatusBadRequest},
+		{"invalid matchers syntax", `matchers=not_a_selector`, http.StatusBadRequest},
 	}
 
 	srv := &HistorySrv{
@@ -52,4 +61,98 @@ func TestRouteQueryStateHistory(t *testing.T) {
 			assert.Equal(t, tt.expectedCode, resp.Status())
 		})
 	}
+}
+
+func TestParseHistoryQuery(t *testing.T) {
+	t.Run("labels_ prefix produces MatchEqual matchers", func(t *testing.T) {
+		q := url.Values{
+			"labels_severity": {"critical"},
+			"labels_env":      {"prod"},
+		}
+		result, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.NoError(t, err)
+		require.Len(t, result.Labels, 2)
+
+		byName := matchersByName(result.Labels)
+		require.Equal(t, labels.MatchEqual, byName["severity"].Type)
+		require.Equal(t, "critical", byName["severity"].Value)
+		require.Equal(t, labels.MatchEqual, byName["env"].Type)
+		require.Equal(t, "prod", byName["env"].Value)
+	})
+
+	t.Run("matchers param supports all operators", func(t *testing.T) {
+		q := url.Values{
+			"matchers": {`{severity=~"crit.*",env!="dev",team="alerting",zone!~"us-.*"}`},
+		}
+		result, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.NoError(t, err)
+		require.Len(t, result.Labels, 4)
+
+		byName := matchersByName(result.Labels)
+		assert.Equal(t, labels.MatchRegexp, byName["severity"].Type)
+		assert.Equal(t, "crit.*", byName["severity"].Value)
+		assert.Equal(t, labels.MatchNotEqual, byName["env"].Type)
+		assert.Equal(t, "dev", byName["env"].Value)
+		assert.Equal(t, labels.MatchEqual, byName["team"].Type)
+		assert.Equal(t, "alerting", byName["team"].Value)
+		assert.Equal(t, labels.MatchNotRegexp, byName["zone"].Type)
+		assert.Equal(t, "us-.*", byName["zone"].Value)
+	})
+
+	t.Run("matchers param can be specified multiple times", func(t *testing.T) {
+		q := url.Values{
+			"matchers": {`{severity="critical"}`, `{env!="dev"}`},
+		}
+		result, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.NoError(t, err)
+		require.Len(t, result.Labels, 2)
+	})
+
+	t.Run("labels_ and matchers params are merged", func(t *testing.T) {
+		q := url.Values{
+			"labels_severity": {"critical"},
+			"matchers":        {`{env=~"prod.*"}`},
+		}
+		result, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.NoError(t, err)
+		require.Len(t, result.Labels, 2)
+
+		byName := matchersByName(result.Labels)
+		assert.Equal(t, labels.MatchEqual, byName["severity"].Type)
+		assert.Equal(t, labels.MatchRegexp, byName["env"].Type)
+	})
+
+	t.Run("invalid regex in matchers returns error", func(t *testing.T) {
+		q := url.Values{
+			"matchers": {`{severity=~"[invalid"}`},
+		}
+		_, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid matchers")
+	})
+
+	t.Run("invalid matchers syntax returns error", func(t *testing.T) {
+		q := url.Values{
+			"matchers": {"not_a_selector"},
+		}
+		_, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid matchers")
+	})
+
+	t.Run("no labels produces nil matchers", func(t *testing.T) {
+		q := url.Values{"ruleUID": {"abc123"}}
+		result, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.NoError(t, err)
+		assert.Empty(t, result.Labels)
+	})
+}
+
+// matchersByName indexes a Matchers slice by label name for easy lookup in tests.
+func matchersByName(ms labels.Matchers) map[string]*labels.Matcher {
+	out := make(map[string]*labels.Matcher, len(ms))
+	for _, m := range ms {
+		out[m.Name] = m
+	}
+	return out
 }

--- a/pkg/services/ngalert/models/history.go
+++ b/pkg/services/ngalert/models/history.go
@@ -3,6 +3,8 @@ package models
 import (
 	"time"
 
+	"github.com/prometheus/alertmanager/pkg/labels"
+
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
@@ -12,7 +14,7 @@ type HistoryQuery struct {
 	OrgID        int64
 	DashboardUID string
 	PanelID      int64
-	Labels       map[string]string
+	Labels       labels.Matchers
 	Previous     string
 	Current      string
 	From         time.Time

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -14,6 +14,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/grafana/alerting/notify/historian/lokiclient"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	amlabels "github.com/prometheus/alertmanager/pkg/labels"
 	"go.opentelemetry.io/otel/trace"
 
 	alertingInstrument "github.com/grafana/alerting/http/instrument"
@@ -518,25 +519,41 @@ func buildQueryTail(query models.HistoryQuery) (string, error) {
 		}
 	}
 
-	requiredSize := 0
-	labelKeys := make([]string, 0, len(query.Labels))
-	for k, v := range query.Labels {
-		requiredSize += len(k) + len(v) + 13 // 13 all literals below
-		labelKeys = append(labelKeys, k)
-	}
-	// Ensure that all queries we build are deterministic.
-	sort.Strings(labelKeys)
-	b.Grow(requiredSize)
-	for _, k := range labelKeys {
+	// Sort matchers by name for deterministic queries.
+	sorted := make(amlabels.Matchers, len(query.Labels))
+	copy(sorted, query.Labels)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Name != sorted[j].Name {
+			return sorted[i].Name < sorted[j].Name
+		}
+		return sorted[i].Value < sorted[j].Value
+	})
+	for _, m := range sorted {
 		b.WriteString(" | labels_")
-		b.WriteString(k)
-		b.WriteString("=")
-		_, err := fmt.Fprintf(&b, "%q", query.Labels[k])
+		b.WriteString(m.Name)
+		b.WriteString(logQLOperator(m.Type))
+		_, err := fmt.Fprintf(&b, "%q", m.Value)
 		if err != nil {
 			return "", err
 		}
 	}
 	return b.String(), nil
+}
+
+// logQLOperator maps an alertmanager MatchType to its LogQL filter operator string.
+func logQLOperator(t amlabels.MatchType) string {
+	switch t {
+	case amlabels.MatchEqual:
+		return "="
+	case amlabels.MatchNotEqual:
+		return "!="
+	case amlabels.MatchRegexp:
+		return "=~"
+	case amlabels.MatchNotRegexp:
+		return "!~"
+	default:
+		return "="
+	}
 }
 
 func queryHasLogFilters(query models.HistoryQuery) bool {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/alerting/notify/historian/lokiclient"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -256,9 +257,9 @@ func TestBuildLogQuery(t *testing.T) {
 			name: "filters instance labels in log line",
 			query: models.HistoryQuery{
 				OrgID: 123,
-				Labels: map[string]string{
-					"customlabel": "customvalue",
-					"labeltwo":    "labelvaluetwo",
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "customlabel", "customvalue"),
+					mustNewMatcher(t, labels.MatchEqual, "labeltwo", "labelvaluetwo"),
 				},
 			},
 			exp: []string{`{orgID="123",from="state-history"} | json | labels_customlabel="customvalue" | labels_labeltwo="labelvaluetwo"`},
@@ -268,8 +269,8 @@ func TestBuildLogQuery(t *testing.T) {
 			query: models.HistoryQuery{
 				OrgID:   123,
 				RuleUID: "rule-uid",
-				Labels: map[string]string{
-					"customlabel": "customvalue",
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "customlabel", "customvalue"),
 				},
 			},
 			exp: []string{`{orgID="123",from="state-history"} | json | ruleUID="rule-uid" | labels_customlabel="customvalue"`},
@@ -279,8 +280,8 @@ func TestBuildLogQuery(t *testing.T) {
 			query: models.HistoryQuery{
 				OrgID:   123,
 				RuleUID: "rule-uid",
-				Labels: map[string]string{
-					"customlabel": strings.Repeat("!", 24),
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "customlabel", strings.Repeat("!", 24)),
 				},
 			},
 			exp: []string{`{orgID="123",from="state-history"} | json | ruleUID="rule-uid" | labels_customlabel="!!!!!!!!!!!!!!!!!!!!!!!!"`},
@@ -290,11 +291,41 @@ func TestBuildLogQuery(t *testing.T) {
 			query: models.HistoryQuery{
 				OrgID:   123,
 				RuleUID: "rule-uid",
-				Labels: map[string]string{
-					"customlabel": strings.Repeat("!", 25),
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "customlabel", strings.Repeat("!", 25)),
 				},
 			},
 			expErr: ErrLokiQueryTooLong,
+		},
+		{
+			name: "filters instance labels with not-equal operator",
+			query: models.HistoryQuery{
+				OrgID: 123,
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchNotEqual, "severity", "critical"),
+				},
+			},
+			exp: []string{`{orgID="123",from="state-history"} | json | labels_severity!="critical"`},
+		},
+		{
+			name: "filters instance labels with regex operator",
+			query: models.HistoryQuery{
+				OrgID: 123,
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchRegexp, "severity", "crit.*"),
+				},
+			},
+			exp: []string{`{orgID="123",from="state-history"} | json | labels_severity=~"crit.*"`},
+		},
+		{
+			name: "filters instance labels with not-regex operator",
+			query: models.HistoryQuery{
+				OrgID: 123,
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchNotRegexp, "env", "prod.*"),
+				},
+			},
+			exp: []string{`{orgID="123",from="state-history"} | json | labels_env!~"prod.*"`},
 		},
 		{
 			name: "filters by all namespaces",
@@ -308,8 +339,8 @@ func TestBuildLogQuery(t *testing.T) {
 			name: "should batch queries to fit all folders",
 			query: models.HistoryQuery{
 				OrgID: 123,
-				Labels: map[string]string{
-					"customlabel": "customvalue",
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "customlabel", "customvalue"),
 				},
 			},
 			folderUIDs: []string{"folder-1", "folder-2", "folder\\d", "folder-" + strings.Repeat("!", 13)},
@@ -323,8 +354,8 @@ func TestBuildLogQuery(t *testing.T) {
 			name: "should fail if a single folder UID is too long",
 			query: models.HistoryQuery{
 				OrgID: 123,
-				Labels: map[string]string{
-					"customlabel": "customvalue",
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "customlabel", "customvalue"),
 				},
 			},
 			folderUIDs: []string{"folder-1", "folder-2", "folder-" + strings.Repeat("!", 14)},
@@ -362,8 +393,8 @@ func TestBuildLogQuery(t *testing.T) {
 				RuleUID:  "rule-uid",
 				Previous: "Pending",
 				Current:  "Alerting",
-				Labels: map[string]string{
-					"instance": "localhost:9090",
+				Labels: labels.Matchers{
+					mustNewMatcher(t, labels.MatchEqual, "instance", "localhost:9090"),
 				},
 			},
 			maxQuerySize: 200,
@@ -1219,4 +1250,12 @@ func toJson[T any](entry T) json.RawMessage {
 		panic(err)
 	}
 	return b
+}
+
+// mustNewMatcher constructs a labels.Matcher and fails the test if it cannot be created (e.g. invalid regex).
+func mustNewMatcher(t *testing.T, mt labels.MatchType, name, value string) *labels.Matcher {
+	t.Helper()
+	m, err := labels.NewMatcher(mt, name, value)
+	require.NoError(t, err)
+	return m
 }

--- a/public/app/features/alerting/unified/api/stateHistoryApi.ts
+++ b/public/app/features/alerting/unified/api/stateHistoryApi.ts
@@ -11,12 +11,12 @@ export const stateHistoryApi = alertingApi.injectEndpoints({
         from?: number;
         to?: number;
         limit?: number;
-        labels?: Record<string, string>;
+        matchers?: string;
         previous?: string;
         current?: string;
       }
     >({
-      query: ({ ruleUid, from, to, limit = 100, labels, previous, current }) => {
+      query: ({ ruleUid, from, to, limit = 100, matchers, previous, current }) => {
         const params: Record<string, string | number | undefined> = {
           ruleUID: ruleUid,
           from,
@@ -24,13 +24,8 @@ export const stateHistoryApi = alertingApi.injectEndpoints({
           limit,
           previous,
           current,
+          matchers,
         };
-
-        if (labels) {
-          Object.entries(labels).forEach(([key, value]) => {
-            params[`labels_${key}`] = value;
-          });
-        }
 
         return {
           url: '/api/v1/rules/history',

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
@@ -12,7 +12,7 @@ import { stateHistoryApi } from '../../../api/stateHistoryApi';
 import { DataSourceInformation } from '../../../home/Insights';
 
 import { LIMIT_EVENTS } from './EventListSceneObject';
-import { historyResultToDataFrame, parseBackendLabelFilters } from './utils';
+import { historyResultToDataFrame, toMatchersParam } from './utils';
 
 const historyDataSourceUid = '__history_api_ds_uid__';
 const historyDataSourcePluginId = '__history_api_ds_pluginId__';
@@ -65,12 +65,10 @@ class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
     const stateTo = templateSrv.replace(query.stateTo ?? '', request.scopedVars);
     const stateFrom = templateSrv.replace(query.stateFrom ?? '', request.scopedVars);
 
-    const labelFilters = parseBackendLabelFilters(labels);
-
     const historyResult = await getHistory(
       from,
       to,
-      labelFilters,
+      toMatchersParam(labels),
       stateTo !== 'all' ? stateTo : undefined,
       stateFrom !== 'all' ? stateFrom : undefined
     );
@@ -93,23 +91,17 @@ class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
  * Fetch the history events from the history api.
  * @param from the start time
  * @param to the end time
- * @param labels optional label filters for backend filtering
+ * @param matchers optional PromQL selector string for backend filtering, e.g. `{severity=~"crit.*",env!="dev"}`
  * @returns the history events filtered by time and labels
  */
-export const getHistory = (
-  from: number,
-  to: number,
-  labels?: Record<string, string>,
-  current?: string,
-  previous?: string
-) => {
+export const getHistory = (from: number, to: number, matchers?: string, current?: string, previous?: string) => {
   return dispatch(
     stateHistoryApi.endpoints.getRuleHistory.initiate(
       {
         from: from,
         to: to,
         limit: LIMIT_EVENTS,
-        labels: labels,
+        matchers: matchers,
         current: current,
         previous: previous,
       },

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -39,7 +39,7 @@ import { LABELS_FILTER, STATE_FILTER_FROM, STATE_FILTER_TO } from './CentralAler
 import { EventDetails } from './EventDetails';
 import { HistoryErrorMessage } from './HistoryErrorMessage';
 import { useRuleHistoryRecords } from './useRuleHistoryRecords';
-import { parseBackendLabelFilters } from './utils';
+import { toMatchersParam } from './utils';
 
 export const LIMIT_EVENTS = 5000; // limit is hard-capped at 5000 at the BE level.
 const PAGE_SIZE = 100;
@@ -69,8 +69,6 @@ export const HistoryEventsList = ({
   const from = timeRange?.from.unix();
   const to = timeRange?.to.unix();
 
-  const labelFilters = parseBackendLabelFilters(valueInLabelFilter.toString());
-
   const stateTo = valueInStateToFilter.toString();
   const stateFrom = valueInStateFromFilter.toString();
 
@@ -83,7 +81,7 @@ export const HistoryEventsList = ({
     from: from,
     to: to,
     limit: LIMIT_EVENTS,
-    labels: labelFilters,
+    matchers: toMatchersParam(valueInLabelFilter.toString()),
     current: stateTo !== 'all' ? stateTo : undefined,
     previous: stateFrom !== 'all' ? stateFrom : undefined,
   });

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -29,6 +29,7 @@ import { trackUseCentralHistoryFilterByClicking, trackUseCentralHistoryMaxEvents
 import { stateHistoryApi } from '../../../api/stateHistoryApi';
 import { AITriageButtonComponent } from '../../../enterprise-components/AI/AIGenTriageButton/addAITriageButton';
 import { usePagination } from '../../../hooks/usePagination';
+import { useSlowQuery } from '../../../hooks/useSlowQuery';
 import { combineMatcherStrings } from '../../../utils/alertmanager';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 import { createRelativeUrl } from '../../../utils/url';
@@ -86,6 +87,8 @@ export const HistoryEventsList = ({
     previous: stateFrom !== 'all' ? stateFrom : undefined,
   });
 
+  const isSlowQuery = useSlowQuery(isLoading, { threshold: 5_000 });
+
   const { historyRecords: historyRecordsNotSorted } = useRuleHistoryRecords(stateHistory, {
     labels: valueInLabelFilter.toString(),
   });
@@ -111,6 +114,17 @@ export const HistoryEventsList = ({
           {t(
             'alerting.central-alert-history.too-many-events.text',
             'The selected time period has too many events to display. Displaying the latest 5000 events. Try using a shorter time period.'
+          )}
+        </Alert>
+      )}
+      {isSlowQuery && (
+        <Alert
+          severity="warning"
+          title={t('alerting.central-alert-history.slow-query.title', 'Query is taking longer than expected')}
+        >
+          {t(
+            'alerting.central-alert-history.slow-query.text',
+            'This query is taking longer than expected. This can happen when a regex or negation label filter matches too many alert instances. Consider using a shorter time range or a more specific filter.'
           )}
         </Alert>
       )}

--- a/public/app/features/alerting/unified/components/rules/central-state-history/HistoryErrorMessage.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/HistoryErrorMessage.tsx
@@ -1,7 +1,8 @@
-import { t } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
+import { getMessageFromError } from 'app/core/utils/errors';
 
 import { stringifyErrorLike } from '../../../utils/misc';
 
@@ -9,10 +10,42 @@ export interface HistoryErrorMessageProps {
   error: unknown;
 }
 
+// Known substrings in the error message that indicate the Loki query itself failed due to
+// being too expensive (context canceled by Grafana after timeout, or Loki returning a non-200
+// because the gRPC response exceeded its max message size).
+const LOKI_QUERY_OVERLOAD_PATTERNS = ['context canceled', 'received a non-200 response from loki'];
+
+function isLokiQueryOverloadError(error: unknown): boolean {
+  if (!isFetchError(error) || error.status !== 500) {
+    return false;
+  }
+  const message = getMessageFromError(error).toLowerCase();
+  return LOKI_QUERY_OVERLOAD_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
 export function HistoryErrorMessage({ error }: HistoryErrorMessageProps) {
   if (isFetchError(error) && error.status === 404) {
     return <EntityNotFound entity="History" />;
   }
+
+  if (isLokiQueryOverloadError(error)) {
+    return (
+      <Alert
+        title={t(
+          'alerting.central-alert-history.error.server-error',
+          'The alert state history query failed — the server returned an error'
+        )}
+        severity="error"
+      >
+        <Trans i18nKey="alerting.central-alert-history.error.server-error.description">
+          This can happen when a regex or negation label filter matches too many alert instances and the response
+          exceeds the server&apos;s size limit. Try using a shorter time range or a more specific filter (e.g. an exact
+          match instead of a regex).
+        </Trans>
+      </Alert>
+    );
+  }
+
   const title = t('alerting.central-alert-history.error', 'Something went wrong loading the alert state history');
   const errorStr = stringifyErrorLike(error);
 

--- a/public/app/features/alerting/unified/components/rules/central-state-history/HistoryEventsList.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/HistoryEventsList.test.tsx
@@ -152,12 +152,12 @@ describe('HistoryEventsList', () => {
   });
 
   describe('backend filtering', () => {
-    it('should send only exact match filters to the backend', async () => {
+    it('should send all matchers (including regex and negation) to the backend via the matchers param', async () => {
       const capture = captureRequests((req) => req.url.includes('/api/v1/rules/history'));
 
       render(
         <HistoryEventsList
-          valueInLabelFilter={'alertname=alert1, grafana_folder=~".*folder.*", severity!=high, team="alerting"'}
+          valueInLabelFilter={'alertname=alert1, grafana_folder=~".*folder.*", severity!="high", team="alerting"'}
           valueInStateToFilter={StateFilterValues.all}
           valueInStateFromFilter={StateFilterValues.all}
           addFilter={jest.fn()}
@@ -174,28 +174,34 @@ describe('HistoryEventsList', () => {
 
       const url = new URL(requests[0].url);
 
-      expect(url.searchParams.get('labels_alertname')).toBe('alert1');
-      expect(url.searchParams.get('labels_team')).toBe('alerting');
-      expect(url.searchParams.get('labels_grafana_folder')).toBeNull();
-      expect(url.searchParams.get('labels_severity')).toBeNull();
+      // All matchers are forwarded as a single `matchers` selector param.
+      const matchersParam = url.searchParams.get('matchers');
+      expect(matchersParam).not.toBeNull();
+      expect(matchersParam).toContain('alertname=alert1');
+      expect(matchersParam).toContain('grafana_folder=~".*folder.*"');
+      expect(matchersParam).toContain('severity!="high"');
+      expect(matchersParam).toContain('team="alerting"');
+
+      // Legacy per-label params must not be used anymore.
+      expect(url.searchParams.get('labels_alertname')).toBeNull();
+      expect(url.searchParams.get('labels_team')).toBeNull();
     });
 
-    it('should apply same backend filtering to chart data via getHistory function', async () => {
+    it('should forward the matchers string to chart data via getHistory function', async () => {
       const capture = captureRequests((req) => req.url.includes('/api/v1/rules/history'));
 
       const from = 123;
       const to = 456;
-      const labels = { alertname: 'alert_1', team: 'alerting' };
+      const matchers = '{alertname="alert_1",team="alerting"}';
 
-      await getHistory(from, to, labels);
+      await getHistory(from, to, matchers);
 
       const requests = await capture;
       expect(requests).toHaveLength(1);
 
       const url = new URL(requests[0].url);
 
-      expect(url.searchParams.get('labels_alertname')).toBe(labels.alertname);
-      expect(url.searchParams.get('labels_team')).toBe(labels.team);
+      expect(url.searchParams.get('matchers')).toBe(matchers);
       expect(url.searchParams.get('from')).toBe(from.toString());
       expect(url.searchParams.get('to')).toBe(to.toString());
     });

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.test.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.test.ts
@@ -1,5 +1,5 @@
 import fixtureData from './__fixtures__/alert-state-history';
-import { historyResultToDataFrame } from './utils';
+import { historyResultToDataFrame, toMatchersParam } from './utils';
 
 describe('historyResultToDataFrame', () => {
   it('should decode', () => {
@@ -15,5 +15,37 @@ describe('historyResultToDataFrame', () => {
   });
   it('should decode and filter example2', () => {
     expect(historyResultToDataFrame(fixtureData, { labels: 'region: EMEA' })).toMatchSnapshot();
+  });
+});
+
+describe('toMatchersParam', () => {
+  it('returns undefined for empty string', () => {
+    expect(toMatchersParam('')).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(toMatchersParam('   ')).toBeUndefined();
+  });
+
+  it('passes through already-wrapped selector unchanged', () => {
+    expect(toMatchersParam('{severity="critical"}')).toBe('{severity="critical"}');
+  });
+
+  it('passes through selector with all operator types unchanged', () => {
+    expect(toMatchersParam('{severity=~"crit.*",env!="dev",zone!~"us-.*"}')).toBe(
+      '{severity=~"crit.*",env!="dev",zone!~"us-.*"}'
+    );
+  });
+
+  it('wraps bare matchers in braces', () => {
+    expect(toMatchersParam('severity="critical"')).toBe('{severity="critical"}');
+  });
+
+  it('wraps bare comma-separated matchers in braces', () => {
+    expect(toMatchersParam('alertname=alert1, team="alerting"')).toBe('{alertname=alert1, team="alerting"}');
+  });
+
+  it('wraps mixed operator bare matchers in braces', () => {
+    expect(toMatchersParam('severity=~"crit.*",env!="dev"')).toBe('{severity=~"crit.*",env!="dev"}');
   });
 });

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -14,7 +14,7 @@ import {
 import { fieldIndexComparer } from '@grafana/data/internal';
 
 import { labelsMatchMatchers } from '../../../utils/alertmanager';
-import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
+import { isPromQLStyleMatcher, parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 import { LogRecord, historyDataFrameToLogRecords } from '../state-history/common';
 
 import { LABELS_FILTER, STATE_FILTER_FROM, STATE_FILTER_TO } from './CentralAlertHistoryScene';
@@ -24,20 +24,19 @@ const GROUPING_INTERVAL = 10 * 1000; // 10 seconds
 const QUERY_PARAM_PREFIX = 'var-'; // Prefix used by Grafana to sync variables in the URL
 
 /**
- * Parse label filters and prepare backend filters.
- * Backend supports only exact matchers.
+ * Normalise a free-text PromQL-style label filter string into the selector
+ * format expected by the backend `matchers` query parameter.
+ *
+ * - Empty / whitespace-only input → undefined (param omitted from request)
+ * - Already wrapped in `{}` → returned as-is
+ * - Bare matchers like `foo="bar",baz=~".*"` → wrapped in `{foo="bar",baz=~".*"}`
  */
-export function parseBackendLabelFilters(labelFilter: string): Record<string, string> {
-  const labelMatchers = parsePromQLStyleMatcherLooseSafe(labelFilter);
-  const labelFilters: Record<string, string> = {};
-
-  labelMatchers.forEach((matcher) => {
-    if (!matcher.isRegex && matcher.isEqual) {
-      labelFilters[matcher.name] = matcher.value;
-    }
-  });
-
-  return labelFilters;
+export function toMatchersParam(labelFilter: string): string | undefined {
+  const trimmed = labelFilter.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return isPromQLStyleMatcher(trimmed) ? trimmed : `{${trimmed}}`;
 }
 
 interface HistoryFilters {

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -10,6 +10,7 @@ import { Trans, t } from '@grafana/i18n';
 import { Alert, Button, Field, Icon, Input, Label, Select, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { stateHistoryApi } from '../../../api/stateHistoryApi';
+import { useSlowQuery } from '../../../hooks/useSlowQuery';
 import { combineMatcherStrings } from '../../../utils/alertmanager';
 import { PopupCard } from '../../HoverCard';
 import { StateFilterValues } from '../central-state-history/constants';
@@ -70,6 +71,8 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
     }
   );
 
+  const isSlowQuery = useSlowQuery(isLoading);
+
   const { dataFrames, historyRecords, commonLabels, totalRecordsCount } = useRuleHistoryRecords(
     stateHistory,
     instancesFilter
@@ -95,9 +98,22 @@ const LokiStateHistory = ({ ruleUID }: Props) => {
 
   if (isLoading) {
     return (
-      <div>
-        <Trans i18nKey="alerting.loki-state-history.loading">Loading...</Trans>
-      </div>
+      <Stack direction="column" gap={1}>
+        {isSlowQuery && (
+          <Alert
+            severity="warning"
+            title={t('alerting.loki-state-history.slow-query.title', 'Query is taking longer than expected')}
+          >
+            {t(
+              'alerting.loki-state-history.slow-query.text',
+              'This query is taking longer than expected. This can happen when a regex or negation label filter matches too many alert instances. Consider using a shorter time range or a more specific filter.'
+            )}
+          </Alert>
+        )}
+        <div>
+          <Trans i18nKey="alerting.loki-state-history.loading">Loading...</Trans>
+        </div>
+      </Stack>
     );
   }
   if (isError) {

--- a/public/app/features/alerting/unified/hooks/useSlowQuery.test.ts
+++ b/public/app/features/alerting/unified/hooks/useSlowQuery.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useSlowQuery } from './useSlowQuery';
+
+describe('useSlowQuery()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns false before the threshold has elapsed', () => {
+    const { result } = renderHook(() => useSlowQuery(true, { threshold: 10_000 }));
+
+    act(() => {
+      jest.advanceTimersByTime(9_999);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true once the threshold has elapsed while loading', () => {
+    const { result } = renderHook(() => useSlowQuery(true, { threshold: 10_000 }));
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('resets to false when loading finishes', () => {
+    const { result, rerender } = renderHook(({ isLoading }) => useSlowQuery(isLoading, { threshold: 10_000 }), {
+      initialProps: { isLoading: true },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+    expect(result.current).toBe(true);
+
+    rerender({ isLoading: false });
+    expect(result.current).toBe(false);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useSlowQuery.ts
+++ b/public/app/features/alerting/unified/hooks/useSlowQuery.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react';
+
+const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 5_000; // 5 seconds
+
+interface UseSlowQueryOptions {
+  /** Time in milliseconds before the query is considered slow. Defaults to 10 000 ms. */
+  threshold?: number;
+}
+
+/**
+ * Returns true once `isLoading` has been continuously true for longer than `threshold` ms.
+ * Resets to false when `isLoading` becomes false.
+ */
+export function useSlowQuery(isLoading: boolean, options: UseSlowQueryOptions = {}): boolean {
+  const { threshold = DEFAULT_SLOW_QUERY_THRESHOLD_MS } = options;
+  const [isSlowQuery, setIsSlowQuery] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (isLoading) {
+      timerRef.current = setTimeout(() => setIsSlowQuery(true), threshold);
+    } else {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setIsSlowQuery(false);
+    }
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [isLoading, threshold]);
+
+  return isSlowQuery;
+}

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -28,6 +28,7 @@ import { EventState } from '../../components/rules/central-state-history/EventLi
 import { LogRecord, historyDataFrameToLogRecords } from '../../components/rules/state-history/common';
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { quoteWithEscape } from '../../utils/matchers';
 import { stringifyErrorLike } from '../../utils/misc';
 import { groups, rulesNav } from '../../utils/navigation';
 import { useWorkbenchContext } from '../WorkbenchContext';
@@ -56,6 +57,20 @@ interface InstanceDetailsDrawerProps {
   onClose: () => void;
 }
 
+/**
+ * Converts a Labels map (Record<string, string>) into a PromQL selector string
+ * suitable for the `matchers` query parameter, e.g. `{alertname="cpu",env="prod"}`.
+ * Returns undefined when the map is empty.
+ */
+function labelsToMatchersParam(labels: Labels): string | undefined {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const parts = entries.map(([k, v]) => `${k}=${quoteWithEscape(v)}`);
+  return `{${parts.join(',')}}`;
+}
+
 export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: InstanceDetailsDrawerProps) {
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
   const [timeRange] = useTimeRange();
@@ -79,7 +94,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: Inst
     isError: stateHistoryError,
   } = useGetRuleHistoryQuery({
     ruleUid: ruleUID,
-    labels: instanceLabels,
+    matchers: labelsToMatchersParam(instanceLabels),
     from: timeRange.from.unix(),
     to: timeRange.to.unix(),
   });

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -28,7 +28,7 @@ import { EventState } from '../../components/rules/central-state-history/EventLi
 import { LogRecord, historyDataFrameToLogRecords } from '../../components/rules/state-history/common';
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
-import { quoteWithEscape } from '../../utils/matchers';
+import { labelsToMatchersParam } from '../../utils/matchers';
 import { stringifyErrorLike } from '../../utils/misc';
 import { groups, rulesNav } from '../../utils/navigation';
 import { useWorkbenchContext } from '../WorkbenchContext';
@@ -55,20 +55,6 @@ interface InstanceDetailsDrawerProps {
   ruleUID: string;
   instanceLabels: Labels;
   onClose: () => void;
-}
-
-/**
- * Converts a Labels map (Record<string, string>) into a PromQL selector string
- * suitable for the `matchers` query parameter, e.g. `{alertname="cpu",env="prod"}`.
- * Returns undefined when the map is empty.
- */
-function labelsToMatchersParam(labels: Labels): string | undefined {
-  const entries = Object.entries(labels);
-  if (entries.length === 0) {
-    return undefined;
-  }
-  const parts = entries.map(([k, v]) => `${k}=${quoteWithEscape(v)}`);
-  return `{${parts.join(',')}}`;
 }
 
 export function InstanceDetailsDrawer({ ruleUID, instanceLabels, onClose }: InstanceDetailsDrawerProps) {

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -4,6 +4,7 @@ import {
   encodeMatcher,
   getMatcherQueryParams,
   isPromQLStyleMatcher,
+  labelsToMatchersParam,
   matcherToObjectMatcher,
   normalizeMatchers,
   parseMatcher,
@@ -295,5 +296,27 @@ describe('parsePromQLStyleMatcherLoose', () => {
       { isEqual: true, isRegex: false, name: 'foo', value: 'bar' },
       { isEqual: true, isRegex: false, name: 'bar', value: 'baz' },
     ]);
+  });
+});
+
+describe('labelsToMatchersParam', () => {
+  it('should return undefined for empty labels', () => {
+    expect(labelsToMatchersParam({})).toBeUndefined();
+  });
+
+  it('should convert single label to matcher param', () => {
+    expect(labelsToMatchersParam({ alertname: 'cpu' })).toBe('{alertname="cpu"}');
+  });
+
+  it('should convert multiple labels to matcher param', () => {
+    expect(labelsToMatchersParam({ alertname: 'cpu', env: 'prod' })).toBe('{alertname="cpu",env="prod"}');
+  });
+
+  it('should escape special characters in values', () => {
+    expect(labelsToMatchersParam({ alertname: 'cpu"alert' })).toBe('{alertname="cpu\\"alert"}');
+  });
+
+  it('should handle labels with special characters', () => {
+    expect(labelsToMatchersParam({ 'job-name': 'my\\job' })).toBe('{job-name="my\\\\job"}');
   });
 });

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -262,3 +262,12 @@ export function convertObjectMatcherToAlertingPackageMatcher(matcher: ObjectMatc
     value,
   };
 }
+
+export function labelsToMatchersParam(labels: Labels): string | undefined {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const parts = entries.map(([k, v]) => `${k}=${quoteWithEscape(v)}`);
+  return `{${parts.join(',')}}`;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -774,7 +774,9 @@
         "unknown-rule": "Unknown",
         "value-in-transition": "Value in transition"
       },
-      "error": "Something went wrong loading the alert state history",
+      "error": {
+        "server-error": "The alert state history query failed — the server returned an error"
+      },
       "filter": {
         "clear": "Clear filters",
         "info": {
@@ -785,6 +787,10 @@
         }
       },
       "filterBy": "Filter by:",
+      "slow-query": {
+        "text": "This query is taking longer than expected. This can happen when a regex or negation label filter matches too many alert instances. Consider using a shorter time range or a more specific filter.",
+        "title": "Query is taking longer than expected"
+      },
       "tab": {
         "alert-events": "Alert events",
         "notifications": "Notifications"
@@ -2010,6 +2016,10 @@
       "error-unable-to-fetch": "Unable to fetch alert state history",
       "loading": "Loading...",
       "no-transitions-match-filters": "No state transitions match the selected filters",
+      "slow-query": {
+        "text": "This query is taking longer than expected. This can happen when a regex or negation label filter matches too many alert instances. Consider using a shorter time range or a more specific filter.",
+        "title": "Query is taking longer than expected"
+      },
       "start-state": "Start state",
       "timeline-hidden": "Timeline is hidden when state filters are active",
       "title-error-fetching-the-state-history": "Error fetching the state history",


### PR DESCRIPTION
**What is this feature?**

Extends the `/api/v1/rules/history` endpoint and its frontend consumers to support all four PromQL label matcher operators: `=`, `!=`, `=~`, `!~`.

Previously only exact equality (\`=\`) was supported for label filtering — non-equality matchers were silently dropped on the frontend before being sent to the backend.

**Why do we need this feature?**

Users querying alert state history often need to filter by regex patterns (e.g. \`severity=~"crit.*"\`) or exclude certain label values (e.g. \`env!="dev"\`). Without this, the only workaround was client-side filtering after fetching a potentially large result set, which is inefficient and doesn't reduce the data transferred from the backend.

**Who is this feature for?**

Grafana users and operators who use the central alert history view or query the history API directly, particularly those managing large numbers of alert instances and needing precise label-based filtering.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The annotation backend still ignores label filters (pre-existing behaviour, unrelated to this change).
- The \`labels_<key>=<value>\` URL param format is preserved for backward compatibility with existing API clients.
- Client-side filtering in \`useRuleHistoryRecords\` / \`groupDataFramesByTimeAndFilterByLabels\` is kept in place as defence-in-depth but is now redundant for label matching.

> **Why frontend and backend changes are in the same PR** (\`no-check-mt-service-compatibility\`): The frontend change switches from the \`labels_<key>=<value>\` param format to the new \`matchers\` param, which only exists after the backend change lands. These changes are backward compatible in both directions — the backend still accepts the old \`labels_\` params, and the frontend gracefully omits \`matchers\` when the filter is empty — so they can be deployed independently without breakage. However, keeping them together simplifies review and ensures the feature works end-to-end from a single PR.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.