### PR TITLE
Provisioning: re-enable flaky incremental metadata name change test

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1565,6 +1565,16 @@ func RequireRepoFolders(t *testing.T, folderClient *apis.K8sResourceClient, ctx 
 		"folders for repo %q should have sourcePaths %v", repoName, expectedSourcePaths)
 }
 
+// RequireJobSuccess asserts that a completed job has state "success" and no errors.
+func RequireJobSuccess(t *testing.T, job *unstructured.Unstructured) {
+	t.Helper()
+	lastState := MustNestedString(job.Object, "status", "state")
+	lastErrors := MustNestedStringSlice(job.Object, "status", "errors")
+	require.Empty(t, lastErrors, "job %q has errors: %v", job.GetName(), lastErrors)
+	require.Equal(t, string(provisioning.JobStateSuccess), lastState,
+		"job %q should succeed", job.GetName())
+}
+
 // GetFolderGeneration returns the current generation of the folder with the given UID.
 func GetFolderGeneration(t *testing.T, helper *ProvisioningTestHelper, folderUID string) int64 {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1565,6 +1565,38 @@ func RequireRepoFolders(t *testing.T, folderClient *apis.K8sResourceClient, ctx 
 		"folders for repo %q should have sourcePaths %v", repoName, expectedSourcePaths)
 }
 
+// WaitForRepoLastRef waits until the repository's status.sync.lastRef is
+// non-empty. This must be satisfied before triggering an incremental sync,
+// otherwise the syncer falls back to a full sync.
+func WaitForRepoLastRef(t *testing.T, repositories *apis.K8sResourceClient, repoName string) {
+	t.Helper()
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		repo, err := repositories.Resource.Get(context.Background(), repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "failed to get repository %s", repoName) {
+			return
+		}
+
+		lastRef, _, _ := unstructured.NestedString(repo.Object, "status", "sync", "lastRef")
+		assert.NotEmpty(collect, lastRef, "repository %s should have lastRef set", repoName)
+	}, WaitTimeoutDefault, WaitIntervalDefault, "repository %s should have lastRef set after sync", repoName)
+}
+
+// SyncAndWaitWithSuccess triggers a full pull sync, asserts that it succeeds,
+// and waits for the repository's lastRef to be set. Use this as the initial
+// sync in tests that later trigger incremental syncs, so that lastRef is
+// guaranteed to be populated.
+func (h *ProvisioningTestHelper) SyncAndWaitWithSuccess(t *testing.T, repoName string) {
+	t.Helper()
+
+	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	RequireJobSuccess(t, job)
+	WaitForRepoLastRef(t, h.Repositories, repoName)
+}
+
 // RequireJobSuccess asserts that a completed job has state "success" and no errors.
 func RequireJobSuccess(t *testing.T, job *unstructured.Unstructured) {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	WaitTimeoutDefault  = 30 * time.Second
+	WaitTimeoutDefault  = 60 * time.Second
 	WaitIntervalDefault = 100 * time.Millisecond
 )
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1597,6 +1597,18 @@ func (h *ProvisioningTestHelper) SyncAndWaitWithSuccess(t *testing.T, repoName s
 	WaitForRepoLastRef(t, h.Repositories, repoName)
 }
 
+// SyncAndWaitSuccessfulIncremental triggers an incremental pull sync, waits for
+// it to complete, and asserts that the job succeeded.
+func (h *ProvisioningTestHelper) SyncAndWaitSuccessfulIncremental(t *testing.T, repoName string) {
+	t.Helper()
+
+	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+	})
+	RequireJobSuccess(t, job)
+}
+
 // RequireJobSuccess asserts that a completed job has state "success" and no errors.
 func RequireJobSuccess(t *testing.T, job *unstructured.Unstructured) {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1631,6 +1631,42 @@ func RequireJobSuccess(t *testing.T, job *unstructured.Unstructured) {
 		"job %q should succeed", job.GetName())
 }
 
