### PR TITLE
Provisioning: Share one Grafana server per package in connection integration tests

### DIFF
--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -156,8 +156,11 @@ func prepareK8sOptsShared(t *testing.T, opts K8sTestHelperOpts) K8sTestHelperOpt
 
 func fillK8sOpts(t *testing.T, opts K8sTestHelperOpts, createDir func(*testing.T, testinfra.GrafanaOpts) (string, string)) K8sTestHelperOpts {
 	t.Helper()
+	// Use GRPC server when not configured
 	if opts.APIServerStorageType == "" && opts.GRPCServerAddress == "" {
-		opts.APIServerStorageType = options.StorageTypeUnified
+		// TODO, this really should be gRPC, but sometimes fails in drone
+		// the two *should* be identical, but we have seen issues when using real gRPC vs channel
+		opts.APIServerStorageType = options.StorageTypeUnified // TODO, should be GRPC
 	}
 	// Always enable `FlagAppPlatformGrpcClientAuth` for k8s integration tests, as this is the desired behavior.
 	// The flag only exists to support the transition from the old to the new behavior in dev/ops/prod.

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -128,25 +128,37 @@ func NewK8sTestHelperWithOpts(t *testing.T, opts K8sTestHelperOpts) *K8sTestHelp
 // (typically in TestMain after m.Run).
 func NewK8sTestHelperShared(t *testing.T, opts K8sTestHelperOpts) (*K8sTestHelper, func()) {
 	t.Helper()
-	opts = prepareK8sOpts(t, opts)
+	opts = prepareK8sOptsShared(t, opts)
+	grafDir := opts.Dir
 	listenerAddress, env, testDB, serverShutdown := testinfra.StartGrafanaEnvWithManualCleanup(t, opts.Dir, opts.DirPath)
 	shutdownFunc := func() {
 		serverShutdown()
 		if !opts.DisableDBCleanup {
 			testDB.Cleanup()
 		}
+		_ = os.RemoveAll(grafDir)
 	}
 	return buildK8sTestHelper(t, opts, listenerAddress, env), shutdownFunc
 }
 
 func prepareK8sOpts(t *testing.T, opts K8sTestHelperOpts) K8sTestHelperOpts {
 	t.Helper()
+	return fillK8sOpts(t, opts, testinfra.CreateGrafDir)
+}
+
+func prepareK8sOptsShared(t *testing.T, opts K8sTestHelperOpts) K8sTestHelperOpts {
+	t.Helper()
+	return fillK8sOpts(t, opts, testinfra.CreateGrafDirShared)
+}
+
+func fillK8sOpts(t *testing.T, opts K8sTestHelperOpts, createDir func(*testing.T, testinfra.GrafanaOpts) (string, string)) K8sTestHelperOpts {
+	t.Helper()
 	if opts.APIServerStorageType == "" && opts.GRPCServerAddress == "" {
 		opts.APIServerStorageType = options.StorageTypeUnified
 	}
 	opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, featuremgmt.FlagAppPlatformGrpcClientAuth)
 	if opts.Dir == "" && opts.DirPath == "" {
-		opts.Dir, opts.DirPath = testinfra.CreateGrafDir(t, opts.GrafanaOpts)
+		opts.Dir, opts.DirPath = createDir(t, opts.GrafanaOpts)
 	}
 	return opts
 }

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -114,28 +114,45 @@ func NewK8sTestHelper(t *testing.T, opts testinfra.GrafanaOpts) *K8sTestHelper {
 
 func NewK8sTestHelperWithOpts(t *testing.T, opts K8sTestHelperOpts) *K8sTestHelper {
 	t.Helper()
-
-	// Use GRPC server when not configured
-	if opts.APIServerStorageType == "" && opts.GRPCServerAddress == "" {
-		// TODO, this really should be gRPC, but sometimes fails in drone
-		// the two *should* be identical, but we have seen issues when using real gRPC vs channel
-		opts.APIServerStorageType = options.StorageTypeUnified // TODO, should be GRPC
-	}
-
-	// Always enable `FlagAppPlatformGrpcClientAuth` for k8s integration tests, as this is the desired behavior.
-	// The flag only exists to support the transition from the old to the new behavior in dev/ops/prod.
-	opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, featuremgmt.FlagAppPlatformGrpcClientAuth)
-	var (
-		dir  = opts.Dir
-		path = opts.DirPath
-	)
-	if opts.Dir == "" && opts.DirPath == "" {
-		dir, path = testinfra.CreateGrafDir(t, opts.GrafanaOpts)
-	}
-	listenerAddress, env, testDB := testinfra.StartGrafanaEnvWithDB(t, dir, path)
+	opts = prepareK8sOpts(t, opts)
+	listenerAddress, env, testDB := testinfra.StartGrafanaEnvWithDB(t, opts.Dir, opts.DirPath)
 	if !opts.DisableDBCleanup {
 		t.Cleanup(testDB.Cleanup)
 	}
+	return buildK8sTestHelper(t, opts, listenerAddress, env)
+}
+
+// NewK8sTestHelperShared is like NewK8sTestHelperWithOpts but uses
+// StartGrafanaEnvWithManualCleanup so the server is not tied to t.Cleanup.
+// The caller is responsible for invoking the returned shutdown function
+// (typically in TestMain after m.Run).
+func NewK8sTestHelperShared(t *testing.T, opts K8sTestHelperOpts) (*K8sTestHelper, func()) {
+	t.Helper()
+	opts = prepareK8sOpts(t, opts)
+	listenerAddress, env, testDB, serverShutdown := testinfra.StartGrafanaEnvWithManualCleanup(t, opts.Dir, opts.DirPath)
+	shutdownFunc := func() {
+		serverShutdown()
+		if !opts.DisableDBCleanup {
+			testDB.Cleanup()
+		}
+	}
+	return buildK8sTestHelper(t, opts, listenerAddress, env), shutdownFunc
+}
+
+func prepareK8sOpts(t *testing.T, opts K8sTestHelperOpts) K8sTestHelperOpts {
+	t.Helper()
+	if opts.APIServerStorageType == "" && opts.GRPCServerAddress == "" {
+		opts.APIServerStorageType = options.StorageTypeUnified
+	}
+	opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, featuremgmt.FlagAppPlatformGrpcClientAuth)
+	if opts.Dir == "" && opts.DirPath == "" {
+		opts.Dir, opts.DirPath = testinfra.CreateGrafDir(t, opts.GrafanaOpts)
+	}
+	return opts
+}
+
+func buildK8sTestHelper(t *testing.T, opts K8sTestHelperOpts, listenerAddress string, env *server.TestEnv) *K8sTestHelper {
+	t.Helper()
 
 	c := &K8sTestHelper{
 		env:             *env,
@@ -186,7 +203,6 @@ func NewK8sTestHelperWithOpts(t *testing.T, opts K8sTestHelperOpts) *K8sTestHelp
 
 	c.loadAPIGroups()
 
-	// ensure unified storage is alive and running
 	ctx := identity.WithRequester(context.Background(), c.Org1.Admin.Identity)
 	rsp, err := c.env.ResourceClient.IsHealthy(ctx, &resourcepb.HealthCheckRequest{}) //nolint:staticcheck
 	require.NoError(t, err, "unable to read resource client health check")

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -218,6 +218,7 @@ func buildK8sTestHelper(t *testing.T, opts K8sTestHelperOpts, listenerAddress st
 
 	c.loadAPIGroups()
 
+	// ensure unified storage is alive and running
 	ctx := identity.WithRequester(context.Background(), c.Org1.Admin.Identity)
 	rsp, err := c.env.ResourceClient.IsHealthy(ctx, &resourcepb.HealthCheckRequest{}) //nolint:staticcheck
 	require.NoError(t, err, "unable to read resource client health check")

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -128,6 +128,7 @@ func NewK8sTestHelperWithOpts(t *testing.T, opts K8sTestHelperOpts) *K8sTestHelp
 // (typically in TestMain after m.Run).
 func NewK8sTestHelperShared(t *testing.T, opts K8sTestHelperOpts) (*K8sTestHelper, func()) {
 	t.Helper()
+	ownsGrafDir := opts.Dir == "" && opts.DirPath == ""
 	opts = prepareK8sOptsShared(t, opts)
 	grafDir := opts.Dir
 	listenerAddress, env, testDB, serverShutdown := testinfra.StartGrafanaEnvWithManualCleanup(t, opts.Dir, opts.DirPath)
@@ -136,7 +137,9 @@ func NewK8sTestHelperShared(t *testing.T, opts K8sTestHelperOpts) (*K8sTestHelpe
 		if !opts.DisableDBCleanup {
 			testDB.Cleanup()
 		}
-		_ = os.RemoveAll(grafDir)
+		if ownsGrafDir {
+			_ = os.RemoveAll(grafDir)
+		}
 	}
 	return buildK8sTestHelper(t, opts, listenerAddress, env), shutdownFunc
 }

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -159,6 +159,8 @@ func fillK8sOpts(t *testing.T, opts K8sTestHelperOpts, createDir func(*testing.T
 	if opts.APIServerStorageType == "" && opts.GRPCServerAddress == "" {
 		opts.APIServerStorageType = options.StorageTypeUnified
 	}
+	// Always enable `FlagAppPlatformGrpcClientAuth` for k8s integration tests, as this is the desired behavior.
+	// The flag only exists to support the transition from the old to the new behavior in dev/ops/prod.
 	opts.EnableFeatureToggles = append(opts.EnableFeatureToggles, featuremgmt.FlagAppPlatformGrpcClientAuth)
 	if opts.Dir == "" && opts.DirPath == "" {
 		opts.Dir, opts.DirPath = createDir(t, opts.GrafanaOpts)

--- a/pkg/tests/apis/provisioning/README.md
+++ b/pkg/tests/apis/provisioning/README.md
@@ -23,7 +23,7 @@ where every test started its own server, which was the main source of slowness.
 |------|---------|
 | `testinfra/testinfra.go` | `StartGrafanaEnvWithManualCleanup` — returns a cleanup func instead of registering on `t.Cleanup` |
 | `apis/helper.go` | `NewK8sTestHelperShared` — wraps the manual-cleanup variant |
-| `common/testing.go` | `SharedEnv`, `RunGrafanaShared`, cleanup helpers (`CleanupConnections`, `CleanupAllResources`, etc.) |
+| `common/testing.go` | `SharedEnv`, `RunGrafanaShared`, `CleanupAllResources` |
 | `<pkg>/helpers_test.go` | Package-level `env` + `sharedHelper(t)` + `TestMain` |
 
 ### Pattern for `helpers_test.go`
@@ -33,10 +33,7 @@ var env = common.NewSharedEnv()  // pass GrafanaOptions here if needed
 
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
     t.Helper()
-    helper := env.GetHelper(t)
-
-    // Per-test cleanup — reset state so tests don't interfere
-    helper.CleanupConnections(context.Background())
+    helper := env.GetCleanHelper(t)  // cleans all resources, fails test on cleanup error
     helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
     return helper
 }
@@ -62,16 +59,11 @@ Each test function changes one line:
 
 ### Test Isolation
 
-`sharedHelper(t)` runs at the start of every test and performs cleanup.
-Available cleanup methods on `ProvisioningTestHelper`:
-
-- `CleanupConnections(ctx)` — deletes all connections
-- `CleanupRepositories(ctx)` — deletes all repositories
-- `CleanupFolders(ctx)` — deletes all folders
-- `CleanupDashboards(ctx)` — deletes all dashboards
-- `CleanupAllResources(ctx)` — all of the above in dependency order
-
-Pick the ones relevant to your package's resource types.
+`GetCleanHelper(t)` runs `CleanupAllResources(t, ctx)` at the start of every
+test, deleting resources in dependency order (repositories → connections →
+dashboards → folders). Cleanup failures are **fatal** to prevent cross-test
+contamination — if resources from a prior test can't be cleaned, the current
+test fails immediately rather than running against dirty state.
 
 ### Enterprise Tests
 
@@ -90,9 +82,7 @@ func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
     if !extensions.IsEnterprise {
         t.Skip("Skipping enterprise integration test")
     }
-    helper := env.GetHelper(t)
-    helper.CleanupConnections(context.Background())
-    return helper
+    return env.GetCleanHelper(t)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/README.md
+++ b/pkg/tests/apis/provisioning/README.md
@@ -1,0 +1,118 @@
+# Provisioning Integration Tests
+
+## Shared Grafana Server Strategy
+
+Each integration test package starts **one Grafana server** shared across all
+`TestIntegration*` functions in that package. This replaces the previous pattern
+where every test started its own server, which was the main source of slowness.
+
+### How It Works
+
+1. **`common.SharedEnv`** encapsulates `sync.Once`, server init, and `TestMain`
+   lifecycle. Each package creates one at the package level.
+2. **`GetHelper(t)`** starts the server on the first call and reuses it for all
+   subsequent tests. It also handles the integration-mode skip check.
+3. **`RunTestMain(m)`** replaces `testsuite.Run(m)` — it sets up the DB, runs
+   all tests, shuts down the shared server, and cleans up.
+4. Each package defines a thin `sharedHelper(t)` that calls `env.GetHelper(t)`
+   and adds package-specific per-test cleanup.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `testinfra/testinfra.go` | `StartGrafanaEnvWithManualCleanup` — returns a cleanup func instead of registering on `t.Cleanup` |
+| `apis/helper.go` | `NewK8sTestHelperShared` — wraps the manual-cleanup variant |
+| `common/testing.go` | `SharedEnv`, `RunGrafanaShared`, cleanup helpers (`CleanupConnections`, `CleanupAllResources`, etc.) |
+| `<pkg>/helpers_test.go` | Package-level `env` + `sharedHelper(t)` + `TestMain` |
+
+### Pattern for `helpers_test.go`
+
+```go
+var env = common.NewSharedEnv()  // pass GrafanaOptions here if needed
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+    t.Helper()
+    helper := env.GetHelper(t)
+
+    // Per-test cleanup — reset state so tests don't interfere
+    helper.CleanupConnections(context.Background())
+    helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+    return helper
+}
+
+func TestMain(m *testing.M) {
+    env.RunTestMain(m)
+}
+```
+
+### Change Per Test
+
+Each test function changes one line:
+
+```diff
+ func TestIntegrationProvisioning_Example(t *testing.T) {
+-    testutil.SkipIntegrationTestInShortMode(t)
+-    helper := common.RunGrafana(t)
++    helper := sharedHelper(t)
+     ctx := context.Background()
+     // ... rest unchanged ...
+ }
+```
+
+### Test Isolation
+
+`sharedHelper(t)` runs at the start of every test and performs cleanup.
+Available cleanup methods on `ProvisioningTestHelper`:
+
+- `CleanupConnections(ctx)` — deletes all connections
+- `CleanupRepositories(ctx)` — deletes all repositories
+- `CleanupFolders(ctx)` — deletes all folders
+- `CleanupDashboards(ctx)` — deletes all dashboards
+- `CleanupAllResources(ctx)` — all of the above in dependency order
+
+Pick the ones relevant to your package's resource types.
+
+### Enterprise Tests
+
+All enterprise-specific provisioning tests live in the `enterprise/` sibling
+package. This keeps enterprise concerns out of the OSS test packages and gives
+enterprise tests their own shared server with enterprise-specific options.
+Their `sharedHelper` includes the `IsEnterprise` guard:
+
+```go
+var env = common.NewSharedEnv(
+    common.WithRepositoryTypes([]string{"github", "gitlab", "bitbucket"}),
+)
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+    t.Helper()
+    if !extensions.IsEnterprise {
+        t.Skip("Skipping enterprise integration test")
+    }
+    helper := env.GetHelper(t)
+    helper.CleanupConnections(context.Background())
+    return helper
+}
+
+func TestMain(m *testing.M) {
+    env.RunTestMain(m)
+}
+```
+
+### Parallel Readiness
+
+- `sync.Once` is goroutine-safe, so `t.Parallel()` can be added later.
+- For parallel execution: replace per-test cleanup in `sharedHelper` with
+  unique resource names and `t.Cleanup` per test instead.
+- Tests that mutate shared mocks (e.g. `GithubRepoFactory.Client`) must
+  remain sequential or use per-test mock instances.
+
+## Migration Checklist for Other Packages
+
+1. Create `helpers_test.go` with `common.NewSharedEnv(...)` + `sharedHelper` + `TestMain`
+2. Replace `common.RunGrafana(t)` with `sharedHelper(t)` in each test (one-line change)
+3. Remove `testutil.SkipIntegrationTestInShortMode(t)` from each test (handled by `GetHelper`)
+4. Add resource cleanup to `sharedHelper` for the resource types the package uses
+5. Move enterprise tests to the `enterprise/` sibling package
+6. Verify no assertions depend on global state without prior cleanup

--- a/pkg/tests/apis/provisioning/README.md
+++ b/pkg/tests/apis/provisioning/README.md
@@ -20,7 +20,7 @@ where every test started its own server, which was the main source of slowness.
 ### Key Files
 
 | File | Purpose |
-|------|---------|
+| ---- | ------- |
 | `testinfra/testinfra.go` | `StartGrafanaEnvWithManualCleanup` — returns a cleanup func instead of registering on `t.Cleanup` |
 | `apis/helper.go` | `NewK8sTestHelperShared` — wraps the manual-cleanup variant |
 | `common/testing.go` | `SharedEnv`, `RunGrafanaShared`, `CleanupAllResources` |

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1064,8 +1064,14 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 		}
 		select {
 		case <-ctx.Done():
+			if firstErr != nil {
+				return fmt.Errorf("deleteAndWait: context cancelled (first delete error: %v): %w", firstErr, ctx.Err())
+			}
 			return fmt.Errorf("deleteAndWait: context cancelled: %w", ctx.Err())
 		case <-timer.C:
+			if firstErr != nil {
+				return fmt.Errorf("deleteAndWait: timed out with %d items remaining (first delete error: %v)", len(remaining.Items), firstErr)
+			}
 			return fmt.Errorf("deleteAndWait: timed out with %d items remaining", len(remaining.Items))
 		case <-ticker.C:
 		}
@@ -1099,6 +1105,7 @@ type SharedEnv struct {
 	Helper       *ProvisioningTestHelper
 	shutdownFunc func()
 	once         sync.Once
+	initErr      string // non-empty if initialization failed
 	options      []GrafanaOption
 }
 
@@ -1116,8 +1123,17 @@ func (e *SharedEnv) GetHelper(t *testing.T) *ProvisioningTestHelper {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	e.once.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				e.initErr = fmt.Sprintf("shared server init panicked: %v", r)
+			}
+		}()
 		e.Helper, e.shutdownFunc = RunGrafanaShared(t, e.options...)
 	})
+
+	if e.initErr != "" {
+		t.Fatalf("SharedEnv: %s", e.initErr)
+	}
 
 	return e.Helper
 }
