### PR TITLE
Revert "FeatureToggles: Feat: add a feature toggle for iam client fetching"

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1730,9 +1730,4 @@ export interface FeatureToggles {
   * @default false
   */
   yAxisTickControl?: boolean;
-  /**
-  * Enables the IAM client integration for fetching remote IAM global roles
-  * @default false
-  */
-  rbacIAMClient?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2744,14 +2744,6 @@ var (
 			Owner:        grafanaDatavizSquad,
 			Expression:   "false",
 		},
-		{
-			Name:         "rbacIAMClient",
-			Description:  "Enables the IAM client integration for fetching remote IAM global roles",
-			Stage:        FeatureStageExperimental,
-			Owner:        identityAccessTeam,
-			HideFromDocs: true,
-			Expression:   "false",
-		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -341,4 +341,3 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-04,inlineLogDetailsNoScrolls,experimental,@grafana/observability-logs,false,false,false
 2026-02-06,colorblindThemes,GA,@grafana/grafana-frontend-platform,false,true,false
 2026-03-19,yAxisTickControl,experimental,@grafana/dataviz-squad,false,false,true
-2026-03-20,rbacIAMClient,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -921,8 +921,4 @@ const (
 	// FlagColorblindThemes
 	// Enables the new colorblind-friendly themes
 	FlagColorblindThemes = "colorblindThemes"
-
-	// FlagRbacIAMClient
-	// Enables the IAM client integration for fetching remote IAM global roles
-	FlagRbacIAMClient = "rbacIAMClient"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4169,20 +4169,6 @@
     },
     {
       "metadata": {
-        "name": "rbacIAMClient",
-        "resourceVersion": "1774034789603",
-        "creationTimestamp": "2026-03-20T19:26:29Z"
-      },
-      "spec": {
-        "description": "Enables the IAM client integration for fetching remote IAM global roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromDocs": true,
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
         "name": "react19",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"


### PR DESCRIPTION
Reverts grafana/grafana#120796

I am reverting this feature registration due to the fact that we are going to use it only in HG: https://github.com/grafana/hosted-grafana/pull/7537 and the registration happens here https://github.com/grafana/deployment_tools/pull/524064