### PR TITLE
Logs CSV export: Include log line body when selected as field

### DIFF
--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -10,8 +10,15 @@ import {
   LogsSortOrder,
   MutableDataFrame,
   DataFrame,
+  standardTransformers,
+  toDataFrame,
+  DataFrameType,
 } from '@grafana/data';
+import { mockTransformationsRegistry } from '@grafana/data/internal';
+import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 import { getMockFrames } from 'app/plugins/datasource/loki/mocks/frames';
+
+import { downloadDataFrameAsCsv } from '../inspector/utils/download';
 
 import { LOG_LINE_BODY_FIELD_NAME } from './components/fieldSelector/logFields';
 import { createLogRow } from './components/mocks/logRow';
@@ -34,6 +41,11 @@ import {
 } from './utils';
 
 jest.mock('file-saver', () => jest.fn());
+
+jest.mock('../inspector/utils/download', () => ({
+  ...jest.requireActual('../inspector/utils/download'),
+  downloadDataFrameAsCsv: jest.fn(),
+}));
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
@@ -665,6 +677,77 @@ describe('downloadLogs', () => {
           fields: { otherLabel: 'other value' },
         })
       );
+    });
+  });
+
+  describe('CSV format', () => {
+    beforeAll(() => {
+      mockTransformationsRegistry([
+        extractFieldsTransformer,
+        standardTransformers.organizeFieldsTransformer,
+        standardTransformers.filterFieldsByNameTransformer,
+      ]);
+    });
+
+    beforeEach(() => {
+      jest.mocked(downloadDataFrameAsCsv).mockClear();
+    });
+
+    it('includes the log line when log line body field is selected', async () => {
+      const csvLogs = [
+        createLogRow({
+          timeEpochMs: 100,
+          entry: 'test entry',
+          labels: { label: 'value' },
+          dataFrame: toDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [100] },
+              { name: 'Line', type: FieldType.string, values: ['test entry'] },
+              { name: 'labels', type: FieldType.other, values: [{ label: 'value' }] },
+            ],
+          }),
+          rowIndex: 0,
+        }),
+      ];
+
+      await downloadLogs(DownloadFormat.CSV, csvLogs, [], [LOG_LINE_BODY_FIELD_NAME]);
+
+      expect(downloadDataFrameAsCsv).toHaveBeenCalledTimes(1);
+      const exportedFrame = jest.mocked(downloadDataFrameAsCsv).mock.calls[0][0];
+      const lineField = exportedFrame.fields.find((f) => f.name === 'Line');
+      expect(lineField).toBeDefined();
+      expect(lineField?.values).toContain('test entry');
+    });
+
+    it('includes the data plane log line when log line body field is selected', async () => {
+      const csvLogs = [
+        createLogRow({
+          timeEpochMs: 100,
+          entry: 'test entry',
+          labels: { label: 'value' },
+          dataFrame: toDataFrame({
+            refId: 'A',
+            fields: [
+              { name: 'timestamp', type: FieldType.time, values: [100] },
+              { name: 'body', type: FieldType.string, values: ['test entry'] },
+              { name: 'labels', type: FieldType.other, values: [{ label: 'value' }] },
+            ],
+            meta: {
+              type: DataFrameType.LogLines,
+            },
+          }),
+          rowIndex: 0,
+        }),
+      ];
+
+      await downloadLogs(DownloadFormat.CSV, csvLogs, [], [LOG_LINE_BODY_FIELD_NAME]);
+
+      expect(downloadDataFrameAsCsv).toHaveBeenCalledTimes(1);
+      const exportedFrame = jest.mocked(downloadDataFrameAsCsv).mock.calls[0][0];
+      const lineField = exportedFrame.fields.find((f) => f.name === 'body');
+      expect(lineField).toBeDefined();
+      expect(lineField?.values).toContain('test entry');
     });
   });
 });

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -40,7 +40,7 @@ import { downloadDataFrameAsCsv, downloadLogsModelAsTxt } from '../inspector/uti
 import { LOG_LINE_BODY_FIELD_NAME } from './components/fieldSelector/logFields';
 import { getDataframeFields } from './components/logParser';
 import { GetRowContextQueryFn } from './components/panel/LogLineMenu';
-import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME } from './logsFrame';
+import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } from './logsFrame';
 
 /**
  * Returns the log level of a log line.
@@ -492,21 +492,26 @@ export const downloadLogs = async (
       const fileName = `Logs-${dateTimeFormat(new Date())}.json`;
       saveAs(blob, fileName);
       break;
-    case DownloadFormat.CSV:
+    case DownloadFormat.CSV: {
       const dataFrameMap = new Map<string, DataFrame>();
       logRows.forEach((row) => {
         if (row.dataFrame?.refId && !dataFrameMap.has(row.dataFrame?.refId)) {
           dataFrameMap.set(row.dataFrame?.refId, row.dataFrame);
         }
       });
-      dataFrameMap.forEach(async (dataFrame) => {
+      for (const dataFrame of dataFrameMap.values()) {
         const transforms: Array<DataTransformerConfig | CustomTransformOperator> = getLogsExtractFields(dataFrame);
         if (fields.length) {
+          const logsFrame = parseLogsFrame(dataFrame);
+          const bodyFieldName = logsFrame?.bodyField.name;
+          const csvFieldNames = fields.map((name) =>
+            name === LOG_LINE_BODY_FIELD_NAME && bodyFieldName ? bodyFieldName : name
+          );
           transforms.push(addISODateTransformation, {
             id: 'filterFieldsByName',
             options: {
               include: {
-                names: ['Date', ...fields],
+                names: ['Date', ...csvFieldNames],
               },
             },
           });
@@ -526,7 +531,9 @@ export const downloadLogs = async (
         }
         const transformedDataFrame = await lastValueFrom(transformDataFrame(transforms, [dataFrame]));
         downloadDataFrameAsCsv(transformedDataFrame[0], `Logs-${dataFrame.refId}`);
-      });
+      }
+      break;
+    }
   }
 };
 


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/120757, adding the log line body when selected as a field to the generatede field.