### PR TITLE
Support default bundling of core data sources

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -94,11 +94,6 @@ inputs:
     type: boolean
     default: true
     required: false
-  catalog-plugins:
-    type: string
-    description: Comma separated list of catalog plugins to bundle.
-    required: false
-    default: 'elasticsearch'
 outputs:
   dist-dir:
     description: Directory where artifacts are placed
@@ -146,7 +141,6 @@ runs:
         CACHE_BUILDERS: ${{ inputs.cache-builders }}
         ALPINE_BASE: ${{ inputs.alpine-base }}
         UBUNTU_BASE: ${{ inputs.ubuntu-base }}
-        CATALOG_PLUGINS: ${{ inputs.catalog-plugins }}
       with:
         verb: run
         dagger-flags: --verbose=0
@@ -168,8 +162,7 @@ runs:
           --registry=${DOCKER_REGISTRY}
           --checksum=${CHECKSUM}
           --cache-builders=${CACHE_BUILDERS}
-          --verify=${VERIFY}
-          --bundle-catalog-plugins=${CATALOG_PLUGINS} > $OUTFILE
+          --verify=${VERIFY} > $OUTFILE
     - id: output
       shell: bash
       env:

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -94,6 +94,11 @@ inputs:
     type: boolean
     default: true
     required: false
+  catalog-plugins:
+    type: string
+    description: Comma separated list of catalog plugins to bundle.
+    required: false
+    default: 'elasticsearch'
 outputs:
   dist-dir:
     description: Directory where artifacts are placed
@@ -141,6 +146,7 @@ runs:
         CACHE_BUILDERS: ${{ inputs.cache-builders }}
         ALPINE_BASE: ${{ inputs.alpine-base }}
         UBUNTU_BASE: ${{ inputs.ubuntu-base }}
+        CATALOG_PLUGINS: ${{ inputs.catalog-plugins }}
       with:
         verb: run
         dagger-flags: --verbose=0
@@ -162,7 +168,8 @@ runs:
           --registry=${DOCKER_REGISTRY}
           --checksum=${CHECKSUM}
           --cache-builders=${CACHE_BUILDERS}
-          --verify=${VERIFY} > $OUTFILE
+          --verify=${VERIFY}
+          --bundle-catalog-plugins=${CATALOG_PLUGINS} > $OUTFILE
     - id: output
       shell: bash
       env:

--- a/pkg/build/daggerbuild/arguments/catalog_plugins.go
+++ b/pkg/build/daggerbuild/arguments/catalog_plugins.go
@@ -24,6 +24,13 @@ type CatalogPluginsManifest struct {
 	Plugins []CatalogPluginSpec `json:"plugins"`
 }
 
