### PR TITLE
Dashboards: Add `apiVersion` query parameter to GET `/api/dashboards/uid/:uid`

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -1068,6 +1068,8 @@ Content-Length: 97
 
 Will return the dashboard given the dashboard unique identifier (uid). Information about the unique identifier of a folder containing the requested dashboard might be found in the metadata.
 
+Optional query parameter **`apiVersion`** requests which API version Grafana tries first when loading the dashboard (for example `v1beta1`). If that request fails, Grafana retries using the default version. When omitted, only the default is used.
+
 **Required permissions**
 
 See note in the [introduction](#dashboard-api) for an explanation.
@@ -1085,6 +1087,14 @@ See note in the [introduction](#dashboard-api) for an explanation.
 GET /api/dashboards/uid/cIBgcSjkk HTTP/1.1
 Accept: application/json
 Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+Example with an explicit API version:
+
+```http
+GET /api/dashboards/uid/cIBgcSjkk?apiVersion=v1beta1 HTTP/1.1
+Accept: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 ```
 

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -17378,7 +17378,7 @@
         "tags": ["dashboards"]
       },
       "get": {
-        "description": "Will return the dashboard given the dashboard unique identifier (uid).",
+        "description": "Optional query parameter `apiVersion` selects the Kubernetes API version used to load the dashboard first\n(for example `v1beta1`). If that request fails, the default version is used instead. When omitted, only the default is used.\n\nWill return the dashboard given the dashboard unique identifier (uid).",
         "operationId": "getDashboardByUID",
         "parameters": [
           {

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -311,9 +311,9 @@ func (hs *HTTPServer) getDashboardHelper(ctx context.Context, orgID int64, uid s
 	defer span.End()
 
 	queryResult, err := hs.DashboardService.GetDashboard(ctx, &dashboards.GetDashboardQuery{
-		UID:               uid,
-		OrgID:             orgID,
-		K8sGetAPIVersion:  k8sGetAPIVersion,
+		UID:              uid,
+		OrgID:            orgID,
+		K8sGetAPIVersion: k8sGetAPIVersion,
 	})
 	if err != nil {
 		return nil, response.Error(http.StatusNotFound, "Dashboard not found", err)

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -72,6 +72,9 @@ func (hs *HTTPServer) isDashboardStarredByUser(c *contextmodel.ReqContext, dashU
 //
 // Get dashboard by uid.
 //
+// Optional query parameter `apiVersion` selects the Kubernetes API version used to load the dashboard first
+// (for example `v1beta1`). If that request fails, the default version is used instead. When omitted, only the default is used.
+//
 // Will return the dashboard given the dashboard unique identifier (uid).
 //
 // Responses:
@@ -89,15 +92,13 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 	c.Req = c.Req.WithContext(ctx)
 
 	uid := web.Params(c.Req)[":uid"]
-	dash, rsp := hs.getDashboardHelper(ctx, c.GetOrgID(), uid)
+	apiVersion := strings.TrimSpace(c.Req.URL.Query().Get("apiVersion"))
+	dash, rsp := hs.getDashboardHelper(ctx, c.GetOrgID(), uid, apiVersion)
 	if rsp != nil {
 		return rsp
 	}
 
-	var (
-		publicDashboardEnabled = false
-		err                    error
-	)
+	publicDashboardEnabled := false
 
 	// If public dashboards is enabled and we have a public dashboard, update meta values
 	if hs.Cfg.PublicDashboardsEnabled {
@@ -305,11 +306,15 @@ func (hs *HTTPServer) getIdentityName(ctx context.Context, orgID, id int64) stri
 	return ident.GetLogin()
 }
 
-func (hs *HTTPServer) getDashboardHelper(ctx context.Context, orgID int64, uid string) (*dashboards.Dashboard, response.Response) {
+func (hs *HTTPServer) getDashboardHelper(ctx context.Context, orgID int64, uid string, k8sGetAPIVersion string) (*dashboards.Dashboard, response.Response) {
 	ctx, span := hs.tracer.Start(ctx, "api.getDashboardHelper")
 	defer span.End()
 
-	queryResult, err := hs.DashboardService.GetDashboard(ctx, &dashboards.GetDashboardQuery{UID: uid, OrgID: orgID})
+	queryResult, err := hs.DashboardService.GetDashboard(ctx, &dashboards.GetDashboardQuery{
+		UID:               uid,
+		OrgID:             orgID,
+		K8sGetAPIVersion:  k8sGetAPIVersion,
+	})
 	if err != nil {
 		return nil, response.Error(http.StatusNotFound, "Dashboard not found", err)
 	}
@@ -341,7 +346,7 @@ func (hs *HTTPServer) deleteDashboard(c *contextmodel.ReqContext) response.Respo
 	uid := web.Params(c.Req)[":uid"]
 
 	var rsp response.Response
-	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), uid)
+	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), uid, "")
 	if rsp != nil {
 		return rsp
 	}
@@ -789,7 +794,7 @@ func (hs *HTTPServer) GetDashboardVersions(c *contextmodel.ReqContext) response.
 		return response.Error(http.StatusBadRequest, "uid is required", nil)
 	}
 
-	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID)
+	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID, "")
 	if rsp != nil {
 		return rsp
 	}
@@ -880,7 +885,7 @@ func (hs *HTTPServer) GetDashboardVersion(c *contextmodel.ReqContext) response.R
 		return response.Error(http.StatusBadRequest, "uid is required", nil)
 	}
 
-	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID)
+	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID, "")
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -38,7 +38,7 @@ func (hs *HTTPServer) GetDashboardPermissionList(c *contextmodel.ReqContext) res
 		return response.Error(http.StatusBadRequest, "uid is required", nil)
 	}
 
