### PR TITLE
Dashboards: Hide save button for users without save permissions in new layout

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -13,6 +13,7 @@ import {
   TextBoxVariable,
 } from '@grafana/scenes';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
+import { contextSrv } from 'app/core/services/context_srv';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { KioskMode } from 'app/types/dashboard';
 
@@ -20,6 +21,12 @@ import { getDashboardSceneFor } from '../utils/utils';
 
 import { DashboardControls, type DashboardControlsState } from './DashboardControls';
 import { DashboardScene } from './DashboardScene';
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    hasEditPermissionInFolders: false,
+  },
+}));
 
 jest.mock('app/features/playlist/PlaylistSrv', () => ({
   playlistSrv: {
@@ -449,21 +456,65 @@ describe('DashboardControls', () => {
       expect(await screen.findByTestId(selectors.components.NavToolbar.editDashboard.editButton)).toBeInTheDocument();
     });
   });
+
+  describe('DashboardControlActions save button visibility', () => {
+    const originalFeatureToggles = { ...config.featureToggles };
+    const mockedContextSrv = jest.mocked(contextSrv);
+
+    beforeEach(() => {
+      config.featureToggles.dashboardNewLayouts = true;
+      jest.mocked(playlistSrv.useState).mockReturnValue({ isPlaying: false });
+      mockedContextSrv.hasEditPermissionInFolders = false;
+    });
+
+    afterEach(() => {
+      config.featureToggles = originalFeatureToggles;
+      jest.clearAllMocks();
+    });
+
+    it('should show save button when user has canSave permission and is editing', async () => {
+      const controls = buildTestSceneWithEditable({ canSave: true, canEdit: true, isEditing: true });
+      renderInGrafanaContext(<controls.Component model={controls} />);
+
+      expect(await screen.findByTestId(selectors.components.NavToolbar.editDashboard.saveButton)).toBeInTheDocument();
+    });
+
+    it('should show save button when user has folder edit permission and is editing', async () => {
+      mockedContextSrv.hasEditPermissionInFolders = true;
+      const controls = buildTestSceneWithEditable({ canSave: false, canEdit: true, isEditing: true });
+      renderInGrafanaContext(<controls.Component model={controls} />);
+
+      expect(await screen.findByText('Save as copy')).toBeInTheDocument();
+    });
+
+    it('should not show save button when user lacks both canSave and folder edit permission', () => {
+      mockedContextSrv.hasEditPermissionInFolders = false;
+      const controls = buildTestSceneWithEditable({ canSave: false, canEdit: true, isEditing: true });
+      renderInGrafanaContext(<controls.Component model={controls} />);
+
+      expect(screen.queryByTestId(selectors.components.NavToolbar.editDashboard.saveButton)).not.toBeInTheDocument();
+      expect(screen.queryByText('Save as copy')).not.toBeInTheDocument();
+    });
+  });
 });
 
 function buildTestSceneWithEditable(options: {
-  editable: boolean;
+  editable?: boolean;
+  isEditing?: boolean;
   canEdit?: boolean;
+  canSave?: boolean;
   canMakeEditable?: boolean;
   isSnapshot?: boolean;
 }): DashboardControls {
-  const { editable, canEdit = true, canMakeEditable = false, isSnapshot = false } = options;
+  const { editable = true, isEditing, canEdit = true, canSave, canMakeEditable = false, isSnapshot = false } = options;
 
   const dashboard = new DashboardScene({
     uid: 'test-uid',
     editable,
+    isEditing,
     meta: {
       canEdit,
+      canSave,
       canMakeEditable,
       isSnapshot,
     },

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -21,6 +21,7 @@ import {
 } from '@grafana/scenes';
 import { Box, Button, ButtonGroup, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
+import { contextSrv } from 'app/core/services/context_srv';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { ContextualNavigationPaneToggle } from 'app/features/scopes/dashboards/ContextualNavigationPaneToggle';
 import { KioskMode } from 'app/types/dashboard';
@@ -336,6 +337,8 @@ function DashboardControlActions({
   }
 
   const canEditDashboard = dashboard.canEditDashboard();
+  const canSave = Boolean(meta.canSave);
+  const canSaveAs = contextSrv.hasEditPermissionInFolders;
   const hasUid = Boolean(uid);
   const isSnapshot = Boolean(meta.isSnapshot);
   const isEmbedded = meta.isEmbedded;
@@ -345,7 +348,7 @@ function DashboardControlActions({
   return (
     <>
       {showShareButton && <ShareDashboardButton dashboard={dashboard} />}
-      {isEditing && <SaveDashboard dashboard={dashboard} />}
+      {isEditing && (canSave || canSaveAs) && <SaveDashboard dashboard={dashboard} />}
       {!isPlaying && canEditDashboard && isEditable && <EditDashboardSwitch dashboard={dashboard} />}
       {!isPlaying && canEditDashboard && !isEditable && !isEditing && (
         <MakeDashboardEditableButton dashboard={dashboard} />

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -25,6 +25,7 @@ import { type Dashboard, DashboardCursorSync, type LibraryPanel } from '@grafana
 import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { appEvents } from 'app/core/app_events';
 import { LS_PANEL_COPY_KEY, LS_STYLES_COPY_KEY } from 'app/core/constants';
+import { contextSrv } from 'app/core/services/context_srv';
 import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { type DecoratedRevisionModel } from 'app/features/dashboard/types/revisionModels';
@@ -79,6 +80,12 @@ jest.mock('@grafana/runtime', () => ({
         angular: { detected: true, hideDeprecation: false },
       },
     },
+  },
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    hasEditPermissionInFolders: true,
   },
 }));
 
@@ -209,6 +216,8 @@ describe('DashboardScene', () => {
         const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
         config.featureToggles.dashboardNewLayouts = true;
 
+        scene.setState({ meta: { ...scene.state.meta, canSave: true } });
+
         const publishSpy = jest.spyOn(appEvents, 'publish');
         const hasActualSaveChangesSpy = jest.spyOn(utils, 'hasActualSaveChanges').mockReturnValue(true);
 
@@ -231,6 +240,31 @@ describe('DashboardScene', () => {
 
         overlay.state.onSaveSuccess!();
         expect(scene.state.isEditing).toBe(false);
+
+        publishSpy.mockRestore();
+        hasActualSaveChangesSpy.mockRestore();
+        config.featureToggles.dashboardNewLayouts = originalFeatureToggle;
+      });
+
+      it('Should not show Save option in unsaved changes modal when user cannot save', () => {
+        const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
+        config.featureToggles.dashboardNewLayouts = true;
+
+        scene.setState({ meta: { ...scene.state.meta, canSave: false } });
+
+        const publishSpy = jest.spyOn(appEvents, 'publish');
+        const hasActualSaveChangesSpy = jest.spyOn(utils, 'hasActualSaveChanges').mockReturnValue(true);
+
+        scene.setState({ title: 'Updated title' });
+        expect(scene.state.isDirty).toBe(true);
+        scene.exitEditMode({ skipConfirm: false });
+
+        const modalCall = publishSpy.mock.calls.find((call) => call[0] instanceof ShowConfirmModalEvent);
+        expect(modalCall).toBeDefined();
+
+        const modalEvent = modalCall![0] as ShowConfirmModalEvent;
+        expect(modalEvent.payload.altActionText).toBeUndefined();
+        expect(modalEvent.payload.onAltAction).toBeUndefined();
 
         publishSpy.mockRestore();
         hasActualSaveChangesSpy.mockRestore();

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -25,7 +25,6 @@ import { type Dashboard, DashboardCursorSync, type LibraryPanel } from '@grafana
 import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { appEvents } from 'app/core/app_events';
 import { LS_PANEL_COPY_KEY, LS_STYLES_COPY_KEY } from 'app/core/constants';
-import { contextSrv } from 'app/core/services/context_srv';
 import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { type DecoratedRevisionModel } from 'app/features/dashboard/types/revisionModels';

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -422,6 +422,8 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     }
 
     if (config.featureToggles.dashboardNewLayouts) {
+      const canSave = Boolean(this.state.meta.canSave);
+
       appEvents.publish(
         new ShowConfirmModalEvent({
           title: t('dashboard-scene.dashboard-scene.modal.title.unsaved-changes', 'Unsaved changes'),
@@ -429,17 +431,19 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
             'dashboard-scene.dashboard-scene.modal.text.save-changes-question',
             'Do you want to save your changes?'
           ),
-          altActionText: t('dashboard-scene.dashboard-scene.modal.save', 'Save'),
+          altActionText: canSave ? t('dashboard-scene.dashboard-scene.modal.save', 'Save') : undefined,
           noText: t('dashboard-scene.dashboard-scene.modal.cancel', 'Cancel'),
           yesText: t('dashboard-scene.dashboard-scene.modal.discard', 'Discard'),
           yesButtonVariant: 'destructive',
-          onAltAction: () => {
-            this.openSaveDrawer({
-              onSaveSuccess: () => {
-                this.exitEditModeConfirmed(false);
-              },
-            });
-          },
+          onAltAction: canSave
+            ? () => {
+                this.openSaveDrawer({
+                  onSaveSuccess: () => {
+                    this.exitEditModeConfirmed(false);
+                  },
+                });
+              }
+            : undefined,
           onConfirm: () => {
             this.exitEditModeConfirmed();
           },

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -210,6 +210,7 @@ describe('setupKeyboardShortcuts', () => {
   describe('edit mode shortcuts', () => {
     beforeEach(() => {
       jest.spyOn(mockScene, 'canEditDashboard').mockReturnValue(true);
+      mockScene.setState({ meta: { ...mockScene.state.meta, canSave: true } });
       setupKeyboardShortcuts(mockScene);
     });
 

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -26,6 +26,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
   let vizPanelPathId: string | null = null;
 
   const canEdit = scene.canEditDashboard();
+  const canSave = Boolean(scene.state.meta.canSave);
 
   const panelAttentionSubscription = appEvents.subscribe(SetPanelAttentionEvent, (event) => {
     if (typeof event.payload.panelId === 'string') {
@@ -239,10 +240,12 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     });
 
     // Open save drawer
-    keybindings.addBinding({
-      key: 'mod+s',
-      onTrigger: () => scene.openSaveDrawer({}),
-    });
+    if (canSave) {
+      keybindings.addBinding({
+        key: 'mod+s',
+        onTrigger: () => scene.openSaveDrawer({}),
+      });
+    }
 
     // delete panel
     keybindings.addBinding({

--- a/public/app/features/dashboard-scene/sharing/SaveBeforeShareModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/SaveBeforeShareModal.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 export function SaveBeforeShareModal({ dashboard, onContinue, onDismiss, title, message }: Props) {
   const isDirty = dashboard.state.isEditing && dashboard.state.isDirty;
+  const canSave = Boolean(dashboard.state.meta.canSave);
 
   // Avoid showing a stale modal if the dashboard gets saved/discarded elsewhere.
   useEffect(() => {
@@ -44,9 +45,13 @@ export function SaveBeforeShareModal({ dashboard, onContinue, onDismiss, title, 
   }, [dashboard, onContinue, onDismiss]);
 
   const defaultTitle = t('dashboard-scene.sharing.save-before-share.title', 'Unsaved changes');
-  const defaultMessage = (
+  const defaultMessage = canSave ? (
     <Trans i18nKey="dashboard-scene.sharing.save-before-share.text">
       You have unsaved changes to this dashboard. You need to save them before you can share it.
+    </Trans>
+  ) : (
+    <Trans i18nKey="dashboard-scene.sharing.save-before-share.text-no-save">
+      You have unsaved changes to this dashboard. Are you sure you want to discard them?
     </Trans>
   );
 
@@ -64,9 +69,11 @@ export function SaveBeforeShareModal({ dashboard, onContinue, onDismiss, title, 
         <Button variant="destructive" onClick={onDiscard}>
           <Trans i18nKey="common.discard">Discard</Trans>
         </Button>
-        <Button onClick={onSave}>
-          <Trans i18nKey="common.save">Save</Trans>
-        </Button>
+        {canSave && (
+          <Button onClick={onSave}>
+            <Trans i18nKey="common.save">Save</Trans>
+          </Button>
+        )}
       </Modal.ButtonRow>
     </Modal>
   );

--- a/public/app/features/dashboard-scene/sharing/SaveBeforeShareModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/SaveBeforeShareModal.tsx
@@ -51,7 +51,7 @@ export function SaveBeforeShareModal({ dashboard, onContinue, onDismiss, title, 
     </Trans>
   ) : (
     <Trans i18nKey="dashboard-scene.sharing.save-before-share.text-no-save">
-      You have unsaved changes to this dashboard. Are you sure you want to discard them?
+      You have unsaved changes. You don’t have permission to save. Discard changes and share the original?
     </Trans>
   );
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7529,7 +7529,7 @@
     "sharing": {
       "save-before-share": {
         "text": "You have unsaved changes to this dashboard. You need to save them before you can share it.",
-        "text-no-save": "You have unsaved changes to this dashboard. Are you sure you want to discard them?",
+        "text-no-save": "You have unsaved changes. You don’t have permission to save. Discard changes and share the original?",
         "title": "Unsaved changes"
       }
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7529,6 +7529,7 @@
     "sharing": {
       "save-before-share": {
         "text": "You have unsaved changes to this dashboard. You need to save them before you can share it.",
+        "text-no-save": "You have unsaved changes to this dashboard. Are you sure you want to discard them?",
         "title": "Unsaved changes"
       }
     },


### PR DESCRIPTION
**What is this feature?**

Hides save action in various places for users who lack save permissions when using `dashboardNewLayouts`

1. Hides the Save button in edit
2. Hides Save option in the "Unsaved changes"
3. Disables "cmd + s" hokey
4. Hides save button when sharing


before
<img width="706" height="136" alt="image" src="https://github.com/user-attachments/assets/e897f1cd-0aa3-49ba-a4f5-690dbd0b37b7" />

<img width="524" height="201" alt="image" src="https://github.com/user-attachments/assets/f394ffce-5f31-4102-86dd-832e5625cb0f" />



after:

<img width="697" height="147" alt="image" src="https://github.com/user-attachments/assets/26900db1-c296-42e3-9ce5-eb5791cbb744" />


<img width="524" height="201" alt="image" src="https://github.com/user-attachments/assets/ba2ce928-6362-406c-bd28-20aa255820e5" />

