### PR TITLE
MenuDivider: Increase vertical margin for clearer menu grouping

### DIFF
--- a/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
@@ -14,7 +14,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     divider: css({
       height: 1,
       backgroundColor: theme.colors.border.weak,
-      margin: theme.spacing(0.5, 0),
+      margin: theme.spacing(1, 0),
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

- `MenuDivider` component: Increase vertical spacing from `theme.spacing(0.5, 0)` to `theme.spacing(1, 0)`
- As menus gain more grouped sections separated by dividers, items start to feel crowded; increasing divider spacing improves visual breathing room and makes groups easier to scan quickly.

| before | after |
| --- | --- |
| <img width="361" height="210" alt="image" src="https://github.com/user-attachments/assets/df863806-93d8-478d-9393-0a58a46c0995" /> | <img width="362" height="217" alt="image" src="https://github.com/user-attachments/assets/37e29ed5-23f3-4486-84d7-e6f3028a2115" /> |

**Why do we need this feature?**
- Improve visual separation between menu sections and make grouped actions easier to scan.

**Which issue(s) does this PR fix?**:

Fixes N/A, follow up from https://github.com/grafana/grafana/pull/120484#discussion_r2964199571
 
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
