### PR TITLE
SSO Settings: add JWT provider

### DIFF
--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -33,6 +33,7 @@ const (
 	OktaProviderName       = "okta"
 	SAMLProviderName       = "saml"
 	LDAPProviderName       = "ldap"
+	JWTProviderName        = "jwt"
 )
 
 var SocialBaseUrl = "/login/"

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -978,7 +978,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	authService, err := jwt.ProvideService(cfg, remoteCache)
+	authService, err := jwt.ProvideService(cfg, remoteCache, ssosettingsimplService)
 	if err != nil {
 		return nil, err
 	}
@@ -1676,7 +1676,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	authService, err := jwt.ProvideService(cfg, remoteCache)
+	authService, err := jwt.ProvideService(cfg, remoteCache, ssosettingsimplService)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/auth/jwt/auth.go
+++ b/pkg/services/auth/jwt/auth.go
@@ -5,23 +5,37 @@ import (
 	"encoding/base64"
 	"errors"
 	"strings"
+	"sync"
 
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 const ServiceName = "AuthService"
 
-func ProvideService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache) (*AuthService, error) {
+func ProvideService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache, ssoSettings ssosettings.Service) (*AuthService, error) {
 	s := newService(cfg, remoteCache)
-	if err := s.init(); err != nil {
-		return nil, err
+
+	ssoSettings.RegisterReloadable(social.JWTProviderName, s)
+
+	settings, err := ssoSettings.GetForProvider(context.Background(), social.JWTProviderName)
+	if err != nil {
+		s.log.Error("failed to load JWT settings from SSO store, falling back to config file", "error", err)
+		if initErr := s.init(); initErr != nil {
+			s.log.Error("failed to apply JWT config file settings", "error", initErr)
+		}
+		return s, nil
 	}
 
+	if err := s.Reload(context.Background(), *settings); err != nil {
+		s.log.Error("failed to apply JWT settings", "error", err)
+	}
 	return s, nil
 }
 
@@ -33,29 +47,57 @@ func newService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache) *AuthSer
 	}
 }
 
