### PR TITLE
Provisioning: react on invalid folder metadata in incremental pull

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_diff_split.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_diff_split.go
@@ -57,7 +57,7 @@ func (input folderMetadataDiffSplit) MetadataChanges() []repository.VersionedFil
 }
 
 // HasMetadataChanges reports whether the diff contains any handled
-// `_folder.json` create, update, or delete entries.
+// `_folder.json` create, update, delete, or rename entries.
 func (input folderMetadataDiffSplit) HasMetadataChanges() bool {
 	return len(input.metadataChanges) > 0
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -126,7 +126,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteCreatedOrUpdatedMetadataCh
 		})
 	}
 
-	replaced, newUID, err := d.replacementsForMetadataChange(ctx, index, folderPath, change)
+	replaced, newUID, err := d.replacementsForMetadataChange(index, folderPath, folder)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -95,7 +95,6 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteMetadataChange(
 		return d.rewriteDeletedMetadataChange(ctx, currentRef, input, index, diffTracker, change)
 	case repository.FileActionRenamed:
 		return d.rewriteRenamedMetadataChange(ctx, currentRef, input, index, diffTracker, change)
-		return d.collectInvalidRenamedMetadataChange(ctx, currentRef, change)
 	default:
 		return nil, nil
 	}
@@ -244,35 +243,36 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteRenamedMetadataChange(
 	index managedResourceIndex,
 	diffTracker *rebuiltIncrementalDiffTracker,
 	change repository.VersionedFileChange,
-) error {
+) ([]*resources.InvalidFolderMetadata, error) {
 	// Destination side: create or update the folder at the new path.
-	if err := d.rewriteCreatedOrUpdatedMetadataChange(ctx, input, index, diffTracker, change); err != nil {
-		return err
+	warnings, err := d.rewriteCreatedOrUpdatedMetadataChange(ctx, input, index, diffTracker, change)
+	if err != nil {
+		return nil, err
 	}
 
 	// Source side: clean up the old path. If the rename originates from a
 	// non-metadata file (e.g. config.json -> _folder.json), there is no
 	// metadata folder to clean up.
 	if !resources.IsFolderMetadataFile(change.PreviousPath) {
-		return nil
+		return warnings, nil
 	}
 
 	// A directory-level rename in the original diff already handles this
 	// folder via RenameFolderPath; skip to avoid duplicate processing.
 	oldFolderPath := folderPathForMetadataChange(change.PreviousPath)
 	if input.HadChangeOriginallyAt(oldFolderPath) {
-		return nil
+		return warnings, nil
 	}
 
 	// No managed folders at the old path — nothing to clean up.
 	items := index.ExistingAt(oldFolderPath)
 	if len(items) == 0 {
-		return nil
+		return warnings, nil
 	}
 
 	directoryExists, err := d.folderDirectoryExists(ctx, currentRef, oldFolderPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Schedule each old-path item for potential deletion.
@@ -291,7 +291,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteRenamedMetadataChange(
 
 	// Old directory is gone — no folder or child entries to re-sync.
 	if !directoryExists {
-		return nil
+		return warnings, nil
 	}
 
 	// Emit an update for the old folder path so it reverts to its
@@ -305,7 +305,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteRenamedMetadataChange(
 	}
 
 	if !hasReplacement {
-		return nil
+		return warnings, nil
 	}
 
 	// Re-parent direct children so they are re-synced under the
@@ -324,16 +324,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteRenamedMetadataChange(
 		})
 	}
 
-	return nil
-}
-
-func (d *folderMetadataIncrementalDiffBuilder) collectInvalidRenamedMetadataChange(
-	ctx context.Context,
-	currentRef string,
-	change repository.VersionedFileChange,
-) ([]*resources.InvalidFolderMetadata, error) {
-	_, invalid, err := d.readMetadata(ctx, folderPathForMetadataChange(change.Path), currentRef, change.Action)
-	return invalid, err
+	return warnings, nil
 }
 
 // readMetadata reads `_folder.json` once and returns either the parsed folder
@@ -374,22 +365,18 @@ func (d *folderMetadataIncrementalDiffBuilder) readMetadata(
 // same path (from prior metadata.name changes) all of them are returned.
 // The new UID is also returned so callers can track it as active.
 func (d *folderMetadataIncrementalDiffBuilder) replacementsForMetadataChange(
-	ctx context.Context,
 	index managedResourceIndex,
 	folderPath string,
 	folder *folders.Folder,
 ) ([]replacedFolder, string, error) {
-	folder, _, err := resources.ReadFolderMetadata(ctx, d.repo, folderPath, change.Ref)
-	if err != nil {
-		if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
-			return nil, "", nil
-		}
-		var invalidErr *resources.InvalidFolderMetadata
-		if errors.As(err, &invalidErr) {
-			return nil, "", nil
-		}
-		return nil, "", fmt.Errorf("read folder metadata for %s: %w", folderPath, err)
+	// Replacements are only scheduled for confirmed identity transitions. If the
+	// managed folder does not exist yet, or metadata could not be parsed into a
+	// trustworthy folder identity, replay still happens but there is no old UID
+	// to delete after apply.
+	if folder == nil {
+		return nil, "", nil
 	}
+
 	newUID := folder.GetName()
 
 	items := index.ExistingAt(folderPath)

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -79,6 +79,9 @@ func (d *folderMetadataIncrementalDiffBuilder) BuildIncrementalDiff(
 
 // rewriteMetadataChange dispatches each handled metadata action to the
 // specialized rewrite flow for create/update or delete semantics.
+// Renamed `_folder.json` entries are dropped from the rewritten diff because
+// folder moves are driven by the directory rename entry, not by replaying the
+// metadata file as a separate resource rename.
 func (d *folderMetadataIncrementalDiffBuilder) rewriteMetadataChange(
 	ctx context.Context,
 	currentRef string,
@@ -337,6 +340,10 @@ func (d *folderMetadataIncrementalDiffBuilder) replacementsForMetadataChange(
 	folder, _, err := resources.ReadFolderMetadata(ctx, d.repo, folderPath, change.Ref)
 	if err != nil {
 		if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+			return nil, "", nil
+		}
+		var invalidErr *resources.InvalidFolderMetadata
+		if errors.As(err, &invalidErr) {
 			return nil, "", nil
 		}
 		return nil, "", fmt.Errorf("read folder metadata for %s: %w", folderPath, err)

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -340,6 +340,10 @@ func (d *folderMetadataIncrementalDiffBuilder) collectInvalidRenamedMetadataChan
 	return d.collectInvalidMetadataErrors(ctx, folderPathForMetadataChange(change.Path), currentRef, change.Action)
 }
 
+// collectInvalidMetadataErrors reads `_folder.json` for the given folder path
+// and returns a warning only for invalid metadata. Missing metadata is ignored
+// here because callers decide separately whether that action should be replayed
+// or left to the normal folder fallback logic.
 func (d *folderMetadataIncrementalDiffBuilder) collectInvalidMetadataErrors(
 	ctx context.Context,
 	folderPath string,

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
@@ -18,12 +19,12 @@ type FolderMetadataIncrementalDiffBuilder interface {
 		ctx context.Context,
 		currentRef string,
 		repoDiff []repository.VersionedFileChange,
+		resourcesList *provisioning.ResourceList,
 	) ([]repository.VersionedFileChange, []replacedFolder, []*resources.InvalidFolderMetadata, error)
 }
 
 type folderMetadataIncrementalDiffBuilder struct {
-	repo                repository.Reader
-	repositoryResources resources.RepositoryResources
+	repo repository.Reader
 }
 
 type replacedFolder struct {
@@ -31,16 +32,14 @@ type replacedFolder struct {
 	OldUID string
 }
 
-// NewFolderMetadataIncrementalDiffBuilder wires the repository reader and
-// managed-resource lister used to rewrite `_folder.json` changes into the
-// directory/resource diff entries consumed by incremental apply.
+// NewFolderMetadataIncrementalDiffBuilder wires the repository reader used to
+// rewrite `_folder.json` changes into the directory/resource diff entries
+// consumed by incremental apply.
 func NewFolderMetadataIncrementalDiffBuilder(
 	repo repository.Reader,
-	repositoryResources resources.RepositoryResources,
 ) *folderMetadataIncrementalDiffBuilder {
 	return &folderMetadataIncrementalDiffBuilder{
-		repo:                repo,
-		repositoryResources: repositoryResources,
+		repo: repo,
 	}
 }
 
@@ -54,18 +53,14 @@ func (d *folderMetadataIncrementalDiffBuilder) BuildIncrementalDiff(
 	ctx context.Context,
 	currentRef string,
 	repoDiff []repository.VersionedFileChange,
+	resourcesList *provisioning.ResourceList,
 ) ([]repository.VersionedFileChange, []replacedFolder, []*resources.InvalidFolderMetadata, error) {
 	input := splitMetadataChanges(repoDiff)
 	if !input.HasMetadataChanges() {
 		return repoDiff, nil, nil, nil
 	}
 
-	target, err := d.repositoryResources.List(ctx)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("list managed resources: %w", err)
-	}
-
-	index := newManagedResourceIndex(target)
+	index := newManagedResourceIndex(resourcesList)
 	diffTracker := newRebuiltIncrementalDiffTracker(input.otherChanges)
 	invalid := make([]*resources.InvalidFolderMetadata, 0)
 
@@ -117,7 +112,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteCreatedOrUpdatedMetadataCh
 	change repository.VersionedFileChange,
 ) ([]*resources.InvalidFolderMetadata, error) {
 	folderPath := folderPathForMetadataChange(change.Path)
-	invalidMetaErrors, err := d.collectInvalidMetadataErrors(ctx, folderPath, change.Ref, change.Action)
+	folder, invalidMetaErrors, err := d.readMetadata(ctx, folderPath, change.Ref, change.Action)
 	if err != nil {
 		return nil, err
 	}
@@ -337,30 +332,38 @@ func (d *folderMetadataIncrementalDiffBuilder) collectInvalidRenamedMetadataChan
 	currentRef string,
 	change repository.VersionedFileChange,
 ) ([]*resources.InvalidFolderMetadata, error) {
-	return d.collectInvalidMetadataErrors(ctx, folderPathForMetadataChange(change.Path), currentRef, change.Action)
+	_, invalid, err := d.readMetadata(ctx, folderPathForMetadataChange(change.Path), currentRef, change.Action)
+	return invalid, err
 }
 
-// collectInvalidMetadataErrors reads `_folder.json` for the given folder path
-// and returns a warning only for invalid metadata. Missing metadata is ignored
-// here because callers decide separately whether that action should be replayed
-// or left to the normal folder fallback logic.
-func (d *folderMetadataIncrementalDiffBuilder) collectInvalidMetadataErrors(
+// readMetadata reads `_folder.json` once and returns either the parsed folder
+// metadata or an action-aware invalid metadata warning.
+//
+// Invalid or missing metadata intentionally returns a nil folder with no hard
+// error. Callers still replay the folder path so apply can fall back to the
+// existing folder at that path or to the path-derived unstable UID, but they do
+// not treat that case as a confirmed identity replacement because there is no
+// trustworthy metadata-defined UID to compare against.
+func (d *folderMetadataIncrementalDiffBuilder) readMetadata(
 	ctx context.Context,
 	folderPath string,
 	ref string,
 	action repository.FileAction,
-) ([]*resources.InvalidFolderMetadata, error) {
-	_, _, err := resources.ReadFolderMetadata(ctx, d.repo, folderPath, ref)
-	if err == nil || errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
-		return nil, nil
+) (*folders.Folder, []*resources.InvalidFolderMetadata, error) {
+	folder, _, err := resources.ReadFolderMetadata(ctx, d.repo, folderPath, ref)
+	if err == nil {
+		return folder, nil, nil
+	}
+	if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+		return nil, nil, nil
 	}
 
 	var invalidErr *resources.InvalidFolderMetadata
 	if errors.As(err, &invalidErr) {
-		return []*resources.InvalidFolderMetadata{invalidErr.WithAction(action)}, nil
+		return nil, []*resources.InvalidFolderMetadata{invalidErr.WithAction(action)}, nil
 	}
 
-	return nil, fmt.Errorf("read folder metadata for %s: %w", folderPath, err)
+	return nil, nil, fmt.Errorf("read folder metadata for %s: %w", folderPath, err)
 }
 
 // replacementsForMetadataChange determines which existing folder identities at
@@ -374,7 +377,7 @@ func (d *folderMetadataIncrementalDiffBuilder) replacementsForMetadataChange(
 	ctx context.Context,
 	index managedResourceIndex,
 	folderPath string,
-	change repository.VersionedFileChange,
+	folder *folders.Folder,
 ) ([]replacedFolder, string, error) {
 	folder, _, err := resources.ReadFolderMetadata(ctx, d.repo, folderPath, change.Ref)
 	if err != nil {

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -18,7 +18,7 @@ type FolderMetadataIncrementalDiffBuilder interface {
 		ctx context.Context,
 		currentRef string,
 		repoDiff []repository.VersionedFileChange,
-	) ([]repository.VersionedFileChange, []replacedFolder, error)
+	) ([]repository.VersionedFileChange, []replacedFolder, []*resources.InvalidFolderMetadata, error)
 }
 
 type folderMetadataIncrementalDiffBuilder struct {
@@ -54,27 +54,30 @@ func (d *folderMetadataIncrementalDiffBuilder) BuildIncrementalDiff(
 	ctx context.Context,
 	currentRef string,
 	repoDiff []repository.VersionedFileChange,
-) ([]repository.VersionedFileChange, []replacedFolder, error) {
+) ([]repository.VersionedFileChange, []replacedFolder, []*resources.InvalidFolderMetadata, error) {
 	input := splitMetadataChanges(repoDiff)
 	if !input.HasMetadataChanges() {
-		return repoDiff, nil, nil
+		return repoDiff, nil, nil, nil
 	}
 
 	target, err := d.repositoryResources.List(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("list managed resources: %w", err)
+		return nil, nil, nil, fmt.Errorf("list managed resources: %w", err)
 	}
 
 	index := newManagedResourceIndex(target)
 	diffTracker := newRebuiltIncrementalDiffTracker(input.otherChanges)
+	invalid := make([]*resources.InvalidFolderMetadata, 0)
 
 	for _, change := range input.MetadataChanges() {
-		if err := d.rewriteMetadataChange(ctx, currentRef, input, index, diffTracker, change); err != nil {
-			return nil, nil, err
+		warnings, err := d.rewriteMetadataChange(ctx, currentRef, input, index, diffTracker, change)
+		if err != nil {
+			return nil, nil, nil, err
 		}
+		invalid = append(invalid, warnings...)
 	}
 
-	return diffTracker.IncrementalDiff(), diffTracker.ReplacedFolders(), nil
+	return diffTracker.IncrementalDiff(), diffTracker.ReplacedFolders(), invalid, nil
 }
 
 // rewriteMetadataChange dispatches each handled metadata action to the
@@ -89,7 +92,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteMetadataChange(
 	index managedResourceIndex,
 	diffTracker *rebuiltIncrementalDiffTracker,
 	change repository.VersionedFileChange,
-) error {
+) ([]*resources.InvalidFolderMetadata, error) {
 	switch change.Action {
 	case repository.FileActionCreated, repository.FileActionUpdated:
 		return d.rewriteCreatedOrUpdatedMetadataChange(ctx, input, index, diffTracker, change)
@@ -97,8 +100,9 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteMetadataChange(
 		return d.rewriteDeletedMetadataChange(ctx, currentRef, input, index, diffTracker, change)
 	case repository.FileActionRenamed:
 		return d.rewriteRenamedMetadataChange(ctx, currentRef, input, index, diffTracker, change)
+		return d.collectInvalidRenamedMetadataChange(ctx, currentRef, change)
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
@@ -111,8 +115,12 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteCreatedOrUpdatedMetadataCh
 	index managedResourceIndex,
 	diffTracker *rebuiltIncrementalDiffTracker,
 	change repository.VersionedFileChange,
-) error {
+) ([]*resources.InvalidFolderMetadata, error) {
 	folderPath := folderPathForMetadataChange(change.Path)
+	invalidMetaErrors, err := d.collectInvalidMetadataErrors(ctx, folderPath, change.Ref, change.Action)
+	if err != nil {
+		return nil, err
+	}
 
 	// In case the folder path is not in the original diff, and we didn't generate a change yet,
 	// we append an update change for it.
@@ -126,7 +134,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteCreatedOrUpdatedMetadataCh
 
 	replaced, newUID, err := d.replacementsForMetadataChange(ctx, index, folderPath, change)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if newUID != "" {
 		diffTracker.TrackActiveUID(newUID)
@@ -151,7 +159,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteCreatedOrUpdatedMetadataCh
 		})
 	}
 
-	return nil
+	return invalidMetaErrors, nil
 }
 
 // rewriteDeletedMetadataChange handles `_folder.json` deletion by either
@@ -167,16 +175,16 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteDeletedMetadataChange(
 	index managedResourceIndex,
 	diffTracker *rebuiltIncrementalDiffTracker,
 	change repository.VersionedFileChange,
-) error {
+) ([]*resources.InvalidFolderMetadata, error) {
 	folderPath := folderPathForMetadataChange(change.Path)
 	items := index.ExistingAt(folderPath)
 	if len(items) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	directoryExists, err := d.folderDirectoryExists(ctx, currentRef, folderPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	hasReplacement := false
@@ -189,7 +197,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteDeletedMetadataChange(
 	}
 
 	if !directoryExists {
-		return nil
+		return nil, nil
 	}
 
 	if !input.HadChangeOriginallyAt(folderPath) && !diffTracker.HasGeneratedPath(folderPath) {
@@ -201,7 +209,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteDeletedMetadataChange(
 	}
 
 	if !hasReplacement {
-		return nil
+		return nil, nil
 	}
 
 	for _, childPath := range index.DirectChildrenOf(folderPath) {
@@ -220,7 +228,7 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteDeletedMetadataChange(
 		})
 	}
 
-	return nil
+	return nil, nil
 }
 
 // rewriteRenamedMetadataChange handles file-only renames of _folder.json
@@ -322,6 +330,33 @@ func (d *folderMetadataIncrementalDiffBuilder) rewriteRenamedMetadataChange(
 	}
 
 	return nil
+}
+
+func (d *folderMetadataIncrementalDiffBuilder) collectInvalidRenamedMetadataChange(
+	ctx context.Context,
+	currentRef string,
+	change repository.VersionedFileChange,
+) ([]*resources.InvalidFolderMetadata, error) {
+	return d.collectInvalidMetadataErrors(ctx, folderPathForMetadataChange(change.Path), currentRef, change.Action)
+}
+
+func (d *folderMetadataIncrementalDiffBuilder) collectInvalidMetadataErrors(
+	ctx context.Context,
+	folderPath string,
+	ref string,
+	action repository.FileAction,
+) ([]*resources.InvalidFolderMetadata, error) {
+	_, _, err := resources.ReadFolderMetadata(ctx, d.repo, folderPath, ref)
+	if err == nil || errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+
+	var invalidErr *resources.InvalidFolderMetadata
+	if errors.As(err, &invalidErr) {
+		return []*resources.InvalidFolderMetadata{invalidErr.WithAction(action)}, nil
+	}
+
+	return nil, fmt.Errorf("read folder metadata for %s: %w", folderPath, err)
 }
 
 // replacementsForMetadataChange determines which existing folder identities at

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -213,6 +213,68 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		}}, replacedFolders)
 	})
 
+	t.Run("invalid metadata update on existing folder keeps replay without replacement", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionUpdated, Path: "myfolder/_folder.json", Ref: "new-ref"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{
+					Name:     "stable-uid",
+					Group:    resources.FolderResource.Group,
+					Resource: resources.FolderResource.Resource,
+					Path:     "myfolder/",
+				},
+				{
+					Name:     "dash-uid",
+					Group:    "dashboards",
+					Resource: "dashboards",
+					Path:     "myfolder/dashboard.json",
+				},
+			},
+		}, nil).Once()
+		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
+		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+
+		require.NoError(t, err)
+		require.Contains(t, filteredDiff, repository.VersionedFileChange{
+			Action: repository.FileActionUpdated, Path: "myfolder/", Ref: "new-ref",
+		})
+		require.Contains(t, filteredDiff, repository.VersionedFileChange{
+			Action: repository.FileActionUpdated, Path: "myfolder/dashboard.json", Ref: "new-ref",
+		})
+		require.Empty(t, replacedFolders)
+	})
+
+	t.Run("invalid metadata creation on new folder still emits folder replay", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
+		}
+
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
+		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
+		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+
+		require.NoError(t, err)
+		require.Equal(t, []repository.VersionedFileChange{
+			{Action: repository.FileActionUpdated, Path: "myfolder/", Ref: "new-ref"},
+		}, filteredDiff)
+		require.Empty(t, replacedFolders)
+	})
+
 	t.Run("does not duplicate synthetic child updates when the real diff already contains them", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
 		repoResources := resources.NewMockRepositoryResources(t)

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -15,47 +15,28 @@ import (
 func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T) {
 	t.Run("returns unchanged diff when no folder metadata changes exist", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "dashboards/test.json", Ref: "new-ref"},
 			{Action: repository.FileActionDeleted, Path: "dashboards/old.json", PreviousRef: "old-ref"},
 		}
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{})
 
 		require.NoError(t, err)
 		require.Equal(t, diff, filteredDiff)
 		require.Empty(t, replacedFolders)