@@ -1133,14 +1149,19 @@ func (e *SharedEnv) GetCleanHelper(t *testing.T) *ProvisioningTestHelper {
 
 // RunTestMain replaces testsuite.Run(m) for packages that share a Grafana
 // server. It handles DB setup, runs all tests, shuts down the shared server,
-// cleans up the DB, and exits.
+// cleans up the DB, and exits. In short mode the DB setup is skipped because
+// GetHelper will skip all integration tests anyway.
 func (e *SharedEnv) RunTestMain(m *testing.M) {
-	db.SetupTestDB()
+	if !testing.Short() {
+		db.SetupTestDB()
+	}
 	code := m.Run()
 	if e.shutdownFunc != nil {
 		e.shutdownFunc()
 	}
-	db.CleanupTestDB()
+	if !testing.Short() {
+		db.CleanupTestDB()
+	}
 	os.Exit(code)
 }
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1118,6 +1118,10 @@ func NewSharedEnv(options ...GrafanaOption) *SharedEnv {
 // GetHelper returns the shared ProvisioningTestHelper, starting the Grafana
 // server on the first call (via sync.Once). Subsequent calls reuse the same
 // server. The test is skipped automatically when running in short mode.
+//
+// If initialization fails (panic or t.FailNow/runtime.Goexit), the error is
+// persisted and every subsequent caller gets a clear t.Fatal rather than a
+// nil-pointer crash.
 func (e *SharedEnv) GetHelper(t *testing.T) *ProvisioningTestHelper {
 	t.Helper()
 	testutil.SkipIntegrationTestInShortMode(t)
@@ -1126,6 +1130,8 @@ func (e *SharedEnv) GetHelper(t *testing.T) *ProvisioningTestHelper {
 		defer func() {
 			if r := recover(); r != nil {
 				e.initErr = fmt.Sprintf("shared server init panicked: %v", r)
+			} else if e.Helper == nil && e.initErr == "" {
+				e.initErr = "shared server init failed (FailNow/Goexit called; see first test output)"
 			}
 		}()
 		e.Helper, e.shutdownFunc = RunGrafanaShared(t, e.options...)

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -986,7 +986,7 @@ func buildProvisioningHelper(t *testing.T, k8sHelper *apis.K8sTestHelper, provis
 		DashboardsV2beta1:  dashboardsV2beta1Client,
 	}
 
-	h.CleanupAllResources(context.Background())
+	h.CleanupAllResources(t, context.Background())
 
 	return h
 }
@@ -1053,7 +1053,7 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 			return fmt.Errorf("deleteAndWait: list while polling: %w", err)
 		}
 		if len(remaining.Items) == 0 {
-			return firstErr
+			return nil
 		}
 		for _, item := range remaining.Items {
 			if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
@@ -1072,41 +1072,24 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 	}
 }
 
-// CleanupConnections deletes all connections and waits until they are gone.
-func (h *ProvisioningTestHelper) CleanupConnections(ctx context.Context) {
-	if err := deleteAndWait(ctx, h.Connections.Resource, 10*time.Second); err != nil {
-		fmt.Fprintf(os.Stderr, "CleanupConnections: %v\n", err)
-	}
-}
-
-// CleanupRepositories deletes all repositories and waits until they are gone.
-func (h *ProvisioningTestHelper) CleanupRepositories(ctx context.Context) {
-	if err := deleteAndWait(ctx, h.Repositories.Resource, 10*time.Second); err != nil {
-		fmt.Fprintf(os.Stderr, "CleanupRepositories: %v\n", err)
-	}
-}
-
-// CleanupFolders deletes all folders and waits until they are gone.
-func (h *ProvisioningTestHelper) CleanupFolders(ctx context.Context) {
-	if err := deleteAndWait(ctx, h.Folders.Resource, 10*time.Second); err != nil {
-		fmt.Fprintf(os.Stderr, "CleanupFolders: %v\n", err)
-	}
-}
-
-// CleanupDashboards deletes all dashboards (via the v1 client, which covers v0+v1+v2).
-func (h *ProvisioningTestHelper) CleanupDashboards(ctx context.Context) {
-	if err := deleteAndWait(ctx, h.DashboardsV1.Resource, 10*time.Second); err != nil {
-		fmt.Fprintf(os.Stderr, "CleanupDashboards: %v\n", err)
-	}
-}
-
 // CleanupAllResources deletes resources in dependency order: repositories
 // reference connections, so they go first; dashboards/folders are cleaned last.
-func (h *ProvisioningTestHelper) CleanupAllResources(ctx context.Context) {
-	h.CleanupRepositories(ctx)
-	h.CleanupConnections(ctx)
-	h.CleanupDashboards(ctx)
-	h.CleanupFolders(ctx)
+// Failures are fatal because cleanup is the primary test-isolation mechanism.
+func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
+	t.Helper()
+	for _, c := range []struct {
+		name   string
+		client dynamic.ResourceInterface
+	}{
+		{"repositories", h.Repositories.Resource},
+		{"connections", h.Connections.Resource},
+		{"dashboards", h.DashboardsV1.Resource},
+		{"folders", h.Folders.Resource},
+	} {
+		if err := deleteAndWait(ctx, c.client, 10*time.Second); err != nil {
+			t.Fatalf("CleanupAllResources(%s): %v", c.name, err)
+		}
+	}
 }
 
 // SharedEnv manages a single shared Grafana server for a test package.
@@ -1144,7 +1127,7 @@ func (e *SharedEnv) GetHelper(t *testing.T) *ProvisioningTestHelper {
 func (e *SharedEnv) GetCleanHelper(t *testing.T) *ProvisioningTestHelper {
 	t.Helper()
 	h := e.GetHelper(t)
-	h.CleanupAllResources(context.Background())
+	h.CleanupAllResources(t, context.Background())
 	return h
 }
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1149,19 +1149,14 @@ func (e *SharedEnv) GetCleanHelper(t *testing.T) *ProvisioningTestHelper {
 
 // RunTestMain replaces testsuite.Run(m) for packages that share a Grafana
 // server. It handles DB setup, runs all tests, shuts down the shared server,
-// cleans up the DB, and exits. In short mode the DB setup is skipped because
-// GetHelper will skip all integration tests anyway.
+// cleans up the DB, and exits.
 func (e *SharedEnv) RunTestMain(m *testing.M) {
-	if !testing.Short() {
-		db.SetupTestDB()
-	}
+	db.SetupTestDB()
 	code := m.Run()
 	if e.shutdownFunc != nil {
 		e.shutdownFunc()
 	}
-	if !testing.Short() {
-		db.CleanupTestDB()
-	}
+	db.CleanupTestDB()
 	os.Exit(code)
 }
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
 	dashboardV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
@@ -38,11 +40,13 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 const (
@@ -888,9 +892,8 @@ func WithoutExportFeatureFlag(opts *testinfra.GrafanaOpts) {
 	opts.EnableFeatureToggles = filtered
 }
 
-func RunGrafana(t *testing.T, options ...GrafanaOption) *ProvisioningTestHelper {
-	provisioningPath := t.TempDir()
-	opts := testinfra.GrafanaOpts{
+func defaultGrafanaOpts(provisioningPath string) testinfra.GrafanaOpts {
+	return testinfra.GrafanaOpts{
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagProvisioning,
 			featuremgmt.FlagProvisioningExport,
@@ -913,83 +916,62 @@ func RunGrafana(t *testing.T, options ...GrafanaOption) *ProvisioningTestHelper 
 		// (instance is needed for export jobs, folder for most operations)
 		ProvisioningAllowedTargets: []string{"folder", "instance"},
 	}
+}
 
-	for _, o := range options {
-		o(&opts)
-	}
-	helper := apis.NewK8sTestHelper(t, opts)
+func buildProvisioningHelper(t *testing.T, k8sHelper *apis.K8sTestHelper, provisioningPath string) *ProvisioningTestHelper {
+	t.Helper()
 
-	// FIXME: keeping these lines here to keep the dependency around until we have tests which use this again.
-	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	k8sHelper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
 
-	repositories := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
+	repositories := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
 		Namespace: "default", // actually org1
 		GVR:       provisioning.RepositoryResourceInfo.GroupVersionResource(),
 	})
-	connections := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	connections := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       provisioning.ConnectionResourceInfo.GroupVersionResource(),
 	})
-	jobsClient := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	jobsClient := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       provisioning.JobResourceInfo.GroupVersionResource(),
 	})
-	foldersClient := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	foldersClient := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       folder.FolderResourceInfo.GroupVersionResource(),
 	})
