### PR TITLE
Provisioning: Handle folder metadata deletion in incremental sync

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -329,10 +329,12 @@ func planFolderMetadataChanges(
 		if !resources.IsFolderMetadataFile(change.Path) {
 			continue
 		}
-		if change.Action == repository.FileActionUpdated {
+		switch change.Action {
+		case repository.FileActionUpdated:
 			metadataUpdateIndices = append(metadataUpdateIndices, i)
-		} else if change.Action == repository.FileActionDeleted {
+		case repository.FileActionDeleted:
 			metadataDeletionIndices = append(metadataDeletionIndices, i)
+		default:
 		}
 	}
 	if len(metadataUpdateIndices) == 0 && len(metadataDeletionIndices) == 0 {

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -198,13 +198,16 @@ func applyIncrementalChanges(ctx context.Context, diff []repository.VersionedFil
 			continue
 		}
 
-		if folderMetadataEnabled && resources.IsFolderMetadataFile(change.Path) &&
-			(change.Action == repository.FileActionCreated || change.Action == repository.FileActionUpdated) {
-			name, err := applyFolderMetadataUpdate(ctx, change, repositoryResources, tracer)
-			if err != nil {
-				resultBuilder.WithError(err)
+		if folderMetadataEnabled && resources.IsFolderMetadataFile(change.Path) {
+			if change.Action == repository.FileActionCreated || change.Action == repository.FileActionUpdated {
+				name, err := applyFolderMetadataUpdate(ctx, change, repositoryResources, tracer)
+				if err != nil {
+					resultBuilder.WithError(err)
+				}
+				resultBuilder.WithName(name)
 			}
-			resultBuilder.WithName(name)
+			// Metadata files are not Grafana resources. Deletions are handled by
+			// planFolderMetadataChanges; other actions are no-ops.
 			progress.Record(ctx, resultBuilder.Build())
 			continue
 		}
@@ -295,15 +298,20 @@ func applyFolderMetadataUpdate(ctx context.Context, change repository.VersionedF
 	return folder, nil
 }
 
-// replacedFolder tracks a folder whose UID changed in a _folder.json update.
+// replacedFolder tracks a folder whose UID changed due to a _folder.json
+// update or deletion. The old folder needs cleanup after children are re-parented.
 type replacedFolder struct {
 	Path   string // folder dir path (with trailing slash)
 	OldUID string // the previous folder UID to delete after children are re-parented
 }
 
-// planFolderMetadataChanges detects UID changes in updated _folder.json files,
-// emits synthetic FileActionUpdated for direct children so they get re-parented,
-// and returns the list of old folder UIDs to clean up after children are moved.
+// planFolderMetadataChanges detects UID changes in updated or deleted _folder.json
+// files, emits synthetic FileActionUpdated for direct children so they get
+// re-parented, and returns the list of old folder UIDs to clean up.
+//
+// For _folder.json updates: reads the new metadata to get the new UID.
+// For _folder.json deletions: computes the hash-based UID that the folder
+// reverts to when metadata is removed.
 func planFolderMetadataChanges(
 	ctx context.Context,
 	repo repository.Reader,
@@ -316,12 +324,18 @@ func planFolderMetadataChanges(
 	defer span.End()
 
 	var metadataUpdateIndices []int
+	var metadataDeletionIndices []int
 	for i, change := range diff {
-		if resources.IsFolderMetadataFile(change.Path) && change.Action == repository.FileActionUpdated {
+		if !resources.IsFolderMetadataFile(change.Path) {
+			continue
+		}
+		if change.Action == repository.FileActionUpdated {
 			metadataUpdateIndices = append(metadataUpdateIndices, i)
+		} else if change.Action == repository.FileActionDeleted {
+			metadataDeletionIndices = append(metadataDeletionIndices, i)
 		}
 	}
-	if len(metadataUpdateIndices) == 0 {
+	if len(metadataUpdateIndices) == 0 && len(metadataDeletionIndices) == 0 {
 		return diff, nil, nil
 	}
 
@@ -341,6 +355,8 @@ func planFolderMetadataChanges(
 
 	var replaced []replacedFolder
 	oldUIDSet := make(map[string]struct{})
+
+	// Detect UID changes from _folder.json updates.
 	for _, idx := range metadataUpdateIndices {
 		change := diff[idx]
 		folderDir := safepath.Dir(change.Path)
@@ -368,8 +384,60 @@ func planFolderMetadataChanges(
 		oldUIDSet[oldUID] = struct{}{}
 	}
 
+	// Detect UID transitions from _folder.json deletions.
+	// When metadata is removed the folder reverts to a hash-derived UID.
+	for _, idx := range metadataDeletionIndices {
+		change := diff[idx]
+		folderDir := safepath.Dir(change.Path)
+
+		oldUID, ok := existingFoldersByPath[folderDir]
+		if !ok {
+			continue
+		}
+
+		// Any non-NotFound error is treated as a hard failure to avoid
+		// triggering an incorrect UID transition on transient errors.
+		_, readErr := repo.Read(ctx, folderDir, currentRef)
+		if readErr != nil {
+			if errors.Is(readErr, repository.ErrFileNotFound) || apierrors.IsNotFound(readErr) {
+				// Directory gone — schedule old folder for deletion.
+				// No synthetic child updates are needed since all
+				// children should already be removed by other diff
+				// entries or previous syncs. We can't rely on
+				// findOrphanedFolders because _folder.json deletions
+				// are skipped in the apply phase and may not populate
+				// affectedFolders.
+				replaced = append(replaced, replacedFolder{
+					Path:   folderDir,
+					OldUID: oldUID,
+				})
+				continue
+			}
+			return nil, nil, fmt.Errorf("read folder directory %s at ref %s: %w", folderDir, currentRef, readErr)
+		}
+
+		newUID := resources.ParseFolder(folderDir, repo.Config().Name).ID
+
+		if newUID != oldUID {
+			repositoryResources.RemoveFolderFromTree(oldUID)
+			replaced = append(replaced, replacedFolder{
+				Path:   folderDir,
+				OldUID: oldUID,
+			})
+			oldUIDSet[oldUID] = struct{}{}
+		}
+
+		// Emit a folder directory update so the folder is recreated with the
+		// hash-based UID (or updated to clear the stale metadata hash).
+		diff = append(diff, repository.VersionedFileChange{
+			Action: repository.FileActionUpdated,
+			Path:   folderDir,
+			Ref:    currentRef,
+		})
+	}
+
 	if len(oldUIDSet) == 0 {
-		return diff, nil, nil
+		return diff, replaced, nil
 	}
 
 	actionsInDiff := make(map[string]repository.FileAction, len(diff))

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -1376,6 +1376,290 @@ func TestPlanFolderMetadataChanges(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "list existing resources: list failed")
 	})
+
+	t.Run("deleted _folder.json with UID transition emits folder update and children", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash1", Folder: "stable-uid"},
+			},
+		}, nil)
+
+		repo.On("Config").Return(&provisioning.Repository{})
+		repo.On("Read", mock.Anything, "alpha/", "ref1").Return(&repository.FileInfo{}, nil)
+		repoResources.On("RemoveFolderFromTree", "stable-uid").Return()
+
+		result, replaced, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.NoError(t, err)
+		require.Len(t, replaced, 1)
+		require.Equal(t, "alpha/", replaced[0].Path)
+		require.Equal(t, "stable-uid", replaced[0].OldUID)
+
+		// Original _folder.json deletion + synthetic folder dir update + synthetic child update
+		require.Len(t, result, 3)
+		require.Equal(t, "alpha/_folder.json", result[0].Path)
+		require.Equal(t, repository.FileActionDeleted, result[0].Action)
+
+		var hasFolderDirUpdate, hasChildUpdate bool
+		for _, r := range result {
+			if r.Path == "alpha/" && r.Action == repository.FileActionUpdated {
+				hasFolderDirUpdate = true
+			}
+			if r.Path == "alpha/dash.json" && r.Action == repository.FileActionUpdated {
+				hasChildUpdate = true
+			}
+		}
+		require.True(t, hasFolderDirUpdate, "should emit folder dir update")
+		require.True(t, hasChildUpdate, "should emit child update")
+	})
+
+	t.Run("deleted _folder.json when directory is also gone schedules old folder deletion", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}, nil)
+
+		repo.On("Read", mock.Anything, "alpha/", "ref1").
+			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound)
+
+		result, replaced, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.NoError(t, err)
+		require.Len(t, replaced, 1, "old folder should be scheduled for deletion even when directory is gone")
+		require.Equal(t, "stable-uid", replaced[0].OldUID)
+		require.Equal(t, "alpha/", replaced[0].Path)
+		require.Equal(t, diff, result)
+	})
+
+	t.Run("deleted _folder.json when folder not in Grafana skips transition", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
+
+		result, replaced, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.NoError(t, err)
+		require.Empty(t, replaced)
+		require.Equal(t, diff, result)
+	})
+
+	t.Run("deleted _folder.json with same UID emits folder update only", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+
+		hashUID := resources.ParseFolder("alpha/", "").ID
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: hashUID},
+				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "d1", Folder: hashUID},
+			},
+		}, nil)
+
+		repo.On("Config").Return(&provisioning.Repository{})
+		repo.On("Read", mock.Anything, "alpha/", "ref1").Return(&repository.FileInfo{}, nil)
+
+		result, replaced, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.NoError(t, err)
+		require.Empty(t, replaced, "same UID should not produce a replacement")
+
+		require.Len(t, result, 2)
+		require.Equal(t, "alpha/_folder.json", result[0].Path)
+
+		var hasFolderDirUpdate bool
+		for _, r := range result {
+			if r.Path == "alpha/" && r.Action == repository.FileActionUpdated {
+				hasFolderDirUpdate = true
+			}
+		}
+		require.True(t, hasFolderDirUpdate, "should emit folder dir update to clear metadata hash")
+	})
+
+	t.Run("deleted _folder.json children already in diff are not duplicated", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+			{Action: repository.FileActionUpdated, Path: "alpha/dash.json", Ref: "ref1"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "d1", Folder: "stable-uid"},
+			},
+		}, nil)
+
+		repo.On("Config").Return(&provisioning.Repository{})
+		repo.On("Read", mock.Anything, "alpha/", "ref1").Return(&repository.FileInfo{}, nil)
+		repoResources.On("RemoveFolderFromTree", "stable-uid").Return()
+
+		result, replaced, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.NoError(t, err)
+		require.Len(t, replaced, 1)
+		// Original deletion + original dash update + synthetic folder dir update (child not duplicated)
+		require.Len(t, result, 3, "child already in diff should not be duplicated")
+	})
+
+	t.Run("transient Read error during deletion is propagated", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}, nil)
+
+		repo.On("Read", mock.Anything, "alpha/", "ref1").
+			Return((*repository.FileInfo)(nil), fmt.Errorf("connection reset"))
+
+		_, _, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "read folder directory alpha/")
+		require.Contains(t, err.Error(), "connection reset")
+	})
+
+	t.Run("List error is propagated for deletions too", func(t *testing.T) {
+		repo := repository.NewMockReader(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+		repoResources.On("List", mock.Anything).Return((*provisioning.ResourceList)(nil), fmt.Errorf("list failed"))
+
+		_, _, err := planFolderMetadataChanges(context.Background(), repo, "ref1", diff, repoResources, tracer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "list existing resources: list failed")
+	})
+}
+
+func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
+	t.Run("metadata deletion re-parents children and deletes old folder", func(t *testing.T) {
+		mockVersioned := repository.NewMockVersioned(t)
+		mockReader := repository.NewMockReader(t)
+		repo := &compositeRepo{
+			MockVersioned: mockVersioned,
+			MockReader:    mockReader,
+		}
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		changes := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "alpha/_folder.json", PreviousRef: "old-ref"},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash1", Folder: "stable-uid"},
+			},
+		}, nil)
+
+		mockReader.On("Config").Return(&provisioning.Repository{})
+		mockReader.On("Read", mock.Anything, "alpha/", "new-ref").Return(&repository.FileInfo{}, nil)
+
+		progress.On("SetTotal", mock.Anything, mock.Anything).Return()
+		progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+		progress.On("TooManyErrors").Return(nil)
+		progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
+		progress.On("HasDirPathFailedDeletion", mock.Anything).Return(false)
+		progress.On("HasChildPathFailedCreation", mock.Anything).Return(false)
+		progress.On("HasChildPathFailedUpdate", mock.Anything).Return(false)
+
+		repoResources.On("RemoveFolderFromTree", "stable-uid").Return()
+		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/").
+			Return("hash-uid", nil)
+		repoResources.On("WriteResourceFromFile", mock.Anything, "alpha/dash.json", "new-ref").
+			Return("dash1", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboard.grafana.app"}, nil)
+		repoResources.On("RemoveFolder", mock.Anything, "stable-uid").Return(nil)
+
+		progress.On("Record", mock.Anything, mock.Anything).Return()
+
+		mockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry{
+			{Path: "alpha", Blob: false},
+			{Path: "alpha/dash.json", Blob: true},
+		}, nil)
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
+
+		repoResources.AssertCalled(t, "RemoveFolderFromTree", "stable-uid")
+		repoResources.AssertCalled(t, "EnsureFolderPathExist", mock.Anything, "alpha/")
+		repoResources.AssertCalled(t, "WriteResourceFromFile", mock.Anything, "alpha/dash.json", "new-ref")
+		repoResources.AssertCalled(t, "RemoveFolder", mock.Anything, "stable-uid")
+	})
+
+	t.Run("deleted _folder.json is skipped in apply phase", func(t *testing.T) {
+		mockVersioned := repository.NewMockVersioned(t)
+		mockReader := repository.NewMockReader(t)
+		repo := &compositeRepo{
+			MockVersioned: mockVersioned,
+			MockReader:    mockReader,
+		}
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		// _folder.json deletion + dashboard creation in same commit
+		changes := []repository.VersionedFileChange{
+			{Action: repository.FileActionDeleted, Path: "beta/_folder.json", PreviousRef: "old-ref"},
+			{Action: repository.FileActionCreated, Path: "beta/new-dash.json", Ref: "new-ref"},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+
+		// No existing folder — just ensure the deletion is skipped gracefully
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
+
+		progress.On("SetTotal", mock.Anything, mock.Anything).Return()
+		progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+		progress.On("TooManyErrors").Return(nil)
+		progress.On("HasDirPathFailedCreation", mock.Anything).Return(false)
+
+		repoResources.On("WriteResourceFromFile", mock.Anything, "beta/new-dash.json", "new-ref").
+			Return("new-dash", schema.GroupVersionKind{Kind: "Dashboard"}, nil)
+
+		progress.On("Record", mock.Anything, mock.Anything).Return()
+
+		mockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry{
+			{Path: "beta", Blob: false},
+			{Path: "beta/new-dash.json", Blob: true},
+		}, nil)
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
+
+		// _folder.json deletion should NOT reach RemoveResourceFromFile
+		repoResources.AssertNotCalled(t, "RemoveResourceFromFile", mock.Anything, "beta/_folder.json", mock.Anything)
+		repoResources.AssertCalled(t, "WriteResourceFromFile", mock.Anything, "beta/new-dash.json", "new-ref")
+	})
 }
 
 func TestIncrementalSync_FolderUIDChange(t *testing.T) {

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -909,3 +909,150 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 	})
 }
