### PR TITLE
E2E: Fix flaky dashboard variable test

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -82,7 +82,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const variable = variableWithDefaults({type: 'interval'});
+      const variable = variableWithDefaults({type: 'interval', value: '1m'});
 
       // common steps to add a new variable
       await flows.newEditPaneVariableClick(dashboardPage, selectors);

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -13,6 +13,14 @@ test.use({
 const PAGE_UNDER_TEST = 'kVi2Gex7z/test-variable-output';
 const DASHBOARD_NAME = 'Test variable output';
 
+const variableWithDefaults = (custom?: Partial<Variable>): Variable => ({
+  type: 'textbox',
+  name: 'VariableUnderTest',
+  value: 'foo',
+  label: 'VariableUnderTestLabel',
+  ...custom
+});
+
 test.describe(
   'Dashboard edit - variables',
   {
@@ -23,12 +31,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const variable: Variable = {
-        type: 'constant',
-        name: 'VariableUnderTest',
-        value: 'foo',
-        label: 'VariableUnderTest', // constant doesn't really need a label
-      };
+      const variable = variableWithDefaults({type: 'constant'});
 
       // common steps to add a new variable
       await flows.newEditPaneVariableClick(dashboardPage, selectors);
@@ -56,12 +59,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const variable: Variable = {
-        type: 'textbox',
-        name: 'VariableUnderTest',
-        value: 'foo',
-        label: 'VariableUnderTest',
-      };
+      const variable = variableWithDefaults();
 
       await flows.addNewTextBoxVariable(dashboardPage, variable);
 
@@ -84,12 +82,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const variable: Variable = {
-        type: 'interval',
-        name: 'VariableUnderTest',
-        value: '1m',
-        label: 'VariableUnderTest',
-      };
+      const variable = variableWithDefaults({type: 'interval'});
 
       // common steps to add a new variable
       await flows.newEditPaneVariableClick(dashboardPage, selectors);
@@ -127,13 +120,7 @@ test.describe(
       await expect(markdownContent).toContainText('VariableUnderTest: 10m');
     });
     test('can make a hidden variable visible', async ({ dashboardPage, selectors, page }) => {
-      const variable: Variable = {
-        type: 'textbox',
-        name: 'VariableUnderTest',
-        value: 'foo',
-        label: 'VariableUnderTest',
-        display: 'Hidden',
-      };
+      const variable = variableWithDefaults({ display: 'Hidden' });
 
       await saveDashboard(dashboardPage, page, selectors, 'can make a hidden variable visible');
       await flows.addNewTextBoxVariable(dashboardPage, variable);
@@ -173,13 +160,9 @@ test.describe(
       ).toBeVisible();
     });
 
-    test.skip('can hide variable under the controls menu', async ({ dashboardPage, selectors, page }) => {
-      const variable: Variable = {
-        type: 'textbox',
-        name: 'VariableUnderTest',
-        value: 'foo',
-        label: 'VariableUnderTest',
-      };
+    test('can hide variable under the controls menu', async ({ dashboardPage, selectors, page }) => {
+      const variable = variableWithDefaults();
+
       await saveDashboard(dashboardPage, page, selectors, 'can hide a variable in controls menu');
 
       await flows.addNewTextBoxVariable(dashboardPage, variable);

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -18,7 +18,7 @@ const variableWithDefaults = (custom?: Partial<Variable>): Variable => ({
   name: 'VariableUnderTest',
   value: 'foo',
   label: 'VariableUnderTestLabel',
-  ...custom
+  ...custom,
 });
 
 test.describe(
@@ -31,7 +31,7 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const variable = variableWithDefaults({type: 'constant'});
+      const variable = variableWithDefaults({ type: 'constant' });
 
       // common steps to add a new variable
       await flows.newEditPaneVariableClick(dashboardPage, selectors);
@@ -52,7 +52,7 @@ test.describe(
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');
-      await expect(markdownContent).toContainText(`VariableUnderTest: ${variable.value}`);
+      await expect(markdownContent).toContainText(`${variable.label}: ${variable.value}`);
     });
 
     test('can add a new textbox variable', async ({ gotoDashboardPage, selectors, page }) => {
@@ -75,14 +75,14 @@ test.describe(
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');
-      await expect(markdownContent).toContainText(`VariableUnderTest: ${variable.value}`);
+      await expect(markdownContent).toContainText(`${variable.label}: ${variable.value}`);
     });
 
     test('can add a new interval variable', async ({ gotoDashboardPage, selectors, page }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const variable = variableWithDefaults({type: 'interval', value: '1m'});
+      const variable = variableWithDefaults({ type: 'interval', value: '1m' });
 
       // common steps to add a new variable
       await flows.newEditPaneVariableClick(dashboardPage, selectors);
@@ -103,7 +103,7 @@ test.describe(
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');
-      await expect(markdownContent).toContainText(`VariableUnderTest: ${variable.value}`);
+      await expect(markdownContent).toContainText(`${variable.label}: ${variable.value}`);
 
       // select the variable in the dashboard and set the Auto option
       const variableDropdown = dashboardPage.getByGrafanaSelector(
@@ -117,7 +117,7 @@ test.describe(
 
       // assert the panel is visible and has the correct "Auto" value
       await expect(panelContent).toBeVisible();
-      await expect(markdownContent).toContainText('VariableUnderTest: 10m');
+      await expect(markdownContent).toContainText(`${variable.label}: 10m`);
     });
     test('can make a hidden variable visible', async ({ dashboardPage, selectors, page }) => {
       const variable = variableWithDefaults({ display: 'Hidden' });

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -107,7 +107,7 @@ test.describe(
 
       // select the variable in the dashboard and set the Auto option
       const variableDropdown = dashboardPage.getByGrafanaSelector(
-        selectors.pages.Dashboard.SubMenu.submenuItemLabels(variable.name!)
+        selectors.pages.Dashboard.SubMenu.submenuItemLabels(variable.label)
       );
       const nextElement = variableDropdown.locator('+ *');
       await expect(nextElement).toHaveText('1m');

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -52,7 +52,7 @@ test.describe(
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');
-      await expect(markdownContent).toContainText(`${variable.label}: ${variable.value}`);
+      await expect(markdownContent).toContainText(`VariableUnderTest: ${variable.value}`);
     });
 
     test('can add a new textbox variable', async ({ gotoDashboardPage, selectors, page }) => {
@@ -75,7 +75,7 @@ test.describe(
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');
-      await expect(markdownContent).toContainText(`${variable.label}: ${variable.value}`);
+      await expect(markdownContent).toContainText(`VariableUnderTest: ${variable.value}`);
     });
 
     test('can add a new interval variable', async ({ gotoDashboardPage, selectors, page }) => {
@@ -103,7 +103,7 @@ test.describe(
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');
-      await expect(markdownContent).toContainText(`${variable.label}: ${variable.value}`);
+      await expect(markdownContent).toContainText(`VariableUnderTest: ${variable.value}`);
 
       // select the variable in the dashboard and set the Auto option
       const variableDropdown = dashboardPage.getByGrafanaSelector(
@@ -117,7 +117,7 @@ test.describe(
 
       // assert the panel is visible and has the correct "Auto" value
       await expect(panelContent).toBeVisible();
-      await expect(markdownContent).toContainText(`${variable.label}: 10m`);
+      await expect(markdownContent).toContainText('VariableUnderTest: 10m');
     });
     test('can make a hidden variable visible', async ({ dashboardPage, selectors, page }) => {
       const variable = variableWithDefaults({ display: 'Hidden' });

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -64,6 +64,11 @@ export const flows = {
     await dashboardPage
       .getByGrafanaSelector(selectors.components.PanelEditor.ElementEditPane.variableType(variable.type))
       .click();
+
+    // New variable creation schedules a delayed autofocus to name input
+    // Let that timer finish before we interact to prevent focus on the wrong input
+    await dashboardPage.ctx.page.waitForTimeout(250);
+
     const variableNameInput = dashboardPage.getByGrafanaSelector(
       selectors.components.PanelEditor.ElementEditPane.variableNameInput
     );

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -70,7 +70,7 @@ export const flows = {
     await variableNameInput.click();
     await variableNameInput.fill(variable.name);
     await variableNameInput.blur();
-    await expect(variableNameInput).toHaveValue(variable.name);
+    // await expect(variableNameInput).toHaveValue(variable.name);
     if (variable.label) {
       const variableLabelInput = dashboardPage.getByGrafanaSelector(
         selectors.components.PanelEditor.ElementEditPane.variableLabelInput
@@ -78,7 +78,7 @@ export const flows = {
       await variableLabelInput.click();
       await variableLabelInput.fill(variable.label);
       await variableLabelInput.blur();
-      await expect(variableLabelInput).toHaveValue(variable.label);
+      // await expect(variableLabelInput).toHaveValue(variable.label);
     }
   },
   async addNewTextBoxVariable(dashboardPage: DashboardPage, variable: Variable) {

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -75,7 +75,6 @@ export const flows = {
     await variableNameInput.click();
     await variableNameInput.fill(variable.name);
     await variableNameInput.blur();
-    // await expect(variableNameInput).toHaveValue(variable.name);
     if (variable.label) {
       const variableLabelInput = dashboardPage.getByGrafanaSelector(
         selectors.components.PanelEditor.ElementEditPane.variableLabelInput
@@ -83,7 +82,6 @@ export const flows = {
       await variableLabelInput.click();
       await variableLabelInput.fill(variable.label);
       await variableLabelInput.blur();
-      // await expect(variableLabelInput).toHaveValue(variable.label);
     }
   },
   async addNewTextBoxVariable(dashboardPage: DashboardPage, variable: Variable) {

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -70,6 +70,7 @@ export const flows = {
     await variableNameInput.click();
     await variableNameInput.fill(variable.name);
     await variableNameInput.blur();
+    await expect(variableNameInput).toHaveValue(variable.name);
     if (variable.label) {
       const variableLabelInput = dashboardPage.getByGrafanaSelector(
         selectors.components.PanelEditor.ElementEditPane.variableLabelInput
@@ -77,6 +78,7 @@ export const flows = {
       await variableLabelInput.click();
       await variableLabelInput.fill(variable.label);
       await variableLabelInput.blur();
+      await expect(variableLabelInput).toHaveValue(variable.label);
     }
   },
   async addNewTextBoxVariable(dashboardPage: DashboardPage, variable: Variable) {


### PR DESCRIPTION
We have a flaky test in variables e2e.
The test fails with this error:
<img width="967" height="190" alt="Screenshot 2026-03-24 at 21 43 45" src="https://github.com/user-attachments/assets/5340a55d-ab14-42db-95ea-74ed1cb86325" />

The runner can't find the correct label for the variable. The cause is that the label is written twice, or rather, the name and the variable are all written in the same input field:
<img width="785" height="469" alt="Screenshot 2026-03-24 at 21 43 29" src="https://github.com/user-attachments/assets/a6f8b5d5-eefa-4f2b-89ea-119a0466b939" />

It seems like the flakiness is caused by [this PR](https://github.com/grafana/grafana/pull/120094) that fixes autofocus on variable name input. The consequence of this is that the test
1. fills out the name input with the variable name
2. switches to the label field
3. the autofocus hook acts with 200ms delay and returns the autofocus onto the name field
4. playwright fill() method fills out the name input again

We could either 
- change the behaviour to remove the timeout in the hook
- adjust the test to act with 250ms timeout before filling out any inputs to make sure the focus won't be unexpectedly switched