### PR TITLE
Provisioning: Share one Grafana server in quota integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -432,6 +432,20 @@ func (h *ProvisioningTestHelper) WriteToProvisioningPath(t *testing.T, name stri
 	require.NoError(t, err, "failed to write file to provisioning path")
 }
 
+// CleanProvisioningDir removes all entries from the provisioning directory
+// so that leftover files from a previous test don't interfere.
+func (h *ProvisioningTestHelper) CleanProvisioningDir(t *testing.T) {
+	t.Helper()
+	entries, err := os.ReadDir(h.ProvisioningPath)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		require.NoError(t, os.RemoveAll(filepath.Join(h.ProvisioningPath, entry.Name())),
+			"failed to clean provisioning dir entry %s", entry.Name())
+	}
+}
+
 // DebugState logs the current state of filesystem, repository, and Grafana resources for debugging
 func (h *ProvisioningTestHelper) DebugState(t *testing.T, repo string, label string) {
 	t.Helper()
@@ -1138,6 +1152,7 @@ func (e *SharedEnv) GetCleanHelper(t *testing.T) *ProvisioningTestHelper {
 	t.Helper()
 	h := e.GetHelper(t)
 	h.CleanupAllResources(t, context.Background())
+	h.CleanProvisioningDir(t)
 	return h
 }
 

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -771,59 +771,47 @@ func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoNam
 
 // TriggerConnectionReconciliation forces the controller to re-process a connection
 // by touching its status (aging the health timestamp by 1ms).
-// Retries on conflict errors caused by optimistic locking.
+// Uses EventuallyWithT to tolerate prolonged optimistic-locking conflicts from
+// concurrent controller reconciliations (common with shared servers).
 func (h *ProvisioningTestHelper) TriggerConnectionReconciliation(t *testing.T, name string) {
 	t.Helper()
 	ctx := t.Context()
-
-	const maxRetries = 5
-	for attempt := range maxRetries {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		conn, err := h.Connections.Resource.Get(ctx, name, metav1.GetOptions{})
-		require.NoError(t, err, "failed to get connection %s", name)
-
-		health, ok := conn.Object["status"].(map[string]any)["health"].(map[string]any)
-		require.True(t, ok, "missing status.health on connection %s", name)
-
-		health["checked"] = time.Now().UnixMilli() - 1
-
-		_, err = h.Connections.Resource.UpdateStatus(ctx, conn, metav1.UpdateOptions{})
-		if err == nil {
+		if !assert.NoError(c, err, "failed to get connection %s", name) {
 			return
 		}
-		if apierrors.IsConflict(err) && attempt < maxRetries-1 {
-			continue
+		health, ok := conn.Object["status"].(map[string]any)["health"].(map[string]any)
+		if !assert.True(c, ok, "missing status.health on connection %s", name) {
+			return
 		}
-		require.NoError(t, err, "failed to update status for connection %s", name)
-	}
+		health["checked"] = time.Now().UnixMilli() - 1
+		_, err = h.Connections.Resource.UpdateStatus(ctx, conn, metav1.UpdateOptions{})
+		assert.NoError(c, err, "failed to update status for connection %s", name)
+	}, WaitTimeoutDefault, 200*time.Millisecond, "should trigger reconciliation for connection %s", name)
 }
 
 // TriggerRepositoryReconciliation forces the controller to re-process a repo
 // by touching its status (aging the health timestamp by 1ms).
 // Updating it by incrementing its generation by +1 is not triggering a reconciliation.
-// Retries on conflict errors caused by optimistic locking.
+// Uses EventuallyWithT to tolerate prolonged optimistic-locking conflicts from
+// concurrent controller reconciliations (common with shared servers).
 func (h *ProvisioningTestHelper) TriggerRepositoryReconciliation(t *testing.T, name string) {
 	t.Helper()
 	ctx := t.Context()
-
-	const maxRetries = 5
-	for attempt := range maxRetries {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		repo, err := h.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
-		require.NoError(t, err, "failed to get repository %s", name)
-
-		health, ok := repo.Object["status"].(map[string]any)["health"].(map[string]any)
-		require.True(t, ok, "missing status.health on repository %s", name)
-
-		health["checked"] = time.Now().UnixMilli() - 1
-
-		_, err = h.Repositories.Resource.UpdateStatus(ctx, repo, metav1.UpdateOptions{})
-		if err == nil {
+		if !assert.NoError(c, err, "failed to get repository %s", name) {
 			return
 		}
-		if apierrors.IsConflict(err) && attempt < maxRetries-1 {
-			continue
+		health, ok := repo.Object["status"].(map[string]any)["health"].(map[string]any)
+		if !assert.True(c, ok, "missing status.health on repository %s", name) {
+			return
 		}
-		require.NoError(t, err, "failed to update status for repository %s", name)
-	}
+		health["checked"] = time.Now().UnixMilli() - 1
+		_, err = h.Repositories.Resource.UpdateStatus(ctx, repo, metav1.UpdateOptions{})
+		assert.NoError(c, err, "failed to update status for repository %s", name)
+	}, WaitTimeoutDefault, 200*time.Millisecond, "should trigger reconciliation for repository %s", name)
 }
 
 // WaitForHealthyRepository waits for a repository to become healthy.

--- a/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
@@ -13,17 +13,12 @@ import (
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
 	t.Run("export succeeds when resources are within quota", func(t *testing.T) {
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 10
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
 		ctx := context.Background()
 
 		// Create 2 unmanaged dashboards directly in Grafana
@@ -66,9 +61,8 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 	})
 
 	t.Run("export fails when existing resources already exceed the quota", func(t *testing.T) {
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 1
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
 		ctx := context.Background()
 
 		// Create 2 unmanaged dashboards — these alone will exceed the quota of 1
@@ -118,9 +112,8 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 	})
 
 	t.Run("export fails when exceeding folders and resources already exceed the quota", func(t *testing.T) {
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 2
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
 		ctx := context.Background()
 
 		// Create 1 unmanaged dashboard (alone would fit in quota of 2)

--- a/pkg/tests/apis/provisioning/quota/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/files_quota_test.go
@@ -73,6 +73,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 	})
 
 	t.Run("within quota allows create and update via files endpoint", func(t *testing.T) {
+		// With folder target: 1 dashboard + 1 folder = 2 resources, limit 10 → within quota
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
 		ctx := context.Background()

--- a/pkg/tests/apis/provisioning/quota/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/files_quota_test.go
@@ -208,7 +208,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 		helper.SyncAndWait(t, repo, nil)
 
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
-		triggerReconciliation(t, helper, repo)
+		helper.TriggerRepositoryReconciliation(t, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 1)
 		helper.SyncAndWait(t, repo, nil)
 		// Wait for quota condition to show exceeded

--- a/pkg/tests/apis/provisioning/quota/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/files_quota_test.go
@@ -208,7 +208,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 		helper.SyncAndWait(t, repo, nil)
 
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
-		helper.TriggerRepositoryReconciliation(t, repo)
+		triggerReconciliation(t, helper, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 1)
 		helper.SyncAndWait(t, repo, nil)
 		// Wait for quota condition to show exceeded

--- a/pkg/tests/apis/provisioning/quota/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/files_quota_test.go
@@ -12,16 +12,11 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
 	t.Run("no quota configured allows create and update via files endpoint", func(t *testing.T) {
-		// No quota limit = unlimited, both POST (create) and PUT (update) should succeed
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 		ctx := context.Background()
 
 		const repo = "files-quota-unlimited-repo"
@@ -78,10 +73,8 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 	})
 
 	t.Run("within quota allows create and update via files endpoint", func(t *testing.T) {
-		// With folder target: 1 dashboard + 1 folder = 2 resources, limit 10 → within quota
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 10
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
 		ctx := context.Background()
 
 		const repo = "files-quota-within-repo"
@@ -138,9 +131,8 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 
 	t.Run("quota reached blocks create but allows update via files endpoint", func(t *testing.T) {
 		// With folder target: 1 dashboard + 1 folder = 2 resources, limit 2 → exactly at limit (reached)
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 2
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
 		ctx := context.Background()
 
 		const repo = "files-quota-reached-repo"
@@ -196,7 +188,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 
 	t.Run("quota exceeded blocks both create and update via files endpoint", func(t *testing.T) {
 		// With folder target: 2 dashboards + 1 folder = 3 resources, limit 1 → exceeded
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 		ctx := context.Background()
 
 		const repo = "files-quota-exceeded-repo"

--- a/pkg/tests/apis/provisioning/quota/helpers_test.go
+++ b/pkg/tests/apis/provisioning/quota/helpers_test.go
@@ -1,12 +1,9 @@
 package quota
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
-	"github.com/stretchr/testify/require"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -19,20 +16,7 @@ func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
 	helper := env.GetCleanHelper(t)
 	helper.SetQuotaStatus(provisioning.QuotaStatus{})
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
-	cleanProvisioningDir(t, helper.ProvisioningPath)
 	return helper
-}
-
-func cleanProvisioningDir(t *testing.T, dir string) {
-	t.Helper()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return
-	}
-	for _, entry := range entries {
-		require.NoError(t, os.RemoveAll(filepath.Join(dir, entry.Name())),
-			"failed to clean provisioning dir entry %s", entry.Name())
-	}
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/quota/helpers_test.go
+++ b/pkg/tests/apis/provisioning/quota/helpers_test.go
@@ -4,12 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -36,28 +33,6 @@ func cleanProvisioningDir(t *testing.T, dir string) {
 		require.NoError(t, os.RemoveAll(filepath.Join(dir, entry.Name())),
 			"failed to clean provisioning dir entry %s", entry.Name())
 	}
-}
-
-// triggerReconciliation forces the controller to re-process a repo by touching
-// its health.checked timestamp. Unlike helper.TriggerRepositoryReconciliation,
-// this uses EventuallyWithT to tolerate prolonged optimistic-locking conflicts
-// that occur when the controller is actively reconciling the same repo.
-func triggerReconciliation(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
-	t.Helper()
-	ctx := t.Context()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		repo, err := helper.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
-		if !assert.NoError(c, err) {
-			return
-		}
-		health, ok := repo.Object["status"].(map[string]any)["health"].(map[string]any)
-		if !assert.True(c, ok, "missing status.health on %s", name) {
-			return
-		}
-		health["checked"] = time.Now().UnixMilli() - 1
-		_, err = helper.Repositories.Resource.UpdateStatus(ctx, repo, metav1.UpdateOptions{})
-		assert.NoError(c, err, "reconciliation trigger for %s", name)
-	}, common.WaitTimeoutDefault, 200*time.Millisecond, "should trigger reconciliation for %s", name)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/quota/helpers_test.go
+++ b/pkg/tests/apis/provisioning/quota/helpers_test.go
@@ -4,9 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -33,6 +36,28 @@ func cleanProvisioningDir(t *testing.T, dir string) {
 		require.NoError(t, os.RemoveAll(filepath.Join(dir, entry.Name())),
 			"failed to clean provisioning dir entry %s", entry.Name())
 	}
+}
+
+// triggerReconciliation forces the controller to re-process a repo by touching
+// its health.checked timestamp. Unlike helper.TriggerRepositoryReconciliation,
+// this uses EventuallyWithT to tolerate prolonged optimistic-locking conflicts
+// that occur when the controller is actively reconciling the same repo.
+func triggerReconciliation(t *testing.T, helper *common.ProvisioningTestHelper, name string) {
+	t.Helper()
+	ctx := t.Context()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		repo, err := helper.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+		if !assert.NoError(c, err) {
+			return
+		}
+		health, ok := repo.Object["status"].(map[string]any)["health"].(map[string]any)
+		if !assert.True(c, ok, "missing status.health on %s", name) {
+			return
+		}
+		health["checked"] = time.Now().UnixMilli() - 1
+		_, err = helper.Repositories.Resource.UpdateStatus(ctx, repo, metav1.UpdateOptions{})
+		assert.NoError(c, err, "reconciliation trigger for %s", name)
+	}, common.WaitTimeoutDefault, 200*time.Millisecond, "should trigger reconciliation for %s", name)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/tests/apis/provisioning/quota/helpers_test.go
+++ b/pkg/tests/apis/provisioning/quota/helpers_test.go
@@ -1,11 +1,40 @@
 package quota
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/tests/testsuite"
+	ghmock "github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+var env = common.NewSharedEnv()
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.SetQuotaStatus(provisioning.QuotaStatus{})
+	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
+	cleanProvisioningDir(t, helper.ProvisioningPath)
+	return helper
+}
+
+func cleanProvisioningDir(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		require.NoError(t, os.RemoveAll(filepath.Join(dir, entry.Name())),
+			"failed to clean provisioning dir entry %s", entry.Name())
+	}
+}
+
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	env.RunTestMain(m)
 }

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -50,8 +50,8 @@ func TestIntegrationProvisioning_NamespaceRepositoryQuota(t *testing.T) {
 
 	// --- Step 2: lower quota to 1 — both repos exceed the limit --------
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 1})
-	helper.TriggerRepositoryReconciliation(t, repo1Name)
-	helper.TriggerRepositoryReconciliation(t, repo2Name)
+	triggerReconciliation(t, helper, repo1Name)
+	triggerReconciliation(t, helper, repo2Name)
 
 	waitForUnhealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaExceeded)
 	waitForUnhealthyWithNamespaceQuota(t, helper, repo2Name, provisioning.ReasonQuotaExceeded)
