### PR TITLE
JWT: fix org switching causing infinite redirect loop

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -546,11 +546,10 @@ func parseNamespace(path string) string {
 	return parts[0]
 }
 
-// name of query string used to target specific org for request
-const orgIDTargetQuery = "targetOrgId"
-
-// orgIDQuery is the query param sent by the Grafana frontend when switching orgs
-const orgIDQuery = "orgId"
+const (
+	orgIDQuery       = "orgId"       // sent by Grafana frontend (preferred)
+	orgIDTargetQuery = "targetOrgId" // legacy API caller param
+)
 
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -553,9 +553,8 @@ const (
 
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()
-	// Prefer orgId (sent by the frontend) over the legacy targetOrgId.
-	// On parse failure, fall through to the next key rather than returning
-	// early so a malformed value doesn't mask a valid one.
+	// Prefer orgId (frontend) over targetOrgId (legacy). Fall through on
+	// parse failure so a malformed value doesn't mask a valid one.
 	for _, key := range []string{orgIDQuery, orgIDTargetQuery} {
 		if !params.Has(key) {
 			continue

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -554,15 +554,18 @@ const orgIDQuery = "orgId"
 
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()
-	// Prefer orgId (sent by the frontend) over the legacy targetOrgId
+	// Prefer orgId (sent by the frontend) over the legacy targetOrgId.
+	// On parse failure, fall through to the next key rather than returning
+	// early so a malformed value doesn't mask a valid one.
 	for _, key := range []string{orgIDQuery, orgIDTargetQuery} {
-		if params.Has(key) {
-			id, err := strconv.ParseInt(params.Get(key), 10, 64)
-			if err != nil {
-				return 0
-			}
-			return id
+		if !params.Has(key) {
+			continue
 		}
+		id, err := strconv.ParseInt(params.Get(key), 10, 64)
+		if err != nil {
+			continue
+		}
+		return id
 	}
 	return 0
 }

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -549,16 +549,22 @@ func parseNamespace(path string) string {
 // name of query string used to target specific org for request
 const orgIDTargetQuery = "targetOrgId"
 
+// orgIDQuery is the query param sent by the Grafana frontend when switching orgs
+const orgIDQuery = "orgId"
+
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()
-	if !params.Has(orgIDTargetQuery) {
-		return 0
+	// Prefer orgId (sent by the frontend) over the legacy targetOrgId
+	for _, key := range []string{orgIDQuery, orgIDTargetQuery} {
+		if params.Has(key) {
+			id, err := strconv.ParseInt(params.Get(key), 10, 64)
+			if err != nil {
+				return 0
+			}
+			return id
+		}
 	}
-	id, err := strconv.ParseInt(params.Get(orgIDTargetQuery), 10, 64)
-	if err != nil {
-		return 0
-	}
-	return id
+	return 0
 }
 
 // name of header containing org id for request

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -554,9 +554,8 @@ const (
 
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()
-	// Prefer orgId (sent by the frontend) over the legacy targetOrgId.
-	// On parse failure, fall through to the next key rather than returning
-	// early so a malformed value doesn't mask a valid one.
+	// Prefer orgId (frontend) over targetOrgId (legacy). Fall through on
+	// parse failure so a malformed value doesn't mask a valid one.
 	for _, key := range []string{orgIDQuery, orgIDTargetQuery} {
 		if !params.Has(key) {
 			continue

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -547,11 +547,10 @@ func parseNamespace(path string) string {
 	return parts[0]
 }
 
-// name of query string used to target specific org for request
-const orgIDTargetQuery = "targetOrgId"
-
-// orgIDQuery is the query param sent by the Grafana frontend when switching orgs
-const orgIDQuery = "orgId"
+const (
+	orgIDQuery       = "orgId"       // sent by Grafana frontend (preferred)
+	orgIDTargetQuery = "targetOrgId" // legacy API caller param
+)
 
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -550,16 +550,22 @@ func parseNamespace(path string) string {
 // name of query string used to target specific org for request
 const orgIDTargetQuery = "targetOrgId"
 
+// orgIDQuery is the query param sent by the Grafana frontend when switching orgs
+const orgIDQuery = "orgId"
+
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()
-	if !params.Has(orgIDTargetQuery) {
-		return 0
+	// Prefer orgId (sent by the frontend) over the legacy targetOrgId
+	for _, key := range []string{orgIDQuery, orgIDTargetQuery} {
+		if params.Has(key) {
+			id, err := strconv.ParseInt(params.Get(key), 10, 64)
+			if err != nil {
+				return 0
+			}
+			return id
+		}
 	}
-	id, err := strconv.ParseInt(params.Get(orgIDTargetQuery), 10, 64)
-	if err != nil {
-		return 0
-	}
-	return id
+	return 0
 }
 
 // name of header containing org id for request

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -555,15 +555,18 @@ const orgIDQuery = "orgId"
 
 func orgIDFromQuery(req *http.Request) int64 {
 	params := req.URL.Query()
-	// Prefer orgId (sent by the frontend) over the legacy targetOrgId
+	// Prefer orgId (sent by the frontend) over the legacy targetOrgId.
+	// On parse failure, fall through to the next key rather than returning
+	// early so a malformed value doesn't mask a valid one.
 	for _, key := range []string{orgIDQuery, orgIDTargetQuery} {
-		if params.Has(key) {
-			id, err := strconv.ParseInt(params.Get(key), 10, 64)
-			if err != nil {
-				return 0
-			}
-			return id
+		if !params.Has(key) {
+			continue
 		}
+		id, err := strconv.ParseInt(params.Get(key), 10, 64)
+		if err != nil {
+			continue
+		}
+		return id
 	}
 	return 0
 }

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -280,12 +280,44 @@ func TestService_OrgID(t *testing.T) {
 			expectedOrgID: 1,
 		},
 		{
-			desc: "should set org id when present in url",
+			desc: "should set org id from ?targetOrgId (legacy api caller param)",
 			req: &authn.Request{HTTPRequest: &http.Request{
 				Header: map[string][]string{},
 				URL:    mustParseURL("http://localhost/?targetOrgId=2"),
 			}},
 			expectedOrgID: 2,
+		},
+		{
+			desc: "should set org id from ?orgId (frontend param)",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+				URL:    mustParseURL("http://localhost/?orgId=2"),
+			}},
+			expectedOrgID: 2,
+		},
+		{
+			desc: "should prefer ?orgId over ?targetOrgId when both are present",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+				URL:    mustParseURL("http://localhost/?orgId=3&targetOrgId=4"),
+			}},
+			expectedOrgID: 3,
+		},
+		{
+			desc: "should fall back to ?targetOrgId when ?orgId is malformed",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+				URL:    mustParseURL("http://localhost/?orgId=abc&targetOrgId=5"),
+			}},
+			expectedOrgID: 5,
+		},
+		{
+			desc: "should return 0 when ?orgId is malformed and ?targetOrgId is missing",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+				URL:    mustParseURL("http://localhost/?orgId=abc"),
+			}},
+			expectedOrgID: 0,
 		},
 		{
 			desc: "should prioritise org id from url when present in both header and url",

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -139,7 +139,9 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	}
 
 	// Honour the org requested via ?orgId query param so that OrgRedirect middleware
-	// does not see a mismatch and cause an infinite redirect loop.
+	// does not see a mismatch and cause an infinite redirect loop. Downstream sync
+	// hooks and RBAC permission checks still verify membership in id.OrgID; this
+	// only sets the active-org selector for the session.
 	if r.OrgID > 0 {
 		id.OrgID = r.OrgID
 	}

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -77,7 +77,7 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	id := &authn.Identity{
 		AuthenticatedBy: login.JWTModule,
 		AuthID:          sub,
-		OrgID:           r.OrgID, // re-grounded by FetchSyncedUserHook against org_user membership
+		OrgID:           r.OrgID,
 		OrgRoles:        map[int64]org.RoleType{},
 		ClientParams: authn.ClientParams{
 			SyncUser:        true,

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -77,6 +77,7 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	id := &authn.Identity{
 		AuthenticatedBy: login.JWTModule,
 		AuthID:          sub,
+		OrgID:           r.OrgID, // re-grounded by FetchSyncedUserHook against org_user membership
 		OrgRoles:        map[int64]org.RoleType{},
 		ClientParams: authn.ClientParams{
 			SyncUser:        true,
@@ -136,14 +137,6 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
-	}
-
-	// Honour the org requested via ?orgId query param so that OrgRedirect middleware
-	// does not see a mismatch and cause an infinite redirect loop. Downstream sync
-	// hooks and RBAC permission checks still verify membership in id.OrgID; this
-	// only sets the active-org selector for the session.
-	if r.OrgID > 0 {
-		id.OrgID = r.OrgID
 	}
 
 	if id.Login == "" && id.Email == "" {

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -138,6 +138,12 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 		}
 	}
 
+	// Honour the org requested via ?orgId query param so that OrgRedirect middleware
+	// does not see a mismatch and cause an infinite redirect loop.
+	if r.OrgID > 0 {
+		id.OrgID = r.OrgID
+	}
+
 	if id.Login == "" && id.Email == "" {
 		s.log.FromContext(ctx).Debug("Failed to get an authentication claim from JWT",
 			"login", id.Login, "email", id.Email)

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -40,7 +40,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Valid Use case with group path",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{1: identity.RoleAdmin},
 				Groups:          []string{"foo", "bar"},
@@ -92,7 +92,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Valid Use case without group path",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{1: identity.RoleAdmin},
 				Login:           "eai-doe",
@@ -143,7 +143,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Valid Use case with org_mapping",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{4: identity.RoleEditor, 5: identity.RoleViewer},
 				Login:           "eai-doe",
@@ -198,7 +198,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Invalid Use case with org_mapping and invalid roles",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{4: identity.RoleEditor, 5: identity.RoleViewer},
 				Login:           "eai-doe",

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -36,7 +36,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Valid Use case with group path",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{1: identity.RoleAdmin},
 				ExternalGroups:  []string{"foo", "bar"},
@@ -87,7 +87,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Valid Use case without group path",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{1: identity.RoleAdmin},
 				Login:           "eai-doe",
@@ -137,7 +137,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Valid Use case with org_mapping",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{4: identity.RoleEditor, 5: identity.RoleViewer},
 				Login:           "eai-doe",
@@ -191,7 +191,7 @@ func TestAuthenticateJWT(t *testing.T) {
 		{
 			name: "Invalid Use case with org_mapping and invalid roles",
 			wantID: &authn.Identity{
-				OrgID:           0,
+				OrgID:           1,
 				OrgName:         "",
 				OrgRoles:        map[int64]identity.RoleType{4: identity.RoleEditor, 5: identity.RoleViewer},
 				Login:           "eai-doe",


### PR DESCRIPTION
Revives and cleans up #105040, rebased on current main.

## Root cause

Two issues combined to cause an infinite 302 redirect loop when a JWT-authenticated user navigated to a URL with `?orgId=N`:

1. `orgIDFromQuery` in `authnimpl/service.go` only read `?targetOrgId` — but the Grafana frontend sends `?orgId`. So `r.OrgID` was always 0 for browser page loads, and the authenticated identity was placed in the wrong org.

2. The JWT client never set `id.OrgID` from `r.OrgID`, so even with a correct `r.OrgID`, the identity ignored the requested org. The `OrgRedirect` middleware would then always see a mismatch and issue another 302.

## Changes

- `pkg/services/authn/authnimpl/service.go`: `orgIDFromQuery` now prefers `?orgId` and falls back to `?targetOrgId` (preserving API caller behaviour)
- `pkg/services/authn/clients/jwt.go`: set `id.OrgID = r.OrgID` when an org is explicitly requested
- `pkg/services/authn/clients/jwt_test.go`: update three test expectations that were asserting the old broken `OrgID: 0` behaviour

Fixes #105040