### PR TITLE
Log Details: Optimized vertical space

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -107,12 +107,12 @@ export const LogLineDetailsLabelFields = ({ fields, log, logs, search }: LogLine
 const getFieldsStyles = (theme: GrafanaTheme2, fontSize: LogListFontSize) => ({
   fieldsTable: css({
     display: 'grid',
-    gap: theme.spacing(1),
+    gap: fontSize === 'small' ? theme.spacing(0.25, 0.5) : theme.spacing(0.5, 1),
     gridTemplateColumns: `${fontSize === 'small' ? theme.spacing(10) : theme.spacing(11.5)} fit-content(30%) 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',
-    gap: theme.spacing(1),
+    gap: fontSize === 'small' ? theme.spacing(0.25, 0.5) : theme.spacing(0.5, 1),
     gridTemplateColumns: `auto 1fr`,
   }),
 });

--- a/public/app/features/logs/components/panel/LogLineDetailsLinks.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLinks.tsx
@@ -9,6 +9,7 @@ import { FieldDef } from '../logParser';
 
 import { useLogDetailsContext } from './LogDetailsContext';
 import { filterFields, MultipleValue, SingleValue } from './LogLineDetailsFields';
+import { LogListFontSize } from './LogList';
 import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
@@ -20,7 +21,8 @@ interface LogLineDetailsLinksProps {
 }
 
 export const LogLineDetailsLinks = memo(({ fields, log, search }: LogLineDetailsLinksProps) => {
-  const styles = useStyles2(getFieldsStyles);
+  const { fontSize } = useLogListContext();
+  const styles = useStyles2(getFieldsStyles, fontSize);
   const filteredFields = useMemo(() => (search ? filterFields(fields, search) : fields), [fields, search]);
 
   if (!fields.length) {
@@ -39,10 +41,10 @@ export const LogLineDetailsLinks = memo(({ fields, log, search }: LogLineDetails
 });
 LogLineDetailsLinks.displayName = 'LogLineDetailsLinks';
 
-const getFieldsStyles = (theme: GrafanaTheme2) => ({
+const getFieldsStyles = (theme: GrafanaTheme2, fontSize: LogListFontSize) => ({
   linksTable: css({
     display: 'grid',
-    gap: theme.spacing(1),
+    gap: fontSize === 'small' ? theme.spacing(0.25, 0.5) : theme.spacing(0.5, 1),
     gridTemplateColumns: `fit-content(30%) 1fr`,
     marginBottom: theme.spacing(1),
   }),


### PR DESCRIPTION
It's been brought up to us that we were using execessive vertical space to separate fields in the LogLineDetails, which was true, and very noticeable once you see it.

Before:

<img width="473" height="815" alt="Before" src="https://github.com/user-attachments/assets/527c15ed-fa3b-43f5-a28e-2b623d3c47f0" />

After:

<img width="477" height="725" alt="After" src="https://github.com/user-attachments/assets/f562f2b7-b95b-40de-b03f-05b688a106e2" />
