### PR TITLE
Faceted filter: fall back to frame names for __name__ facet

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -112,7 +112,7 @@
   "dev-dashboards-output/panel-timeline/timeline-thresholds-mappings.v42.json": "89c9d54097d157e404d6e6527813883fb754b0507961111bd4a00e06f6f0b21f",
   "dev-dashboards-output/panel-timeseries/timeseries-bars-high-density.v42.json": "2bf342c03944869f07ca11454b9fe3634069bd5f581b00eaedf6d2ee16182ef9",
   "dev-dashboards-output/panel-timeseries/timeseries-by-value-color-schemes.v42.json": "5f7f401cb6d1333fd33afe7025ec5f4d8e34b6e4af7fe0ea04b144b43ff472cc",
-  "dev-dashboards-output/panel-timeseries/timeseries-faceted-labels.v42.json": "e19fc15e431bfa945a1d06b26346b72d1b5b879bcacbd09b56f53ab69310e091",
+  "dev-dashboards-output/panel-timeseries/timeseries-faceted-labels.v42.json": "d17dbd4c024a1703cb8affea0903578a0ba9ba7646e40a9a2c94162c4be524e2",
   "dev-dashboards-output/panel-timeseries/timeseries-formats.v42.json": "63d06391e6b2dfa7095d415aa313ccfaad5bc181b588b217b52656e537ab373c",
   "dev-dashboards-output/panel-timeseries/timeseries-gradient-area.v42.json": "c6c0d8e70f05577d4203e86ce82fc3ef9d971bf829c3f6add7512250581d5401",
   "dev-dashboards-output/panel-timeseries/timeseries-hue-gradients.v42.json": "70a767fbd244f07b6621a5758fdd0b031d2a6af05ab5fd31c09b316174b982ca",

