### PR TITLE
Search: Increase index rebuild jitter range from maxAge/5 to maxAge/2

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -749,7 +749,7 @@ func (s *searchServer) runPeriodicScanForIndexesToRebuild(ctx context.Context) {
 }
 
 // jitterForKey returns a deterministic jitter duration for the given key,
-// bounded to [0, maxAge/5). This spreads index rebuilds across scan intervals
+// bounded to [0, maxAge/2). This spreads index rebuilds across scan intervals
 // to avoid thundering herd CPU spikes when many indexes become stale at once.
 func jitterForKey(key NamespacedResource, maxAge time.Duration) time.Duration {
 	if maxAge <= 0 {
@@ -757,7 +757,7 @@ func jitterForKey(key NamespacedResource, maxAge time.Duration) time.Duration {
 	}
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(key.String()))
-	jitterRange := uint64(maxAge / 5)
+	jitterRange := uint64(maxAge / 2)
 	if jitterRange == 0 {
 		return 0
 	}

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1023,12 +1023,12 @@ func TestJitterForKey(t *testing.T) {
 		require.Equal(t, time.Duration(0), jitterForKey(key, 0))
 	})
 
-	t.Run("bounded to maxAge/5", func(t *testing.T) {
+	t.Run("bounded to maxAge/2", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			key := NamespacedResource{Namespace: fmt.Sprintf("ns%d", i), Group: "g", Resource: "r"}
 			j := jitterForKey(key, maxAge)
 			require.GreaterOrEqual(t, j, time.Duration(0))
-			require.Less(t, j, maxAge/5)
+			require.Less(t, j, maxAge/2)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Increases the per-namespace jitter range for Bleve index rebuild staleness checks from `maxAge/5` to `maxAge/2`
- The previous range (~4.8h for 24h maxAge) wasn't providing enough spread to effectively prevent thundering herd CPU spikes
- New range (~12h for 24h maxAge) distributes rebuilds across ~144 five-minute scan intervals instead of ~57

## Test plan

- [x] `TestJitterForKey` bounds updated and passing
- [x] `TestFindIndexesToRebuildWithJitter` passing
- [x] Existing `TestFindIndexesForRebuild` and `TestRebuildIndexes` passing
- [ ] Monitor CPU usage in staging to verify improved rebuild spread