### PR TITLE
Unified Storage: remove unnecessary nil check for uninitializedSearchServer

### DIFF
--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -336,10 +336,8 @@ func (s *service) starting(ctx context.Context) error {
 	// Initialize the server (builds search indexes) while in JOINING state.
 	// The ring is Running so OwnsIndex checks work, but this instance won't
 	// receive ring-routed queries until it switches to ACTIVE below.
-	if s.uninitializedSearchServer != nil {
-		if err := s.uninitializedSearchServer.Init(ctx); err != nil {
-			return fmt.Errorf("failed to initialize server: %w", err)
-		}
+	if err := s.uninitializedSearchServer.Init(ctx); err != nil {
+		return fmt.Errorf("failed to initialize server: %w", err)
 	}
 
 	if s.cfg.EnableSharding {


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/grafana/grafana/pull/120815.

- `uninitializedSearchServer` is always set in `createAndRegisterServer()`, which always runs before `starting()`. The nil check is unnecessary.

Refs: grafana/search-and-storage-team#713

## Test plan

- [x] `go test ./pkg/storage/unified/sql/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)