### PR TITLE
Provisioning: incremental permission test cases share grafana and git instances

### DIFF
--- a/pkg/tests/apis/provisioning/git/common/testing.go
+++ b/pkg/tests/apis/provisioning/git/common/testing.go
@@ -160,9 +160,21 @@ func (h *GitTestHelper) GitServer() *gittest.Server {
 	return h.gitServer
 }
 
-// createGitRepo creates a git repository using gittest and registers it with Grafana provisioning.
-// workflows parameter is optional - if not provided, defaults to ["write"].
+// CreateGitRepo creates a git repository with sync target "instance" and registers
+// it with Grafana provisioning. workflows is optional; defaults to ["write"].
 func (h *GitTestHelper) CreateGitRepo(t *testing.T, repoName string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
+	return h.createGitRepo(t, repoName, "instance", initialFiles, workflows...)
+}
+
+// CreateFolderTargetGitRepo creates a git repository with sync target "folder" and
+// registers it with Grafana provisioning. Unlike "instance" repos, multiple "folder"
+// repos can coexist on the same Grafana server. workflows is optional; defaults to ["write"].
+func (h *GitTestHelper) CreateFolderTargetGitRepo(t *testing.T, repoName string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
+	return h.createGitRepo(t, repoName, "folder", initialFiles, workflows...)
+}
+
+// createGitRepo is the shared implementation for CreateGitRepo and CreateFolderTargetGitRepo.
+func (h *GitTestHelper) createGitRepo(t *testing.T, repoName string, syncTarget string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -226,7 +238,7 @@ func (h *GitTestHelper) CreateGitRepo(t *testing.T, repoName string, initialFile
 			},
 			"sync": map[string]interface{}{
 				"enabled":         false,
-				"target":          "instance",
+				"target":          syncTarget,
 				"intervalSeconds": 60,
 			},
 			"workflows": workflows,

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_permissions_move_test.go
@@ -18,420 +18,396 @@ import (
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
-// TestIntegrationProvisioning_IncrementalSync_FolderMovePreservesPermissions verifies
-// that custom permissions set on a provisioned folder are preserved after the folder is
-// moved to a different location via git mv and an incremental sync is performed.
-func TestIntegrationProvisioning_IncrementalSync_FolderMovePreservesPermissions(t *testing.T) {
+// TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions bundles all
+// folder-move-preserves-permissions scenarios under a single Grafana + git server
+// to avoid the cost of spinning up a new server per sub-case. Each scenario uses
+// a distinct repo name and globally-unique folder UIDs so the subtests can share
+// the same Grafana namespace without interfering with one another.
+func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 	ctx := context.Background()
-
-	const repoName = "incr-move-perms"
-
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"teamA/_folder.json": folderMetadataJSON("team-a-uid", "Team A"),
-		"teamB/_folder.json": folderMetadataJSON("team-b-uid", "Team B"),
-	})
-
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
-
-	requireGitFolderState(t, helper, ctx, "team-a-uid", "Team A", "teamA", "")
-	requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamB", "")
-
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 
-	// Set a known ACL on teamA (check 4) so we can assert it is not touched when
-	// a child folder is moved into it.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/team-a-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Admin", "permission": 4},
+	// FolderMovePreservesPermissions verifies that custom permissions set on a
+	// provisioned folder are preserved after the folder is moved to a different
+	// location via git mv and an incremental sync is performed.
+	t.Run("FolderMovePreservesPermissions", func(t *testing.T) {
+		const repoName = "incr-move-perms"
+
+		_, local := helper.CreateFolderTargetGitRepo(t, repoName, map[string][]byte{
+			"teamA/_folder.json": folderMetadataJSON("team-a-uid", "Team A"),
+			"teamB/_folder.json": folderMetadataJSON("team-b-uid", "Team B"),
+		})
+
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+		requireGitFolderState(t, helper, ctx, "team-a-uid", "Team A", "teamA", repoName)
+		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamB", repoName)
+
+		// Set a known ACL on teamA (check 4) so we can assert it is not touched when
+		// a child folder is moved into it.
+		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
+			"/api/folders/team-a-uid/permissions",
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Admin", "permission": 4},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on teamA folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on teamA folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	// Set multiple role-based ACL entries on teamB (check 3):
-	// Viewer → View (1) and Editor → Edit (2).
-	_, code, err = common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/team-b-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
-				{"role": "Editor", "permission": 2},
+		// Set multiple role-based ACL entries on teamB (check 3):
+		// Viewer → View (1) and Editor → Edit (2).
+		_, code, err = common.PostHelper(t, *helper.K8sTestHelper,
+			"/api/folders/team-b-uid/permissions",
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Viewer", "permission": 1},
+					{"role": "Editor", "permission": 2},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on teamB folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on teamB folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	// Snapshot permissions before the move and verify the expected entries are present.
-	teamAPermsBefore := snapshotFolderPermissions(t, addr, "team-a-uid")
-	requirePermissionsContainRole(t, teamAPermsBefore, "Admin", 4)
+		// Snapshot permissions before the move and verify the expected entries are present.
+		teamAPermsBefore := snapshotFolderPermissions(t, addr, "team-a-uid")
+		requirePermissionsContainRole(t, teamAPermsBefore, "Admin", 4)
 
-	teamBPermsBefore := snapshotFolderPermissions(t, addr, "team-b-uid")
-	requirePermissionsContainRole(t, teamBPermsBefore, "Viewer", 1)
-	requirePermissionsContainRole(t, teamBPermsBefore, "Editor", 2)
+		teamBPermsBefore := snapshotFolderPermissions(t, addr, "team-b-uid")
+		requirePermissionsContainRole(t, teamBPermsBefore, "Viewer", 1)
+		requirePermissionsContainRole(t, teamBPermsBefore, "Editor", 2)
 
-	// Move teamB inside teamA via git mv, commit, and push.
-	_, err = local.Git("mv", "teamB", "teamA/teamB")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "move teamB into teamA")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
+		// Move teamB inside teamA via git mv, commit, and push.
+		_, err = local.Git("mv", "teamB", "teamA/teamB")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move teamB into teamA")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
-	// teamB should now live under teamA with the same stable UID.
-	requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
+		// teamB should now live under teamA with the same stable UID.
+		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
 
-	teamBPermsAfter := snapshotFolderPermissions(t, addr, "team-b-uid")
+		teamBPermsAfter := snapshotFolderPermissions(t, addr, "team-b-uid")
 
-	// Check 1: The ACL entry count must not change after the move.
-	require.Equal(t, len(teamBPermsBefore), len(teamBPermsAfter),
-		"ACL entry count must not change after folder move")
+		// Check 1: The ACL entry count must not change after the move.
+		require.Equal(t, len(teamBPermsBefore), len(teamBPermsAfter),
+			"ACL entry count must not change after folder move")
 
-	// Check 2 & 3: The full (role → permission) map must be identical before and after.
-	requireRolePermissionSetEqual(t, teamBPermsBefore, teamBPermsAfter)
-	requirePermissionsContainRole(t, teamBPermsAfter, "Viewer", 1)
-	requirePermissionsContainRole(t, teamBPermsAfter, "Editor", 2)
+		// Check 2 & 3: The full (role → permission) map must be identical before and after.
+		requireRolePermissionSetEqual(t, teamBPermsBefore, teamBPermsAfter)
+		requirePermissionsContainRole(t, teamBPermsAfter, "Viewer", 1)
+		requirePermissionsContainRole(t, teamBPermsAfter, "Editor", 2)
 
-	// Check 4: teamA's own ACL must be unaffected by moving a child into it.
-	teamAPermsAfter := snapshotFolderPermissions(t, addr, "team-a-uid")
-	requireRolePermissionSetEqual(t, teamAPermsBefore, teamAPermsAfter)
+		// Check 4: teamA's own ACL must be unaffected by moving a child into it.
+		teamAPermsAfter := snapshotFolderPermissions(t, addr, "team-a-uid")
+		requireRolePermissionSetEqual(t, teamAPermsBefore, teamAPermsAfter)
 
-	// Check 5: The moved folder must still be effectively accessible to a user
-	// carrying the granted role.
-	requireFolderAccessible(t, addr, "team-b-uid", "viewer", "viewer")
-}
-
-// TestIntegrationProvisioning_IncrementalSync_FolderMoveDoesNotPreservePermissionsForLegacyFolder
-// contrasts with the metadata test: a folder without _folder.json receives a brand-new UID when
-// its path changes (delete + recreate), so permissions associated with the old UID are gone.
-func TestIntegrationProvisioning_IncrementalSync_FolderMoveDoesNotPreservePermissionsForLegacyFolder(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
-	ctx := context.Background()
-
-	const repoName = "incr-move-legacy-perms"
-
-	// Parent has stable metadata; the folder being moved does not.
-	// plain has no _folder.json, so syncs will warn about missing metadata.
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"parent/_folder.json": folderMetadataJSON("parent-uid", "Parent"),
-		"plain/.keep":         {},
+		// Check 5: The moved folder must still be effectively accessible to a user
+		// carrying the granted role.
+		requireFolderAccessible(t, addr, "team-b-uid", "viewer", "viewer")
 	})
 
-	common.SyncAndWaitWithWarning(t, helper, repoName)
+	// FolderMoveDoesNotPreservePermissionsForLegacyFolder contrasts with the
+	// metadata test: a folder without _folder.json receives a brand-new UID when
+	// its path changes (delete + recreate), so permissions associated with the
+	// old UID are gone.
+	t.Run("FolderMoveDoesNotPreservePermissionsForLegacyFolder", func(t *testing.T) {
+		const repoName = "incr-move-legacy-perms"
 
-	requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", "")
-	plainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "plain")
-	require.NotEmpty(t, plainUID)
+		// Parent has stable metadata; the folder being moved does not.
+		// plain has no _folder.json, so syncs will warn about missing metadata.
+		_, local := helper.CreateFolderTargetGitRepo(t, repoName, map[string][]byte{
+			"parent/_folder.json": folderMetadataJSON("parent-uid", "Parent"),
+			"plain/.keep":         {},
+		})
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		common.SyncAndWaitWithWarning(t, helper, repoName)
 
-	// Set a Viewer permission on the legacy (no-metadata) folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		fmt.Sprintf("/api/folders/%s/permissions", plainUID),
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
+		requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", repoName)
+		plainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "plain")
+		require.NotEmpty(t, plainUID)
+
+		// Set a Viewer permission on the legacy (no-metadata) folder.
+		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
+			fmt.Sprintf("/api/folders/%s/permissions", plainUID),
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Viewer", "permission": 1},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on plain folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on plain folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	plainPermsBefore := snapshotFolderPermissions(t, addr, plainUID)
-	requirePermissionsContainRole(t, plainPermsBefore, "Viewer", 1)
+		plainPermsBefore := snapshotFolderPermissions(t, addr, plainUID)
+		requirePermissionsContainRole(t, plainPermsBefore, "Viewer", 1)
 
-	// Move the legacy folder under the parent via git mv, commit, and push.
-	_, err = local.Git("mv", "plain", "parent/plain")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "move plain folder under parent")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
+		// Move the legacy folder under the parent via git mv, commit, and push.
+		_, err = local.Git("mv", "plain", "parent/plain")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move plain folder under parent")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
 