-		repoResources.AssertNotCalled(t, "List", mock.Anything)
-	})
-
-	t.Run("returns an error when listing managed resources fails", func(t *testing.T) {
-		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
-		diff := []repository.VersionedFileChange{
-			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
-		}
-
-		repoResources.On("List", mock.Anything).Return(nil, fmt.Errorf("list failed")).Once()
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
-
-		require.Error(t, err)
-		require.Nil(t, filteredDiff)
-		require.Nil(t, replacedFolders)
-		require.Contains(t, err.Error(), "list managed resources: list failed")
 	})
 
 	t.Run("creates folder replay and direct child updates for metadata creation on existing folder", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 1)
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "hash-uid",
@@ -76,11 +57,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -106,12 +83,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata updates with unchanged uid do not mark the folder as replaced", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 1)
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "stable-uid",
@@ -132,11 +111,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -159,12 +134,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata updates with changed uid mark the folder as replaced", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "new-stable-uid", 1)
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "old-stable-uid",
@@ -185,11 +162,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "new-stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -215,12 +188,16 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("invalid metadata update on existing folder keeps replay without replacement", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "stable-uid",
@@ -235,13 +212,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
-			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
-		}, nil).Twice()
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -257,18 +228,16 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("invalid metadata creation on new folder still emits folder replay", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
 		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
-		}, nil).Twice()
+		}, nil).Once()
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{})
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -281,13 +250,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("does not duplicate synthetic child updates when the real diff already contains them", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 			{Action: repository.FileActionUpdated, Path: "myfolder/dashboard.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 1)
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "hash-uid",
@@ -302,11 +273,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -321,13 +288,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("skips synthetic update for renamed direct child old path", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 			{Action: repository.FileActionRenamed, Path: "myfolder/dashboard-renamed.json", PreviousPath: "myfolder/dashboard.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 1)
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "hash-uid",
@@ -342,11 +311,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -374,12 +339,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("only emits direct children and not grandchildren for metadata creation", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "parent/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		expectFolderMetadataReadTimes(repo, "parent/", "new-ref", "stable-uid", 1)
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "hash-uid",
@@ -406,11 +373,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "parent/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "parent/", "new-ref", "stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -441,16 +404,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("creates folder update replay when metadata is added for a brand-new folder", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "new-folder-uid", 2)
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "new-folder-uid", 1)
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{})
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -461,12 +422,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata deletion while folder remains emits folder update, direct child updates, and replacement", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionDeleted, Path: "myfolder/_folder.json", PreviousRef: "old-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "stable-uid",
@@ -487,11 +450,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -517,12 +476,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata deletion while folder directory is gone only schedules replacement", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionDeleted, Path: "myfolder/_folder.json", PreviousRef: "old-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").
+			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "stable-uid",
@@ -531,12 +493,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/",
 				},
 			},
-		}, nil).Once()
-		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").
-			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Empty(t, filteredDiff)
@@ -548,13 +505,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata deletion with unchanged fallback uid only emits folder update", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionDeleted, Path: "myfolder/_folder.json", PreviousRef: "old-ref"},
 		}
 
 		hashUID := resources.ParseFolder("myfolder/", repo.Config().Name).ID
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     hashUID,
@@ -569,11 +528,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -584,16 +539,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("renamed metadata file with no existing resources emits folder update for new path", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "renamed/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
 		expectFolderMetadataReadTimes(repo, "renamed/", "new-ref", "stable-uid", 1)
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{})
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -841,13 +794,16 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("nested metadata changes are both expanded deterministically", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "parent/_folder.json", Ref: "new-ref"},
 			{Action: repository.FileActionCreated, Path: "parent/child/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		expectFolderMetadataReadTimes(repo, "parent/child/", "new-ref", "child-stable-uid", 1)
+		expectFolderMetadataReadTimes(repo, "parent/", "new-ref", "parent-stable-uid", 1)
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "parent-hash-uid",
@@ -874,12 +830,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "parent/child/dashboard.json",
 				},
 			},
