### PR TITLE
Plugins: Use CDN URL for core meta 

### DIFF
--- a/apps/plugins/pkg/app/meta/core.go
+++ b/apps/plugins/pkg/app/meta/core.go
@@ -2,6 +2,9 @@ package meta
 
 import (
 	"context"
+	"net/url"
+	"path"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -16,7 +19,9 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/initialization"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/termination"
 	"github.com/grafana/grafana/pkg/plugins/manager/pipeline/validation"
+	"github.com/grafana/grafana/pkg/plugins/manager/signature"
 	"github.com/grafana/grafana/pkg/plugins/manager/sources"
+	"github.com/grafana/grafana/pkg/plugins/pluginassets"
 	"github.com/grafana/grafana/pkg/plugins/pluginerrs"
 	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 )
@@ -27,32 +32,50 @@ const (
 
 // CoreProvider retrieves plugin metadata for core plugins.
 type CoreProvider struct {
-	mu              sync.RWMutex
-	loadedPlugins   map[string]pluginsv0alpha1.MetaSpec
-	initialized     bool
-	ttl             time.Duration
-	loader          pluginsLoader.Service
-	pluginsPathFunc func() (string, error)
-	logger          logging.Logger
+	mu            sync.RWMutex
+	loadedPlugins map[string]pluginsv0alpha1.MetaSpec
+	initialized   bool
+	ttl           time.Duration
+	loader        pluginsLoader.Service
+	pluginsPath   string
+	logger        logging.Logger
+}
+
+type CoreProviderOpts struct {
+	PluginsPath  func() (string, error)
+	RemoteAssets CoreProviderRemoteAssets
+}
+
+type CoreProviderRemoteAssets struct {
+	Enabled       bool
+	GrafanaCDNURL func() (string, error)
 }
 
 // NewCoreProvider creates a new CoreProvider for core plugins.
-func NewCoreProvider(logger logging.Logger, pluginsPath func() (string, error)) *CoreProvider {
-	return NewCoreProviderWithTTL(logger, pluginsPath, defaultCoreTTL)
+func NewCoreProvider(logger logging.Logger, opts CoreProviderOpts) (*CoreProvider, error) {
+	pluginsPath, err := opts.PluginsPath()
+	if err != nil {
+		logger.Warn("Could not get core plugins path", "error", err)
+		return nil, err
+	}
+
+	return NewCoreProviderWithTTL(logger, pluginsPath, opts.RemoteAssets, defaultCoreTTL)
 }
 
 // NewCoreProviderWithTTL creates a new CoreProvider with a custom TTL.
-func NewCoreProviderWithTTL(logger logging.Logger, pluginsPathFunc func() (string, error), ttl time.Duration) *CoreProvider {
-	cfg := &config.PluginManagementCfg{
-		Features: config.Features{},
+func NewCoreProviderWithTTL(logger logging.Logger, pluginsPath string, remoteAssets CoreProviderRemoteAssets, ttl time.Duration) (*CoreProvider, error) {
+	loader, err := createLoader(remoteAssets)
+	if err != nil {
+		return nil, err
 	}
+
 	return &CoreProvider{
-		loadedPlugins:   make(map[string]pluginsv0alpha1.MetaSpec),
-		ttl:             ttl,
-		loader:          createLoader(cfg),
-		pluginsPathFunc: pluginsPathFunc,
-		logger:          logger,
-	}
+		loadedPlugins: make(map[string]pluginsv0alpha1.MetaSpec),
+		ttl:           ttl,
+		loader:        loader,
+		pluginsPath:   pluginsPath,
+		logger:        logger,
+	}, nil
 }
 
 func (p *CoreProvider) Init(ctx context.Context) error {
@@ -114,13 +137,7 @@ func (p *CoreProvider) GetMeta(ctx context.Context, ref PluginRef) (*Result, err
 // This error will be handled gracefully by GetMeta, which will return ErrMetaNotFound
 // to allow other providers to handle the request.
 func (p *CoreProvider) loadPlugins(ctx context.Context) error {
-	pluginsPath, err := p.pluginsPathFunc()
-	if err != nil {
-		p.logger.WithContext(ctx).Warn("Could not get core plugins path", "error", err)
-		return err
-	}
-
-	src := sources.NewLocalSource(plugins.ClassCore, []string{pluginsPath})
+	src := sources.NewLocalSource(plugins.ClassCore, []string{p.pluginsPath})
 	loadedPlugins, err := p.loader.Load(ctx, src)
 	if err != nil {
 		return err
@@ -140,13 +157,25 @@ func (p *CoreProvider) loadPlugins(ctx context.Context) error {
 }
 
 // createLoader creates a loader service configured for core plugins.
-func createLoader(cfg *config.PluginManagementCfg) pluginsLoader.Service {
+func createLoader(remoteAssets CoreProviderRemoteAssets) (pluginsLoader.Service, error) {
+	cfg := &config.PluginManagementCfg{}
+
+	constructFunc := bootstrap.DefaultConstructFunc(cfg, signature.DefaultCalculator(cfg), pluginassets.NewLocalProvider())
+	if remoteAssets.Enabled {
+		cdnURL, err := remoteAssets.GrafanaCDNURL()
+		if err != nil {
+			return nil, err
+		}
+		constructFunc = bootstrap.DefaultConstructFunc(cfg, signature.DefaultCalculator(cfg), newCoreAssetProvider(cdnURL))
+	}
+
 	d := discovery.New(cfg, discovery.Opts{
 		FilterFuncs: []discovery.FilterFunc{
 			// Allow all plugin types for core plugins
 		},
 	})
 	b := bootstrap.New(cfg, bootstrap.Opts{
+		ConstructFunc: constructFunc,
 		DecorateFuncs: []bootstrap.DecorateFunc{
 			bootstrap.LoadingStrategyDecorateFunc(cfg, pluginscdn.ProvideService(cfg)),
 		}, // no decoration required for metadata
@@ -169,5 +198,23 @@ func createLoader(cfg *config.PluginManagementCfg) pluginsLoader.Service {
 
 	et := pluginerrs.ProvideErrorTracker()
 
-	return pluginsLoader.New(cfg, d, b, v, i, t, et)
+	return pluginsLoader.New(cfg, d, b, v, i, t, et), nil
+}
+
+type CoreAssetProvider struct {
+	cdnURL string
+}
+
+func newCoreAssetProvider(cdnURL string) *CoreAssetProvider {
+	return &CoreAssetProvider{
+		cdnURL: cdnURL,
+	}
+}
+
+func (p *CoreAssetProvider) Module(plugin pluginassets.PluginInfo) (string, error) {
+	return path.Join("core:plugin", filepath.Base(plugin.FS.Base())), nil
+}
+
+func (p *CoreAssetProvider) AssetPath(_ pluginassets.PluginInfo, assetPath ...string) (string, error) {
+	return url.JoinPath(p.cdnURL, assetPath...)
 }

--- a/apps/plugins/pkg/app/meta/core_test.go
+++ b/apps/plugins/pkg/app/meta/core_test.go
@@ -21,7 +21,10 @@ func TestCoreProvider_GetMeta(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns cached plugin when available", func(t *testing.T) {
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(""))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(""),
+		})
+		require.NoError(t, err)
 
 		expectedMeta := pluginsv0alpha1.MetaSpec{
 			PluginJson: pluginsv0alpha1.MetaJSONData{
@@ -45,7 +48,10 @@ func TestCoreProvider_GetMeta(t *testing.T) {
 	})
 
 	t.Run("returns ErrMetaNotFound for non-existent plugin", func(t *testing.T) {
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(""))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(""),
+		})
+		require.NoError(t, err)
 
 		provider.mu.Lock()
 		provider.initialized = true
@@ -59,7 +65,10 @@ func TestCoreProvider_GetMeta(t *testing.T) {
 	})
 
 	t.Run("ignores version parameter", func(t *testing.T) {
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(""))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(""),
+		})
+		require.NoError(t, err)
 
 		expectedMeta := pluginsv0alpha1.MetaSpec{
 			PluginJson: pluginsv0alpha1.MetaJSONData{
@@ -84,7 +93,8 @@ func TestCoreProvider_GetMeta(t *testing.T) {
 
 	t.Run("uses custom TTL when provided", func(t *testing.T) {
 		customTTL := 2 * time.Hour
-		provider := NewCoreProviderWithTTL(&logging.NoOpLogger{}, pluginsPathFunc(""), customTTL)
+		provider, err := NewCoreProviderWithTTL(&logging.NoOpLogger{}, "", CoreProviderRemoteAssets{}, customTTL)
+		require.NoError(t, err)
 
 		expectedMeta := pluginsv0alpha1.MetaSpec{
 			PluginJson: pluginsv0alpha1.MetaJSONData{
@@ -117,7 +127,11 @@ func TestCoreProvider_GetMeta(t *testing.T) {
 
 		require.NoError(t, os.Chdir(tempDir))
 
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(""))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(""),
+		})
+		require.NoError(t, err)
+
 		result, err := provider.GetMeta(ctx, PluginRef{ID: "any-plugin", Version: "1.0.0"})
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, ErrMetaNotFound))
@@ -146,7 +160,10 @@ func TestCoreProvider_loadPlugins(t *testing.T) {
 		require.NoError(t, os.Chdir(grafanaRoot))
 
 		pluginsPath := filepath.Join(grafanaRoot, "public", "app", "plugins")
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(pluginsPath))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(pluginsPath),
+		})
+		require.NoError(t, err)
 		err = provider.loadPlugins(ctx)
 		require.NoError(t, err)
 		assert.Len(t, provider.loadedPlugins, 52)
@@ -163,10 +180,11 @@ func TestCoreProvider_loadPlugins(t *testing.T) {
 
 		require.NoError(t, os.Chdir(tempDir))
 
-		provider := NewCoreProvider(&logging.NoOpLogger{}, func() (string, error) { return "", errors.New("not found") })
-		err = provider.loadPlugins(ctx)
-
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: func() (string, error) { return "", errors.New("not found") },
+		})
 		assert.Error(t, err)
+		assert.Nil(t, provider)
 	})
 
 	t.Run("returns no error when no plugins found", func(t *testing.T) {
@@ -183,7 +201,10 @@ func TestCoreProvider_loadPlugins(t *testing.T) {
 		require.NoError(t, os.Chdir(tempDir))
 
 		pluginsPath := filepath.Join(tempDir, "public", "app", "plugins")
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(pluginsPath))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(pluginsPath),
+		})
+		require.NoError(t, err)
 		err = provider.loadPlugins(ctx)
 		assert.NoError(t, err)
 	})
@@ -221,7 +242,10 @@ func TestCoreProvider_loadPlugins(t *testing.T) {
 		require.NoError(t, os.Chdir(tempDir))
 
 		pluginsPath := filepath.Join(tempDir, "public", "app", "plugins")
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc(pluginsPath))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc(pluginsPath),
+		})
+		require.NoError(t, err)
 		err = provider.loadPlugins(ctx)
 
 		if err != nil {
@@ -243,33 +267,36 @@ func TestCoreProvider_loadPlugins(t *testing.T) {
 
 func TestNewCoreProvider(t *testing.T) {
 	t.Run("creates provider with default TTL", func(t *testing.T) {
-		provider := NewCoreProvider(&logging.NoOpLogger{}, pluginsPathFunc("/test/path"))
+		provider, err := NewCoreProvider(&logging.NoOpLogger{}, CoreProviderOpts{
+			PluginsPath: pluginsPathFunc("/test/path"),
+		})
+		require.NoError(t, err)
 		assert.Equal(t, defaultCoreTTL, provider.ttl)
 		assert.NotNil(t, provider.loadedPlugins)
 		assert.False(t, provider.initialized)
-		assert.NotNil(t, provider.pluginsPathFunc)
+		assert.Equal(t, "/test/path", provider.pluginsPath)
 	})
 }
 
 func TestNewCoreProviderWithTTL(t *testing.T) {
 	t.Run("creates provider with custom TTL", func(t *testing.T) {
 		customTTL := 2 * time.Hour
-		provider := NewCoreProviderWithTTL(&logging.NoOpLogger{}, pluginsPathFunc("/test/path"), customTTL)
+		provider, err := NewCoreProviderWithTTL(&logging.NoOpLogger{}, "/test/path", CoreProviderRemoteAssets{}, customTTL)
+		require.NoError(t, err)
 		assert.Equal(t, customTTL, provider.ttl)
 	})
 
 	t.Run("accepts zero TTL", func(t *testing.T) {
-		provider := NewCoreProviderWithTTL(&logging.NoOpLogger{}, pluginsPathFunc("/test/path"), 0)
+		provider, err := NewCoreProviderWithTTL(&logging.NoOpLogger{}, "/test/path", CoreProviderRemoteAssets{}, 0)
+		require.NoError(t, err)
 		assert.Equal(t, time.Duration(0), provider.ttl)
 	})
 
-	t.Run("stores plugins path function", func(t *testing.T) {
+	t.Run("stores plugins path", func(t *testing.T) {
 		expectedPath := "/usr/share/grafana/public/app/plugins"
-		provider := NewCoreProviderWithTTL(&logging.NoOpLogger{}, pluginsPathFunc(expectedPath), defaultCoreTTL)
-		assert.NotNil(t, provider.pluginsPathFunc)
-		path, err := provider.pluginsPathFunc()
+		provider, err := NewCoreProviderWithTTL(&logging.NoOpLogger{}, expectedPath, CoreProviderRemoteAssets{}, defaultCoreTTL)
 		require.NoError(t, err)
-		assert.Equal(t, expectedPath, path)
+		assert.Equal(t, expectedPath, provider.pluginsPath)
 	})
 }
 

--- a/pkg/registry/apps/plugins/register.go
+++ b/pkg/registry/apps/plugins/register.go
@@ -57,10 +57,15 @@ func ProvideAppInstaller(
 	logger := logging.DefaultLogger.With("app", "plugins.app")
 
 	localProvider := meta.NewLocalProvider(pluginStore, moduleHashCalc)
-	coreProvider := meta.NewCoreProvider(logger, func() (string, error) {
-		return getPluginsPath(cfgProvider)
+	coreProvider, err := meta.NewCoreProvider(logger, meta.CoreProviderOpts{
+		PluginsPath: func() (string, error) {
+			return getPluginsPath(cfgProvider)
+		},
 	})
-	if err := coreProvider.Init(context.Background()); err != nil {
+	if err != nil {
+		return nil, err
+	}
+	if err = coreProvider.Init(context.Background()); err != nil {
 		logger.Warn("Failed to eagerly load core plugins", "error", err)
 	}
 	metaProviderManager := meta.NewProviderManager(coreProvider, localProvider)
@@ -93,7 +98,7 @@ func getPluginsPath(cfgProvider configprovider.ConfigProvider) (string, error) {
 		return pluginsPath, nil
 	}
 
-	pluginsPath := filepath.Join(cfg.StaticRootPath, "public", "app", "plugins")
+	pluginsPath := filepath.Join(cfg.StaticRootPath, "app", "plugins")
 	if _, err = os.Stat(pluginsPath); err != nil {
 		return "", errors.New("could not find core plugins directory")
 	}


### PR DESCRIPTION
This ensures we use the appropriate asset URLs for base URL for core plugin meta responses