### PR TITLE
Provisioning: Full Sync - react on invalid folder metadata

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -43,38 +43,40 @@ func (c *ResourceFileChange) IsUpdatedFolder() bool {
 
 // Compare reads the repository tree at ref, lists the current Grafana resources,
 // and delegates to Changes to produce the diff. It also returns the list of
-// folder paths that are missing a _folder.json metadata file.
+// folder paths that are missing a _folder.json metadata file, plus any invalid
+// folder metadata warnings detected during compare.
 func Compare(
 	ctx context.Context,
 	repo repository.Reader,
 	repositoryResources resources.RepositoryResources,
 	ref string,
 	folderMetadataEnabled bool,
-) ([]ResourceFileChange, []string, error) {
+) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error) {
 	target, err := repositoryResources.List(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error listing current: %w", err)
+		return nil, nil, nil, fmt.Errorf("error listing current: %w", err)
 	}
 
 	source, err := repo.ReadTree(ctx, ref)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading tree: %w", err)
+		return nil, nil, nil, fmt.Errorf("error reading tree: %w", err)
 	}
 
 	changes, err := Changes(ctx, source, target, folderMetadataEnabled)
 	if err != nil {
-		return nil, nil, fmt.Errorf("calculate changes: %w", err)
+		return nil, nil, nil, fmt.Errorf("calculate changes: %w", err)
 	}
 
+	var invalidFolderMetadata []*resources.InvalidFolderMetadata
 	if folderMetadataEnabled {
-		changes, err = augmentChangesForFolderMetadata(ctx, repo, ref, source, target, changes)
+		changes, invalidFolderMetadata, err = augmentChangesForFolderMetadata(ctx, repo, ref, source, target, changes)
 		if err != nil {
-			return nil, nil, fmt.Errorf("augment changes for folder metadata: %w", err)
+			return nil, nil, nil, fmt.Errorf("augment changes for folder metadata: %w", err)
 		}
 
 		changes, err = augmentChangesForFolderMoves(ctx, repo, ref, changes)
 		if err != nil {
-			return nil, nil, fmt.Errorf("augment changes for folder moves: %w", err)
+			return nil, nil, nil, fmt.Errorf("augment changes for folder moves: %w", err)
 		}
 	}
 
@@ -86,7 +88,7 @@ func Compare(
 
 	missingMetadata := resources.FindFoldersMissingMetadata(source)
 
-	return changes, missingMetadata, nil
+	return changes, missingMetadata, invalidFolderMetadata, nil
 }
 
 // Changes computes the diff between a repository source tree and the current Grafana state (target).