-		}, nil).Once()
-		expectFolderMetadataReadTimes(repo, "parent/child/", "new-ref", "child-stable-uid", 2)
-		expectFolderMetadataReadTimes(repo, "parent/", "new-ref", "parent-stable-uid", 2)
-
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		})
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -558,12 +558,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("renamed metadata file tracks old folder for orphan cleanup when old directory is gone", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "old-uid",
@@ -572,15 +571,16 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "old/",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "old/", "new-ref").
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
 		expectFolderMetadataRead(repo, "new/", "new-ref", "new-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated,
 			Path:   "new/",
@@ -594,12 +594,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("renamed metadata file re-parents children and tracks replacement when old directory still exists", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "old-uid",
@@ -614,15 +613,16 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "old/dashboard.json",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "old/", "new-ref").
 			Return(&repository.FileInfo{Path: "old/"}, nil).Once()
 		expectFolderMetadataRead(repo, "new/", "new-ref", "new-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated,
 			Path:   "new/",
@@ -646,13 +646,12 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("renamed metadata file skips old path cleanup when directory rename already in diff", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "new/", PreviousPath: "old/", PreviousRef: "old-ref", Ref: "new-ref"},
 			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "old-uid",
@@ -661,13 +660,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "old/",
 				},
 			},
-		}, nil).Once()
+		}
 		expectFolderMetadataRead(repo, "new/", "new-ref", "new-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
+		require.Empty(t, replacedFolders)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action:       repository.FileActionRenamed,
 			Path:         "new/",
@@ -683,13 +684,12 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 	})
 	t.Run("nested metadata renames do not emit spurious updates for old child paths", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 			{Action: repository.FileActionRenamed, Path: "new/child/_folder.json", PreviousPath: "old/child/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "parent-uid",
@@ -704,7 +704,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "old/child/",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "old/child/", "new-ref").
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
 		repo.MockReader.On("Read", mock.Anything, "old/", "new-ref").
@@ -712,10 +712,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		expectFolderMetadataRead(repo, "new/child/", "new-ref", "new-child-uid")
 		expectFolderMetadataRead(repo, "new/", "new-ref", "new-parent-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated, Path: "new/", Ref: "new-ref",
 		})
@@ -734,12 +735,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("rename from non-metadata file to _folder.json only emits create at new path", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "team/_folder.json", PreviousPath: "team/config.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "team-uid",
@@ -748,13 +748,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "team/",
 				},
 			},
-		}, nil).Once()
+		}
 		expectFolderMetadataRead(repo, "team/", "new-ref", "team-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated, Path: "team/", Ref: "new-ref",
 		})
@@ -763,12 +764,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("identity-preserving rename does not schedule old UID for deletion", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "stable-uid",
@@ -777,19 +777,53 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "old/",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "old/", "new-ref").
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
 		expectFolderMetadataRead(repo, "new/", "new-ref", "stable-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated, Path: "new/", Ref: "new-ref",
 		})
 		require.Empty(t, replacedFolders, "same UID at old and new path means folder is moved, not replaced")