-	// parent/plain still has no _folder.json after the move, so the incremental
-	// sync warns about missing metadata.
-	common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		// parent/plain still has no _folder.json after the move, so the incremental
+		// sync warns about missing metadata.
+		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
 
-	// The old folder object must be gone — without metadata the path change
-	// causes a delete-and-recreate rather than an in-place update.
-	assertGitFolderAbsent(t, helper, ctx, plainUID)
+		// The old folder object must be gone — without metadata the path change
+		// causes a delete-and-recreate rather than an in-place update.
+		assertGitFolderAbsent(t, helper, ctx, plainUID)
 
-	// The new folder at the moved path must exist with a different (hash-based) UID.
-	newPlainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "parent/plain")
-	require.NotEmpty(t, newPlainUID)
-	require.NotEqual(t, plainUID, newPlainUID,
-		"legacy folder must get a new UID when its path changes")
+		// The new folder at the moved path must exist with a different (hash-based) UID.
+		newPlainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "parent/plain")
+		require.NotEmpty(t, newPlainUID)
+		require.NotEqual(t, plainUID, newPlainUID,
+			"legacy folder must get a new UID when its path changes")
 
-	// The new folder must NOT carry the Viewer permission from the old object.
-	newPlainPerms := snapshotFolderPermissions(t, addr, newPlainUID)
-	for _, p := range newPlainPerms {
-		entry, ok := p.(map[string]interface{})
-		if !ok {
-			continue
+		// The new folder must NOT carry the Viewer permission from the old object.
+		newPlainPerms := snapshotFolderPermissions(t, addr, newPlainUID)
+		for _, p := range newPlainPerms {
+			entry, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			role, _ := entry["role"].(string)
+			level, _ := entry["permission"].(float64)
+			require.False(t, role == "Viewer" && int(level) == 1,
+				"new legacy folder must not inherit Viewer permission from the deleted predecessor; got: %v", newPlainPerms)
 		}
-		role, _ := entry["role"].(string)
-		level, _ := entry["permission"].(float64)
-		require.False(t, role == "Viewer" && int(level) == 1,
-			"new legacy folder must not inherit Viewer permission from the deleted predecessor; got: %v", newPlainPerms)
-	}
-}
-
-// TestIntegrationProvisioning_IncrementalSync_NestedFolderMovePreservesPermissions verifies that
-// permissions on a deeply nested folder survive when its parent subtree is relocated.
-// All folders in the hierarchy carry _folder.json metadata, so UIDs are stable.
-func TestIntegrationProvisioning_IncrementalSync_NestedFolderMovePreservesPermissions(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
-	ctx := context.Background()
-
-	const repoName = "incr-move-nested-perms"
-
-	// Build root → child → grandchild; all have metadata so UIDs are stable.
-	// destination also carries _folder.json so it doesn't trigger a missing-metadata warning.
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"root/_folder.json":                  folderMetadataJSON("root-uid", "Root"),
-		"root/child/_folder.json":            folderMetadataJSON("child-uid", "Child"),
-		"root/child/grandchild/_folder.json": folderMetadataJSON("grandchild-uid", "Grandchild"),
-		"destination/_folder.json":           folderMetadataJSON("destination-uid", "Destination"),
 	})
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	// NestedFolderMovePreservesPermissions verifies that permissions on a deeply
+	// nested folder survive when its parent subtree is relocated. All folders in
+	// the hierarchy carry _folder.json metadata, so UIDs are stable.
+	t.Run("NestedFolderMovePreservesPermissions", func(t *testing.T) {
+		const repoName = "incr-move-nested-perms"
 
-	requireGitFolderState(t, helper, ctx, "root-uid", "Root", "root", "")
-	requireGitFolderState(t, helper, ctx, "child-uid", "Child", "root/child", "root-uid")
-	requireGitFolderState(t, helper, ctx, "grandchild-uid", "Grandchild", "root/child/grandchild", "child-uid")
-	requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", "")
+		// Build root → child → grandchild; all have metadata so UIDs are stable.
+		// destination also carries _folder.json so it doesn't trigger a missing-metadata warning.
+		_, local := helper.CreateFolderTargetGitRepo(t, repoName, map[string][]byte{
+			"root/_folder.json":                  folderMetadataJSON("root-uid", "Root"),
+			"root/child/_folder.json":            folderMetadataJSON("child-uid", "Child"),
+			"root/child/grandchild/_folder.json": folderMetadataJSON("grandchild-uid", "Grandchild"),
+			"destination/_folder.json":           folderMetadataJSON("destination-uid", "Destination"),
+		})
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
-	// Grant Editor permission on the deepest (grandchild) folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/grandchild-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Editor", "permission": 2},
+		requireGitFolderState(t, helper, ctx, "root-uid", "Root", "root", repoName)
+		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "root/child", "root-uid")
+		requireGitFolderState(t, helper, ctx, "grandchild-uid", "Grandchild", "root/child/grandchild", "child-uid")
+		requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", repoName)
+
+		// Grant Editor permission on the deepest (grandchild) folder.
+		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
+			"/api/folders/grandchild-uid/permissions",
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Editor", "permission": 2},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on grandchild folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on grandchild folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	grandchildPermsBefore := snapshotFolderPermissions(t, addr, "grandchild-uid")
-	requirePermissionsContainRole(t, grandchildPermsBefore, "Editor", 2)
+		grandchildPermsBefore := snapshotFolderPermissions(t, addr, "grandchild-uid")
+		requirePermissionsContainRole(t, grandchildPermsBefore, "Editor", 2)
 
-	// Move the child subtree (carrying grandchild with it) under destination via git mv.
-	_, err = local.Git("mv", "root/child", "destination/child")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "move child subtree into destination")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
+		// Move the child subtree (carrying grandchild with it) under destination via git mv.
+		_, err = local.Git("mv", "root/child", "destination/child")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move child subtree into destination")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
-	requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", "")
-	requireGitFolderState(t, helper, ctx, "child-uid", "Child", "destination/child", "destination-uid")
-	requireGitFolderState(t, helper, ctx, "grandchild-uid", "Grandchild", "destination/child/grandchild", "child-uid")
+		requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", repoName)
+		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "destination/child", "destination-uid")
+		requireGitFolderState(t, helper, ctx, "grandchild-uid", "Grandchild", "destination/child/grandchild", "child-uid")
 
