### PR TITLE
Provisioning: Fix data race in jobProgressRecorder.TooManyErrors()

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -211,8 +211,13 @@ func (r *jobProgressRecorder) StrictMaxErrors(maxErrors int) {
 }
 
 func (r *jobProgressRecorder) TooManyErrors() error {
-	if r.maxErrors > 0 && r.errorCount >= r.maxErrors {
-		return fmt.Errorf("too many errors: %d", r.errorCount)
+	r.mu.RLock()
+	maxErrors := r.maxErrors
+	errorCount := r.errorCount
+	r.mu.RUnlock()
+
+	if maxErrors > 0 && errorCount >= maxErrors {
+		return fmt.Errorf("too many errors: %d", errorCount)
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -749,3 +749,32 @@ func TestJobProgressRecorderResultReasons(t *testing.T) {
 		recorder.mu.RUnlock()
 	})
 }
+
+func TestJobProgressRecorderTooManyErrorsConcurrency(t *testing.T) {
+	ctx := context.Background()
+
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error { return nil }
+	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+
+	const maxErrors = 5
+	const goroutines = 20
+	recorder.StrictMaxErrors(maxErrors)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			recorder.Record(ctx, NewPathOnlyResult("file.json").
+				WithError(assert.AnError).
+				WithAction(repository.FileActionCreated).
+				Build())
+			_ = recorder.TooManyErrors()
+		}()
+	}
+	wg.Wait()
+
+	err := recorder.TooManyErrors()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many errors")
+}


### PR DESCRIPTION
## Summary

- `TooManyErrors()` reads `errorCount` and `maxErrors` without holding the `RWMutex`, while `Record()` increments `errorCount` under a write lock from concurrent goroutines (e.g. `applyResourcesInParallel` in full sync). This triggers data races under `go test -race`.
- Adds `r.mu.RLock()`/`r.mu.RUnlock()` to `TooManyErrors()`, consistent with how `Complete()` already reads the same fields.
- Adds a concurrent test (`TestJobProgressRecorderTooManyErrorsConcurrency`) that exercises the race with 20 goroutines calling `Record()` + `TooManyErrors()` simultaneously.

## Test plan

- [x] `go test -race -run TestJobProgressRecorderTooManyErrorsConcurrency ./pkg/registry/apis/provisioning/jobs/` passes
- [x] Full package test suite passes with `-race`


Made with [Cursor](https://cursor.com)