+	})
+
+	t.Run("directory rename plus invalid renamed metadata only records a warning", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionRenamed, Path: "new/", PreviousPath: "old/", PreviousRef: "old-ref", Ref: "new-ref"},
+			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
+		}
+
+		repo.MockReader.On("Read", mock.Anything, "new/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{
+					Name:     "old-uid",
+					Group:    resources.FolderResource.Group,
+					Resource: resources.FolderResource.Resource,
+					Path:     "old/",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []repository.VersionedFileChange{
+			{Action: repository.FileActionRenamed, Path: "new/", PreviousPath: "old/", PreviousRef: "old-ref", Ref: "new-ref"},
+		}, filteredDiff)
+		require.Empty(t, replacedFolders)
+		require.Len(t, invalidFolderMetadata, 1)
+		require.ErrorIs(t, invalidFolderMetadata[0], resources.ErrInvalidFolderMetadata)
+		require.Equal(t, repository.FileActionRenamed, invalidFolderMetadata[0].Action)
 	})
 
 	t.Run("nested metadata changes are both expanded deterministically", func(t *testing.T) {
@@ -1095,4 +1129,8 @@ func expectFolderMetadataReadTimes(repo *compositeRepo, folderPath, ref, uid str
 	repo.MockReader.On("Read", mock.Anything, folderPath+"_folder.json", ref).Return(&repository.FileInfo{
 		Data: []byte(fmt.Sprintf(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"%s"},"spec":{"title":"Title"}}`, uid)),
 	}, nil).Times(times)
+}
+
+func expectFolderMetadataRead(repo *compositeRepo, folderPath, ref, uid string) {
+	expectFolderMetadataReadTimes(repo, folderPath, ref, uid, 1)
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -22,7 +22,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		}
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Equal(t, diff, filteredDiff)
@@ -40,7 +40,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		repoResources.On("List", mock.Anything).Return(nil, fmt.Errorf("list failed")).Once()
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.Error(t, err)
 		require.Nil(t, filteredDiff)
@@ -77,10 +77,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "stable-uid")
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -133,10 +133,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "stable-uid")
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -186,10 +186,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "new-stable-uid")
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "new-stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -238,10 +238,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		}, nil).Once()
 		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
-		}, nil).Once()
+		}, nil).Twice()
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -251,6 +251,8 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 			Action: repository.FileActionUpdated, Path: "myfolder/dashboard.json", Ref: "new-ref",
 		})
 		require.Empty(t, replacedFolders)
+		require.Len(t, invalidFolderMetadata, 1)
+		require.ErrorIs(t, invalidFolderMetadata[0], resources.ErrInvalidFolderMetadata)
 	})
 
 	t.Run("invalid metadata creation on new folder still emits folder replay", func(t *testing.T) {
@@ -263,16 +265,18 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
 		repo.MockReader.On("Read", mock.Anything, "myfolder/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
-		}, nil).Once()
+		}, nil).Twice()
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "myfolder/", Ref: "new-ref"},
 		}, filteredDiff)
 		require.Empty(t, replacedFolders)
+		require.Len(t, invalidFolderMetadata, 1)
+		require.ErrorIs(t, invalidFolderMetadata[0], resources.ErrInvalidFolderMetadata)
 	})
 
 	t.Run("does not duplicate synthetic child updates when the real diff already contains them", func(t *testing.T) {
@@ -299,10 +303,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "stable-uid")
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -339,10 +343,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "stable-uid")
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -403,10 +407,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "parent/", "new-ref", "stable-uid")
+		expectFolderMetadataReadTimes(repo, "parent/", "new-ref", "stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -443,10 +447,10 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		}
 
 		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
-		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "new-folder-uid")
+		expectFolderMetadataReadTimes(repo, "myfolder/", "new-ref", "new-folder-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -487,7 +491,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -532,7 +536,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Empty(t, filteredDiff)
@@ -569,7 +573,7 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
@@ -586,16 +590,17 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 		}
 
 		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
-		expectFolderMetadataRead(repo, "renamed/", "new-ref", "new-uid")
+		expectFolderMetadataReadTimes(repo, "renamed/", "new-ref", "stable-uid", 1)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Equal(t, []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "renamed/", Ref: "new-ref"},
 		}, filteredDiff)
 		require.Empty(t, replacedFolders)
+		require.Empty(t, invalidFolderMetadata)
 	})
 
 	t.Run("renamed metadata file tracks old folder for orphan cleanup when old directory is gone", func(t *testing.T) {
@@ -870,11 +875,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 				},
 			},
 		}, nil).Once()
-		expectFolderMetadataRead(repo, "parent/child/", "new-ref", "child-stable-uid")
-		expectFolderMetadataRead(repo, "parent/", "new-ref", "parent-stable-uid")
+		expectFolderMetadataReadTimes(repo, "parent/child/", "new-ref", "child-stable-uid", 2)
+		expectFolderMetadataReadTimes(repo, "parent/", "new-ref", "parent-stable-uid", 2)
 
 		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		filteredDiff, replacedFolders, _, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
 
 		require.NoError(t, err)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
@@ -1135,8 +1140,8 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 	})
 }
 
-func expectFolderMetadataRead(repo *compositeRepo, folderPath, ref, uid string) {
+func expectFolderMetadataReadTimes(repo *compositeRepo, folderPath, ref, uid string, times int) {
 	repo.MockReader.On("Read", mock.Anything, folderPath+"_folder.json", ref).Return(&repository.FileInfo{
 		Data: []byte(fmt.Sprintf(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"%s"},"spec":{"title":"Title"}}`, uid)),
-	}, nil).Once()
+	}, nil).Times(times)
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go
@@ -902,12 +902,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata creation with multiple orphans at same path replaces all non-matching UIDs", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionCreated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "orphan-uid-1",
@@ -928,13 +927,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
+		}
 		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "stable-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated,
 			Path:   "myfolder/",
@@ -952,12 +952,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata update with multiple orphans keeps the matching UID and replaces others", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionUpdated, Path: "myfolder/_folder.json", Ref: "new-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "stable-uid",
@@ -972,13 +971,14 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/",
 				},
 			},
-		}, nil).Once()
+		}
 		expectFolderMetadataRead(repo, "myfolder/", "new-ref", "stable-uid")
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated,
 			Path:   "myfolder/",
@@ -989,12 +989,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata deletion with multiple orphans when directory still exists replaces non-fallback UIDs", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionDeleted, Path: "myfolder/_folder.json", PreviousRef: "old-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "orphan-uid-1",
@@ -1015,14 +1014,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").
 			Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated,
 			Path:   "myfolder/",
@@ -1040,12 +1040,11 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata deletion with multiple orphans when directory is gone replaces all", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionDeleted, Path: "myfolder/_folder.json", PreviousRef: "old-ref"},
 		}
 
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     "orphan-uid-1",
@@ -1060,14 +1059,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").
 			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Empty(t, filteredDiff)
 		require.Len(t, replacedFolders, 2)
 		require.Contains(t, replacedFolders, replacedFolder{Path: "myfolder/", OldUID: "orphan-uid-1"})
@@ -1076,13 +1076,12 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 
 	t.Run("metadata deletion with mix of fallback-matching and orphaned UIDs only replaces orphans", func(t *testing.T) {
 		repo := newCompositeRepoWithConfig(t)
-		repoResources := resources.NewMockRepositoryResources(t)
 		diff := []repository.VersionedFileChange{
 			{Action: repository.FileActionDeleted, Path: "myfolder/_folder.json", PreviousRef: "old-ref"},
 		}
 
 		hashUID := resources.ParseFolder("myfolder/", repo.Config().Name).ID
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+		resourcesList := &provisioning.ResourceList{
 			Items: []provisioning.ResourceListItem{
 				{
 					Name:     hashUID,
@@ -1103,14 +1102,15 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 					Path:     "myfolder/dashboard.json",
 				},
 			},
-		}, nil).Once()
+		}
 		repo.MockReader.On("Read", mock.Anything, "myfolder/", "new-ref").
 			Return(&repository.FileInfo{Path: "myfolder/"}, nil).Once()
 
-		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo, repoResources)
-		filteredDiff, replacedFolders, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff)
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, resourcesList)
 
 		require.NoError(t, err)
+		require.Empty(t, invalidFolderMetadata)
 		require.Contains(t, filteredDiff, repository.VersionedFileChange{
 			Action: repository.FileActionUpdated,
 			Path:   "myfolder/",
@@ -1122,6 +1122,40 @@ func TestFolderMetadataIncrementalDiffBuilder_BuildIncrementalDiff(t *testing.T)
 			Ref:    "new-ref",
 		})
 		require.Equal(t, []replacedFolder{{Path: "myfolder/", OldUID: "orphan-uid"}}, replacedFolders)
+	})
+
+	t.Run("file-only invalid renamed metadata emits warning and old-path cleanup", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		diff := []repository.VersionedFileChange{
+			{Action: repository.FileActionRenamed, Path: "new/_folder.json", PreviousPath: "old/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
+		}
+
+		repo.MockReader.On("Read", mock.Anything, "new/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Once()
+		repo.MockReader.On("Read", mock.Anything, "old/", "new-ref").
+			Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
+
+		diffBuilder := NewFolderMetadataIncrementalDiffBuilder(repo)
+		filteredDiff, replacedFolders, invalidFolderMetadata, err := diffBuilder.BuildIncrementalDiff(context.Background(), "new-ref", diff, &provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{
+					Name:     "old-uid",
+					Group:    resources.FolderResource.Group,
+					Resource: resources.FolderResource.Resource,
+					Path:     "old/",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []repository.VersionedFileChange{
+			{Action: repository.FileActionUpdated, Path: "new/", Ref: "new-ref"},
+		}, filteredDiff)
+		require.Equal(t, []replacedFolder{{Path: "old/", OldUID: "old-uid"}}, replacedFolders)
+		require.Len(t, invalidFolderMetadata, 1)
+		require.ErrorIs(t, invalidFolderMetadata[0], resources.ErrInvalidFolderMetadata)
+		require.Equal(t, repository.FileActionRenamed, invalidFolderMetadata[0].Action)
 	})
 }
 

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -48,8 +48,6 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	}
 	compareSpan.End()
 	metrics.RecordIncrementalSyncPhase(jobs.IncrementalSyncPhaseCompare, time.Since(compareStart))
-	originalDiff := slices.Clone(diff)
-
 	if len(diff) < 1 {
 		progress.SetFinalMessage(ctx, "no changes detected between commits")
 		return nil
@@ -64,13 +62,9 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 		}
 
 		folderMetadataIncrementalDiffBuilder := NewFolderMetadataIncrementalDiffBuilder(readerRepo, repositoryResources)
-		diff, replaced, err = folderMetadataIncrementalDiffBuilder.BuildIncrementalDiff(ctx, currentRef, diff)
+		diff, replaced, invalidFolderMetadata, err = folderMetadataIncrementalDiffBuilder.BuildIncrementalDiff(ctx, currentRef, diff)
 		if err != nil {
 			return tracing.Error(span, fmt.Errorf("build folder metadata incremental diff: %w", err))
-		}
-		invalidFolderMetadata, err = collectInvalidFolderMetadata(ctx, readerRepo, currentRef, originalDiff, tracer)
-		if err != nil {
-			return tracing.Error(span, err)
 		}
 		if len(invalidFolderMetadata) > 0 {
 			target, err := repositoryResources.List(ctx)
@@ -431,55 +425,6 @@ func deleteFolders(
 		}
 		progress.Record(ctx, resultBuilder.Build())
 	}
