### PR TITLE
Provisioning: Fix false orphan deletion of renamed folders during incremental sync

### DIFF
--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -328,6 +328,15 @@ func (r *ResourcesManager) RenameResourceFile(ctx context.Context, previousPath,
 	if err != nil {
 		return oldParsed.Obj.GetName(), oldFolderName, gvk, fmt.Errorf("failed to write resource: %w", err)
 	}
+
+	// When the resource's parent folder didn't change (e.g. the entire
+	// directory was renamed and the folder was updated in place with the
+	// same UID), the old folder was not emptied — suppress the signal so
+	// the caller doesn't mark it for orphan deletion.
+	if newParsed.Meta.GetFolder() == oldFolderName {
+		oldFolderName = ""
+	}
+
 	return newName, oldFolderName, gvk, nil
 }
 

--- a/pkg/registry/apis/provisioning/resources/resources_remove_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_remove_test.go
@@ -419,4 +419,130 @@ func TestRenameResourceFile(t *testing.T) {
 		require.Empty(t, folderName, "folder should be empty when resource does not exist in grafana")
 		mockClient.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
+
+	t.Run("same parent folder after rename suppresses old folder signal", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		mockParser := NewMockParser(t)
+		dashClient := &MockDynamicResourceInterface{}
+
+		config := newTestRepoConfig(testRepoName)
+		repo.On("Config").Return(config)
+
+		expectedFolderID := ParseFolder("team/", testRepoName).ID
+
+		tree := NewEmptyFolderTree()
+		tree.Add(ParseFolder("team/", testRepoName), "")
+		folderMgr := NewFolderManager(repo, nil, tree)
+
+		oldFileInfo := &repository.FileInfo{Data: []byte(`{}`), Path: "team/old-dash.json"}
+		repo.On("Read", mock.Anything, "team/old-dash.json", "old-ref").Return(oldFileInfo, nil)
+		mockParser.On("Parse", mock.Anything, oldFileInfo).Return(&ParsedResource{
+			Obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "dashboard.grafana.app/v0alpha1",
+				"kind":       "Dashboard",
+				"metadata":   map[string]any{"name": "dash-uid", "namespace": "default"},
+			}},
+			GVK:    dashboardGVK,
+			GVR:    DashboardResource,
+			Client: dashClient,
+			Repo:   testRepoInfo(),
+		}, nil)
+
+		newObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"kind":       "Dashboard",
+			"metadata":   map[string]any{"name": "dash-uid", "namespace": "default"},
+		}}
+		newMeta, err := utils.MetaAccessor(newObj)
+		require.NoError(t, err)
+
+		newFileInfo := &repository.FileInfo{Data: []byte(`{}`), Path: "team/new-dash.json"}
+		repo.On("Read", mock.Anything, "team/new-dash.json", "new-ref").Return(newFileInfo, nil)
+		mockParser.On("Parse", mock.Anything, newFileInfo).Return(&ParsedResource{
+			Obj:    newObj,
+			Meta:   newMeta,
+			GVK:    dashboardGVK,
+			GVR:    DashboardResource,
+			Client: dashClient,
+			Repo:   testRepoInfo(),
+		}, nil)
+
+		grafanaObj := managedGrafanaObj("dash-uid", "default", map[string]any{
+			utils.AnnoKeyFolder: expectedFolderID,
+		})
+		dashClient.On("Get", mock.Anything, "dash-uid", metav1.GetOptions{}, mock.Anything).Return(grafanaObj, nil)
+		dashClient.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newObj, nil)
+
+		mgr := NewResourcesManager(repo, folderMgr, mockParser, nil)
+		name, folderName, gvk, err := mgr.RenameResourceFile(context.Background(), "team/old-dash.json", "old-ref", "team/new-dash.json", "new-ref")
+
+		require.NoError(t, err)
+		require.Equal(t, "dash-uid", name)
+		require.Empty(t, folderName, "should suppress old folder signal when parent folder didn't change")
+		require.Equal(t, dashboardGVK, gvk)
+	})
+
+	t.Run("different parent folder after rename returns old folder for cleanup", func(t *testing.T) {
+		repo := repository.NewMockReaderWriter(t)
+		mockParser := NewMockParser(t)
+		dashClient := &MockDynamicResourceInterface{}
+
+		config := newTestRepoConfig(testRepoName)
+		repo.On("Config").Return(config)
+
+		oldFolderID := ParseFolder("a-team/", testRepoName).ID
+		newFolderID := ParseFolder("b-team/", testRepoName).ID
+
+		tree := NewEmptyFolderTree()
+		tree.Add(ParseFolder("b-team/", testRepoName), "")
+		folderMgr := NewFolderManager(repo, nil, tree)
+
+		oldFileInfo := &repository.FileInfo{Data: []byte(`{}`), Path: "a-team/dash.json"}
+		repo.On("Read", mock.Anything, "a-team/dash.json", "old-ref").Return(oldFileInfo, nil)
+		mockParser.On("Parse", mock.Anything, oldFileInfo).Return(&ParsedResource{
+			Obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "dashboard.grafana.app/v0alpha1",
+				"kind":       "Dashboard",
+				"metadata":   map[string]any{"name": "dash-uid", "namespace": "default"},
+			}},
+			GVK:    dashboardGVK,
+			GVR:    DashboardResource,
+			Client: dashClient,
+			Repo:   testRepoInfo(),
+		}, nil)
+
+		newObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "dashboard.grafana.app/v0alpha1",
+			"kind":       "Dashboard",
+			"metadata":   map[string]any{"name": "dash-uid", "namespace": "default"},
+		}}
+		newMeta, err := utils.MetaAccessor(newObj)
+		require.NoError(t, err)
+
+		newFileInfo := &repository.FileInfo{Data: []byte(`{}`), Path: "b-team/dash.json"}
+		repo.On("Read", mock.Anything, "b-team/dash.json", "new-ref").Return(newFileInfo, nil)
+		mockParser.On("Parse", mock.Anything, newFileInfo).Return(&ParsedResource{
+			Obj:    newObj,
+			Meta:   newMeta,
+			GVK:    dashboardGVK,
+			GVR:    DashboardResource,
+			Client: dashClient,
+			Repo:   testRepoInfo(),
+		}, nil)
+
+		grafanaObj := managedGrafanaObj("dash-uid", "default", map[string]any{
+			utils.AnnoKeyFolder: oldFolderID,
+		})
+		dashClient.On("Get", mock.Anything, "dash-uid", metav1.GetOptions{}, mock.Anything).Return(grafanaObj, nil)
+		dashClient.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newObj, nil)
+
+		mgr := NewResourcesManager(repo, folderMgr, mockParser, nil)
+		name, folderName, gvk, err := mgr.RenameResourceFile(context.Background(), "a-team/dash.json", "old-ref", "b-team/dash.json", "new-ref")
+
+		require.NoError(t, err)
+		require.Equal(t, "dash-uid", name)
+		require.Equal(t, oldFolderID, folderName, "should return old folder for cleanup when parent folder changed")
+		require.NotEqual(t, newFolderID, folderName)
+		require.Equal(t, dashboardGVK, gvk)
+	})
 }

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_folder_metadata_test.go
@@ -630,13 +630,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
-		// producing errors. The rename still works via fallback, so we only
-		// wait for completion without asserting success.
-		helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
@@ -690,13 +684,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
-		// producing errors. The rename still works via fallback, so we only
-		// wait for completion without asserting success.
-		helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		childAfter, err := helper.FoldersV1.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
@@ -750,13 +738,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
-		// producing errors. The rename still works via fallback, so we only
-		// wait for completion without asserting success.
-		helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -811,13 +793,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
-		// producing errors. The rename still works via fallback, so we only
-		// wait for completion without asserting success.
-		helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		folderAfter, err := helper.FoldersV1.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -882,13 +858,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		// FIXME: RenameResourceFile currently fails to delete non-empty folders,
-		// producing errors. The rename still works via fallback, so we only
-		// wait for completion without asserting success.
-		helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-			Action: provisioning.JobActionPull,
-			Pull:   &provisioning.SyncJobOptions{Incremental: true},
-		})
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
 		// Verify parent folder updated in place.
 		parentAfter, err := helper.FoldersV1.Resource.Get(ctx, parentUID, metav1.GetOptions{})


