### PR TITLE
StatsPicker: Convert to Combobox

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -371,7 +371,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         <Icon
           name="times"
           className={styles.clear}
-          data-testid="combobox-clear"
           title={t('combobox.clear.title', 'Clear value')}
           aria-label={t('combobox.clear.title', 'Clear value')}
           tabIndex={0}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -371,7 +371,9 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         <Icon
           name="times"
           className={styles.clear}
+          data-testid="combobox-clear"
           title={t('combobox.clear.title', 'Clear value')}
+          aria-label={t('combobox.clear.title', 'Clear value')}
           tabIndex={0}
           role="button"
           onClick={() => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -372,7 +372,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
           name="times"
           className={styles.clear}
           title={t('combobox.clear.title', 'Clear value')}
-          aria-label={t('combobox.clear.title', 'Clear value')}
           tabIndex={0}
           role="button"
           onClick={() => {

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -24,13 +24,12 @@ export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>,
 export const selectableValueToComboboxOption = <T extends string | number>(
   v: SelectableValue<T>
 ): ComboboxOption<T> | undefined => {
-  if (v == null) {
-    return undefined;
-  }
-  if (v.value == null) {
+  if (v == null || v.value == null) {
+    console.warn('selectableValueToComboboxOption: value is null or undefined', v);
     return undefined;
   }
   if (v.icon != null && !isIconName(v.icon)) {
+    console.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
     return undefined;
   }
   return {

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,3 +1,5 @@
+import { isIconName, SelectableValue } from '@grafana/data';
+
 import { ComboboxOption } from './types';
 
 export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>, prevOption?: ComboboxOption<T>) => {
@@ -12,4 +14,31 @@ export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>,
   }
 
   return prevOption.group !== currentGroup;
+};
+
+/**
+ * returns a ComboboxOption from a SelectableValue, or undefined if it could not be converted.
+ * @param v - The SelectableValue to convert.
+ * @returns The ComboboxOption, or undefined if it could not be converted.
+ */
+export const selectableValueToComboboxOption = <T extends string | number>(
+  v: SelectableValue<T>
+): ComboboxOption<T> | undefined => {
+  if (v == null) {
+    return undefined;
+  }
+  if (v.value == null) {
+    return undefined;
+  }
+  if (v.icon != null && !isIconName(v.icon)) {
+    return undefined;
+  }
+  return {
+    label: v.label,
+    value: v.value,
+    description: v.description,
+    group: v.group,
+    infoOption: v.infoOption,
+    icon: v.icon,
+  };
 };

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.story.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.story.tsx
@@ -4,15 +4,15 @@ import { memo, useState } from 'react';
 
 import { Field } from '../Forms/Field';
 
-import { Props, StatsPicker } from './StatsPicker';
+import { StatsPickerProps, StatsPicker } from './StatsPicker';
 
-const WrapperWithState = memo<Props>(({ placeholder, allowMultiple, menuPlacement, width }) => {
+const WrapperWithState = memo<StatsPickerProps>(({ placeholder, allowMultiple, width }) => {
   const [stats, setStats] = useState<string[]>([]);
 
   return (
     <Field label="Pick stats">
       <StatsPicker
-        inputId="stats-picker"
+        id="stats-picker"
         placeholder={placeholder}
         allowMultiple={allowMultiple}
         stats={stats}
@@ -20,7 +20,6 @@ const WrapperWithState = memo<Props>(({ placeholder, allowMultiple, menuPlacemen
           action('Picked:')(newStats);
           setStats(newStats);
         }}
-        menuPlacement={menuPlacement}
         width={width}
       />
     </Field>
@@ -34,7 +33,7 @@ const meta: Meta<typeof StatsPicker> = {
   component: StatsPicker,
   parameters: {
     controls: {
-      exclude: ['onChange', 'stats', 'defaultStat', 'className'],
+      exclude: ['onChange', 'stats', 'defaultStat'],
     },
   },
 };
@@ -49,7 +48,6 @@ export const Picker: StoryFn<typeof StatsPicker> = (args) => {
 Picker.args = {
   placeholder: 'placeholder',
   allowMultiple: false,
-  menuPlacement: 'auto',
   width: 10,
 };
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useCallback, useRef, useState, type ReactElement } from 'react';
+import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
 
 import { ReducerID } from '@grafana/data';
 
@@ -42,18 +43,7 @@ describe('StatsPicker', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
   beforeAll(() => {
-    const mockGetBoundingClientRect = jest.fn(() => ({
-      width: 300,
-      height: 40,
-      top: 0,
-      left: 0,
-      bottom: 0,
-      right: 0,
-    }));
-
-    Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
-      value: mockGetBoundingClientRect,
-    });
+    comboboxTestSetup();
   });
 
   beforeEach(() => {
@@ -76,19 +66,9 @@ describe('StatsPicker', () => {
     expect(screen.getByDisplayValue('Total')).toBeInTheDocument();
   });
 
-  it('applies deprecated inputId to the combobox input', () => {
-    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} inputId="stats-picker-field" />);
-    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'stats-picker-field');
-  });
-
   it('applies the id prop to the combobox input', () => {
     render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} id="stats-picker-by-id" />);
     expect(screen.getByRole('combobox')).toHaveAttribute('id', 'stats-picker-by-id');
-  });
-
-  it('uses id over inputId when both are set', () => {
-    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} id="canonical-id" inputId="legacy-input-id" />);
-    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'canonical-id');
   });
 
   it('applies id to the MultiCombobox input', () => {
@@ -143,7 +123,7 @@ describe('StatsPicker', () => {
   it('renders MultiCombobox when allowMultiple is true', () => {
     render(
       <StatsPicker
-        inputId={TEST_INPUT_ID}
+        id={TEST_INPUT_ID}
         data-testid={TEST_INPUT_TESTID}
         stats={[ReducerID.sum]}
         onChange={jest.fn()}
@@ -180,7 +160,7 @@ describe('StatsPicker', () => {
 
   it('shows the clear control when defaultStat is omitted and a value is selected', () => {
     render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} data-testid={TEST_INPUT_TESTID} />);
-    expect(screen.getByTestId('combobox-clear')).toBeInTheDocument();
+    expect(screen.getByLabelText('Clear value')).toBeInTheDocument();
   });
 
   it('hides the clear control when defaultStat is provided', () => {
@@ -192,7 +172,7 @@ describe('StatsPicker', () => {
         data-testid={TEST_INPUT_TESTID}
       />
     );
-    expect(screen.queryByTestId('combobox-clear')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Clear value')).not.toBeInTheDocument();
   });
 
   it('forwards combobox selection to onChange as a single-element array', async () => {
@@ -252,7 +232,7 @@ describe('StatsPicker', () => {
 
     renderWithField(<Controlled />);
 
-    await user.click(screen.getByTestId('combobox-clear'));
+    await user.click(screen.getByLabelText('Clear value'));
 
     await waitFor(() => {
       expect(onChange).toHaveBeenLastCalledWith([]);

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useCallback, useRef, useState, type ReactElement } from 'react';
-import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
 
 import { ReducerID } from '@grafana/data';
 
@@ -9,6 +8,22 @@ import { Field } from '../Forms/Field';
 
 import { StatsPicker } from './StatsPicker';
 import { pickComboboxLayout } from './pickComboboxLayout';
+
+/** Needed for Combobox virtual list. Clone of `public/test/helpers/comboboxTestSetup` (avoid cross-package import). */
+const comboboxTestSetup = () => {
+  const mockGetBoundingClientRect = jest.fn(() => ({
+    width: 120,
+    height: 120,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+  }));
+
+  Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+    value: mockGetBoundingClientRect,
+  });
+};
 
 describe('pickComboboxLayout', () => {
   it('returns auto layout with default minWidth 8 when minWidth is omitted', () => {

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
@@ -175,7 +175,7 @@ describe('StatsPicker', () => {
 
   it('shows the clear control when defaultStat is omitted and a value is selected', () => {
     render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} data-testid={TEST_INPUT_TESTID} />);
-    expect(screen.getByLabelText('Clear value')).toBeInTheDocument();
+    expect(screen.getByTitle('Clear value')).toBeInTheDocument();
   });
 
   it('hides the clear control when defaultStat is provided', () => {
@@ -187,7 +187,7 @@ describe('StatsPicker', () => {
         data-testid={TEST_INPUT_TESTID}
       />
     );
-    expect(screen.queryByLabelText('Clear value')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Clear value')).not.toBeInTheDocument();
   });
 
   it('forwards combobox selection to onChange as a single-element array', async () => {
@@ -247,7 +247,7 @@ describe('StatsPicker', () => {
 
     renderWithField(<Controlled />);
 
-    await user.click(screen.getByLabelText('Clear value'));
+    await user.click(screen.getByTitle('Clear value'));
 
     await waitFor(() => {
       expect(onChange).toHaveBeenLastCalledWith([]);

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
@@ -1,0 +1,261 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useCallback, useRef, useState, type ReactElement } from 'react';
+
+import { ReducerID } from '@grafana/data';
+
+import { Field } from '../Forms/Field';
+
+import { StatsPicker } from './StatsPicker';
+import { pickComboboxLayout } from './pickComboboxLayout';
+
+describe('pickComboboxLayout', () => {
+  it('returns auto layout with default minWidth 8 when minWidth is omitted', () => {
+    expect(pickComboboxLayout('auto', undefined, undefined)).toEqual({
+      width: 'auto',
+      minWidth: 8,
+      maxWidth: undefined,
+    });
+  });
+
+  it('returns auto layout with the given minWidth and maxWidth', () => {
+    expect(pickComboboxLayout('auto', 12, 320)).toEqual({
+      width: 'auto',
+      minWidth: 12,
+      maxWidth: 320,
+    });
+  });
+
+  it('returns only numeric width when width is a number (ignores minWidth and maxWidth)', () => {
+    expect(pickComboboxLayout(40, 8, 200)).toEqual({ width: 40 });
+  });
+
+  it('returns undefined width when width is omitted (ignores minWidth and maxWidth)', () => {
+    expect(pickComboboxLayout(undefined, 16, 400)).toEqual({ width: undefined });
+  });
+});
+
+const TEST_INPUT_ID = 'stats-picker-test-input';
+const TEST_INPUT_TESTID = 'stats-picker-test-input';
+
+describe('StatsPicker', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeAll(() => {
+    const mockGetBoundingClientRect = jest.fn(() => ({
+      width: 300,
+      height: 40,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+    }));
+
+    Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+      value: mockGetBoundingClientRect,
+    });
+  });
+
+  beforeEach(() => {
+    user = userEvent.setup({ applyAccept: false });
+    jest.clearAllMocks();
+  });
+
+  const renderWithField = (picker: ReactElement) =>
+    render(
+      <Field label="Stats" htmlFor={TEST_INPUT_ID}>
+        {picker}
+      </Field>
+    );
+
+  it('renders a combobox and shows the label for the selected stat', () => {
+    renderWithField(
+      <StatsPicker id={TEST_INPUT_ID} data-testid={TEST_INPUT_TESTID} stats={[ReducerID.sum]} onChange={jest.fn()} />
+    );
+    expect(screen.getByRole('combobox', { name: 'Stats' })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Total')).toBeInTheDocument();
+  });
+
+  it('applies deprecated inputId to the combobox input', () => {
+    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} inputId="stats-picker-field" />);
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'stats-picker-field');
+  });
+
+  it('applies the id prop to the combobox input', () => {
+    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} id="stats-picker-by-id" />);
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'stats-picker-by-id');
+  });
+
+  it('uses id over inputId when both are set', () => {
+    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} id="canonical-id" inputId="legacy-input-id" />);
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'canonical-id');
+  });
+
+  it('applies id to the MultiCombobox input', () => {
+    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} allowMultiple id="multi-stats-input" />);
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', 'multi-stats-input');
+  });
+
+  it('associates Field label with the input via htmlFor and id', async () => {
+    renderWithField(<StatsPicker id={TEST_INPUT_ID} stats={[ReducerID.sum]} onChange={jest.fn()} />);
+
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', TEST_INPUT_ID);
+    await user.click(screen.getByText('Stats'));
+    expect(screen.getByRole('combobox')).toHaveFocus();
+  });
+
+  it('calls onChange with only known stats when the list contains unknown ids', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const onChange = jest.fn();
+
+    render(<StatsPicker stats={['not-a-real-reducer', ReducerID.sum]} onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([ReducerID.sum]);
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('calls onChange with the first stat when multiple are passed and allowMultiple is false', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const onChange = jest.fn();
+
+    render(<StatsPicker stats={[ReducerID.sum, ReducerID.mean]} onChange={onChange} allowMultiple={false} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([ReducerID.sum]);
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('calls onChange with defaultStat when stats is empty', async () => {
+    const onChange = jest.fn();
+
+    render(<StatsPicker stats={[]} onChange={onChange} defaultStat={ReducerID.last} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([ReducerID.last]);
+    });
+  });
+
+  it('renders MultiCombobox when allowMultiple is true', () => {
+    render(
+      <StatsPicker
+        inputId={TEST_INPUT_ID}
+        data-testid={TEST_INPUT_TESTID}
+        stats={[ReducerID.sum]}
+        onChange={jest.fn()}
+        allowMultiple
+      />
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Total' })).toBeInTheDocument();
+  });
+
+  it('renders Combobox when allowMultiple is false', () => {
+    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove Total' })).not.toBeInTheDocument();
+  });
+
+  it('passes only filterOptions-matching stats as combobox options', async () => {
+    render(
+      <StatsPicker
+        stats={[ReducerID.sum]}
+        onChange={jest.fn()}
+        filterOptions={(ext) => ext.id === ReducerID.sum}
+        data-testid={TEST_INPUT_TESTID}
+      />
+    );
+
+    await user.click(screen.getByTestId(TEST_INPUT_TESTID));
+
+    await waitFor(() => {
+      expect(document.querySelector('#combobox-option-sum')).toBeInTheDocument();
+    });
+    expect(document.querySelector('#combobox-option-mean')).not.toBeInTheDocument();
+  });
+
+  it('shows the clear control when defaultStat is omitted and a value is selected', () => {
+    render(<StatsPicker stats={[ReducerID.sum]} onChange={jest.fn()} data-testid={TEST_INPUT_TESTID} />);
+    expect(screen.getByTestId('combobox-clear')).toBeInTheDocument();
+  });
+
+  it('hides the clear control when defaultStat is provided', () => {
+    render(
+      <StatsPicker
+        stats={[ReducerID.sum]}
+        onChange={jest.fn()}
+        defaultStat={ReducerID.last}
+        data-testid={TEST_INPUT_TESTID}
+      />
+    );
+    expect(screen.queryByTestId('combobox-clear')).not.toBeInTheDocument();
+  });
+
+  it('forwards combobox selection to onChange as a single-element array', async () => {
+    const onChange = jest.fn();
+    const sumOrMean = (ext: { id: string }) => ext.id === ReducerID.sum || ext.id === ReducerID.mean;
+
+    const Controlled = () => {
+      const [stats, setStats] = useState<string[]>([ReducerID.sum]);
+      const onChangeRef = useRef(onChange);
+      onChangeRef.current = onChange;
+      const handleChange = useCallback((next: string[]) => {
+        onChangeRef.current(next);
+        setStats(next);
+      }, []);
+
+      return (
+        <StatsPicker
+          id={TEST_INPUT_ID}
+          data-testid={TEST_INPUT_TESTID}
+          stats={stats}
+          onChange={handleChange}
+          filterOptions={sumOrMean}
+        />
+      );
+    };
+
+    renderWithField(<Controlled />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Stats' }));
+
+    await waitFor(() => {
+      expect(document.getElementById('combobox-option-mean')).toBeInTheDocument();
+    });
+
+    await user.click(document.getElementById('combobox-option-mean')!);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith([ReducerID.mean]);
+    });
+    expect(screen.getByDisplayValue('Mean')).toBeInTheDocument();
+  });
+
+  it('maps a cleared combobox value to an empty stats array', async () => {
+    const onChange = jest.fn();
+
+    const Controlled = () => {
+      const [stats, setStats] = useState<string[]>([ReducerID.sum]);
+      const onChangeRef = useRef(onChange);
+      onChangeRef.current = onChange;
+      const handleChange = useCallback((next: string[]) => {
+        onChangeRef.current(next);
+        setStats(next);
+      }, []);
+
+      return <StatsPicker id={TEST_INPUT_ID} data-testid={TEST_INPUT_TESTID} stats={stats} onChange={handleChange} />;
+    };
+
+    renderWithField(<Controlled />);
+
+    await user.click(screen.getByTestId('combobox-clear'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith([]);
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -2,6 +2,7 @@ import { difference } from 'lodash';
 import { memo, useEffect } from 'react';
 
 import { fieldReducers, FieldReducerInfo } from '@grafana/data';
+import { t } from '@grafana/i18n';
 
 import { Combobox, ComboboxProps } from '../Combobox/Combobox';
 import { MultiCombobox, MultiComboboxProps } from '../Combobox/MultiCombobox';
@@ -34,7 +35,7 @@ export type StatsPickerProps = BaseProps & (MultiProps | SingleProps);
 
 export const StatsPicker = memo<StatsPickerProps>(
   ({
-    placeholder,
+    placeholder = t('grafana-ui.stats-picker.placeholder', 'Choose'),
     onChange,
     stats,
     allowMultiple = false,
@@ -73,47 +74,40 @@ export const StatsPicker = memo<StatsPickerProps>(
     const value = select.current.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
 
     if (allowMultiple) {
-      const multiOnlyRest: MultiSpread = rest;
-      const multiProps = {
-        ...multiOnlyRest,
-        ...layout,
-        value,
-        isClearable: !defaultStat,
-        options,
-        placeholder,
-        onChange: (items: Array<ComboboxOption<string>>) => onChange(items.map((v) => v.value)),
-      } satisfies MultiComboboxProps<string>;
-
-      return <MultiCombobox {...multiProps} />;
+      return (
+        <MultiCombobox
+          {...rest}
+          {...layout}
+          value={value}
+          options={options}
+          placeholder={placeholder}
+          isClearable={!defaultStat}
+          onChange={(items: Array<ComboboxOption<string>>) => onChange(items.map((v) => v.value))}
+        />
+      );
     }
 
-    const singleSpread: SingleSpread = rest;
-
-    if (defaultStat) {
-      const notClearableProps = {
-        ...singleSpread,
-        ...layout,
-        value: value[0],
-        options,
-        placeholder,
-        isClearable: false as const,
-        onChange: (item: ComboboxOption) => onChange(item.value ? [item.value] : []),
-      } satisfies ComboboxProps<string>;
-
-      return <Combobox {...notClearableProps} />;
-    }
-
-    const clearableProps = {
-      ...singleSpread,
+    const commonOptions = {
+      ...rest,
       ...layout,
       value: value[0],
       options,
       placeholder,
-      isClearable: true as const,
-      onChange: (item: ComboboxOption | null) => onChange(item && item.value ? [item.value] : []),
-    } satisfies ComboboxProps<string>;
+    };
 
-    return <Combobox {...clearableProps} />;
+    return defaultStat ? (
+      <Combobox
+        {...commonOptions}
+        isClearable={false}
+        onChange={(item: ComboboxOption | null) => onChange(item && item.value ? [item.value] : [])}
+      />
+    ) : (
+      <Combobox
+        {...commonOptions}
+        isClearable={true}
+        onChange={(item: ComboboxOption | null) => onChange(item && item.value ? [item.value] : [])}
+      />
+    );
   }
 );
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -8,18 +8,32 @@ import { MultiCombobox, MultiComboboxProps } from '../Combobox/MultiCombobox';
 import { ComboboxOption } from '../Combobox/types';
 import { selectableValueToComboboxOption } from '../Combobox/utils';
 
+import { pickComboboxLayout } from './pickComboboxLayout';
+
+/** Props managed by StatsPicker — forwarded combobox props must not replace these. */
+type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable' | 'width' | 'minWidth' | 'maxWidth';
+
+/** Forwarded props (managed keys + layout are applied after the spread). */
+type MultiSpread = Omit<MultiComboboxProps<string>, ComboboxManagedProps>;
+type SingleSpread = Omit<ComboboxProps<string>, ComboboxManagedProps>;
+
 interface BaseProps {
-  onChange: (stats: string[]) => void;
   stats: string[];
+  onChange: (stats: string[]) => void;
   defaultStat?: string;
-  /** @deprecated use id instead */
+  /** @deprecated use `id` instead */
   inputId?: string;
+  id?: string;
+  width?: number | 'auto';
+  minWidth?: number;
+  maxWidth?: number;
   filterOptions?: (ext: FieldReducerInfo) => boolean;
 }
-type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable';
-type MultiProps = Omit<MultiComboboxProps<string>, ComboboxManagedProps> & { allowMultiple: true };
-type SingleProps = Omit<ComboboxProps<string>, ComboboxManagedProps> & { allowMultiple?: false };
-type StatsPickerProps = BaseProps & (MultiProps | SingleProps);
+
+type MultiProps = MultiSpread & { allowMultiple: true };
+type SingleProps = SingleSpread & { allowMultiple?: false };
+
+export type StatsPickerProps = BaseProps & (MultiProps | SingleProps);
 
 export const StatsPicker = memo<StatsPickerProps>(
   ({
@@ -29,12 +43,15 @@ export const StatsPicker = memo<StatsPickerProps>(
     allowMultiple = false,
     defaultStat,
     width,
+    minWidth,
+    maxWidth,
     inputId,
     id: idProp,
     filterOptions,
     ...rest
   }) => {
     const id = idProp ?? inputId;
+    const layout = pickComboboxLayout(width, minWidth, maxWidth);
 
     useEffect(() => {
       const current = fieldReducers.list(stats);
@@ -60,29 +77,52 @@ export const StatsPicker = memo<StatsPickerProps>(
     const select = fieldReducers.selectOptions(stats, filterOptions);
     const options = select.options.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
     const value = select.current.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
-    return allowMultiple ? (
-      <MultiCombobox<string>
-        id={id}
-        value={value}
-        isClearable={!defaultStat}
-        width={width}
-        options={options}
-        placeholder={placeholder}
-        onChange={(items) => onChange(items.map((v) => v.value))}
-        {...rest}
-      />
-    ) : (
-      <Combobox<string>
-        id={id}
-        value={value[0]}
-        isClearable={!defaultStat}
-        width={width}
-        options={options}
-        placeholder={placeholder}
-        onChange={(item: ComboboxOption<string> | null) => onChange(item && item.value ? [item.value] : [])}
-        {...rest}
-      />
-    );
+
+    if (allowMultiple) {
+      const multiOnlyRest: MultiSpread = rest;
+      const multiProps = {
+        ...multiOnlyRest,
+        id,
+        ...layout,
+        value,
+        isClearable: !defaultStat,
+        options,
+        placeholder,
+        onChange: (items: Array<ComboboxOption<string>>) => onChange(items.map((v) => v.value)),
+      } satisfies MultiComboboxProps<string>;
+
+      return <MultiCombobox {...multiProps} />;
+    }
+
+    const singleSpread: SingleSpread = rest;
+
+    if (defaultStat) {
+      const notClearableProps = {
+        ...singleSpread,
+        id,
+        ...layout,
+        value: value[0],
+        options,
+        placeholder,
+        isClearable: false as const,
+        onChange: (item: ComboboxOption<string>) => onChange(item.value ? [item.value] : []),
+      } satisfies ComboboxProps<string>;
+
+      return <Combobox {...notClearableProps} />;
+    }
+
+    const clearableProps = {
+      ...singleSpread,
+      id,
+      ...layout,
+      value: value[0],
+      options,
+      placeholder,
+      isClearable: true as const,
+      onChange: (item: ComboboxOption<string> | null) => onChange(item && item.value ? [item.value] : []),
+    } satisfies ComboboxProps<string>;
+
+    return <Combobox {...clearableProps} />;
   }
 );
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -1,9 +1,12 @@
 import { difference } from 'lodash';
 import { memo, useEffect } from 'react';
 
-import { fieldReducers, SelectableValue, FieldReducerInfo } from '@grafana/data';
+import { fieldReducers, FieldReducerInfo } from '@grafana/data';
 
-import { Select } from '../Select/Select';
+import { Combobox } from '../Combobox/Combobox';
+import { MultiCombobox } from '../Combobox/MultiCombobox';
+import { ComboboxOption } from '../Combobox/types';
+import { selectableValueToComboboxOption } from '../Combobox/utils';
 
 export interface Props {
   placeholder?: string;
@@ -13,24 +16,12 @@ export interface Props {
   defaultStat?: string;
   className?: string;
   width?: number;
-  menuPlacement?: 'auto' | 'bottom' | 'top';
   inputId?: string;
   filterOptions?: (ext: FieldReducerInfo) => boolean;
 }
 
 export const StatsPicker = memo<Props>(
-  ({
-    placeholder,
-    onChange,
-    stats,
-    allowMultiple = false,
-    defaultStat,
-    className,
-    width,
-    menuPlacement,
-    inputId,
-    filterOptions,
-  }) => {
+  ({ placeholder, onChange, stats, allowMultiple = false, defaultStat, width, inputId, filterOptions }) => {
     useEffect(() => {
       const current = fieldReducers.list(stats);
       if (current.length !== stats.length) {
@@ -52,28 +43,28 @@ export const StatsPicker = memo<Props>(
       }
     }, [stats, allowMultiple, defaultStat, onChange]);
 
-    const onSelectionChange = (item: SelectableValue<string>) => {
-      if (Array.isArray(item)) {
-        onChange(item.map((v) => v.value));
-      } else {
-        onChange(item && item.value ? [item.value] : []);
-      }
-    };
-
     const select = fieldReducers.selectOptions(stats, filterOptions);
-    return (
-      <Select
-        value={select.current}
-        className={className}
+    const options = select.options.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
+    const value = select.current.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
+    return allowMultiple ? (
+      <MultiCombobox<string>
+        id={inputId}
+        value={value}
         isClearable={!defaultStat}
-        isMulti={allowMultiple}
         width={width}
-        isSearchable={true}
-        options={select.options}
+        options={options}
         placeholder={placeholder}
-        onChange={onSelectionChange}
-        menuPlacement={menuPlacement}
-        inputId={inputId}
+        onChange={(items) => onChange(items.map((v) => v.value))}
+      />
+    ) : (
+      <Combobox<string>
+        id={inputId}
+        value={value[0]}
+        isClearable={!defaultStat}
+        width={width}
+        options={options}
+        placeholder={placeholder}
+        onChange={(item: ComboboxOption<string> | null) => onChange(item && item.value ? [item.value] : [])}
       />
     );
   }

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -14,7 +14,6 @@ export interface Props {
   stats: string[];
   allowMultiple?: boolean;
   defaultStat?: string;
-  className?: string;
   width?: number;
   inputId?: string;
   filterOptions?: (ext: FieldReducerInfo) => boolean;

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -21,9 +21,6 @@ interface BaseProps {
   stats: string[];
   onChange: (stats: string[]) => void;
   defaultStat?: string;
-  /** @deprecated use `id` instead */
-  inputId?: string;
-  id?: string;
   width?: number | 'auto';
   minWidth?: number;
   maxWidth?: number;
@@ -45,12 +42,9 @@ export const StatsPicker = memo<StatsPickerProps>(
     width,
     minWidth,
     maxWidth,
-    inputId,
-    id: idProp,
     filterOptions,
     ...rest
   }) => {
-    const id = idProp ?? inputId;
     const layout = pickComboboxLayout(width, minWidth, maxWidth);
 
     useEffect(() => {
@@ -82,7 +76,6 @@ export const StatsPicker = memo<StatsPickerProps>(
       const multiOnlyRest: MultiSpread = rest;
       const multiProps = {
         ...multiOnlyRest,
-        id,
         ...layout,
         value,
         isClearable: !defaultStat,
@@ -99,7 +92,6 @@ export const StatsPicker = memo<StatsPickerProps>(
     if (defaultStat) {
       const notClearableProps = {
         ...singleSpread,
-        id,
         ...layout,
         value: value[0],
         options,
@@ -113,7 +105,6 @@ export const StatsPicker = memo<StatsPickerProps>(
 
     const clearableProps = {
       ...singleSpread,
-      id,
       ...layout,
       value: value[0],
       options,

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -3,24 +3,39 @@ import { memo, useEffect } from 'react';
 
 import { fieldReducers, FieldReducerInfo } from '@grafana/data';
 
-import { Combobox } from '../Combobox/Combobox';
-import { MultiCombobox } from '../Combobox/MultiCombobox';
+import { Combobox, ComboboxProps } from '../Combobox/Combobox';
+import { MultiCombobox, MultiComboboxProps } from '../Combobox/MultiCombobox';
 import { ComboboxOption } from '../Combobox/types';
 import { selectableValueToComboboxOption } from '../Combobox/utils';
 
-export interface Props {
-  placeholder?: string;
+interface BaseProps {
   onChange: (stats: string[]) => void;
   stats: string[];
-  allowMultiple?: boolean;
   defaultStat?: string;
-  width?: number;
+  /** @deprecated use id instead */
   inputId?: string;
   filterOptions?: (ext: FieldReducerInfo) => boolean;
 }
+type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable';
+type MultiProps = Omit<MultiComboboxProps<string>, ComboboxManagedProps> & { allowMultiple: true };
+type SingleProps = Omit<ComboboxProps<string>, ComboboxManagedProps> & { allowMultiple?: false };
+type StatsPickerProps = BaseProps & (MultiProps | SingleProps);
 
-export const StatsPicker = memo<Props>(
-  ({ placeholder, onChange, stats, allowMultiple = false, defaultStat, width, inputId, filterOptions }) => {
+export const StatsPicker = memo<StatsPickerProps>(
+  ({
+    placeholder,
+    onChange,
+    stats,
+    allowMultiple = false,
+    defaultStat,
+    width,
+    inputId,
+    id: idProp,
+    filterOptions,
+    ...rest
+  }) => {
+    const id = idProp ?? inputId;
+
     useEffect(() => {
       const current = fieldReducers.list(stats);
       if (current.length !== stats.length) {
@@ -47,23 +62,25 @@ export const StatsPicker = memo<Props>(
     const value = select.current.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
     return allowMultiple ? (
       <MultiCombobox<string>
-        id={inputId}
+        id={id}
         value={value}
         isClearable={!defaultStat}
         width={width}
         options={options}
         placeholder={placeholder}
         onChange={(items) => onChange(items.map((v) => v.value))}
+        {...rest}
       />
     ) : (
       <Combobox<string>
-        id={inputId}
+        id={id}
         value={value[0]}
         isClearable={!defaultStat}
         width={width}
         options={options}
         placeholder={placeholder}
         onChange={(item: ComboboxOption<string> | null) => onChange(item && item.value ? [item.value] : [])}
+        {...rest}
       />
     );
   }

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -97,7 +97,7 @@ export const StatsPicker = memo<StatsPickerProps>(
         options,
         placeholder,
         isClearable: false as const,
-        onChange: (item: ComboboxOption<string>) => onChange(item.value ? [item.value] : []),
+        onChange: (item: ComboboxOption) => onChange(item.value ? [item.value] : []),
       } satisfies ComboboxProps<string>;
 
       return <Combobox {...notClearableProps} />;

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -110,7 +110,7 @@ export const StatsPicker = memo<StatsPickerProps>(
       options,
       placeholder,
       isClearable: true as const,
-      onChange: (item: ComboboxOption<string> | null) => onChange(item && item.value ? [item.value] : []),
+      onChange: (item: ComboboxOption | null) => onChange(item && item.value ? [item.value] : []),
     } satisfies ComboboxProps<string>;
 
     return <Combobox {...clearableProps} />;

--- a/packages/grafana-ui/src/components/StatsPicker/pickComboboxLayout.ts
+++ b/packages/grafana-ui/src/components/StatsPicker/pickComboboxLayout.ts
@@ -1,0 +1,13 @@
+/** Satisfies `Combobox` / `MultiCombobox` `AutoSizeConditionals` (mutually exclusive branches). */
+export type ComboboxLayout = { width: 'auto'; minWidth: number; maxWidth?: number } | { width?: number };
+
+export function pickComboboxLayout(
+  width: number | 'auto' | undefined,
+  minWidth: number | undefined,
+  maxWidth: number | undefined
+): ComboboxLayout {
+  if (width === 'auto') {
+    return { width: 'auto', minWidth: minWidth ?? 8, maxWidth };
+  }
+  return { width };
+}

--- a/packages/grafana-ui/src/components/StatsPicker/pickComboboxLayout.ts
+++ b/packages/grafana-ui/src/components/StatsPicker/pickComboboxLayout.ts
@@ -1,13 +1,15 @@
 /** Satisfies `Combobox` / `MultiCombobox` `AutoSizeConditionals` (mutually exclusive branches). */
 export type ComboboxLayout = { width: 'auto'; minWidth: number; maxWidth?: number } | { width?: number };
 
+const DEFAULT_MIN_WIDTH = 8;
+
 export function pickComboboxLayout(
   width: number | 'auto' | undefined,
-  minWidth: number | undefined,
+  minWidth = DEFAULT_MIN_WIDTH,
   maxWidth: number | undefined
 ): ComboboxLayout {
   if (width === 'auto') {
-    return { width: 'auto', minWidth: minWidth ?? 8, maxWidth };
+    return { width: 'auto', minWidth, maxWidth };
   }
   return { width };
 }

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -45,7 +45,7 @@ export {
 export { EmptySearchResult } from './components/EmptySearchResult/EmptySearchResult';
 export { EmptyState } from './components/EmptyState/EmptyState';
 export { UnitPicker } from './components/UnitPicker/UnitPicker';
-export { StatsPicker } from './components/StatsPicker/StatsPicker';
+export { StatsPicker, type StatsPickerProps } from './components/StatsPicker/StatsPicker';
 export { RefreshPicker, defaultIntervals } from './components/RefreshPicker/RefreshPicker';
 export { TimeRangePicker, type TimeRangePickerProps } from './components/DateTimePickers/TimeRangePicker';
 export { TimeRangeProvider } from './components/DateTimePickers/TimeRangeContext';

--- a/public/app/core/components/OptionsUI/stats.tsx
+++ b/public/app/core/components/OptionsUI/stats.tsx
@@ -9,11 +9,11 @@ export const StatsPickerEditor = ({
 }: StandardEditorProps<string[], StatsPickerConfigSettings>) => {
   return (
     <StatsPicker
+      id={id}
       stats={value}
       onChange={onChange}
       allowMultiple={!!item.settings?.allowMultiple}
       defaultStat={item.settings?.defaultStat}
-      inputId={id}
     />
   );
 };

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx
@@ -52,7 +52,6 @@ export const CumulativeOptionsEditor = (props: {
       >
         <StatsPicker
           allowMultiple={false}
-          className="width-18"
           stats={[cumulative?.reducer || ReducerID.sum]}
           onChange={onCumulativeStatsChange}
           defaultStat={ReducerID.sum}

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx
@@ -71,7 +71,6 @@ export const ReduceRowOptionsEditor = (props: {
       >
         <StatsPicker
           allowMultiple={false}
-          className="width-18"
           stats={[reduce?.reducer || ReducerID.sum]}
           onChange={onStatsChange}
           defaultStat={ReducerID.sum}

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx
@@ -105,7 +105,6 @@ export const WindowOptionsEditor = (props: {
       >
         <StatsPicker
           allowMultiple={false}
-          className="width-18"
           stats={[window?.reducer || ReducerID.mean]}
           onChange={onWindowStatsChange}
           defaultStat={ReducerID.mean}

--- a/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupByTransformerEditor.tsx
@@ -130,7 +130,6 @@ const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }: FieldP
 
         {config?.operation && (
           <StatsPicker
-            className={styles.aggregations}
             placeholder={t('transformers.group-by-field-configuration.placeholder-select-stats', 'Select stats')}
             allowMultiple
             stats={config.aggregations}
@@ -158,9 +157,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexShrink: 0,
       height: '100%',
       width: theme.spacing(24),
-    }),
-    aggregations: css({
-      flexGrow: 1,
     }),
   };
 };

--- a/public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx
@@ -167,7 +167,6 @@ export const GroupByFieldConfiguration = ({ fieldName, config, onConfigChange }:
 
         {config?.operation === GroupByOperationID.aggregate && (
           <StatsPicker
-            className={styles.aggregations}
             placeholder={t('transformers.group-by-field-configuration.placeholder-select-stats', 'Select stats')}
             allowMultiple
             stats={config.aggregations}
@@ -191,9 +190,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexShrink: 0,
       height: '100%',
       width: theme.spacing(24),
-    }),
-    aggregations: css({
-      flexGrow: 1,
     }),
   };
 };

--- a/public/app/features/transformers/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
+++ b/public/app/features/transformers/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
@@ -1,10 +1,15 @@
-import { fireEvent, render, screen, getByText, getByLabelText } from '@testing-library/react';
+import { fireEvent, render, screen, getByText, getByLabelText, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
-import { toDataFrame, FieldType } from '@grafana/data';
+import { ReducerID, toDataFrame, FieldType } from '@grafana/data';
 
 import { Props, FieldToConfigMappingEditor } from './FieldToConfigMappingEditor';
+
+beforeAll(() => {
+  comboboxTestSetup();
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -73,16 +78,21 @@ describe('FieldToConfigMappingEditor', () => {
 
     const reducer = await screen.findByTestId('max-reducer');
 
-    expect(getByText(reducer, 'All values')).toBeInTheDocument();
+    expect(within(reducer).getByDisplayValue('All values')).toBeInTheDocument();
   });
 
   it('Can change reducer', async () => {
+    const user = userEvent.setup({ applyAccept: false });
     setup();
 
-    const reducer = await (await screen.findByTestId('max-reducer')).childNodes[0];
+    const reducerCell = await screen.findByTestId('max-reducer');
+    await user.click(within(reducerCell).getByRole('combobox'));
 
-    await fireEvent.keyDown(reducer, { keyCode: 40 });
-    await selectOptionInTest(reducer as HTMLElement, 'Last');
+    await waitFor(() => {
+      expect(document.getElementById(`combobox-option-${ReducerID.last}`)).toBeInTheDocument();
+    });
+
+    await user.click(document.getElementById(`combobox-option-${ReducerID.last}`)!);
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.arrayContaining([{ fieldName: 'max', handlerKey: 'max', reducerId: 'last' }])

--- a/public/app/features/transformers/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
+++ b/public/app/features/transformers/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, getByText, getByLabelText, within, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, getByLabelText, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10217,6 +10217,9 @@
       "group": "Group",
       "group-tooltip": "Name of the stacking group"
     },
+    "stats-picker": {
+      "placeholder": "Choose"
+    },
     "table": {
       "cell-filter-on": "Filter for value",
       "cell-filter-out": "Filter out value",


### PR DESCRIPTION
### Summary

- updated StatsPicker to use Combobox and MultiCombobox instead of Select
- adds unit tests for StatsPicker
- **breaking** deleted `inputId` prop in favor of a matching `id` prop for Combobox.
- **breaking** deletes the `className` prop from `StatsPicker` in favor of passing `Combobox` and `MultiCombobox`'s props through, allowing customization that way.

According to our [plugin stat dashboards](https://ops.grafana-ops.net/d/dmb2o0xnz/imported-property-details?orgId=1&var-propertyName=StatsPicker&var-packageName=@grafana%2Fui&from=now-6h&to=now&timezone=utc), StatsPicker is not used by any plugins, so we should be safe to make the breaking prop changes. _Grafana 13 is probably a good time to do it since that's the case._

### Background and demo

While testing Presets, we noticed the Calculation Select in Value options had an annoying flickering when we tested with high-refresh live data.

https://github.com/user-attachments/assets/702ee785-f596-4bfa-9b66-76038377c6f9

As an attempt at fixing it, I thought I'd just try converting the StatsPicker to a Combobox/MultiCombobox. It fixes the issue and is also a nice upgrade for anything using StatsPicker.

https://github.com/user-attachments/assets/fabc7f74-d4da-42b9-a071-2de02011754c

https://github.com/user-attachments/assets/a2c64260-3983-485c-b005-a93500097675

I opted to go a step further and set up the element to pass props through to Combobox and MultiCombobox, which makes props like `data-testid` or setting custom widths much simpler.