-}
-
-// collectInvalidFolderMetadata reads the original `_folder.json` create/update/rename
-// changes and returns warnings for malformed or incomplete folder metadata.
-//
-// The original git diff is used so the recorded warning action preserves the
-// user's actual change (`created`, `updated`, or `renamed`) instead of the synthetic
-// directory `updated` entries emitted by the incremental diff builder.
-func collectInvalidFolderMetadata(ctx context.Context, repo repository.Reader, currentRef string, diff []repository.VersionedFileChange, tracer tracing.Tracer) ([]*resources.InvalidFolderMetadata, error) {
-	ctx, span := tracer.Start(ctx, "provisioning.sync.incremental.detect_invalid_folder_metadata")
-	defer span.End()
-
-	seen := make(map[string]struct{}, len(diff))
-	invalid := make([]*resources.InvalidFolderMetadata, 0)
-	for _, change := range diff {
-		if change.Action != repository.FileActionCreated &&
-			change.Action != repository.FileActionUpdated &&
-			change.Action != repository.FileActionRenamed {
-			continue
-		}
-		if !resources.IsFolderMetadataFile(change.Path) {
-			continue
-		}
-
-		folderPath := safepath.EnsureTrailingSlash(safepath.Dir(change.Path))
-		if _, ok := seen[folderPath]; ok {
-			continue
-		}
-		seen[folderPath] = struct{}{}
-
-		_, _, err := resources.ReadFolderMetadata(ctx, repo, folderPath, currentRef)
-		if err == nil {
-			continue
-		}
-		if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
-			continue
-		}
-
-		var invalidErr *resources.InvalidFolderMetadata
-		if errors.As(err, &invalidErr) {
-			invalid = append(invalid, invalidErr.WithAction(change.Action))
-			continue
-		}
-
-		span.RecordError(err)
-		return nil, fmt.Errorf("collect invalid folder metadata for %s: %w", folderPath, err)
-	}
-
-	return invalid, nil
 }
 
 // recordInvalidFolderMetadataWarnings writes collected invalid `_folder.json`

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -48,6 +48,7 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	}
 	compareSpan.End()
 	metrics.RecordIncrementalSyncPhase(jobs.IncrementalSyncPhaseCompare, time.Since(compareStart))
+	originalDiff := slices.Clone(diff)
 
 	if len(diff) < 1 {
 		progress.SetFinalMessage(ctx, "no changes detected between commits")
@@ -55,6 +56,7 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	}
 
 	var replaced []replacedFolder
+	var invalidFolderMetadata []*resources.InvalidFolderMetadata
 	if folderMetadataEnabled {
 		readerRepo, ok := repo.(repository.Reader)
 		if !ok {
@@ -65,6 +67,17 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 		diff, replaced, err = folderMetadataIncrementalDiffBuilder.BuildIncrementalDiff(ctx, currentRef, diff)
 		if err != nil {
 			return tracing.Error(span, fmt.Errorf("build folder metadata incremental diff: %w", err))
+		}
+		invalidFolderMetadata, err = collectInvalidFolderMetadata(ctx, readerRepo, currentRef, originalDiff, tracer)
+		if err != nil {
+			return tracing.Error(span, err)
+		}
+		if len(invalidFolderMetadata) > 0 {
+			target, err := repositoryResources.List(ctx)
+			if err != nil {
+				return tracing.Error(span, fmt.Errorf("list managed resources: %w", err))
+			}
+			repositoryResources.SetTree(resources.NewFolderTreeFromResourceList(target))
 		}
 	}
 
@@ -101,6 +114,7 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 	// Run after deleteFolders so its informational warnings (e.g. missing
 	// _folder.json) don't interfere with HasChildPathFailedUpdate safety checks.
 	if folderMetadataEnabled {
+		recordInvalidFolderMetadataWarnings(ctx, invalidFolderMetadata, progress)
 		if err := detectMissingFolderMetadata(ctx, repo, currentRef, diff, progress, tracer); err != nil {
 			return err
 		}
@@ -416,6 +430,70 @@ func deleteFolders(
 			resultBuilder.WithError(fmt.Errorf("delete folder %s: %w", entry.UID, err))
 		}
 		progress.Record(ctx, resultBuilder.Build())
+	}
+}
+
+// collectInvalidFolderMetadata reads the original `_folder.json` create/update/rename
+// changes and returns warnings for malformed or incomplete folder metadata.
+//
+// The original git diff is used so the recorded warning action preserves the
+// user's actual change (`created`, `updated`, or `renamed`) instead of the synthetic
+// directory `updated` entries emitted by the incremental diff builder.
+func collectInvalidFolderMetadata(ctx context.Context, repo repository.Reader, currentRef string, diff []repository.VersionedFileChange, tracer tracing.Tracer) ([]*resources.InvalidFolderMetadata, error) {
+	ctx, span := tracer.Start(ctx, "provisioning.sync.incremental.detect_invalid_folder_metadata")
+	defer span.End()
+
+	seen := make(map[string]struct{}, len(diff))
+	invalid := make([]*resources.InvalidFolderMetadata, 0)
+	for _, change := range diff {
+		if change.Action != repository.FileActionCreated &&
+			change.Action != repository.FileActionUpdated &&
+			change.Action != repository.FileActionRenamed {
+			continue
+		}
+		if !resources.IsFolderMetadataFile(change.Path) {
+			continue
+		}
+
+		folderPath := safepath.EnsureTrailingSlash(safepath.Dir(change.Path))
+		if _, ok := seen[folderPath]; ok {
+			continue
+		}
+		seen[folderPath] = struct{}{}
+
+		_, _, err := resources.ReadFolderMetadata(ctx, repo, folderPath, currentRef)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err) {
+			continue
+		}
+
+		var invalidErr *resources.InvalidFolderMetadata
+		if errors.As(err, &invalidErr) {
+			invalid = append(invalid, invalidErr.WithAction(change.Action))
+			continue
+		}
+
+		span.RecordError(err)
+		return nil, fmt.Errorf("collect invalid folder metadata for %s: %w", folderPath, err)
+	}
+
+	return invalid, nil
+}
+
+// recordInvalidFolderMetadataWarnings writes collected invalid `_folder.json`
+// warnings to job progress after folder cleanup has completed.
+func recordInvalidFolderMetadataWarnings(ctx context.Context, invalid []*resources.InvalidFolderMetadata, progress jobs.JobProgressRecorder) {
+	for _, warning := range invalid {
+		action := warning.Action
+		if action == "" {
+			action = repository.FileActionIgnored
+		}
+		progress.Record(ctx, jobs.NewFolderResult(warning.Path).
+			WithAction(action).
+			WithWarning(warning).
+			Build())
 	}
 }
 

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -65,23 +65,22 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 		if err != nil {
 			return tracing.Error(span, fmt.Errorf("list managed resources: %w", err))
 		}
-		// Incremental sync normally starts with an empty folder tree, but folder
-		// metadata handling needs the current managed path->UID state before apply:
-		// - invalid `_folder.json` falls back to the existing folder at that path
-		// - valid metadata replacements remove old UIDs from that same tree before replay
-		// Seed the tree here, before building the rewritten diff, so both the
-		// builder and the later apply phase reason from the same managed state.
-		repositoryResources.SetTree(resources.NewFolderTreeFromResourceList(target))
 
-		folderMetadataIncrementalDiffBuilder := NewFolderMetadataIncrementalDiffBuilder(readerRepo, repositoryResources)
-		diff, replaced, invalidFolderMetadata, err = folderMetadataIncrementalDiffBuilder.BuildIncrementalDiff(ctx, currentRef, diff)
+		folderMetadataIncrementalDiffBuilder := NewFolderMetadataIncrementalDiffBuilder(readerRepo)
+		diff, replaced, invalidFolderMetadata, err = folderMetadataIncrementalDiffBuilder.BuildIncrementalDiff(ctx, currentRef, diff, target)
 		if err != nil {
 			return tracing.Error(span, fmt.Errorf("build folder metadata incremental diff: %w", err))
 		}
 
+		// Incremental sync normally starts with an empty folder tree, but folder
+		// metadata handling needs the current managed path->UID state before apply:
+		// - invalid `_folder.json` falls back to the existing folder at that path
+		// - valid metadata replacements remove old UIDs from that same tree before replay
+		tree := resources.NewFolderTreeFromResourceList(target)
 		for _, replacedFolder := range replaced {
-			repositoryResources.RemoveFolderFromTree(replacedFolder.OldUID)
+			tree.Remove(replacedFolder.OldUID)
 		}
+		repositoryResources.SetTree(tree)
 	}
 
 	progress.SetTotal(ctx, len(diff))

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -79,10 +79,8 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 			return tracing.Error(span, fmt.Errorf("build folder metadata incremental diff: %w", err))
 		}
 
-		if len(invalidFolderMetadata) > 0 {
-			for _, replacedFolder := range replaced {
-				repositoryResources.RemoveFolderFromTree(replacedFolder.OldUID)
-			}
+		for _, replacedFolder := range replaced {
+			repositoryResources.RemoveFolderFromTree(replacedFolder.OldUID)
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -61,17 +61,28 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 			return tracing.Error(span, fmt.Errorf("folder metadata incremental sync requires repository.Reader"))
 		}
 
+		target, err := repositoryResources.List(ctx)
+		if err != nil {
+			return tracing.Error(span, fmt.Errorf("list managed resources: %w", err))
+		}
+		// Incremental sync normally starts with an empty folder tree, but folder
+		// metadata handling needs the current managed path->UID state before apply:
+		// - invalid `_folder.json` falls back to the existing folder at that path
+		// - valid metadata replacements remove old UIDs from that same tree before replay
+		// Seed the tree here, before building the rewritten diff, so both the
+		// builder and the later apply phase reason from the same managed state.
+		repositoryResources.SetTree(resources.NewFolderTreeFromResourceList(target))
+
 		folderMetadataIncrementalDiffBuilder := NewFolderMetadataIncrementalDiffBuilder(readerRepo, repositoryResources)
 		diff, replaced, invalidFolderMetadata, err = folderMetadataIncrementalDiffBuilder.BuildIncrementalDiff(ctx, currentRef, diff)
 		if err != nil {
 			return tracing.Error(span, fmt.Errorf("build folder metadata incremental diff: %w", err))
 		}
+
 		if len(invalidFolderMetadata) > 0 {
-			target, err := repositoryResources.List(ctx)
-			if err != nil {
-				return tracing.Error(span, fmt.Errorf("list managed resources: %w", err))
+			for _, replacedFolder := range replaced {
+				repositoryResources.RemoveFolderFromTree(replacedFolder.OldUID)
 			}
-			repositoryResources.SetTree(resources.NewFolderTreeFromResourceList(target))
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -1162,11 +1162,11 @@ func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
 			{Action: repository.FileActionCreated, Path: "alpha/_folder.json", Ref: "new-ref"},
 		}
 		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Twice()
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
-		}, nil).Twice()
+		}, nil).Once()
 
 		progress.On("SetTotal", mock.Anything, 1).Return()
 		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
