### PR TITLE
IAM: Fix NULL column scan errors in scanMember

### DIFF
--- a/pkg/registry/apis/iam/legacy/team_binding.go
+++ b/pkg/registry/apis/iam/legacy/team_binding.go
@@ -444,9 +444,22 @@ func (s *legacySQLStore) DeleteTeamMember(ctx context.Context, ns claims.Namespa
 func scanMember(rows *stdsql.Rows) (TeamMember, error) {
 	m := TeamMember{}
 	var nullableExternal stdsql.NullBool
-	err := rows.Scan(&m.ID, &m.UID, &m.TeamUID, &m.TeamID, &m.UserUID, &m.UserID, &m.Name, &m.Email, &m.Username, &nullableExternal, &m.Created, &m.Updated, &m.Permission)
+	var name, email, username stdsql.NullString
+	err := rows.Scan(&m.ID, &m.UID, &m.TeamUID, &m.TeamID, &m.UserUID, &m.UserID, &name, &email, &username, &nullableExternal, &m.Created, &m.Updated, &m.Permission)
+	if err != nil {
+		return m, err
+	}
 	if nullableExternal.Valid {
 		m.External = nullableExternal.Bool
 	}
-	return m, err
+	if name.Valid {
+		m.Name = name.String
+	}
+	if email.Valid {
+		m.Email = email.String
+	}
+	if username.Valid {
+		m.Username = username.String
+	}
+	return m, nil
 }


### PR DESCRIPTION
## Summary
Fix `sql: Scan error ... converting NULL to string is unsupported` ([link](https://ops.grafana-ops.net/goto/cfglwjstcqosga?orgId=stacks-27821)) when the Zanzana reconciler queries team members against a database with NULL values in `user.name`, `user.email`, or `user.login` columns
- Use `sql.NullString` for the `name`, `email`, and `username` fields in `scanMember`, matching the existing pattern already applied to `ListUsers` in `user.go` (#120788)

## Test plan

- [x] `go test ./pkg/registry/apis/iam/legacy/...` passes
- [x] `go test ./pkg/services/authz/zanzana/server/reconciler/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)