### PR TITLE
Provisioning: Validate hidden characters in private key field and surface non-fetch errors

### DIFF
--- a/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.test.tsx
@@ -122,6 +122,22 @@ describe('ConnectionForm', () => {
         expect(screen.getAllByText('This field is required')).toHaveLength(4);
       });
     });
+
+    it('should show validation error for private key containing hidden characters', async () => {
+      const { user } = setup();
+
+      await user.type(screen.getByLabelText(/^Title/), 'My GitHub App');
+      await user.type(screen.getByLabelText(/^GitHub App ID/), '123456');
+      await user.type(screen.getByLabelText(/^GitHub Installation ID/), '12345678');
+      await user.click(screen.getByLabelText(/^Private Key \(PEM\)/));
+      await user.paste('-----BEGIN RSA PRIVATE KEY-----\u200B...');
+
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/hidden characters/i)).toBeInTheDocument();
+      });
+    });
   });
 
   describe('Form Submission - Create', () => {
@@ -294,6 +310,27 @@ describe('ConnectionForm', () => {
       await waitFor(() => {
         expect(screen.getByText('Invalid Private Key format')).toBeInTheDocument();
       });
+    });
+
+    it('should show generic error when a non-fetch error occurs during submission', async () => {
+      const btoaSpy = jest.spyOn(window, 'btoa').mockImplementation(() => {
+        throw new DOMException('The string contains characters outside Latin1 range');
+      });
+
+      const { user } = setup();
+
+      await user.type(screen.getByLabelText(/^Title/), 'My GitHub App');
+      await user.type(screen.getByLabelText(/^GitHub App ID/), '123456');
+      await user.type(screen.getByLabelText(/^GitHub Installation ID/), '12345678');
+      await user.type(screen.getByLabelText(/^Private Key \(PEM\)/), 'some-valid-key');
+
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      btoaSpy.mockRestore();
     });
   });
 });

--- a/public/app/features/provisioning/Connection/ConnectionForm.tsx
+++ b/public/app/features/provisioning/Connection/ConnectionForm.tsx
@@ -1,18 +1,19 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { t } from '@grafana/i18n';
 import { isFetchError, reportInteraction } from '@grafana/runtime';
-import { Button, Combobox, Field, Stack } from '@grafana/ui';
+import { Alert, Button, Combobox, Field, Stack } from '@grafana/ui';
 import { Connection } from 'app/api/clients/provisioning/v0alpha1';
+import { extractErrorMessage } from 'app/api/utils';
 import { FormPrompt } from 'app/core/components/FormPrompt/FormPrompt';
 
 import { GitHubConnectionFields } from '../components/Shared/GitHubConnectionFields';
 import { CONNECTIONS_TAB_URL } from '../constants';
 import { useCreateOrUpdateConnection } from '../hooks/useCreateOrUpdateConnection';
 import { ConnectionFormData } from '../types';
-import { getConnectionFormErrors } from '../utils/getFormErrors';
+import { extractFormErrors, getConnectionFormErrors } from '../utils/getFormErrors';
 
 import { DeleteConnectionButton } from './DeleteConnectionButton';
 
@@ -73,7 +74,10 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
     }
   }, [isEdit, data?.status?.fieldErrors, setError]);
 
+  const [submitError, setSubmitError] = useState<string>();
+
   const onSubmit = async (form: ConnectionFormData) => {
+    setSubmitError(undefined);
     try {
       const spec = {
         title: form.title,
@@ -96,7 +100,19 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
           }
           return;
         }
+
+        // Show unmapped error details as a top-level form error
+        const allErrors = extractFormErrors(err.data);
+        const detail = allErrors.find((e) => e.detail)?.detail;
+        if (detail) {
+          setSubmitError(detail);
+          return;
+        }
       }
+
+      setSubmitError(
+        extractErrorMessage(err) || t('provisioning.connection-form.error-submit', 'Failed to save connection')
+      );
     }
   };
 
