### PR TITLE
DataLinks: Add field display name variable suggestion

### DIFF
--- a/packages/grafana-data/src/utils/dataLinks.ts
+++ b/packages/grafana-data/src/utils/dataLinks.ts
@@ -16,6 +16,7 @@ export const DataLinkBuiltInVars = {
   includeVars: '__all_variables',
   seriesName: '__series.name',
   fieldName: '__field.name',
+  fieldDisplayName: '__field.displayName',
   valueTime: '__value.time',
   valueNumeric: '__value.numeric',
   valueText: '__value.text',

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -51,6 +51,12 @@ describe('getVisualizationOptions', () => {
           value: '__field.name',
         },
         {
+          documentation: 'Display name of the field (includes overrides and transformations)',
+          label: 'Display name',
+          origin: 'field',
+          value: '__field.displayName',
+        },
+        {
           documentation: 'Adds current variables',
           label: 'All variables',
           origin: 'template',
@@ -114,6 +120,12 @@ describe('getVisualizationOptions', () => {
           label: 'Name',
           origin: 'field',
           value: '__field.name',
+        },
+        {
+          documentation: 'Display name of the field (includes overrides and transformations)',
+          label: 'Display name',
+          origin: 'field',
+          value: '__field.displayName',
         },
         {
           documentation: 'Formatted value for time on the same row',

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -148,6 +148,12 @@ const getFieldVars = (dataFrames: DataFrame[]) => {
       documentation: 'Field name of the clicked datapoint (in ms epoch)',
       origin: VariableOrigin.Field,
     },
+    {
+      value: `${DataLinkBuiltInVars.fieldDisplayName}`,
+      label: t('panel.get-field-vars.label.display-name', 'Display name'),
+      documentation: 'Display name of the field (includes overrides and transformations)',
+      origin: VariableOrigin.Field,
+    },
     ...labels.map((label) => ({
       value: `__field.labels${buildLabelPath(label)}`,
       label: `labels.${label}`,

--- a/public/app/features/templating/dataMacros.test.ts
+++ b/public/app/features/templating/dataMacros.test.ts
@@ -152,6 +152,9 @@ describe('dataMacros', () => {
     const scopedVars = { __dataContext: dataContext };
 
     expect(_templateSrv.replace('${__field.name}', scopedVars)).toBe('CoolNumber');
+    expect(_templateSrv.replace('${__field.displayName}', scopedVars)).toBe(
+      'CoolNumber {cluster="US", region="west=1"}'
+    );
     expect(_templateSrv.replace('${__field.labels.cluster}', scopedVars)).toBe('US');
     expect(_templateSrv.replace('${__field.labels.region:percentencode}', scopedVars)).toBe('west%3D1');
   });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12332,6 +12332,7 @@
     },
     "get-field-vars": {
       "label": {
+        "display-name": "Display name",
         "name": "Name"
       }
     },


### PR DESCRIPTION
Adds `${__field.displayName}` as a selectable variable suggestion in the data link URL editor.
<img width="1124" height="1072" alt="image" src="https://github.com/user-attachments/assets/31ad4841-802e-4255-964d-e08f015ca8b1" />