@@ -1207,11 +1207,11 @@ func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
 			Items: []provisioning.ResourceListItem{
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
 			},
-		}, nil).Twice()
+		}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
-		}, nil).Twice()
+		}, nil).Once()
 
 		progress.On("SetTotal", mock.Anything, 1).Return()
 		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
@@ -1254,7 +1254,7 @@ func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
 			Items: []provisioning.ResourceListItem{
 				{Path: "team/", Group: resources.FolderResource.Group, Name: "stable-uid"},
 			},
-		}, nil).Twice()
+		}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
 		repo.MockReader.On("Read", mock.Anything, "moved/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
@@ -1421,9 +1421,8 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
 				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash1", Folder: "stable-uid"},
 			},
-		}, nil).Twice()
+		}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
-		repoResources.On("RemoveFolderFromTree", "stable-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/", "new-ref").Return(&repository.FileInfo{}, nil)
 
@@ -1469,7 +1468,7 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
 
 		// No existing folder — just ensure the deletion is skipped gracefully
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Twice()
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
 
 		progress.On("SetTotal", mock.Anything, mock.Anything).Return()
@@ -1517,9 +1516,8 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "old-alpha-uid"},
 				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash1", Folder: "old-alpha-uid"},
 			},
-		}, nil).Twice()
+		}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
-		repoResources.On("RemoveFolderFromTree", "old-alpha-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-alpha-uid", "Alpha Renamed"),
@@ -1572,9 +1570,8 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "old-uid"},
 				{Path: "alpha/beta", Group: resources.FolderResource.Group, Name: "beta-uid", Folder: "old-uid"},
 			},
-		}, nil).Twice()
+		}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
-		repoResources.On("RemoveFolderFromTree", "old-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-uid", "Alpha"),
@@ -1621,9 +1618,8 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 			Items: []provisioning.ResourceListItem{
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "old-uid"},
 			},
-		}, nil).Twice()
+		}, nil).Once()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
-		repoResources.On("RemoveFolderFromTree", "old-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-uid", "Alpha"),

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -1071,6 +1071,7 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 			},
 		}
 		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		allowFolderTreeSeed(repoResources, &provisioning.ResourceList{})
 		progress.On("SetTotal", mock.Anything, 1).Return()
 		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
@@ -1131,6 +1132,7 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 			},
 		}
 		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		allowFolderTreeSeed(repoResources, &provisioning.ResourceList{})
 		progress.On("SetTotal", mock.Anything, 1).Return()
 		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
@@ -1147,6 +1149,155 @@ func TestIncrementalSync_MissingFolderMetadata(t *testing.T) {
 		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "detect missing folder metadata: read tree failed")
+	})
+}
+
+func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
+	t.Run("created invalid metadata records created warning and still applies fallback folder replay", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		changes := []repository.VersionedFileChange{
+			{Action: repository.FileActionCreated, Path: "alpha/_folder.json", Ref: "new-ref"},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Twice()
+
+		progress.On("SetTotal", mock.Anything, 1).Return()
+		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
+		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
+		progress.On("TooManyErrors").Return(nil)
+		progress.On("HasDirPathFailedCreation", "alpha/").Return(false)
+
+		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/").Return("hash-uid", nil)
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionUpdated && result.Path() == "alpha/" && result.Name() == "hash-uid"
+		})).Return().Once()
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionCreated &&
+				result.Path() == "alpha/" &&
+				result.Warning() != nil &&
+				errors.Is(result.Warning(), resources.ErrInvalidFolderMetadata)
+		})).Return().Once()
+
+		repo.MockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry{
+			{Path: "alpha", Blob: false},
+			{Path: "alpha/_folder.json", Blob: true},
+		}, nil)
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
+	})
+
+	t.Run("updated invalid metadata records updated warning without replacing the folder", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		changes := []repository.VersionedFileChange{
+			{Action: repository.FileActionUpdated, Path: "alpha/_folder.json", Ref: "new-ref"},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Twice()
+
+		progress.On("SetTotal", mock.Anything, 1).Return()
+		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
+		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
+		progress.On("TooManyErrors").Return(nil)
+		progress.On("HasDirPathFailedCreation", "alpha/").Return(false)
+
+		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/").Return("stable-uid", nil)
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionUpdated && result.Path() == "alpha/" && result.Name() == "stable-uid"
+		})).Return().Once()
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionUpdated &&
+				result.Path() == "alpha/" &&
+				result.Warning() != nil &&
+				errors.Is(result.Warning(), resources.ErrInvalidFolderMetadata)
+		})).Return().Once()
+
+		repo.MockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry{
+			{Path: "alpha", Blob: false},
+			{Path: "alpha/_folder.json", Blob: true},
+		}, nil)
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
+		repoResources.AssertNotCalled(t, "RemoveFolder", mock.Anything, mock.Anything)
+	})
+
+	t.Run("renamed invalid metadata records renamed warning and recreates the folder", func(t *testing.T) {
+		repo := newCompositeRepoWithConfig(t)
+		repoResources := resources.NewMockRepositoryResources(t)
+		progress := jobs.NewMockJobProgressRecorder(t)
+
+		changes := []repository.VersionedFileChange{
+			{Action: repository.FileActionRenamed, Path: "moved/", PreviousPath: "team/", PreviousRef: "old-ref", Ref: "new-ref"},
+			{Action: repository.FileActionRenamed, Path: "moved/_folder.json", PreviousPath: "team/_folder.json", PreviousRef: "old-ref", Ref: "new-ref"},
+		}
+		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{
+			Items: []provisioning.ResourceListItem{
+				{Path: "team/", Group: resources.FolderResource.Group, Name: "stable-uid"},
+			},
+		}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repo.MockReader.On("Read", mock.Anything, "moved/_folder.json", "new-ref").Return(&repository.FileInfo{
+			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
+		}, nil).Once()
+		repo.MockReader.On("Read", mock.Anything, "team/", "").Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
+
+		progress.On("SetTotal", mock.Anything, 1).Return()
+		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
+		progress.On("SetMessage", mock.Anything, "versioned changes replicated").Return()
+		progress.On("TooManyErrors").Return(nil)
+		progress.On("HasDirPathFailedCreation", "moved/").Return(false)
+		progress.On("HasDirPathFailedCreation", "team/").Return(false)
+		progress.On("HasDirPathFailedDeletion", "team/").Return(false)
+		progress.On("HasChildPathFailedCreation", "team/").Return(false)
+		progress.On("HasChildPathFailedUpdate", "team/").Return(false)
+
+		repoResources.On("RenameFolderPath", mock.Anything, "team/", "old-ref", "moved/", "new-ref").Return("stable-uid", nil).Once()
+		repoResources.On("RemoveFolder", mock.Anything, "stable-uid").Return(nil).Once()
+
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionRenamed &&
+				result.Path() == "moved/" &&
+				result.Error() == nil
+		})).Return().Once()
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionDeleted &&
+				result.Path() == "team/" &&
+				result.Name() == "stable-uid"
+		})).Return().Once()
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action() == repository.FileActionRenamed &&
+				result.Path() == "moved/" &&
+				result.Warning() != nil &&
+				errors.Is(result.Warning(), resources.ErrInvalidFolderMetadata)
+		})).Return().Once()
+
+		repo.MockReader.On("ReadTree", mock.Anything, "new-ref").Return([]repository.FileTreeEntry{
+			{Path: "moved", Blob: false},
+			{Path: "moved/_folder.json", Blob: true},
+		}, nil)
+
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), newPermissiveMockQuotaTracker(t), true)
+		require.NoError(t, err)
 	})
 }
 
@@ -1710,4 +1861,9 @@ func TestDeduplicateFolderDeletions(t *testing.T) {
 		result := deduplicateFolderDeletions(nil)
 		require.Empty(t, result)
 	})
+}
+
+func allowFolderTreeSeed(repoResources *resources.MockRepositoryResources, target *provisioning.ResourceList) {
+	repoResources.On("List", mock.Anything).Return(target, nil).Maybe()
+	repoResources.On("SetTree", mock.Anything).Return().Maybe()
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -1174,7 +1174,7 @@ func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
 		progress.On("TooManyErrors").Return(nil)
 		progress.On("HasDirPathFailedCreation", "alpha/").Return(false)
 
-		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/").Return("hash-uid", nil)
+		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/", "new-ref").Return("hash-uid", nil)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Action() == repository.FileActionUpdated && result.Path() == "alpha/" && result.Name() == "hash-uid"
 		})).Return().Once()
@@ -1219,7 +1219,7 @@ func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
 		progress.On("TooManyErrors").Return(nil)
 		progress.On("HasDirPathFailedCreation", "alpha/").Return(false)
 
-		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/").Return("stable-uid", nil)
+		repoResources.On("EnsureFolderPathExist", mock.Anything, "alpha/", "new-ref").Return("stable-uid", nil)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Action() == repository.FileActionUpdated && result.Path() == "alpha/" && result.Name() == "stable-uid"
 		})).Return().Once()
@@ -1259,7 +1259,7 @@ func TestIncrementalSync_InvalidFolderMetadata(t *testing.T) {
 		repo.MockReader.On("Read", mock.Anything, "moved/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"Broken"}}`),
 		}, nil).Once()
-		repo.MockReader.On("Read", mock.Anything, "team/", "").Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
+		repo.MockReader.On("Read", mock.Anything, "team/", "new-ref").Return((*repository.FileInfo)(nil), repository.ErrFileNotFound).Once()
 
 		progress.On("SetTotal", mock.Anything, 1).Return()
 		progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -1421,7 +1421,8 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "stable-uid"},
 				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash1", Folder: "stable-uid"},
 			},
-		}, nil)
+		}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/", "new-ref").Return(&repository.FileInfo{}, nil)
 