-	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID)
+	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID, "")
 	if rsp != nil {
 		return rsp
 	}
@@ -101,7 +101,7 @@ func (hs *HTTPServer) UpdateDashboardPermissions(c *contextmodel.ReqContext) res
 		return response.Error(http.StatusBadRequest, "uid is required", nil)
 	}
 
-	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID)
+	dash, rsp := hs.getDashboardHelper(c.Req.Context(), c.GetOrgID(), dashUID, "")
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/services/apiserver/client/client_mock.go
+++ b/pkg/services/apiserver/client/client_mock.go
@@ -33,6 +33,10 @@ func (m *MockK8sHandler) Get(ctx context.Context, name string, orgID int64, opti
 	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
 }
 
+func (m *MockK8sHandler) GetWithPreferredAPIVersion(ctx context.Context, name string, orgID int64, options v1.GetOptions, _ string, subresource ...string) (*unstructured.Unstructured, error) {
+	return m.Get(ctx, name, orgID, options, subresource...)
+}
+
 func (m *MockK8sHandler) Create(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts v1.CreateOptions) (*unstructured.Unstructured, error) {
 	args := m.Called(ctx, obj, orgID, opts)
 	if args.Get(0) == nil {

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -356,6 +356,8 @@ type GetDashboardQuery struct {
 	FolderID  *int64
 	FolderUID *string
 	OrgID     int64
+	// k8s version to try first when loading (e.g. v1beta1). empty uses the default. on error, falls back to default
+	K8sGetAPIVersion string
 }
 
 type DashboardTagCloudItem struct {

--- a/pkg/services/dashboards/service/client/client.go
+++ b/pkg/services/dashboards/service/client/client.go
@@ -37,6 +37,9 @@ const (
 // K8sHandlerWithFallback is a wrapper around the K8sHandler that provides a fallback to the stored version.
 type K8sHandlerWithFallback interface {
 	client.K8sHandler
+	// GetWithPreferredAPIVersion loads the dashboard using the given k8s API version (for example v1beta1).
+	// When preferredVersion is empty, it uses the default. On conversion failure, it also falls back to the default.
+	GetWithPreferredAPIVersion(ctx context.Context, name string, orgID int64, options metav1.GetOptions, preferredVersion string, subresources ...string) (*unstructured.Unstructured, error)
 }
 
 // K8sClientFactory creates a K8sHandler for a given version.
@@ -125,6 +128,48 @@ func (h *K8sClientWithFallback) Get(
 	)
 
 	span.AddEvent(fmt.Sprintf("%s Get", storedVersion))
+	return h.newClientFunc(spanCtx, storedVersion).Get(spanCtx, name, orgID, options, subresources...)
+}
+
+// GetWithPreferredAPIVersion loads using the requested API version first. When preferredVersion is empty, delegates to Get.
+func (h *K8sClientWithFallback) GetWithPreferredAPIVersion(
+	ctx context.Context, name string, orgID int64, options metav1.GetOptions, preferredVersion string, subresources ...string,
+) (*unstructured.Unstructured, error) {
+	if preferredVersion == "" {
+		return h.Get(ctx, name, orgID, options, subresources...)
+	}
+
+	spanCtx, span := tracing.Start(ctx, "K8sClientWithFallback.GetWithPreferredAPIVersion")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("dashboard.metadata.name", name),
+		attribute.Int64("org.id", orgID),
+		attribute.String("preferred_api_version", preferredVersion),
+		attribute.Bool("fallback", false),
+	)
+
+	result, err := h.newClientFunc(spanCtx, preferredVersion).Get(spanCtx, name, orgID, options, subresources...)
+	if err != nil {
+		h.log.Info("falling back to default API version after preferred get failed", "name", name, "preferredVersion", preferredVersion, "err", err)
+		span.SetAttributes(attribute.Bool("preferred_get_failed", true))
+		return h.Get(ctx, name, orgID, options, subresources...)
+	}
+
+	failed, storedVersion, conversionErr := getConversionStatus(result)
+	if !failed {
+		return result, nil
+	}
+
+	h.log.Info("falling back to stored version", "name", name, "storedVersion", storedVersion, "conversionErr", conversionErr)
+	h.metrics.fallbackCounter.WithLabelValues(storedVersion).Inc()
+
+	span.SetAttributes(
+		attribute.Bool("fallback", true),
+		attribute.String("fallback.stored_version", storedVersion),
+		attribute.String("fallback.conversion_error", conversionErr),
+	)
+
 	return h.newClientFunc(spanCtx, storedVersion).Get(spanCtx, name, orgID, options, subresources...)
 }
 

--- a/pkg/services/dashboards/service/client/client_test.go
+++ b/pkg/services/dashboards/service/client/client_test.go
@@ -215,6 +215,85 @@ func TestK8sHandlerWithFallback_Get(t *testing.T) {
 	})
 }
 
