### PR TITLE
OAuth: add wildcard matching in org mapping

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -165,7 +165,7 @@ func (s *SocialAzureAD) UserInfo(ctx context.Context, client *http.Client, token
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -364,7 +364,7 @@ func (s *SocialGenericOAuth) extractUserGroups(userInfo *social.BasicUserInfo, d
 // postProcessUserInfo handles post-processing of user info (org roles, private email, etc.)
 func (s *SocialGenericOAuth) postProcessUserInfo(ctx context.Context, client *http.Client, userInfo *social.BasicUserInfo, externalOrgs []string) error {
 	if !s.info.SkipOrgRoleSync {
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, userInfo.Role)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, userInfo.Role)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -353,7 +353,7 @@ func (s *SocialGithub) UserInfo(ctx context.Context, client *http.Client, token 
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/gitlab_oauth.go
+++ b/pkg/login/social/connectors/gitlab_oauth.go
@@ -224,7 +224,7 @@ func (s *SocialGitlab) UserInfo(ctx context.Context, client *http.Client, token 
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -178,7 +178,7 @@ func (s *SocialGoogle) UserInfo(ctx context.Context, client *http.Client, token 
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/grafana_com_oauth.go
+++ b/pkg/login/social/connectors/grafana_com_oauth.go
@@ -163,7 +163,7 @@ func (s *SocialGrafanaCom) UserInfo(ctx context.Context, client *http.Client, _ 
 	}
 
 	if !s.info.SkipOrgRoleSync {
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), nil, identity.RoleType(data.Role))
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), nil, identity.RoleType(data.Role))
 	}
 
 	if !s.isOrganizationMember(data.Orgs) {

--- a/pkg/login/social/connectors/okta_oauth.go
+++ b/pkg/login/social/connectors/okta_oauth.go
@@ -194,7 +194,7 @@ func (s *SocialOkta) UserInfo(ctx context.Context, client *http.Client, token *o
 			return nil, err
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,17 +27,39 @@ type OrgRoleMapper struct {
 	orgService org.Service
 }
 
+// WildcardMapping represents a dynamic (that is, potentially containing a glob wildcard) org mapping that will not be
+// resolved during the ParseOrgMappingSettings, but during MapOrgRoles when actual external orgs from the JWT are
+// supplied.
+type WildcardMapping struct {
+	externalPattern string
+	internalPattern string
+	role            org.RoleType
+}
+
 // MappingConfiguration represents the mapping configuration from external orgs to Grafana orgs and roles.
-// orgMapping: mapping from external orgs to Grafana orgs and roles
+// orgMapping: static mapping from external orgs to Grafana orgs and roles
+// wildcardMappings: list of dynamic mappings to be resolved once an input value is supplied
 // strictRoleMapping: if true, the mapper ensures that the evaluated role from orgMapping or the directlyMappedRole is a valid role, otherwise it will return nil.
+// The MappingConfiguration could theoretically handle both static and dynamic (with wildcard) resolutions.
+// In practice, it only does one or the other depending on a configuration setting.
 type MappingConfiguration struct {
 	orgMapping        map[string]map[int64]org.RoleType
+	wildcardMappings  []WildcardMapping
 	strictRoleMapping bool
 }
 
 func NewMappingConfiguration(orgMapping map[string]map[int64]org.RoleType, strictRoleMapping bool) MappingConfiguration {
 	return MappingConfiguration{
 		orgMapping,
+		[]WildcardMapping{},
+		strictRoleMapping,
+	}
+}
+
+func NewDynamicMappingConfiguration(wildcardMappings []WildcardMapping, strictRoleMapping bool) MappingConfiguration {
+	return MappingConfiguration{
+		map[string]map[int64]org.RoleType{},
+		wildcardMappings,
 		strictRoleMapping,
 	}
 }
@@ -57,16 +80,24 @@ func ProvideOrgRoleMapper(cfg *setting.Cfg, orgService org.Service) *OrgRoleMapp
 //
 // directlyMappedRole: role that is directly mapped to the user (ex: through `role_attribute_path`)
 func (m *OrgRoleMapper) MapOrgRoles(
+	ctx context.Context,
 	mappingCfg MappingConfiguration,
 	externalOrgs []string,
 	directlyMappedRole org.RoleType,
 ) map[int64]org.RoleType {
-	if len(mappingCfg.orgMapping) == 0 {
+	if len(mappingCfg.orgMapping) == 0 && len(mappingCfg.wildcardMappings) == 0 {
 		// Org mapping is not configured
 		return m.getDefaultOrgMapping(mappingCfg.strictRoleMapping, directlyMappedRole)
 	}
 
 	userOrgRoles := getMappedOrgRoles(externalOrgs, mappingCfg.orgMapping)
+	if userOrgRoles == nil {
+		userOrgRoles = map[int64]org.RoleType{}
+	}
+	for _, externalOrg := range externalOrgs {
+		additionalOrgRoles := m.resolveWildcardMappings(ctx, externalOrg, mappingCfg)
+		maps.Copy(userOrgRoles, additionalOrgRoles)
+	}
 
 	if err := m.handleGlobalOrgMapping(userOrgRoles); err != nil {
 		// Cannot map global org roles, return nil (prevent resetting asignments)
@@ -90,6 +121,25 @@ func (m *OrgRoleMapper) MapOrgRoles(
 	}
 
 	return userOrgRoles
+}
+
+func (m *OrgRoleMapper) resolveWildcardMappings(ctx context.Context, externalOrg string, mappingConfiguration MappingConfiguration) map[int64]org.RoleType {
+	orgRoles := make(map[int64]org.RoleType, 0)
+	for _, mapping := range mappingConfiguration.wildcardMappings {
+		found, internalOrg := getMappedOrgByWildcardMatch(mapping.externalPattern, mapping.internalPattern, externalOrg)
+		if found {
+			orgId, err := m.getOrgIDForInternalMapping(ctx, internalOrg)
+			if err != nil {
+				m.logger.Warn("Could not fetch OrgID. Skipping.", "err", err, "org", internalOrg)
+				if mappingConfiguration.strictRoleMapping {
+					return map[int64]org.RoleType{}
+				}
+				continue
+			}
+			orgRoles[int64(orgId)] = mapping.role
+		}
+	}
+	return orgRoles
 }
 
 func (m *OrgRoleMapper) getDefaultOrgMapping(strictRoleMapping bool, directlyMappedRole org.RoleType) map[int64]org.RoleType {
@@ -137,9 +187,12 @@ func (m *OrgRoleMapper) handleGlobalOrgMapping(orgRoles map[int64]org.RoleType) 
 
 // ParseOrgMappingSettings parses the `org_mapping` setting and returns an internal representation of the mapping.
 // If the roleStrict is enabled, the mapping should contain a valid role for each org.
+// The resulting MappingConfiguration could theoretically handle both static and dynamic (by glob) resolutions.
+// In practice, it only does one or the other depending on a configuration setting.
 // FIXME: Consider introducing a struct to represent the org mapping settings
 func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []string, roleStrict bool) MappingConfiguration {
-	res := map[string]map[int64]org.RoleType{}
+	orgMapping := map[string]map[int64]org.RoleType{}
+	wildcardMappings := []WildcardMapping{}
 
 	for _, v := range mappings {
 		kv := splitOrgMapping(v)
@@ -149,6 +202,25 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 				// Return empty mapping if the mapping format is invalied and roleStrict is enabled
 				return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
 			}
+			continue
+		}
+
+		if roleStrict && (len(kv) < 3 || !org.RoleType(kv[2]).IsValid()) {
+			// Return empty mapping if at least one org mapping is invalid (missing role, invalid role)
+			m.logger.Warn("Skipping org mapping due to missing or invalid role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", v))
+			return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
+		}
+		role := getRoleForInternalOrgMapping(kv)
+
+		if m.cfg.JWTAuth.AllowWildcardInOrgMapping {
+			// We will only be able to resolve the information
+			// during the actual mapping, so we just store the parsed mapping
+			// and move on
+			wildcardMappings = append(wildcardMappings, WildcardMapping{
+				externalPattern: kv[0],
+				internalPattern: kv[1],
+				role:            role,
+			})
 			continue
 		}
 
@@ -162,21 +234,19 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 			continue
 		}
 
-		if roleStrict && (len(kv) < 3 || !org.RoleType(kv[2]).IsValid()) {
-			// Return empty mapping if at least one org mapping is invalid (missing role, invalid role)
-			m.logger.Warn("Skipping org mapping due to missing or invalid role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", v))
-			return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
-		}
-
 		orga := kv[0]
-		if res[orga] == nil {
-			res[orga] = map[int64]org.RoleType{}
+		if orgMapping[orga] == nil {
+			orgMapping[orga] = map[int64]org.RoleType{}
 		}
 
-		res[orga][int64(orgID)] = getRoleForInternalOrgMapping(kv)
+		orgMapping[orga][int64(orgID)] = role
 	}
 
-	return NewMappingConfiguration(res, roleStrict)
+	return MappingConfiguration{
+		orgMapping:        orgMapping,
+		wildcardMappings:  wildcardMappings,
+		strictRoleMapping: roleStrict,
+	}
 }
 
 func (m *OrgRoleMapper) getOrgIDForInternalMapping(ctx context.Context, orgIdCfg string) (int, error) {
@@ -260,9 +330,7 @@ func getMappedOrgRoles(externalOrgs []string, orgMapping map[string]map[int64]or
 	}
 
 	if orgRoles, ok := orgMapping["*"]; ok {
-		for orgID, role := range orgRoles {
-			userOrgRoles[orgID] = role
-		}
+		maps.Copy(userOrgRoles, orgRoles)
 	}
 
 	for _, org := range externalOrgs {
@@ -289,4 +357,47 @@ func getTopRole(currRole org.RoleType, otherRole org.RoleType) org.RoleType {
 	}
 
 	return otherRole
+}
+
+// getMappedOrgByWildcardMatch performs a mapping from src to dst, allowing a single wildcard.
+// The value matched by src's wildcard is substituted into dst's wildcard position.
+// If neither src nor dst have a wildcard, the function simply returns dst.
+// If only src contains a wildcard, the function will return src if input matches the internal pattern.
+// If only dst contains a wildcard, the match will always fail.
+// FIXME: We could imagine supporting the last case, but that would require reworking the store to be able to search
+// on more generic LIKE patterns, and right now it can only handle prefix match.
+//
+// Examples:
+//
+// getMappedOrgByWildcardMatch("*_admin", "*", "foo_admin")                  => true, "foo"
+// getMappedOrgByWildcardMatch("team_*", "grafana_*", "team_dev")            => true, "grafana_dev"
+// getMappedOrgByWildcardMatch("*_admin", "*", "foo_other")                  => false, ""
+// getMappedOrgByWildcardMatch("*_admin", "internalOrg", "foo_admin")        => true, "internalOrg"
+func getMappedOrgByWildcardMatch(src, dst, input string) (bool, string) {
+	srcPrefix, srcSuffix, srcHasStar := strings.Cut(src, "*")
+	dstPrefix, dstSuffix, dstHasStar := strings.Cut(dst, "*")
+
+	if !srcHasStar && !dstHasStar {
+		return true, dst
+	}
+
+	if !srcHasStar {
+		return false, ""
+	}
+
+	// Poor man's glob match: we sucessively cut the prefix and the suffix from the input
+	// to get the captured match in-between, checking each time we managed to do so.
+	rest, matchesPrefix := strings.CutPrefix(input, srcPrefix)
+	if !matchesPrefix {
+		return false, ""
+	}
+	capture, matchesSuffix := strings.CutSuffix(rest, srcSuffix)
+	if !matchesSuffix {
+		return false, ""
+	}
+
+	if !dstHasStar {
+		return true, dst
+	}
+	return true, dstPrefix + capture + dstSuffix
 }

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -14,13 +14,14 @@ import (
 
 func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 	testCases := []struct {
-		name               string
-		externalOrgs       []string
-		orgMappingSettings []string
-		directlyMappedRole org.RoleType
-		strictRoleMapping  bool
-		getAllOrgsError    error
-		expected           map[int64]org.RoleType
+		name                      string
+		externalOrgs              []string
+		orgMappingSettings        []string
+		directlyMappedRole        org.RoleType
+		strictRoleMapping         bool
+		AllowWildcardInOrgMapping bool
+		getAllOrgsError           error
+		expected                  map[int64]org.RoleType
 	}{
 		{
 			name:               "should return the default mapping when no org mapping settings are provided and directly mapped role is not set",
@@ -177,11 +178,12 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 			expected:           map[int64]org.RoleType{1: org.RoleAdmin, 2: org.RoleAdmin},
 		},
 		{
-			name:               "should map correctly and respect the mapping precedence when multiple org mappings are provided for the same org",
-			externalOrgs:       []string{"First"},
-			orgMappingSettings: []string{"First:1:Editor", "First:1:Viewer"},
-			directlyMappedRole: "",
-			expected:           map[int64]org.RoleType{1: org.RoleViewer},
+			name:                      "should map correctly and respect the mapping precedence when multiple org mappings are provided for the same org",
+			externalOrgs:              []string{"First"},
+			orgMappingSettings:        []string{"First:1:Editor", "First:1:Viewer"},
+			directlyMappedRole:        "",
+			AllowWildcardInOrgMapping: true,
+			expected:                  map[int64]org.RoleType{1: org.RoleViewer},
 		},
 		{
 			name:               "should map to all organizations when global org mapping is provided and the directly mapped role is higher than the role found in the org mappings",
@@ -197,6 +199,16 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 			getAllOrgsError:    assert.AnError,
 			directlyMappedRole: org.RoleAdmin,
 			expected:           nil,
+		},
+		// MapOrgRoles immediately resolves wildcard mappings into static ones, so all behavior for them applies
+		// Besides a smoke test, most of the testing resides with resolveWildcardMappings.
+		{
+			name:                      "should map to all organizations matching the wildcard",
+			externalOrgs:              []string{"First_viewer", "Second_edit", "3_Admin", "Fourth_Frobulator"},
+			orgMappingSettings:        []string{"*_viewer:*:Viewer", "*_edit:*:Editor", "*_Admin:*:Admin"},
+			directlyMappedRole:        "",
+			AllowWildcardInOrgMapping: true,
+			expected:                  map[int64]org.RoleType{1: org.RoleViewer, 2: org.RoleEditor, 3: org.RoleAdmin},
 		},
 	}
 	orgService := orgtest.NewOrgServiceFake()
@@ -217,8 +229,9 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 					{Name: "Third", ID: 3},
 				}
 			}
+			cfg.JWTAuth.AllowWildcardInOrgMapping = tc.AllowWildcardInOrgMapping
 			mappingCfg := mapper.ParseOrgMappingSettings(context.Background(), tc.orgMappingSettings, tc.strictRoleMapping)
-			actual := mapper.MapOrgRoles(mappingCfg, tc.externalOrgs, tc.directlyMappedRole)
+			actual := mapper.MapOrgRoles(context.Background(), mappingCfg, tc.externalOrgs, tc.directlyMappedRole)
 
 			assert.EqualValues(t, tc.expected, actual)
 		})