-	grandchildPermsAfter := snapshotFolderPermissions(t, addr, "grandchild-uid")
-	require.Equal(t, len(grandchildPermsBefore), len(grandchildPermsAfter),
-		"ACL entry count must not change after nested folder move")
-	requireRolePermissionSetEqual(t, grandchildPermsBefore, grandchildPermsAfter)
-	requirePermissionsContainRole(t, grandchildPermsAfter, "Editor", 2)
-}
-
-// TestIntegrationProvisioning_IncrementalSync_RootToLeafMovePreservesPermissions verifies that
-// a top-level (root) folder that is moved to a deeply nested position retains its permissions.
-func TestIntegrationProvisioning_IncrementalSync_RootToLeafMovePreservesPermissions(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
-	ctx := context.Background()
-
-	const repoName = "incr-move-root-to-leaf"
-
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"top/_folder.json":             folderMetadataJSON("top-uid", "Top"),
-		"container/_folder.json":       folderMetadataJSON("container-uid", "Container"),
-		"container/inner/_folder.json": folderMetadataJSON("inner-uid", "Inner"),
+		grandchildPermsAfter := snapshotFolderPermissions(t, addr, "grandchild-uid")
+		require.Equal(t, len(grandchildPermsBefore), len(grandchildPermsAfter),
+			"ACL entry count must not change after nested folder move")
+		requireRolePermissionSetEqual(t, grandchildPermsBefore, grandchildPermsAfter)
+		requirePermissionsContainRole(t, grandchildPermsAfter, "Editor", 2)
 	})
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	// RootToLeafMovePreservesPermissions verifies that a top-level (root) folder
+	// moved to a deeply nested position retains its permissions.
+	t.Run("RootToLeafMovePreservesPermissions", func(t *testing.T) {
+		const repoName = "incr-move-root-to-leaf"
 
-	requireGitFolderState(t, helper, ctx, "top-uid", "Top", "top", "")
-	requireGitFolderState(t, helper, ctx, "container-uid", "Container", "container", "")
-	requireGitFolderState(t, helper, ctx, "inner-uid", "Inner", "container/inner", "container-uid")
+		_, local := helper.CreateFolderTargetGitRepo(t, repoName, map[string][]byte{
+			"top/_folder.json":             folderMetadataJSON("top-uid", "Top"),
+			"container/_folder.json":       folderMetadataJSON("container-uid", "Container"),
+			"container/inner/_folder.json": folderMetadataJSON("inner-uid", "Inner"),
+		})
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
-	// Grant Viewer permission on the root-level "top" folder before the move.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/top-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
+		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "top", repoName)
+		requireGitFolderState(t, helper, ctx, "container-uid", "Container", "container", repoName)
+		requireGitFolderState(t, helper, ctx, "inner-uid", "Inner", "container/inner", "container-uid")
+
+		// Grant Viewer permission on the root-level "top" folder before the move.
+		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
+			"/api/folders/top-uid/permissions",
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Viewer", "permission": 1},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on top folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on top folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	topPermsBefore := snapshotFolderPermissions(t, addr, "top-uid")
-	requirePermissionsContainRole(t, topPermsBefore, "Viewer", 1)
+		topPermsBefore := snapshotFolderPermissions(t, addr, "top-uid")
+		requirePermissionsContainRole(t, topPermsBefore, "Viewer", 1)
 
-	// Move "top" under container/inner, making it a leaf three levels deep.
-	_, err = local.Git("mv", "top", "container/inner/top")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "move top folder to leaf position under container/inner")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
+		// Move "top" under container/inner, making it a leaf three levels deep.
+		_, err = local.Git("mv", "top", "container/inner/top")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move top folder to leaf position under container/inner")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
-	requireGitFolderState(t, helper, ctx, "top-uid", "Top", "container/inner/top", "inner-uid")
+		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "container/inner/top", "inner-uid")
 
