### PR TITLE
Provisioning: Track failed renames by source path for cleanup safety

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -84,13 +84,14 @@ func isWarningError(err error) bool {
 
 // JobResourceResult represents the result of a resource operation in a job.
 type JobResourceResult struct {
-	name    string
-	group   string
-	kind    string
-	path    string
-	action  repository.FileAction
-	err     error
-	warning error
+	name         string
+	group        string
+	kind         string
+	path         string
+	previousPath string
+	action       repository.FileAction
+	err          error
+	warning      error
 }
 
 // jobResourceResultBuilder is a builder for creating JobResourceResult instances using a fluent API.
@@ -171,6 +172,14 @@ func (b *jobResourceResultBuilder) WithPath(path string) *jobResourceResultBuild
 	return b
 }
 
+// WithPreviousPath sets the source path for rename operations.
+// When a rename fails the resource stays at the previous (source) path,
+// so safety checks need both paths to prevent premature folder deletion.
+func (b *jobResourceResultBuilder) WithPreviousPath(path string) *jobResourceResultBuilder {
+	b.result.previousPath = path
+	return b
+}
+
 // WithAction sets the action performed on the resource.
 func (b *jobResourceResultBuilder) WithAction(action repository.FileAction) *jobResourceResultBuilder {
 	b.result.action = action
@@ -234,6 +243,11 @@ func (r JobResourceResult) Kind() string {
 // Path returns the path of the resource.
 func (r JobResourceResult) Path() string {
 	return r.path
+}
+
+// PreviousPath returns the source path for rename operations.
+func (r JobResourceResult) PreviousPath() string {
+	return r.previousPath
 }
 
 // Action returns the action performed on the resource.

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -114,6 +114,9 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 		// A rename is a move operation; if it fails the child stays under the old folder.
 		if result.Action() == repository.FileActionUpdated || result.Action() == repository.FileActionRenamed {
 			r.failedUpdates = append(r.failedUpdates, result.Path())
+			if result.Action() == repository.FileActionRenamed && result.PreviousPath() != "" {
+				r.failedUpdates = append(r.failedUpdates, result.PreviousPath())
+			}
 		}
 	} else if result.Warning() != nil {
 		// Track failed deletions/updates/renames with warnings — these still represent
@@ -123,6 +126,9 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 		}
 		if result.Action() == repository.FileActionUpdated || result.Action() == repository.FileActionRenamed {
 			r.failedUpdates = append(r.failedUpdates, result.Path())
+			if result.Action() == repository.FileActionRenamed && result.PreviousPath() != "" {
+				r.failedUpdates = append(r.failedUpdates, result.PreviousPath())
+			}
 		}
 
 		if reason := result.WarningReason(); reason != "" {

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -610,19 +610,25 @@ func TestJobProgressRecorderHasChildPathFailedUpdate(t *testing.T) {
 
 	// Failed renames are tracked as update failures — a rename moves a child,
 	// so if it fails the child stays under the old folder.
+	// Cross-folder rename: source is oldfolder/, destination is newfolder/.
+	// Both paths must be tracked so the old folder is not deleted prematurely.
 	recorder.Record(ctx, NewResourceResult().
-		WithPath("renamed/old-dash.json").
+		WithPath("newfolder/old-dash.json").
+		WithPreviousPath("oldfolder/old-dash.json").
 		WithAction(repository.FileActionRenamed).
 		WithError(assert.AnError).
 		Build())
-	assert.True(t, recorder.HasChildPathFailedUpdate("renamed/"), "failed renames must be tracked as update failures")
+	assert.True(t, recorder.HasChildPathFailedUpdate("oldfolder/"), "failed renames must protect the source folder")
+	assert.True(t, recorder.HasChildPathFailedUpdate("newfolder/"), "failed renames must also protect the destination folder")
 
 	recorder.Record(ctx, NewResourceResult().
-		WithPath("rename-warn/panel.json").
+		WithPath("new-warn/panel.json").
+		WithPreviousPath("old-warn/panel.json").
 		WithAction(repository.FileActionRenamed).
 		WithWarning(errors.New("rename conflict")).
 		Build())
-	assert.True(t, recorder.HasChildPathFailedUpdate("rename-warn/"), "warning-level rename failures must be tracked")
+	assert.True(t, recorder.HasChildPathFailedUpdate("old-warn/"), "warning-level rename failures must protect the source folder")
+	assert.True(t, recorder.HasChildPathFailedUpdate("new-warn/"), "warning-level rename failures must protect the destination folder")
 
 	// Empty recorder should always return false
 	emptyRecorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -237,6 +237,7 @@ func applyIncrementalChanges(ctx context.Context, diff []repository.VersionedFil
 
 			removeSpan.End()
 		case repository.FileActionRenamed:
+			resultBuilder.WithPreviousPath(change.PreviousPath)
 			if safepath.IsDir(change.Path) {
 				renameFolderCtx, renameFolderSpan := tracer.Start(ctx, "provisioning.sync.incremental.rename_folder_path")
 				oldFolderID, err := repositoryResources.RenameFolderPath(renameFolderCtx, change.PreviousPath, change.PreviousRef, change.Path, change.Ref)

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
@@ -279,12 +279,12 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				repoResources.On("RenameResourceFile", mock.Anything, "oldfolder/file.json", "old-ref", "newfolder/file.json", "new-ref").
 					Return("", "", schema.GroupVersionKind{}, folderErr).Once()
 
-			progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-				return r.Path() == "newfolder/file.json" &&
-					r.PreviousPath() == "oldfolder/file.json" &&
-					r.Action() == repository.FileActionRenamed &&
-					r.Error() != nil
-			})).Return().Once()
+				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+					return r.Path() == "newfolder/file.json" &&
+						r.PreviousPath() == "oldfolder/file.json" &&
+						r.Action() == repository.FileActionRenamed &&
+						r.Error() != nil
+				})).Return().Once()
 			},
 		},
 		{

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_hierarchical_test.go
@@ -279,11 +279,12 @@ func TestIncrementalSync_HierarchicalErrorHandling(t *testing.T) { // nolint:goc
 				repoResources.On("RenameResourceFile", mock.Anything, "oldfolder/file.json", "old-ref", "newfolder/file.json", "new-ref").
 					Return("", "", schema.GroupVersionKind{}, folderErr).Once()
 
-				progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
-					return r.Path() == "newfolder/file.json" &&
-						r.Action() == repository.FileActionRenamed &&
-						r.Error() != nil
-				})).Return().Once()
+			progress.On("Record", mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+				return r.Path() == "newfolder/file.json" &&
+					r.PreviousPath() == "oldfolder/file.json" &&
+					r.Action() == repository.FileActionRenamed &&
+					r.Error() != nil
+			})).Return().Once()
 			},
 		},
 		{

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -268,13 +268,14 @@ func TestIncrementalSync(t *testing.T) {
 				repoResources.On("RenameResourceFile", mock.Anything, "dashboards/old.json", "old-ref", "dashboards/new.json", "new-ref").
 					Return("renamed-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
-					"renamed-dashboard",
-					"dashboards",
-					"Dashboard",
-				).WithPath("dashboards/new.json").
-					WithAction(repository.FileActionRenamed).
-					Build()).Return()
+			progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+				"renamed-dashboard",
+				"dashboards",
+				"Dashboard",
+			).WithPath("dashboards/new.json").
+				WithPreviousPath("dashboards/old.json").
+				WithAction(repository.FileActionRenamed).
+				Build()).Return()
 
 				progress.On("TooManyErrors").Return(nil)
 			},

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -268,14 +268,14 @@ func TestIncrementalSync(t *testing.T) {
 				repoResources.On("RenameResourceFile", mock.Anything, "dashboards/old.json", "old-ref", "dashboards/new.json", "new-ref").
 					Return("renamed-dashboard", "", schema.GroupVersionKind{Kind: "Dashboard", Group: "dashboards"}, nil)
 
-			progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
-				"renamed-dashboard",
-				"dashboards",
-				"Dashboard",
-			).WithPath("dashboards/new.json").
-				WithPreviousPath("dashboards/old.json").
-				WithAction(repository.FileActionRenamed).
-				Build()).Return()
+				progress.On("Record", mock.Anything, jobs.NewGroupKindResult(
+					"renamed-dashboard",
+					"dashboards",
+					"Dashboard",
+				).WithPath("dashboards/new.json").
+					WithPreviousPath("dashboards/old.json").
+					WithAction(repository.FileActionRenamed).
+					Build()).Return()
 
 				progress.On("TooManyErrors").Return(nil)
 			},