@@ -60,13 +60,13 @@ func TestIntegrationProvisioning_NamespaceRepositoryQuota(t *testing.T) {
 	err := helper.Repositories.Resource.Delete(t.Context(), repo2Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 
-	helper.TriggerRepositoryReconciliation(t, repo1Name)
+	triggerReconciliation(t, helper, repo1Name)
 	waitForHealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaReached)
 
 	// --- Step 4: set quota back to unlimited — repo fully recovers -----
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 0})
 
-	helper.TriggerRepositoryReconciliation(t, repo1Name)
+	triggerReconciliation(t, helper, repo1Name)
 	waitForHealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaUnlimited)
 }
 
@@ -215,8 +215,8 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 
 	// --- Step 3: lower quota to 1 — both repos exceed the limit ---------------
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 1})
-	helper.TriggerRepositoryReconciliation(t, repoName1)
-	helper.TriggerRepositoryReconciliation(t, repoName2)
+	triggerReconciliation(t, helper, repoName1)
+	triggerReconciliation(t, helper, repoName2)
 
 	waitForUnhealthyWithNamespaceQuota(t, helper, repoName1, provisioning.ReasonQuotaExceeded)
 

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -230,10 +229,11 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 	now := time.Now()
 	var staledHealthChecked, staledTokenLastUpdated int64
 
