### PR TITLE
Alerting: Create alert rule from dashboard iterations

### DIFF
--- a/public/app/features/alerting/unified/__snapshots__/PanelAlertTabContent.test.tsx.snap
+++ b/public/app/features/alerting/unified/__snapshots__/PanelAlertTabContent.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
   ],
   "condition": "C",
   "folder": {
-    "kind": "folder",
     "title": "super folder",
     "uid": "abc",
   },

--- a/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
@@ -5,6 +5,7 @@ import { useFormContext } from 'react-hook-form';
 import { notificationsAPIv0alpha1 } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import {
   Button,
   Combobox,
@@ -27,6 +28,7 @@ import { Annotation } from '../utils/constants';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 import { NeedHelpInfoForNotificationPolicy } from './rule-editor/NotificationsStep';
+import { PolicyTreeSelector } from './rule-editor/notificaton-preview/PolicyTreeSelector';
 
 // Form path for selected contact point, using the Grafana alert manager name
 const CONTACT_POINT_PATH = `contactPoints.${GRAFANA_RULES_SOURCE_NAME}.selectedContactPoint` as const;
@@ -128,6 +130,7 @@ export function RuleNotificationSection() {
   // Validate runbook URL for form-level validation feedback
   const runbookUrlError = useMemo(() => validateRunbookUrl(runbookUrlValue), [runbookUrlValue]);
   const runbookUrlErrorId = useId();
+  const multiplePoliciesEnabled = config.featureToggles.alertingMultiplePolicies ?? false;
 
   return (
     <section className={styles.section} aria-labelledby="notification-section-heading">
@@ -191,7 +194,10 @@ export function RuleNotificationSection() {
             </Stack>
             {useNotificationPolicy ? (
               <div className={styles.contentTopSpacer}>
-                <NeedHelpInfoForNotificationPolicy />
+                <Stack direction="column" gap={2}>
+                  {multiplePoliciesEnabled && <PolicyTreeSelector />}
+                  <NeedHelpInfoForNotificationPolicy />
+                </Stack>
               </div>
             ) : (
               <div className={styles.contentTopSpacer}>

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -23,6 +23,7 @@ import {
   cleanAnnotations,
   cleanLabels,
   fixMissingRefIdsInExpressionModel,
+  folderFromDashboardMeta,
   formValuesToRulerGrafanaRuleDTO,
   formValuesToRulerRuleDTO,
   getContactPointsFromDTO,
@@ -31,6 +32,34 @@ import {
   getNotificationSettingsForDTO,
   rulerRuleToFormValues,
 } from './rule-form';
+
+describe('folderFromDashboardMeta', () => {
+  it('returns undefined when no folder metadata', () => {
+    expect(folderFromDashboardMeta({})).toBeUndefined();
+    expect(folderFromDashboardMeta({ folderUid: '', folderTitle: '' })).toBeUndefined();
+  });
+
+  it('returns folder uid and title for nested dashboards', () => {
+    expect(folderFromDashboardMeta({ folderUid: 'f1', folderTitle: 'Infra' })).toEqual({
+      uid: 'f1',
+      title: 'Infra',
+    });
+  });
+
+  it('returns root folder when only title is set (e.g. Dashboards)', () => {
+    expect(folderFromDashboardMeta({ folderUid: '', folderTitle: 'Dashboards' })).toEqual({
+      uid: '',
+      title: 'Dashboards',
+    });
+  });
+
+  it('uses uid as display title when title is missing but uid is set', () => {
+    expect(folderFromDashboardMeta({ folderUid: 'abc', folderTitle: '' })).toEqual({
+      uid: 'abc',
+      title: 'abc',
+    });
+  });
+});
 
 describe('formValuesToRulerGrafanaRuleDTO', () => {
   it('should correctly convert rule form values for grafana alerting rule', () => {

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -10,6 +10,7 @@ import {
   getNextRefId,
   rangeUtil,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { PromQuery } from '@grafana/prometheus';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
@@ -47,6 +48,7 @@ import { normalizeDefaultAnnotations } from '../rule-editor/formProcessing';
 import {
   AlertManagerManualRouting,
   ContactPoint,
+  Folder,
   KVObject,
   RuleFormType,
   RuleFormValues,
@@ -806,6 +808,19 @@ export const dataQueriesToGrafanaQueries = async (
   return result;
 };
 
+/**
+ * Folder that contains the dashboard, used to pre-fill the alert rule folder.
+ */
+export function folderFromDashboardMeta(meta: { folderUid?: string; folderTitle?: string }): Folder | undefined {
+  const uid = meta.folderUid ?? '';
+  const title = meta.folderTitle ?? '';
+  if (!uid && !title) {
+    return undefined;
+  }
+  const displayTitle = title || (uid ? uid : t('browse-dashboards.folder-picker.root-title', 'Dashboards'));
+  return { uid, title: displayTitle };
+}
+
 export const panelToRuleFormValues = async (
   panel: PanelModel,
   dashboard: DashboardModel
@@ -843,15 +858,7 @@ export const panelToRuleFormValues = async (
     queries.push(...expressions);
   }
 
-  const { folderTitle, folderUid } = dashboard.meta;
-  const folder =
-    folderUid && folderTitle
-      ? {
-          kind: 'folder',
-          uid: folderUid,
-          title: folderTitle,
-        }
-      : undefined;
+  const folder = folderFromDashboardMeta(dashboard.meta);
 
   const formValues = {
     type: RuleFormType.grafana,
@@ -921,16 +928,7 @@ export const scenesPanelToRuleFormValues = async (vizPanel: VizPanel): Promise<P
     grafanaQueries.push(...expressions);
   }
 
-  const { folderTitle, folderUid } = dashboard.state.meta;
-
-  const folder =
-    folderUid && folderTitle
-      ? {
-          kind: 'folder',
-          uid: folderUid,
-          title: folderTitle,
-        }
-      : undefined;
+  const folder = folderFromDashboardMeta(dashboard.state.meta);
 
   const formValues = {
     type: RuleFormType.grafana,

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/__snapshots__/PanelDataAlertingTab.test.tsx.snap
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/__snapshots__/PanelDataAlertingTab.test.tsx.snap
@@ -13,6 +13,10 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
     },
   ],
   "condition": "C",
+  "folder": {
+    "title": "super folder",
+    "uid": "",
+  },
   "name": "mypanel",
   "queries": [
     {


### PR DESCRIPTION
This PR addresses feedback on the intial PR: https://github.com/grafana/grafana/pull/113119
- Automatically prefill the folder based on folder title or UID (folder is set whenever metadata is usable)
- Allow user to pick notification policy if alertingMultiplePolicies is true & routing is set to Notification Policy

https://github.com/user-attachments/assets/6956f9af-bed9-4d8f-8a71-a11e9bb9dafc