+
+// TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion verifies that
+// deleting a _folder.json during incremental sync transitions the folder from a
+// stable UID back to a hash-derived UID, re-parents children, and deletes the old folder.
+func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("simple metadata deletion re-parents dashboard", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-delete-simple"
+		const stableUID = "stable-folder-uid"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"alpha/_folder.json": folderMetadataJSON(stableUID, "Alpha"),
+			"alpha/dash.json":    dashboardJSON("meta-del-001", "Alpha Dashboard", 1),
+		})
+
+		helper.syncAndWait(t, repoName)
+
+		// Verify folder exists with stable UID
+		_, err := helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		require.NoError(t, err, "folder with stable UID should exist after full sync")
+
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"meta-del-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: stableUID},
+		})
+
+		// Delete _folder.json only, keeping the directory and dashboard
+		_, err = local.Git("rm", "alpha/_folder.json")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "delete folder metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Old stable UID folder should be deleted
+		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted after metadata deletion")
+
+		// New folder should exist with hash-based UID and directory name as title
+		newFolderUID := requireRepoFolderTitle(t, helper, ctx, repoName, "alpha")
+		require.NotEqual(t, stableUID, newFolderUID, "new folder should have a different UID")
+
+		// Dashboard should be re-parented to the new folder
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"meta-del-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: newFolderUID},
+		})
+	})
+
+	t.Run("metadata deletion with nested child folder", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-delete-nested"
+		const parentStableUID = "parent-stable-uid"
+		const childStableUID = "child-stable-uid"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"parent/_folder.json":           folderMetadataJSON(parentStableUID, "Parent"),
+			"parent/child/_folder.json":     folderMetadataJSON(childStableUID, "Child"),
+			"parent/parent-dash.json":       dashboardJSON("nested-parent-001", "Parent Dashboard", 1),
+			"parent/child/child-dash.json":  dashboardJSON("nested-child-001", "Child Dashboard", 1),
+		})
+
+		helper.syncAndWait(t, repoName)
+
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"nested-parent-001": {Title: "Parent Dashboard", SourcePath: "parent/parent-dash.json", Folder: parentStableUID},
+			"nested-child-001":  {Title: "Child Dashboard", SourcePath: "parent/child/child-dash.json", Folder: childStableUID},
+		})
+
+		// Delete only the parent's _folder.json
+		_, err := local.Git("rm", "parent/_folder.json")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "delete parent folder metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Old parent folder should be gone
+		_, err = helper.FoldersV1.Resource.Get(ctx, parentStableUID, metav1.GetOptions{})
+		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
+
+		// New parent folder should exist with hash-based UID
+		newParentUID := requireRepoFolderTitle(t, helper, ctx, repoName, "parent")
+		require.NotEqual(t, parentStableUID, newParentUID)
+
+		// Child folder should still exist with its stable UID, re-parented under new parent
+		childAfter, err := helper.FoldersV1.Resource.Get(ctx, childStableUID, metav1.GetOptions{})
+		require.NoError(t, err, "child folder should still exist")
+		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
+		require.Equal(t, newParentUID, childParent, "child should be re-parented to new parent UID")
+
+		// Parent dashboard re-parented; child dashboard unchanged
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"nested-parent-001": {Title: "Parent Dashboard", SourcePath: "parent/parent-dash.json", Folder: newParentUID},
+			"nested-child-001":  {Title: "Child Dashboard", SourcePath: "parent/child/child-dash.json", Folder: childStableUID},
+		})
+	})
+
+	t.Run("metadata deletion alongside dashboard update in same commit", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-delete-combo"
+		const stableUID = "combo-stable-uid"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"team/_folder.json": folderMetadataJSON(stableUID, "Team"),
+			"team/dash.json":    dashboardJSON("combo-del-001", "Original Dashboard", 1),
+		})
+
+		helper.syncAndWait(t, repoName)
+
+		// Delete metadata and update dashboard in the same commit
+		_, err := local.Git("rm", "team/_folder.json")
+		require.NoError(t, err)
+		require.NoError(t, local.UpdateFile("team/dash.json", string(dashboardJSON("combo-del-001", "Updated Dashboard", 2))))
+		_, err = local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "delete metadata and update dashboard")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Old folder should be gone
+		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted")
+
+		// New folder with hash-based UID
+		newFolderUID := requireRepoFolderTitle(t, helper, ctx, repoName, "team")
+		require.NotEqual(t, stableUID, newFolderUID)
+
+		// Dashboard should be updated and re-parented
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"combo-del-001": {Title: "Updated Dashboard", SourcePath: "team/dash.json", Folder: newFolderUID},
+		})
+	})
+}

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -803,7 +803,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, newUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder with new UID should exist")
@@ -851,7 +854,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		_, err = helper.FoldersV1.Resource.Get(ctx, parentNewUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent folder with new UID should exist")
@@ -894,7 +900,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, newUID, metav1.GetOptions{})
 		require.NoError(t, err)
