### PR TITLE
datasources: query service: consider an empty datasource list as false

### DIFF
--- a/packages/grafana-runtime/src/utils/qscheck.test.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.test.ts
@@ -37,7 +37,7 @@ describe('qscheck', () => {
       name: 'no queries',
       ds: [],
       flag: { types: ['prometheus', 'loki'] },
-      expected: true,
+      expected: false,
       errorLogs: 0,
     },
     {

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -58,6 +58,14 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
 }
 
 export function isQueryServiceCompatible(datasources: DSSettings[], allowedTypes: unknown) {
+  if (datasources.length === 0) {
+    // note: this probably means something went wrong,
+    // we should not have no-queries. still,
+    // in this case we take the safer choice,
+    // and say no to query service.
+    return false;
+  }
+
   const at = parseAllowedTypes(allowedTypes);
   if (!areDataSourceTypesAllowed(datasources, new Set(at.types))) {
     return false;


### PR DESCRIPTION
when executing a data source query in the browser, we check if the given datasource/datasources are compatible with the query-service.

there are cases involving dashboard variables, where the list-of-datasources is empty. 
currently the code returns "query-service compatible" for an empty datasource list.

this PR changes this, and when the datasource list is empty, we will choose the safer choice, "not query-service compatible".