-func (s *AuthService) init() error {
-	if !s.Cfg.JWTAuth.Enabled {
-		return nil
-	}
-
-	if err := s.initClaimExpectations(); err != nil {
-		return err
-	}
-	if err := s.initKeySet(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 type AuthService struct {
 	Cfg         *setting.Cfg
 	RemoteCache *remotecache.RemoteCache
+	log         log.Logger
 
+	// mu protects all fields below. Reload swaps the snapshot under Lock;
+	// Verify takes RLock to copy the pointers it needs and drops the lock
+	// before doing any I/O.
+	mu               sync.RWMutex
+	settings         setting.AuthJWTSettings
 	keySet           keySet
-	log              log.Logger
 	expect           map[string]any
 	expectRegistered jwt.Expected
+}
+
+// init applies the file-config (cfg.JWTAuth) as the current effective state.
+// Used as a fallback when no SSO settings store is available.
+func (s *AuthService) init() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.apply(s.Cfg.JWTAuth)
+}
+
+// apply installs a parsed settings struct as the current state.
+// Callers must hold s.mu for writing.
+func (s *AuthService) apply(next setting.AuthJWTSettings) error {
+	s.settings = next
+	s.keySet = nil
+	s.expect = nil
+	s.expectRegistered = jwt.Expected{}
+
+	if !next.Enabled {
+		return nil
+	}
+	if err := s.initClaimExpectations(); err != nil {
+		return err
+	}
+	return s.initKeySet()
+}
+
+// Settings returns a snapshot of the current JWT auth settings.
+// The returned struct is safe to use independently of subsequent reloads:
+// the OrgMapping slice is copied so callers can't mutate the live state.
+func (s *AuthService) Settings() setting.AuthJWTSettings {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := s.settings
+	if len(s.settings.OrgMapping) > 0 {
+		out.OrgMapping = append([]string(nil), s.settings.OrgMapping...)
+	}
+	return out
 }
 
 // Sanitize JWT base64 strings to remove paddings everywhere
@@ -69,6 +111,16 @@ func sanitizeJWT(jwtToken string) string {
 func (s *AuthService) Verify(ctx context.Context, strToken string) (map[string]any, error) {
 	s.log.Debug("Parsing JSON Web Token")
 
+	s.mu.RLock()
+	keySet := s.keySet
+	expect := s.expect
+	expectRegistered := s.expectRegistered
+	s.mu.RUnlock()
+
+	if keySet == nil {
+		return nil, errors.New("jwt auth not configured")
+	}
+
 	strToken = sanitizeJWT(strToken)
 	token, err := jwt.ParseSigned(strToken, []jose.SignatureAlgorithm{jose.EdDSA, jose.HS256, jose.HS384,
 		jose.HS512, jose.RS512, jose.RS256, jose.ES256, jose.ES384, jose.ES512, jose.PS256, jose.PS384, jose.PS512})
@@ -76,7 +128,7 @@ func (s *AuthService) Verify(ctx context.Context, strToken string) (map[string]a
 		return nil, err
 	}
 
-	keys, err := s.keySet.Key(ctx, token.Headers[0].KeyID)
+	keys, err := keySet.Key(ctx, token.Headers[0].KeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +150,7 @@ func (s *AuthService) Verify(ctx context.Context, strToken string) (map[string]a
 
 	s.log.Debug("Validating JSON Web Token claims")
 
-	if err = s.validateClaims(claims); err != nil {
+	if err = validateClaims(claims, expect, expectRegistered); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/auth/jwt/jwt.go
+++ b/pkg/services/auth/jwt/jwt.go
@@ -2,18 +2,28 @@ package jwt
 
 import (
 	"context"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type JWTService interface {
 	Verify(ctx context.Context, strToken string) (map[string]any, error)
+	// Settings returns a snapshot of the JWT auth settings currently in effect.
+	// Implementations must be safe to call concurrently with reloads.
+	Settings() setting.AuthJWTSettings
 }
 
 type FakeJWTService struct {
 	VerifyProvider func(context.Context, string) (map[string]any, error)
+	SettingsValue  setting.AuthJWTSettings
 }
 
 func (s *FakeJWTService) Verify(ctx context.Context, token string) (map[string]any, error) {
 	return s.VerifyProvider(ctx, token)
+}
+
+func (s *FakeJWTService) Settings() setting.AuthJWTSettings {
+	return s.SettingsValue
 }
 
 func NewFakeJWTService() *FakeJWTService {

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -48,15 +47,15 @@ type keySetHTTP struct {
 	cacheExpiration time.Duration
 }
 
-func (s *AuthService) checkKeySetConfiguration() error {
+func checkKeySetConfiguration(settings setting.AuthJWTSettings) error {
 	var count int
-	if s.Cfg.JWTAuth.KeyFile != "" {
+	if settings.KeyFile != "" {
 		count++
 	}
-	if s.Cfg.JWTAuth.JWKSetFile != "" {
+	if settings.JWKSetFile != "" {
 		count++
 	}
-	if s.Cfg.JWTAuth.JWKSetURL != "" {
+	if settings.JWKSetURL != "" {
 		count++
 	}
 
@@ -74,11 +73,11 @@ func (s *AuthService) checkKeySetConfiguration() error {
 // initKeySet creates a provider for JWKSet, either file, or https
 // nolint:gocyclo
 func (s *AuthService) initKeySet() error {
-	if err := s.checkKeySetConfiguration(); err != nil {
+	if err := checkKeySetConfiguration(s.settings); err != nil {
 		return err
 	}
 
-	if keyFilePath := s.Cfg.JWTAuth.KeyFile; keyFilePath != "" {
+	if keyFilePath := s.settings.KeyFile; keyFilePath != "" {
 		// nolint:gosec
 		// We can ignore the gosec G304 warning on this one because `fileName` comes from grafana configuration file
 		file, err := os.Open(keyFilePath)
@@ -128,10 +127,10 @@ func (s *AuthService) initKeySet() error {
 
 		s.keySet = &keySetJWKS{
 			jose.JSONWebKeySet{
-				Keys: []jose.JSONWebKey{{Key: key, KeyID: s.Cfg.JWTAuth.KeyID}},
+				Keys: []jose.JSONWebKey{{Key: key, KeyID: s.settings.KeyID}},
 			},
 		}
-	} else if keyFilePath := s.Cfg.JWTAuth.JWKSetFile; keyFilePath != "" {
+	} else if keyFilePath := s.settings.JWKSetFile; keyFilePath != "" {
 		// nolint:gosec
 		// We can ignore the gosec G304 warning on this one because `fileName` comes from grafana configuration file
 		file, err := os.Open(keyFilePath)
@@ -150,36 +149,31 @@ func (s *AuthService) initKeySet() error {
 		}
 
 		s.keySet = &keySetJWKS{jwks}
-	} else if urlStr := s.Cfg.JWTAuth.JWKSetURL; urlStr != "" {
-		urlParsed, err := url.Parse(urlStr)
-		if err != nil {
+	} else if urlStr := s.settings.JWKSetURL; urlStr != "" {
+		if err := validateJWKSetURL(urlStr, s.Cfg.Env); err != nil {
 			return err
-		}
-		if urlParsed.Scheme != "https" && s.Cfg.Env != setting.Dev {
-			return ErrJWTSetURLMustHaveHTTPSScheme
 		}
 
 		var caCertPool *x509.CertPool
-		if s.Cfg.JWTAuth.TlsClientCa != "" {
+		if s.settings.TlsClientCa != "" {
 			s.log.Debug("reading ca from TlsClientCa path")
 			// nolint:gosec
 			// We can ignore the gosec G304 warning on this one because `tlsClientCa` comes from grafana configuration file
-			caCert, err := os.ReadFile(s.Cfg.JWTAuth.TlsClientCa)
+			caCert, err := os.ReadFile(s.settings.TlsClientCa)
 			if err != nil {
-				s.log.Error("Failed to read TlsClientCa", "path", s.Cfg.JWTAuth.TlsClientCa, "error", err)
+				s.log.Error("Failed to read TlsClientCa", "path", s.settings.TlsClientCa, "error", err)
 				return fmt.Errorf("failed to read TlsClientCa: %w", err)
 			}
 
 			caCertPool = x509.NewCertPool()
 			if !caCertPool.AppendCertsFromPEM(caCert) {
-				s.log.Error("failed to decode provided PEM certs", "path", s.Cfg.JWTAuth.TlsClientCa)
+				s.log.Error("failed to decode provided PEM certs", "path", s.settings.TlsClientCa)
 				return fmt.Errorf("failed to decode provided PEM certs file from TlsClientCa")
 			}
 		}
 
-		// Read Bearer token from file during init
-		if s.Cfg.JWTAuth.JWKSetBearerTokenFile != "" {
-			if _, err := getBearerToken(s.Cfg.JWTAuth.JWKSetBearerTokenFile); err != nil {
+		if s.settings.JWKSetBearerTokenFile != "" {
+			if _, err := getBearerToken(s.settings.JWKSetBearerTokenFile); err != nil {
 				return err
 			}
 		}
@@ -187,12 +181,12 @@ func (s *AuthService) initKeySet() error {
 		s.keySet = &keySetHTTP{
 			url:             urlStr,
 			log:             s.log,
-			bearerTokenPath: s.Cfg.JWTAuth.JWKSetBearerTokenFile,
+			bearerTokenPath: s.settings.JWKSetBearerTokenFile,
 			client: &http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{
 						Renegotiation:      tls.RenegotiateFreelyAsClient,
-						InsecureSkipVerify: s.Cfg.JWTAuth.TlsSkipVerify,
+						InsecureSkipVerify: s.settings.TlsSkipVerify,
 						RootCAs:            caCertPool,
 					},
 					Proxy: http.ProxyFromEnvironment,
@@ -208,7 +202,7 @@ func (s *AuthService) initKeySet() error {
 				Timeout: time.Second * 30,
 			},
 			cacheKey:        fmt.Sprintf("auth-jwt:jwk-%s", urlStr),
-			cacheExpiration: s.Cfg.JWTAuth.CacheTTL,
+			cacheExpiration: s.settings.CacheTTL,
 			cache:           s.RemoteCache,
 		}
 	}

--- a/pkg/services/auth/jwt/reload.go
+++ b/pkg/services/auth/jwt/reload.go
@@ -1,0 +1,80 @@
+package jwt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var _ ssosettings.Reloadable = (*AuthService)(nil)
+
+func (s *AuthService) Validate(_ context.Context, settings models.SSOSettings, _ models.SSOSettings, _ identity.Requester) error {
+	parsed, err := SettingsFromMap(settings.Settings)
+	if err != nil {
+		return ssosettings.ErrInvalidSettings.Errorf("%w", err)
+	}
+	if err := validateJWTSettings(parsed, s.Cfg.Env); err != nil {
+		return ssosettings.ErrInvalidSettings.Errorf("%w", err)
+	}
+	return nil
+}
+
+func (s *AuthService) Reload(_ context.Context, settings models.SSOSettings) error {
+	parsed, err := SettingsFromMap(settings.Settings)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.apply(parsed)
+}
+
+// validateJWKSetURL parses the URL and rejects non-https outside Dev mode.
+// Empty input is a no-op so callers can pass through unconditionally.
+func validateJWKSetURL(rawURL, env string) error {
+	if rawURL == "" {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid jwk_set_url: %w", err)
+	}
+	if u.Scheme != "https" && env != setting.Dev {
+		return ErrJWTSetURLMustHaveHTTPSScheme
+	}
+	return nil
+}
+
+func validateJWTSettings(parsed setting.AuthJWTSettings, env string) error {
+	if !parsed.Enabled {
+		return nil
+	}
+
+	if parsed.HeaderName == "" && !parsed.URLLogin {
+		return fmt.Errorf("either header_name must be set or url_login must be enabled")
+	}
+
+	if err := checkKeySetConfiguration(parsed); err != nil {
+		return err
+	}
+
+	if err := validateJWKSetURL(parsed.JWKSetURL, env); err != nil {
+		return err
+	}
+
+	if parsed.ExpectClaims != "" {
+		var dummy map[string]any
+		if err := json.Unmarshal([]byte(parsed.ExpectClaims), &dummy); err != nil {
+			return fmt.Errorf("invalid expect_claims: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/auth/jwt/reload_test.go
+++ b/pkg/services/auth/jwt/reload_test.go
@@ -1,0 +1,172 @@
+package jwt
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestSettings_RoundTrip(t *testing.T) {
+	src := setting.AuthJWTSettings{
+		Enabled:                 true,
+		HeaderName:              "X-JWT-Assertion",
+		EmailClaim:              "email",
+		UsernameClaim:           "sub",
+		ExpectClaims:            `{"iss":"https://example.com"}`,
+		JWKSetURL:               "https://example.com/.well-known/jwks.json",
+		CacheTTL:                30 * time.Minute,
+		AutoSignUp:              true,
+		RoleAttributePath:       "roles[0]",
+		RoleAttributeStrict:     true,
+		AllowAssignGrafanaAdmin: false,
+		SkipOrgRoleSync:         false,
+		OrgMapping:              []string{"team-a:1:Editor", "team-b:2:Viewer"},
+		OrgAttributePath:        "groups",
+	}
+
+	got, err := SettingsFromMap(SettingsToMap(src))
+	require.NoError(t, err)
+	require.Equal(t, src, got)
+}
+
+func TestSettingsFromMap_RejectsTypeMismatch(t *testing.T) {
+	_, err := SettingsFromMap(map[string]any{"header_name": 42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header_name")
+}
+
+func TestSettingsFromMap_RejectsInvalidCacheTTL(t *testing.T) {
+	_, err := SettingsFromMap(map[string]any{"cache_ttl": "not-a-duration"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cache_ttl")
+}
+
+func TestValidate_NoOpWhenDisabled(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{"enabled": false},
+	}, models.SSOSettings{}, nil)
+	require.NoError(t, err)
+}
+
+func TestValidate_RequiresHeaderOrURLLogin(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":     true,
+			"jwk_set_url": "https://example.com/.well-known/jwks.json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header_name")
+}
+
+func TestValidate_RejectsAmbiguousKeySource(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":      true,
+			"header_name":  "X-JWT",
+			"jwk_set_url":  "https://example.com/.well-known/jwks.json",
+			"jwk_set_file": "/tmp/jwks.json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.ErrorIs(t, err, ErrKeySetConfigurationAmbiguous)
+}
+
+func TestValidate_RequiresHTTPSJWKSetURL(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{Env: setting.Prod}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":     true,
+			"header_name": "X-JWT",
+			"jwk_set_url": "http://example.com/.well-known/jwks.json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.ErrorIs(t, err, ErrJWTSetURLMustHaveHTTPSScheme)
+}
+
+func TestValidate_RejectsInvalidExpectClaims(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":       true,
+			"header_name":   "X-JWT",
+			"jwk_set_url":   "https://example.com/.well-known/jwks.json",
+			"expect_claims": "{not-json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expect_claims")
+}
+
+func TestReload_DisabledClearsKeyset(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}, log: log.New("test")}
+
+	err := s.Reload(context.Background(), models.SSOSettings{
+		Settings: map[string]any{"enabled": false},
+	})
+	require.NoError(t, err)
+	require.False(t, s.Settings().Enabled)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	require.Nil(t, s.keySet)
+}
+
+// TestReload_RaceWithVerify exercises Verify against concurrent Reload calls
+// under -race. The mutex contract on AuthService is what keeps Verify's
+// snapshot of keySet/expect/expectRegistered consistent — this test exists to
+// catch any future change that breaks that invariant.
+func TestReload_RaceWithVerify(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}, log: log.New("test")}
+
+	disabled := models.SSOSettings{Settings: map[string]any{"enabled": false}}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = s.Reload(context.Background(), disabled)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// Verify will return an error (no keyset configured) but must
+				// not race or panic against the concurrent Reload.
+				_, _ = s.Verify(context.Background(), "not.a.token")
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/services/auth/jwt/sso_settings.go
+++ b/pkg/services/auth/jwt/sso_settings.go
@@ -1,0 +1,153 @@
+package jwt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/login/social/connectors"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// jwtField is a single SSO setting key paired with how to project it to and
+// from setting.AuthJWTSettings. The set of fields lives in jwtFields() so the
+// SSO settings strategy and the reload-from-map path read the same source of
+// truth.
+type jwtField struct {
+	key string
+	get func(s *setting.AuthJWTSettings) any
+	set func(s *setting.AuthJWTSettings, v any) error
+}
+
+func stringField(key string, ptr func(*setting.AuthJWTSettings) *string) jwtField {
+	return jwtField{
+		key: key,
+		get: func(s *setting.AuthJWTSettings) any { return *ptr(s) },
+		set: func(s *setting.AuthJWTSettings, v any) error {
+			if v == nil {
+				return nil
+			}
+			out, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("%s: expected string, got %T", key, v)
+			}
+			*ptr(s) = out
+			return nil
+		},
+	}
+}
+
+func boolField(key string, ptr func(*setting.AuthJWTSettings) *bool) jwtField {
+	return jwtField{
+		key: key,
+		get: func(s *setting.AuthJWTSettings) any { return *ptr(s) },
+		set: func(s *setting.AuthJWTSettings, v any) error {
+			*ptr(s) = connectors.MustBool(v, *ptr(s))
+			return nil
+		},
+	}
+}
+
+func jwtFields() []jwtField {
+	return []jwtField{
+		boolField("enabled", func(s *setting.AuthJWTSettings) *bool { return &s.Enabled }),
+		stringField("header_name", func(s *setting.AuthJWTSettings) *string { return &s.HeaderName }),
+		boolField("url_login", func(s *setting.AuthJWTSettings) *bool { return &s.URLLogin }),
+		stringField("email_claim", func(s *setting.AuthJWTSettings) *string { return &s.EmailClaim }),
+		stringField("username_claim", func(s *setting.AuthJWTSettings) *string { return &s.UsernameClaim }),
+		stringField("expect_claims", func(s *setting.AuthJWTSettings) *string { return &s.ExpectClaims }),
+		stringField("jwk_set_url", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetURL }),
+		stringField("jwk_set_file", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetFile }),
+		stringField("jwk_set_bearer_token_file", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetBearerTokenFile }),
+		stringField("key_file", func(s *setting.AuthJWTSettings) *string { return &s.KeyFile }),
+		stringField("key_id", func(s *setting.AuthJWTSettings) *string { return &s.KeyID }),
+		{
+			key: "cache_ttl",
+			get: func(s *setting.AuthJWTSettings) any { return s.CacheTTL.String() },
+			set: func(s *setting.AuthJWTSettings, v any) error {
+				if v == nil {
+					return nil
+				}
+				str, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("cache_ttl: expected string, got %T", v)
+				}
+				if str == "" {
+					return nil
+				}
+				d, err := time.ParseDuration(str)
+				if err != nil {
+					return fmt.Errorf("invalid cache_ttl: %w", err)
+				}
+				s.CacheTTL = d
+				return nil
+			},
+		},
+		boolField("auto_sign_up", func(s *setting.AuthJWTSettings) *bool { return &s.AutoSignUp }),
+		stringField("role_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.RoleAttributePath }),
+		boolField("role_attribute_strict", func(s *setting.AuthJWTSettings) *bool { return &s.RoleAttributeStrict }),
+		boolField("allow_assign_grafana_admin", func(s *setting.AuthJWTSettings) *bool { return &s.AllowAssignGrafanaAdmin }),
+		boolField("skip_org_role_sync", func(s *setting.AuthJWTSettings) *bool { return &s.SkipOrgRoleSync }),
+		stringField("groups_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.GroupsAttributePath }),
+		stringField("email_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.EmailAttributePath }),
+		stringField("username_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.UsernameAttributePath }),
+		stringField("org_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.OrgAttributePath }),
+		{
+			key: "org_mapping",
+			get: func(s *setting.AuthJWTSettings) any { return strings.Join(s.OrgMapping, ",") },
+			set: func(s *setting.AuthJWTSettings, v any) error {
+				if v == nil {
+					return nil
+				}
+				str, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("org_mapping: expected string, got %T", v)
+				}
+				s.OrgMapping = util.SplitString(str)
+				return nil
+			},
+		},
+		stringField("tls_client_ca", func(s *setting.AuthJWTSettings) *string { return &s.TlsClientCa }),
+		boolField("tls_skip_verify_insecure", func(s *setting.AuthJWTSettings) *bool { return &s.TlsSkipVerify }),
+	}
+}
+
+// defaultSettings returns a struct pre-populated with the defaults that
+// setting/setting_jwt.go applies when reading from the ini file.
+func defaultSettings() setting.AuthJWTSettings {
+	return setting.AuthJWTSettings{
+		ExpectClaims: "{}",
+		CacheTTL:     time.Hour,
+	}
+}
+
+// SettingsToMap projects an AuthJWTSettings struct into the map shape used by
+// the SSO settings API (read path).
+func SettingsToMap(s setting.AuthJWTSettings) map[string]any {
+	fields := jwtFields()
+	m := make(map[string]any, len(fields))
+	for _, f := range fields {
+		m[f.key] = f.get(&s)
+	}
+	return m
+}
+
+// SettingsFromMap converts an SSO settings map back into AuthJWTSettings.
+// Missing keys retain their default values.
+func SettingsFromMap(m map[string]any) (setting.AuthJWTSettings, error) {
+	out := defaultSettings()
+	if m == nil {
+		return out, nil
+	}
+	for _, f := range jwtFields() {
+		v, ok := m[f.key]
+		if !ok {
+			continue
+		}
+		if err := f.set(&out, v); err != nil {
+			return setting.AuthJWTSettings{}, err
+		}
+	}
+	return out, nil
+}

--- a/pkg/services/auth/jwt/validation.go
+++ b/pkg/services/auth/jwt/validation.go
@@ -10,49 +10,53 @@ import (
 )
 
 func (s *AuthService) initClaimExpectations() error {
-	if err := json.Unmarshal([]byte(s.Cfg.JWTAuth.ExpectClaims), &s.expect); err != nil {
+	expect := map[string]any{}
+	if err := json.Unmarshal([]byte(s.settings.ExpectClaims), &expect); err != nil {
 		return err
 	}
 
-	for key, value := range s.expect {
+	var expectRegistered jwt.Expected
+	for key, value := range expect {
 		switch key {
 		case "iss":
 			if stringValue, ok := value.(string); ok {
-				s.expectRegistered.Issuer = stringValue
+				expectRegistered.Issuer = stringValue
 			} else {
 				return fmt.Errorf("%q expectation has invalid type %T, string expected", key, value)
 			}
-			delete(s.expect, key)
+			delete(expect, key)
 		case "sub":
 			if stringValue, ok := value.(string); ok {
-				s.expectRegistered.Subject = stringValue
+				expectRegistered.Subject = stringValue
 			} else {
 				return fmt.Errorf("%q expectation has invalid type %T, string expected", key, value)
 			}
-			delete(s.expect, key)
+			delete(expect, key)
 		case "aud":
 			switch value := value.(type) {
 			case []any:
 				for _, val := range value {
 					if v, ok := val.(string); ok {
-						s.expectRegistered.AnyAudience = append(s.expectRegistered.AnyAudience, v)
+						expectRegistered.AnyAudience = append(expectRegistered.AnyAudience, v)
 					} else {
 						return fmt.Errorf("%q expectation contains value with invalid type %T, string expected", key, val)
 					}
 				}
 			case string:
-				s.expectRegistered.AnyAudience = []string{value}
+				expectRegistered.AnyAudience = []string{value}
 			default:
 				return fmt.Errorf("%q expectation has invalid type %T, array or string expected", key, value)
 			}
-			delete(s.expect, key)
+			delete(expect, key)
 		}
 	}
 
+	s.expect = expect
+	s.expectRegistered = expectRegistered
 	return nil
 }
 
-func (s *AuthService) validateClaims(claims map[string]any) error {
+func validateClaims(claims map[string]any, expect map[string]any, expectRegistered jwt.Expected) error {
 	var registeredClaims jwt.Claims
 	for key, value := range claims {
 		switch key {
@@ -116,13 +120,12 @@ func (s *AuthService) validateClaims(claims map[string]any) error {
 		}
 	}
 
-	expectRegistered := s.expectRegistered
 	expectRegistered.Time = time.Now()
 	if err := registeredClaims.Validate(expectRegistered); err != nil {
 		return err
 	}
 
-	for key, expected := range s.expect {
+	for key, expected := range expect {
 		value, ok := claims[key]
 		if !ok {
 			return fmt.Errorf("%q claim is missing", key)

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -111,7 +111,7 @@ func ProvideRegistration(
 
 	if cfg.JWTAuth.Enabled {
 		orgRoleMapper := connectors.ProvideOrgRoleMapper(cfg, orgService)
-		authnSvc.RegisterClient(clients.ProvideJWT(jwtService, orgRoleMapper, cfg, tracer))
+		authnSvc.RegisterClient(clients.ProvideJWT(jwtService, orgRoleMapper, tracer))
 	}
 
 	if cfg.ExtJWTAuth.Enabled {

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -32,24 +32,27 @@ var (
 		"jwt.invalid_role", errutil.WithPublicMessage("Invalid Role in claim"))
 )
 
-func ProvideJWT(jwtService auth.JWTVerifierService, orgRoleMapper *connectors.OrgRoleMapper, cfg *setting.Cfg, tracer trace.Tracer) *JWT {
+func ProvideJWT(jwtService auth.JWTVerifierService, orgRoleMapper *connectors.OrgRoleMapper, tracer trace.Tracer) *JWT {
 	return &JWT{
-		cfg:           cfg,
 		log:           log.New(authn.ClientJWT),
 		jwtService:    jwtService,
 		orgRoleMapper: orgRoleMapper,
-		orgMappingCfg: orgRoleMapper.ParseOrgMappingSettings(context.Background(), cfg.JWTAuth.OrgMapping, cfg.JWTAuth.RoleAttributeStrict),
 		tracer:        tracer,
 	}
 }
 
 type JWT struct {
-	cfg           *setting.Cfg
 	orgRoleMapper *connectors.OrgRoleMapper
-	orgMappingCfg connectors.MappingConfiguration
 	log           log.Logger
 	jwtService    auth.JWTVerifierService
 	tracer        trace.Tracer
+}
+
+// settings returns the live JWT settings snapshot. Reading through the
+// jwtService rather than s.cfg.JWTAuth ensures that updates pushed via the
+// SSO settings API are picked up at auth time.
+func (s *JWT) settings() setting.AuthJWTSettings {
+	return s.jwtService.Settings()
 }
 
 func (s *JWT) Name() string {
@@ -60,8 +63,10 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	ctx, span := s.tracer.Start(ctx, "authn.jwt.Authenticate")
 	defer span.End()
 
-	jwtToken := s.retrieveToken(r.HTTPRequest)
-	s.stripSensitiveParam(r.HTTPRequest)
+	jwtSettings := s.settings()
+
+	jwtToken := retrieveToken(r.HTTPRequest, jwtSettings)
+	stripSensitiveParam(r.HTTPRequest, jwtSettings)
 
 	claims, err := s.jwtService.Verify(ctx, jwtToken)
 	if err != nil {
@@ -82,28 +87,28 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 			SyncUser:        true,
 			FetchSyncedUser: true,
 			SyncPermissions: true,
-			SyncOrgRoles:    !s.cfg.JWTAuth.SkipOrgRoleSync,
-			AllowSignUp:     s.cfg.JWTAuth.AutoSignUp,
-			SyncTeams:       s.cfg.JWTAuth.GroupsAttributePath != "",
+			SyncOrgRoles:    !jwtSettings.SkipOrgRoleSync,
+			AllowSignUp:     jwtSettings.AutoSignUp,
+			SyncTeams:       jwtSettings.GroupsAttributePath != "",
 		},
 	}
 
-	if key := s.cfg.JWTAuth.UsernameClaim; key != "" {
+	if key := jwtSettings.UsernameClaim; key != "" {
 		id.Login, _ = claims[key].(string)
 		id.ClientParams.LookUpParams.Login = &id.Login
-	} else if key := s.cfg.JWTAuth.UsernameAttributePath; key != "" {
-		id.Login, err = util.SearchJSONForStringAttr(s.cfg.JWTAuth.UsernameAttributePath, claims)
+	} else if key := jwtSettings.UsernameAttributePath; key != "" {
+		id.Login, err = util.SearchJSONForStringAttr(key, claims)
 		if err != nil {
 			return nil, err
 		}
 		id.ClientParams.LookUpParams.Login = &id.Login
 	}
 
-	if key := s.cfg.JWTAuth.EmailClaim; key != "" {
+	if key := jwtSettings.EmailClaim; key != "" {
 		id.Email, _ = claims[key].(string)
 		id.ClientParams.LookUpParams.Email = &id.Email
-	} else if key := s.cfg.JWTAuth.EmailAttributePath; key != "" {
-		id.Email, err = util.SearchJSONForStringAttr(s.cfg.JWTAuth.EmailAttributePath, claims)
+	} else if key := jwtSettings.EmailAttributePath; key != "" {
+		id.Email, err = util.SearchJSONForStringAttr(key, claims)
 		if err != nil {
 			return nil, err
 		}
@@ -114,26 +119,29 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 		id.Name = name
 	}
 
-	id.Groups, err = s.extractGroups(claims)
+	id.Groups, err = extractGroups(claims, jwtSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	if !s.cfg.JWTAuth.SkipOrgRoleSync {
-		role, grafanaAdmin := s.extractRoleAndAdmin(claims)
+	if !jwtSettings.SkipOrgRoleSync {
+		role, grafanaAdmin := extractRoleAndAdmin(claims, jwtSettings)
 
-		if s.cfg.JWTAuth.AllowAssignGrafanaAdmin {
+		if jwtSettings.AllowAssignGrafanaAdmin {
 			id.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		externalOrgs, err := s.extractOrgs(claims)
+		externalOrgs, err := extractOrgs(claims, jwtSettings)
 		if err != nil {
 			s.log.Warn("Failed to extract orgs", "err", err)
 			return nil, err
 		}
 
-		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, role)
-		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
+		// Org mapping is parsed per-call so changes pushed via the SSO settings
+		// API take effect at the next authentication.
+		orgMappingCfg := s.orgRoleMapper.ParseOrgMappingSettings(ctx, jwtSettings.OrgMapping, jwtSettings.RoleAttributeStrict)
+		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(orgMappingCfg, externalOrgs, role)
+		if jwtSettings.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 	}
@@ -148,13 +156,13 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 }
 
 func (s *JWT) IsEnabled() bool {
-	return s.cfg.JWTAuth.Enabled
+	return s.settings().Enabled
 }
 
-// remove sensitive query param
-// avoid JWT URL login passing auth_token in URL
-func (s *JWT) stripSensitiveParam(httpRequest *http.Request) {
-	if s.cfg.JWTAuth.URLLogin {
+// stripSensitiveParam removes the auth_token query parameter when URL login is
+// enabled, so it doesn't leak into logs or metrics.
+func stripSensitiveParam(httpRequest *http.Request, settings setting.AuthJWTSettings) {
+	if settings.URLLogin {
 		params := httpRequest.URL.Query()
 		if params.Has(authQueryParamName) {
 			params.Del(authQueryParamName)
@@ -164,9 +172,9 @@ func (s *JWT) stripSensitiveParam(httpRequest *http.Request) {
 }
 
 // retrieveToken retrieves the JWT token from the request.
-func (s *JWT) retrieveToken(httpRequest *http.Request) string {
-	jwtToken := httpRequest.Header.Get(s.cfg.JWTAuth.HeaderName)
-	if jwtToken == "" && s.cfg.JWTAuth.URLLogin {
+func retrieveToken(httpRequest *http.Request, settings setting.AuthJWTSettings) string {
+	jwtToken := httpRequest.Header.Get(settings.HeaderName)
+	if jwtToken == "" && settings.URLLogin {
 		jwtToken = httpRequest.URL.Query().Get("auth_token")
 	}
 	// Strip the 'Bearer' prefix if it exists.
@@ -174,11 +182,12 @@ func (s *JWT) retrieveToken(httpRequest *http.Request) string {
 }
 
 func (s *JWT) Test(ctx context.Context, r *authn.Request) bool {
-	if !s.cfg.JWTAuth.Enabled || s.cfg.JWTAuth.HeaderName == "" {
+	jwtSettings := s.settings()
+	if !jwtSettings.Enabled || jwtSettings.HeaderName == "" {
 		return false
 	}
 
-	jwtToken := s.retrieveToken(r.HTTPRequest)
+	jwtToken := retrieveToken(r.HTTPRequest, jwtSettings)
 
 	if jwtToken == "" {
 		return false
@@ -198,12 +207,12 @@ func (s *JWT) Priority() uint {
 
 const roleGrafanaAdmin = "GrafanaAdmin"
 
-func (s *JWT) extractRoleAndAdmin(claims map[string]any) (org.RoleType, bool) {
-	if s.cfg.JWTAuth.RoleAttributePath == "" {
+func extractRoleAndAdmin(claims map[string]any, settings setting.AuthJWTSettings) (org.RoleType, bool) {
+	if settings.RoleAttributePath == "" {
 		return "", false
 	}
 
-	role, err := util.SearchJSONForStringAttr(s.cfg.JWTAuth.RoleAttributePath, claims)
+	role, err := util.SearchJSONForStringAttr(settings.RoleAttributePath, claims)
 	if err != nil || role == "" {
 		return "", false
 	}
@@ -214,19 +223,19 @@ func (s *JWT) extractRoleAndAdmin(claims map[string]any) (org.RoleType, bool) {
 	return org.RoleType(role), false
 }
 
-func (s *JWT) extractGroups(claims map[string]any) ([]string, error) {
-	if s.cfg.JWTAuth.GroupsAttributePath == "" {
+func extractGroups(claims map[string]any, settings setting.AuthJWTSettings) ([]string, error) {
+	if settings.GroupsAttributePath == "" {
 		return []string{}, nil
 	}
 
-	return util.SearchJSONForStringSliceAttr(s.cfg.JWTAuth.GroupsAttributePath, claims)
+	return util.SearchJSONForStringSliceAttr(settings.GroupsAttributePath, claims)
 }
 
 // This code was copied from the social_base.go file and was adapted to match with the JWT structure
-func (s *JWT) extractOrgs(claims map[string]any) ([]string, error) {
-	if s.cfg.JWTAuth.OrgAttributePath == "" {
+func extractOrgs(claims map[string]any, settings setting.AuthJWTSettings) ([]string, error) {
+	if settings.OrgAttributePath == "" {
 		return []string{}, nil
 	}
 
-	return util.SearchJSONForStringSliceAttr(s.cfg.JWTAuth.OrgAttributePath, claims)
+	return util.SearchJSONForStringSliceAttr(settings.OrgAttributePath, claims)
 }

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -258,12 +258,13 @@ func TestAuthenticateJWT(t *testing.T) {
 			t.Parallel()
 			jwtService := &jwt.FakeJWTService{
 				VerifyProvider: tc.verifyProvider,
+				SettingsValue:  tc.cfg.JWTAuth,
 			}
 
 			jwtClient := ProvideJWT(jwtService,
 				connectors.ProvideOrgRoleMapper(tc.cfg,
 					&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				tc.cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			validHTTPReq := &http.Request{
 				Header: map[string][]string{
 					jwtHeaderName: {"sample-token"}},
@@ -282,16 +283,14 @@ func TestAuthenticateJWT(t *testing.T) {
 
 func TestJWTClaimConfig(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{
-		VerifyProvider: func(context.Context, string) (map[string]any, error) {
-			return map[string]any{
-				"sub":                "1234567890",
-				"email":              "eai.doe@cor.po",
-				"preferred_username": "eai-doe",
-				"name":               "Eai Doe",
-				"roles":              "Admin",
-			}, nil
-		},
+	verifyClaims := func(context.Context, string) (map[string]any, error) {
+		return map[string]any{
+			"sub":                "1234567890",
+			"email":              "eai.doe@cor.po",
+			"preferred_username": "eai-doe",
+			"name":               "Eai Doe",
+			"roles":              "Admin",
+		}, nil
 	}
 
 	jwtHeaderName := "X-Forwarded-User"
@@ -379,9 +378,13 @@ func TestJWTClaimConfig(t *testing.T) {
 				Header: map[string][]string{
 					jwtHeaderName: {token}},
 			}
+			jwtService := &jwt.FakeJWTService{
+				VerifyProvider: verifyClaims,
+				SettingsValue:  cfg.JWTAuth,
+			}
 			jwtClient := ProvideJWT(jwtService, connectors.ProvideOrgRoleMapper(cfg,
 				&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 				OrgID:       1,
 				HTTPRequest: httpReq,
@@ -397,7 +400,6 @@ func TestJWTClaimConfig(t *testing.T) {
 
 func TestJWTTest(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{}
 	jwtHeaderName := "X-Forwarded-User"
 	// #nosec G101 -- This is dummy/test token
 	validFormatToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
@@ -491,10 +493,11 @@ func TestJWTTest(t *testing.T) {
 					RoleAttributeStrict:     true,
 				},
 			}
+			jwtService := &jwt.FakeJWTService{SettingsValue: cfg.JWTAuth}
 			jwtClient := ProvideJWT(jwtService,
 				connectors.ProvideOrgRoleMapper(cfg,
 					&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			httpReq := &http.Request{
 				URL: &url.URL{RawQuery: "auth_token=" + tc.token},
 				Header: map[string][]string{
@@ -513,18 +516,6 @@ func TestJWTTest(t *testing.T) {
 
 func TestJWTStripParam(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{
-		VerifyProvider: func(context.Context, string) (map[string]any, error) {
-			return map[string]any{
-				"sub":                "1234567890",
-				"email":              "eai.doe@cor.po",
-				"preferred_username": "eai-doe",
-				"name":               "Eai Doe",
-				"roles":              "Admin",
-			}, nil
-		},
-	}
-
 	jwtHeaderName := "X-Forwarded-User"
 
 	cfg := &setting.Cfg{
@@ -541,6 +532,19 @@ func TestJWTStripParam(t *testing.T) {
 		},
 	}
 
+	jwtService := &jwt.FakeJWTService{
+		VerifyProvider: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{
+				"sub":                "1234567890",
+				"email":              "eai.doe@cor.po",
+				"preferred_username": "eai-doe",
+				"name":               "Eai Doe",
+				"roles":              "Admin",
+			}, nil
+		},
+		SettingsValue: cfg.JWTAuth,
+	}
+
 	// #nosec G101 -- This is a dummy/test token
 	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
 
@@ -550,7 +554,7 @@ func TestJWTStripParam(t *testing.T) {
 	jwtClient := ProvideJWT(jwtService,
 		connectors.ProvideOrgRoleMapper(cfg,
 			&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-		cfg, tracing.InitializeTracerForTest())
+		tracing.InitializeTracerForTest())
 	_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,
@@ -604,12 +608,13 @@ func TestJWTSubClaimsConfig(t *testing.T) {
 		VerifyProvider: func(context.Context, string) (map[string]any, error) {
 			return response, nil
 		},
+		SettingsValue: cfg.JWTAuth,
 	}
 
 	jwtClient := ProvideJWT(jwtService,
 		connectors.ProvideOrgRoleMapper(cfg,
 			&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-		cfg, tracing.InitializeTracerForTest())
+		tracing.InitializeTracerForTest())
 	identity, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -56,6 +56,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	fbStrategies := []ssosettings.FallbackStrategy{
 		strategies.NewOAuthStrategy(cfg),
 		strategies.NewLDAPStrategy(cfg),
+		strategies.NewJWTStrategy(cfg),
 	}
 
 	configurableProviders := make(map[string]bool)
@@ -66,6 +67,8 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	providersList := ssosettings.AllOAuthProviders
 	providersList = append(providersList, social.LDAPProviderName)
 	configurableProviders[social.LDAPProviderName] = true
+	providersList = append(providersList, social.JWTProviderName)
+	configurableProviders[social.JWTProviderName] = true
 
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
 		fbStrategies = append(fbStrategies, strategies.NewSAMLStrategy(settingsProvider))

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -269,13 +269,7 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 		return err
 	}
 
-	newSettingsMap := make(map[string]any)
-	for k, v := range storedSettings.Settings {
-		newSettingsMap[k] = v
-	}
-	for k, v := range data {
-		newSettingsMap[k] = v
-	}
+	newSettingsMap := overrideMaps(storedSettings.Settings, data)
 
 	newSettings := &models.SSOSettings{
 		Provider: provider,
@@ -365,13 +359,10 @@ func (s *Service) Reload(ctx context.Context, provider string) {
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {
-	if s.reloadables == nil {
-		s.reloadables = make(map[string]ssosettings.Reloadable)
-	}
 	s.reloadables[provider] = reloadable
 }
 
-func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssosettings.FallbackStrategy) {
+func (s *Service) RegisterFallbackStrategy(_ string, strategy ssosettings.FallbackStrategy) {
 	s.fbStrategies = append(s.fbStrategies, strategy)
 }
 
@@ -652,10 +643,10 @@ func overrideMaps(maps ...map[string]any) map[string]any {
 	return result
 }
 
+var secretFieldPatterns = []string{"secret", "private", "certificate", "password", "client_key"}
+
 // IsSecretField returns true if the SSO settings field provided is a secret
 func IsSecretField(fieldName string) bool {
-	secretFieldPatterns := []string{"secret", "private", "certificate", "password", "client_key"}
-
 	for _, v := range secretFieldPatterns {
 		if strings.Contains(strings.ToLower(fieldName), strings.ToLower(v)) {
 			return true

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -916,6 +916,11 @@ func TestService_List(t *testing.T) {
 					Settings: map[string]any(nil),
 					Source:   models.System,
 				},
+				{
+					Provider: "jwt",
+					Settings: map[string]any(nil),
+					Source:   models.System,
+				},
 			},
 			wantErr: false,
 		},
@@ -1103,6 +1108,11 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 					Settings: map[string]any{},
 					Source:   models.System,
 				},
+				{
+					Provider: "jwt",
+					Settings: map[string]any{},
+					Source:   models.System,
+				},
 			},
 			wantErr: false,
 		},
@@ -1225,6 +1235,11 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 				},
 				{
 					Provider: "ldap",
+					Settings: map[string]any{},
+					Source:   models.System,
+				},
+				{
+					Provider: "jwt",
 					Settings: map[string]any{},
 					Source:   models.System,
 				},
@@ -2399,8 +2414,9 @@ func Test_ProviderService(t *testing.T) {
 				"azuread",
 				"okta",
 				"ldap",
+				"jwt",
 			},
-			strategiesLength: 2,
+			strategiesLength: 3,
 		},
 		{
 			name:             "should return all fallback strategies and it should return all OAuth providers and SAML because the licensing feature is enabled and the provider is setup",
@@ -2414,9 +2430,10 @@ func Test_ProviderService(t *testing.T) {
 				"azuread",
 				"okta",
 				"ldap",
+				"jwt",
 				"saml",
 			},
-			strategiesLength: 3,
+			strategiesLength: 4,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/services/ssosettings/strategies/jwt_strategy.go
+++ b/pkg/services/ssosettings/strategies/jwt_strategy.go
@@ -1,0 +1,28 @@
+package strategies
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type JWTStrategy struct {
+	cfg *setting.Cfg
+}
+
+var _ ssosettings.FallbackStrategy = (*JWTStrategy)(nil)
+
+func NewJWTStrategy(cfg *setting.Cfg) *JWTStrategy {
+	return &JWTStrategy{cfg: cfg}
+}
+
+func (s *JWTStrategy) IsMatch(provider string) bool {
+	return provider == social.JWTProviderName
+}
+
+func (s *JWTStrategy) GetProviderConfig(_ context.Context, _ string) (map[string]any, error) {
+	return jwt.SettingsToMap(s.cfg.JWTAuth), nil
+}

--- a/pkg/services/ssosettings/strategies/jwt_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/jwt_strategy_test.go
@@ -1,0 +1,75 @@
+package strategies
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const jwtConfig = `[auth.jwt]
+enabled = true
+header_name = X-JWT-Assertion
+email_claim = email
+username_claim = sub
+jwk_set_url = https://example.com/.well-known/jwks.json
+cache_ttl = 60m
+expect_claims = {"iss": "https://example.com"}
+role_attribute_path = roles[0]
+role_attribute_strict = true
+allow_assign_grafana_admin = false
+skip_org_role_sync = false
+auto_sign_up = true
+tls_skip_verify_insecure = false`
+
+func TestGetJWTConfig(t *testing.T) {
+	iniFile, err := ini.Load([]byte(jwtConfig))
+	require.NoError(t, err)
+
+	cfg, err := setting.NewCfgFromINIFile(iniFile)
+	require.NoError(t, err)
+
+	strategy := NewJWTStrategy(cfg)
+
+	require.True(t, strategy.IsMatch("jwt"))
+	require.False(t, strategy.IsMatch("ldap"))
+	require.False(t, strategy.IsMatch("generic_oauth"))
+
+	result, err := strategy.GetProviderConfig(context.Background(), "jwt")
+	require.NoError(t, err)
+
+	require.Equal(t, true, result["enabled"])
+	require.Equal(t, "X-JWT-Assertion", result["header_name"])
+	require.Equal(t, "email", result["email_claim"])
+	require.Equal(t, "sub", result["username_claim"])
+	require.Equal(t, "https://example.com/.well-known/jwks.json", result["jwk_set_url"])
+	require.Equal(t, `{"iss": "https://example.com"}`, result["expect_claims"])
+	require.Equal(t, "roles[0]", result["role_attribute_path"])
+	require.Equal(t, true, result["role_attribute_strict"])
+	require.Equal(t, false, result["allow_assign_grafana_admin"])
+	require.Equal(t, false, result["skip_org_role_sync"])
+	require.Equal(t, true, result["auto_sign_up"])
+	require.Equal(t, false, result["tls_skip_verify_insecure"])
+}
+
+func TestGetJWTConfigDefaults(t *testing.T) {
+	// Empty config — should return safe defaults (not error)
+	iniFile, err := ini.Load([]byte("[auth.jwt]"))
+	require.NoError(t, err)
+
+	cfg, err := setting.NewCfgFromINIFile(iniFile)
+	require.NoError(t, err)
+
+	strategy := NewJWTStrategy(cfg)
+	result, err := strategy.GetProviderConfig(context.Background(), "jwt")
+	require.NoError(t, err)
+
+	require.Equal(t, false, result["enabled"])
+	require.Equal(t, "{}", result["expect_claims"])
+	require.Equal(t, false, result["role_attribute_strict"])
+	require.Equal(t, false, result["tls_skip_verify_insecure"])
+	require.Equal(t, false, result["auto_sign_up"])
+}


### PR DESCRIPTION
Adds JWT as a provider in the SSO Settings API. Settings round-trip through the same `Reloadable` shape used by OAuth/LDAP, and user-mapping fields (`org_mapping`, role/email/username paths, etc.) take effect at the next authentication without a restart.

## Behaviour

- `GET /api/v1/sso-settings/jwt` returns the current `auth.jwt` settings merged from the config file and the DB.
- `PUT/PATCH /api/v1/sso-settings/jwt` validates the payload, persists to the DB, and triggers an async reload.
- `DELETE` removes the DB row; the JWT auth service falls back to the config-file values.

## Implementation

- `pkg/services/auth/jwt.AuthService` implements `ssosettings.Reloadable`. A `sync.RWMutex` protects `keySet`, `expect`, `expectRegistered`, and the parsed settings; `Verify` snapshots them under RLock and drops the lock before any I/O.
- `JWTService` gains `Settings() setting.AuthJWTSettings` returning a copy of the live settings. The authn JWT client (`pkg/services/authn/clients/jwt`) reads through this getter instead of the global `cfg.JWTAuth`, so changes pushed via the API take effect at the next authentication.
- The `JWTStrategy` (read fallback) and the `Reload` path share a single field list (`jwtFields()` in `auth/jwt/sso_settings.go`), so the GET shape and the validator can't drift.
- The first commit is an unrelated cleanup of `ssosettingsimpl` (replaces a manual map merge with the existing `overrideMaps`, drops a dead nil-check, blanks an unused parameter, lifts a regex slice to a package var). Happy to split out if preferred.

## Notes

- `cache_ttl` in API responses is the parsed `time.Duration.String()` (e.g. `"1h0m0s"`) rather than the raw ini value (e.g. `"60m"`). Same value, different formatting.
- `org_mapping` is exposed as a comma-joined string, matching the OAuth strategy and the existing ini-file convention.
- `ProvideJWT` (authn client) no longer takes `*setting.Cfg`; it reads everything through the `JWTService.Settings()` snapshot.