@@ -1467,7 +1468,8 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 		repo.MockVersioned.On("CompareFiles", mock.Anything, "old-ref", "new-ref").Return(changes, nil)
 
 		// No existing folder — just ensure the deletion is skipped gracefully
-		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil)
+		repoResources.On("List", mock.Anything).Return(&provisioning.ResourceList{}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
 
 		progress.On("SetTotal", mock.Anything, mock.Anything).Return()
 		progress.On("SetMessage", mock.Anything, mock.Anything).Return()
@@ -1514,7 +1516,8 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "old-alpha-uid"},
 				{Path: "alpha/dash.json", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash1", Folder: "old-alpha-uid"},
 			},
-		}, nil)
+		}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-alpha-uid", "Alpha Renamed"),
@@ -1567,7 +1570,8 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "old-uid"},
 				{Path: "alpha/beta", Group: resources.FolderResource.Group, Name: "beta-uid", Folder: "old-uid"},
 			},
-		}, nil)
+		}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-uid", "Alpha"),
@@ -1614,7 +1618,8 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 			Items: []provisioning.ResourceListItem{
 				{Path: "alpha/", Group: resources.FolderResource.Group, Name: "old-uid"},
 			},
-		}, nil)
+		}, nil).Twice()
+		repoResources.On("SetTree", mock.Anything).Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-uid", "Alpha"),

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -1423,6 +1423,7 @@ func TestIncrementalSync_FolderMetadataDeletion(t *testing.T) {
 			},
 		}, nil).Twice()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repoResources.On("RemoveFolderFromTree", "stable-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/", "new-ref").Return(&repository.FileInfo{}, nil)
 
@@ -1518,6 +1519,7 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 			},
 		}, nil).Twice()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repoResources.On("RemoveFolderFromTree", "old-alpha-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-alpha-uid", "Alpha Renamed"),
@@ -1572,6 +1574,7 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 			},
 		}, nil).Twice()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repoResources.On("RemoveFolderFromTree", "old-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-uid", "Alpha"),
@@ -1620,6 +1623,7 @@ func TestIncrementalSync_FolderUIDChange(t *testing.T) {
 			},
 		}, nil).Twice()
 		repoResources.On("SetTree", mock.Anything).Return().Once()
+		repoResources.On("RemoveFolderFromTree", "old-uid").Return().Once()
 
 		repo.MockReader.On("Read", mock.Anything, "alpha/_folder.json", "new-ref").Return(&repository.FileInfo{
 			Data: folderJSON(t, "new-uid", "Alpha"),

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -335,6 +335,12 @@ func (fm *FolderManager) RemoveFolder(ctx context.Context, name string) error {
 // updated in place and an empty string is returned (no cleanup needed).
 // For non-metadata folders the UID changes, so a new folder is created
 // at newPath and the old folder ID is returned for cleanup.
+//
+// Invalid `_folder.json` does not abort the rename. For the old path we fall
+// back to the existing folder in the seeded tree (or to the path-derived UID if
+// there is no tree entry), and for the new path we fall back to the
+// path-derived UID. That gives delete+recreate semantics instead of preserving
+// a metadata-backed identity we can no longer trust.
 func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, previousRef, newPath, newRef string) (string, error) {
 	oldFolder, err := ParseFolderWithMetadata(ctx, fm.repo, previousPath, previousRef, fm.folderMetadataEnabled)
 	if err != nil {
@@ -343,6 +349,9 @@ func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, pre
 			return "", fmt.Errorf("parse old folder: %w", err)
 		}
 
+		// Invalid old metadata means we cannot trust a metadata-backed identity for
+		// the source path. Reuse the seeded-tree entry when available so follow-up
+		// child reconciliation keeps pointing at the currently managed folder.
 		if existing, ok := fm.tree.GetByPath(previousPath); ok {
 			oldFolder = existing
 		} else {
@@ -360,6 +369,10 @@ func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, pre
 		if !errors.As(err, &invalidErr) {
 			return "", fmt.Errorf("parse new folder: %w", err)
 		}
+
+		// Invalid new metadata means the destination cannot claim a stable
+		// metadata-defined UID, so the rename degrades to the normal path-derived
+		// folder identity at newPath.
 		newFolder = ParseFolder(newPath, fm.repo.Config().Name)
 	}
 

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -338,7 +338,16 @@ func (fm *FolderManager) RemoveFolder(ctx context.Context, name string) error {
 func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, previousRef, newPath, newRef string) (string, error) {
 	oldFolder, err := ParseFolderWithMetadata(ctx, fm.repo, previousPath, previousRef, fm.folderMetadataEnabled)
 	if err != nil {
-		return "", fmt.Errorf("parse old folder: %w", err)
+		var invalidErr *InvalidFolderMetadata
+		if !errors.As(err, &invalidErr) {
+			return "", fmt.Errorf("parse old folder: %w", err)
+		}
+
+		if existing, ok := fm.tree.GetByPath(previousPath); ok {
+			oldFolder = existing
+		} else {
+			oldFolder = ParseFolder(previousPath, fm.repo.Config().Name)
+		}
 	}
 
 	if _, err := fm.EnsureFolderPathExist(ctx, newPath, newRef); err != nil {
@@ -347,7 +356,11 @@ func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, pre
 
 	newFolder, err := ParseFolderWithMetadata(ctx, fm.repo, newPath, newRef, fm.folderMetadataEnabled)
 	if err != nil {
-		return "", fmt.Errorf("parse new folder: %w", err)
+		var invalidErr *InvalidFolderMetadata
+		if !errors.As(err, &invalidErr) {
+			return "", fmt.Errorf("parse new folder: %w", err)
+		}
+		newFolder = ParseFolder(newPath, fm.repo.Config().Name)
 	}
 
 	if oldFolder.ID == newFolder.ID {

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
@@ -142,6 +142,117 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		})
 	})
 
+	t.Run("follow-up child update under already-invalid metadata keeps the existing stable uid", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-follow-up-child"
+		const stableUID = "team-stable-uid"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"team/_folder.json":   folderMetadataJSON(stableUID, "Team"),
+			"team/dashboard.json": gitcommon.DashboardJSON("team-dash", "Team Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "break folder metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionUpdated)
+
+		require.NoError(t, local.CreateFile("team/dashboard.json", string(gitcommon.DashboardJSON("team-dash", "Team Dashboard Follow-up", 2))))
+		_, err = local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "update child under already-invalid metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job = helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj = &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State)
+
+		common.RequireRepoFolderUID(t, helper.FoldersV1, ctx, repoName, stableUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", stableUID)
+		gitcommon.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"team-dash": {Title: "Team Dashboard Follow-up", SourcePath: "team/dashboard.json", Folder: stableUID},
+		})
+	})
+
+	t.Run("invalid metadata creation on existing folder does not break valid folder meta creation on another folder in the same incremental sync", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-with-valid-replaced"
+		const parentStableUID = "parent-stable-uid"
+		const childUID = "child-stable-uid"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"broken/dashboard.json":         gitcommon.DashboardJSON("broken-dash", "Broken Dashboard", 1),
+			"parent/child/_folder.json":     folderMetadataJSON(childUID, "Child"),
+			"parent/child/dashboard.json":   gitcommon.DashboardJSON("child-dash", "Child Dashboard", 1),
+			"parent/child/second-dash.json": gitcommon.DashboardJSON("child-dash-2", "Child Dashboard Two", 1),
+		})
+
+		common.SyncAndWaitWithWarning(t, helper, repoName)
+
+		oldBrokenUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "broken")
+		oldParentUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "parent")
+		require.NotEqual(t, parentStableUID, oldParentUID, "parent should start with an unstable uid")
+		common.RequireFolderState(t, helper.FoldersV1, childUID, "Child", "parent/child", oldParentUID)
+
+		require.NoError(t, local.CreateFile("broken/_folder.json", string(invalidFolderMetadataJSON("Broken Folder"))))
+		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON(parentStableUID, "Parent"))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "mix invalid metadata with valid parent replacement")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "broken/", repository.FileActionCreated)
+
+		common.RequireRepoFolderUID(t, helper.FoldersV1, ctx, repoName, parentStableUID)
+		common.RequireFolderState(t, helper.FoldersV1, childUID, "Child", "parent/child", parentStableUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "parent/child/dashboard.json", childUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "parent/child/second-dash.json", childUID)
+
+		_, err = helper.FoldersV1.Resource.Get(ctx, oldParentUID, metav1.GetOptions{})
+		require.Error(t, err)
+		require.True(t, apierrors.IsNotFound(err), "old unstable parent folder should be deleted")
+
+		common.RequireRepoFolderUID(t, helper.FoldersV1, ctx, repoName, oldBrokenUID)
+	})
+
 	t.Run("moving a resource into an existing folder with invalid metadata still works", func(t *testing.T) {
 		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
@@ -266,6 +377,56 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "moved/dashboard.json", newUID)
 		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 			"team-dash": {Title: "Team Dashboard", SourcePath: "moved/dashboard.json", Folder: newUID},
+		})
+	})
+
+	t.Run("invalid metadata creation does not break valid metadata-backed folder rename in the same incremental sync", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-with-valid-rename"
+		const parentStableUID = "parent-stable-uid"
+		const childUID = "child-stable-uid"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"old-parent/_folder.json":         folderMetadataJSON(parentStableUID, "Parent"),
+			"old-parent/child/_folder.json":   folderMetadataJSON(childUID, "Child"),
+			"old-parent/child/dashboard.json": gitcommon.DashboardJSON("child-dash", "Child Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		common.RequireFolderState(t, helper.FoldersV1, parentStableUID, "Parent", "old-parent", "")
+		common.RequireFolderState(t, helper.FoldersV1, childUID, "Child", "old-parent/child", parentStableUID)
+
+		require.NoError(t, local.CreateFile("broken/_folder.json", string(invalidFolderMetadataJSON("Broken Folder"))))
+		require.NoError(t, local.CreateFile("broken/dashboard.json", string(gitcommon.DashboardJSON("broken-dash", "Broken Dashboard", 1))))
+		_, err := local.Git("mv", "old-parent", "new-parent")
+		require.NoError(t, err)
+		_, err = local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "mix invalid metadata with valid folder rename")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "broken/", repository.FileActionCreated)
+
+		common.RequireFolderState(t, helper.FoldersV1, parentStableUID, "Parent", "new-parent", "")
+		common.RequireFolderState(t, helper.FoldersV1, childUID, "Child", "new-parent/child", parentStableUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "new-parent/child/dashboard.json", childUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"broken-dash": {Title: "Broken Dashboard", SourcePath: "broken/dashboard.json", Folder: common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "broken")},
+			"child-dash":  {Title: "Child Dashboard", SourcePath: "new-parent/child/dashboard.json", Folder: childUID},
 		})
 	})
 }

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
@@ -1,0 +1,296 @@
+package foldermetadataincremental
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	t.Run("invalid metadata creation on existing folder keeps unstable uid and reconciles changed child", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-existing"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"team/dashboard.json": gitcommon.DashboardJSON("team-dash", "Team Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithWarning(t, helper, repoName)
+		oldUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "team")
+
+		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
+		require.NoError(t, local.CreateFile("team/dashboard.json", string(gitcommon.DashboardJSON("team-dash", "Team Dashboard Updated", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add invalid folder metadata to existing folder")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionCreated)
+
+		common.RequireRepoFolderUID(t, helper.FoldersV1, ctx, repoName, oldUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", oldUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"team-dash": {Title: "Team Dashboard Updated", SourcePath: "team/dashboard.json", Folder: oldUID},
+		})
+	})
+
+	t.Run("invalid metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-new"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"root.json": gitcommon.DashboardJSON("root-dash", "Root Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
+		require.NoError(t, local.CreateFile("team/dashboard.json", string(gitcommon.DashboardJSON("team-dash", "Team Dashboard", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "add new folder with invalid metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionCreated)
+
+		folderUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "team")
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", folderUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"root-dash": {Title: "Root Dashboard", SourcePath: "root.json"},
+			"team-dash": {Title: "Team Dashboard", SourcePath: "team/dashboard.json", Folder: folderUID},
+		})
+	})
+
+	t.Run("invalid metadata update on stable folder keeps stable uid and reconciles changed child", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-update"
+		const stableUID = "team-stable-uid"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"team/_folder.json":   folderMetadataJSON(stableUID, "Team"),
+			"team/dashboard.json": gitcommon.DashboardJSON("team-dash", "Team Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
+		require.NoError(t, local.CreateFile("team/dashboard.json", string(gitcommon.DashboardJSON("team-dash", "Team Dashboard Updated", 1))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "break existing folder metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionUpdated)
+
+		common.RequireRepoFolderUID(t, helper.FoldersV1, ctx, repoName, stableUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", stableUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"team-dash": {Title: "Team Dashboard Updated", SourcePath: "team/dashboard.json", Folder: stableUID},
+		})
+	})
+
+	t.Run("moving a resource into an existing folder with invalid metadata still works", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-move-into-existing"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"team/_folder.json": invalidFolderMetadataJSON("Broken Team"),
+			"root.json":         gitcommon.DashboardJSON("root-dash", "Root Dashboard", 1),
+		})
+
+		helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		folderUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "team")
+
+		_, err := local.Git("mv", "root.json", "team/root.json")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move dashboard into existing invalid folder")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/root.json", folderUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"root-dash": {Title: "Root Dashboard", SourcePath: "team/root.json", Folder: folderUID},
+		})
+	})
+
+	t.Run("moving a resource into a new folder with invalid metadata falls back to unstable uid", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-move-into-new"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"root.json": gitcommon.DashboardJSON("root-dash", "Root Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
+		_, err := local.Git("mv", "root.json", "team/")
+		require.NoError(t, err)
+		_, err = local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move dashboard into new invalid folder")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionCreated)
+
+		folderUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "team")
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/root.json", folderUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"root-dash": {Title: "Root Dashboard", SourcePath: "team/root.json", Folder: folderUID},
+		})
+	})
+
+	t.Run("moving a folder with invalid metadata falls back to delete and recreate", func(t *testing.T) {
+		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		ctx := context.Background()
+
+		const repoName = "incr-invalid-meta-folder-move"
+		const stableUID = "team-stable-uid"
+
+		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+			"team/_folder.json":   folderMetadataJSON(stableUID, "Team"),
+			"team/dashboard.json": gitcommon.DashboardJSON("team-dash", "Team Dashboard", 1),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		_, err := local.Git("mv", "team", "moved")
+		require.NoError(t, err)
+		require.NoError(t, local.CreateFile("moved/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
+		_, err = local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move folder with invalid metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
+
+		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Empty(t, jobObj.Status.Errors)
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+		requireInvalidFolderMetadataWarning(t, jobObj, "moved/", repository.FileActionCreated)
+
+		_, err = helper.FoldersV1.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		require.Error(t, err)
+		require.True(t, apierrors.IsNotFound(err))
+
+		newUID := common.RequireRepoFolderTitle(t, helper.FoldersV1, ctx, repoName, "moved")
+		require.NotEqual(t, stableUID, newUID)
+
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "moved/dashboard.json", newUID)
+		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+			"team-dash": {Title: "Team Dashboard", SourcePath: "moved/dashboard.json", Folder: newUID},
+		})
+	})
+}
+
+func invalidFolderMetadataJSON(title string) []byte {
+	folder := map[string]any{
+		"apiVersion": "folder.grafana.app/v1beta1",
+		"kind":       "Folder",
+		"metadata":   map[string]any{},
+		"spec": map[string]any{
+			"title": title,
+		},
+	}
+	data, _ := json.MarshalIndent(folder, "", "\t")
+	return data
+}
+
+func requireInvalidFolderMetadataWarning(t *testing.T, jobObj *provisioning.Job, path string, action repository.FileAction) {
+	t.Helper()
+	for _, warning := range jobObj.Status.Warnings {
+		if strings.Contains(warning, "invalid folder metadata") &&
+			strings.Contains(warning, path) &&
+			strings.Contains(warning, "action: "+string(action)) {
+			return
+		}
+	}
+	t.Fatalf("expected invalid folder metadata warning for %q with action %q, got: %v", path, action, jobObj.Status.Warnings)
+}