@@ -233,7 +246,7 @@ func TestOrgRoleMapper_MapOrgRoles_ReturnsDefaultOnNilMapping(t *testing.T) {
 	cfg.AutoAssignOrgRole = string(org.RoleViewer)
 	mapper := ProvideOrgRoleMapper(cfg, orgService)
 
-	actual := mapper.MapOrgRoles(NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), []string{"First"}, org.RoleNone)
+	actual := mapper.MapOrgRoles(context.Background(), NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), []string{"First"}, org.RoleNone)
 
 	assert.EqualValues(t, map[int64]org.RoleType{2: org.RoleNone}, actual)
 }
@@ -351,6 +364,172 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 			actual := mapper.ParseOrgMappingSettings(context.Background(), tc.rawMapping, tc.roleStrict)
 
 			assert.EqualValues(t, tc.expected, actual)
+		})
+	}
+}
+
+// Since the AllowWildcardInOrgMapping flag changes the behaviour by deferring lookup, we test it separately
+func TestOrgRoleMapper_ParseOrgMappingSettings_WithAllowWildcardInOrgMapping(t *testing.T) {
+	testCases := []struct {
+		name       string
+		rawMapping []string
+		roleStrict bool
+		expected   MappingConfiguration
+	}{
+		{
+			name:       "should store the parsed mapping for latter resolution",
+			rawMapping: []string{"First:1:Editor", "*_admin:*:Admin", "team_*_viewer:org_*:Viewer"},
+			roleStrict: true,
+			expected: NewDynamicMappingConfiguration([]WildcardMapping{
+				{
+					externalPattern: "First",
+					internalPattern: "1",
+					role:            "Editor",
+				},
+				{
+					externalPattern: "*_admin",
+					internalPattern: "*",
+					role:            "Admin",
+				},
+				{
+					externalPattern: "team_*_viewer",
+					internalPattern: "org_*",
+					role:            "Viewer",
+				},
+			}, true),
+		},
+		{
+			name:       "should just ignore an invalid mapping if roleStrict is false",
+			rawMapping: []string{"First:1:Editor", "*_admin:*:Admin:AlsoILikePonies", "team_*_viewer:org_*:Viewer"},
+			roleStrict: false,
+			expected: NewDynamicMappingConfiguration([]WildcardMapping{
+				{
+					externalPattern: "First",
+					internalPattern: "1",
+					role:            "Editor",
+				},
+				{
+					externalPattern: "team_*_viewer",
+					internalPattern: "org_*",
+					role:            "Viewer",
+				},
+			}, false),
+		},
+		{
+			name:       "should return a completely empty mapping config if one mapping is invalid and roleStrict is true",
+			rawMapping: []string{"First:1:Editor", "*_admin:*:Admin:AlsoILikePonies", "team_*_viewer:org_*:Viewer"},
+			roleStrict: true,
+			expected:   NewDynamicMappingConfiguration([]WildcardMapping{}, true),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.JWTAuth.AllowWildcardInOrgMapping = true
+			orgService := orgtest.NewOrgServiceFake()
+			mapper := ProvideOrgRoleMapper(cfg, orgService)
+
+			actual := mapper.ParseOrgMappingSettings(context.Background(), tc.rawMapping, tc.roleStrict)
+
+			assert.EqualValues(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestOrgRoleMapper_getMappedOrgByWildcardMatch(t *testing.T) {
+	testCases := []struct {
+		name            string
+		src             string
+		dst             string
+		input           string
+		expectedMatched bool
+		expectedOut     string
+	}{
+		{
+			name: "should replace the wildcard in dst from the match in src",
+			src:  "*_admin", dst: "*", input: "foo_admin",
+			expectedMatched: true, expectedOut: "foo",
+		},
+		{
+			name: "should return dst if neither src nor dst have a wildcard",
+			src:  "src", dst: "dst", input: "foobar",
+			expectedMatched: true, expectedOut: "dst",
+		},
+		{
+			name: "should return no match if input does not match src",
+			src:  "*_admin", dst: "*", input: "foo_other",
+			expectedMatched: false, expectedOut: "",
+		},
+		{
+			name: "should return a litteral dst if input matches src",
+			src:  "foo_*", dst: "litteral", input: "foo_bar",
+			expectedMatched: true, expectedOut: "litteral",
+		},
+		{
+			name: "should return no match if only dst has a wildcard",
+			src:  "literal", dst: "*", input: "literal",
+			expectedMatched: false, expectedOut: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, out := getMappedOrgByWildcardMatch(tc.src, tc.dst, tc.input)
+			assert.EqualValues(t, tc.expectedMatched, matched)
+			assert.EqualValues(t, tc.expectedOut, out)
+		})
+	}
+}
+
+func TestOrgRoleMapper_resolveWildcardMappings(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		externalOrg          string
+		mappingConfiguration MappingConfiguration
+		want                 map[int64]org.RoleType
+	}{
+		{
+			name:        "should resolve back to a static mapping",
+			externalOrg: "foo",
+			mappingConfiguration: NewDynamicMappingConfiguration([]WildcardMapping{
+				{
+					externalPattern: "First",
+					internalPattern: "1",
+					role:            org.RoleEditor,
+				},
+				{
+					externalPattern: "First",
+					internalPattern: "1",
+					role:            org.RoleViewer,
+				},
+			}, true),
+			want: map[int64]org.RoleType{1: org.RoleViewer},
+		},
+		{
+			name:        "should resolve back by resolving the wildcard in the pattern",
+			externalOrg: "Third_admin",
+			mappingConfiguration: NewDynamicMappingConfiguration([]WildcardMapping{
+				{
+					externalPattern: "*_admin",
+					internalPattern: "*",
+					role:            org.RoleAdmin,
+				},
+			}, true),
+			want: map[int64]org.RoleType{3: org.RoleAdmin},
+		},
+	}
+	orgService := orgtest.NewOrgServiceFake()
+	orgService.ExpectedOrgs = []*org.OrgDTO{
+		{Name: "First", ID: 1},
+		{Name: "Second", ID: 2},
+		{Name: "Third", ID: 3},
+	}
+	cfg := setting.NewCfg()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := ProvideOrgRoleMapper(cfg, orgService)
+			got := m.resolveWildcardMappings(context.Background(), tc.externalOrg, tc.mappingConfiguration)
+			assert.EqualValues(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -132,7 +132,7 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 			return nil, err
 		}
 
-		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, role)
+		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, role)
 		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/setting/setting_jwt.go
+++ b/pkg/setting/setting_jwt.go
@@ -12,30 +12,31 @@ const (
 
 type AuthJWTSettings struct {
 	// JWT Auth
-	Enabled                 bool
-	HeaderName              string
-	URLLogin                bool
-	EmailClaim              string
-	UsernameClaim           string
-	ExpectClaims            string
-	JWKSetURL               string
-	JWKSetBearerTokenFile   string
-	CacheTTL                time.Duration
-	KeyFile                 string
-	KeyID                   string
-	JWKSetFile              string
-	AutoSignUp              bool
-	RoleAttributePath       string
-	RoleAttributeStrict     bool
-	OrgMapping              []string
-	OrgAttributePath        string
-	AllowAssignGrafanaAdmin bool
-	SkipOrgRoleSync         bool
-	GroupsAttributePath     string
-	EmailAttributePath      string
-	UsernameAttributePath   string
-	TlsClientCa             string
-	TlsSkipVerify           bool
+	Enabled                   bool
+	HeaderName                string
+	URLLogin                  bool
+	EmailClaim                string
+	UsernameClaim             string
+	ExpectClaims              string
+	JWKSetURL                 string
+	JWKSetBearerTokenFile     string
+	CacheTTL                  time.Duration
+	KeyFile                   string
+	KeyID                     string
+	JWKSetFile                string
+	AutoSignUp                bool
+	RoleAttributePath         string
+	RoleAttributeStrict       bool
+	OrgMapping                []string
+	OrgAttributePath          string
+	AllowWildcardInOrgMapping bool
+	AllowAssignGrafanaAdmin   bool
+	SkipOrgRoleSync           bool
+	GroupsAttributePath       string
+	EmailAttributePath        string
+	UsernameAttributePath     string
+	TlsClientCa               string
+	TlsSkipVerify             bool
 }
 
 type ExtJWTSettings struct {
@@ -82,6 +83,7 @@ func (cfg *Cfg) readAuthJWTSettings() {
 	jwtSettings.TlsClientCa = valueAsString(authJWT, "tls_client_ca", "")
 	jwtSettings.TlsSkipVerify = authJWT.Key("tls_skip_verify_insecure").MustBool(false)
 	jwtSettings.OrgAttributePath = valueAsString(authJWT, "org_attribute_path", "")
+	jwtSettings.AllowWildcardInOrgMapping = authJWT.Key("allow_wildcard_in_org_mapping").MustBool(false)
 	jwtSettings.OrgMapping = util.SplitString(valueAsString(authJWT, "org_mapping", ""))
 
 	cfg.JWTAuth = jwtSettings


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This features introduces a new setting for the `auth` section, `allow_wildcard_in_org_mapping`, that allows the entries in `org_mapping` to be dynamically (as in, at login time) resolved by matching on the roles found in the JWT.

For example, with this flag enabled, the following entry in the configuration file could be made:

```ini
[auth.generic_oauth]
org_attribute_path = "groups"
org_mapping = "*_viewer:*:Viewer team_*:*:Editor"
allow_wildcard_in_org_mapping = true
```

If a user were to log in with the `groups` claim in their  jwt set to `["foo_viewer", "team_bar"]`, then the org mapping would be dynamically resolved to `foo_viewer:foo:Viewer team_bar:bar:Editor`, giving them the appropriate permissions.

Note that this feature clashes with the original meaning of `*`, which is why it is gated behind a configuration setting to switch its meaning. Alternatively, an entirely new metacharacter or syntax could be chosen, but this might lead to confusion.

**Why do we need this feature?**

`org_mapping` currently required an explicit mapping for each org, meaning that any approach to dynamically provision them (with e.g. the terraform or crossplane provider) also needs to modify the config file and restart grafana.
With this feature, we could have a handful of rules to cover all current and future orgs that match a pattern.

**Who is this feature for?**

Grafana administrators who dynamically provision organizations.



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #106340


**Special notes for your reviewer:**

This is my first time contributing to this repository, so I took the liberty of making this a draft PR to get feedback and see how to proceed. Mainly, I have not yet written the docs, and haven't started the hunt for all the edge cases in the new tests, as I wanted early feedback before diving too deep. I of course intend to improve these areas before merging.


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Cheers!