### PR TITLE
datasources: handle implicit datasource better in query-service decision

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -71,11 +71,19 @@ jest.mock('../services', () => ({
 }));
 jest.mock('./publicDashboardQueryHandler');
 
+const mockIsQueryServiceCompatible = jest.fn().mockReturnValue(false);
+jest.mock('./qscheck', () => ({
+  ...jest.requireActual('./qscheck'),
+  isQueryServiceCompatible: (a: unknown, b: unknown) => mockIsQueryServiceCompatible(a, b),
+}));
+
 const mockGetBooleanValue = jest.fn().mockReturnValue(false);
+const mockGetObjectValue = jest.fn().mockReturnValue({ types: ['prometheus'] });
 jest.mock('../internal/openFeature', () => ({
   ...jest.requireActual('../internal/openFeature'),
   getFeatureFlagClient: () => ({
     getBooleanValue: mockGetBooleanValue,
+    getObjectValue: mockGetObjectValue,
   }),
 }));
 
@@ -768,6 +776,68 @@ describe('DataSourceWithBackend', () => {
       mockGetBooleanValue.mockReturnValue(false);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(url).toBe('/api/datasources/uid/abc/resources/api/v1/labels');
+    });
+  });
+
+  describe('queryServiceDecision', () => {
+    let oldQsUI: boolean | undefined = undefined;
+    beforeEach(() => {
+      oldQsUI = config.featureToggles.queryServiceFromUI;
+      config.featureToggles.queryServiceFromUI = true;
+    });
+    afterEach(() => {
+      config.featureToggles.queryServiceFromUI = oldQsUI;
+      mockGetObjectValue.mockReset().mockReturnValue({ types: ['prometheus'] });
+      mockIsQueryServiceCompatible.mockReset().mockReturnValue(false);
+    });
+
+    const prometheus = {
+      name: 'prm',
+      id: 1,
+      uid: 'p',
+      type: 'prometheus',
+      jsonData: {},
+    } as DataSourceInstanceSettings;
+
+    const loki = {
+      name: 'lk',
+      id: 2,
+      uid: 'l',
+      type: 'loki',
+      jsonData: {},
+    } as DataSourceInstanceSettings;
+
+    it.each([
+      [
+        'handle per-query data source references',
+        [
+          { refId: 'A', datasource: prometheus },
+          { refId: 'B', datasource: loki },
+        ],
+        ['prometheus', 'loki'],
+      ],
+      ['handle no per-query data source references', [{ refId: 'A' }, { refId: 'B' }], ['dummy', 'dummy']],
+      [
+        'handle a mix of query and no-query data source references',
+        [{ refId: 'A' }, { refId: 'B', datasource: loki }],
+        ['dummy', 'loki'],
+      ],
+    ])('%s', (_, targets, expectedTypes) => {
+      const { ds } = createMockDatasource();
+
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets,
+        range: getDefaultTimeRange(),
+      } as DataQueryRequest);
+
+      const { calls } = mockIsQueryServiceCompatible.mock;
+      expect(calls).toHaveLength(1);
+
+      const [datasources, compatibilityFlag] = calls[0];
+      expect([datasources, compatibilityFlag]).toHaveLength(2);
+      expect((datasources as Array<{ type: string }>).map((ds) => ds.type)).toStrictEqual(expectedTypes);
     });
   });
 });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -153,10 +153,12 @@ class DataSourceWithBackend<
   TOptions extends DataSourceJsonData = DataSourceJsonData,
 > extends DataSourceApi<TQuery, TOptions> {
   userStorage: UserStorage;
+  datasourceInstanceSettings: DataSourceInstanceSettings<TOptions>;
 
   constructor(instanceSettings: DataSourceInstanceSettings<TOptions>) {
     super(instanceSettings);
     this.userStorage = new UserStorage(instanceSettings.type);
+    this.datasourceInstanceSettings = instanceSettings;
   }
 
   /**
@@ -205,6 +207,9 @@ class DataSourceWithBackend<
           // instance (async) and apply the template variables but it seems it's not necessary for now.
           shouldApplyTemplateVariables = false;
         }
+      } else {
+        // if there is no per-query datasource, we use the implicit datasource
+        datasources.push(this.datasourceInstanceSettings);
       }
       if (datasource.type?.length) {
         pluginIDs.add(datasource.type);


### PR DESCRIPTION
to decide whether the data source query should go to the old `/api/ds/query` endpoint, or to the new `/apis/query.grafana.app` endpoint, we need to check the datasources involved.

current we only check the "per query" datasources, but there are cases (dashboard variable query for example), where there is no "per query" datasource. in that case we should use the implicit datasource. this PR does so.