### PR DESCRIPTION
## What

Fix a safety gap in incremental sync where a failed cross-folder rename does not prevent the old folder from being deleted, potentially removing a folder that still contains children.

Addresses review comment: https://github.com/grafana/grafana/pull/120848#discussion_r2969575778

## Why

When a `FileActionRenamed` operation fails, the resource stays at its **source** location. However, `Record` in `progress.go` only appends `result.Path()` (the **destination** path) to `failedUpdates`. The safety check `HasChildPathFailedUpdate` in `deleteFolders` evaluates against the **old folder** path, so for cross-folder renames the failure is invisible and the old folder can be deleted.

### Example: cross-folder rename failure causes data loss

Consider a folder UID change that triggers re-parenting of `oldfolder/dash.json` to `newfolder/dash.json`:

```
Rename: oldfolder/dash.json -> newfolder/dash.json   (FAILS)
```

**Before this fix:**

| Step | What happens |
|------|-------------|
| Rename fails | `dash.json` stays at `oldfolder/dash.json` |
| `Record` stores | `failedUpdates = ["newfolder/dash.json"]` |
| `deleteFolders` checks | `HasChildPathFailedUpdate("oldfolder/")` |
| `InDir("newfolder/dash.json", "oldfolder/")` | returns **false** |
| Result | `oldfolder/` is **deleted** despite still containing `dash.json` |