+// RequireJobWarning asserts that a completed job has state "warning" and no errors.
+func RequireJobWarning(t *testing.T, job *unstructured.Unstructured) {
+	t.Helper()
+	lastState := MustNestedString(job.Object, "status", "state")
+	lastErrors := MustNestedStringSlice(job.Object, "status", "errors")
+	require.Empty(t, lastErrors, "job %q has errors: %v", job.GetName(), lastErrors)
+	require.Equal(t, string(provisioning.JobStateWarning), lastState,
+		"job %q should have warning state", job.GetName())
+}
+
+// SyncAndWaitWithWarning triggers a full pull sync, asserts that it completes
+// with a warning state (no errors), and waits for lastRef. Use this for syncs
+// where a warning is the expected outcome (e.g. missing folder metadata).
+func SyncAndWaitWithWarning(t *testing.T, h SyncHelper, repoName string) {
+	t.Helper()
+
+	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	RequireJobWarning(t, job)
+	WaitForRepoLastRef(t, h.GetRepositories(), repoName)
+}
+
+// SyncAndWaitIncrementalWithWarning triggers an incremental pull sync, waits
+// for it to complete, and asserts that the job finished with a warning state.
+func SyncAndWaitIncrementalWithWarning(t *testing.T, h SyncHelper, repoName string) {
+	t.Helper()
+
+	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+	})
+	RequireJobWarning(t, job)
+}
+
 // GetFolderGeneration returns the current generation of the folder with the given UID.
 func GetFolderGeneration(t *testing.T, helper *ProvisioningTestHelper, folderUID string) int64 {
 	t.Helper()

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1582,11 +1582,23 @@ func WaitForRepoLastRef(t *testing.T, repositories *apis.K8sResourceClient, repo
 	}, WaitTimeoutDefault, WaitIntervalDefault, "repository %s should have lastRef set after sync", repoName)
 }
 
+// SyncHelper abstracts the ability to trigger sync jobs and inspect repository
+// state. Both ProvisioningTestHelper and gitTestHelper satisfy this interface.
+type SyncHelper interface {
+	TriggerJobAndWaitForComplete(t *testing.T, repoName string, spec provisioning.JobSpec) *unstructured.Unstructured
+	GetRepositories() *apis.K8sResourceClient
+}
+
+// GetRepositories implements SyncHelper.
+func (h *ProvisioningTestHelper) GetRepositories() *apis.K8sResourceClient {
+	return h.Repositories
+}
+
 // SyncAndWaitWithSuccess triggers a full pull sync, asserts that it succeeds,
 // and waits for the repository's lastRef to be set. Use this as the initial
 // sync in tests that later trigger incremental syncs, so that lastRef is
 // guaranteed to be populated.
-func (h *ProvisioningTestHelper) SyncAndWaitWithSuccess(t *testing.T, repoName string) {
+func SyncAndWaitWithSuccess(t *testing.T, h SyncHelper, repoName string) {
 	t.Helper()
 
 	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -1594,12 +1606,12 @@ func (h *ProvisioningTestHelper) SyncAndWaitWithSuccess(t *testing.T, repoName s
 		Pull:   &provisioning.SyncJobOptions{},
 	})
 	RequireJobSuccess(t, job)
-	WaitForRepoLastRef(t, h.Repositories, repoName)
+	WaitForRepoLastRef(t, h.GetRepositories(), repoName)
 }
 
 // SyncAndWaitSuccessfulIncremental triggers an incremental pull sync, waits for
 // it to complete, and asserts that the job succeeded.
-func (h *ProvisioningTestHelper) SyncAndWaitSuccessfulIncremental(t *testing.T, repoName string) {
+func SyncAndWaitSuccessfulIncremental(t *testing.T, h SyncHelper, repoName string) {
 	t.Helper()
 
 	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/git/helpers_test.go
+++ b/pkg/tests/apis/provisioning/git/helpers_test.go
@@ -326,16 +326,14 @@ func (h *gitTestHelper) syncAndWait(t *testing.T, repoName string) {
 	h.waitForJobsComplete(t, repoName)
 }
 
-// syncAndWaitSuccessfulIncremental triggers an incremental pull sync, waits
-// for completion, and asserts the job succeeded.
-func (h *gitTestHelper) syncAndWaitSuccessfulIncremental(t *testing.T, repoName string) {
-	t.Helper()
+// TriggerJobAndWaitForComplete implements common.SyncHelper.
+func (h *gitTestHelper) TriggerJobAndWaitForComplete(t *testing.T, repoName string, spec provisioning.JobSpec) *unstructured.Unstructured {
+	return h.triggerJobAndWaitForComplete(t, repoName, spec)
+}
 
-	job := h.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{Incremental: true},
-	})
-	common.RequireJobSuccess(t, job)
+// GetRepositories implements common.SyncHelper.
+func (h *gitTestHelper) GetRepositories() *apis.K8sResourceClient {
+	return h.Repositories
 }
 
 // waitForJobsComplete waits for all active jobs for a repository to complete.
@@ -359,17 +357,6 @@ func (h *gitTestHelper) waitForJobsComplete(t *testing.T, repoName string) {
 
 		assert.False(collect, hasActiveJobs, "jobs still active for repository %s", repoName)
 	}, waitTimeoutDefault, waitIntervalDefault, "jobs should complete for repository %s", repoName)