### PR DESCRIPTION
## Summary

Fixes a bug where renaming a directory in git (e.g. `old-team` → `new-team`) during incremental sync would incorrectly attempt to delete the folder, producing `"Folder cannot be deleted: folder is not empty"` errors. The rename itself succeeded via fallback, but the job reported errors.

### Root cause

When a directory is renamed in git, incremental sync processes each file rename individually via `RenameResourceFile`. For dashboard files, this correctly updates the resource in place but also returned the old parent folder UID as a signal that the folder may now be empty. This UID was added to `affectedFolders[oldPath]`, and since the old directory path no longer exists in git, `findOrphanedFolders` marked the folder for deletion — even though it was simply moved in place (same UID at the new path) and still had children.

```
git mv old-team new-team
```
```
Diff:
  old-team/_folder.json → new-team/_folder.json   (renamed, same UID)
  old-team/dashboard.json → new-team/dashboard.json (renamed, same UID)

Flow:
  1. dashboard rename → RenameResourceFile → updates in place
     → returns oldFolderName = "rr-folder-uid"
     → affectedFolders["old-team"] = "rr-folder-uid"
  2. findOrphanedFolders: "old-team" gone from git → mark for deletion
  3. deleteFolders: delete "rr-folder-uid" → ERROR: folder is not empty
     (the folder was moved to "new-team", not emptied)
```

### Fix

In `RenameResourceFile`, after writing the resource at its new path, compare the old and new parent folder IDs. When they match (the folder was moved in place along with its contents), return an empty `oldFolderName` so the caller doesn't mark it for orphan deletion.

```go
// resources.go — after writeResourceFromParsed succeeds
if newParsed.Meta.GetFolder() == oldFolderName {
    oldFolderName = ""
}
```

This correctly handles:
- **Directory renames with metadata** (same stable UID) — signal suppressed
- **File moves between different folders** (different UIDs) — old folder still flagged for cleanup
- **Non-metadata directory renames** (hash-based UIDs change) — old folder still flagged for cleanup

### Changes

| File | Change |
|------|--------|
| `resources/resources.go` | Compare old/new parent folder IDs after write; suppress signal when equal |
| `resources/resources_remove_test.go` | Add 2 unit tests covering same-folder suppression and cross-folder cleanup |
| `foldermetadata_incremental/...test.go` | Replace 5 FIXME workarounds with `SyncAndWaitSuccessfulIncremental` assertions |

Fixes https://github.com/grafana/git-ui-sync-project/issues/1009
Related: https://github.com/grafana/grafana/pull/120856 (uncovered the issue), https://github.com/grafana/grafana/pull/120835 (unblocked this fix)

## Test plan
- [x] All `RenameResourceFile` unit tests pass (7 tests, including 2 new)
- [x] All incremental sync unit tests pass
- [x] All 6 `TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename` sub-tests pass (5 previously failing now pass)
- [ ] CI green