-	dashboardsV0 := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	dashboardsV0 := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       dashboardV0.DashboardResourceInfo.GroupVersionResource(),
 	})
-	dashboardsV1 := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	dashboardsV1 := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       dashboardV1.DashboardResourceInfo.GroupVersionResource(),
 	})
-	dashboardsV2alpha1Client := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	dashboardsV2alpha1Client := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       dashboardsV2alpha1.DashboardResourceInfo.GroupVersionResource(),
 	})
-	dashboardsV2beta1Client := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: "default", // actually org1
+	dashboardsV2beta1Client := k8sHelper.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8sHelper.Org1.Admin,
+		Namespace: "default",
 		GVR:       dashboardsV2beta1.DashboardResourceInfo.GroupVersionResource(),
 	})
 
-	// Repo client, but less guard rails. Useful for subresources. We'll need this later...
 	gv := &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"}
-	adminClient := helper.Org1.Admin.RESTClient(t, gv)
-	editorClient := helper.Org1.Editor.RESTClient(t, gv)
-	viewerClient := helper.Org1.Viewer.RESTClient(t, gv)
+	adminClient := k8sHelper.Org1.Admin.RESTClient(t, gv)
+	editorClient := k8sHelper.Org1.Editor.RESTClient(t, gv)
+	viewerClient := k8sHelper.Org1.Viewer.RESTClient(t, gv)
 
