### PR TITLE
Unistore: avoid KV GC deleting history for live or recreated resources

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -500,7 +500,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			}
 
 			// since we are processing keys in descending order of resource version,
-			// if the first occurence is a create or update action, then it means the
+			// if the first occurrence is a create or update action, then it means the
 			// resource is live, so we can add the key to the live keys map and
 			// skip the rest of the logic for this key (no need to delete anything)
 			if dk.Action == DataActionCreated || dk.Action == DataActionUpdated {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -453,11 +453,10 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	seenKeys := map[ListRequestKey]struct{}{}
 
 	// Data keys are group/resource/namespace/name/{rv}~…, so lexicographic order (asc or
-	// desc) keeps all revisions for one resource contiguous. While iterating one resource,
-	// the first key we see is the newest; if it is create/update, the resource is live and
-	// we skip older keys until the name changes. State persists across paginated batches.
+	// desc) keeps all revisions for one resource contiguous. While iterating in descending
+	// RV order, only the first key per ListRequestKey is the head revision; older rows for
+	// the same resource are skipped. State persists across paginated batches.
 	var currentResource ListRequestKey
-	var currentResourceLive bool
 
 	for {
 		keysProcessed := int64(0)
@@ -498,19 +497,11 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			// the next end key is the immediate previous key for the current key
 			endKey = previousKey(dataKey)
 
-			if k != currentResource {
-				currentResource = k
-				currentResourceLive = false
-			}
-			if currentResourceLive {
+			if k == currentResource {
+				// Older revision for a resource we already handled at its head key.
 				continue
 			}
-
-			// First key seen for this resource (newest revision): create/update means live.
-			if dk.Action == DataActionCreated || dk.Action == DataActionUpdated {
-				currentResourceLive = true
-				continue
-			}
+			currentResource = k
 
 			// if the action is deleted and the resource version is older than the cutoff, get all previous versions
 			// of the same resource and delete them in batch

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -452,6 +452,9 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	// track keys that have been processed to avoid processing the same key twice
 	seenKeys := map[ListRequestKey]struct{}{}
 
+	// track keys that are live
+	liveKeys := map[ListRequestKey]struct{}{}
+
 	for {
 		keysProcessed := int64(0)
 		keysDeleted := int64(0)
@@ -491,6 +494,20 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			// the next end key is the immediate previous key for the current key
 			endKey = previousKey(dataKey)
 
+			// the resource is live, no need to delete anything
+			if _, live := liveKeys[k]; live {
+				continue
+			}
+
+			// since we are processing keys in descending order of resource version,
+			// if the first occurence is a create or update action, then it means the
+			// resource is live, so we can add the key to the live keys map and
+			// skip the rest of the logic for this key (no need to delete anything)
+			if dk.Action == DataActionCreated || dk.Action == DataActionUpdated {
+				liveKeys[k] = struct{}{}
+				continue
+			}
+
 			// if the action is deleted and the resource version is older than the cutoff, get all previous versions
 			// of the same resource and delete them in batch
 			if dk.Action == DataActionDeleted && dk.ResourceVersion < cutoffTimestamp {
@@ -517,6 +534,18 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					keysToDelete = append(keysToDelete, deleteKey)
 				}
 
+				// check if the resource still exists
+				_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
+					Group:     dk.Group,
+					Resource:  dk.Resource,
+					Namespace: dk.Namespace,
+					Name:      dk.Name,
+				})
+				if err == nil {
+					// resource still exists, no need to delete anything
+					continue
+				}
+
 				if b.garbageCollection.DryRun {
 					// if in dry run mode, just count the keys to delete
 					totalDryRun += int64(len(keysToDelete))
@@ -524,7 +553,7 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 				}
 
 				// if not in dry run mode, batch delete the keys
-				err := b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
+				err = b.kv.BatchDelete(ctx, kv.DataSection, keysToDelete)
 				if err != nil {
 					return fmt.Errorf("failed to batch delete keys: %s", err)
 				}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -545,6 +545,9 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 					// resource still exists, no need to delete anything
 					continue
 				}
+				if !errors.Is(err, ErrNotFound) {
+					return fmt.Errorf("garbage collection: latest resource key lookup for %s: %w", dk, err)
+				}
 
 				if b.garbageCollection.DryRun {
 					// if in dry run mode, just count the keys to delete

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -452,8 +452,12 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 	// track keys that have been processed to avoid processing the same key twice
 	seenKeys := map[ListRequestKey]struct{}{}
 
-	// track keys that are live
-	liveKeys := map[ListRequestKey]struct{}{}
+	// Data keys are group/resource/namespace/name/{rv}~…, so lexicographic order (asc or
+	// desc) keeps all revisions for one resource contiguous. While iterating one resource,
+	// the first key we see is the newest; if it is create/update, the resource is live and
+	// we skip older keys until the name changes. State persists across paginated batches.
+	var currentResource ListRequestKey
+	var currentResourceLive bool
 
 	for {
 		keysProcessed := int64(0)
@@ -494,17 +498,17 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 			// the next end key is the immediate previous key for the current key
 			endKey = previousKey(dataKey)
 
-			// the resource is live, no need to delete anything
-			if _, live := liveKeys[k]; live {
+			if k != currentResource {
+				currentResource = k
+				currentResourceLive = false
+			}
+			if currentResourceLive {
 				continue
 			}
 
-			// since we are processing keys in descending order of resource version,
-			// if the first occurrence is a create or update action, then it means the
-			// resource is live, so we can add the key to the live keys map and
-			// skip the rest of the logic for this key (no need to delete anything)
+			// First key seen for this resource (newest revision): create/update means live.
 			if dk.Action == DataActionCreated || dk.Action == DataActionUpdated {
-				liveKeys[k] = struct{}{}
+				currentResourceLive = true
 				continue
 			}
 

--- a/pkg/storage/unified/resource/storage_backend_gc_test.go
+++ b/pkg/storage/unified/resource/storage_backend_gc_test.go
@@ -458,7 +458,10 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		err = b.garbageCollectGroupResource(ctx, "group", "resource", cutoffTimestamp)
 		require.NoError(t, err)
 
-		// Both resources should be fully GC'd; no history keys left
+		// other-dash was deleted and not recreated: all of its history is removed.
+		// my-dash still exists (recreated after delete); GC skips deleting its history when
+		// GetLatestResourceKey succeeds, so all five revision keys remain.
+		// BatchSize=3 exercises pagination across both resources without dropping my-dash history.
 		historyResp := storageBackend.kv.Keys(ctx, dataSection, ListOptions{
 			StartKey: "group/resource/namespace/",
 			EndKey:   "group/resource/namespace0",
@@ -466,10 +469,12 @@ func TestIntegrationGarbageCollectionGroupResource(t *testing.T) {
 		count := 0
 		historyResp(func(k string, err error) bool {
 			require.NoError(t, err)
+			require.Contains(t, k, "/my-dash/")
+			require.NotContains(t, k, "/other-dash/")
 			count++
 			return true
 		})
-		require.Equal(t, 2, count)
+		require.Equal(t, 5, count)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Tightens KV **garbageCollectGroupResource** so we do not remove history resource records for a (namespace, group, resource, name) when that object still exists in the store. That matches how the SQL backend already selects GC candidates.

**Why do we need this feature?**

Feature parity between SQL backend and KV backend

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/search-and-storage-team/issues/682

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