-	topPermsAfter := snapshotFolderPermissions(t, addr, "top-uid")
-	require.Equal(t, len(topPermsBefore), len(topPermsAfter),
-		"ACL entry count must not change when moving a root folder to a leaf position")
-	requireRolePermissionSetEqual(t, topPermsBefore, topPermsAfter)
-	requirePermissionsContainRole(t, topPermsAfter, "Viewer", 1)
-	requireFolderAccessible(t, addr, "top-uid", "viewer", "viewer")
-}
-
-// TestIntegrationProvisioning_IncrementalSync_LeafToRootMovePreservesPermissions verifies that
-// a deeply nested folder promoted to the root level retains its permissions.
-func TestIntegrationProvisioning_IncrementalSync_LeafToRootMovePreservesPermissions(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
-	ctx := context.Background()
-
-	const repoName = "incr-move-leaf-to-root"
-
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"parent/_folder.json":           folderMetadataJSON("parent-uid", "Parent"),
-		"parent/deep/_folder.json":      folderMetadataJSON("deep-uid", "Deep"),
-		"parent/deep/leaf/_folder.json": folderMetadataJSON("leaf-uid", "Leaf"),
+		topPermsAfter := snapshotFolderPermissions(t, addr, "top-uid")
+		require.Equal(t, len(topPermsBefore), len(topPermsAfter),
+			"ACL entry count must not change when moving a root folder to a leaf position")
+		requireRolePermissionSetEqual(t, topPermsBefore, topPermsAfter)
+		requirePermissionsContainRole(t, topPermsAfter, "Viewer", 1)
+		requireFolderAccessible(t, addr, "top-uid", "viewer", "viewer")
 	})
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	// LeafToRootMovePreservesPermissions verifies that a deeply nested folder
+	// promoted to the root level retains its permissions.
+	// UIDs are prefixed with "ltroot-" to avoid collisions with the
+	// FolderMoveDoesNotPreservePermissionsForLegacyFolder subtest above, which
+	// also uses a folder named "parent" — UIDs must be globally unique in the
+	// shared Grafana namespace.
+	t.Run("LeafToRootMovePreservesPermissions", func(t *testing.T) {
+		const repoName = "incr-move-leaf-to-root"
 
-	requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", "")
-	requireGitFolderState(t, helper, ctx, "deep-uid", "Deep", "parent/deep", "parent-uid")
-	requireGitFolderState(t, helper, ctx, "leaf-uid", "Leaf", "parent/deep/leaf", "deep-uid")
+		_, local := helper.CreateFolderTargetGitRepo(t, repoName, map[string][]byte{
+			"parent/_folder.json":           folderMetadataJSON("ltroot-parent-uid", "Parent"),
+			"parent/deep/_folder.json":      folderMetadataJSON("ltroot-deep-uid", "Deep"),
+			"parent/deep/leaf/_folder.json": folderMetadataJSON("ltroot-leaf-uid", "Leaf"),
+		})
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		common.SyncAndWaitWithSuccess(t, helper, repoName)
 
-	// Grant Editor permission on the deeply nested leaf folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/leaf-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Editor", "permission": 2},
+		requireGitFolderState(t, helper, ctx, "ltroot-parent-uid", "Parent", "parent", repoName)
+		requireGitFolderState(t, helper, ctx, "ltroot-deep-uid", "Deep", "parent/deep", "ltroot-parent-uid")
+		requireGitFolderState(t, helper, ctx, "ltroot-leaf-uid", "Leaf", "parent/deep/leaf", "ltroot-deep-uid")
+
+		// Grant Editor permission on the deeply nested leaf folder.
+		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
+			"/api/folders/ltroot-leaf-uid/permissions",
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Editor", "permission": 2},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on leaf folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on leaf folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	leafPermsBefore := snapshotFolderPermissions(t, addr, "leaf-uid")
-	requirePermissionsContainRole(t, leafPermsBefore, "Editor", 2)
+		leafPermsBefore := snapshotFolderPermissions(t, addr, "ltroot-leaf-uid")
+		requirePermissionsContainRole(t, leafPermsBefore, "Editor", 2)
 
-	// Promote the leaf to the repository root level via git mv.
-	_, err = local.Git("mv", "parent/deep/leaf", "leaf")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "promote leaf folder to root level")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
+		// Promote the leaf to the repository root level via git mv.
+		_, err = local.Git("mv", "parent/deep/leaf", "leaf")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "promote leaf folder to root level")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
 