@@ -152,7 +154,7 @@ func Changes(
 			// for existing folders we compare hashes to detect metadata changes.
 			if resources.IsFolderMetadataFile(file.Path) {
 				if !folderMetadataEnabled {
-					logger.Debug("skipping folder metadata file - will be handled by parent directory change", "path", file.Path)
+					logger.Debug("skipping folder metadata file as feature flag is off", "path", file.Path)
 					if err := keep.Add(file.Path); err != nil {
 						return nil, fmt.Errorf("failed to add path to keep folder metadata file: %w", err)
 					}
@@ -251,8 +253,12 @@ func augmentChangesForFolderMetadata(
 	source []repository.FileTreeEntry,
 	target *provisioning.ResourceList,
 	changes []ResourceFileChange,
-) ([]ResourceFileChange, error) {
+) ([]ResourceFileChange, []*resources.InvalidFolderMetadata, error) {
 	sourceFolders, foldersWithMetadata := buildSourceMetadataIndex(source)
+	changes, invalidFolderMetadata, err := processInvalidFolderMetadataChanges(ctx, repo, ref, changes, foldersWithMetadata)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	pathsWithChanges := make(map[string]bool, len(changes))
 	for _, c := range changes {
@@ -270,22 +276,72 @@ func augmentChangesForFolderMetadata(
 	affectedFolders = mergeAffectedFolders(affectedFolders, deletedAffected)
 
 	// Detect folders whose _folder.json UID changed.
-	var err error
 	uidAffected, err := detectFolderUIDChanges(ctx, repo, ref, changes)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	affectedFolders = mergeAffectedFolders(affectedFolders, uidAffected)
 
 	// No folders will be renamed, so we can return the changes as is.
 	if len(affectedFolders) == 0 {
-		return changes, nil
+		return changes, invalidFolderMetadata, nil
 	}
 
 	// Emit children for re-parenting and re-sort by path depth.
 	changes = emitDirectChildrenChanges(source, target, pathsWithChanges, affectedFolders, changes)
 	safepath.SortByDepth(changes, func(c ResourceFileChange) string { return c.Path }, false)
-	return changes, nil
+	return changes, invalidFolderMetadata, nil
+}
+
+// processInvalidFolderMetadataChanges performs a single metadata read for each
+// created/updated folder path that currently has a _folder.json file. Invalid
+// metadata is surfaced as warnings. Existing-folder updates are suppressed so
+// the current folder UID is preserved; brand-new folders keep their created
+// change so apply can fall back to the hash-derived folder identity.
+func processInvalidFolderMetadataChanges(
+	ctx context.Context,
+	repo repository.Reader,
+	ref string,
+	changes []ResourceFileChange,
+	foldersWithMetadata map[string]bool,
+) ([]ResourceFileChange, []*resources.InvalidFolderMetadata, error) {
+	filtered := make([]ResourceFileChange, 0, len(changes))
+	var invalidFolderMetadata []*resources.InvalidFolderMetadata
+
+	for _, change := range changes {
+		if !safepath.IsDir(change.Path) || (change.Action != repository.FileActionCreated && change.Action != repository.FileActionUpdated) {
+			filtered = append(filtered, change)
+			continue
+		}
+		if !foldersWithMetadata[change.Path] {
+			filtered = append(filtered, change)
+			continue
+		}
+
+		_, _, err := resources.ReadFolderMetadata(ctx, repo, change.Path, ref)
+		if err == nil {
+			filtered = append(filtered, change)
+			continue
+		}
+
+		var invalidErr *resources.InvalidFolderMetadata
+		if errors.As(err, &invalidErr) {
+			invalidFolderMetadata = append(invalidFolderMetadata, invalidErr)
+			if change.Action == repository.FileActionCreated {
+				filtered = append(filtered, change)
+			}
+			continue
+		}
+
+		if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+			filtered = append(filtered, change)
+			continue
+		}
+
+		return nil, nil, fmt.Errorf("read folder metadata for %s: %w", change.Path, err)
+	}
+
+	return filtered, invalidFolderMetadata, nil
 }
 
 // buildSourceMetadataIndex performs a single pass over the source tree, returning
@@ -542,7 +598,9 @@ func emitDirectChildrenChanges(
 // directory path changed but the UID in _folder.json stayed the same. The initial
 // diff produces a DELETE (old path) and a CREATE (new path); this function merges
 // them into a single UPDATE so the folder is updated in-place instead of being
-// deleted and recreated (which would reset the K8s generation).
+// deleted and recreated (which would reset the K8s generation). Invalid
+// metadata is left as a normal delete+create sequence because the move cannot be
+// matched safely.
 func augmentChangesForFolderMoves(
 	ctx context.Context,
 	repo repository.Reader,
@@ -573,6 +631,9 @@ func augmentChangesForFolderMoves(
 		meta, _, err := resources.ReadFolderMetadata(ctx, repo, create.Path, ref)
 		if err != nil {
 			if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+				continue
+			}
+			if errors.Is(err, resources.ErrInvalidFolderMetadata) {
 				continue
 			}
 			return nil, fmt.Errorf("read folder metadata for %s: %w", create.Path, err)

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -326,6 +326,7 @@ func processInvalidFolderMetadataChanges(
 
 		var invalidErr *resources.InvalidFolderMetadata
 		if errors.As(err, &invalidErr) {
+			invalidErr.WithAction(change.Action)
 			invalidFolderMetadata = append(invalidFolderMetadata, invalidErr)
 			if change.Action == repository.FileActionCreated {
 				filtered = append(filtered, change)

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -326,7 +326,7 @@ func processInvalidFolderMetadataChanges(
 
 		var invalidErr *resources.InvalidFolderMetadata
 		if errors.As(err, &invalidErr) {
-			invalidErr.WithAction(change.Action)
+			invalidErr = invalidErr.WithAction(change.Action)
 			invalidFolderMetadata = append(invalidFolderMetadata, invalidErr)
 			if change.Action == repository.FileActionCreated {
 				filtered = append(filtered, change)

--- a/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
@@ -801,6 +801,7 @@ func TestCompare_InvalidFolderMetadataWarning(t *testing.T) {
 			require.Len(t, invalid, 1)
 			require.ErrorIs(t, invalid[0], resources.ErrInvalidFolderMetadata)
 			require.Equal(t, "my-folder/", invalid[0].Path)
+			require.Equal(t, repository.FileActionUpdated, invalid[0].Action)
 		})
 	}
 }
@@ -831,6 +832,7 @@ func TestCompare_InvalidCreatedFolderMetadataWarningPreservesFolderCreate(t *tes
 	require.Empty(t, missing)
 	require.Len(t, invalid, 1)
 	require.ErrorIs(t, invalid[0], resources.ErrInvalidFolderMetadata)
+	require.Equal(t, repository.FileActionCreated, invalid[0].Action)
 
 	actionsByPath := make(map[string]repository.FileAction, len(changes))
 	for _, change := range changes {

--- a/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes_test.go
@@ -700,16 +700,18 @@ func TestCompare(t *testing.T) {
 
 			tt.setupMocks(repo, repoResources)
 
-			changes, missing, err := Compare(context.Background(), repo, repoResources, "current-ref", true)
+			changes, missing, invalid, err := Compare(context.Background(), repo, repoResources, "current-ref", true)
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError, tt.description)
 				require.Nil(t, changes)
 				require.Nil(t, missing)
+				require.Nil(t, invalid)
 			} else {
 				require.NoError(t, err, tt.description)
 				require.Equal(t, tt.expectedChanges, changes, tt.description)
 				require.Equal(t, tt.expectedMissing, missing, tt.description)
+				require.Nil(t, invalid, tt.description)
 			}
 		})
 	}
@@ -737,8 +739,9 @@ func TestCompare_FolderMetadataFlagDisabled(t *testing.T) {
 		// it would call ReadFolderMetadata which calls repo.Read, and
 		// the mock would panic on unexpected call.
 
-		changes, _, err := Compare(context.Background(), repo, repoResources, "ref", false)
+		changes, _, invalid, err := Compare(context.Background(), repo, repoResources, "ref", false)
 		require.NoError(t, err)
+		require.Nil(t, invalid)
 
 		// No folder update should be emitted — the metadata processing is skipped.
 		for _, c := range changes {
@@ -747,6 +750,94 @@ func TestCompare_FolderMetadataFlagDisabled(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestCompare_InvalidFolderMetadataWarning(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadataData []byte
+	}{
+		{
+			name:         "malformed json",
+			metadataData: []byte("not-json"),
+		},
+		{
+			name:         "missing metadata name",
+			metadataData: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"My Folder"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := repository.NewMockRepository(t)
+			repoResources := resources.NewMockRepositoryResources(t)
+
+			source := []repository.FileTreeEntry{
+				{Path: "my-folder/", Hash: "folder-hash", Blob: false},
+				{Path: "my-folder/_folder.json", Hash: "new-metadata-hash", Blob: true},
+			}
+			target := &provisioning.ResourceList{
+				Items: []provisioning.ResourceListItem{
+					{
+						Path:     "my-folder/",
+						Hash:     "old-metadata-hash",
+						Resource: resources.FolderResource.Resource,
+						Group:    resources.FolderResource.Group,
+						Name:     "existing-uid",
+					},
+				},
+			}
+
+			repoResources.On("List", mock.Anything).Return(target, nil)
+			repo.On("ReadTree", mock.Anything, "current-ref").Return(source, nil)
+			repo.On("Read", mock.Anything, "my-folder/_folder.json", "current-ref").
+				Return(&repository.FileInfo{Data: tt.metadataData, Hash: "new-metadata-hash"}, nil)
+
+			changes, missing, invalid, err := Compare(context.Background(), repo, repoResources, "current-ref", true)
+
+			require.NoError(t, err)
+			require.Empty(t, changes)
+			require.Empty(t, missing)
+			require.Len(t, invalid, 1)
+			require.ErrorIs(t, invalid[0], resources.ErrInvalidFolderMetadata)
+			require.Equal(t, "my-folder/", invalid[0].Path)
+		})
+	}
+}
+
+func TestCompare_InvalidCreatedFolderMetadataWarningPreservesFolderCreate(t *testing.T) {
+	repo := repository.NewMockRepository(t)
+	repoResources := resources.NewMockRepositoryResources(t)
+
+	source := []repository.FileTreeEntry{
+		{Path: "my-folder/", Hash: "folder-hash", Blob: false},
+		{Path: "my-folder/_folder.json", Hash: "new-metadata-hash", Blob: true},
+		{Path: "my-folder/dashboard.json", Hash: "dashboard-hash", Blob: true},
+	}
+	target := &provisioning.ResourceList{}
+
+	repoResources.On("List", mock.Anything).Return(target, nil)
+	repoResources.On("SetTree", mock.Anything).Return().Maybe()
+	repo.On("ReadTree", mock.Anything, "current-ref").Return(source, nil)
+	repo.On("Read", mock.Anything, "my-folder/_folder.json", "current-ref").
+		Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken Folder"}}`),
+			Hash: "new-metadata-hash",
+		}, nil)
+
+	changes, missing, invalid, err := Compare(context.Background(), repo, repoResources, "current-ref", true)
+
+	require.NoError(t, err)
+	require.Empty(t, missing)
+	require.Len(t, invalid, 1)
+	require.ErrorIs(t, invalid[0], resources.ErrInvalidFolderMetadata)
+
+	actionsByPath := make(map[string]repository.FileAction, len(changes))
+	for _, change := range changes {
+		actionsByPath[change.Path] = change.Action
+	}
+	require.Equal(t, repository.FileActionCreated, actionsByPath["my-folder/"])
+	require.Equal(t, repository.FileActionCreated, actionsByPath["my-folder/dashboard.json"])
 }
 
 func TestAugmentChangesForFolderMoves(t *testing.T) {
@@ -877,7 +968,7 @@ func TestAugmentChangesForFolderMoves(t *testing.T) {
 		require.Len(t, result, 2)
 	})
 
-	t.Run("empty UID in metadata is skipped", func(t *testing.T) {
+	t.Run("invalid metadata leaves folder move as delete plus create", func(t *testing.T) {
 		repo := repository.NewMockReader(t)
 		repo.On("Read", mock.Anything, "new-folder/_folder.json", "main").
 			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"No UID"}}`)}, nil)
@@ -891,9 +982,12 @@ func TestAugmentChangesForFolderMoves(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 2)
 
+		paths := map[string]repository.FileAction{}
 		for _, c := range result {
-			require.NotEqual(t, repository.FileActionUpdated, c.Action, "no UPDATE should be emitted")
+			paths[c.Path] = c.Action
 		}
+		require.Equal(t, repository.FileActionDeleted, paths["old-folder/"])
+		require.Equal(t, repository.FileActionCreated, paths["new-folder/"])
 	})
 
 	t.Run("non-folder paths are ignored", func(t *testing.T) {
@@ -1010,7 +1104,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		paths := make(map[string]bool)
@@ -1050,7 +1144,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Len(t, result, 1, "only the original folder update — no children emitted")
 		require.Equal(t, "my-folder/", result[0].Path)
@@ -1087,7 +1181,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		paths := make(map[string]bool)
@@ -1133,7 +1227,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		count := 0
@@ -1160,7 +1254,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			{Action: repository.FileActionCreated, Path: "my-folder/dashboard.json"},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Equal(t, changes, result, "should return changes unchanged")
 	})
@@ -1184,7 +1278,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 
 		changes := []ResourceFileChange{} // no changes from Changes()
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		require.Len(t, result, 1)
@@ -1214,7 +1308,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 
 		changes := []ResourceFileChange{} // empty
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		require.Len(t, result, 3, "folder update + dashboard + child folder")
@@ -1246,7 +1340,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, nil)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, nil)
 		require.NoError(t, err)
 
 		paths := make(map[string]bool)
@@ -1274,7 +1368,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 
 		changes := []ResourceFileChange{}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Empty(t, result, "no changes expected when folder never had metadata")
 	})
@@ -1296,7 +1390,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 
 		changes := []ResourceFileChange{}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Empty(t, result, "no changes expected when _folder.json still exists")
 	})
@@ -1320,7 +1414,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			}},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 		require.Equal(t, changes, result, "no additional changes expected when folder is entirely deleted")
 	})
@@ -1350,7 +1444,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 			},
 		}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		folderCount := 0
@@ -1389,7 +1483,7 @@ func TestAugmentChangesForFolderMetadata(t *testing.T) {
 
 		changes := []ResourceFileChange{}
 
-		result, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
+		result, _, err := augmentChangesForFolderMetadata(context.Background(), repo, "main", source, target, changes)
 		require.NoError(t, err)
 
 		paths := make(map[string]bool)

--- a/pkg/registry/apis/provisioning/jobs/sync/compare_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/compare_fn_mock.go
@@ -25,7 +25,7 @@ func (_m *MockCompareFn) EXPECT() *MockCompareFn_Expecter {
 }
 
 // Execute provides a mock function with given fields: ctx, repo, repositoryResources, ref, folderMetadataEnabled
-func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, error) {
+func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error) {
 	ret := _m.Called(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 
 	if len(ret) == 0 {
@@ -34,8 +34,9 @@ func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, re
 
 	var r0 []ResourceFileChange
 	var r1 []string
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) ([]ResourceFileChange, []string, error)); ok {
+	var r2 []*resources.InvalidFolderMetadata
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error)); ok {
 		return rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) []ResourceFileChange); ok {
@@ -54,13 +55,21 @@ func (_m *MockCompareFn) Execute(ctx context.Context, repo repository.Reader, re
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) []*resources.InvalidFolderMetadata); ok {
 		r2 = rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).([]*resources.InvalidFolderMetadata)
+		}
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) error); ok {
+		r3 = rf(ctx, repo, repositoryResources, ref, folderMetadataEnabled)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockCompareFn_Execute_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Execute'
@@ -85,12 +94,12 @@ func (_c *MockCompareFn_Execute_Call) Run(run func(ctx context.Context, repo rep
 	return _c
 }
 
-func (_c *MockCompareFn_Execute_Call) Return(_a0 []ResourceFileChange, _a1 []string, _a2 error) *MockCompareFn_Execute_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockCompareFn_Execute_Call) Return(_a0 []ResourceFileChange, _a1 []string, _a2 []*resources.InvalidFolderMetadata, _a3 error) *MockCompareFn_Execute_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockCompareFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) ([]ResourceFileChange, []string, error)) *MockCompareFn_Execute_Call {
+func (_c *MockCompareFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, resources.RepositoryResources, string, bool) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error)) *MockCompareFn_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -93,8 +93,12 @@ func FullSync(
 
 	if folderMetadataEnabled && len(invalidFolderMetadata) > 0 {
 		for _, invalid := range invalidFolderMetadata {
+			action := invalid.Action
+			if action == "" {
+				action = repository.FileActionIgnored
+			}
 			progress.Record(ctx, jobs.NewFolderResult(invalid.Path).
-				WithAction(repository.FileActionIgnored).
+				WithAction(action).
 				WithWarning(invalid).
 				Build())
 		}

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -63,8 +63,9 @@ func FullSync(
 	compareCtx, compareSpan := tracer.Start(ctx, "provisioning.sync.full.compare")
 	var changes []ResourceFileChange
 	var missingFolderMetadata []string
+	var invalidFolderMetadata []*resources.InvalidFolderMetadata
 	err := instrumentedFullSyncPhase(jobs.FullSyncPhaseCompare, func() (err error) {
-		changes, missingFolderMetadata, err = compare(compareCtx, repo, repositoryResources, currentRef, folderMetadataEnabled)
+		changes, missingFolderMetadata, invalidFolderMetadata, err = compare(compareCtx, repo, repositoryResources, currentRef, folderMetadataEnabled)
 		return
 	}, metrics)
 	compareSpan.End()
@@ -87,6 +88,15 @@ func FullSync(
 				builder = builder.WithAction(repository.FileActionIgnored)
 			}
 			progress.Record(ctx, builder.Build())
+		}
+	}
+
+	if folderMetadataEnabled && len(invalidFolderMetadata) > 0 {
+		for _, invalid := range invalidFolderMetadata {
+			progress.Record(ctx, jobs.NewFolderResult(invalid.Path).
+				WithAction(repository.FileActionIgnored).
+				WithWarning(invalid).
+				Build())
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
@@ -411,7 +411,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 
 			tt.setupMocks(repo, repoResources, clients, progress, dynamicClient)
 
-			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil)
+			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil, nil)
 			progress.On("SetTotal", mock.Anything, len(tt.changes)).Return()
 			progress.On("TooManyErrors").Return(nil).Maybe()
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -1286,6 +1286,54 @@ func TestFullSync_InvalidFolderMetadataWarning(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestFullSync_InvalidFolderMetadataWarning_ActionAware(t *testing.T) {
+	tests := []struct {
+		name         string
+		action       repository.FileAction
+		resultAction repository.FileAction
+	}{
+		{
+			name:         "created folder metadata keeps created action",
+			action:       repository.FileActionCreated,
+			resultAction: repository.FileActionCreated,
+		},
+		{
+			name:         "updated folder metadata keeps updated action",
+			action:       repository.FileActionUpdated,
+			resultAction: repository.FileActionUpdated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := repository.NewMockRepository(t)
+			repoResources := resources.NewMockRepositoryResources(t)
+			clients := resources.NewMockResourceClients(t)
+			progress := jobs.NewMockJobProgressRecorder(t)
+			compareFn := NewMockCompareFn(t)
+
+			repo.On("Config").Return(&provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+			})
+
+			invalidWarning := resources.NewInvalidFolderMetadata("myfolder/", errors.New("missing metadata.name")).WithAction(tt.action)
+			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return([]ResourceFileChange{}, nil, []*resources.InvalidFolderMetadata{invalidWarning}, nil)
+
+			progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+				return r.Path() == "myfolder/" &&
+					r.Action() == tt.resultAction &&
+					r.Warning() != nil &&
+					errors.Is(r.Warning(), resources.ErrInvalidFolderMetadata)
+			})).Return()
+			progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
+
+			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestApplyChanges_DefersOldFolderDeletion(t *testing.T) {
 	// Verify that old folder UIDs are deleted AFTER folder creations and file creations.
 	// The ordering must be: folder phase -> file phase -> old folder deletion.

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -44,7 +44,7 @@ func TestFullSync_ContextCancelled(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{{}}, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{{}}, nil, nil, nil)
 	progress.On("SetTotal", mock.Anything, 1).Return()
 
 	err := FullSync(ctx, repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
@@ -64,7 +64,7 @@ func TestFullSync_Error(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("some error"))
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, fmt.Errorf("some error"))
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
 	require.EqualError(t, err, "compare changes: some error")
@@ -83,7 +83,7 @@ func TestFullSync_NoChanges(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil, nil)
 	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
@@ -109,7 +109,7 @@ func TestFullSync_SuccessfulFolderCreation(t *testing.T) {
 		},
 	})
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]ResourceFileChange{}, nil, nil, nil)
 	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
 	repoResources.On("EnsureFolderExists", mock.Anything, resources.Folder{
 		ID:    "test-repo",
@@ -173,7 +173,7 @@ func TestFullSync_FolderCreationFailedWithInstanceTarget(t *testing.T) {
 	// No folder creation should be attempted with instance target
 	// But we should still test the error path for completeness
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil, fmt.Errorf("compare error"))
+		Return(nil, nil, nil, fmt.Errorf("compare error"))
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
 	require.Error(t, err)
@@ -806,7 +806,7 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 			compareFn := NewMockCompareFn(t)
 
 			tt.setupMocks(repo, repoResources, clients, progress, compareFn)
-			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil)
+			compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.changes, nil, nil, nil)
 			repo.On("Config").Return(&provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -1113,7 +1113,7 @@ func TestFullSync_QuotaTrackerSkipsCreationsAtLimit(t *testing.T) {
 		{Action: repository.FileActionCreated, Path: "dashboards/c.json"},
 	}
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil, nil)
 	progress.On("SetTotal", mock.Anything, 3).Return()
 	progress.On("TooManyErrors").Return(nil)
 
@@ -1159,7 +1159,7 @@ func TestFullSync_QuotaTrackerAllowsUpdatesRegardlessOfQuota(t *testing.T) {
 		{Action: repository.FileActionUpdated, Path: "dashboards/existing.json"},
 	}
 
-	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil)
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(changes, nil, nil, nil)
 	progress.On("SetTotal", mock.Anything, 1).Return()
 	progress.On("TooManyErrors").Return(nil)
 	progress.On("HasDirPathFailedCreation", "dashboards/existing.json").Return(false)
@@ -1197,7 +1197,7 @@ func TestFullSync_MissingFolderMetadata_FlagEnabled(t *testing.T) {
 	}
 	// Compare returns the missing folder metadata list directly
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(changes, []string{"myfolder/"}, nil)
+		Return(changes, []string{"myfolder/"}, nil, nil)
 
 	// Expect a warning record for the missing folder metadata with action derived from changes
 	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
@@ -1242,7 +1242,7 @@ func TestFullSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 	}
 	// Compare always returns missing list, even when flag is disabled
 	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(changes, []string{"myfolder/"}, nil)
+		Return(changes, []string{"myfolder/"}, nil, nil)
 
 	progress.On("SetTotal", mock.Anything, 1).Return()
 	progress.On("TooManyErrors").Return(nil)
@@ -1256,6 +1256,33 @@ func TestFullSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 	})).Return()
 
 	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), false)
+	require.NoError(t, err)
+}
+
+func TestFullSync_InvalidFolderMetadataWarning(t *testing.T) {
+	repo := repository.NewMockRepository(t)
+	repoResources := resources.NewMockRepositoryResources(t)
+	clients := resources.NewMockResourceClients(t)
+	progress := jobs.NewMockJobProgressRecorder(t)
+	compareFn := NewMockCompareFn(t)
+
+	repo.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+	})
+
+	invalidWarning := resources.NewInvalidFolderMetadata("myfolder/", errors.New("missing metadata.name"))
+	compareFn.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]ResourceFileChange{}, nil, []*resources.InvalidFolderMetadata{invalidWarning}, nil)
+
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+		return r.Path() == "myfolder/" &&
+			r.Action() == repository.FileActionIgnored &&
+			r.Warning() != nil &&
+			errors.Is(r.Warning(), resources.ErrInvalidFolderMetadata)
+	})).Return()
+	progress.On("SetFinalMessage", mock.Anything, "no changes to sync").Return()
+
+	err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 1, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotas.NewInMemoryQuotaTracker(0, 0), true)
 	require.NoError(t, err)
 }
 

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -17,7 +17,7 @@ import (
 type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error
 
 //go:generate mockery --name CompareFn --structname MockCompareFn --inpackage --filename compare_fn_mock.go --with-expecter
-type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, error)
+type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string, folderMetadataEnabled bool) ([]ResourceFileChange, []string, []*resources.InvalidFolderMetadata, error)
 
 //go:generate mockery --name IncrementalSyncFn --structname MockIncrementalSyncFn --inpackage --filename incremental_sync_fn_mock.go --with-expecter
 type IncrementalSyncFn func(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics, quotaTracker quotas.QuotaTracker, folderMetadataEnabled bool) error

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -48,6 +48,37 @@ func NewMissingFolderMetadata(path string) *MissingFolderMetadata {
 	return &MissingFolderMetadata{Path: path}
 }
 
+// ErrInvalidFolderMetadata is a sentinel error for malformed or incomplete _folder.json files.
+var ErrInvalidFolderMetadata = errors.New("invalid folder metadata")
+
+// InvalidFolderMetadata is returned when a folder metadata file exists but
+// cannot be used to resolve folder identity.
+type InvalidFolderMetadata struct {
+	Path string
+	Err  error
+}
+
+func (e *InvalidFolderMetadata) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("invalid folder metadata at %q", e.Path)
+	}
+	return fmt.Sprintf("invalid folder metadata at %q: %v", e.Path, e.Err)
+}
+
+// Unwrap supports errors.Is(err, ErrInvalidFolderMetadata) while preserving the
+// underlying validation/parsing failure.
+func (e *InvalidFolderMetadata) Unwrap() []error {
+	if e.Err == nil {
+		return []error{ErrInvalidFolderMetadata}
+	}
+	return []error{ErrInvalidFolderMetadata, e.Err}
+}
+
+// NewInvalidFolderMetadata creates an InvalidFolderMetadata error for the given path.
+func NewInvalidFolderMetadata(path string, err error) *InvalidFolderMetadata {
+	return &InvalidFolderMetadata{Path: path, Err: err}
+}
+
 // ErrFolderMetadataConflict is a sentinel error for folder metadata conflicts.
 var ErrFolderMetadataConflict = errors.New("folder metadata conflict")
 
@@ -137,7 +168,10 @@ func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath,
 	}
 	var f folders.Folder
 	if err := json.Unmarshal(info.Data, &f); err != nil {
-		return nil, "", fmt.Errorf("parse folder manifest: %w", err)
+		return nil, "", NewInvalidFolderMetadata(folderPath, fmt.Errorf("parse folder manifest: %w", err))
+	}
+	if f.Name == "" {
+		return nil, "", NewInvalidFolderMetadata(folderPath, errors.New("missing metadata.name"))
 	}
 	return &f, info.Hash, nil
 }

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -54,8 +54,9 @@ var ErrInvalidFolderMetadata = errors.New("invalid folder metadata")
 // InvalidFolderMetadata is returned when a folder metadata file exists but
 // cannot be used to resolve folder identity.
 type InvalidFolderMetadata struct {
-	Path string
-	Err  error
+	Path   string
+	Action repository.FileAction
+	Err    error
 }
 
 func (e *InvalidFolderMetadata) Error() string {
@@ -77,6 +78,12 @@ func (e *InvalidFolderMetadata) Unwrap() []error {
 // NewInvalidFolderMetadata creates an InvalidFolderMetadata error for the given path.
 func NewInvalidFolderMetadata(path string, err error) *InvalidFolderMetadata {
 	return &InvalidFolderMetadata{Path: path, Err: err}
+}
+
+// WithAction records the intended file action for this invalid metadata warning.
+func (e *InvalidFolderMetadata) WithAction(action repository.FileAction) *InvalidFolderMetadata {
+	e.Action = action
+	return e
 }
 
 // ErrFolderMetadataConflict is a sentinel error for folder metadata conflicts.

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -62,6 +62,18 @@ func TestReadFolderMetadata(t *testing.T) {
 		_, _, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
 
 		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidFolderMetadata)
+	})
+
+	t.Run("missing metadata.name returns invalid folder metadata error", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
+			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"My Folder"}}`)}, nil)
+
+		_, _, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidFolderMetadata)
 	})
 }
 
@@ -212,6 +224,41 @@ func TestFolderMetadataConflict_SentinelError(t *testing.T) {
 		wrapped := fmt.Errorf("wrap: %w", &FolderMetadataConflict{Path: "y/", Reason: "deleted"})
 		assert.True(t, errors.Is(wrapped, ErrFolderMetadataConflict))
 	})
+}
+
+func TestInvalidFolderMetadata_SentinelError(t *testing.T) {
+	t.Run("errors.Is matches ErrInvalidFolderMetadata", func(t *testing.T) {
+		err := &InvalidFolderMetadata{Path: "x/", Err: errors.New("missing metadata.name")}
+		assert.True(t, errors.Is(err, ErrInvalidFolderMetadata))
+	})
+
+	t.Run("errors.Is does not match unrelated error", func(t *testing.T) {
+		assert.False(t, errors.Is(errors.New("other"), ErrInvalidFolderMetadata))
+	})
+
+	t.Run("errors.As extracts InvalidFolderMetadata from wrapped error", func(t *testing.T) {
+		original := &InvalidFolderMetadata{Path: "x/", Err: errors.New("bad manifest")}
+		wrapped := fmt.Errorf("wrap: %w", original)
+
+		var target *InvalidFolderMetadata
+		require.True(t, errors.As(wrapped, &target))
+		assert.Equal(t, "x/", target.Path)
+		assert.EqualError(t, target.Err, "bad manifest")
+	})
+}
+
+func TestNewInvalidFolderMetadata(t *testing.T) {
+	err := NewInvalidFolderMetadata("team-a/dashboards/", errors.New("missing metadata.name"))
+	require.NotNil(t, err)
+	assert.Equal(t, "team-a/dashboards/", err.Path)
+	assert.EqualError(t, err.Err, "missing metadata.name")
+}
+
+func TestInvalidFolderMetadata_Error(t *testing.T) {
+	err := &InvalidFolderMetadata{Path: "team-a/dashboards/", Err: errors.New("missing metadata.name")}
+	assert.Contains(t, err.Error(), "team-a/dashboards/")
+	assert.Contains(t, err.Error(), "invalid folder metadata")
+	assert.Contains(t, err.Error(), "missing metadata.name")
 }
 
 func TestFolderMetadataConflict_Error(t *testing.T) {

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -685,7 +685,7 @@ func TestGetFolderID(t *testing.T) {
 			description: "When metadata read fails with non-NotFound error, propagate the error",
 		},
 		{
-			name:                  "metadata enabled but empty UID - returns hash-based ID",
+			name:                  "metadata enabled but empty UID - returns invalid folder metadata error",
 			folderMetadataEnabled: true,
 			setupMock: func(reader *repository.MockReader) {
 				reader.On("Config").Return(testRepoConfig)
@@ -697,9 +697,9 @@ func TestGetFolderID(t *testing.T) {
 						Path: "team-a/project-x/_folder.json",
 					}, nil)
 			},
-			expectedID:  ParseFolder(testPath, testRepoConfig.Name).ID,
-			expectedErr: false,
-			description: "When metadata exists but UID is empty, fall back to hash-based ID",
+			expectedID:  "",
+			expectedErr: true,
+			description: "When metadata exists but UID is empty, return invalid folder metadata error",
 		},
 		{
 			name:                  "metadata disabled - returns hash-based ID",

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -251,6 +251,7 @@ func TestNewInvalidFolderMetadata(t *testing.T) {
 	err := NewInvalidFolderMetadata("team-a/dashboards/", errors.New("missing metadata.name"))
 	require.NotNil(t, err)
 	assert.Equal(t, "team-a/dashboards/", err.Path)
+	assert.Empty(t, err.Action)
 	assert.EqualError(t, err.Err, "missing metadata.name")
 }
 
@@ -259,6 +260,17 @@ func TestInvalidFolderMetadata_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "team-a/dashboards/")
 	assert.Contains(t, err.Error(), "invalid folder metadata")
 	assert.Contains(t, err.Error(), "missing metadata.name")
