### PR TITLE
Alerting: Fix Page not found breadcrumb in import wizard

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -23,6 +23,7 @@ import {
   trackImportToGMAWizardStepSkipped,
 } from '../../Analytics';
 import { fetchAlertManagerConfig } from '../../api/alertmanager';
+import { getAlertRulesNavId } from '../../navigation/useAlertRulesNav';
 import { Folder } from '../../types/rule-form';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
 import { stringifyErrorLike } from '../../utils/misc';
@@ -86,7 +87,7 @@ export interface ImportFormValues {
 const ImportToGMA = () => {
   return (
     <AlertingPageWrapper
-      navId="alert-list"
+      navId={getAlertRulesNavId()}
       pageNav={{
         text: t('alerting.import-to-gma-tool.pageTitle', 'Import to Grafana Alerting'),
       }}


### PR DESCRIPTION
**What is this feature?**

This PR fixes the `Page not found` breadcrumb in the Import Wizard page.

**Why do we need this feature?**
It's a bug.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

Before:

<img width="674" height="197" alt="Screenshot 2026-03-24 at 10 55 58" src="https://github.com/user-attachments/assets/466e1e72-458a-44c1-af89-3b7dc726201f" />

After:

<img width="542" height="133" alt="Screenshot 2026-03-24 at 11 00 32" src="https://github.com/user-attachments/assets/ebd47a57-69ab-4af9-b6b3-9d49be6c11d8" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