--- a/devenv/dev-dashboards/panel-timeseries/timeseries-faceted-labels.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-faceted-labels.json
@@ -98,8 +98,8 @@
     },
     {
       "id": 7,
-      "title": "No filter: same name, no labels",
-      "description": "Multiple fields all named 'value', no labels. Eye icon should NOT appear (single unique name, no labels).",
+      "title": "Frame name disambiguation",
+      "description": "Multiple frames all with field named 'value', different frame names. 'By name' shows frame names (Frame1, Frame2).",
       "type": "timeseries",
       "gridPos": { "h": 14, "w": 8, "x": 16, "y": 28 },
       "options": {
@@ -112,6 +112,158 @@
           "datasource": { "type": "grafana-testdata-datasource" },
           "scenarioId": "raw_frame",
           "rawFrameContent": "[{\"name\":\"Frame1\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"value\",\"type\":\"number\",\"values\":[10,12,11,14,13,12]}]},{\"name\":\"Frame2\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"value\",\"type\":\"number\",\"values\":[20,22,21,24,23,22]}]}]"
+        }
+      ],
+      "datasource": { "type": "grafana-testdata-datasource" }
+    },
+    {
+      "id": 8,
+      "title": "Multi-query, same field name, frame name disambiguation",
+      "description": "Three queries each returning 4 frames (io, ir, oe, ov) with a generic 'Value' field and no labels. 'By name' shows frame names.",
+      "type": "timeseries",
+      "gridPos": { "h": 14, "w": 12, "x": 0, "y": 42 },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["mean"],
+          "enableFacetedFilter": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"io\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[22,24,21,26,23,25]}]},{\"name\":\"ir\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[20,18,22,19,21,20]}]},{\"name\":\"oe\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[15,17,14,18,16,15]}]},{\"name\":\"ov\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[30,33,28,35,31,32]}]}]"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"io\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[25,27,24,29,26,28]}]},{\"name\":\"ir\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[18,20,17,22,19,21]}]},{\"name\":\"oe\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[12,14,11,16,13,12]}]},{\"name\":\"ov\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[28,31,26,33,29,30]}]}]"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"io\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[20,22,19,24,21,23]}]},{\"name\":\"ir\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[16,18,15,20,17,19]}]},{\"name\":\"oe\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[10,12,9,14,11,10]}]},{\"name\":\"ov\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[26,29,24,31,27,28]}]}]"
+        }
+      ],
+      "datasource": { "type": "grafana-testdata-datasource" }
+    },
+    {
+      "id": 9,
+      "title": "Multi-query, frame names + labels",
+      "description": "Three queries each returning 4 frames (io, ir, oe, ov) with a generic 'Value' field and region/env labels. 'By name' shows frame names, 'By labels' shows region and env.",
+      "type": "timeseries",
+      "gridPos": { "h": 14, "w": 12, "x": 12, "y": 42 },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["mean"],
+          "enableFacetedFilter": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"io\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"us\",\"env\":\"prod\"},\"values\":[22,24,21,26,23,25]}]},{\"name\":\"ir\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"us\",\"env\":\"prod\"},\"values\":[20,18,22,19,21,20]}]},{\"name\":\"oe\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"eu\",\"env\":\"prod\"},\"values\":[15,17,14,18,16,15]}]},{\"name\":\"ov\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"eu\",\"env\":\"dev\"},\"values\":[30,33,28,35,31,32]}]}]"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"io\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"us\",\"env\":\"dev\"},\"values\":[25,27,24,29,26,28]}]},{\"name\":\"ir\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"eu\",\"env\":\"prod\"},\"values\":[18,20,17,22,19,21]}]},{\"name\":\"oe\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"eu\",\"env\":\"dev\"},\"values\":[12,14,11,16,13,12]}]},{\"name\":\"ov\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"us\",\"env\":\"prod\"},\"values\":[28,31,26,33,29,30]}]}]"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"io\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"eu\",\"env\":\"prod\"},\"values\":[20,22,19,24,21,23]}]},{\"name\":\"ir\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"us\",\"env\":\"dev\"},\"values\":[16,18,15,20,17,19]}]},{\"name\":\"oe\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"us\",\"env\":\"prod\"},\"values\":[10,12,9,14,11,10]}]},{\"name\":\"ov\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"region\":\"eu\",\"env\":\"dev\"},\"values\":[26,29,24,31,27,28]}]}]"
+        }
+      ],
+      "datasource": { "type": "grafana-testdata-datasource" }
+    },
+    {
+      "id": 10,
+      "title": "User-renamed queries (Task Up / Down / Configured)",
+      "description": "Three queries with custom names simulating user-renamed queries. Each returns a single frame with generic 'Value' field. 'By name' shows Task Up, Task Down, Task Configured.",
+      "type": "timeseries",
+      "gridPos": { "h": 14, "w": 12, "x": 0, "y": 56 },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["mean"],
+          "enableFacetedFilter": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"Task Up\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[85,88,82,90,87,86]}]}]"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"Task Down\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[5,3,8,2,6,4]}]}]"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"Task Configured\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"values\":[42,45,40,48,43,44]}]}]"
+        }
+      ],
+      "datasource": { "type": "grafana-testdata-datasource" }
+    },
+    {
+      "id": 11,
+      "title": "Recommended: frame.name=refId, labels=metric",
+      "description": "frame.name = refId (Task Up/Down/Configured), field.labels = {metric: io/ir/oe/ov}. 'By name' shows tasks, 'By labels' shows metrics.",
+      "type": "timeseries",
+      "gridPos": { "h": 14, "w": 12, "x": 12, "y": 56 },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["mean"],
+          "enableFacetedFilter": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"Task Up\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"io\"},\"values\":[22,24,21,26,23,25]}]},{\"name\":\"Task Up\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"ir\"},\"values\":[20,18,22,19,21,20]}]},{\"name\":\"Task Up\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"oe\"},\"values\":[15,17,14,18,16,15]}]},{\"name\":\"Task Up\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"ov\"},\"values\":[30,33,28,35,31,32]}]}]"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"Task Down\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"io\"},\"values\":[5,3,8,2,6,4]}]},{\"name\":\"Task Down\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"ir\"},\"values\":[3,2,5,1,4,3]}]},{\"name\":\"Task Down\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"oe\"},\"values\":[7,5,9,4,8,6]}]},{\"name\":\"Task Down\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"ov\"},\"values\":[2,1,4,1,3,2]}]}]"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "grafana-testdata-datasource" },
+          "scenarioId": "raw_frame",
+          "rawFrameContent": "[{\"name\":\"Task Configured\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"io\"},\"values\":[42,45,40,48,43,44]}]},{\"name\":\"Task Configured\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"ir\"},\"values\":[38,41,36,44,39,40]}]},{\"name\":\"Task Configured\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"oe\"},\"values\":[50,53,48,55,51,52]}]},{\"name\":\"Task Configured\",\"fields\":[{\"name\":\"time\",\"type\":\"time\",\"values\":[1700000000000,1700000060000,1700000120000,1700000180000,1700000240000,1700000300000]},{\"name\":\"Value\",\"type\":\"number\",\"labels\":{\"metric\":\"ov\"},\"values\":[45,48,43,50,46,47]}]}]"
         }
       ],
       "datasource": { "type": "grafana-testdata-datasource" }