-	const maxStatusRetries = 5
-	for attempt := range maxStatusRetries {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		repoUnstr, err := helper.Repositories.Resource.Get(ctx, repoName1, metav1.GetOptions{})
-		require.NoError(t, err, "failed to get repo1 before status manipulation")
+		if !assert.NoError(c, err, "failed to get repo1 before status manipulation") {
+			return
+		}
 		repo1 := common.UnstructuredToRepository(t, repoUnstr)
 
 		// Token lastUpdated far in the past (not "recently created") and expiration
@@ -251,14 +251,8 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 
 		updatedUnstr := common.RepositoryToUnstructured(t, repo1)
 		_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedUnstr, metav1.UpdateOptions{})
-		if err == nil {
-			break
-		}
-		if apierrors.IsConflict(err) && attempt < maxStatusRetries-1 {
-			continue
-		}
-		require.NoError(t, err, "failed to update repo1 status with near-expiry token")
-	}
+		assert.NoError(c, err, "failed to update repo1 status with near-expiry token")
+	}, common.WaitTimeoutDefault, 200*time.Millisecond, "should update repo1 status with near-expiry token")
 
 	// --- Step 5: verify health check AND token refresh happened, repo still blocked
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -50,8 +50,8 @@ func TestIntegrationProvisioning_NamespaceRepositoryQuota(t *testing.T) {
 
 	// --- Step 2: lower quota to 1 — both repos exceed the limit --------
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 1})
-	triggerReconciliation(t, helper, repo1Name)
-	triggerReconciliation(t, helper, repo2Name)
+	helper.TriggerRepositoryReconciliation(t, repo1Name)
+	helper.TriggerRepositoryReconciliation(t, repo2Name)
 
 	waitForUnhealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaExceeded)
 	waitForUnhealthyWithNamespaceQuota(t, helper, repo2Name, provisioning.ReasonQuotaExceeded)
