### PR TITLE
Elasticsearch: Add support for runtime fields

### DIFF
--- a/packages/grafana-schema/src/raw/composable/elasticsearch/dataquery/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/elasticsearch/dataquery/x/types.gen.ts
@@ -396,6 +396,10 @@ export interface ElasticsearchDataQuery extends common.DataQuery {
    */
   editorType?: string;
   /**
+   * Whether to include runtime fields in the response
+   */
+  includeRuntimeFields?: boolean;
+  /**
    * Metadata for variable queries
    */
   meta?: {

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -117,6 +117,18 @@ func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField stri
 	return b
 }
 
+// EnableRuntimeFields adds a wildcard to the fields list so that
+// Elasticsearch returns runtime field values in each hit's "fields" map.
+func (b *SearchRequestBuilder) EnableRuntimeFields() *SearchRequestBuilder {
+	if existing, ok := b.customProps["fields"]; ok {
+		existingFields := existing.([]map[string]string)
+		b.customProps["fields"] = append(existingFields, map[string]string{"field": "*"})
+	} else {
+		b.customProps["fields"] = []map[string]string{{"field": "*"}}
+	}
+	return b
+}
+
 // AddDocValueField adds a doc value field to the search request
 func (b *SearchRequestBuilder) AddDocValueField(field string) *SearchRequestBuilder {
 	b.customProps["docvalue_fields"] = []string{field}

--- a/pkg/tsdb/elasticsearch/client/search_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/search_request_test.go
@@ -152,6 +152,46 @@ func TestSearchRequest(t *testing.T) {
 		})
 	})
 
+	t.Run("When enabling runtime fields without existing fields", func(t *testing.T) {
+		b := setup()
+		b.EnableRuntimeFields()
+
+		t.Run("should set fields with wildcard", func(t *testing.T) {
+			fields, ok := b.customProps["fields"].([]map[string]string)
+			require.True(t, ok)
+			require.Equal(t, 1, len(fields))
+			require.Equal(t, "*", fields[0]["field"])
+		})
+
+		t.Run("When building search request and marshal to JSON", func(t *testing.T) {
+			sr, err := b.Build()
+			require.Nil(t, err)
+			body, err := json.Marshal(sr)
+			require.Nil(t, err)
+			j, err := simplejson.NewJson(body)
+			require.Nil(t, err)
+			fieldsArr := j.Get("fields").MustArray()
+			require.Equal(t, 1, len(fieldsArr))
+			fieldEntry := fieldsArr[0].(map[string]interface{})
+			require.Equal(t, "*", fieldEntry["field"])
+		})
+	})
+
+	t.Run("When enabling runtime fields with existing time field", func(t *testing.T) {
+		b := setup()
+		b.AddTimeFieldWithStandardizedFormat(timeField)
+		b.EnableRuntimeFields()
+
+		t.Run("should append wildcard to existing fields", func(t *testing.T) {
+			fields, ok := b.customProps["fields"].([]map[string]string)
+			require.True(t, ok)
+			require.Equal(t, 2, len(fields))
+			require.Equal(t, timeField, fields[0]["field"])
+			require.Equal(t, "strict_date_optional_time_nanos", fields[0]["format"])
+			require.Equal(t, "*", fields[1]["field"])
+		})
+	})
+
 	t.Run("and adding multiple top level aggs", func(t *testing.T) {
 		b := setup()
 		aggBuilder := b.Agg()

--- a/pkg/tsdb/elasticsearch/data_query_processor.go
+++ b/pkg/tsdb/elasticsearch/data_query_processor.go
@@ -66,6 +66,10 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("limit").MustString(), defaultSize))
 	b.AddHighlight()
 
+	if q.IncludeRuntimeFields {
+		b.EnableRuntimeFields()
+	}
+
 	// This is currently used only for log context query to get
 	// log lines before and after the selected log line
 	searchAfter := metric.Settings.Get("searchAfter").MustArray()
