### PR TITLE
Alerting: Document Grafana HA Alertmanager cluster metrics prefix change

### DIFF
--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -247,19 +247,23 @@ The HA settings (`ha_peers`, etc.) apply only to communication between alertmana
 
 You can also confirm your high availability setup by monitoring Alertmanager metrics exposed by Grafana.
 
-| Metric                                               | Description                                                                                                                                                |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| alertmanager_cluster_members                         | Number indicating current number of members in cluster.                                                                                                    |
-| alertmanager_cluster_messages_received_total         | Total number of cluster messages received.                                                                                                                 |
-| alertmanager_cluster_messages_received_size_total    | Total size of cluster messages received.                                                                                                                   |
-| alertmanager_cluster_messages_sent_total             | Total number of cluster messages sent.                                                                                                                     |
-| alertmanager_cluster_messages_sent_size_total        | Total number of cluster messages received.                                                                                                                 |
-| alertmanager_cluster_messages_publish_failures_total | Total number of messages that failed to be published.                                                                                                      |
-| alertmanager_cluster_pings_seconds                   | Histogram of latencies for ping messages.                                                                                                                  |
-| alertmanager_cluster_pings_failures_total            | Total number of failed pings.                                                                                                                              |
-| alertmanager_peer_position                           | The position an Alertmanager instance believes it holds, which defines its role in the cluster. Peers should be numbered sequentially, starting from zero. |
+{{< admonition type="note" >}}
+Starting in Grafana v12.4, these metrics are prefixed with `grafana_` (for example, `grafana_alertmanager_cluster_members`). If you are upgrading from an earlier version, update your dashboards and alert rules accordingly.
+{{< /admonition >}}
 
-You can confirm the number of Grafana instances in your alerting high availability setup by querying the `alertmanager_cluster_members` and `alertmanager_peer_position` metrics.
+| Metric                                                         | Description                                                                                                                                                |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grafana_alertmanager_cluster_members`                         | Number indicating current number of members in cluster.                                                                                                    |
+| `grafana_alertmanager_cluster_messages_received_total`         | Total number of cluster messages received.                                                                                                                 |
+| `grafana_alertmanager_cluster_messages_received_size_total`    | Total size of cluster messages received.                                                                                                                   |
+| `grafana_alertmanager_cluster_messages_sent_total`             | Total number of cluster messages sent.                                                                                                                     |
+| `grafana_alertmanager_cluster_messages_sent_size_total`        | Total number of cluster messages received.                                                                                                                 |
+| `grafana_alertmanager_cluster_messages_publish_failures_total` | Total number of messages that failed to be published.                                                                                                      |
+| `grafana_alertmanager_cluster_pings_seconds`                   | Histogram of latencies for ping messages.                                                                                                                  |
+| `grafana_alertmanager_cluster_pings_failures_total`            | Total number of failed pings.                                                                                                                              |
+| `grafana_alertmanager_peer_position`                           | The position an Alertmanager instance believes it holds, which defines its role in the cluster. Peers should be numbered sequentially, starting from zero. |
+
+You can confirm the number of Grafana instances in your alerting high availability setup by querying the `grafana_alertmanager_cluster_members` and `grafana_alertmanager_peer_position` metrics.
 
 Note that these alerting high availability metrics are exposed via the `/metrics` endpoint in Grafana, and are not automatically collected or displayed. If you have a Prometheus instance connected to Grafana, add a `scrape_config` to scrape Grafana metrics and then query these metrics in Explore.
 

--- a/pkg/services/ngalert/metrics/multi_org_alertmanager_test.go
+++ b/pkg/services/ngalert/metrics/multi_org_alertmanager_test.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/grafana/dskit/metrics"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertmanagerAggregatedMetrics_DescribeMetricNames(t *testing.T) {
+	registries := metrics.NewTenantRegistries(log.NewNopLogger())
+	m := NewAlertmanagerAggregatedMetrics(registries)
+
+	ch := make(chan *prometheus.Desc, 100)
+	m.Describe(ch)
+	close(ch)
+
+	var names []string
+	for desc := range ch {
+		names = append(names, desc.String())
+	}
+
+	expectedNames := []string{
+		"grafana_alerting_alerts_received_total",
+		"grafana_alerting_alerts_invalid_total",
+		"grafana_alerting_alertmanager_receivers",
+		"grafana_alerting_alertmanager_integrations",
+		"grafana_alerting_alertmanager_inhibition_rules",
+		"grafana_alerting_notifications_total",
+		"grafana_alerting_notifications_failed_total",
+		"grafana_alerting_notification_requests_total",
+		"grafana_alerting_notification_requests_failed_total",
+		"grafana_alerting_notification_latency_seconds",
+		"grafana_alerting_nflog_gc_duration_seconds",
+		"grafana_alerting_nflog_snapshot_duration_seconds",
+		"grafana_alerting_nflog_snapshot_size_bytes",
+		"grafana_alerting_nflog_queries_total",
+		"grafana_alerting_nflog_query_errors_total",
+		"grafana_alerting_nflog_query_duration_seconds",
+		"grafana_alerting_nflog_gossip_messages_propagated_total",
+		"grafana_alerting_alertmanager_alerts",
+		"grafana_alerting_silences_gc_duration_seconds",
+		"grafana_alerting_silences_snapshot_duration_seconds",
+		"grafana_alerting_silences_snapshot_size_bytes",
+		"grafana_alerting_silences_queries_total",
+		"grafana_alerting_silences_query_errors_total",
+		"grafana_alerting_silences_query_duration_seconds",
+		"grafana_alerting_silences_gossip_messages_propagated_total",
+		"grafana_alerting_silences",
+		"grafana_alerting_dispatcher_aggregation_groups",
+		"grafana_alerting_dispatcher_alert_processing_duration_seconds",
+		"grafana_alerting_alertmanager_config_matchers",
+		"grafana_alerting_alertmanager_config_match_re",
+		"grafana_alerting_alertmanager_config_match",
+		"grafana_alerting_alertmanager_config_object_matchers",
+		"grafana_alerting_alertmanager_config_hash",
+		"grafana_alerting_alertmanager_config_size_bytes",
+	}
+
+	require.Len(t, names, len(expectedNames), "number of described metrics should match")
+
+	for i, expected := range expectedNames {
+		assert.Contains(t, names[i], "fqName: \""+expected+"\"",
+			"metric at position %d should have name %s", i, expected)
+	}
+}


### PR DESCRIPTION
**What is this feature?**

The `alertmanager_cluster_*` and `alertmanager_peer_*` metrics are now prefixed with `grafana_` when scraped from Grafana's /metrics endpoint (https://github.com/grafana/grafana/pull/117099).

Related to https://github.com/grafana/grafana/issues/120761