-	deleteAll := func(client *apis.K8sResourceClient) error {
-		ctx := context.Background()
-		list, err := client.Resource.List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
-		for _, resource := range list.Items {
-			if err := client.Resource.Delete(ctx, resource.GetName(), metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	require.NoError(t, deleteAll(dashboardsV1), "deleting all dashboards") // v0+v1+v2
-	require.NoError(t, deleteAll(foldersClient), "deleting all folders")
-	require.NoError(t, deleteAll(repositories), "deleting all repositories")
-
-	return &ProvisioningTestHelper{
+	h := &ProvisioningTestHelper{
 		ProvisioningPath: provisioningPath,
-		K8sTestHelper:    helper,
+		K8sTestHelper:    k8sHelper,
 
 		Repositories:       repositories,
 		Connections:        connections,
@@ -1003,6 +985,180 @@ func RunGrafana(t *testing.T, options ...GrafanaOption) *ProvisioningTestHelper 
 		DashboardsV2alpha1: dashboardsV2alpha1Client,
 		DashboardsV2beta1:  dashboardsV2beta1Client,
 	}
+
+	h.CleanupAllResources(context.Background())
+
+	return h
+}
+
+func RunGrafana(t *testing.T, options ...GrafanaOption) *ProvisioningTestHelper {
+	provisioningPath := t.TempDir()
+	opts := defaultGrafanaOpts(provisioningPath)
+	for _, o := range options {
+		o(&opts)
+	}
+	k8sHelper := apis.NewK8sTestHelper(t, opts)
+	return buildProvisioningHelper(t, k8sHelper, provisioningPath)
+}
+
+// RunGrafanaShared is like RunGrafana but the server shutdown is not tied to
+// t.Cleanup. The caller is responsible for invoking the returned shutdown
+// function (typically in TestMain after m.Run). The provisioning path uses
+// os.MkdirTemp so it survives beyond the initializing test's lifetime.
+func RunGrafanaShared(t *testing.T, options ...GrafanaOption) (*ProvisioningTestHelper, func()) {
+	provisioningPath, err := os.MkdirTemp("", "grafana-provisioning-*")
+	require.NoError(t, err, "failed to create shared provisioning temp dir")
+
+	opts := defaultGrafanaOpts(provisioningPath)
+	for _, o := range options {
+		o(&opts)
+	}
+	k8sHelper, serverShutdown := apis.NewK8sTestHelperShared(t, apis.K8sTestHelperOpts{GrafanaOpts: opts})
+	shutdownFunc := func() {
+		serverShutdown()
+		_ = os.RemoveAll(provisioningPath)
+	}
+	return buildProvisioningHelper(t, k8sHelper, provisioningPath), shutdownFunc
+}
+
+// deleteAndWait deletes all resources from a dynamic client and polls until
+// none remain. It retries deletes on each iteration to handle transient
+// resource-version conflicts from concurrent controller updates.
+func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeout time.Duration) error {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("deleteAndWait: initial list: %w", err)
+	}
+	if len(list.Items) == 0 {
+		return nil
+	}
+
+	var firstErr error
+	for _, item := range list.Items {
+		if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
+			}
+		}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		remaining, err := client.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("deleteAndWait: list while polling: %w", err)
+		}
+		if len(remaining.Items) == 0 {
+			return firstErr
+		}
+		for _, item := range remaining.Items {
+			if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("deleteAndWait: context cancelled: %w", ctx.Err())
+		case <-timer.C:
+			return fmt.Errorf("deleteAndWait: timed out with %d items remaining", len(remaining.Items))
+		case <-ticker.C:
+		}
+	}
+}
+
+// CleanupConnections deletes all connections and waits until they are gone.
+func (h *ProvisioningTestHelper) CleanupConnections(ctx context.Context) {
+	if err := deleteAndWait(ctx, h.Connections.Resource, 10*time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "CleanupConnections: %v\n", err)
+	}
+}
+
+// CleanupRepositories deletes all repositories and waits until they are gone.
+func (h *ProvisioningTestHelper) CleanupRepositories(ctx context.Context) {
+	if err := deleteAndWait(ctx, h.Repositories.Resource, 10*time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "CleanupRepositories: %v\n", err)
+	}
+}
+
+// CleanupFolders deletes all folders and waits until they are gone.
+func (h *ProvisioningTestHelper) CleanupFolders(ctx context.Context) {
+	if err := deleteAndWait(ctx, h.Folders.Resource, 10*time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "CleanupFolders: %v\n", err)
+	}
+}
+
+// CleanupDashboards deletes all dashboards (via the v1 client, which covers v0+v1+v2).
+func (h *ProvisioningTestHelper) CleanupDashboards(ctx context.Context) {
+	if err := deleteAndWait(ctx, h.DashboardsV1.Resource, 10*time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "CleanupDashboards: %v\n", err)
+	}
+}
+
+// CleanupAllResources deletes resources in dependency order: repositories
+// reference connections, so they go first; dashboards/folders are cleaned last.
+func (h *ProvisioningTestHelper) CleanupAllResources(ctx context.Context) {
+	h.CleanupRepositories(ctx)
+	h.CleanupConnections(ctx)
+	h.CleanupDashboards(ctx)
+	h.CleanupFolders(ctx)
+}
+
+// SharedEnv manages a single shared Grafana server for a test package.
+// It encapsulates the sync.Once init, server shutdown, and TestMain lifecycle
+// so that individual packages only need to define their per-test cleanup.
+type SharedEnv struct {
+	Helper       *ProvisioningTestHelper
+	shutdownFunc func()
+	once         sync.Once
+	options      []GrafanaOption
+}
+
+// NewSharedEnv creates a SharedEnv that will lazily start a Grafana server
+// with the given options on the first call to GetHelper.
+func NewSharedEnv(options ...GrafanaOption) *SharedEnv {
+	return &SharedEnv{options: options}
+}
+
+// GetHelper returns the shared ProvisioningTestHelper, starting the Grafana
+// server on the first call (via sync.Once). Subsequent calls reuse the same
+// server. The test is skipped automatically when running in short mode.
+func (e *SharedEnv) GetHelper(t *testing.T) *ProvisioningTestHelper {
+	t.Helper()
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	e.once.Do(func() {
+		e.Helper, e.shutdownFunc = RunGrafanaShared(t, e.options...)
+	})
+
+	return e.Helper
+}
+
+// GetCleanHelper returns the shared helper after cleaning up all resources
+// from the previous test. This is the standard per-test entry point.
+func (e *SharedEnv) GetCleanHelper(t *testing.T) *ProvisioningTestHelper {
+	t.Helper()
+	h := e.GetHelper(t)
+	h.CleanupAllResources(context.Background())
+	return h
+}
+
+// RunTestMain replaces testsuite.Run(m) for packages that share a Grafana
+// server. It handles DB setup, runs all tests, shuts down the shared server,
+// cleans up the DB, and exits.
+func (e *SharedEnv) RunTestMain(m *testing.M) {
+	db.SetupTestDB()
+	code := m.Run()
+	if e.shutdownFunc != nil {
+		e.shutdownFunc()
+	}
+	db.CleanupTestDB()
+	os.Exit(code)
 }
 
 func MustNestedString(obj map[string]interface{}, fields ...string) string {

--- a/pkg/tests/apis/provisioning/connection/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection/connection_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-github/v82/github"
 	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
-	"github.com/grafana/grafana/pkg/extensions"
-	"github.com/grafana/grafana/pkg/util/testutil"
 	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,9 +28,7 @@ import (
 )
 
 func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
@@ -188,9 +184,7 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
@@ -306,231 +300,8 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 	})
 }
 