### PR DESCRIPTION
## What

This PR makes incremental sync tolerate invalid `_folder.json` files instead of failing folder reconciliation.

This work is partially based on the full-sync behavior introduced in https://github.com/grafana/grafana/pull/120882, adapted to the incremental diff/replay flow.

Incremental sync now reacts to malformed or incomplete folder metadata during folder-metadata create/update flows. In particular:
- existing folders with invalid `_folder.json` keep their current UID and continue to reconcile child resources
- new folders with invalid `_folder.json` fall back to the path-derived unstable UID and still reconcile their children
- invalid folder metadata is surfaced to the user as a warning in the sync job
- moving resources into folders with invalid metadata is supported
- moving a folder with invalid metadata falls back to delete+recreate semantics, so the folder transitions from its previous stable metadata-backed UID to a new unstable path-derived UID at the destination

This PR fixes https://github.com/grafana/git-ui-sync-project/issues/1016.

## Why

Before this change, incremental sync was too brittle around invalid folder metadata:
- malformed or incomplete `_folder.json` could abort folder metadata handling
- child resources under folders with invalid metadata could fail to reconcile
- incremental rename flows involving invalid folder metadata were not handled consistently
- warnings shown to users did not reflect the actual action being taken during sync

This change makes incremental sync degrade safely:
- folder identity falls back to the current or path-derived UID when metadata is invalid
- resource reconciliation continues whenever possible
- sync jobs surface clear warnings instead of failing outright

## Diff summary

### Incremental metadata diff handling
- `pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go`
  - tolerates invalid `_folder.json` during create/update rewrites
  - keeps replaying folder/resource diffs without scheduling replacement when metadata is invalid
  - treats metadata-file renames as owned by the directory rename flow instead of replaying them separately

- `pkg/registry/apis/provisioning/jobs/sync/folder_metadata_diff_split.go`
  - recognizes `_folder.json` renames as handled metadata actions so the builder can suppress the raw metadata-file rename entry

### Incremental sync behavior
- `pkg/registry/apis/provisioning/jobs/sync/incremental.go`
  - collects invalid folder metadata warnings from the original git diff
  - records action-aware warnings in progress results (`created`, `updated`, or `renamed` where applicable)
  - preserves the rewritten incremental diff flow for folder metadata handling

### Folder resolution during invalid metadata
- `pkg/registry/apis/provisioning/resources/folders.go`
  - extends incremental folder rename handling so invalid metadata can still fall back safely:
    - moving resources into invalid-metadata folders works
    - moving folders with invalid metadata uses delete+recreate semantics

### Test coverage
- `pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff_test.go`
  - covers invalid metadata during incremental diff rewriting
  - covers suppression of metadata-file rename entries

- `pkg/registry/apis/provisioning/jobs/sync/incremental_test.go`
  - covers action-aware invalid metadata warnings in incremental sync
  - covers renamed invalid metadata fallback behavior

- `pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go`
  - adds end-to-end incremental coverage for:
    - invalid metadata on existing folders
    - invalid metadata on new folders
    - invalid metadata updates on stable folders
    - moving resources into existing/new folders with invalid metadata
    - moving folders with invalid metadata using delete+recreate semantics

## Scope

This PR is about **incremental sync** behavior when `_folder.json` is invalid.

It does not change full sync behavior.

## Testing

- `go test ./pkg/registry/apis/provisioning/jobs/sync/...`
- `go test -tags=enterprise ./pkg/tests/apis/provisioning/git/foldermetadata_incremental/... -run 'TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata/moving_a_resource_into_an_existing_folder_with_invalid_metadata_still_works$'`
- `go test -tags=enterprise ./pkg/tests/apis/provisioning/git/foldermetadata_incremental/... -run 'TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata/moving_a_resource_into_a_new_folder_with_invalid_metadata_falls_back_to_unstable_uid$'`
- `go test -tags=enterprise ./pkg/tests/apis/provisioning/git/foldermetadata_incremental/... -run 'TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata/moving_a_folder_with_invalid_metadata_falls_back_to_delete_and_recreate$'`