-	requireGitFolderState(t, helper, ctx, "leaf-uid", "Leaf", "leaf", "")
+		requireGitFolderState(t, helper, ctx, "ltroot-leaf-uid", "Leaf", "leaf", repoName)
 
-	leafPermsAfter := snapshotFolderPermissions(t, addr, "leaf-uid")
-	require.Equal(t, len(leafPermsBefore), len(leafPermsAfter),
-		"ACL entry count must not change when a leaf folder is promoted to root")
-	requireRolePermissionSetEqual(t, leafPermsBefore, leafPermsAfter)
-	requirePermissionsContainRole(t, leafPermsAfter, "Editor", 2)
-}
-
-// TestIntegrationProvisioning_IncrementalSync_MetadataFolderMovedUnderLegacyPreservesPermissions
-// verifies that a folder backed by _folder.json (stable UID, carries permissions) keeps
-// its ACL when it is moved under a folder that has no _folder.json (legacy, hash-based UID).
-func TestIntegrationProvisioning_IncrementalSync_MetadataFolderMovedUnderLegacyPreservesPermissions(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
-	ctx := context.Background()
-
-	const repoName = "incr-move-meta-under-legacy"
-
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"child-with-meta/_folder.json": folderMetadataJSON("child-meta-uid", "Child With Meta"),
-		"legacy-parent/.keep":          {},
+		leafPermsAfter := snapshotFolderPermissions(t, addr, "ltroot-leaf-uid")
+		require.Equal(t, len(leafPermsBefore), len(leafPermsAfter),
+			"ACL entry count must not change when a leaf folder is promoted to root")
+		requireRolePermissionSetEqual(t, leafPermsBefore, leafPermsAfter)
+		requirePermissionsContainRole(t, leafPermsAfter, "Editor", 2)
 	})
 