-}
-
-func (h *gitTestHelper) syncAndWaitWithSuccess(t *testing.T, repoName string) {
-	t.Helper()
-
-	job := h.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{},
-	})
-	common.RequireJobSuccess(t, job)
-	common.WaitForRepoLastRef(t, h.Repositories, repoName)
 }
 
 // asJSON serialises v to a JSON byte slice, panicking on encoding errors

--- a/pkg/tests/apis/provisioning/git/helpers_test.go
+++ b/pkg/tests/apis/provisioning/git/helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/nanogit/gittest"
@@ -394,6 +395,21 @@ func (h *gitTestHelper) waitForRepoLastRef(t *testing.T, repoName string) {
 		lastRef, _, _ := unstructured.NestedString(repo.Object, "status", "sync", "lastRef")
 		assert.NotEmpty(collect, lastRef, "repository %s should have lastRef set", repoName)
 	}, waitTimeoutDefault, waitIntervalDefault, "repository %s should have lastRef set after sync", repoName)
+}
+
+// syncAndWaitWithSuccess triggers a full pull sync, asserts that it succeeds,
+// and waits for the repository's lastRef to be set. Use this as the initial
+// sync in tests that later trigger incremental syncs, so that lastRef is
+// guaranteed to be populated.
+func (h *gitTestHelper) syncAndWaitWithSuccess(t *testing.T, repoName string) {
+	t.Helper()
+
+	job := h.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	common.RequireJobSuccess(t, job)
+	h.waitForRepoLastRef(t, repoName)
 }
 
 // asJSON serialises v to a JSON byte slice, panicking on encoding errors

--- a/pkg/tests/apis/provisioning/git/helpers_test.go
+++ b/pkg/tests/apis/provisioning/git/helpers_test.go
@@ -326,35 +326,16 @@ func (h *gitTestHelper) syncAndWait(t *testing.T, repoName string) {
 	h.waitForJobsComplete(t, repoName)
 }
 
-// syncAndWaitIncremental triggers an incremental pull sync — only files changed
-// since the previous sync (LastRef) are processed — and waits for completion.
-func (h *gitTestHelper) syncAndWaitIncremental(t *testing.T, repoName string) {
+// syncAndWaitSuccessfulIncremental triggers an incremental pull sync, waits
+// for completion, and asserts the job succeeded.
+func (h *gitTestHelper) syncAndWaitSuccessfulIncremental(t *testing.T, repoName string) {
 	t.Helper()
 
-	jobSpec := map[string]interface{}{
-		"action": "pull",
-		"pull":   map[string]interface{}{"incremental": true},
-	}
-
-	jobJSON, err := json.Marshal(jobSpec)
-	require.NoError(t, err)
-
-	result := h.AdminREST.Post().
-		Namespace("default").
-		Resource("repositories").
-		Name(repoName).
-		SubResource("jobs").
-		Body(jobJSON).
-		SetHeader("Content-Type", "application/json").
-		Do(context.Background())
-
-	if apierrors.IsAlreadyExists(result.Error()) {
-		h.waitForJobsComplete(t, repoName)
-		return
-	}
-
-	require.NoError(t, result.Error(), "failed to trigger incremental sync")
-	h.waitForJobsComplete(t, repoName)
+	job := h.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+	})
+	common.RequireJobSuccess(t, job)
 }
 
 // waitForJobsComplete waits for all active jobs for a repository to complete.

--- a/pkg/tests/apis/provisioning/git/helpers_test.go
+++ b/pkg/tests/apis/provisioning/git/helpers_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
-	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/nanogit/gittest"

--- a/pkg/tests/apis/provisioning/git/helpers_test.go
+++ b/pkg/tests/apis/provisioning/git/helpers_test.go
@@ -379,6 +379,23 @@ func (h *gitTestHelper) waitForJobsComplete(t *testing.T, repoName string) {
 	}, waitTimeoutDefault, waitIntervalDefault, "jobs should complete for repository %s", repoName)
 }
 
+// waitForRepoLastRef waits until the repository's status.sync.lastRef is
+// non-empty. This must be satisfied before triggering an incremental sync,
+// otherwise the syncer falls back to a full sync.
+func (h *gitTestHelper) waitForRepoLastRef(t *testing.T, repoName string) {
+	t.Helper()
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		repo, err := h.Repositories.Resource.Get(context.Background(), repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err, "failed to get repository %s", repoName) {
+			return
+		}
+
+		lastRef, _, _ := unstructured.NestedString(repo.Object, "status", "sync", "lastRef")
+		assert.NotEmpty(collect, lastRef, "repository %s should have lastRef set", repoName)
+	}, waitTimeoutDefault, waitIntervalDefault, "repository %s should have lastRef set after sync", repoName)
+}
+
 // asJSON serialises v to a JSON byte slice, panicking on encoding errors
 // (acceptable in test helpers where the input is always a known-good struct).
 func asJSON(v interface{}) []byte {

--- a/pkg/tests/apis/provisioning/git/helpers_test.go
+++ b/pkg/tests/apis/provisioning/git/helpers_test.go
@@ -380,27 +380,6 @@ func (h *gitTestHelper) waitForJobsComplete(t *testing.T, repoName string) {
 	}, waitTimeoutDefault, waitIntervalDefault, "jobs should complete for repository %s", repoName)
 }
 