--- a/packages/grafana-data/src/utils/labels.test.ts
+++ b/packages/grafana-data/src/utils/labels.test.ts
@@ -89,9 +89,9 @@ describe('matchAllLabels()', () => {
   });
 });
 
-function makeFrame(fields: Array<{ name?: string; labels?: Labels; type?: FieldType }>): DataFrame {
+function makeFrame(fields: Array<{ name?: string; labels?: Labels; type?: FieldType }>, frameName = 'test'): DataFrame {
   return {
-    name: 'test',
+    name: frameName,
     length: 0,
     fields: fields.map((f) => ({
       name: f.name ?? 'value',
@@ -145,6 +145,16 @@ describe('extractFacetedLabels()', () => {
     expect(extractFacetedLabels([frame])).toEqual({ host: ['a', 'b'] });
     expect(extractFacetedLabels([frame])[FIELD_NAME_FACET_KEY]).toBeUndefined();
   });
+
+  it('falls back to frame names when all fields share the same raw name', () => {
+    const frames = [
+      makeFrame([{ name: 'Value' }], 'io'),
+      makeFrame([{ name: 'Value' }], 'ir'),
+      makeFrame([{ name: 'Value' }], 'ov'),
+    ];
+    const result = extractFacetedLabels(frames);
+    expect(result[FIELD_NAME_FACET_KEY]).toEqual(['io', 'ir', 'ov']);
+  });
 });
 
 describe('resolveFacetedFilterNames()', () => {
@@ -182,9 +192,15 @@ describe('resolveFacetedFilterNames()', () => {
     expect(result).toEqual([]);
   });
 
-  it('matches fields using the __name__ facet', () => {
+  it('matches fields using the __name__ facet by field name', () => {
     const result = resolveFacetedFilterNames(frames, { [FIELD_NAME_FACET_KEY]: ['cpu'] }, getFieldDisplayName);
     expect(result).toEqual(['cpu {host="a", region="us"}', 'cpu {host="b", region="eu"}']);
+  });
+
+  it('matches __name__ facet by frame name when fields share the same raw name', () => {
+    const multiQueryFrames = [makeFrame([{ name: 'Value' }], 'io'), makeFrame([{ name: 'Value' }], 'ir')];
+    const result = resolveFacetedFilterNames(multiQueryFrames, { [FIELD_NAME_FACET_KEY]: ['io'] }, getFieldDisplayName);
+    expect(result).toEqual(['io']);
   });
 
   it('combines __name__ and label filters with AND', () => {

--- a/packages/grafana-data/src/utils/labels.ts
+++ b/packages/grafana-data/src/utils/labels.ts
@@ -81,10 +81,13 @@ export function matchAllLabels(expect: Labels, against?: Labels): boolean {
 /**
  * Collects unique label values per key across all fields.
  * Adds a synthetic `__name__` facet when fields have multiple distinct names.
+ * Falls back to frame names when all fields share the same raw name
+ * (e.g. multiple queries each returning a "Value" field with distinct frame names).
  */
 export function extractFacetedLabels(frames: DataFrame[]): Record<string, string[]> {
   const valuesByKey: Record<string, Set<string>> = {};
   const fieldNames = new Set<string>();
+  const frameNames = new Set<string>();
 
   for (const frame of frames) {
     for (const field of frame.fields) {
@@ -93,6 +96,10 @@ export function extractFacetedLabels(frames: DataFrame[]): Record<string, string
       }
 
       fieldNames.add(field.name);
+
+      if (frame.name) {
+        frameNames.add(frame.name);
+      }
 
       if (field.labels) {
         for (const [key, value] of Object.entries(field.labels)) {
@@ -104,8 +111,9 @@ export function extractFacetedLabels(frames: DataFrame[]): Record<string, string
 
   const result: Record<string, string[]> = {};
 
-  if (fieldNames.size > 1) {
-    result[FIELD_NAME_FACET_KEY] = Array.from(fieldNames).sort();
+  const names = fieldNames.size > 1 ? fieldNames : frameNames;
+  if (names.size > 1) {
+    result[FIELD_NAME_FACET_KEY] = Array.from(names).sort();
   }
 
   for (const key in valuesByKey) {
@@ -140,7 +148,7 @@ export function resolveFacetedFilterNames(
 
       const matches = activeKeys.every(([key, allowed]) => {
         if (key === FIELD_NAME_FACET_KEY) {
-          return allowed.includes(field.name);
+          return allowed.includes(field.name) || (frame.name != null && allowed.includes(frame.name));
         }
         return field.labels?.[key] !== undefined && allowed.includes(field.labels[key]);
       });

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -123,13 +123,14 @@ export const PlotLegend = memo(function PlotLegend({
       return false;
     }
 
+    const expectedSet = new Set(expectedVisible);
     const actuallyVisible = new Set(legendItems.filter((item) => !item.disabled).map((item) => item.label));
 
-    if (expectedVisible.length !== actuallyVisible.size) {
+    if (expectedSet.size !== actuallyVisible.size) {
       return true;
     }
 
-    return !expectedVisible.every((name) => actuallyVisible.has(name));
+    return !Array.from(expectedSet).every((name) => actuallyVisible.has(name));
   }, [hasActiveFilters, data, selectedLabels, legendItems]);
 
   const handleLabelsChange = useCallback(

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.09,
+      "score": 0.093,
       "explain": {
         "children": [
           {
@@ -46,12 +46,12 @@
                           {
                             "children": [
                               {
-                                "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=16.000000)",
-                                "value": 2.031
+                                "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=17.000000)",
+                                "value": 1.926
                               }
                             ],
-                            "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=2.031250))",
-                            "value": 0.288
+                            "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=1.926471))",
+                            "value": 0.297
                           },
                           {
                             "message": "idf(docFreq=1, maxDocs=17)",
@@ -59,19 +59,19 @@
                           }
                         ],
                         "message": "fieldWeight(fields.panel_title:orange in \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001), as per bm25 model, product of:",
-                        "value": 1.239
+                        "value": 1.277
                       }
                     ],
                     "message": "weight(fields.panel_title:orange^5.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001), product of:",
-                    "value": 0.362
+                    "value": 0.373
                   }
                 ],
                 "message": "sum of:",
-                "value": 0.362
+                "value": 0.373
               }
             ],
             "message": "sum of:",
-            "value": 0.362
+            "value": 0.373
           },
           {
             "message": "coord(1/4)",
@@ -80,9 +80,9 @@
         ],
         "message": "product of:",
         "partial_match": true,
-        "value": 0.09
+        "value": 0.093
       }
     }
   ],
-  "maxScore": 0.09
+  "maxScore": 0.093
 }


### PR DESCRIPTION
Followup to https://github.com/grafana/grafana/pull/119918

## Fix faceted filter for multi-query panels where all fields share the same name

When multiple queries each return data frames with a generic field name like "Value" but distinct frame names (e.g. "io", "ir", "oe", "ov"), the faceted filter's "By name" section did not appear because `extractFacetedLabels` only considered `field.name` for the `__name__` facet.

This change adds a fallback: when all fields share the same raw name, `extractFacetedLabels` collects unique `frame.name` values instead. `resolveFacetedFilterNames` now matches the `__name__` facet against both `field.name` and `frame.name`.

Also fixes a bug where the filter would incorrectly dim after selecting a checkbox in panels with duplicate display names across queries. The `legendHasPrecedence` comparison now deduplicates expected visible names before comparing with the actual visible set.

## How to test

- Open the "Faceted labels demo" dashboard (provisioned under gdev dashboards)
- Panel 8 ("Multi-query, same field name, frame name disambiguation"): 3 queries, 4 frames each, all with "Value" field, no labels. The "By name" filter should show io, ir, oe, ov.
- Panel 9 ("Multi-query, frame names + labels"): same structure but with region/env labels. Filter should show both "By name" (frame names) and "By labels" (region, env).
- Selecting a filter checkbox should not dim the filter UI.