+// DefaultCatalogPlugins defines the plugins that are always bundled unless
+// explicitly disabled with --no-default-catalog-plugins. Versions are left
+// empty so the resolver picks the latest compatible version automatically.
+var DefaultCatalogPlugins = []CatalogPluginSpec{
+	{ID: "elasticsearch"},
+}
+
 var flagBundleCatalogPlugins = &cli.StringSliceFlag{
 	Name:  "bundle-catalog-plugins",
 	Usage: "Plugins to download from grafana.com catalog (format: id or id:version, version optional). Supports comma-separated and repeated flags.",
@@ -34,9 +41,15 @@ var flagBundleCatalogPluginsFile = &cli.StringFlag{
 	Usage: "Path to JSON manifest file containing catalog plugins to bundle",
 }
 
+var flagNoDefaultCatalogPlugins = &cli.BoolFlag{
+	Name:  "no-default-catalog-plugins",
+	Usage: "Skip bundling the default catalog plugins",
+}
+
 var CatalogPluginsFlags = []cli.Flag{
 	flagBundleCatalogPlugins,
 	flagBundleCatalogPluginsFile,
+	flagNoDefaultCatalogPlugins,
 }
 
 // CatalogPlugins is the argument that provides the list of catalog plugins to bundle.
@@ -51,8 +64,13 @@ func catalogPluginsValueFunc(ctx context.Context, opts *pipeline.ArgumentOpts) (
 	// StringSlice handles both comma-separated and repeated flags
 	pluginsList := opts.CLIContext.StringSlice("bundle-catalog-plugins")
 	manifestFile := opts.CLIContext.String("bundle-catalog-plugins-file")
+	skipDefaults := opts.CLIContext.Bool("no-default-catalog-plugins")
 
 	var plugins []CatalogPluginSpec
+
+	if !skipDefaults {
+		plugins = append(plugins, DefaultCatalogPlugins...)
+	}
 
 	// Parse plugin specs from CLI flags
 	for _, item := range pluginsList {
@@ -139,11 +157,17 @@ func ParseCatalogPluginsFile(path string) ([]CatalogPluginSpec, error) {
 	return manifest.Plugins, nil
 }
 
-// HasCatalogPlugins returns true if any catalog plugins were specified via CLI flags.
+// HasCatalogPlugins returns true if any catalog plugins will be bundled,
+// including default plugins (unless --no-default-catalog-plugins is set).
 func HasCatalogPlugins(ctx context.Context, opts *pipeline.ArgumentOpts) bool {
 	pluginsList := opts.CLIContext.StringSlice("bundle-catalog-plugins")
 	manifestFile := opts.CLIContext.String("bundle-catalog-plugins-file")
-	return len(pluginsList) > 0 || manifestFile != ""
+	skipDefaults := opts.CLIContext.Bool("no-default-catalog-plugins")
+
+	if len(pluginsList) > 0 || manifestFile != "" {
+		return true
+	}
+	return !skipDefaults && len(DefaultCatalogPlugins) > 0
 }
 
 // GetCatalogPlugins retrieves the catalog plugins from the argument state.
@@ -192,7 +216,15 @@ func MergeCatalogPluginSpecs(plugins []CatalogPluginSpec) ([]CatalogPluginSpec, 
 		}
 
 		existing := merged[idx]
-		if existing.Version != plugin.Version {
+
+		switch {
+		case existing.Version == plugin.Version:
+			// Same version, continue to checksum merge.
+		case existing.Version == "":
+			existing.Version = plugin.Version
+		case plugin.Version == "":
+			// Keep existing pinned version.
+		default:
 			return nil, fmt.Errorf("conflicting versions for plugin %q: %q vs %q", plugin.ID, existing.Version, plugin.Version)
 		}
 
@@ -201,12 +233,13 @@ func MergeCatalogPluginSpecs(plugins []CatalogPluginSpec) ([]CatalogPluginSpec, 
 			// Identical duplicate, no-op.
 		case existing.Checksum == "":
 			existing.Checksum = plugin.Checksum
-			merged[idx] = existing
 		case plugin.Checksum == "":
 			// Keep existing checksum.
 		default:
 			return nil, fmt.Errorf("conflicting checksums for plugin %q", plugin.ID)
 		}
+
+		merged[idx] = existing
 	}
 
 	return merged, nil

--- a/pkg/build/daggerbuild/arguments/catalog_plugins_test.go
+++ b/pkg/build/daggerbuild/arguments/catalog_plugins_test.go
@@ -256,6 +256,26 @@ func TestMergeCatalogPluginSpecs(t *testing.T) {
 			},
 		},
 		{
+			name: "empty version overridden by pinned version",
+			input: []CatalogPluginSpec{
+				{ID: "grafana-clock-panel", Version: ""},
+				{ID: "grafana-clock-panel", Version: "1.3.1"},
+			},
+			want: []CatalogPluginSpec{
+				{ID: "grafana-clock-panel", Version: "1.3.1"},
+			},
+		},
+		{
+			name: "pinned version kept when second has empty version",
+			input: []CatalogPluginSpec{
+				{ID: "grafana-clock-panel", Version: "1.3.1"},
+				{ID: "grafana-clock-panel", Version: ""},
+			},
+			want: []CatalogPluginSpec{
+				{ID: "grafana-clock-panel", Version: "1.3.1"},
+			},
+		},
+		{
 			name: "conflicting versions fail",
 			input: []CatalogPluginSpec{
 				{ID: "grafana-clock-panel", Version: "1.3.1"},
@@ -292,6 +312,9 @@ func TestMergeCatalogPluginSpecs(t *testing.T) {
 func TestGetCatalogPlugins_WithWrappedState(t *testing.T) {
 	state := &pipeline.State{
 		CLIContext: &fakeCLIContext{
+			boolValues: map[string]bool{
+				"no-default-catalog-plugins": true,
+			},
 			stringSliceValues: map[string][]string{
 				"bundle-catalog-plugins": {"grafana-clock-panel:1.3.1,grafana-clock-panel:1.3.1"},
 			},
@@ -313,6 +336,126 @@ func TestGetCatalogPlugins_WithWrappedState(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("GetCatalogPlugins() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCatalogPluginsValueFunc_IncludesDefaults(t *testing.T) {
+	state := &pipeline.State{
+		CLIContext: &fakeCLIContext{},
+	}
+
+	wrapped := pipeline.StateWithLogger(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		state,
+	)
+
+	got, err := GetCatalogPlugins(context.Background(), wrapped)
+	if err != nil {
+		t.Fatalf("GetCatalogPlugins() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got, DefaultCatalogPlugins) {
+		t.Fatalf("GetCatalogPlugins() with no flags = %#v, want defaults %#v", got, DefaultCatalogPlugins)
+	}
+}
+
+func TestCatalogPluginsValueFunc_NoDefaultsFlag(t *testing.T) {
+	state := &pipeline.State{
+		CLIContext: &fakeCLIContext{
+			boolValues: map[string]bool{
+				"no-default-catalog-plugins": true,
+			},
+		},
+	}
+
+	wrapped := pipeline.StateWithLogger(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		state,
+	)
+
+	got, err := GetCatalogPlugins(context.Background(), wrapped)
+	if err != nil {
+		t.Fatalf("GetCatalogPlugins() error = %v", err)
+	}
+
+	if got != nil {
+		t.Fatalf("GetCatalogPlugins() with --no-default-catalog-plugins = %#v, want nil", got)
+	}
+}
+
+func TestCatalogPluginsValueFunc_DefaultsMergedWithCLI(t *testing.T) {
+	state := &pipeline.State{
+		CLIContext: &fakeCLIContext{
+			stringSliceValues: map[string][]string{
+				"bundle-catalog-plugins": {"grafana-clock-panel:1.3.1"},
+			},
+		},
+	}
+
+	wrapped := pipeline.StateWithLogger(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		state,
+	)
+
+	got, err := GetCatalogPlugins(context.Background(), wrapped)
+	if err != nil {
+		t.Fatalf("GetCatalogPlugins() error = %v", err)
+	}
+
+	want := append([]CatalogPluginSpec{}, DefaultCatalogPlugins...)
+	want = append(want, CatalogPluginSpec{ID: "grafana-clock-panel", Version: "1.3.1"})
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetCatalogPlugins() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCatalogPluginsValueFunc_CLIPinsDefaultPluginVersion(t *testing.T) {
+	state := &pipeline.State{
+		CLIContext: &fakeCLIContext{
+			stringSliceValues: map[string][]string{
+				"bundle-catalog-plugins": {"grafana-elasticsearch-datasource:5.0.0"},
+			},
+		},
+	}
+
+	wrapped := pipeline.StateWithLogger(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		state,
+	)
+
+	got, err := GetCatalogPlugins(context.Background(), wrapped)
+	if err != nil {
+		t.Fatalf("GetCatalogPlugins() error = %v", err)
+	}
+
+	want := []CatalogPluginSpec{
+		{ID: "grafana-elasticsearch-datasource", Version: "5.0.0"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetCatalogPlugins() = %#v, want %#v", got, want)
+	}
+}
+
+func TestHasCatalogPlugins_DefaultsPresent(t *testing.T) {
+	opts := &pipeline.ArgumentOpts{
+		CLIContext: &fakeCLIContext{},
+	}
+	if !HasCatalogPlugins(context.Background(), opts) {
+		t.Fatal("HasCatalogPlugins() = false, want true (defaults exist)")
+	}
+}
+
+func TestHasCatalogPlugins_DefaultsDisabled(t *testing.T) {
+	opts := &pipeline.ArgumentOpts{
+		CLIContext: &fakeCLIContext{
+			boolValues: map[string]bool{
+				"no-default-catalog-plugins": true,
+			},
+		},
+	}
+	if HasCatalogPlugins(context.Background(), opts) {
+		t.Fatal("HasCatalogPlugins() = true, want false (defaults disabled, no CLI flags)")
 	}
 }
 

--- a/pkg/build/daggerbuild/arguments/catalog_plugins_test.go
+++ b/pkg/build/daggerbuild/arguments/catalog_plugins_test.go
@@ -414,7 +414,7 @@ func TestCatalogPluginsValueFunc_CLIPinsDefaultPluginVersion(t *testing.T) {
 	state := &pipeline.State{
 		CLIContext: &fakeCLIContext{
 			stringSliceValues: map[string][]string{
-				"bundle-catalog-plugins": {"grafana-elasticsearch-datasource:5.0.0"},
+				"bundle-catalog-plugins": {"elasticsearch:5.0.0"},
 			},
 		},
 	}
@@ -430,7 +430,7 @@ func TestCatalogPluginsValueFunc_CLIPinsDefaultPluginVersion(t *testing.T) {
 	}
 
 	want := []CatalogPluginSpec{
-		{ID: "grafana-elasticsearch-datasource", Version: "5.0.0"},
+		{ID: "elasticsearch", Version: "5.0.0"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("GetCatalogPlugins() = %#v, want %#v", got, want)


### PR DESCRIPTION
Minor change to the bundling logic to specify the list of default plugins in code and to support disabling the default bundling if we want.