-func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	if !extensions.IsEnterprise {
-		t.Skip("Skipping integration test when not enterprise")
-	}
-
-	// Enforcing enterprise connection types for the test (defaults to github only)
-	helper := common.RunGrafana(t, common.WithRepositoryTypes([]string{"github", "gitlab", "bitbucket"}))
-	ctx := context.Background()
-
-	gitlabNamePrefix := fmt.Sprintf("%s-", provisioning.GitlabConnectionType)
-	bitbucketNamePrefix := fmt.Sprintf("%s-", provisioning.BitbucketConnectionType)
-
-	t.Run("should update gitlab connection name with type prefix", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  provisioning.GitlabConnectionType,
-				"gitlab": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-
-		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "failed to create resource")
-		require.Contains(t, c.GetName(), gitlabNamePrefix, "name should be updated")
-
-		t.Cleanup(func() {
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-				require.NoError(collect, err)
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	})
-
-	t.Run("should update gitlab connection name with given prefix", func(t *testing.T) {
-		generateName := "some-name-"
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"namespace":    "default",
-				"generateName": generateName,
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  provisioning.GitlabConnectionType,
-				"gitlab": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-
-		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "failed to create resource")
-		require.Contains(t, c.GetName(), generateName, "name should be updated")
-
-		t.Cleanup(func() {
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-				require.NoError(collect, err)
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	})
-
-	t.Run("should keep gitlab connection name if name is already given", func(t *testing.T) {
-		name := "some-name"
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      name,
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  provisioning.GitlabConnectionType,
-				"gitlab": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-
-		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "failed to create resource")
-		require.Equal(t, name, c.GetName(), "name should be identical")
-
-		t.Cleanup(func() {
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-				require.NoError(collect, err)
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	})
-
-	t.Run("should update bitbucket connection name with type prefix", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  provisioning.BitbucketConnectionType,
-				"bitbucket": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-
-		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "failed to create resource")
-		require.Contains(t, c.GetName(), bitbucketNamePrefix, "name should be updated")
-
-		t.Cleanup(func() {
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-				require.NoError(collect, err)
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	})
-
-	t.Run("should update bitbucket connection name with given prefix", func(t *testing.T) {
-		generateName := "some-name-"
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"namespace":    "default",
-				"generateName": generateName,
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  provisioning.BitbucketConnectionType,
-				"bitbucket": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-
-		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "failed to create resource")
-		require.Contains(t, c.GetName(), generateName, "name should be updated")
-
-		t.Cleanup(func() {
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-				require.NoError(collect, err)
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	})
-
-	t.Run("should keep bitbucket connection name if name is already given", func(t *testing.T) {
-		name := "some-name"
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      name,
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  provisioning.BitbucketConnectionType,
-				"bitbucket": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-
-		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "failed to create resource")
-		require.Equal(t, name, c.GetName(), "name should be identical")
-
-		t.Cleanup(func() {
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
-				require.NoError(collect, err)
-			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-		})
-	})
-}
-
 func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -896,169 +667,8 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 	})
 }
 
-func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	if !extensions.IsEnterprise {
-		t.Skip("Skipping integration test when not enterprise")
-	}
-
-	// Enforcing enterprise connection types for the test (defaults to github only)
-	helper := common.RunGrafana(t, common.WithRepositoryTypes([]string{"github", "gitlab", "bitbucket"}))
-	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
-	ctx := context.Background()
-
-	t.Run("should fail when type is bitbucket but 'bitbucket' field is not there", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  "bitbucket",
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
-		require.Error(t, err, "failed to create resource")
-		assert.Contains(t, err.Error(), "bitbucket info must be specified in Bitbucket connection")
-	})
-
-	t.Run("should fail when type is bitbucket but client secret is not there", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  "bitbucket",
-				"bitbucket": map[string]any{
-					"clientID": "123456",
-				},
-			},
-		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
-		require.Error(t, err, "failed to create resource")
-		assert.Contains(t, err.Error(), "clientSecret must be specified for Bitbucket connection")
-	})
-
-	t.Run("should fail when type is bitbucket but a private key is specified", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  "bitbucket",
-				"bitbucket": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"privateKey": map[string]any{
-					"create": "someSecret",
-				},
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
-		require.Error(t, err, "failed to create resource")
-		assert.Contains(t, err.Error(), "privateKey is forbidden in Bitbucket connection")
-	})
-
-	t.Run("should fail when type is gitlab but 'gitlab' field is not there", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  "gitlab",
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
-		require.Error(t, err, "failed to create resource")
-		assert.Contains(t, err.Error(), "gitlab info must be specified in Gitlab connection")
-	})
-
-	t.Run("should fail when type is gitlab but client secret is not there", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  "gitlab",
-				"gitlab": map[string]any{
-					"clientID": "123456",
-				},
-			},
-		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
-		require.Error(t, err, "failed to create resource")
-		assert.Contains(t, err.Error(), "clientSecret must be specified for Gitlab connection")
-	})
-
-	t.Run("should fail when type is gitlab but a private key is specified", func(t *testing.T) {
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Connection",
-				"type":  "gitlab",
-				"gitlab": map[string]any{
-					"clientID": "123456",
-				},
-			},
-			"secure": map[string]any{
-				"privateKey": map[string]any{
-					"create": "someSecret",
-				},
-				"clientSecret": map[string]any{
-					"create": "someSecret",
-				},
-			},
-		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
-		require.Error(t, err, "failed to create resource")
-		assert.Contains(t, err.Error(), "privateKey is forbidden in Gitlab connection")
-	})
-}
-
 func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	namespace := "default"
 
@@ -1265,9 +875,7 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 }
 
 func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	namespace := "default"
 
@@ -1436,9 +1044,7 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 }
 
 func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	namespace := "default"
 
@@ -1676,9 +1282,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 }
 
 func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	namespace := "default"
 
@@ -1839,9 +1443,7 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -2015,9 +1617,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 }
 
 func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	createOptions := metav1.CreateOptions{}
 	deleteOptions := metav1.DeleteOptions{}
@@ -2114,9 +1714,7 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 }
 
 func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	createOptions := metav1.CreateOptions{}
 	deleteOptions := metav1.DeleteOptions{}
@@ -2161,9 +1759,7 @@ func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) 
 }
 
 func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	namespace := "default"
 
@@ -2253,218 +1849,6 @@ func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) 
 		assert.Equal(t, provisioning.ReasonServiceUnavailable, readyCondition.Reason, "Ready condition should have ServiceUnavailable reason for 503 errors")
 		// Verify message contains the actual error returned by the GitHub client
 		assert.Contains(t, readyCondition.Message, "github is unavailable", "condition message should contain the actual error text")
-	})
-}
-
-func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	if !extensions.IsEnterprise {
-		t.Skip("Skipping integration test when not enterprise")
-	}
-
-	// Enforcing enterprise connection types for the test (defaults to github only)
-	helper := common.RunGrafana(t, common.WithRepositoryTypes([]string{"github", "gitlab", "bitbucket"}))
-	ctx := context.Background()
-
-	t.Run("GitLab connection can be created and reconciled", func(t *testing.T) {
-		clientSecret := base64.StdEncoding.EncodeToString([]byte("test-client-secret"))
-
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "test-gitlab-connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test GitLab Connection",
-				"type":  string(provisioning.GitlabConnectionType),
-				"url":   "https://gitlab.com",
-				"gitlab": map[string]any{
-					"clientID": "test-client-id",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": clientSecret,
-				},
-			},
-		}}
-
-		// CREATE
-		created, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
-		require.NoError(t, err, "failed to create GitLab connection")
-		require.NotNil(t, created)
-
-		connectionName := created.GetName()
-		require.NotEmpty(t, connectionName, "connection name should not be empty")
-
-		// Cleanup
-		defer func() {
-			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
-		}()
-
-		// READ
-		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
-		require.NoError(t, err, "failed to read back GitLab connection")
-		assert.Equal(t, connectionName, output.GetName(), "name should be equal")
-
-		spec := output.Object["spec"].(map[string]any)
-		assert.Equal(t, string(provisioning.GitlabConnectionType), spec["type"], "type should be gitlab")
-
-		// Get typed client for status checks
-		restConfig := helper.Org1.Admin.NewRestConfig()
-		provClient, err := clientset.NewForConfig(restConfig)
-		require.NoError(t, err, "failed to create provisioning client")
-		connClient := provClient.ProvisioningV0alpha1().Connections("default")
-
-		// Wait for reconciliation - controller should process the resource
-		// With fake credentials, health check will fail, but reconciliation should happen
-		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			// Check that controller has reconciled (ObservedGeneration matches Generation)
-			// and that health check was attempted (Checked > 0)
-			return updated.Status.ObservedGeneration == updated.Generation &&
-				updated.Status.Health.Checked > 0
-		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled by controller")
-
-		// Verify reconciliation status
-		reconciled, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		// Controller should have set ObservedGeneration - this proves reconciliation happened
-		assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration,
-			"controller should have reconciled the connection")
-
-		// Health check should have been attempted - proves the controller processed it
-		assert.Greater(t, reconciled.Status.Health.Checked, int64(0),
-			"health check should have been attempted")
-
-		// Should have a ready condition - proves status was updated
-		readyCondition := meta.FindStatusCondition(reconciled.Status.Conditions, provisioning.ConditionTypeReady)
-		assert.NotNil(t, readyCondition, "should have ready condition")
-
-		t.Logf("GitLab connection reconciled successfully. Health: %v, ObservedGen: %d, Checked: %d",
-			reconciled.Status.Health.Healthy, reconciled.Status.ObservedGeneration, reconciled.Status.Health.Checked)
-	})
-
-	t.Run("Bitbucket connection can be created and reconciled", func(t *testing.T) {
-		clientSecret := base64.StdEncoding.EncodeToString([]byte("test-client-secret"))
-
-		connection := &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Connection",
-			"metadata": map[string]any{
-				"name":      "test-bitbucket-connection",
-				"namespace": "default",
-			},
-			"spec": map[string]any{
-				"title": "Test Bitbucket Connection",
-				"type":  string(provisioning.BitbucketConnectionType),
-				"bitbucket": map[string]any{
-					"clientID": "test-client-id",
-				},
-			},
-			"secure": map[string]any{
-				"clientSecret": map[string]any{
-					"create": clientSecret,
-				},
-			},
-		}}
-
-		// CREATE
-		created, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
-		require.NoError(t, err, "failed to create Bitbucket connection")
-		require.NotNil(t, created)
-
-		connectionName := created.GetName()
-		require.NotEmpty(t, connectionName, "connection name should not be empty")
-
-		// Cleanup
-		defer func() {
-			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
-		}()
-
-		// READ
-		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
-		require.NoError(t, err, "failed to read back Bitbucket connection")
-		assert.Equal(t, connectionName, output.GetName(), "name should be equal")
-
-		spec := output.Object["spec"].(map[string]any)
-		assert.Equal(t, string(provisioning.BitbucketConnectionType), spec["type"], "type should be bitbucket")
-
-		// Get typed client for status checks
-		restConfig := helper.Org1.Admin.NewRestConfig()
-		provClient, err := clientset.NewForConfig(restConfig)
-		require.NoError(t, err, "failed to create provisioning client")
-		connClient := provClient.ProvisioningV0alpha1().Connections("default")
-
-		// Wait for reconciliation
-		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			return updated.Status.ObservedGeneration == updated.Generation &&
-				updated.Status.Health.Checked > 0
-		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled by controller")
-
-		// Verify reconciliation status
-		reconciled, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration,
-			"controller should have reconciled the connection")
-		assert.Greater(t, reconciled.Status.Health.Checked, int64(0),
-			"health check should have been attempted")
-
-		readyCondition := meta.FindStatusCondition(reconciled.Status.Conditions, provisioning.ConditionTypeReady)
-		assert.NotNil(t, readyCondition, "should have ready condition")
-
-		t.Logf("Bitbucket connection reconciled successfully. Health: %v, ObservedGen: %d, Checked: %d",
-			reconciled.Status.Health.Healthy, reconciled.Status.ObservedGeneration, reconciled.Status.Health.Checked)
-	})
-
-	t.Run("All connection types are supported", func(t *testing.T) {
-		// List all supported connection types by attempting to create connections
-		// This validates the factory has all expected types registered
-
-		supportedTypes := []provisioning.ConnectionType{
-			provisioning.GithubConnectionType,
-			provisioning.GitlabConnectionType,
-			provisioning.BitbucketConnectionType,
-		}
-
-		for _, connType := range supportedTypes {
-			t.Run(string(connType), func(t *testing.T) {
-				// We just check that we can create the object without factory errors
-				// Validation errors are expected if credentials are missing/invalid
-				conn := &unstructured.Unstructured{Object: map[string]any{
-					"apiVersion": "provisioning.grafana.app/v0alpha1",
-					"kind":       "Connection",
-					"metadata": map[string]any{
-						"generateName": "test-",
-						"namespace":    "default",
-					},
-					"spec": map[string]any{
-						"title": "Test Connection",
-						"type":  string(connType),
-					},
-				}}
-
-				// Try to create - we expect validation error, not "type not supported"
-				_, err := helper.Connections.Resource.Create(ctx, conn, metav1.CreateOptions{})
-				if err != nil {
-					// Should be a validation error, not "type not supported"
-					assert.NotContains(t, err.Error(), "is not supported",
-						"type %s should be supported by factory", connType)
-				}
-			})
-		}
 	})
 }
 