-// waitForRepoLastRef waits until the repository's status.sync.lastRef is
-// non-empty. This must be satisfied before triggering an incremental sync,
-// otherwise the syncer falls back to a full sync.
-func (h *gitTestHelper) waitForRepoLastRef(t *testing.T, repoName string) {
-	t.Helper()
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		repo, err := h.Repositories.Resource.Get(context.Background(), repoName, metav1.GetOptions{})
-		if !assert.NoError(collect, err, "failed to get repository %s", repoName) {
-			return
-		}
-
-		lastRef, _, _ := unstructured.NestedString(repo.Object, "status", "sync", "lastRef")
-		assert.NotEmpty(collect, lastRef, "repository %s should have lastRef set", repoName)
-	}, waitTimeoutDefault, waitIntervalDefault, "repository %s should have lastRef set after sync", repoName)
-}
-
-// syncAndWaitWithSuccess triggers a full pull sync, asserts that it succeeds,
-// and waits for the repository's lastRef to be set. Use this as the initial
-// sync in tests that later trigger incremental syncs, so that lastRef is
-// guaranteed to be populated.
 func (h *gitTestHelper) syncAndWaitWithSuccess(t *testing.T, repoName string) {
 	t.Helper()
 
@@ -409,7 +388,7 @@ func (h *gitTestHelper) syncAndWaitWithSuccess(t *testing.T, repoName string) {
 		Pull:   &provisioning.SyncJobOptions{},
 	})
 	common.RequireJobSuccess(t, job)
-	h.waitForRepoLastRef(t, repoName)
+	common.WaitForRepoLastRef(t, h.Repositories, repoName)
 }
 
 // asJSON serialises v to a JSON byte slice, panicking on encoding errors

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -212,7 +212,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		require.NoError(t, err)
 
 		// Incremental sync.
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		// Verify the Grafana folder was created with the metadata title, not the directory name.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "My Team Display Name")
@@ -239,7 +239,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		// Should use directory name "reports" as the title.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "reports")
@@ -265,7 +265,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		// Should use directory name "analytics" as the title.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "analytics")
@@ -293,7 +293,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		// Both folders should use their metadata titles.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Display")
@@ -328,7 +328,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Alpha Renamed")
 	})
@@ -357,7 +357,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Title")
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Child Title Updated")
@@ -387,7 +387,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Updated Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Updated Dashboard")
@@ -432,7 +432,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
@@ -488,7 +488,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		childAfter, err := helper.FoldersV1.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
@@ -544,7 +544,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -601,7 +601,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -668,7 +668,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		// Verify parent folder updated in place.
 		parentAfter, err := helper.FoldersV1.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -728,7 +728,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.syncAndWaitSuccessfulIncremental(t, repoName)
 
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"new-team"})
 

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -30,7 +30,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync the root dashboard.
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 		// Add a dashboard inside a folder that has no _folder.json.
 		require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(dashboardJSON("folder-dash", "Folder Dashboard", 1))))
@@ -69,7 +69,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync (should produce a warning about missing metadata).
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -110,7 +110,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisab
 	})
 
 	// Full sync.
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 	// Add a dashboard inside a folder with no _folder.json.
 	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(dashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))
@@ -199,7 +199,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash", "Root Dashboard", 1),
 		})
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 		// Push a folder with _folder.json that has a custom title different from the directory name.
 		require.NoError(t, local.CreateFile("my-team/_folder.json", string(folderMetadataJSON("stable-uid-1", "My Team Display Name"))))
@@ -212,7 +212,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		require.NoError(t, err)
 
 		// Incremental sync.
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		// Verify the Grafana folder was created with the metadata title, not the directory name.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "My Team Display Name")
@@ -227,7 +227,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash-2", "Root Dashboard", 1),
 		})
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 		// Push a folder with _folder.json that has an empty title — should fall back to dir name.
 		require.NoError(t, local.CreateFile("reports/_folder.json", string(folderMetadataJSON("stable-uid-2", ""))))
@@ -239,7 +239,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		// Should use directory name "reports" as the title.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "reports")
@@ -254,7 +254,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash-3", "Root Dashboard", 1),
 		})
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 		// Push a folder without _folder.json.
 		require.NoError(t, local.CreateFile("analytics/dash.json", string(dashboardJSON("analytics-dash", "Analytics Dashboard", 1))))