+}
+
+func TestInvalidFolderMetadata_WithAction(t *testing.T) {
+	err := NewInvalidFolderMetadata("team-a/dashboards/", errors.New("missing metadata.name"))
+
+	got := err.WithAction(repository.FileActionCreated)
+
+	require.Same(t, err, got)
+	assert.Equal(t, "team-a/dashboards/", err.Path)
+	assert.Equal(t, repository.FileActionCreated, err.Action)
+	assert.EqualError(t, err.Err, "missing metadata.name")
 }
 
 func TestFolderMetadataConflict_Error(t *testing.T) {

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -163,7 +163,6 @@ func (fm *FolderManager) resolveFolderForPath(ctx context.Context, path string) 
 		return existing, nil
 	}
 
-
 	return ParseFolder(path, fm.repo.Config().Name), nil
 }
 

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -102,7 +102,7 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 		return parent, nil
 	}
 
-	f, err := ParseFolderWithMetadata(ctx, fm.repo, dir, "", fm.folderMetadataEnabled)
+	f, err := fm.resolveFolderForPath(ctx, dir)
 	if err != nil {
 		return "", err
 	}
@@ -115,7 +115,7 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 	}
 
 	err = safepath.Walk(ctx, f.Path, func(ctx context.Context, traverse string) error {
-		f, err := ParseFolderWithMetadata(ctx, fm.repo, traverse, "", fm.folderMetadataEnabled)
+		f, err := fm.resolveFolderForPath(ctx, traverse)
 		if err != nil {
 			return err
 		}
@@ -143,6 +143,28 @@ func (fm *FolderManager) EnsureFolderPathExist(ctx context.Context, filePath str
 	}
 
 	return f.ID, nil
+}
+
+// resolveFolderForPath parses folder metadata when possible. If metadata is
+// invalid, it falls back to the current folder already known at that path. When
+// no folder exists yet, it falls back to the hash/path-derived folder identity.
+func (fm *FolderManager) resolveFolderForPath(ctx context.Context, path string) (Folder, error) {
+	f, err := ParseFolderWithMetadata(ctx, fm.repo, path, "", fm.folderMetadataEnabled)
+	if err == nil {
+		return f, nil
+	}
+
+	var invalidErr *InvalidFolderMetadata
+	if !errors.As(err, &invalidErr) {
+		return Folder{}, err
+	}
+
+	if existing, ok := fm.tree.GetByPath(path); ok {
+		return existing, nil
+	}
+
+
+	return ParseFolder(path, fm.repo.Config().Name), nil
 }
 
 // EnsureFolderExists creates the folder if it doesn't exist.

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -20,11 +20,10 @@ import (
 //go:generate mockery --name FolderTree --structname MockFolderTree --inpackage --filename tree_mock.go --with-expecter
 type FolderTree interface {
 	In(folder string) bool
-	// Get returns the folder entry for the given ID, or false if not found.
 	Get(folderID string) (Folder, bool)
+	GetByPath(path string) (Folder, bool)
 	DirPath(folder, baseFolder string) (Folder, bool)
 	Add(folder Folder, parent string)
-	// Remove deletes folderID and all its descendants from the tree.
 	Remove(folderID string)
 	AddUnstructured(item *unstructured.Unstructured) error
 	Count() int
@@ -34,6 +33,7 @@ type FolderTree interface {
 type folderTree struct {
 	tree    map[string]string
 	folders map[string]Folder
+	paths   map[string]string
 	count   int
 	mu      sync.RWMutex
 }
@@ -46,14 +46,31 @@ func (t *folderTree) In(folder string) bool {
 	return t.in(folder)
 }
 
+// in is the unlocked implementation of In used by helpers that already hold the mutex.
 func (t *folderTree) in(folder string) bool {
 	_, ok := t.tree[folder]
 	return ok || folder == ""
 }
 
+// Get returns the folder entry stored for a specific folder UID.
 func (t *folderTree) Get(folderID string) (Folder, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
+	f, ok := t.folders[folderID]
+	return f, ok
+}
+
+// GetByPath returns the folder entry stored at the given source path.
+// Paths are normalized to trailing-slash directory form.
+func (t *folderTree) GetByPath(path string) (Folder, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	folderID, ok := t.paths[safepath.EnsureTrailingSlash(path)]
+	if !ok {
+		return Folder{}, false
+	}
+
 	f, ok := t.folders[folderID]
 	return f, ok
 }
@@ -106,14 +123,22 @@ func (t *folderTree) dirPath(folder, baseFolder string) (fid Folder, ok bool) {
 	return fid, ok
 }
 
+// Add inserts or updates a folder entry and keeps the UID and path indexes in sync.
 func (t *folderTree) Add(folder Folder, parent string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	_, exists := t.tree[folder.ID]
+	// Remove the stale path key when an existing folder entry is updated in place.
+	if existing, ok := t.folders[folder.ID]; ok && existing.Path != "" && existing.Path != folder.Path {
+		delete(t.paths, safepath.EnsureTrailingSlash(existing.Path))
+	}
 	t.tree[folder.ID] = parent
 	// Ensure the parent folder is set
 	folder.ParentID = parent
 	t.folders[folder.ID] = folder
+	if folder.Path != "" {
+		t.paths[safepath.EnsureTrailingSlash(folder.Path)] = folder.ID
+	}
 	if !exists {
 		t.count++
 	}
@@ -141,6 +166,9 @@ func (t *folderTree) Remove(folderID string) {
 	// Delete collected nodes and adjust count.
 	for _, id := range toDelete {
 		if _, exists := t.tree[id]; exists {
+			if folder, ok := t.folders[id]; ok && folder.Path != "" {
+				delete(t.paths, safepath.EnsureTrailingSlash(folder.Path))
+			}
 			delete(t.tree, id)
 			delete(t.folders, id)
 			t.count--
@@ -148,6 +176,7 @@ func (t *folderTree) Remove(folderID string) {
 	}
 }
 
+// Count returns the number of folders currently stored in the tree.
 func (t *folderTree) Count() int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -156,6 +185,7 @@ func (t *folderTree) Count() int {
 
 type WalkFunc func(ctx context.Context, folder Folder, parent string) error
 
+// Walk visits all folders in shallowest-first order and passes each folder's parent UID.
 func (t *folderTree) Walk(ctx context.Context, fn WalkFunc) error {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -177,13 +207,16 @@ func (t *folderTree) Walk(ctx context.Context, fn WalkFunc) error {
 	return nil
 }
 
+// NewEmptyFolderTree creates an empty folder tree with UID and source-path indexes.
 func NewEmptyFolderTree() FolderTree {
 	return &folderTree{
 		tree:    make(map[string]string, 0),
 		folders: make(map[string]Folder, 0),
+		paths:   make(map[string]string, 0),
 	}
 }
 
+// AddUnstructured adds a live folder object into the tree using its metadata annotations.
 func (t *folderTree) AddUnstructured(item *unstructured.Unstructured) error {
 	meta, err := utils.MetaAccessor(item)
 	if err != nil {
@@ -203,9 +236,11 @@ func (t *folderTree) AddUnstructured(item *unstructured.Unstructured) error {
 	return nil
 }
 
+// NewFolderTreeFromResourceList seeds a tree from the current managed resource listing.
 func NewFolderTreeFromResourceList(resources *provisioning.ResourceList) FolderTree {
 	tree := make(map[string]string, len(resources.Items))
 	folderIDs := make(map[string]Folder, len(resources.Items))
+	paths := make(map[string]string, len(resources.Items))
 	for _, rf := range resources.Items {
 		if rf.Group != folders.GROUP {
 			continue
@@ -219,11 +254,15 @@ func NewFolderTreeFromResourceList(resources *provisioning.ResourceList) FolderT
 			MetadataHash: rf.Hash,
 			ParentID:     rf.Folder,
 		}
+		if rf.Path != "" {
+			paths[safepath.EnsureTrailingSlash(rf.Path)] = rf.Name
+		}
 	}
 
 	return &folderTree{
 		tree:    tree,
 		folders: folderIDs,
+		paths:   paths,
 		count:   len(resources.Items),
 	}
 }

--- a/pkg/registry/apis/provisioning/resources/tree_test.go
+++ b/pkg/registry/apis/provisioning/resources/tree_test.go
@@ -124,6 +124,34 @@ func TestFolderTree(t *testing.T) {
 		assert.Equal(t, "New Title", id.Title)
 	})
 
+	t.Run("get by path returns folder with normalized path", func(t *testing.T) {
+		tree := NewEmptyFolderTree()
+		tree.Add(Folder{ID: "a", Title: "A", Path: "a/"}, "")
+
+		ft := tree.(*folderTree)
+		byPath, ok := ft.GetByPath("a")
+		require.True(t, ok)
+		assert.Equal(t, "a", byPath.ID)
+
+		byPath, ok = ft.GetByPath("a/")
+		require.True(t, ok)
+		assert.Equal(t, "a", byPath.ID)
+	})
+
+	t.Run("updating folder path removes the previous path lookup", func(t *testing.T) {
+		tree := NewEmptyFolderTree()
+		tree.Add(Folder{ID: "a", Title: "A", Path: "old/"}, "")
+		tree.Add(Folder{ID: "a", Title: "A", Path: "new/"}, "")
+
+		ft := tree.(*folderTree)
+		_, ok := ft.GetByPath("old")
+		require.False(t, ok)
+
+		byPath, ok := ft.GetByPath("new")
+		require.True(t, ok)
+		assert.Equal(t, "a", byPath.ID)
+	})
+
 	t.Run("remove existing folder decrements count and removes from tree", func(t *testing.T) {
 		tree := NewEmptyFolderTree()
 		tree.Add(Folder{ID: "a", Title: "A", Path: "a/"}, "")

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
@@ -1,0 +1,240 @@
+package foldermetadata
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("invalid folder metadata created on existing folder keeps unstable uid and preserves children", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+		const repo = "full-sync-invalid-meta-existing"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:                   repo,
+			Target:                 "folder",
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		writeToProvisioningPath(t, helper, "myfolder/dashboard.json", gitcommon.DashboardJSON("existing-parent-dash", "Parent Dashboard", 1))
+		writeToProvisioningPath(t, helper, "myfolder/child/child-dashboard.json", gitcommon.DashboardJSON("existing-child-dash", "Child Dashboard", 1))
+
+		helper.SyncAndWait(t, repo, nil)
+
+		parentUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder")
+		childUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder/child")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "existing-child-dash", "Child Dashboard")
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"myfolder/dashboard.json":             parentUID,
+			"myfolder/child/child-dashboard.json": childUID,
+		})
+
+		writeToProvisioningPath(t, helper, "myfolder/child/child-dashboard.json", gitcommon.DashboardJSON("existing-child-dash", "Child Dashboard Updated", 2))
+		writeToProvisioningPath(t, helper, "myfolder/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, job)
+		requireWarningContains(t, job.Object, "invalid folder metadata")
+		requireWarningContains(t, job.Object, "myfolder")
+
+		require.Equal(t, parentUID, findFolderUIDBySourcePath(t, helper, repo, "myfolder"))
+		require.Equal(t, childUID, findFolderUIDBySourcePath(t, helper, repo, "myfolder/child"))
+		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "existing-child-dash", "Child Dashboard Updated")
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"myfolder/dashboard.json":             parentUID,
+			"myfolder/child/child-dashboard.json": childUID,
+		})
+	})
+
+	t.Run("invalid folder metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+		const repo = "full-sync-invalid-meta-new"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:                   repo,
+			Target:                 "folder",
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		writeToProvisioningPath(t, helper, "myfolder/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
+		writeToProvisioningPath(t, helper, "myfolder/dashboard.json", gitcommon.DashboardJSON("new-parent-dash", "Parent Dashboard", 1))
+		writeToProvisioningPath(t, helper, "myfolder/child/child-dashboard.json", gitcommon.DashboardJSON("new-child-dash", "Child Dashboard", 1))
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, job)
+		requireWarningContains(t, job.Object, "invalid folder metadata")
+		requireWarningContains(t, job.Object, "myfolder")
+
+		parentUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder")
+		childUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder/child")
+		require.NotEmpty(t, parentUID)
+		require.NotEmpty(t, childUID)
+		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "new-parent-dash", "Parent Dashboard")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "new-child-dash", "Child Dashboard")
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"myfolder/dashboard.json":             parentUID,
+			"myfolder/child/child-dashboard.json": childUID,
+		})
+	})
+
+	t.Run("resource move into existing folder with invalid metadata keeps using that folder uid", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "fs-inv-move-existing"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:                   repo,
+			Target:                 "folder",
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		writeToProvisioningPath(t, helper, "dashboard.json", gitcommon.DashboardJSON("move-into-existing-invalid", "Move Into Existing Invalid", 1))
+		writeToProvisioningPath(t, helper, "broken/existing.json", gitcommon.DashboardJSON("existing-invalid-target", "Existing Invalid Target", 1))
+
+		helper.SyncAndWait(t, repo, nil)
+
+		brokenUID := findFolderUIDBySourcePath(t, helper, repo, "broken")
+		require.NotEmpty(t, brokenUID)
+
+		writeToProvisioningPath(t, helper, "broken/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
+
+		initialWarningJob := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, initialWarningJob)
+		requireWarningContains(t, initialWarningJob.Object, "invalid folder metadata")
+		require.Equal(t, brokenUID, findFolderUIDBySourcePath(t, helper, repo, "broken"))
+
+		moveInProvisioningPath(t, helper, "dashboard.json", "broken/moved-dashboard.json")
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, job)
+		requireWarningContains(t, job.Object, "invalid folder metadata")
+		requireWarningContains(t, job.Object, "broken")
+
+		require.Equal(t, brokenUID, findFolderUIDBySourcePath(t, helper, repo, "broken"))
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"broken/existing.json":        brokenUID,
+			"broken/moved-dashboard.json": brokenUID,
+		})
+	})
+
+	t.Run("resource move into new folder with invalid metadata falls back to unstable uid", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "fs-inv-move-new"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:                   repo,
+			Target:                 "folder",
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		writeToProvisioningPath(t, helper, "dashboard.json", gitcommon.DashboardJSON("move-into-new-invalid", "Move Into New Invalid", 1))
+
+		helper.SyncAndWait(t, repo, nil)
+
+		writeToProvisioningPath(t, helper, "broken/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
+		moveInProvisioningPath(t, helper, "dashboard.json", "broken/dashboard.json")
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, job)
+		requireWarningContains(t, job.Object, "invalid folder metadata")
+		requireWarningContains(t, job.Object, "broken")
+
+		brokenUID := findFolderUIDBySourcePath(t, helper, repo, "broken")
+		require.NotEmpty(t, brokenUID)
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"broken/dashboard.json": brokenUID,
+		})
+	})
+
+	t.Run("moving folder with invalid metadata deletes old path and recreates at new path", func(t *testing.T) {
+		helper := common.RunGrafana(t, common.WithProvisioningFolderMetadata)
+		const repo = "fs-inv-folder-move"
+
+		helper.CreateRepo(t, common.TestRepo{
+			Name:                   repo,
+			Target:                 "folder",
+			SkipSync:               true,
+			SkipResourceAssertions: true,
+		})
+		writeToProvisioningPath(t, helper, "broken/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
+		writeToProvisioningPath(t, helper, "broken/dashboard.json", gitcommon.DashboardJSON("move-invalid-folder", "Move Invalid Folder", 1))
+
+		initialJob := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, initialJob)
+
+		oldUID := findFolderUIDBySourcePath(t, helper, repo, "broken")
+		require.NotEmpty(t, oldUID)
+
+		moveInProvisioningPath(t, helper, "broken", "moved")
+
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		common.RequireJobWarning(t, job)
+		requireWarningContains(t, job.Object, "invalid folder metadata")
+		requireWarningContains(t, job.Object, "moved")
+
+		newUID := findFolderUIDBySourcePath(t, helper, repo, "moved")
+		require.NotEmpty(t, newUID)
+		require.NotEqual(t, oldUID, newUID)
+		assertNoFolderAtPath(t, helper, repo, "broken")
+		assertNoFolderByUID(t, helper, oldUID)
+		requireDashboardParents(t, helper, repo, map[string]string{
+			"moved/dashboard.json": newUID,
+		})
+	})
+}
+
+func invalidFolderMetadataMissingNameJSON(title string) []byte {
+	return []byte(`{
+		"apiVersion": "folder.grafana.app/v1beta1",
+		"kind": "Folder",
+		"metadata": {
+			"name": ""
+		},
+		"spec": {
+			"title": "` + title + `"
+		}
+	}`)
+}
+
+func requireWarningContains(t *testing.T, job map[string]any, needle string) {
+	t.Helper()
+	warnings := common.MustNestedStringSlice(job, "status", "warnings")
+	for _, warning := range warnings {
+		if strings.Contains(warning, needle) {
+			return
+		}
+	}
+	require.Failf(t, "warning not found", "expected warning containing %q, got %v", needle, warnings)
+}

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -48,8 +49,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, job)
-		requireWarningContains(t, job.Object, "invalid folder metadata")
-		requireWarningContains(t, job.Object, "myfolder")
+		requireInvalidFolderMetadataWarning(t, job.Object, "myfolder", repository.FileActionUpdated)
 
 		require.Equal(t, parentUID, findFolderUIDBySourcePath(t, helper, repo, "myfolder"))
 		require.Equal(t, childUID, findFolderUIDBySourcePath(t, helper, repo, "myfolder/child"))