@@ -2561,9 +1945,7 @@ func createAppInstallationWithPermissions(id int64, permissions map[string]strin
 }
 
 func TestIntegrationProvisioning_GithubAppPermissionValidation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 
 	// Base64 encoded test private key
@@ -2776,9 +2158,7 @@ func TestIntegrationProvisioning_GithubAppPermissionValidation(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_GithubAppInstallationPermissionValidation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 
 	// Base64 encoded test private key

--- a/pkg/tests/apis/provisioning/connection/github_branch_protection_test.go
+++ b/pkg/tests/apis/provisioning/connection/github_branch_protection_test.go
@@ -18,15 +18,12 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 // TestIntegrationGitHubBranchProtection tests that branch protection rules are properly validated
 // when configuring a GitHub repository with the write workflow.
 func TestIntegrationGitHubBranchProtection(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 
 	// Start test git server that responds to nanogit's smart HTTP protocol
@@ -662,9 +659,7 @@ func startTestGitServer(t *testing.T) *httptest.Server {
 // TestIntegrationGitHubBranchProtection_HealthStatus tests that repositories with branch protection
 // are created successfully, but their health status reflects the branch protection issue.
 func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 
 	// Start test git server

--- a/pkg/tests/apis/provisioning/connection/helpers_test.go
+++ b/pkg/tests/apis/provisioning/connection/helpers_test.go
@@ -3,9 +3,20 @@ package connection
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/tests/testsuite"
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+var env = common.NewSharedEnv()
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	return helper
+}
+
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	env.RunTestMain(m)
 }

--- a/pkg/tests/apis/provisioning/connection/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/connection/pending_delete_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 // labelPendingDelete mirrors the constant defined in the connection controller
@@ -24,9 +23,7 @@ const labelPendingDelete = "cloud.grafana.com/pending-delete"
 // reconciliation – in particular it never advances ObservedGeneration for a soft-deleted
 // stack, which would otherwise happen within a few seconds of a spec change.
 func TestIntegrationProvisioning_ConnectionPendingDeleteLabel_SkipsReconciliation(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 
 	const connName = "pending-delete-skip-conn"
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))