@@ -265,7 +265,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		// Should use directory name "analytics" as the title.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "analytics")
@@ -280,7 +280,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash-4", "Root Dashboard", 1),
 		})
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
 		// Push nested folders, each with their own _folder.json and custom titles.
 		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON("parent-uid", "Parent Display"))))
@@ -293,7 +293,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		// Both folders should use their metadata titles.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Display")
@@ -317,7 +317,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"alpha/dash.json":    dashboardJSON("alpha-dash", "Alpha Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Alpha")
 
 		require.NoError(t, local.UpdateFile("alpha/_folder.json", string(folderMetadataJSON("alpha-uid", "Alpha Renamed"))))
@@ -328,7 +328,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Alpha Renamed")
 	})
@@ -345,7 +345,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"parent/child/dash.json":    dashboardJSON("nested-upd-dash", "Nested Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Title")
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Child Title")
 
@@ -357,7 +357,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Title")
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Child Title Updated")
@@ -374,7 +374,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"team/dash.json":    dashboardJSON("combo-dash", "Original Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Original Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Original Dashboard")
 
@@ -387,7 +387,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Updated Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Updated Dashboard")
@@ -414,7 +414,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": dashboardJSON("rr-dash-001", "Team Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 		folderBefore, err := helper.FoldersV1.Resource.Get(ctx, folderUID, metav1.GetOptions{})
@@ -432,7 +432,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
@@ -470,7 +470,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/old-child/dashboard1.json": dashboardJSON("nn-dash-001", "Child Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/old-child"})
 
 		childBefore, err := helper.FoldersV1.Resource.Get(ctx, childUID, metav1.GetOptions{})
@@ -488,7 +488,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		childAfter, err := helper.FoldersV1.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
@@ -526,7 +526,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"my-folder/dashboard1.json": dashboardJSON("rn-dash-001", "Moved Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "my-folder"})
 
 		folderBefore, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -544,7 +544,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -583,7 +583,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/my-folder/dashboard1.json": dashboardJSON("nr-dash-001", "Moved Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/my-folder"})
 
 		folderBefore, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -601,7 +601,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -641,7 +641,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-parent/child/child-dash.json": dashboardJSON("mx-child-dash", "Child Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-parent", "old-parent/child"})
 
 		parentBefore, err := helper.FoldersV1.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -668,7 +668,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		// Verify parent folder updated in place.
 		parentAfter, err := helper.FoldersV1.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -718,7 +718,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": dashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repoName)
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
@@ -728,7 +728,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"new-team"})
 

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -68,8 +68,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 			"myfolder/dashboard.json": dashboardJSON("noop-dash", "Noop Dashboard", 1),
 		})
 
-		// Full sync (should produce a warning about missing metadata).
-		helper.syncAndWait(t, repoName)
+		common.SyncAndWaitWithWarning(t, helper, repoName)
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -265,12 +264,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// Incremental sync — folder without _folder.json produces a warning
-		// (missing folder metadata), so we don't assert success.
-		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
 
 		// Should use directory name "analytics" as the title.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "analytics")
@@ -437,7 +431,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
+		// producing errors. The rename still works via fallback, so we only
+		// wait for completion without asserting success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
@@ -493,7 +493,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
+		// producing errors. The rename still works via fallback, so we only
+		// wait for completion without asserting success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		childAfter, err := helper.FoldersV1.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
@@ -549,7 +555,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
+		// producing errors. The rename still works via fallback, so we only
+		// wait for completion without asserting success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -606,7 +618,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
+		// producing errors. The rename still works via fallback, so we only
+		// wait for completion without asserting success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -673,7 +691,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
+		// producing errors. The rename still works via fallback, so we only
+		// wait for completion without asserting success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		// Verify parent folder updated in place.
 		parentAfter, err := helper.FoldersV1.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -723,9 +747,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": dashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		// Full sync — folder without _folder.json produces a warning
-		// (missing folder metadata), so we don't assert success.
-		helper.syncAndWait(t, repoName)
+		common.SyncAndWaitWithWarning(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
@@ -735,12 +757,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// Incremental sync — folder without _folder.json produces a warning
-		// (missing folder metadata), so we don't assert success.
-		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
 
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"new-team"})
 

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -30,7 +30,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync the root dashboard.
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 
 		// Add a dashboard inside a folder that has no _folder.json.
 		require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(dashboardJSON("folder-dash", "Folder Dashboard", 1))))
@@ -69,7 +69,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync (should produce a warning about missing metadata).
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -110,7 +110,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisab
 	})
 
 	// Full sync.
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 
 	// Add a dashboard inside a folder with no _folder.json.
 	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(dashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))