-	// legacy-parent has no _folder.json, so the sync correctly warns about missing metadata.
-	common.SyncAndWaitWithWarning(t, helper, repoName)
+	// MetadataFolderMovedUnderLegacyPreservesPermissions verifies that a folder
+	// backed by _folder.json (stable UID, carries permissions) keeps its ACL when
+	// it is moved under a folder that has no _folder.json (legacy, hash-based UID).
+	t.Run("MetadataFolderMovedUnderLegacyPreservesPermissions", func(t *testing.T) {
+		const repoName = "incr-move-meta-under-legacy"
 
-	requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "child-with-meta", "")
-	legacyParentUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "legacy-parent")
-	require.NotEmpty(t, legacyParentUID)
+		_, local := helper.CreateFolderTargetGitRepo(t, repoName, map[string][]byte{
+			"child-with-meta/_folder.json": folderMetadataJSON("child-meta-uid", "Child With Meta"),
+			"legacy-parent/.keep":          {},
+		})
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		// legacy-parent has no _folder.json, so the sync correctly warns about missing metadata.
+		common.SyncAndWaitWithWarning(t, helper, repoName)
 
-	// Set Viewer permission on the metadata-backed child folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/child-meta-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
+		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "child-with-meta", repoName)
+		legacyParentUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "legacy-parent")
+		require.NotEmpty(t, legacyParentUID)
+
+		// Set Viewer permission on the metadata-backed child folder.
+		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
+			"/api/folders/child-meta-uid/permissions",
+			map[string]interface{}{
+				"items": []map[string]interface{}{
+					{"role": "Viewer", "permission": 1},
+				},
 			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on child-with-meta folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+			helper.Org1.Admin)
