### PR TITLE
update the resources api to include the correct group name

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -757,7 +757,7 @@ describe('DataSourceWithBackend', () => {
       mockGetBooleanValue.mockReturnValue(true);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', false);
-      expect(url).toBe('/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
+      expect(url).toBe('/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/api/v1/labels');
     });
 
     test('check that buildResourcesDatasourceUrl uses the legacy URL when feature flag is disabled', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -757,7 +757,7 @@ describe('DataSourceWithBackend', () => {
       mockGetBooleanValue.mockReturnValue(true);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', false);
-      expect(url).toBe('/apis/dummy.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
+      expect(url).toBe('/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/api/v1/labels');
     });
 
     test('check that buildResourcesDatasourceUrl uses the legacy URL when feature flag is disabled', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -757,7 +757,9 @@ describe('DataSourceWithBackend', () => {
       mockGetBooleanValue.mockReturnValue(true);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', false);
-      expect(url).toBe('/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
+      expect(url).toBe(
+        '/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels'
+      );
     });
 
     test('check that buildResourcesDatasourceUrl uses the legacy URL when feature flag is disabled', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -757,7 +757,7 @@ describe('DataSourceWithBackend', () => {
       mockGetBooleanValue.mockReturnValue(true);
       const url = createMockDatasource().ds.buildResourcesDatasourceUrl('api/v1/labels');
       expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.apiserver.useNewAPIsForDatasourceResources', false);
-      expect(url).toBe('/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/api/v1/labels');
+      expect(url).toBe('/apis/dummy.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/api/v1/labels');
     });
 
     test('check that buildResourcesDatasourceUrl uses the legacy URL when feature flag is disabled', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -392,7 +392,7 @@ class DataSourceWithBackend<
       // example:
       // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';
-      return `/apis/${this.type}.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
+      return `/apis/${this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
     }
     return `/api/datasources/uid/${this.uid}/resources/${path}`;
   }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -392,7 +392,7 @@ class DataSourceWithBackend<
       // example:
       // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';
-      return `/apis/${this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
+      return `/apis/${this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resource/${path}`;
     }
     return `/api/datasources/uid/${this.uid}/resources/${path}`;
   }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -392,7 +392,7 @@ class DataSourceWithBackend<
       // example:
       // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';
-      return `/apis/${this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resource/${path}`;
+      return `/apis/${this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
     }
     return `/api/datasources/uid/${this.uid}/resources/${path}`;
   }


### PR DESCRIPTION
Was missing `.datasource` in the group which resulted in 404 all the time. 

updating the endpoints [here](https://github.com/grafana/grafana/pull/120958)