--- a/pkg/tests/apis/provisioning/connection/repositories_test.go
+++ b/pkg/tests/apis/provisioning/connection/repositories_test.go
@@ -13,13 +13,10 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 	connectionName := "connection-repositories-test"
@@ -132,9 +129,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_ConnectionRepositoriesResponseType(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 

--- a/pkg/tests/apis/provisioning/connection/status_auth_test.go
+++ b/pkg/tests/apis/provisioning/connection/status_auth_test.go
@@ -11,13 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 

--- a/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
+++ b/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
@@ -1,0 +1,568 @@
+package enterprise
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+func TestIntegrationProvisioning_ConnectionEnterpriseMutation(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	gitlabNamePrefix := fmt.Sprintf("%s-", provisioning.GitlabConnectionType)
+	bitbucketNamePrefix := fmt.Sprintf("%s-", provisioning.BitbucketConnectionType)
+
+	t.Run("should update gitlab connection name with type prefix", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  provisioning.GitlabConnectionType,
+				"gitlab": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+
+		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Contains(t, c.GetName(), gitlabNamePrefix, "name should be updated")
+
+		t.Cleanup(func() {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		})
+	})
+
+	t.Run("should update gitlab connection name with given prefix", func(t *testing.T) {
+		generateName := "some-name-"
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"namespace":    "default",
+				"generateName": generateName,
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  provisioning.GitlabConnectionType,
+				"gitlab": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+
+		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Contains(t, c.GetName(), generateName, "name should be updated")
+
+		t.Cleanup(func() {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		})
+	})
+
+	t.Run("should keep gitlab connection name if name is already given", func(t *testing.T) {
+		name := "some-name"
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  provisioning.GitlabConnectionType,
+				"gitlab": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+
+		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Equal(t, name, c.GetName(), "name should be identical")
+
+		t.Cleanup(func() {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		})
+	})
+
+	t.Run("should update bitbucket connection name with type prefix", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  provisioning.BitbucketConnectionType,
+				"bitbucket": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+
+		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Contains(t, c.GetName(), bitbucketNamePrefix, "name should be updated")
+
+		t.Cleanup(func() {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		})
+	})
+
+	t.Run("should update bitbucket connection name with given prefix", func(t *testing.T) {
+		generateName := "some-name-"
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"namespace":    "default",
+				"generateName": generateName,
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  provisioning.BitbucketConnectionType,
+				"bitbucket": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+
+		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Contains(t, c.GetName(), generateName, "name should be updated")
+
+		t.Cleanup(func() {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		})
+	})
+
+	t.Run("should keep bitbucket connection name if name is already given", func(t *testing.T) {
+		name := "some-name"
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  provisioning.BitbucketConnectionType,
+				"bitbucket": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+
+		c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "failed to create resource")
+		require.Equal(t, name, c.GetName(), "name should be identical")
+
+		t.Cleanup(func() {
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				require.NoError(collect, err)
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		})
+	})
+}
+
+func TestIntegrationProvisioning_ConnectionEnterpriseValidation(t *testing.T) {
+	helper := sharedHelper(t)
+	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
+	ctx := context.Background()
+
+	t.Run("should fail when type is bitbucket but 'bitbucket' field is not there", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  "bitbucket",
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		require.Error(t, err, "failed to create resource")
+		assert.Contains(t, err.Error(), "bitbucket info must be specified in Bitbucket connection")
+	})
+
+	t.Run("should fail when type is bitbucket but client secret is not there", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  "bitbucket",
+				"bitbucket": map[string]any{
+					"clientID": "123456",
+				},
+			},
+		}}
+		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		require.Error(t, err, "failed to create resource")
+		assert.Contains(t, err.Error(), "clientSecret must be specified for Bitbucket connection")
+	})
+
+	t.Run("should fail when type is bitbucket but a private key is specified", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  "bitbucket",
+				"bitbucket": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"privateKey": map[string]any{
+					"create": "someSecret",
+				},
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		require.Error(t, err, "failed to create resource")
+		assert.Contains(t, err.Error(), "privateKey is forbidden in Bitbucket connection")
+	})
+
+	t.Run("should fail when type is gitlab but 'gitlab' field is not there", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  "gitlab",
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		require.Error(t, err, "failed to create resource")
+		assert.Contains(t, err.Error(), "gitlab info must be specified in Gitlab connection")
+	})
+
+	t.Run("should fail when type is gitlab but client secret is not there", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  "gitlab",
+				"gitlab": map[string]any{
+					"clientID": "123456",
+				},
+			},
+		}}
+		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		require.Error(t, err, "failed to create resource")
+		assert.Contains(t, err.Error(), "clientSecret must be specified for Gitlab connection")
+	})
+
+	t.Run("should fail when type is gitlab but a private key is specified", func(t *testing.T) {
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Connection",
+				"type":  "gitlab",
+				"gitlab": map[string]any{
+					"clientID": "123456",
+				},
+			},
+			"secure": map[string]any{
+				"privateKey": map[string]any{
+					"create": "someSecret",
+				},
+				"clientSecret": map[string]any{
+					"create": "someSecret",
+				},
+			},
+		}}
+		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		require.Error(t, err, "failed to create resource")
+		assert.Contains(t, err.Error(), "privateKey is forbidden in Gitlab connection")
+	})
+}
+
+func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	t.Run("GitLab connection can be created and reconciled", func(t *testing.T) {
+		clientSecret := base64.StdEncoding.EncodeToString([]byte("test-client-secret"))
+
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "test-gitlab-connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test GitLab Connection",
+				"type":  string(provisioning.GitlabConnectionType),
+				"url":   "https://gitlab.com",
+				"gitlab": map[string]any{
+					"clientID": "test-client-id",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": clientSecret,
+				},
+			},
+		}}
+
+		created, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
+		require.NoError(t, err, "failed to create GitLab connection")
+		require.NotNil(t, created)
+
+		connectionName := created.GetName()
+		require.NotEmpty(t, connectionName, "connection name should not be empty")
+
+		defer func() {
+			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+		}()
+
+		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
+		require.NoError(t, err, "failed to read back GitLab connection")
+		assert.Equal(t, connectionName, output.GetName(), "name should be equal")
+
+		spec := output.Object["spec"].(map[string]any)
+		assert.Equal(t, string(provisioning.GitlabConnectionType), spec["type"], "type should be gitlab")
+
+		restConfig := helper.Org1.Admin.NewRestConfig()
+		provClient, err := clientset.NewForConfig(restConfig)
+		require.NoError(t, err, "failed to create provisioning client")
+		connClient := provClient.ProvisioningV0alpha1().Connections("default")
+
+		require.Eventually(t, func() bool {
+			updated, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return updated.Status.ObservedGeneration == updated.Generation &&
+				updated.Status.Health.Checked > 0
+		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled by controller")
+
+		reconciled, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration,
+			"controller should have reconciled the connection")
+		assert.Greater(t, reconciled.Status.Health.Checked, int64(0),
+			"health check should have been attempted")
+
+		readyCondition := meta.FindStatusCondition(reconciled.Status.Conditions, provisioning.ConditionTypeReady)
+		assert.NotNil(t, readyCondition, "should have ready condition")
+
+		t.Logf("GitLab connection reconciled successfully. Health: %v, ObservedGen: %d, Checked: %d",
+			reconciled.Status.Health.Healthy, reconciled.Status.ObservedGeneration, reconciled.Status.Health.Checked)
+	})
+
+	t.Run("Bitbucket connection can be created and reconciled", func(t *testing.T) {
+		clientSecret := base64.StdEncoding.EncodeToString([]byte("test-client-secret"))
+
+		connection := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Connection",
+			"metadata": map[string]any{
+				"name":      "test-bitbucket-connection",
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"title": "Test Bitbucket Connection",
+				"type":  string(provisioning.BitbucketConnectionType),
+				"bitbucket": map[string]any{
+					"clientID": "test-client-id",
+				},
+			},
+			"secure": map[string]any{
+				"clientSecret": map[string]any{
+					"create": clientSecret,
+				},
+			},
+		}}
+
+		created, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
+		require.NoError(t, err, "failed to create Bitbucket connection")
+		require.NotNil(t, created)
+
+		connectionName := created.GetName()
+		require.NotEmpty(t, connectionName, "connection name should not be empty")
+
+		defer func() {
+			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+		}()
+
+		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
+		require.NoError(t, err, "failed to read back Bitbucket connection")
+		assert.Equal(t, connectionName, output.GetName(), "name should be equal")
+
+		spec := output.Object["spec"].(map[string]any)
+		assert.Equal(t, string(provisioning.BitbucketConnectionType), spec["type"], "type should be bitbucket")
+
+		restConfig := helper.Org1.Admin.NewRestConfig()
+		provClient, err := clientset.NewForConfig(restConfig)
+		require.NoError(t, err, "failed to create provisioning client")
+		connClient := provClient.ProvisioningV0alpha1().Connections("default")
+
+		require.Eventually(t, func() bool {
+			updated, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return updated.Status.ObservedGeneration == updated.Generation &&
+				updated.Status.Health.Checked > 0
+		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled by controller")
+
+		reconciled, err := connClient.Get(ctx, connectionName, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration,
+			"controller should have reconciled the connection")
+		assert.Greater(t, reconciled.Status.Health.Checked, int64(0),
+			"health check should have been attempted")
+
+		readyCondition := meta.FindStatusCondition(reconciled.Status.Conditions, provisioning.ConditionTypeReady)
+		assert.NotNil(t, readyCondition, "should have ready condition")
+
+		t.Logf("Bitbucket connection reconciled successfully. Health: %v, ObservedGen: %d, Checked: %d",
+			reconciled.Status.Health.Healthy, reconciled.Status.ObservedGeneration, reconciled.Status.Health.Checked)
+	})
+
+	t.Run("All connection types are supported", func(t *testing.T) {
+		supportedTypes := []provisioning.ConnectionType{
+			provisioning.GithubConnectionType,
+			provisioning.GitlabConnectionType,
+			provisioning.BitbucketConnectionType,
+		}
+
+		for _, connType := range supportedTypes {
+			t.Run(string(connType), func(t *testing.T) {
+				conn := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "provisioning.grafana.app/v0alpha1",
+					"kind":       "Connection",
+					"metadata": map[string]any{
+						"generateName": "test-",
+						"namespace":    "default",
+					},
+					"spec": map[string]any{
+						"title": "Test Connection",
+						"type":  string(connType),
+					},
+				}}
+
+				created, err := helper.Connections.Resource.Create(ctx, conn, metav1.CreateOptions{})
+				if err != nil {
+					assert.NotContains(t, err.Error(), "is not supported",
+						"type %s should be supported by factory", connType)
+					return
+				}
+				t.Cleanup(func() {
+					_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+				})
+			})
+		}
+	})
+}

--- a/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
+++ b/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/meta"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 

--- a/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
+++ b/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -420,7 +421,9 @@ func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
 		connectionName := created.GetName()
 		require.NotEmpty(t, connectionName, "connection name should not be empty")
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+			if err := helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup: failed to delete GitLab connection %q: %v", connectionName, err)
+			}
 		})
 
 		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
@@ -490,7 +493,9 @@ func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
 		connectionName := created.GetName()
 		require.NotEmpty(t, connectionName, "connection name should not be empty")
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+			if err := helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				t.Errorf("cleanup: failed to delete Bitbucket connection %q: %v", connectionName, err)
+			}
 		})
 
 		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
@@ -558,7 +563,9 @@ func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
 					return
 				}
 				t.Cleanup(func() {
-					_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+					if err := helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+						t.Errorf("cleanup: failed to delete connection %q: %v", created.GetName(), err)
+					}
 				})
 			})
 		}

--- a/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
+++ b/pkg/tests/apis/provisioning/enterprise/enterprise_test.go
@@ -419,10 +419,9 @@ func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
 
 		connectionName := created.GetName()
 		require.NotEmpty(t, connectionName, "connection name should not be empty")
-
-		defer func() {
+		t.Cleanup(func() {
 			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
-		}()
+		})
 
 		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
 		require.NoError(t, err, "failed to read back GitLab connection")
@@ -490,10 +489,9 @@ func TestIntegrationConnectionController_EnterpriseWiring(t *testing.T) {
 
 		connectionName := created.GetName()
 		require.NotEmpty(t, connectionName, "connection name should not be empty")
-
-		defer func() {
+		t.Cleanup(func() {
 			_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
-		}()
+		})
 
 		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
 		require.NoError(t, err, "failed to read back Bitbucket connection")

--- a/pkg/tests/apis/provisioning/enterprise/helpers_test.go
+++ b/pkg/tests/apis/provisioning/enterprise/helpers_test.go
@@ -1,0 +1,26 @@
+package enterprise
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/extensions"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+var env = common.NewSharedEnv(
+	common.WithRepositoryTypes([]string{"github", "gitlab", "bitbucket"}),
+)
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+
+	if !extensions.IsEnterprise {
+		t.Skip("Skipping enterprise integration test")
+	}
+
+	return env.GetCleanHelper(t)
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -233,8 +233,6 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 
 // CreateGrafDir creates the Grafana directory.
 // The log by default is muted in the regression test, to activate it, pass option EnableLog = true
-//
-//nolint:gocyclo
 func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	t.Helper()
 	return createGrafDir(t, t.TempDir(), opts)
@@ -250,6 +248,7 @@ func CreateGrafDirShared(t *testing.T, opts GrafanaOpts) (string, string) {
 	return createGrafDir(t, tmpDir, opts)
 }
 
+//nolint:gocyclo
 func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, string) {
 	t.Helper()
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -58,6 +58,16 @@ func StartGrafanaEnv(t *testing.T, grafDir, cfgPath string) (string, *server.Tes
 }
 
 func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *server.TestEnv, *sqlutil.TestDB) {
+	addr, env, testDB, cleanup := StartGrafanaEnvWithManualCleanup(t, grafDir, cfgPath)
+	t.Cleanup(cleanup)
+	return addr, env, testDB
+}
+
+// StartGrafanaEnvWithManualCleanup starts a Grafana server without registering
+// shutdown on t.Cleanup. The caller is responsible for calling the returned
+// cleanup function. This is useful when the server must outlive any single
+// test, e.g. when shared across an entire package via sync.Once.
+func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (string, *server.TestEnv, *sqlutil.TestDB, func()) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -179,9 +189,10 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 			t.Log("Server exited uncleanly", "error", err)
 		}
 	}()