@@ -199,7 +199,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash", "Root Dashboard", 1),
 		})
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 
 		// Push a folder with _folder.json that has a custom title different from the directory name.
 		require.NoError(t, local.CreateFile("my-team/_folder.json", string(folderMetadataJSON("stable-uid-1", "My Team Display Name"))))
@@ -227,7 +227,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash-2", "Root Dashboard", 1),
 		})
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 
 		// Push a folder with _folder.json that has an empty title — should fall back to dir name.
 		require.NoError(t, local.CreateFile("reports/_folder.json", string(folderMetadataJSON("stable-uid-2", ""))))
@@ -254,7 +254,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash-3", "Root Dashboard", 1),
 		})
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 
 		// Push a folder without _folder.json.
 		require.NoError(t, local.CreateFile("analytics/dash.json", string(dashboardJSON("analytics-dash", "Analytics Dashboard", 1))))
@@ -280,7 +280,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": dashboardJSON("root-dash-4", "Root Dashboard", 1),
 		})
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 
 		// Push nested folders, each with their own _folder.json and custom titles.
 		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON("parent-uid", "Parent Display"))))
@@ -317,7 +317,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"alpha/dash.json":    dashboardJSON("alpha-dash", "Alpha Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Alpha")
 
 		require.NoError(t, local.UpdateFile("alpha/_folder.json", string(folderMetadataJSON("alpha-uid", "Alpha Renamed"))))
@@ -345,7 +345,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"parent/child/dash.json":    dashboardJSON("nested-upd-dash", "Nested Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Parent Title")
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Child Title")
 
@@ -374,7 +374,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"team/dash.json":    dashboardJSON("combo-dash", "Original Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		requireRepoFolderTitle(t, helper, ctx, repoName, "Original Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Original Dashboard")
 
@@ -414,7 +414,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": dashboardJSON("rr-dash-001", "Team Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 		folderBefore, err := helper.FoldersV1.Resource.Get(ctx, folderUID, metav1.GetOptions{})
@@ -470,7 +470,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/old-child/dashboard1.json": dashboardJSON("nn-dash-001", "Child Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/old-child"})
 
 		childBefore, err := helper.FoldersV1.Resource.Get(ctx, childUID, metav1.GetOptions{})
@@ -526,7 +526,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"my-folder/dashboard1.json": dashboardJSON("rn-dash-001", "Moved Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "my-folder"})
 
 		folderBefore, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -583,7 +583,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/my-folder/dashboard1.json": dashboardJSON("nr-dash-001", "Moved Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"parent", "parent/my-folder"})
 
 		folderBefore, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -641,7 +641,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-parent/child/child-dash.json": dashboardJSON("mx-child-dash", "Child Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-parent", "old-parent/child"})
 
 		parentBefore, err := helper.FoldersV1.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -718,7 +718,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": dashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		helper.syncAndWait(t, repoName)
+		helper.syncAndWaitWithSuccess(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -265,7 +265,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// Incremental sync — folder without _folder.json produces a warning
+		// (missing folder metadata), so we don't assert success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		// Should use directory name "analytics" as the title.
 		requireRepoFolderTitle(t, helper, ctx, repoName, "analytics")
@@ -718,7 +723,9 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": dashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		// Full sync — folder without _folder.json produces a warning
+		// (missing folder metadata), so we don't assert success.
+		helper.syncAndWait(t, repoName)
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
@@ -728,7 +735,12 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		// Incremental sync — folder without _folder.json produces a warning
+		// (missing folder metadata), so we don't assert success.
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		common.RequireRepoFolders(t, helper.FoldersV1, ctx, repoName, []string{"new-team"})
 

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -69,7 +69,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync (should produce a warning about missing metadata).
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		helper.syncAndWait(t, repoName)
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -27,7 +27,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(dashboardJSON("incr-dash-002", "Dashboard Two", 1))))
@@ -38,7 +38,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }
 
@@ -56,7 +56,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
@@ -67,7 +67,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "incr-dash-001", "Dashboard One Updated")
 }
@@ -87,7 +87,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 		"dashboard2.json": dashboardJSON("incr-dash-002", "Dashboard Two", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
@@ -97,7 +97,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -120,10 +120,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 }
 
@@ -141,7 +141,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -153,7 +153,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
 	})
@@ -173,7 +173,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 		"dashboard1.json": dashboardJSON("move-in-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -187,7 +187,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
 	})
@@ -209,7 +209,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 		"folder-b/.keep":           {},
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
@@ -222,7 +222,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
 	})
