### PR TITLE
Alerting: Improve StringToAlertmanagersChoice error string

### DIFF
--- a/pkg/services/ngalert/models/admin_configuration.go
+++ b/pkg/services/ngalert/models/admin_configuration.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"errors"
+	"fmt"
 )
 
 type AlertmanagersChoice int
@@ -45,5 +45,5 @@ func StringToAlertmanagersChoice(str string) (AlertmanagersChoice, error) {
 			return k, nil
 		}
 	}
-	return 0, errors.New("invalid alertmanager choice")
+	return 0, fmt.Errorf("invalid alertmanager choice: %q", str)
 }

--- a/pkg/services/ngalert/models/admin_configuration_test.go
+++ b/pkg/services/ngalert/models/admin_configuration_test.go
@@ -42,7 +42,7 @@ func TestStringToAlertmanagersChoice(t *testing.T) {
 			"invalid string",
 			"invalid",
 			0,
-			errors.New("invalid alertmanager choice"),
+			errors.New("invalid alertmanager choice: \"invalid\""),
 		},
 	}
 


### PR DESCRIPTION
We can include the actual string that was passed to the function.