### PR TITLE
extractErrorMessage: make extractErrorMessage optional with explicit fallbacks

### DIFF
--- a/public/app/api/utils.test.ts
+++ b/public/app/api/utils.test.ts
@@ -1,8 +1,10 @@
 import { extractErrorMessage } from './utils';
 
 describe('extractErrorMessage', () => {
-  it('returns data.message when present', () => {
+  it('returns data.message properly', () => {
     expect(extractErrorMessage({ data: { message: 'Request failed' } })).toBe('Request failed');
+    expect(extractErrorMessage({ data: { message: undefined } })).toBe(undefined);
+    expect(extractErrorMessage({ data: { message: undefined } }, 'fallback')).toBe('fallback');
   });
 
   it('returns top-level message when present', () => {
@@ -30,6 +32,14 @@ describe('extractErrorMessage', () => {
 
   it('stringifies non-string message values', () => {
     expect(extractErrorMessage({ message: 404 })).toBe('404');
-    expect(extractErrorMessage({ data: { message: false } })).toBe('false');
+    expect(extractErrorMessage({ data: { message: false } }, 'fallback')).toBe('false');
+    expect(extractErrorMessage({ message: 0 }, 'fallback')).toBe('0');
+  });
+
+  it('returns fallback message when no error message is present', () => {
+    expect(extractErrorMessage(null, 'fallback message')).toBe('fallback message');
+    expect(extractErrorMessage({}, 'fallback message')).toBe('fallback message');
+    expect(extractErrorMessage(false, 'fallback message')).toBe('fallback message');
+    expect(extractErrorMessage(undefined, 'fallback message')).toBe('fallback message');
   });
 });

--- a/public/app/api/utils.test.ts
+++ b/public/app/api/utils.test.ts
@@ -1,0 +1,29 @@
+import { extractErrorMessage } from './utils';
+
+describe('extractErrorMessage', () => {
+  it('returns data.message when present', () => {
+    expect(extractErrorMessage({ data: { message: 'Request failed' } })).toBe('Request failed');
+  });
+
+  it('returns top-level message when present', () => {
+    expect(extractErrorMessage({ message: 'Top level error' })).toBe('Top level error');
+  });
+
+  it('returns string error values as-is', () => {
+    expect(extractErrorMessage('plain string error')).toBe('plain string error');
+  });
+
+  it('returns undefined for missing or invalid object error shapes', () => {
+    expect(extractErrorMessage(null)).toBeUndefined();
+    expect(extractErrorMessage({})).toBeUndefined();
+    expect(extractErrorMessage({ data: {} })).toBeUndefined();
+    expect(extractErrorMessage(0)).toBeUndefined();
+    expect(extractErrorMessage(false)).toBeUndefined();
+    expect(extractErrorMessage({ data: 'bad-shape' })).toBeUndefined();
+  });
+
+  it('stringifies non-string message values', () => {
+    expect(extractErrorMessage({ message: 404 })).toBe('404');
+    expect(extractErrorMessage({ data: { message: false } })).toBe('false');
+  });
+});

--- a/public/app/api/utils.test.ts
+++ b/public/app/api/utils.test.ts
@@ -11,6 +11,11 @@ describe('extractErrorMessage', () => {
 
   it('returns string error values as-is', () => {
     expect(extractErrorMessage('plain string error')).toBe('plain string error');
+    expect(extractErrorMessage('')).toBe('');
+  });
+
+  it('return extracts message from Error instances', () => {
+    expect(extractErrorMessage(new Error('test error'))).toBe('test error');
   });
 
   it('returns undefined for missing or invalid object error shapes', () => {
@@ -20,6 +25,7 @@ describe('extractErrorMessage', () => {
     expect(extractErrorMessage(0)).toBeUndefined();
     expect(extractErrorMessage(false)).toBeUndefined();
     expect(extractErrorMessage({ data: 'bad-shape' })).toBeUndefined();
+    expect(extractErrorMessage(undefined)).toBeUndefined();
   });
 
   it('stringifies non-string message values', () => {

--- a/public/app/api/utils.ts
+++ b/public/app/api/utils.ts
@@ -19,24 +19,31 @@ export const handleError = (e: unknown, dispatch: ThunkDispatch, message: string
 };
 
 /**
- * Extracts the error message from an error object.
- * @param error The error object to extract the message from.
- * @returns The error message, or undefined if no proper error object is provided or the error message is not a string.
+ * Extracts a human-readable message from an unknown error value.
+ * @param error The raw error value to inspect.
+ * @param fallbackMsg Optional fallback message returned when no extractable message is found.
+ * @returns A message string if extracted; otherwise returns `fallbackMsg` when provided, or `undefined`.
+ *
+ * **Overloads:**
+ * - `extractErrorMessage(error)` returns `string | undefined`
+ * - `extractErrorMessage(error, fallbackMsg)` returns `string`
  */
-export function extractErrorMessage(error: unknown): string | undefined {
+export function extractErrorMessage(error: unknown): string | undefined;
+export function extractErrorMessage(error: unknown, fallback: string): string;
+export function extractErrorMessage(error: unknown, fallback?: string): string | undefined {
   if (typeof error === 'string') {
     return error;
   }
 
   if (isObject(error)) {
-    if ('data' in error && isObject(error.data) && 'message' in error.data) {
+    if ('data' in error && isObject(error.data) && 'message' in error.data && error.data.message != null) {
       return String(error.data.message);
     }
-    if ('message' in error) {
+    if ('message' in error && error.message != null) {
       return String(error.message);
     }
   }
-  return undefined;
+  return fallback; // when no fallback is provided, undefined is returned
 }
 
 /**

--- a/public/app/api/utils.ts
+++ b/public/app/api/utils.ts
@@ -42,6 +42,10 @@ export function extractErrorMessage(error: unknown, fallback?: string): string |
     if ('message' in error && error.message != null) {
       return String(error.message);
     }
+
+    if ('error' in error && typeof error.error === 'string') {
+      return error.error;
+    }
   }
   return fallback; // when no fallback is provided, undefined is returned
 }

--- a/public/app/api/utils.ts
+++ b/public/app/api/utils.ts
@@ -21,7 +21,7 @@ export const handleError = (e: unknown, dispatch: ThunkDispatch, message: string
 /**
  * Extracts a human-readable message from an unknown error value.
  * @param error The raw error value to inspect.
- * @param fallbackMsg Optional fallback message returned when no extractable message is found.
+ * @param fallback Optional fallback message returned when no extractable message is found.
  * @returns A message string if extracted; otherwise returns `fallbackMsg` when provided, or `undefined`.
  *
  * **Overloads:**

--- a/public/app/api/utils.ts
+++ b/public/app/api/utils.ts
@@ -18,7 +18,16 @@ export const handleError = (e: unknown, dispatch: ThunkDispatch, message: string
   dispatch(notifyApp(createErrorNotification(message, errorMessage)));
 };
 
-export function extractErrorMessage(error: unknown): string {
+/**
+ * Extracts the error message from an error object.
+ * @param error The error object to extract the message from.
+ * @returns The error message, or undefined if no proper error object is provided or the error message is not a string.
+ */
+export function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') {
+    return error;
+  }
+
   if (isObject(error)) {
     if ('data' in error && isObject(error.data) && 'message' in error.data) {
       return String(error.data.message);
@@ -27,7 +36,7 @@ export function extractErrorMessage(error: unknown): string {
       return String(error.message);
     }
   }
-  return String(error);
+  return undefined;
 }
 
 /**

--- a/public/app/core/components/OwnerReferences/ManageOwnerReferences.tsx
+++ b/public/app/core/components/OwnerReferences/ManageOwnerReferences.tsx
@@ -45,7 +45,7 @@ export const ManageOwnerReferences = ({
       setOwnerRef(null);
       onSave();
     } catch (error) {
-      const errorMessage = extractErrorMessage(error);
+      const errorMessage = extractErrorMessage(error, t('manage-owner-references.unknown-error', 'Unknown error'));
       setApiErrorMessage(errorMessage);
       notify.error(t('manage-owner-references.folder-owner-error', 'Error updating folder owner'));
     }

--- a/public/app/features/provisioning/components/BulkActions/useBulkActionJob.ts
+++ b/public/app/features/provisioning/components/BulkActions/useBulkActionJob.ts
@@ -1,3 +1,4 @@
+import { t } from '@grafana/i18n';
 import { useCreateRepositoryJobsMutation, RepositoryView, Job } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
 
@@ -59,7 +60,10 @@ export function useBulkActionJob(): UseBulkActionJobResult {
         job: response, // Return the full job object
       };
     } catch (error) {
-      return { success: false, error: extractErrorMessage(error) };
+      return {
+        success: false,
+        error: extractErrorMessage(error) ?? t('browse-dashboards.bulk-actions.error-generic', 'Unexpected error'),
+      };
     }
   };
 

--- a/public/app/features/provisioning/components/BulkActions/useBulkActionJob.ts
+++ b/public/app/features/provisioning/components/BulkActions/useBulkActionJob.ts
@@ -62,7 +62,7 @@ export function useBulkActionJob(): UseBulkActionJobResult {
     } catch (error) {
       return {
         success: false,
-        error: extractErrorMessage(error) ?? t('browse-dashboards.bulk-actions.error-generic', 'Unexpected error'),
+        error: extractErrorMessage(error, t('browse-dashboards.bulk-actions.error-generic', 'Unexpected error')),
       };
     }
   };

--- a/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
+++ b/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
@@ -4,12 +4,11 @@ import { extractErrorMessage } from 'app/api/utils';
 
 export function FormLoadingErrorAlert({ error }: { error: unknown }) {
   const message =
-    error == null
-      ? t(
-          'dashboard-scene.save-provisioned-dashboard-form.form-loading-error-unknown',
-          'An unexpected error occurred while loading the form.'
-        )
-      : extractErrorMessage(error);
+    extractErrorMessage(error) ??
+    t(
+      'dashboard-scene.save-provisioned-dashboard-form.form-loading-error-unknown',
+      'An unexpected error occurred while loading the form.'
+    );
 
   return (
     <Alert

--- a/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
+++ b/public/app/features/provisioning/components/Dashboards/FormLoadingErrorAlert.tsx
@@ -3,12 +3,13 @@ import { Alert } from '@grafana/ui';
 import { extractErrorMessage } from 'app/api/utils';
 
 export function FormLoadingErrorAlert({ error }: { error: unknown }) {
-  const message =
-    extractErrorMessage(error) ??
+  const message = extractErrorMessage(
+    error,
     t(
       'dashboard-scene.save-provisioned-dashboard-form.form-loading-error-unknown',
       'An unexpected error occurred while loading the form.'
-    );
+    )
+  );
 
   return (
     <Alert

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4250,6 +4250,9 @@
     "browse-view": {
       "this-folder-is-empty": "This folder is empty"
     },
+    "bulk-actions": {
+      "error-generic": "Unexpected error"
+    },
     "bulk-delete-resources-form": {
       "button-cancel": "Cancel",
       "button-delete": "Delete",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11431,7 +11431,8 @@
     "save-owner": "Save owner",
     "select-owner": "Select an owner",
     "selected-team-not-found": "Selected team not found, or you do not have the necessary permissions to view it.",
-    "team-not-found": "[Unknown team]"
+    "team-not-found": "[Unknown team]",
+    "unknown-error": "Unknown error"
   },
   "metric-select": {
     "noOptionsMessage-no-options-found": "No options found"


### PR DESCRIPTION
**What is this feature?**

- update `extractErrorMessage` to use overloads and return `undefined` when no valid message is present unless a fallback is provided.
- Add unit tests 
This is blocked by enterprise PR to fix tests: https://github.com/grafana/grafana-enterprise/pull/11406

**Why do we need this feature?**

The previous helper contract always returned a string, even for invalid shapes, which masked missing/invalid error payloads and surfaced low-quality messages in the UI. Moving to string | undefined makes error handling explicit and safer at call sites.

**Who is this feature for?**

Primarily for devs need to extract message from error response obj

**Which issue(s) does this PR fix?**:

N/A, follow up from https://github.com/grafana/grafana/pull/120560#discussion_r2969250775

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