@@ -105,6 +121,7 @@ export function ConnectionForm({ data }: ConnectionFormProps) {
       <form onSubmit={handleSubmit(onSubmit)} style={{ maxWidth: 700 }}>
         <FormPrompt onDiscard={reset} confirmRedirect={isDirty} />
         <Stack direction="column" gap={2}>
+          {submitError && <Alert severity="error" title={submitError} />}
           <Field
             noMargin
             htmlFor="type"

--- a/public/app/features/provisioning/components/Shared/GitHubConnectionFields.tsx
+++ b/public/app/features/provisioning/components/Shared/GitHubConnectionFields.tsx
@@ -5,6 +5,7 @@ import { t, Trans } from '@grafana/i18n';
 import { Button, Field, Input, SecretTextArea, Stack } from '@grafana/ui';
 
 import { ConnectionFormData } from '../../types';
+import { validateNoHiddenCharacters } from '../../utils/validators';
 
 export interface GitHubConnectionFieldsProps {
   /** Whether fields are required. Depends if we are in edit mode or not. */
@@ -120,6 +121,7 @@ export const GitHubConnectionFields = memo<GitHubConnectionFieldsProps>(
             control={control}
             rules={{
               required: requiredValidation,
+              validate: validateNoHiddenCharacters,
             }}
             render={({ field: { ref, ...field } }) => (
               <SecretTextArea

--- a/public/app/features/provisioning/utils/validators.test.ts
+++ b/public/app/features/provisioning/utils/validators.test.ts
@@ -1,0 +1,83 @@
+import { validateNoHiddenCharacters } from './validators';
+
+describe('validateNoHiddenCharacters', () => {
+  // Should pass for valid inputs
+  it('returns true for a normal ASCII string', () => {
+    expect(validateNoHiddenCharacters('hello world')).toBe(true);
+  });
+
+  it('returns true for a valid PEM private key', () => {
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIE...base64...\n-----END RSA PRIVATE KEY-----';
+    expect(validateNoHiddenCharacters(pem)).toBe(true);
+  });
+
+  it('returns true for empty string', () => {
+    expect(validateNoHiddenCharacters('')).toBe(true);
+  });
+
+  it('returns true for undefined', () => {
+    expect(validateNoHiddenCharacters(undefined)).toBe(true);
+  });
+
+  it('returns true for string with newlines and carriage returns', () => {
+    expect(validateNoHiddenCharacters('line1\r\nline2\nline3')).toBe(true);
+  });
+
+  it('returns true for string with tabs', () => {
+    expect(validateNoHiddenCharacters('col1\tcol2')).toBe(true);
+  });
+
+  // Should fail for hidden characters
+  it('returns error for zero-width space (U+200B)', () => {
+    expect(validateNoHiddenCharacters('abc\u200Bdef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for zero-width non-joiner (U+200C)', () => {
+    expect(validateNoHiddenCharacters('abc\u200Cdef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for zero-width joiner (U+200D)', () => {
+    expect(validateNoHiddenCharacters('abc\u200Ddef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for BOM (U+FEFF)', () => {
+    expect(validateNoHiddenCharacters('\uFEFFkey content')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for left-to-right mark (U+200E)', () => {
+    expect(validateNoHiddenCharacters('abc\u200Edef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for right-to-left mark (U+200F)', () => {
+    expect(validateNoHiddenCharacters('abc\u200Fdef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for soft hyphen (U+00AD)', () => {
+    expect(validateNoHiddenCharacters('abc\u00ADdef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for word joiner (U+2060)', () => {
+    expect(validateNoHiddenCharacters('abc\u2060def')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  // Unicode whitespace that breaks btoa() but looks like a regular space
+  it('returns error for thin space (U+2009)', () => {
+    expect(validateNoHiddenCharacters('abc\u2009def')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for narrow no-break space (U+202F)', () => {
+    expect(validateNoHiddenCharacters('abc\u202Fdef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for ideographic space (U+3000)', () => {
+    expect(validateNoHiddenCharacters('abc\u3000def')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for medium mathematical space (U+205F)', () => {
+    expect(validateNoHiddenCharacters('abc\u205Fdef')).toEqual(expect.stringContaining('hidden'));
+  });
+
+  it('returns error for en space (U+2002)', () => {
+    expect(validateNoHiddenCharacters('abc\u2002def')).toEqual(expect.stringContaining('hidden'));
+  });
+});

--- a/public/app/features/provisioning/utils/validators.ts
+++ b/public/app/features/provisioning/utils/validators.ts
@@ -1,0 +1,28 @@
+import { t } from '@grafana/i18n';
+
+// Invisible Unicode characters commonly introduced by copy-paste from
+// rich text sources (web pages, PDFs, chat apps).
+// Includes:
+//   - Formatting/directional marks (U+034F, U+061C, U+200B–U+200F, U+202A–U+202E, U+2066–U+2069)
+//   - Zero-width and word joiners (U+2060–U+2064, U+FEFF)
+//   - Unicode whitespace that looks like a normal space but breaks btoa()
+//     (U+2000–U+200A, U+202F, U+205F, U+3000)
+//   - Other invisibles (U+00AD soft hyphen, U+180E, U+2028/2029, U+FFF9–U+FFFB)
+// Excludes \n, \r, \t, and regular spaces (U+0020, U+00A0) which are legitimate in PEM keys.
+const HIDDEN_CHARS_REGEX =
+  /[\u00AD\u034F\u061C\u180E\u2000-\u200F\u2028\u2029\u202A-\u202F\u205F\u2060-\u2064\u2066-\u2069\u3000\uFEFF\uFFF9-\uFFFB]/;
+
+/**
+ * react-hook-form `validate` function.
+ * Returns `true` when valid, or an error message string when hidden characters are detected.
+ */
+export function validateNoHiddenCharacters(value: string | undefined): string | true {
+  if (!value || !HIDDEN_CHARS_REGEX.test(value)) {
+    return true;
+  }
+
+  return t(
+    'provisioning.validation.hidden-characters',
+    'This field contains hidden characters that may have been introduced by copying and pasting. Please retype or clean the value and try again.'
+  );
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12960,6 +12960,7 @@
       "error-delete-connection": "Failed to delete connection",
       "error-required": "This field is required",
       "error-save-connection": "Failed to save connection",
+      "error-submit": "Failed to save connection",
       "grafana-repositories": "Repositories using this connection",
       "label-app-id": "GitHub App ID",
       "label-description": "Description",
@@ -13484,6 +13485,9 @@
       },
       "go-to": "Go to",
       "make-sure": "Create a token with these permissions"
+    },
+    "validation": {
+      "hidden-characters": "This field contains hidden characters that may have been introduced by copying and pasting. Please retype or clean the value and try again."
     },
     "warning-title-default": "Warning",
     "watch-stream": {


### PR DESCRIPTION
**What is this feature?**

Adds hidden character validation to the private key (PEM) field in the provisioning connection form and fixes silent error swallowing for non-fetch errors during form submission.

**Why do we need this feature?**

When users paste a private key from rich text sources (web pages, PDFs, chat apps, password managers), invisible Unicode characters can be silently included. These characters cause `btoa()` to throw a `DOMException` because they fall outside the Latin1 range.

In the connection wizard, the error was caught by a fallback handler. In the regular connection form (`ConnectionForm.tsx`), the catch block only checked `isFetchError()` — a `DOMException` is not a fetch error, so it fell through silently. The user saw no error message and the connection was not saved.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/995