### PR TITLE
TenantWatcher: handle conflict errors in editResourceLabel

### DIFF
--- a/pkg/storage/unified/resource/tenant_watcher.go
+++ b/pkg/storage/unified/resource/tenant_watcher.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	authnlib "github.com/grafana/authlib/authn"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -324,9 +325,60 @@ func (tw *TenantWatcher) editResourceLabel(dataKey DataKey, addLabel bool) error
 	}
 
 	if _, err := tw.writeEvent(tw.ctx, event); err != nil {
-		return fmt.Errorf("writing event: %w", err)
+		if !isConflictError(err) {
+			return fmt.Errorf("writing event: %w", err)
+		}
+		// Another pod may have already modified this resource. Re-read the
+		// latest version and check whether the label is already correct.
+		if checkErr := tw.verifyLabelState(dataKey, addLabel); checkErr != nil {
+			return fmt.Errorf("writing event: %w", err)
+		}
+		// The latest version already has the desired label state — treat as success.
+		return nil
 	}
 	return nil
+}
+
+// verifyLabelState reads the latest version of a resource and returns nil if
+// the pending-delete label is already in the desired state.
+func (tw *TenantWatcher) verifyLabelState(dataKey DataKey, wantLabel bool) error {
+	latestKey, err := tw.dataStore.GetLatestResourceKey(tw.ctx, GetRequestKey{
+		Group:     dataKey.Group,
+		Resource:  dataKey.Resource,
+		Namespace: dataKey.Namespace,
+		Name:      dataKey.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("fetching latest key: %w", err)
+	}
+
+	reader, err := tw.dataStore.Get(tw.ctx, latestKey)
+	if err != nil {
+		return fmt.Errorf("reading latest resource: %w", err)
+	}
+	value, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil {
+		return fmt.Errorf("reading latest resource bytes: %w", err)
+	}
+
+	tmp := &unstructured.Unstructured{}
+	if err := tmp.UnmarshalJSON(value); err != nil {
+		return fmt.Errorf("unmarshaling latest resource: %w", err)
+	}
+
+	labels := tmp.GetLabels()
+	hasLabel := labels[labelPendingDelete] == "true"
+	if hasLabel != wantLabel {
+		return fmt.Errorf("label state mismatch: want=%v, got=%v", wantLabel, hasLabel)
+	}
+	return nil
+}
+
+// isConflictError returns true if the error indicates an optimistic locking /
+// resource version conflict.
+func isConflictError(err error) bool {
+	return apierrors.IsConflict(err) || strings.Contains(err.Error(), "optimistic locking failed")
 }
 
 // clearTenantPendingDelete removes the pending-delete record for a tenant from the

--- a/pkg/storage/unified/resource/tenant_watcher_test.go
+++ b/pkg/storage/unified/resource/tenant_watcher_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
@@ -274,6 +276,70 @@ func TestTenantResourceLabelling(t *testing.T) {
 		tw.handleTenant(pendingDeleteTenant("tenant-1", "2026-03-01T00:00:00Z"))
 
 		assert.Empty(t, collector.all(), "should not write events for already-labelled resources")
+	})
+
+	t.Run("conflict error during labelling succeeds when latest version already has label", func(t *testing.T) {
+		ds := newDataStore(setupBadgerKV(t))
+
+		// Save the resource at RV 100 without the label (this is what the stale dataKey will read).
+		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+		// Save a newer version at RV 200 WITH the label (simulating another pod having already labelled it).
+		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 200, map[string]string{labelPendingDelete: "true"})
+
+		callCount := 0
+		conflictOnce := func(_ context.Context, _ *WriteEvent) (int64, error) {
+			callCount++
+			// Return a conflict error (as produced by the backwards-compatible update path).
+			return 0, apierrors.NewConflict(schema.GroupResource{
+				Group: "apps", Resource: "dashboards",
+			}, "dash1", fmt.Errorf("resource version does not match current value"))
+		}
+
+		tw := &TenantWatcher{
+			log:                log.NewNopLogger(),
+			pendingDeleteStore: newPendingDeleteStore(ds.kv),
+			dataStore:          ds,
+			writeEvent:         conflictOnce,
+			ctx:                t.Context(),
+			stopCh:             make(chan struct{}),
+		}
+
+		tw.handleTenant(pendingDeleteTenant("tenant-1", "2026-03-01T00:00:00Z"))
+
+		// The write failed with a conflict, but the latest version already has
+		// the label, so the operation should have succeeded overall.
+		_, err := tw.pendingDeleteStore.Get(t.Context(), "tenant-1")
+		require.NoError(t, err, "pending delete record should be created despite conflict error")
+	})
+
+	t.Run("conflict error during labelling fails when latest version does not have label", func(t *testing.T) {
+		ds := newDataStore(setupBadgerKV(t))
+
+		// Save the resource at RV 100 without the label.
+		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+		// Save a newer version at RV 200 also without the label (e.g., an unrelated modification).
+		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 200, nil)
+
+		conflictWriter := func(_ context.Context, _ *WriteEvent) (int64, error) {
+			return 0, apierrors.NewConflict(schema.GroupResource{
+				Group: "apps", Resource: "dashboards",
+			}, "dash1", fmt.Errorf("resource version does not match current value"))
+		}
+
+		tw := &TenantWatcher{
+			log:                log.NewNopLogger(),
+			pendingDeleteStore: newPendingDeleteStore(ds.kv),
+			dataStore:          ds,
+			writeEvent:         conflictWriter,
+			ctx:                t.Context(),
+			stopCh:             make(chan struct{}),
+		}
+
+		tw.handleTenant(pendingDeleteTenant("tenant-1", "2026-03-01T00:00:00Z"))
+
+		// The latest version does NOT have the label, so this should have failed.
+		_, err := tw.pendingDeleteStore.Get(t.Context(), "tenant-1")
+		assert.ErrorIs(t, err, ErrNotFound, "record should not be created when conflict cannot be resolved")
 	})
 }
 


### PR DESCRIPTION
**The Bug**
Fixes optimistic locking errors when multiple pods process the same tenant pending-delete event simultaneously:

```
1. Tenant marked pending-delete — all pods receive the event
2. All pods call ListLatestResourceKeys — each gets the same resource keys with the same ResourceVersions
3. Pods iterate through resources and call editResourceLabel for each one
4. editResourceLabel reads the resource data at the listed RV (e.g. RV 100) and writes with PreviousRV: 100
5. One pod's write succeeds, bumping the RV to 101
6. The other pod's write arrives with PreviousRV: 100 — the backwards-compatible update path compares it against the current RV (now 101), finds a mismatch, and returns a conflict error
7. The failing pod aborts the entire tenant labelling operation, even though the resource was already labelled by the other pod
```

**The Fix**
If we encounter an OL error when adding the pending-delete label to the resource, we check if the current resource already has the pending delete label (bc another pod probably added it already).