+		require.NoError(t, err, "setting permissions on child-with-meta folder should succeed")
+		require.Equal(t, http.StatusOK, code)
 
-	childPermsBefore := snapshotFolderPermissions(t, addr, "child-meta-uid")
-	requirePermissionsContainRole(t, childPermsBefore, "Viewer", 1)
+		childPermsBefore := snapshotFolderPermissions(t, addr, "child-meta-uid")
+		requirePermissionsContainRole(t, childPermsBefore, "Viewer", 1)
 
-	// Move the metadata child under the legacy (no _folder.json) parent via git mv.
-	_, err = local.Git("mv", "child-with-meta", "legacy-parent/child-with-meta")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "move child-with-meta under legacy-parent")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
+		// Move the metadata child under the legacy (no _folder.json) parent via git mv.
+		_, err = local.Git("mv", "child-with-meta", "legacy-parent/child-with-meta")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "move child-with-meta under legacy-parent")
+		require.NoError(t, err)
+		_, err = local.Git("push")
+		require.NoError(t, err)
 
-	// After the move, legacy-parent still has no _folder.json, so the incremental sync
-	// also warns about missing metadata.
-	common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		// After the move, legacy-parent still has no _folder.json, so the incremental sync
+		// also warns about missing metadata.
+		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
 