**After this fix:**

| Step | What happens |
|------|-------------|
| Rename fails | `dash.json` stays at `oldfolder/dash.json` |
| `Record` stores | `failedUpdates = ["newfolder/dash.json", "oldfolder/dash.json"]` |
| `deleteFolders` checks | `HasChildPathFailedUpdate("oldfolder/")` |
| `InDir("oldfolder/dash.json", "oldfolder/")` | returns **true** |
| Result | `oldfolder/` is **kept** safely |

## How

1. **`job_resource_result.go`** -- Add `previousPath` field, `WithPreviousPath()` builder method, and `PreviousPath()` accessor to `JobResourceResult`.

2. **`progress.go`** -- In `Record()`, for both error and warning branches, when a `FileActionRenamed` has a non-empty `PreviousPath()`, also append it to `failedUpdates`. This ensures both source and destination folders are protected.

3. **`incremental.go`** -- Add `resultBuilder.WithPreviousPath(change.PreviousPath)` at the top of the `FileActionRenamed` case so the source path is always carried in the result.

4. **Tests** -- Update rename failure tests to use cross-folder scenarios and assert both source and destination folders are protected by `HasChildPathFailedUpdate`.

## Test plan

- [x] Updated `TestJobProgressRecorderHasChildPathFailedUpdate` to use cross-folder rename scenarios and assert both source and destination folders are protected
- [x] Updated `TestIncrementalSync/file_rename` mock expectation to verify `PreviousPath` is set
- [x] Updated hierarchical test rename matcher to assert `PreviousPath()` is propagated
- [x] All existing tests pass (`go test ./pkg/registry/apis/provisioning/jobs/...`)