### PR TITLE
Gauge: Fix sparkline positioning issue in horizontal orientation

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -71,7 +71,7 @@
   "dev-dashboards-output/panel-flamegraph/panel_tests_flame_graph.v42.json": "1cb247f8757032496c725dd6f5d932cc04980d0cc7c664db81612b83d6aec035",
   "dev-dashboards-output/panel-gauge/gauge-multi-series.v42.json": "712bd116080613648de9e493d93bb39f83e11d752f93d08e29a7231289bba777",
   "dev-dashboards-output/panel-gauge/gauge_tests.v42.json": "2eade52f43f2859ed93d2148f695e24739c88a41fa80104d90e9d145321e6e10",
-  "dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json": "490829d6fa96e833a13f2034762c26b4feb4a85e686c628076009d53fdc84144",
+  "dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json": "28e2f048eaaa21fb88afb2a4bf999ab4d727d8dd74e3682de3dd4320d00b3d09",
   "dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json": "6cf057d0cf13ead60d8a039662d1d6b320230dbf1de2b2892dd0b3790c158760",
   "dev-dashboards-output/panel-geomap/geomap-color-field.v42.json": "a3dc6a3291a47088a229bea0eca833fd3ff7f227b1d0296a52dbd42d03907124",
   "dev-dashboards-output/panel-geomap/geomap-photo-layer.v42.json": "1b9eca89aeb6244e5eb9415ff4f737b4ae0dafcbf3310213cef60567a3d09f3c",

--- a/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
@@ -1498,7 +1498,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 18,
         "x": 0,
         "y": 33
       },
@@ -1555,6 +1555,87 @@
         "defaults": {
           "color": {
             "fixedColor": "blue",
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 6,
+        "x": 18,
+        "y": 33
+      },
+      "id": 41,
+      "maxDataPoints": 20,
+      "options": {
+        "barShape": "rounded",
+        "barWidth": 12,
+        "barWidthFactor": 0.4,
+        "effects": {
+          "barGlow": true,
+          "centerGlow": true,
+          "gradient": true
+        },
+        "endpointMarker": "glow",
+        "glow": "both",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "segmentCount": 1,
+        "segmentSpacing": 0.3,
+        "shape": "gauge",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "sparkline": true
+      },
+      "pluginVersion": "13.0.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "max": 98,
+          "min": 5,
+          "noise": 22,
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 2,
+          "spread": 12,
+          "startValue": 50
+        }
+      ],
+      "title": "Horizontal orientation",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
             "mode": "continuous-GrYlRd"
           },
           "mappings": [],
@@ -1579,7 +1660,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 18,
         "x": 0,
         "y": 39
       },

--- a/e2e-playwright/panels-suite/gauge.spec.ts
+++ b/e2e-playwright/panels-suite/gauge.spec.ts
@@ -11,7 +11,7 @@ const NEW_GAUGES_DASHBOARD_UID = 'panel-tests-gauge-new';
 const OLD_TO_NEW_GAUGES_DASHBOARD_UID = 'panel-tests-old-gauge-to-new';
 
 const OLD_GAUGES_DASHBOARD_GAUGE_COUNT = 16;
-const NEW_GAUGE_DASHBOARD_GAUGE_COUNT = 34;
+const NEW_GAUGE_DASHBOARD_GAUGE_COUNT = 36;
 
 test.describe(
   'Gauge Panel',

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -286,6 +286,7 @@ export function RadialGauge(props: RadialGaugeProps) {
       display="flex"
       justifyContent="center"
       alignItems="center"
+      position="relative"
       data-testid={selectors.components.Panels.Visualization.Gauge.Container}
     >
       <svg


### PR DESCRIPTION
Ensures that the container with the SVG and sparkline has `position=relative` to correctly vertically position the sparklines correctly relative to the gauges.

Also adds a new panel to the Gauge (new) gdev dashboard.

_No unit tests in this PR because the fix is completely visual._

### Before

<img width="430" height="491" alt="Screenshot 2026-03-20 at 2 36 50 PM" src="https://github.com/user-attachments/assets/8802a4d6-ac9c-4069-8d78-76616e27acc7" />

### After

<img width="458" height="502" alt="Screenshot 2026-03-20 at 2 35 13 PM" src="https://github.com/user-attachments/assets/450a9aa8-b325-4e80-8f89-4a74a1666ec1" />