@@ -102,6 +106,10 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 		b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
 	}
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("size").MustString(), defaultSize))
+
+	if q.IncludeRuntimeFields {
+		b.EnableRuntimeFields()
+	}
 }
 
 // processTimeSeriesQuery processes a time series query with aggregations and metrics

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1467,6 +1467,66 @@ func TestExecuteElasticsearchDataQuery(t *testing.T) {
 			require.Equal(t, secondSearchAfter, "2")
 		})
 
+		t.Run("With log query and includeRuntimeFields enabled should add fields wildcard", func(t *testing.T) {
+			c := newFakeClient()
+			_, err := executeElasticsearchDataQuery(c, `{
+				"includeRuntimeFields": true,
+				"metrics": [{ "type": "logs", "id": "1"}]
+			}`, from, to)
+			require.NoError(t, err)
+			sr := c.multisearchRequests[0].Requests[0]
+			fields, ok := sr.CustomProps["fields"].([]map[string]string)
+			require.True(t, ok)
+			require.Equal(t, 2, len(fields))
+			require.Equal(t, "@timestamp", fields[0]["field"])
+			require.Equal(t, "strict_date_optional_time_nanos", fields[0]["format"])
+			require.Equal(t, "*", fields[1]["field"])
+		})
+
+		t.Run("With log query and includeRuntimeFields disabled should not add fields wildcard", func(t *testing.T) {
+			c := newFakeClient()
+			_, err := executeElasticsearchDataQuery(c, `{
+				"includeRuntimeFields": false,
+				"metrics": [{ "type": "logs", "id": "1"}]
+			}`, from, to)
+			require.NoError(t, err)
+			sr := c.multisearchRequests[0].Requests[0]
+			fields, ok := sr.CustomProps["fields"].([]map[string]string)
+			require.True(t, ok)
+			require.Equal(t, 1, len(fields))
+			require.Equal(t, "@timestamp", fields[0]["field"])
+		})
+
+		t.Run("With raw_data query and includeRuntimeFields enabled should add fields wildcard", func(t *testing.T) {
+			c := newFakeClient()
+			_, err := executeElasticsearchDataQuery(c, `{
+				"includeRuntimeFields": true,
+				"bucketAggs": [],
+				"metrics": [{ "id": "1", "type": "raw_data", "settings": {} }]
+			}`, from, to)
+			require.NoError(t, err)
+			sr := c.multisearchRequests[0].Requests[0]
+			fields, ok := sr.CustomProps["fields"].([]map[string]string)
+			require.True(t, ok)
+			require.Equal(t, 2, len(fields))
+			require.Equal(t, "*", fields[1]["field"])
+		})
+
+		t.Run("With raw_document query and includeRuntimeFields enabled should add fields wildcard", func(t *testing.T) {
+			c := newFakeClient()
+			_, err := executeElasticsearchDataQuery(c, `{
+				"includeRuntimeFields": true,
+				"bucketAggs": [],
+				"metrics": [{ "id": "1", "type": "raw_document", "settings": {} }]
+			}`, from, to)
+			require.NoError(t, err)
+			sr := c.multisearchRequests[0].Requests[0]
+			fields, ok := sr.CustomProps["fields"].([]map[string]string)
+			require.True(t, ok)
+			require.Equal(t, 1, len(fields))
+			require.Equal(t, "*", fields[0]["field"])
+		})
+
 		t.Run("With invalid query should return error", (func(t *testing.T) {
 			c := newFakeClient()
 			res, err := executeElasticsearchDataQuery(c, `{

--- a/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/elasticsearch/kinds/dataquery/types_dataquery_gen.go
@@ -801,6 +801,8 @@ type ElasticsearchDataQuery struct {
 	BucketAggs []BucketAggregation `json:"bucketAggs,omitempty"`
 	// List of metric aggregations
 	Metrics []MetricAggregation `json:"metrics,omitempty"`
+	// Whether to include runtime fields in the response
+	IncludeRuntimeFields *bool `json:"includeRuntimeFields,omitempty"`
 	// Metadata for variable queries
 	Meta *DataqueryElasticsearchDataQueryMeta `json:"meta,omitempty"`
 	// For mixed data sources the selected datasource is on the query level.

--- a/pkg/tsdb/elasticsearch/logs_response_processor.go
+++ b/pkg/tsdb/elasticsearch/logs_response_processor.go
@@ -64,7 +64,7 @@ func (p *logsResponseProcessor) processLogsResponse(res *es.SearchResponse, targ
 			source, ok := hit["fields"].(map[string]interface{})
 			if ok {
 				for k, v := range source {
-					doc[k] = v
+					doc[k] = unwrapFieldValue(v)
 				}
 			}
 		}

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -9,17 +9,18 @@ import (
 
 // Query represents the time series query model of the datasource
 type Query struct {
-	RawQuery      string       `json:"query"`
-	QueryType     *string      `json:"queryType"`
-	BucketAggs    []*BucketAgg `json:"bucketAggs"`
-	Metrics       []*MetricAgg `json:"metrics"`
-	Alias         string       `json:"alias"`
-	Interval      time.Duration
-	IntervalMs    int64
-	RefID         string
-	MaxDataPoints int64
-	TimeRange     backend.TimeRange
-	EditorType    *string `json:"editorType"`
+	RawQuery             string       `json:"query"`
+	QueryType            *string      `json:"queryType"`
+	BucketAggs           []*BucketAgg `json:"bucketAggs"`
+	Metrics              []*MetricAgg `json:"metrics"`
+	Alias                string       `json:"alias"`
+	Interval             time.Duration
+	IntervalMs           int64
+	RefID                string
+	MaxDataPoints        int64
+	TimeRange            backend.TimeRange
+	EditorType           *string `json:"editorType"`
+	IncludeRuntimeFields bool    `json:"includeRuntimeFields"`
 }
 
 // BucketAgg represents a bucket aggregation of the time series query model of the datasource

--- a/pkg/tsdb/elasticsearch/parse_query.go
+++ b/pkg/tsdb/elasticsearch/parse_query.go
@@ -45,19 +45,21 @@ func parseQuery(tsdbQuery []backend.DataQuery, logger log.Logger) ([]*Query, err
 		alias := model.Get("alias").MustString("")
 		intervalMs := model.Get("intervalMs").MustInt64(0)
 		interval := q.Interval
+		includeRuntimeFields := model.Get("includeRuntimeFields").MustBool(false)
 
 		queries = append(queries, &Query{
-			RawQuery:      rawQuery,
-			QueryType:     queryType,
-			BucketAggs:    bucketAggs,
-			Metrics:       metrics,
-			Alias:         alias,
-			Interval:      interval,
-			IntervalMs:    intervalMs,
-			RefID:         q.RefID,
-			MaxDataPoints: q.MaxDataPoints,
-			TimeRange:     q.TimeRange,
-			EditorType:    editorType,
+			RawQuery:             rawQuery,
+			QueryType:            queryType,
+			BucketAggs:           bucketAggs,
+			Metrics:              metrics,
+			Alias:                alias,
+			Interval:             interval,
+			IntervalMs:           intervalMs,
+			RefID:                q.RefID,
+			MaxDataPoints:        q.MaxDataPoints,
+			TimeRange:            q.TimeRange,
+			EditorType:           editorType,
+			IncludeRuntimeFields: includeRuntimeFields,
 		})
 	}
 

--- a/pkg/tsdb/elasticsearch/parse_query_test.go
+++ b/pkg/tsdb/elasticsearch/parse_query_test.go
@@ -102,5 +102,34 @@ func TestParseQuery(t *testing.T) {
 			require.Equal(t, q.BucketAggs[1].Settings.Get("min_doc_count").MustInt(), 0)
 			require.Equal(t, q.BucketAggs[1].Settings.Get("trimEdges").MustInt(), 0)
 		})
+
+		t.Run("Should parse includeRuntimeFields when true", func(t *testing.T) {
+			body := `{
+				"query": "*",
+				"includeRuntimeFields": true,
+				"metrics": [{"type": "logs", "id": "1"}],
+				"bucketAggs": []
+			}`
+			dataQuery, err := newDataQuery(body)
+			require.NoError(t, err)
+			queries, err := parseQuery(dataQuery.Queries, log.New())
+			require.NoError(t, err)
+			require.Len(t, queries, 1)
+			require.True(t, queries[0].IncludeRuntimeFields)
+		})
+
+		t.Run("Should default includeRuntimeFields to false when absent", func(t *testing.T) {
+			body := `{
+				"query": "*",
+				"metrics": [{"type": "logs", "id": "1"}],
+				"bucketAggs": []
+			}`
+			dataQuery, err := newDataQuery(body)
+			require.NoError(t, err)
+			queries, err := parseQuery(dataQuery.Queries, log.New())
+			require.NoError(t, err)
+			require.Len(t, queries, 1)
+			require.False(t, queries[0].IncludeRuntimeFields)
+		})
 	})
 }

--- a/pkg/tsdb/elasticsearch/raw_response_processor.go
+++ b/pkg/tsdb/elasticsearch/raw_response_processor.go
@@ -49,7 +49,7 @@ func (p *rawResponseProcessor) processRawDataResponse(res *es.SearchResponse, ta
 			source, ok := hit["fields"].(map[string]interface{})
 			if ok {
 				for k, v := range source {
-					doc[k] = v
+					doc[k] = unwrapFieldValue(v)
 				}
 			}
 		}
@@ -99,7 +99,7 @@ func (p *rawResponseProcessor) processRawDocumentResponse(res *es.SearchResponse
 			source, ok := hit["fields"].(map[string]interface{})
 			if ok {
 				for k, v := range source {
-					doc[k] = v
+					doc[k] = unwrapFieldValue(v)
 				}
 			}
 		}

--- a/pkg/tsdb/elasticsearch/response_utils.go
+++ b/pkg/tsdb/elasticsearch/response_utils.go
@@ -35,6 +35,16 @@ func step(currentDepth, maxDepth int, target map[string]interface{}, prev string
 	}
 }
 
+// unwrapFieldValue unwraps single-element arrays returned by Elasticsearch's
+// "fields" response into scalar values so that processDocsToDataFrameFields
+// can assign them a proper typed column instead of a JSON blob.
+func unwrapFieldValue(v interface{}) interface{} {
+	if arr, ok := v.([]interface{}); ok && len(arr) == 1 {
+		return arr[0]
+	}
+	return v
+}
+
 // sortPropNames orders propNames so that timeField is first (if it exists), log message field is second
 // if shouldSortLogMessageField is true, and rest of propNames are ordered alphabetically
 func sortPropNames(propNames map[string]bool, configuredFields es.ConfiguredFields, shouldSortLogMessageField bool) []string {

--- a/pkg/tsdb/elasticsearch/response_utils_test.go
+++ b/pkg/tsdb/elasticsearch/response_utils_test.go
@@ -1,0 +1,38 @@
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnwrapFieldValue(t *testing.T) {
+	t.Run("Should unwrap single-element array to scalar", func(t *testing.T) {
+		result := unwrapFieldValue([]interface{}{"hello"})
+		require.Equal(t, "hello", result)
+	})
+
+	t.Run("Should unwrap single-element numeric array", func(t *testing.T) {
+		result := unwrapFieldValue([]interface{}{42.0})
+		require.Equal(t, 42.0, result)
+	})
+
+	t.Run("Should not unwrap multi-element array", func(t *testing.T) {
+		input := []interface{}{"a", "b"}
+		result := unwrapFieldValue(input)
+		require.Equal(t, input, result)
+	})
+
+	t.Run("Should not unwrap empty array", func(t *testing.T) {
+		input := []interface{}{}
+		result := unwrapFieldValue(input)
+		require.Equal(t, input, result)
+	})
+
+	t.Run("Should return scalar values unchanged", func(t *testing.T) {
+		require.Equal(t, "hello", unwrapFieldValue("hello"))
+		require.Equal(t, 42.0, unwrapFieldValue(42.0))
+		require.Equal(t, true, unwrapFieldValue(true))
+		require.Nil(t, unwrapFieldValue(nil))
+	})
+}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryOptions.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryOptions.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from 'react';
 
 import { QueryOptionGroup } from '@grafana/plugin-ui';
-import { Box, Button, InlineField, Input } from '@grafana/ui';
+import { Box, Button, InlineField, InlineSwitch, Input } from '@grafana/ui';
 
+import { ElasticsearchDataQuery } from '../../dataquery.gen';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 
 import { useQuery } from './ElasticsearchQueryContext';
@@ -11,9 +12,11 @@ import { changeMetricSetting } from './MetricAggregationsEditor/state/actions';
 
 interface Props {
   onFormat?: () => void;
+  onChange?: (query: ElasticsearchDataQuery) => void;
+  onRunQuery?: () => void;
 }
 
-export function ElasticsearchQueryOptions({ onFormat }: Props) {
+export function ElasticsearchQueryOptions({ onFormat, onChange, onRunQuery }: Props) {
   const query = useQuery();
   const dispatch = useDispatch();
 
@@ -31,13 +34,18 @@ export function ElasticsearchQueryOptions({ onFormat }: Props) {
     ? String((isLogs ? firstMetricWithSettings!.settings?.limit : firstMetricWithSettings!.settings?.size) ?? '')
     : '';
 
+  const includeRuntimeFields = query.includeRuntimeFields ?? false;
+
   const collapsedInfo = useMemo(() => {
     const infoArray = [];
     if (showSizeField && currentValue) {
       infoArray.push(`${label}: ${currentValue}`);
     }
+    if (!isCodeEditor && includeRuntimeFields) {
+      infoArray.push('Runtime fields: enabled');
+    }
     return infoArray;
-  }, [showSizeField, currentValue, label]);
+  }, [showSizeField, currentValue, label, isCodeEditor, includeRuntimeFields]);
 
   let sizeField: React.ReactElement | null = null;
 
@@ -72,14 +80,29 @@ export function ElasticsearchQueryOptions({ onFormat }: Props) {
     );
   }
 
-  if (sizeField === null && onFormat == null) {
-    return null;
-  }
-
   return (
     <Box backgroundColor="secondary" borderRadius="default">
       <QueryOptionGroup title="Options" collapsedInfo={collapsedInfo}>
         {sizeField}
+        {!isCodeEditor && (
+          <InlineField
+            label="Include runtime fields"
+            labelWidth={22}
+            tooltip="When enabled, runtime fields defined in the index mapping will be included in the response"
+            htmlFor="es-include-runtime-fields"
+          >
+            <InlineSwitch
+              id="es-include-runtime-fields"
+              value={includeRuntimeFields}
+              onChange={(e) => {
+                if (onChange) {
+                  onChange({ ...query, includeRuntimeFields: e.currentTarget.checked });
+                  onRunQuery?.();
+                }
+              }}
+            />
+          </InlineField>
+        )}
         {onFormat != null && (
           <Button
             size="sm"

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -128,4 +128,43 @@ describe('QueryEditor', () => {
 
     expect(screen.getByText('Group By')).toBeInTheDocument();
   });
+
+  describe('Include runtime fields toggle', () => {
+    it('Should render the toggle and trigger onChange when clicked', () => {
+      const query: ElasticsearchDataQuery = {
+        refId: 'A',
+        query: '',
+        metrics: [{ id: '1', type: 'logs' }],
+        bucketAggs: [],
+      };
+
+      const onChange = jest.fn<void, [ElasticsearchDataQuery]>();
+      const onRunQuery = jest.fn();
+
+      render(<QueryEditor query={query} datasource={datasourceMock} onChange={onChange} onRunQuery={onRunQuery} />);
+
+      fireEvent.click(screen.getByText('Options'));
+
+      const toggle = screen.getByLabelText('Include runtime fields');
+      expect(toggle).toBeInTheDocument();
+
+      fireEvent.click(toggle);
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ includeRuntimeFields: true }));
+    });
+
+    it('Should show the toggle even for non-logs queries', () => {
+      const query: ElasticsearchDataQuery = {
+        refId: 'A',
+        query: '',
+        metrics: [{ id: '1', type: 'count' }],
+        bucketAggs: [{ id: '2', type: 'date_histogram' }],
+      };
+
+      render(<QueryEditor query={query} datasource={datasourceMock} onChange={noop} onRunQuery={noop} />);
+
+      fireEvent.click(screen.getByText('Options'));
+
+      expect(screen.getByLabelText('Include runtime fields')).toBeInTheDocument();
+    });
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -66,7 +66,7 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, range }: 
       range={range || getDefaultTimeRange()}
     >
       {showUnsupportedMessage && <Alert title={unsupportedVersionMessage} />}
-      <QueryEditorForm value={query} onRunQuery={onRunQuery} />
+      <QueryEditorForm value={query} onChange={onChange} onRunQuery={onRunQuery} />
     </ElasticsearchProvider>
   );
 };
@@ -95,7 +95,11 @@ export const ElasticSearchQueryField = ({ value, onChange }: { value?: string; o
   );
 };
 
-const QueryEditorForm = ({ value, onRunQuery }: Props & { onRunQuery: () => void }) => {
+const QueryEditorForm = ({
+  value,
+  onChange,
+  onRunQuery,
+}: Props & { onChange: (query: ElasticsearchDataQuery) => void; onRunQuery: () => void }) => {
   const dispatch = useDispatch();
   const nextId = useNextId();
   const inputId = useId();
@@ -216,7 +220,11 @@ const QueryEditorForm = ({ value, onRunQuery }: Props & { onRunQuery: () => void
           {showBucketAggregationsEditor && <BucketAggregationsEditor nextId={nextId} />}
         </>
       )}
-      <ElasticsearchQueryOptions onFormat={isCodeEditor && rawDSLFeatureEnabled ? handleFormat : undefined} />
+      <ElasticsearchQueryOptions
+        onFormat={isCodeEditor && rawDSLFeatureEnabled ? handleFormat : undefined}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+      />
       {isRawDocumentEditor && <Alert severity="warning" title="The 'Raw Document' query type is deprecated." />}
     </>
   );

--- a/public/app/plugins/datasource/elasticsearch/dataquery.cue
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.cue
@@ -41,6 +41,8 @@ composableKinds: DataQuery: {
 				bucketAggs?: [...#BucketAggregation]
 				// List of metric aggregations
 				metrics?: [...#MetricAggregation]
+				// Whether to include runtime fields in the response
+				includeRuntimeFields?: bool
 				// Metadata for variable queries
 				meta?: {
 					textField?:  string

--- a/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
+++ b/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
@@ -394,6 +394,10 @@ export interface ElasticsearchDataQuery extends common.DataQuery {
    */
   editorType?: string;
   /**
+   * Whether to include runtime fields in the response
+   */
+  includeRuntimeFields?: boolean;
+  /**
    * Metadata for variable queries
    */
   meta?: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds support to runtime fields by using the `fields` property to retrieve the fields in ES. There's a new field under `Options` the allow users to define when to retrieve runtime fields on their search.

**Why do we need this feature?**

Runtime fields offer enhanced flexibility to index on ES.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

Everyone that uses runtime fields on ES.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/96028

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---

https://github.com/user-attachments/assets/cf6232f9-13fb-4da5-9689-466754d36c7a

Index definition:
```
PUT /grafana-runtime-fields-test
{
  "mappings": {
    "runtime": {
      "request_duration_category": {
        "type": "keyword",
        "script": {
          "source": "if (doc['duration_ms'].size() > 0) { double val = doc['duration_ms'].value; if (val < 100) { emit('fast'); } else if (val < 500) { emit('medium'); } else { emit('slow'); } }"
        }
      },
      "full_name": {
        "type": "keyword",
        "script": {
          "source": "if (doc['user.first_name'].size() > 0 && doc['user.last_name'].size() > 0) { emit(doc['user.first_name'].value + ' ' + doc['user.last_name'].value); }"
        }
      },
      "is_error": {
        "type": "boolean",
        "script": {
          "source": "if (doc['status_code'].size() > 0) { emit(doc['status_code'].value >= 400); }"
        }
      }
    },
    "properties": {
      "@timestamp": { "type": "date" },
      "message": { "type": "text" },
      "level": { "type": "keyword" },
      "method": { "type": "keyword" },
      "path": { "type": "keyword" },
      "status_code": { "type": "integer" },
      "duration_ms": { "type": "float" },
      "user": {
        "properties": {
          "first_name": { "type": "keyword" },
          "last_name": { "type": "keyword" }
        }
      }
    }
  }
}
POST /grafana-runtime-fields-test/_bulk
{"index":{}}
{"@timestamp":"2026-03-23T10:00:00Z","message":"GET /api/users 200 OK","level":"info","method":"GET","path":"/api/users","status_code":200,"duration_ms":45.2,"user":{"first_name":"Alice","last_name":"Smith"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:01:00Z","message":"POST /api/orders 201 Created","level":"info","method":"POST","path":"/api/orders","status_code":201,"duration_ms":230.5,"user":{"first_name":"Bob","last_name":"Johnson"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:02:00Z","message":"GET /api/products 500 Internal Server Error","level":"error","method":"GET","path":"/api/products","status_code":500,"duration_ms":1520.8,"user":{"first_name":"Charlie","last_name":"Brown"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:03:00Z","message":"PUT /api/users/42 200 OK","level":"info","method":"PUT","path":"/api/users/42","status_code":200,"duration_ms":88.1,"user":{"first_name":"Diana","last_name":"Prince"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:04:00Z","message":"DELETE /api/sessions 401 Unauthorized","level":"warn","method":"DELETE","path":"/api/sessions","status_code":401,"duration_ms":12.3,"user":{"first_name":"Eve","last_name":"Davis"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:05:00Z","message":"GET /api/dashboard 200 OK","level":"info","method":"GET","path":"/api/dashboard","status_code":200,"duration_ms":310.0,"user":{"first_name":"Frank","last_name":"Miller"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:06:00Z","message":"POST /api/auth/login 403 Forbidden","level":"error","method":"POST","path":"/api/auth/login","status_code":403,"duration_ms":55.7,"user":{"first_name":"Grace","last_name":"Lee"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:07:00Z","message":"GET /api/metrics 200 OK","level":"info","method":"GET","path":"/api/metrics","status_code":200,"duration_ms":670.4,"user":{"first_name":"Henry","last_name":"Wilson"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:08:00Z","message":"PATCH /api/settings 404 Not Found","level":"warn","method":"PATCH","path":"/api/settings","status_code":404,"duration_ms":33.9,"user":{"first_name":"Ivy","last_name":"Chen"}}
{"index":{}}
{"@timestamp":"2026-03-23T10:09:00Z","message":"GET /api/alerts 200 OK","level":"info","method":"GET","path":"/api/alerts","status_code":200,"duration_ms":92.6,"user":{"first_name":"Jack","last_name":"Taylor"}}
GET /grafana-runtime-fields-test/_search
{
  "size": 3,
  "fields": ["*"],
  "_source": true
}
```
