### PR TITLE
Dashboards: Announce row title in the collapse button aria label

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -145,8 +145,8 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
                 className={cx(clearStyles, styles.rowTitleButton)}
                 aria-label={
                   isCollapsed
-                    ? t('dashboard.rows-layout.row.expand', 'Expand row with title {{title}}', { title })
-                    : t('dashboard.rows-layout.row.collapse', 'Collapse row with title {{title}}', { title })
+                    ? t('dashboard.rows-layout.row.expand', 'Expand row {{title}}', { title })
+                    : t('dashboard.rows-layout.row.collapse', 'Collapse row {{title}}', { title })
                 }
                 data-testid={selectors.components.DashboardRow.toggle(title)}
               >

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -145,8 +145,8 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
                 className={cx(clearStyles, styles.rowTitleButton)}
                 aria-label={
                   isCollapsed
-                    ? t('dashboard.rows-layout.row.expand', 'Expand row')
-                    : t('dashboard.rows-layout.row.collapse', 'Collapse row')
+                    ? t('dashboard.rows-layout.row.expand', 'Expand row with title {{title}}', { title })
+                    : t('dashboard.rows-layout.row.collapse', 'Collapse row with title {{title}}', { title })
                 }
                 data-testid={selectors.components.DashboardRow.toggle(title)}
               >

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6022,8 +6022,8 @@
       "name": "Rows",
       "new-row-title": "New row",
       "row": {
-        "collapse": "Collapse row",
-        "expand": "Expand row",
+        "collapse": "Collapse row with title {{title}}",
+        "expand": "Expand row with title {{title}}",
         "new": "New row",
         "repeat": {
           "learn-more": "Learn more",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6022,8 +6022,8 @@
       "name": "Rows",
       "new-row-title": "New row",
       "row": {
-        "collapse": "Collapse row with title {{title}}",
-        "expand": "Expand row with title {{title}}",
+        "collapse": "Collapse row {{title}}",
+        "expand": "Expand row {{title}}",
         "new": "New row",
         "repeat": {
           "learn-more": "Learn more",


### PR DESCRIPTION
So I made PR in scenes to improve this, but it seems like that component isn't being used in rows? in any case, this actually makes the collapse buttons more accessible