### PR TITLE
Elasticsearch: Support legacy Elastic variable queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -82,13 +82,13 @@ describe('ElasticsearchVariableEditor', () => {
     expect(screen.getByDisplayValue('id')).toBeInTheDocument();
   });
 
-  it('should migrate string query to object query', () => {
+  it('should not migrate legacy queries', () => {
     const stringQuery = 'test string query' as unknown as ElasticsearchDataQuery;
 
     render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: stringQuery }} />);
 
-    // migrateVariableQuery should have converted the string into an object query
-    expect(screen.getByText('Query: test string query')).toBeInTheDocument();
+    expect(screen.getByText('Legacy variable query')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('test string query')).toBeInTheDocument();
   });
 
   it('should handle query errors gracefully', async () => {

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.test.tsx
@@ -18,7 +18,7 @@ describe('ElasticsearchVariableEditor', () => {
     query: {
       refId: 'A',
       query: 'test query',
-      metrics: [{ type: 'raw_document', id: '1' }],
+      metrics: [{ type: 'count', id: '1' }],
     },
     onChange: jest.fn(),
     onRunQuery: jest.fn(),
@@ -195,15 +195,15 @@ describe('ElasticsearchVariableEditor', () => {
     const onChange = jest.fn();
     const queryWithMeta: ElasticsearchDataQuery = {
       ...defaultProps.query,
-      metrics: [{ type: 'raw_document', id: '1' }],
+      metrics: [{ type: 'count', id: '1' }],
       meta: { textField: 'name', valueField: 'id' },
     };
 
     render(<ElasticsearchVariableEditor {...{ ...defaultProps, query: queryWithMeta, onChange }} />);
 
-    // Simulate the user clicking the Metrics tab inside QueryEditor
+    // Simulate the user switching the metric type inside QueryEditor
     const queryEditorOnChange = (QueryEditor as jest.Mock).mock.calls.at(-1)[0].onChange;
-    act(() => queryEditorOnChange({ ...queryWithMeta, metrics: [{ type: 'count', id: '1' }] }));
+    act(() => queryEditorOnChange({ ...queryWithMeta, metrics: [{ type: 'raw_document', id: '1' }] }));
 
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ meta: undefined }));
   });

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableEditor.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { DataQueryRequest, dateTime, Field } from '@grafana/data';
-import { EditorRows, EditorRow, EditorField } from '@grafana/plugin-ui';
-import { Combobox, ComboboxOption, Text } from '@grafana/ui';
+import { EditorField, EditorRow, EditorRows } from '@grafana/plugin-ui';
+import { Alert, Combobox, ComboboxOption, Input, Text } from '@grafana/ui';
 
 import { ElasticsearchVariableQuery, migrateVariableQuery, refId } from './ElasticsearchVariableUtils';
 import { ElasticQueryEditorProps, QueryEditor } from './components/QueryEditor';
@@ -12,6 +12,10 @@ type ElasticsearchVariableQueryEditorProps = ElasticQueryEditorProps;
 
 export const ElasticsearchVariableEditor = (props: ElasticsearchVariableQueryEditorProps) => {
   const query = useMemo(() => migrateVariableQuery(props.query), [props.query]);
+
+  if (query.queryType === 'legacy_variable') {
+    return <LegacyVariableEditor {...props} query={query} />;
+  }
 
   const handleQueryChange = (newQuery: ElasticsearchDataQuery) => {
     // Clear field mapping when the query structure changes significantly — the available fields
@@ -31,6 +35,26 @@ export const ElasticsearchVariableEditor = (props: ElasticsearchVariableQueryEdi
       <QueryEditor {...props} query={query} onChange={handleQueryChange} />
       <FieldMapping datasource={props.datasource} query={query} onChange={props.onChange} />
     </>
+  );
+};
+
+const LegacyVariableEditor = (props: ElasticsearchVariableQueryEditorProps) => {
+  const { query, onChange } = props;
+
+  return (
+    <EditorRows>
+      <EditorRow>
+        <Alert severity="warning" title="Legacy variable query">
+          This variable uses a legacy query format. You can continue using it as-is but it is deprecated and will be
+          removed in the future. New variables will use the new query editor.
+        </Alert>
+      </EditorRow>
+      <EditorRow>
+        <EditorField label="Query" width={80}>
+          <Input value={query.query ?? ''} onChange={(e) => onChange({ ...query, query: e.currentTarget.value })} />
+        </EditorField>
+      </EditorRow>
+    </EditorRows>
   );
 };
 

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
@@ -27,7 +27,7 @@ describe('ElasticsearchVariableSupport', () => {
       expect(defaultQuery).toEqual({
         refId: 'ElasticsearchVariableQueryEditor-VariableQuery',
         query: '',
-        metrics: [{ type: 'raw_document', id: '1' }],
+        metrics: [{ type: 'count', id: '1' }],
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
@@ -117,9 +117,7 @@ describe('ElasticsearchVariableSupport', () => {
     });
 
     it('should handle string query migration', (done) => {
-      mockDatasource.metricFindQuery = jest
-        .fn()
-        .mockResolvedValue([{ text: 'value1', value: 'value1' }]) as ElasticDatasource['metricFindQuery'];
+      mockDatasource.metricFindQuery = jest.fn().mockResolvedValue([{ text: 'value1', value: 'value1' }]);
 
       const request: DataQueryRequest<ElasticsearchDataQuery> = {
         targets: ['test query' as unknown as ElasticsearchDataQuery],

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.test.ts
@@ -117,18 +117,9 @@ describe('ElasticsearchVariableSupport', () => {
     });
 
     it('should handle string query migration', (done) => {
-      const mockResponse: DataQueryResponse = {
-        data: [
-          {
-            name: 'test',
-            refId: 'A',
-            length: 1,
-            fields: [{ name: 'field', type: FieldType.string, config: {}, values: ['value'] }],
-          },
-        ],
-      };
-
-      mockDatasource.query.mockReturnValue(of(mockResponse));
+      mockDatasource.metricFindQuery = jest
+        .fn()
+        .mockResolvedValue([{ text: 'value1', value: 'value1' }]) as ElasticDatasource['metricFindQuery'];
 
       const request: DataQueryRequest<ElasticsearchDataQuery> = {
         targets: ['test query' as unknown as ElasticsearchDataQuery],
@@ -148,10 +139,12 @@ describe('ElasticsearchVariableSupport', () => {
 
       variableSupport.query(request).subscribe({
         next: (response) => {
-          expect(mockDatasource.query).toHaveBeenCalled();
-          const calledRequest = mockDatasource.query.mock.calls[0][0];
-          expect(calledRequest.targets[0].query).toBe('test query');
-          expect(calledRequest.targets[0].metrics).toEqual([{ type: 'raw_document', id: '1' }]);
+          expect(mockDatasource.metricFindQuery).toHaveBeenCalledWith('test query', { range: request.range });
+          expect(response.data).toHaveLength(1);
+          expect(response.data[0].fields[0].name).toBe('text');
+          expect(response.data[0].fields[0].values).toEqual(['value1']);
+          expect(response.data[0].fields[1].name).toBe('value');
+          expect(response.data[0].fields[1].values).toEqual(['value1']);
           done();
         },
         error: done,

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
@@ -8,6 +8,8 @@ import {
   DataQueryResponse,
   DataFrame,
   DataSourceApi,
+  FieldType,
+  MetricFindValue,
   QueryEditorProps,
 } from '@grafana/data';
 
@@ -30,12 +32,49 @@ export class ElasticsearchVariableSupport<
       throw new Error('no variable query found');
     }
     const updatedQuery = migrateVariableQuery(request.targets[0]);
+
+    if (updatedQuery.queryType === 'legacy_variable') {
+      return this.legacyQuery(updatedQuery, request);
+    }
+
     return from(this.datasource.query({ ...request, targets: [updatedQuery] })).pipe(
       map((d: DataQueryResponse) => {
         return {
           ...d,
           data: (d.data || []).map((frame: DataFrame) => updateFrame(frame, updatedQuery.meta)),
         };
+      })
+    );
+  }
+
+  private legacyQuery(
+    query: ElasticsearchDataQuery,
+    request: DataQueryRequest<ElasticsearchDataQuery>
+  ): Observable<DataQueryResponse> {
+    if (!this.datasource.metricFindQuery) {
+      return from(Promise.resolve({ data: [] }));
+    }
+    return from(this.datasource.metricFindQuery(query.query || '', { range: request.range })).pipe(
+      map((values: MetricFindValue[]) => {
+        const frame: DataFrame = {
+          fields: [
+            {
+              name: 'text',
+              type: FieldType.string,
+              config: {},
+              values: values.map((v) => String(v.text)),
+            },
+            {
+              name: 'value',
+              type: FieldType.string,
+              config: {},
+              values: values.map((v) => String(v.value ?? v.text)),
+            },
+          ],
+          length: values.length,
+        };
+        const response: DataQueryResponse = { data: [frame] };
+        return response;
       })
     );
   }

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableSupport.ts
@@ -83,7 +83,7 @@ export class ElasticsearchVariableSupport<
     return {
       refId,
       query: '',
-      metrics: [{ type: 'raw_document', id: '1' }],
+      metrics: [{ type: 'count', id: '1' }],
     };
   }
 }

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.test.ts
@@ -11,6 +11,7 @@ describe('ElasticsearchVariableUtils', () => {
       expect(result).toEqual({
         refId,
         query: 'test query',
+        queryType: 'legacy_variable',
         metrics: [{ type: 'raw_document', id: '1' }],
       });
     });

--- a/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticsearchVariableUtils.ts
@@ -19,6 +19,7 @@ export const migrateVariableQuery = (rawQuery: string | ElasticsearchDataQuery):
   return {
     refId,
     query: rawQuery,
+    queryType: 'legacy_variable',
     metrics: [{ type: 'raw_document', id: '1' }],
   };
 };


### PR DESCRIPTION
The new variable editor (#118539) broke existing variable queries.

This PR re-adds support for legacy variable queries (finding `terms` and `fields`). New variable queries will still work as they should.

I've also switched the new variable editor to default to the `metrics` query type rather than the deprecated raw document type.