@@ -80,8 +80,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, job)
-		requireWarningContains(t, job.Object, "invalid folder metadata")
-		requireWarningContains(t, job.Object, "myfolder")
+		requireInvalidFolderMetadataWarning(t, job.Object, "myfolder", repository.FileActionCreated)
 
 		parentUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder")
 		childUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder/child")
@@ -120,7 +119,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, initialWarningJob)
-		requireWarningContains(t, initialWarningJob.Object, "invalid folder metadata")
+		requireInvalidFolderMetadataWarning(t, initialWarningJob.Object, "broken", repository.FileActionUpdated)
 		require.Equal(t, brokenUID, findFolderUIDBySourcePath(t, helper, repo, "broken"))
 
 		moveInProvisioningPath(t, helper, "dashboard.json", "broken/moved-dashboard.json")
@@ -130,8 +129,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, job)
-		requireWarningContains(t, job.Object, "invalid folder metadata")
-		requireWarningContains(t, job.Object, "broken")
+		requireInvalidFolderMetadataWarning(t, job.Object, "broken", repository.FileActionUpdated)
 
 		require.Equal(t, brokenUID, findFolderUIDBySourcePath(t, helper, repo, "broken"))
 		requireDashboardParents(t, helper, repo, map[string]string{
@@ -162,8 +160,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, job)
-		requireWarningContains(t, job.Object, "invalid folder metadata")
-		requireWarningContains(t, job.Object, "broken")
+		requireInvalidFolderMetadataWarning(t, job.Object, "broken", repository.FileActionCreated)
 
 		brokenUID := findFolderUIDBySourcePath(t, helper, repo, "broken")
 		require.NotEmpty(t, brokenUID)
@@ -190,6 +187,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, initialJob)
+		requireInvalidFolderMetadataWarning(t, initialJob.Object, "broken", repository.FileActionCreated)
 
 		oldUID := findFolderUIDBySourcePath(t, helper, repo, "broken")
 		require.NotEmpty(t, oldUID)