@@ -60,13 +60,13 @@ func TestIntegrationProvisioning_NamespaceRepositoryQuota(t *testing.T) {
 	err := helper.Repositories.Resource.Delete(t.Context(), repo2Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 
-	triggerReconciliation(t, helper, repo1Name)
+	helper.TriggerRepositoryReconciliation(t, repo1Name)
 	waitForHealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaReached)
 
 	// --- Step 4: set quota back to unlimited — repo fully recovers -----
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 0})
 
-	triggerReconciliation(t, helper, repo1Name)
+	helper.TriggerRepositoryReconciliation(t, repo1Name)
 	waitForHealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaUnlimited)
 }
 
@@ -215,8 +215,8 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 
 	// --- Step 3: lower quota to 1 — both repos exceed the limit ---------------
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 1})
-	triggerReconciliation(t, helper, repoName1)
-	triggerReconciliation(t, helper, repoName2)
+	helper.TriggerRepositoryReconciliation(t, repoName1)
+	helper.TriggerRepositoryReconciliation(t, repoName2)
 
 	waitForUnhealthyWithNamespaceQuota(t, helper, repoName1, provisioning.ReasonQuotaExceeded)
 

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -15,42 +15,10 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
-//nolint:gosec // Test RSA private key (generated for testing purposes only)
-const testPrivateKeyPEM = "-----BEGIN RSA PRIVATE KEY-----\n" + // trufflehog:ignore
-	`MIIEowIBAAKCAQEAoInVbLY9io2Q/wHvUIXlEHg2Qyvd8eRzBAVEJ92DS6fx9H10
-06V0VRm78S0MXyo6i+n8ZAbZ0/R+GWpP2Ephxm0Gs2zo+iO2mpB19xQFI4o6ZTOw
-b2WyjSaa2Vr4oyDkqti6AvfjW4VUAu932e08GkgwmmQSHXj7FX2CMWjgUwTTcuaX
-65SHNKLNYLUP0HTumLzoZeqDTdoMMpKNdgH9Avr4/8vkVJ0mD6rqvxnw3JHsseNO
-WdQTxf2aApBNHIIKxWZ2i/ZmjLNey7kltgjEquGiBdJvip3fHhH5XHdkrXcjRtnw
-OJDnDmi5lQwv5yUBOSkbvbXRv/L/m0YLoD/fbwIDAQABAoIBAFfl//hM8/cnuesV
-+R1Con/ZAgTXQOdPqPXbmEyniVrkMqMmCdBUOBTcST4s5yg36+RtkeaGpb/ajyyF
-PAB2AYDucwvMpudGpJWOYTiOOp4R8hU1LvZfXVrRd1lo6NgQi4NLtNUpOtACeVQ+
-H4Yv0YemXQ47mnuOoRNMK/u3q5NoIdSahWptXBgUno8KklNpUrH3IYWaUxfBzDN3
-2xsVRTn2SfTSyoDmTDdTgptJONmoK1/sV7UsgWksdFc6XyYhsFAZgOGEJrBABRvF
-546dyQ0cWxuPyVXpM7CN3tqC5ssvLjElg3LicK1V6gnjpdRnnvX88d1Eh3Uc/9IM
-OZInT2ECgYEA6W8sQXTWinyEwl8SDKKMbB2ApIghAcFgdRxprZE4WFxjsYNCNL70
-dnSB7MRuzmxf5W77cV0N7JhH66N8HvY6Xq9olrpQ5dNttR4w8Pyv3wavDe8x7seL
-5L2Xtbu7ihDr8Dk27MjiBSin3IxhBP5CJS910+pR6LrAWtEuU+FzFfECgYEAsA6y
-qxHhCMXlTnauXhsnmPd1g61q7chW8kLQFYtHMLlQlgjHTW7irDZ9cPbPYDNjwRLO
-7KLorcpv2NKe7rqq2ZyCm6hf1b9WnlQjo3dLpNWMu6fhy/smK8MgbRqcWpX+oTKF
-79mK6hbY7o6eBzsQHBl7Z+LBNuwYmp9qOodPa18CgYEArv6ipKdcNhFGzRfMRiCN
-OHederp6VACNuP2F05IsNUF9kxOdTEFirnKE++P+VU01TqA2azOhPp6iO+ohIGzi
-MR06QNSH1OL9OWvasK4dggpWrRGF00VQgDgJRTnpS4WH+lxJ6pRlrAxgWpv6F24s
-VAgSQr1Ejj2B+hMasdMvHWECgYBJ4uE4yhgXBnZlp4kmFV9Y4wF+cZkekaVrpn6N
-jBYkbKFVVfnOlWqru3KJpgsB5I9IyAvvY68iwIKQDFSG+/AXw4dMrC0MF3DSoZ0T
-TU2Br92QI7SvVod+djV1lGVp3ukt3XY4YqPZ+hywgUnw3uiz4j3YK2HLGup4ec6r
-IX5DIQKBgHRLzvT3zqtlR1Oh0vv098clLwt+pGzXOxzJpxioOa5UqK13xIpFXbcg
-iWUVh5YXCcuqaICUv4RLIEac5xQitk9Is/9IhP0NJ/81rHniosvdSpCeFXzxTImS
-B8Uc0WUgheB4+yVKGnYpYaSOgFFI5+1BYUva/wDHLy2pWHz39Usb
------END RSA PRIVATE KEY-----`
-
 func TestIntegrationProvisioning_NamespaceRepositoryQuota(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 
 	const (
 		repo1Name = "ns-quota-repo1"
@@ -146,11 +114,9 @@ func waitForHealthyWithNamespaceQuota(t *testing.T, helper *common.ProvisioningT
 // that auth token refresh and health checks are not skipped when a repository is
 // blocked due to namespace quota being exceeded.
 func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := common.RunGrafana(t)
+	helper := sharedHelper(t)
 	ctx := context.Background()
-	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
+	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	const (
 		connName  = "ns-quota-token-conn"

--- a/pkg/tests/apis/provisioning/quota/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_test.go
@@ -91,7 +91,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 		helper.RequireRepoDashboardCount(t, repo, 2)
 
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		triggerReconciliation(t, helper, repo)
+		helper.TriggerRepositoryReconciliation(t, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 

--- a/pkg/tests/apis/provisioning/quota/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_test.go
@@ -71,6 +71,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 	// Is only possible to set the first sync to exceed quota when the repo is created.
 	// It should be possible to get that situation when https://github.com/grafana/git-ui-sync-project/issues/832 is implemented.
 	t.Run("quota condition is ResourceQuotaExceeded when limit is exceeded", func(t *testing.T) {
+		// Set a low resource limit
 		helper := sharedHelper(t)
 		ctx := context.Background()
 
@@ -134,6 +135,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 	})
 
 	t.Run("quota condition is WithinQuota when resources are below limit", func(t *testing.T) {
+		// Set a limit higher than resources
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
 		ctx := context.Background()
@@ -222,6 +224,7 @@ func nestedField(obj map[string]interface{}, fields ...string) (interface{}, boo
 
 func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 	t.Run("quota status shows configured limits", func(t *testing.T) {
+		// Set specific quota limits
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{
 			MaxResourcesPerRepository: 50,
@@ -282,6 +285,7 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 	})
 
 	t.Run("quota status shows unlimited when no limits configured", func(t *testing.T) {
+		// Don't set any quota limits (defaults to 0 = unlimited)
 		helper := sharedHelper(t)
 		ctx := context.Background()
 

--- a/pkg/tests/apis/provisioning/quota/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_test.go
@@ -10,15 +10,11 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
 	t.Run("quota condition is QuotaUnlimited when no limit is configured", func(t *testing.T) {
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 		ctx := context.Background()
 
 		const repo = "quota-unlimited-repo"
@@ -75,8 +71,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 	// Is only possible to set the first sync to exceed quota when the repo is created.
 	// It should be possible to get that situation when https://github.com/grafana/git-ui-sync-project/issues/832 is implemented.
 	t.Run("quota condition is ResourceQuotaExceeded when limit is exceeded", func(t *testing.T) {
-		// Set a low resource limit
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 		ctx := context.Background()
 
 		const repo = "quota-exceeded-repo"
@@ -139,10 +134,8 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 	})
 
 	t.Run("quota condition is WithinQuota when resources are below limit", func(t *testing.T) {
-		// Set a limit higher than resources
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 10 // Allow 10 resources
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
 		ctx := context.Background()
 
 		const repo = "quota-within-repo"
@@ -228,13 +221,11 @@ func nestedField(obj map[string]interface{}, fields ...string) (interface{}, boo
 }
 
 func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
 	t.Run("quota status shows configured limits", func(t *testing.T) {
-		// Set specific quota limits
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 50
-			opts.ProvisioningMaxRepositories = 5
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{
+			MaxResourcesPerRepository: 50,
+			MaxRepositories:           5,
 		})
 		ctx := context.Background()
 
@@ -291,11 +282,7 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 	})
 
 	t.Run("quota status shows unlimited when no limits configured", func(t *testing.T) {
-		// Don't set any quota limits (defaults to 0 = unlimited)
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 0
-			opts.ProvisioningMaxRepositories = 0
-		})
+		helper := sharedHelper(t)
 		ctx := context.Background()
 
 		const repo = "quota-status-unlimited-repo"

--- a/pkg/tests/apis/provisioning/quota/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_test.go
@@ -91,7 +91,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 		helper.RequireRepoDashboardCount(t, repo, 2)
 
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		helper.TriggerRepositoryReconciliation(t, repo)
+		triggerReconciliation(t, helper, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -43,7 +43,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 2 dashboards = 3 resources, new limit 2 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		helper.TriggerRepositoryReconciliation(t, repo)
+		triggerReconciliation(t, helper, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
@@ -133,7 +133,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 2 dashboards = 3 resources, new limit 2 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		helper.TriggerRepositoryReconciliation(t, testRepo.Name)
+		triggerReconciliation(t, helper, testRepo.Name)
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
@@ -398,7 +398,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 3 dashboards = 4 resources, new limit 3 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
-		helper.TriggerRepositoryReconciliation(t, repo)
+		triggerReconciliation(t, helper, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 3)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
@@ -446,7 +446,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 3 dashboards = 4 resources, new limit 1 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
-		helper.TriggerRepositoryReconciliation(t, repo)
+		triggerReconciliation(t, helper, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 1)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -170,6 +170,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonQuotaExceeded)
 	})
 	t.Run("full sync that exceeds quota creates some resources and skips others with warnings", func(t *testing.T) {
+		// Allow 3 total resources: 1 folder + 2 dashboards
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
 
@@ -254,6 +255,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 	})
 
 	t.Run("full sync with nested folders counts folders toward quota and skips resources", func(t *testing.T) {
+		// Allow 6 total resources: 1 root folder + 2 nested folders + 2 dashboards + 1 new folder = 6
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 6})
 

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -43,7 +43,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 2 dashboards = 3 resources, new limit 2 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		triggerReconciliation(t, helper, repo)
+		helper.TriggerRepositoryReconciliation(t, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
@@ -133,7 +133,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 2 dashboards = 3 resources, new limit 2 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		triggerReconciliation(t, helper, testRepo.Name)
+		helper.TriggerRepositoryReconciliation(t, testRepo.Name)
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
@@ -398,7 +398,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 3 dashboards = 4 resources, new limit 3 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
-		triggerReconciliation(t, helper, repo)
+		helper.TriggerRepositoryReconciliation(t, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 3)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
@@ -446,7 +446,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Lower the quota to put the repo over the limit:
 		// 1 folder + 3 dashboards = 4 resources, new limit 1 → exceeded
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
-		triggerReconciliation(t, helper, repo)
+		helper.TriggerRepositoryReconciliation(t, repo)
 		helper.WaitForResourceQuotaLimit(t, repo, 1)
 		helper.SyncAndWait(t, repo, nil)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -15,15 +15,11 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
 	t.Run("out of limit repo works fine with deletions", func(t *testing.T) {
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 
 		const repo = "quota-deletion-test-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -67,9 +63,8 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 	})
 
 	t.Run("within limit repo syncs successfully and allows adding more resources", func(t *testing.T) {
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			opts.ProvisioningMaxResourcesPerRepository = 5
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 5})
 
 		const repo = "quota-within-limit-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -114,7 +109,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 	})
 
 	t.Run("on the limit repo blocks new resource creation on subsequent sync", func(t *testing.T) {
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 
 		const repo = "quota-blocks-creation-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -175,10 +170,8 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		helper.WaitForConditionReason(t, repo, provisioning.ConditionTypePullStatus, provisioning.ReasonQuotaExceeded)
 	})
 	t.Run("full sync that exceeds quota creates some resources and skips others with warnings", func(t *testing.T) {
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			// Allow 3 total resources: 1 folder + 2 dashboards
-			opts.ProvisioningMaxResourcesPerRepository = 3
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
 
 		const repo = "quota-partial-sync-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -261,10 +254,8 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 	})
 
 	t.Run("full sync with nested folders counts folders toward quota and skips resources", func(t *testing.T) {
-		helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-			// Allow 6 total resources: 1 root folder + 2 nested folders + 2 dashboards + 1 new folder = 6
-			opts.ProvisioningMaxResourcesPerRepository = 6
-		})
+		helper := sharedHelper(t)
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 6})
 
 		const repo = "quota-nested-folders-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -382,7 +373,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 	})
 
 	t.Run("out of limit repo allows delete-only sync", func(t *testing.T) {
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 
 		const repo = "quota-net-change-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -430,7 +421,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 	})
 
 	t.Run("out of limit repo allows delete-only sync when result is still over quota", func(t *testing.T) {
-		helper := common.RunGrafana(t)
+		helper := sharedHelper(t)
 
 		const repo = "quota-net-change-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)


### PR DESCRIPTION
## Why

Quota integration tests start **20 separate Grafana servers** — one per subtest. Each startup involves Wire DI, database provisioning, HTTP listener binding, health polling, and shutdown. This is the main bottleneck making these tests slow.

## What

Refactor the `quota` package to share **one Grafana server** across all tests using `sync.Once` + `TestMain` shutdown — the same pattern established in #120906 for connection tests.

**Server startups drop from 20 → 1.**

## How

### Key Insight: `SetQuotaStatus` replaces startup options

Many quota tests previously required different `ProvisioningMaxResourcesPerRepository` or `ProvisioningMaxRepositories` values at Grafana startup. However, `FixedQuotaGetter.SetQuotaStatus()` atomically updates quotas at runtime, making per-test server startup unnecessary. Each test now:

1. Calls `sharedHelper(t)` which cleans all K8s resources, resets quota to unlimited, and clears the provisioning directory
2. Calls `helper.SetQuotaStatus(...)` to configure the quota for that specific test
3. Proceeds with the test logic unchanged

### Per-test Cleanup

`sharedHelper(t)` runs at the start of every test and:

- Calls `CleanupAllResources` to remove all K8s resources in dependency order
- Resets quota to unlimited via `SetQuotaStatus(QuotaStatus{})`
- Restores default GitHub mock client  
- Cleans the shared provisioning directory (removes all files/subdirectories)

### Changes Per Test

Each test/subtest changes from:
```diff
-    testutil.SkipIntegrationTestInShortMode(t)
-    helper := common.RunGrafana(t, func(opts *testinfra.GrafanaOpts) {
-        opts.ProvisioningMaxResourcesPerRepository = 10
-    })
+    helper := sharedHelper(t)
+    helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
```

## Files Changed

| File | Change |
| ---- | ------ |
| `quota/helpers_test.go` | Rewrite with `common.NewSharedEnv()` + `sharedHelper` + `cleanProvisioningDir` + `TestMain` |
| `quota/quota_test.go` | Replace `RunGrafana` with `sharedHelper` + `SetQuotaStatus` (5 subtests) |
| `quota/sync_quota_test.go` | Replace `RunGrafana` with `sharedHelper` + `SetQuotaStatus` (6 subtests) |
| `quota/namespace_quota_test.go` | Replace `RunGrafana` with `sharedHelper` (2 tests); use `common.TestGithubPrivateKeyPEM` |
| `quota/files_quota_test.go` | Replace `RunGrafana` with `sharedHelper` + `SetQuotaStatus` (4 subtests) |
| `quota/exportjob_quota_test.go` | Replace `RunGrafana` with `sharedHelper` + `SetQuotaStatus` (3 subtests) |

## Test plan
- [ ] `go vet ./pkg/tests/apis/provisioning/quota/...` passes
- [ ] Integration tests pass: `go test -v -count=1 -run TestIntegration ./pkg/tests/apis/provisioning/quota/...`
- [ ] No enterprise tests affected (quota package has no enterprise-specific tests)


Made with [Cursor](https://cursor.com)