@@ -946,7 +955,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		// Old stable UID folder should be deleted
 		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
@@ -971,10 +983,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		const childStableUID = "child-stable-uid"
 
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
-			"parent/_folder.json":           folderMetadataJSON(parentStableUID, "Parent"),
-			"parent/child/_folder.json":     folderMetadataJSON(childStableUID, "Child"),
-			"parent/parent-dash.json":       dashboardJSON("nested-parent-001", "Parent Dashboard", 1),
-			"parent/child/child-dash.json":  dashboardJSON("nested-child-001", "Child Dashboard", 1),
+			"parent/_folder.json":          folderMetadataJSON(parentStableUID, "Parent"),
+			"parent/child/_folder.json":    folderMetadataJSON(childStableUID, "Child"),
+			"parent/parent-dash.json":      dashboardJSON("nested-parent-001", "Parent Dashboard", 1),
+			"parent/child/child-dash.json": dashboardJSON("nested-child-001", "Child Dashboard", 1),
 		})
 
 		helper.syncAndWait(t, repoName)
@@ -992,7 +1004,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		// Old parent folder should be gone
 		_, err = helper.FoldersV1.Resource.Get(ctx, parentStableUID, metav1.GetOptions{})
@@ -1024,12 +1039,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		const childFolderUID = "child-folder-uid"
 
 		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