@@ -201,8 +199,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 		common.RequireJobWarning(t, job)
-		requireWarningContains(t, job.Object, "invalid folder metadata")
-		requireWarningContains(t, job.Object, "moved")
+		requireInvalidFolderMetadataWarning(t, job.Object, "moved", repository.FileActionCreated)
 
 		newUID := findFolderUIDBySourcePath(t, helper, repo, "moved")
 		require.NotEmpty(t, newUID)
@@ -228,13 +225,15 @@ func invalidFolderMetadataMissingNameJSON(title string) []byte {
 	}`)
 }
 
-func requireWarningContains(t *testing.T, job map[string]any, needle string) {
+func requireInvalidFolderMetadataWarning(t *testing.T, job map[string]any, path string, action repository.FileAction) {
 	t.Helper()
 	warnings := common.MustNestedStringSlice(job, "status", "warnings")
 	for _, warning := range warnings {
-		if strings.Contains(warning, needle) {
+		if strings.Contains(warning, "invalid folder metadata") &&
+			strings.Contains(warning, path) &&
+			strings.Contains(warning, "action: "+string(action)) {
 			return
 		}
 	}
-	require.Failf(t, "warning not found", "expected warning containing %q, got %v", needle, warnings)
+	require.Failf(t, "warning not found", "expected invalid folder metadata warning for %q with action %q, got %v", path, action, warnings)
 }


### PR DESCRIPTION
## What

This PR makes full sync tolerate invalid `_folder.json` files instead of failing the entire reconciliation.

Full sync now treats malformed or incomplete folder metadata as a warning and keeps reconciling the rest of the repository. In particular:
- existing folders with invalid `_folder.json` keep their current unstable UID
- new folders with invalid `_folder.json` fall back to the path-derived unstable UID
- child resources can still reconcile when their parent folder metadata is invalid
- moves into folders with invalid metadata are supported
- when a folder with invalid metadata is moved, full sync falls back to delete+recreate semantics, so the folder transitions from its previous stable metadata-backed UID to a new unstable path-derived UID at the destination
- invalid folder metadata warnings now preserve the effective sync action when one exists, so the job output distinguishes between invalid metadata handled via `created` and `updated` flows instead of always reporting `ignored`

<img width="1469" height="452" alt="image" src="https://github.com/user-attachments/assets/b202c915-b801-4226-96f1-31a521c7d632" />

This PR fixes https://github.com/grafana/git-ui-sync-project/issues/1015.

## Why

Before this change, invalid folder metadata could stop full sync entirely or block unrelated resource reconciliation.

That made `_folder.json` errors too disruptive:
- a malformed file could prevent child dashboards from updating
- a new folder with invalid metadata could fail to reconcile at all
- move handling was brittle because metadata-backed folder moves assumed valid metadata

This change makes the system degrade more safely:
- metadata problems are surfaced to the user as warnings
- folder identity falls back to the current or path-derived UID when needed
- unrelated resources and child resources continue to reconcile whenever possible

## Diff summary

### Invalid metadata classification
- `pkg/registry/apis/provisioning/resources/folder_metadata.go`
  - adds/uses `ErrInvalidFolderMetadata` and `InvalidFolderMetadata`
  - treats malformed JSON and missing `metadata.name` as invalid folder metadata

### Folder path resolution fallback
- `pkg/registry/apis/provisioning/resources/folders.go`
  - `EnsureFolderPathExist(...)` now resolves folders through a fallback path:
    - valid metadata -> use metadata-defined folder identity
    - invalid metadata on existing folder -> reuse the folder already known at that path
    - invalid metadata on new folder -> use the path-derived unstable UID
  - this lets child resources reconcile even when parent metadata is invalid

- `pkg/registry/apis/provisioning/resources/tree.go`
  - adds path-based lookup support to the in-memory folder tree
  - keeps the path index in sync when folder entries are updated or removed

### Full sync compare/apply behavior
- `pkg/registry/apis/provisioning/jobs/sync/changes.go`
  - invalid folder metadata is detected during compare and surfaced as warnings
  - existing-folder metadata updates with invalid `_folder.json` are suppressed so the current UID is preserved
  - created folders with invalid metadata keep their create change so apply can fall back safely
  - metadata-backed folder moves only collapse into in-place updates when `_folder.json` is valid
  - invalid-metadata folder moves are left as delete+create, which gives safe recreate semantics

- `pkg/registry/apis/provisioning/jobs/sync/full.go`
  - records invalid folder metadata as warning results visible in the job
  - preserves the effective action (`created` / `updated`) when one exists instead of always reporting `ignored`

### Test coverage
- `pkg/registry/apis/provisioning/resources/folder_metadata_test.go`
  - covers malformed JSON, missing `metadata.name`, and action-aware invalid metadata warnings

- `pkg/registry/apis/provisioning/resources/tree_test.go`
  - covers path-based folder lookup and path index updates

- `pkg/registry/apis/provisioning/jobs/sync/changes_test.go`
  - covers compare-time invalid metadata warnings
  - covers created-folder invalid metadata preserving folder creation
  - covers invalid folder move behavior staying as delete+create
  - covers action-aware invalid metadata warnings for created vs updated folder paths

- `pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go`
  - adds end-to-end coverage for:
    - invalid metadata on existing folders
    - invalid metadata on new folders
    - changed child resources under invalid metadata
    - moving resources into existing/new folders with invalid metadata
    - moving folders with invalid metadata using delete+recreate semantics
    - warning output reflecting the effective action taken by full sync

## Scope

This PR is about **full sync** behavior when `_folder.json` is invalid.

It does not change incremental sync behavior.

## Testing

- `go test ./pkg/registry/apis/provisioning/resources/...`
- `go test ./pkg/registry/apis/provisioning/jobs/sync/...`
- `go test -tags=enterprise ./pkg/tests/apis/provisioning/foldermetadata/...`
