### PR TITLE
SSO Settings: fix Reload panic and improve LDAP error context

### DIFF
--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -361,7 +361,19 @@ func (s *Service) reload(reloadable ssosettings.Reloadable, provider string, cur
 }
 
 func (s *Service) Reload(ctx context.Context, provider string) {
-	panic("not implemented") // TODO: Implement
+	reloadable, ok := s.reloadables[provider]
+	if !ok {
+		s.logger.Warn("no reloadable found for provider, skipping reload", "provider", provider)
+		return
+	}
+
+	settings, err := s.GetForProvider(ctx, provider)
+	if err != nil {
+		s.logger.Error("failed to get settings for provider, skipping reload", "provider", provider, "error", err)
+		return
+	}
+
+	go s.reload(reloadable, provider, *settings)
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -2242,6 +2242,63 @@ func TestService_DoReload(t *testing.T) {
 	})
 }
 
+func TestService_Reload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("triggers reload for the requested provider", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+		provider := social.AzureADProviderName
+
+		env.store.ExpectedSSOSetting = &models.SSOSettings{
+			Provider: provider,
+			Settings: map[string]any{"enabled": true},
+			Source:   models.DB,
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		reloadable := ssosettingstests.NewMockReloadable(t)
+		reloadable.On("Reload", mock.Anything, mock.MatchedBy(func(settings models.SSOSettings) bool {
+			defer wg.Done()
+			return settings.Provider == provider && settings.Settings["enabled"] == true
+		})).Return(nil).Once()
+		env.reloadables[provider] = reloadable
+
+		env.service.Reload(context.Background(), provider)
+
+		wg.Wait()
+	})
+
+	t.Run("no-op when no reloadable is registered for the provider", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+
+		require.NotPanics(t, func() {
+			env.service.Reload(context.Background(), "unknown-provider")
+		})
+	})
+
+	t.Run("no-op when GetForProvider returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+		provider := social.AzureADProviderName
+
+		env.store.ExpectedError = errors.New("failed fetching the settings")
+
+		reloadable := ssosettingstests.NewMockReloadable(t)
+		env.reloadables[provider] = reloadable
+
+		require.NotPanics(t, func() {
+			env.service.Reload(context.Background(), provider)
+		})
+	})
+}
+
 func TestService_decryptSecrets(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/ssosettings/strategies/ldap_strategy.go
+++ b/pkg/services/ssosettings/strategies/ldap_strategy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/ldap"
@@ -88,17 +89,17 @@ func replaceNumbersInMap(m map[string]any) (map[string]any, error) {
 		case json.Number:
 			result[k], err = v.Int64()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %q: %w", k, err)
 			}
 		case []any:
 			result[k], err = replaceNumbersInSlice(v)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %q: %w", k, err)
 			}
 		case map[string]any:
 			result[k], err = replaceNumbersInMap(v)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %q: %w", k, err)
 			}
 		default:
 			result[k] = v


### PR DESCRIPTION
Two isolated fixes found during an audit of `pkg/services/ssosettings`.

## Changes

**`Service.Reload` was panicking**
The method was listed on the `Service` interface but never implemented (`panic("not implemented")`). It now follows the same pattern as `Delete`: fetches current settings via `GetForProvider`, then triggers an async reload via the internal `reload` helper.

**`replaceNumbersInMap` returned bare errors**
When a `json.Number` value in the LDAP config couldn't be parsed as `int64`, the error gave no indication of which field failed. Errors now include the field key name.