-			"team/_folder.json":              folderMetadataJSON(stableUID, "Team"),
-			"team/dash-a.json":               dashboardJSON("child-dash-a", "Dashboard A", 1),
-			"team/dash-b.json":               dashboardJSON("child-dash-b", "Dashboard B", 1),
-			"team/dash-c.json":               dashboardJSON("child-dash-c", "Dashboard C", 1),
-			"team/sub/_folder.json":          folderMetadataJSON(childFolderUID, "Sub"),
-			"team/sub/nested-dash.json":      dashboardJSON("child-nested", "Nested Dashboard", 1),
+			"team/_folder.json":         folderMetadataJSON(stableUID, "Team"),
+			"team/dash-a.json":          dashboardJSON("child-dash-a", "Dashboard A", 1),
+			"team/dash-b.json":          dashboardJSON("child-dash-b", "Dashboard B", 1),
+			"team/dash-c.json":          dashboardJSON("child-dash-c", "Dashboard C", 1),
+			"team/sub/_folder.json":     folderMetadataJSON(childFolderUID, "Sub"),
+			"team/sub/nested-dash.json": dashboardJSON("child-nested", "Nested Dashboard", 1),
 		})
 
 		helper.syncAndWait(t, repoName)
@@ -1057,7 +1072,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		// Old stable UID folder should be deleted
 		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