@@ -243,7 +243,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 		"team-x/dashboard1.json": dashboardJSON("move-root-001", "Dashboard Root", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
@@ -256,7 +256,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
@@ -279,7 +279,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 		"old-team/dashboard2.json": dashboardJSON("ren-fold-002", "Folder Dash Two", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
@@ -293,7 +293,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
@@ -316,7 +316,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 		"parent/child-b/.keep":           {},
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
@@ -329,7 +329,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
 	})
@@ -351,7 +351,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 		"parent/sibling/dashboard2.json":   dashboardJSON("ren-nest-002", "Sibling Dash", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
@@ -365,7 +365,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitSuccessfulIncremental(t, repoName)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -38,7 +38,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }
 
@@ -67,7 +67,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "incr-dash-001", "Dashboard One Updated")
 }
@@ -97,7 +97,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -123,7 +123,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 }
 
@@ -153,7 +153,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
 	})
@@ -187,7 +187,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
 	})
@@ -222,7 +222,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
 	})
@@ -256,7 +256,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
@@ -293,7 +293,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
@@ -329,7 +329,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
 	})
@@ -365,7 +365,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	helper.syncAndWaitSuccessfulIncremental(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -27,7 +27,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(dashboardJSON("incr-dash-002", "Dashboard Two", 1))))
@@ -56,7 +56,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
@@ -87,7 +87,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 		"dashboard2.json": dashboardJSON("incr-dash-002", "Dashboard Two", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
@@ -120,7 +120,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	helper.syncAndWaitIncremental(t, repoName)
@@ -141,7 +141,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 		"dashboard1.json": dashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -173,7 +173,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 		"dashboard1.json": dashboardJSON("move-in-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -209,7 +209,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 		"folder-b/.keep":           {},
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
@@ -243,7 +243,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 		"team-x/dashboard1.json": dashboardJSON("move-root-001", "Dashboard Root", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
@@ -279,7 +279,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 		"old-team/dashboard2.json": dashboardJSON("ren-fold-002", "Folder Dash Two", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
@@ -316,7 +316,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 		"parent/child-b/.keep":           {},
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
@@ -351,7 +351,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 		"parent/sibling/dashboard2.json":   dashboardJSON("ren-nest-002", "Sibling Dash", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -93,11 +92,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{Incremental: true},
-	})
-	common.RequireJobSuccess(t, job)
+	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -102,9 +101,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		Action: provisioning.JobActionPull,
 		Pull:   &provisioning.SyncJobOptions{Incremental: true},
 	})
-	jobState, _, _ := unstructured.NestedString(job.Object, "status", "state")
-	require.Equal(t, string(provisioning.JobStateSuccess), jobState,
-		"incremental sync job should succeed")
+	common.RequireJobSuccess(t, job)
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -80,7 +80,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		"dashboard1.json": dashboardJSON("name-change-incr-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWaitWithSuccess(t, repoName)
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
 

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -68,7 +70,6 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 // path, incremental sync creates a new resource with the new name while the old
 // resource remains orphaned.
 func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testing.T) {
-	t.Skip("Skipping incremental sync test (flaky)")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafanaWithGitServer(t)
@@ -84,6 +85,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
 
+	// Ensure lastRef is set so the next sync actually runs incrementally
+	// rather than falling back to a full sync.
+	helper.waitForRepoLastRef(t, repoName)
+
 	// Change the metadata.name (uid) in the same file path.
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("name-change-incr-002", "Dashboard One Renamed", 2))))
 	_, err := local.Git("add", ".")
@@ -93,7 +98,13 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	helper.syncAndWaitIncremental(t, repoName)
+	job := helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+	})
+	jobState, _, _ := unstructured.NestedString(job.Object, "status", "state")
+	require.Equal(t, string(provisioning.JobStateSuccess), jobState,
+		"incremental sync job should succeed")
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -80,13 +80,9 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		"dashboard1.json": dashboardJSON("name-change-incr-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	helper.syncAndWait(t, repoName)
+	helper.syncAndWaitWithSuccess(t, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
-
-	// Ensure lastRef is set so the next sync actually runs incrementally
-	// rather than falling back to a full sync.
-	helper.waitForRepoLastRef(t, repoName)
 
 	// Change the metadata.name (uid) in the same file path.
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(dashboardJSON("name-change-incr-002", "Dashboard One Renamed", 2))))

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -162,7 +162,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repo)
+		helper.syncAndWaitSuccessfulIncremental(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
@@ -177,7 +177,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repo)
+		helper.syncAndWaitSuccessfulIncremental(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
@@ -268,7 +268,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		// Incremental sync processes the deletion; orphan cleanup removes folder1.
-		helper.syncAndWaitIncremental(t, repo)
+		helper.syncAndWaitSuccessfulIncremental(t, repo)
 
 		// dashboard1 and folder1 are gone; only dashboard2 remains.
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync fills the quota (2/2).
-		helper.syncAndWaitWithSuccess(t, repo)
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -85,7 +86,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": dashboardJSON("incr-swap-dash-001", "Dashboard One", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repo)
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -148,7 +149,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard2.json": dashboardJSON("incr-rel-dash-002", "Dashboard Two", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repo)
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -162,7 +163,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repo)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
@@ -177,7 +178,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		helper.syncAndWaitSuccessfulIncremental(t, repo)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
@@ -198,7 +199,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: 2 dashboards + 1 implicit folder = 3/3 resources.
-		helper.syncAndWaitWithSuccess(t, repo)
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		requireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -253,7 +254,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: folder1 + dash1 + dash2 = 3/3 resources.
-		helper.syncAndWaitWithSuccess(t, repo)
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		requireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -268,7 +269,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		// Incremental sync processes the deletion; orphan cleanup removes folder1.
-		helper.syncAndWaitSuccessfulIncremental(t, repo)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
 
 		// dashboard1 and folder1 are gone; only dashboard2 remains.
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
@@ -288,7 +289,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": dashboardJSON("incr-ulim-dash-001", "Dashboard One", 1),
 		})
 