+func TestK8sHandlerWithFallback_GetWithPreferredAPIVersion(t *testing.T) {
+	t.Run("empty preferred delegates to Get", func(t *testing.T) {
+		setup := setupTest(t)
+		ctx := context.Background()
+		name := "d"
+		orgID := int64(1)
+		options := metav1.GetOptions{}
+		expected := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": name}}}
+		setup.mockClientV1Beta1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(expected, nil).Once()
+
+		result, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, "")
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+		setup.mockClientV1Beta1.AssertExpectations(t)
+	})
+
+	t.Run("uses requested version", func(t *testing.T) {
+		setup := setupTest(t)
+		ctx := context.Background()
+		name := "d2"
+		orgID := int64(1)
+		options := metav1.GetOptions{}
+		expected := &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "dashboard.grafana.app/v2beta1"}}
+		setup.mockClientV2Beta1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(expected, nil).Once()
+
+		result, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, v2beta1.VERSION)
+		require.NoError(t, err)
+		require.Equal(t, expected, result)
+		require.Equal(t, 1, setup.mockFactoryCalls[v2beta1.VERSION])
+		setup.mockClientV2Beta1.AssertExpectations(t)
+	})
+
+	t.Run("preferred Get error falls back to default Get", func(t *testing.T) {
+		setup := setupTest(t)
+		ctx := context.Background()
+		name := "d-fallback-err"
+		orgID := int64(1)
+		options := metav1.GetOptions{}
+		fallbackResult := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": name}}}
+		setup.mockClientV2Beta1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(nil, errors.New("preferred get failed")).Once()
+		setup.mockClientV1Beta1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(fallbackResult, nil).Once()
+
+		result, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, v2beta1.VERSION)
+		require.NoError(t, err)
+		require.Equal(t, fallbackResult, result)
+		setup.mockClientV2Beta1.AssertExpectations(t)
+		setup.mockClientV1Beta1.AssertExpectations(t)
+	})
+
+	t.Run("fallback on conversion failure", func(t *testing.T) {
+		setup := setupTest(t)
+		ctx := context.Background()
+		name := "d3"
+		orgID := int64(2)
+		options := metav1.GetOptions{}
+		storedVersion := v2alpha1.VERSION
+		bad := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"conversion": map[string]interface{}{
+						"failed":        true,
+						"storedVersion": storedVersion,
+						"error":         "conv err",
+					},
+				},
+			},
+		}
+		ok := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": name}}}
+		setup.mockClientV2Beta1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(bad, nil).Once()
+		setup.mockClientV2Alpha1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(ok, nil).Once()
+
+		result, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, v2beta1.VERSION)
+		require.NoError(t, err)
+		require.Equal(t, ok, result)
+		setup.mockClientV2Beta1.AssertExpectations(t)
+		setup.mockClientV2Alpha1.AssertExpectations(t)
+	})
+}
+
 func TestK8sHandlerWithFallback_List(t *testing.T) {
 	// Helper function to create a dashboard item
 	createDashboard := func(name, resourceVersion string, status map[string]interface{}) unstructured.Unstructured {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1910,7 +1910,7 @@ func (dr *DashboardServiceImpl) getDashboardThroughK8s(ctx context.Context, quer
 		query.UID = result.UID
 	}
 
-	out, err := dr.k8sclient.Get(ctx, query.UID, query.OrgID, v1.GetOptions{}, "")
+	out, err := dr.k8sclient.GetWithPreferredAPIVersion(ctx, query.UID, query.OrgID, v1.GetOptions{}, query.K8sGetAPIVersion, "")
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	} else if err != nil || out == nil {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3707,7 +3707,7 @@
     },
     "/dashboards/uid/{uid}": {
       "get": {
-        "description": "Will return the dashboard given the dashboard unique identifier (uid).",
+        "description": "Optional query parameter `apiVersion` selects the Kubernetes API version used to load the dashboard first\n(for example `v1beta1`). If that request fails, the default version is used instead. When omitted, only the default is used.\n\nWill return the dashboard given the dashboard unique identifier (uid).",
         "tags": [
           "dashboards"
         ],

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -17952,7 +17952,7 @@
         ]
       },
       "get": {
-        "description": "Will return the dashboard given the dashboard unique identifier (uid).",
+        "description": "Optional query parameter `apiVersion` selects the Kubernetes API version used to load the dashboard first\n(for example `v1beta1`). If that request fails, the default version is used instead. When omitted, only the default is used.\n\nWill return the dashboard given the dashboard unique identifier (uid).",
         "operationId": "getDashboardByUID",
         "parameters": [
           {


### PR DESCRIPTION
This PR adds the query param `apiVersion` to the `GET /api/dashboards/uid/:uid` endpoint to be able to retrieve the json in the desired format

Example:
<img width="1125" height="1000" alt="Screenshot 2026-03-20 at 12 56 54 PM" src="https://github.com/user-attachments/assets/6d076d2b-2941-4534-91ce-e279b353fb52" />
<img width="1030" height="942" alt="Screenshot 2026-03-20 at 12 57 06 PM" src="https://github.com/user-attachments/assets/604cac6f-b988-48e2-b3bd-8d3cb29d2b14" />
