### PR TITLE
Unified Storage: Tenant watcher fix token renewal

### DIFF
--- a/pkg/storage/unified/resource/tenant_watcher.go
+++ b/pkg/storage/unified/resource/tenant_watcher.go
@@ -146,7 +146,7 @@ func NewTenantRESTConfig(cfg TenantWatcherConfig) (*rest.Config, error) {
 	}
 
 	restCfg := &rest.Config{
-		Host: cfg.TenantAPIServerURL,
+		Host:          cfg.TenantAPIServerURL,
 		WrapTransport: newBearerTokenExchangeWrapper(tc, "cloud.grafana.com", "*"),
 		TLSClientConfig: rest.TLSClientConfig{
 			CAFile:   cfg.CAFile,

--- a/pkg/storage/unified/resource/tenant_watcher.go
+++ b/pkg/storage/unified/resource/tenant_watcher.go
@@ -17,6 +17,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/transport"
+
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
@@ -91,6 +94,36 @@ func NewTenantWatcherConfig(cfg *setting.Cfg) *TenantWatcherConfig {
 	return tenantWatcherCfg
 }
 
+// bearerTokenExchangeRT is an http.RoundTripper that exchanges a fresh token
+// on every request and sets it in the standard Authorization header.
+type bearerTokenExchangeRT struct {
+	exchanger authnlib.TokenExchanger
+	audience  string
+	namespace string
+	next      http.RoundTripper
+}
+
+func (rt *bearerTokenExchangeRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.exchanger.Exchange(req.Context(), authnlib.TokenExchangeRequest{
+		Audiences: []string{rt.audience},
+		Namespace: rt.namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("exchanging token: %w", err)
+	}
+	req = utilnet.CloneRequest(req)
+	req.Header.Set("Authorization", "Bearer "+resp.Token)
+	return rt.next.RoundTrip(req)
+}
+
+// newBearerTokenExchangeWrapper returns a transport.WrapperFunc for use with
+// rest.Config.WrapTransport that exchanges a fresh token on every request.
+func newBearerTokenExchangeWrapper(exchanger authnlib.TokenExchanger, audience, namespace string) transport.WrapperFunc {
+	return func(rt http.RoundTripper) http.RoundTripper {
+		return &bearerTokenExchangeRT{exchanger: exchanger, audience: audience, namespace: namespace, next: rt}
+	}
+}
+
 // NewTenantRESTConfig creates a rest.Config that authenticates to the
 // app-platform API server using a signed access token sent via the
 // Authorization header.
@@ -112,22 +145,13 @@ func NewTenantRESTConfig(cfg TenantWatcherConfig) (*rest.Config, error) {
 		return nil, fmt.Errorf("creating token exchange client: %w", err)
 	}
 
-	tokenResp, err := tc.Exchange(context.Background(), authnlib.TokenExchangeRequest{
-		Namespace: "*",
-		Audiences: []string{"cloud.grafana.com"},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("exchanging token: %w", err)
-	}
-
 	restCfg := &rest.Config{
-		Host:        cfg.TenantAPIServerURL,
-		BearerToken: tokenResp.Token,
-	}
-
-	restCfg.TLSClientConfig = rest.TLSClientConfig{
-		CAFile:   cfg.CAFile,
-		Insecure: cfg.AllowInsecure && cfg.CAFile == "",
+		Host: cfg.TenantAPIServerURL,
+		WrapTransport: newBearerTokenExchangeWrapper(tc, "cloud.grafana.com", "*"),
+		TLSClientConfig: rest.TLSClientConfig{
+			CAFile:   cfg.CAFile,
+			Insecure: cfg.AllowInsecure && cfg.CAFile == "",
+		},
 	}
 
 	return restCfg, nil


### PR DESCRIPTION
Was running into auth errors. The tenant watcher was listing/watching successfully on startup, but would fail later on. This was bc we got a token on startup, but never renewed it on subsequent informer syncs.

This fixes that to renew the token every time the informer syncs. The tenant api expects the auth token to be in the Authorization header as a bearer token, so had to add a custom wrapper to make that happen.