-		helper.syncAndWaitWithSuccess(t, repo)
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
 
 		// Add three more dashboards as separate git commits pushed to the remote.

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -31,7 +31,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync fills the quota (2/2).
-		helper.syncAndWait(t, repo)
+		helper.syncAndWaitWithSuccess(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -85,7 +85,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": dashboardJSON("incr-swap-dash-001", "Dashboard One", 1),
 		})
 
-		helper.syncAndWait(t, repo)
+		helper.syncAndWaitWithSuccess(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -148,7 +148,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard2.json": dashboardJSON("incr-rel-dash-002", "Dashboard Two", 1),
 		})
 
-		helper.syncAndWait(t, repo)
+		helper.syncAndWaitWithSuccess(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -198,7 +198,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: 2 dashboards + 1 implicit folder = 3/3 resources.
-		helper.syncAndWait(t, repo)
+		helper.syncAndWaitWithSuccess(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		requireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -253,7 +253,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: folder1 + dash1 + dash2 = 3/3 resources.
-		helper.syncAndWait(t, repo)
+		helper.syncAndWaitWithSuccess(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 2)
 		requireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.waitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -288,7 +288,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": dashboardJSON("incr-ulim-dash-001", "Dashboard One", 1),
 		})
 
-		helper.syncAndWait(t, repo)
+		helper.syncAndWaitWithSuccess(t, repo)
 		requireRepoDashboardCount(t, helper, ctx, repo, 1)
 
 		// Add three more dashboards as separate git commits pushed to the remote.


### PR DESCRIPTION
## Summary

Fixes the flaky `TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange` test that was disabled in #120851, and hardens all incremental sync integration tests.

### Root cause

Two issues caused the flaky timeout:

1. **`lastRef` race**: The incremental sync could silently fall back to a full sync if `status.sync.lastRef` wasn't yet visible from the previous sync. A full sync with a UID change deletes the original dashboard, causing assertions (expecting both old and new) to fail and retry until timeout.

2. **Silent job failures**: `syncAndWaitIncremental` only waited for jobs to disappear from the active queue — it never checked if the job actually **succeeded**. A failed job would let subsequent `require.EventuallyWithT` assertions retry for their full 60s timeout, silently consuming the 8-minute test budget.

### Changes

- **Re-enable the test** — remove the `t.Skip` added in #120851.
- **New `common.SyncHelper` interface** — both `ProvisioningTestHelper` and `gitTestHelper` satisfy it, enabling shared sync helpers across test packages.
- **`common.WaitForRepoLastRef`** — standalone function that polls until `status.sync.lastRef` is non-empty.
- **`common.RequireJobSuccess`** — standalone assertion that a completed job has state `success` and no errors.
- **`common.SyncAndWaitWithSuccess`** — triggers a full sync, asserts success, waits for `lastRef`. Used as the initial sync before all incremental tests.
- **`common.SyncAndWaitSuccessfulIncremental`** — triggers an incremental sync and asserts success.
- **Updated all incremental sync tests** to use the new helpers, providing:
  - Fast failure on job errors (no more 60s retry loops on a failed sync)
  - Guaranteed `lastRef` before incremental syncs
  - Consistent assertion patterns across all test files

Tests that expect non-success states (quota warnings, missing folder metadata) continue to use `triggerJobAndWaitForComplete` directly.

## Test plan

- [ ] CI passes for `pkg/tests/apis/provisioning/git/...`
- [ ] `TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange` no longer flakes
- [ ] Tests expecting warnings (e.g. missing folder metadata) still pass