-	// The legacy parent keeps its original hash-based UID (its path did not change).
-	requireGitFolderState(t, helper, ctx, legacyParentUID, "legacy-parent", "legacy-parent", "")
+		// The legacy parent keeps its original hash-based UID (its path did not change).
+		requireGitFolderState(t, helper, ctx, legacyParentUID, "legacy-parent", "legacy-parent", repoName)
 
-	// The metadata child retains its stable UID and is now under the legacy parent.
-	requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "legacy-parent/child-with-meta", legacyParentUID)
+		// The metadata child retains its stable UID and is now under the legacy parent.
+		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "legacy-parent/child-with-meta", legacyParentUID)
 
-	childPermsAfter := snapshotFolderPermissions(t, addr, "child-meta-uid")
-	require.Equal(t, len(childPermsBefore), len(childPermsAfter),
-		"ACL entry count must not change when metadata folder is moved under a legacy parent")
-	requireRolePermissionSetEqual(t, childPermsBefore, childPermsAfter)
-	requirePermissionsContainRole(t, childPermsAfter, "Viewer", 1)
-	requireFolderAccessible(t, addr, "child-meta-uid", "viewer", "viewer")
+		childPermsAfter := snapshotFolderPermissions(t, addr, "child-meta-uid")
+		require.Equal(t, len(childPermsBefore), len(childPermsAfter),
+			"ACL entry count must not change when metadata folder is moved under a legacy parent")
+		requireRolePermissionSetEqual(t, childPermsBefore, childPermsAfter)
+		requirePermissionsContainRole(t, childPermsAfter, "Viewer", 1)
+		requireFolderAccessible(t, addr, "child-meta-uid", "viewer", "viewer")
+	})
 }
 
 // requireGitFolderState asserts that a folder tracked by the gitTestHelper has the expected


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Incremental permission tests reuse git and grafana servers instead of spin their own.

**Why do we need this feature?**

Reduce integration test execution time as it takes a few seconds to spin-up each instance.

**Who is this feature for?**

Grafana CI systems, to have shorter integration test runs.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