-	t.Cleanup(func() {
+
+	cleanup := func() {
 		if err := env.Server.Shutdown(ctx, "test cleanup"); err != nil {
-			t.Error("Timed out waiting on server to shut down")
+			t.Log("Timed out waiting on server to shut down")
 		}
 		if storage != nil {
 			storage.StopAsync()
@@ -189,7 +200,7 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 		if grpcService != nil {
 			grpcService.StopAsync()
 		}
-	})
+	}
 
 	// Wait for Grafana to be ready, retrying until the health endpoint responds or the timeout is reached.
 	addr := listener.Addr().String()
@@ -217,7 +228,7 @@ func StartGrafanaEnvWithDB(t *testing.T, grafDir, cfgPath string) (string, *serv
 
 	t.Logf("Grafana is listening on %s", addr)
 
-	return addr, env, testDB
+	return addr, env, testDB, cleanup
 }
 
 // CreateGrafDir creates the Grafana directory.

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -186,13 +186,13 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 	go func() {
 		// When the server runs, it will also build and initialize the service graph
 		if err := env.Server.Run(); err != nil {
-			t.Log("Server exited uncleanly", "error", err)
+			fmt.Fprintf(os.Stderr, "Server exited uncleanly: %v\n", err)
 		}
 	}()
 
 	cleanup := func() {
 		if err := env.Server.Shutdown(ctx, "test cleanup"); err != nil {
-			t.Log("Timed out waiting on server to shut down")
+			fmt.Fprintf(os.Stderr, "Timed out waiting on server to shut down: %v\n", err)
 		}
 		if storage != nil {
 			storage.StopAsync()
@@ -237,8 +237,21 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 //nolint:gocyclo
 func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 	t.Helper()
+	return createGrafDir(t, t.TempDir(), opts)
+}
 
-	tmpDir := t.TempDir()
+// CreateGrafDirShared is like CreateGrafDir but uses os.MkdirTemp instead of
+// t.TempDir() so the directory outlives the initializing test. The caller is
+// responsible for removing the returned directory.
+func CreateGrafDirShared(t *testing.T, opts GrafanaOpts) (string, string) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "grafana-shared-*")
+	require.NoError(t, err)
+	return createGrafDir(t, tmpDir, opts)
+}
+
+func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, string) {
+	t.Helper()
 
 	// Search upwards in directory tree for project root
 	var rootDir string


### PR DESCRIPTION
## Why

Connection integration tests start **22 separate Grafana servers** — one per `TestIntegration*` function. Each startup involves Wire DI, database provisioning, HTTP listener binding, health polling, and shutdown. This is the main bottleneck making these tests slow.

## What

Refactor the `connection` package to share **one Grafana server** across all tests using `sync.Once` + `TestMain` shutdown. Enterprise tests move to a dedicated `enterprise/` sibling package (intended to hold all enterprise provisioning tests) with its own shared server.

**Server startups drop from 22 → 1** (one standard; enterprise in separate package).

## Performance Results

| | main | branch | delta |
|---|---|---|---|
| `go test` reported time | 84s | 31s | **-63% (2.7x faster)** |
| Wall clock time | 1m39s | 42s | **-58% (2.4x faster)** |
| Grafana server startups | 22 | 1 | -21 startups eliminated |
| Passing tests | 21/22 | 19/19 | All pass |
| Broken tests | 1 (`ConnectionRepositoriesResponseType`) | 0 | Fixed by robust cleanup |

> **Note:** `TestIntegrationProvisioning_ConnectionRepositoriesResponseType` fails on `main` due to a resource version conflict when two tests use the same connection name. The new `deleteAndWait` cleanup (which retries deletes on conflict) fixes this pre-existing issue.

## How

### The `t.Cleanup` Problem

`testinfra.StartGrafanaEnvWithDB` registers server shutdown on `t.Cleanup`. If multiple top-level tests share a server started with the first test's `t`, the server dies when that first test finishes.

### Solution: Manual Cleanup + `sync.Once`

```mermaid
flowchart TD
    subgraph connectionPkg ["connection/ package"]
        TM1["TestMain"] --> DBSetup["db.SetupTestDB()"]
        DBSetup --> MRun["m.Run()"]
        MRun --> T1["TestIntegration_CRUDL"]
        MRun --> T2["TestIntegration_Mutation"]
        MRun --> TN["... 19 tests in separate files"]
        T1 -->|"first call → sync.Once"| Server["Start Grafana once"]
        T2 -->|"reuses shared helper"| Server
        TN -->|"reuses shared helper"| Server
        MRun --> Shutdown["shutdownFunc()"]
        Shutdown --> DBClean["db.CleanupTestDB()"]
    end

    subgraph enterprisePkg ["enterprise/ package"]
        TM2["TestMain + sync.Once"] --> E1["TestIntegration_EnterpriseMutation"]
        TM2 --> E2["TestIntegration_EnterpriseValidation"]
        TM2 --> E3["TestIntegration_EnterpriseWiring"]
    end
```

### Layer Diagram

```mermaid
flowchart TB
    subgraph "Test Layer (per package)"
        HT["helpers_test.go<br/>sync.Once + TestMain"]
        TF["*_test.go files<br/>sharedHelper(t) one-liner"]
    end

    subgraph "Common Layer"
        RGS["common.RunGrafanaShared()<br/>Returns (helper, shutdownFunc)"]
        CC["CleanupAllResources()<br/>Per-test state isolation"]
    end

    subgraph "Infrastructure Layer"
        KTS["apis.NewK8sTestHelperShared()<br/>Manual cleanup variant"]
        TI["testinfra.StartGrafanaEnvWithManualCleanup()<br/>Returns cleanup func"]
    end

    TF --> HT
    HT --> RGS
    HT --> CC
    RGS --> KTS
    KTS --> TI
```

### Implementation

1. **`testinfra.go`** — Extract `StartGrafanaEnvWithManualCleanup` that returns a cleanup func instead of registering on `t.Cleanup`. Existing `StartGrafanaEnvWithDB` delegates to it (backward compatible).

2. **`apis/helper.go`** — Add `NewK8sTestHelperShared` wrapping the manual-cleanup variant.

3. **`common/testing.go`** — Add `RunGrafanaShared` (returns `helper, shutdownFunc`), `SharedEnv` (reusable `sync.Once` + `TestMain` wrapper), and robust `deleteAndWait` cleanup that retries on resource version conflicts.

4. **`connection/helpers_test.go`** — Uses `common.NewSharedEnv()` for `sync.Once` + `TestMain` lifecycle.

5. **All test files** — One-line change per test:
   ```diff
    func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
   -    testutil.SkipIntegrationTestInShortMode(t)
   -    helper := common.RunGrafana(t)
   +    helper := sharedHelper(t)
        ctx := context.Background()
        // ... rest unchanged ...
    }
   ```

6. **`enterprise/`** (new package) — All enterprise provisioning tests live here with their own `sharedHelper` that includes `IsEnterprise` guard and enterprise connection types. This package is intended to hold enterprise tests from all provisioning areas, not just connections.

### Test Isolation

`sharedHelper(t)` runs at the start of every test and:
- Calls `CleanupAllResources` to remove all resources in dependency order (retries on resource version conflicts; failures are fatal to prevent cross-test contamination)
- Restores default GitHub mock client

### Parallel Readiness

- `sync.Once` is goroutine-safe — `t.Parallel()` can be added later
- For parallel: replace per-test cleanup with unique resource names + `t.Cleanup`
- Tests that mutate shared mocks stay sequential

## Files Changed

| File | Change |
|------|--------|
| `pkg/tests/testinfra/testinfra.go` | Add `StartGrafanaEnvWithManualCleanup`, refactor existing func |
| `pkg/tests/apis/helper.go` | Add `NewK8sTestHelperShared` |
| `pkg/tests/apis/provisioning/common/testing.go` | Add `RunGrafanaShared`, `SharedEnv`, `deleteAndWait`, cleanup methods |
| `pkg/tests/apis/provisioning/connection/helpers_test.go` | Rewrite with `common.NewSharedEnv()` |
| `pkg/tests/apis/provisioning/connection/connection_test.go` | One-line change ×16, remove 3 enterprise tests |
| `pkg/tests/apis/provisioning/connection/status_auth_test.go` | One-line change |
| `pkg/tests/apis/provisioning/connection/pending_delete_test.go` | One-line change |
| `pkg/tests/apis/provisioning/connection/repositories_test.go` | One-line change ×2 |
| `pkg/tests/apis/provisioning/connection/github_branch_protection_test.go` | One-line change ×2 |
| `pkg/tests/apis/provisioning/enterprise/` | **New** — All enterprise provisioning tests + shared helper |
| `pkg/tests/apis/provisioning/README.md` | **New** — Strategy documentation + migration checklist |

## Migration Checklist (for other packages)

1. Add `helpers_test.go` using `common.NewSharedEnv(...)` + `sharedHelper` + `TestMain`
2. Replace `common.RunGrafana(t)` with `sharedHelper(t)` in each test (one-line change)
3. Remove `testutil.SkipIntegrationTestInShortMode(t)` from each test (handled by `GetHelper`)
4. Add resource cleanup to `sharedHelper` for the resource types the package uses
5. Move enterprise tests to the `enterprise/` sibling package
6. Verify no assertions depend on global state without prior cleanup

Made with [Cursor](https://cursor.com)