@@ -1107,7 +1125,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		helper.syncAndWaitIncremental(t, repoName)
+		helper.triggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
 
 		// Old folder should be gone
 		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go
@@ -1015,6 +1015,73 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 	})
 
+	t.Run("metadata deletion re-parents all direct children", func(t *testing.T) {
+		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-meta-delete-children"
+		const stableUID = "children-stable-uid"
+		const childFolderUID = "child-folder-uid"
+
+		_, local := helper.createGitRepo(t, repoName, map[string][]byte{
+			"team/_folder.json":              folderMetadataJSON(stableUID, "Team"),
+			"team/dash-a.json":               dashboardJSON("child-dash-a", "Dashboard A", 1),
+			"team/dash-b.json":               dashboardJSON("child-dash-b", "Dashboard B", 1),
+			"team/dash-c.json":               dashboardJSON("child-dash-c", "Dashboard C", 1),
+			"team/sub/_folder.json":          folderMetadataJSON(childFolderUID, "Sub"),
+			"team/sub/nested-dash.json":      dashboardJSON("child-nested", "Nested Dashboard", 1),
+		})
+
+		helper.syncAndWait(t, repoName)
+
+		_, err := helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		require.NoError(t, err, "folder with stable UID should exist")
+
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"child-dash-a": {Title: "Dashboard A", SourcePath: "team/dash-a.json", Folder: stableUID},
+			"child-dash-b": {Title: "Dashboard B", SourcePath: "team/dash-b.json", Folder: stableUID},
+			"child-dash-c": {Title: "Dashboard C", SourcePath: "team/dash-c.json", Folder: stableUID},
+			"child-nested": {Title: "Nested Dashboard", SourcePath: "team/sub/nested-dash.json", Folder: childFolderUID},
+		})
+
+		childBefore, err := helper.FoldersV1.Resource.Get(ctx, childFolderUID, metav1.GetOptions{})
+		require.NoError(t, err)
+		childParentBefore, _, _ := unstructured.NestedString(childBefore.Object, "metadata", "annotations", "grafana.app/folder")
+		require.Equal(t, stableUID, childParentBefore, "child folder should initially be parented under stable UID")
+
+		// Delete only the parent _folder.json
+		_, err = local.Git("rm", "team/_folder.json")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "delete parent folder metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		helper.syncAndWaitIncremental(t, repoName)
+
+		// Old stable UID folder should be deleted
+		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted")
+
+		// New folder should exist with hash-based UID
+		newFolderUID := requireRepoFolderTitle(t, helper, ctx, repoName, "team")
+		require.NotEqual(t, stableUID, newFolderUID)
+
+		// All three dashboards should be re-parented to the new folder
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"child-dash-a": {Title: "Dashboard A", SourcePath: "team/dash-a.json", Folder: newFolderUID},
+			"child-dash-b": {Title: "Dashboard B", SourcePath: "team/dash-b.json", Folder: newFolderUID},
+			"child-dash-c": {Title: "Dashboard C", SourcePath: "team/dash-c.json", Folder: newFolderUID},
+			"child-nested": {Title: "Nested Dashboard", SourcePath: "team/sub/nested-dash.json", Folder: childFolderUID},
+		})
+
+		// Child folder should be re-parented to the new parent UID
+		childAfter, err := helper.FoldersV1.Resource.Get(ctx, childFolderUID, metav1.GetOptions{})
+		require.NoError(t, err, "child folder should still exist")
+		childParentAfter, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
+		require.Equal(t, newFolderUID, childParentAfter, "child folder should be re-parented to new hash-based UID")
+	})
+
 	t.Run("metadata deletion alongside dashboard update in same commit", func(t *testing.T) {
 		helper := runGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()


### PR DESCRIPTION
## Summary

- Extends incremental sync to handle `_folder.json` deletion: when a folder's metadata file is removed, the folder transitions from its stable UID (`metadata.name`) back to a hash-derived UID, with all direct children re-parented and the old folder deleted.
- Adds a safety guard in the apply phase so deleted `_folder.json` files are properly skipped instead of being treated as deletable Grafana resources.
- Builds on top of #120848 which adds support for `_folder.json` UID **changes**; this PR handles the **removal** case.

## Changes

**`pkg/registry/apis/provisioning/jobs/sync/incremental.go`**
- `planFolderMetadataChanges` now scans for `FileActionDeleted` on `_folder.json` files. When the parent directory still exists in Git, it computes the hash-based UID via `ParseFolder`, records the old UID for deferred cleanup, and emits synthetic `FileActionUpdated` entries for the folder and its direct children.
- `applyIncrementalChanges` extends the `IsFolderMetadataFile` guard to cover all action types, preventing deleted metadata files from reaching `RemoveResourceFromFile`.

**`pkg/registry/apis/provisioning/jobs/sync/incremental_test.go`**
- Unit tests for `planFolderMetadataChanges` deletion scenarios: UID transition, directory also gone, folder not in Grafana, same UID, child deduplication, and `List` error propagation.
- Full-flow tests: re-parenting + old folder deletion, apply-phase skip for deleted metadata.

**`pkg/tests/apis/provisioning/git/incremental_folder_metadata_test.go`**
- Integration tests: simple metadata deletion with re-parenting, nested child folder, and combined deletion + dashboard update in the same commit.

## Test plan

- [x] Unit tests pass (`go test ./pkg/registry/apis/provisioning/jobs/sync/...`)
- [x] Integration tests pass (`go test ./pkg/tests/apis/provisioning/git/...`)
- [x] No regressions in broader module (`go test ./pkg/registry/apis/provisioning/...`)
- [ ] CI passes


Made with [Cursor](https://cursor.com)