### PR TITLE
update to use resources to match old naming

### DIFF
--- a/packages/grafana-openapi/src/apis/grafana-testdata-datasource.datasource.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/grafana-testdata-datasource.datasource.grafana.app-v0alpha1.json
@@ -921,11 +921,149 @@
         }
       ]
     },
-    "/datasources/{name}/resource": {
+    "/datasources/{name}/resources": {
       "get": {
         "tags": ["DataSource"],
-        "description": "Get resources in the datasource plugin. NOTE, additional routes may exist, but are not exposed via OpenAPI",
-        "operationId": "getDataSourceResource",
+        "description": "connect GET requests to resources of DataSource",
+        "operationId": "getDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "put": {
+        "tags": ["DataSource"],
+        "description": "connect PUT requests to resources of DataSource",
+        "operationId": "replaceDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "post": {
+        "tags": ["DataSource"],
+        "description": "connect POST requests to resources of DataSource",
+        "operationId": "createDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "delete": {
+        "tags": ["DataSource"],
+        "description": "connect DELETE requests to resources of DataSource",
+        "operationId": "deleteDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "options": {
+        "tags": ["DataSource"],
+        "description": "connect OPTIONS requests to resources of DataSource",
+        "operationId": "optionsDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "head": {
+        "tags": ["DataSource"],
+        "description": "connect HEAD requests to resources of DataSource",
+        "operationId": "headDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "patch": {
+        "tags": ["DataSource"],
+        "description": "connect PATCH requests to resources of DataSource",
+        "operationId": "updateDataSourceResources",
         "responses": {
           "200": {
             "description": "OK",
@@ -950,6 +1088,191 @@
           "name": "name",
           "in": "path",
           "description": "name of the Status",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/datasources/{name}/resources/{path}": {
+      "get": {
+        "tags": ["DataSource"],
+        "description": "connect GET requests to resources of DataSource",
+        "operationId": "getDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "put": {
+        "tags": ["DataSource"],
+        "description": "connect PUT requests to resources of DataSource",
+        "operationId": "replaceDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "post": {
+        "tags": ["DataSource"],
+        "description": "connect POST requests to resources of DataSource",
+        "operationId": "createDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "delete": {
+        "tags": ["DataSource"],
+        "description": "connect DELETE requests to resources of DataSource",
+        "operationId": "deleteDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "options": {
+        "tags": ["DataSource"],
+        "description": "connect OPTIONS requests to resources of DataSource",
+        "operationId": "optionsDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "head": {
+        "tags": ["DataSource"],
+        "description": "connect HEAD requests to resources of DataSource",
+        "operationId": "headDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "patch": {
+        "tags": ["DataSource"],
+        "description": "connect PATCH requests to resources of DataSource",
+        "operationId": "updateDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the Status",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "path",
+          "in": "path",
+          "description": "path to the resource",
           "required": true,
           "schema": {
             "type": "string",

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -249,7 +249,7 @@ func (b *DataSourceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 	storage[ds.StoragePath("query")] = &subQueryREST{builder: b}
 
 	if b.cfg.EnableResourceEndpoint {
-		storage[ds.StoragePath("resource")] = &subResourceREST{builder: b}
+		storage[ds.StoragePath("resources")] = &subResourceREST{builder: b}
 	}
 
 	if b.cfg.EnableHealthEndpoint {

--- a/pkg/registry/apis/datasource/sub_resource.go
+++ b/pkg/registry/apis/datasource/sub_resource.go
@@ -93,13 +93,13 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 }
 
 func resourceRequest(req *http.Request) (*http.Request, error) {
-	idx := strings.LastIndex(req.URL.Path, "/resource")
+	idx := strings.LastIndex(req.URL.Path, "/resources")
 	if idx < 0 {
 		return nil, fmt.Errorf("expected resource path") // 400?
 	}
 
 	clonedReq := req.Clone(req.Context())
-	rawURL := strings.TrimLeft(req.URL.Path[idx+len("/resource"):], "/")
+	rawURL := strings.TrimLeft(req.URL.Path[idx+len("/resources"):], "/")
 
 	clonedReq.URL = &url.URL{
 		Path:     rawURL,

--- a/pkg/registry/apis/datasource/sub_resource_test.go
+++ b/pkg/registry/apis/datasource/sub_resource_test.go
@@ -105,31 +105,31 @@ func TestResourceRequest(t *testing.T) {
 		},
 		{
 			desc:         "root resource path",
-			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource",
+			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources",
 			expectedPath: "",
 			expectedURL:  "",
 		},
 		{
 			desc:         "root resource path",
-			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/",
+			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/",
 			expectedPath: "",
 			expectedURL:  "",
 		},
 		{
 			desc:         "resource sub path",
-			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/test",
+			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/test",
 			expectedPath: "test",
 			expectedURL:  "test",
 		},
 		{
 			desc:         "resource sub path with colon",
-			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/test-*,*:test-*/_mapping",
+			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/test-*,*:test-*/_mapping",
 			expectedPath: "test-*,*:test-*/_mapping",
 			expectedURL:  "./test-%2A,%2A:test-%2A/_mapping",
 		},
 		{
 			desc:         "resource sub path with query params",
-			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resource/test?k1=v1&k2=v2",
+			url:          "http://localhost:6443/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/abc/resources/test?k1=v1&k2=v2",
 			expectedPath: "test",
 			expectedURL:  "test?k1=v1&k2=v2",
 		},
@@ -240,7 +240,7 @@ func TestSubResourceREST_Connect(t *testing.T) {
 		require.NotNil(t, handler)
 
 		reqBody := []byte(`{"test": "data"}`)
-		req := httptest.NewRequest(http.MethodPost, "http://localhost/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-ds/resource/some/path?key=value", bytes.NewReader(reqBody))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost/apis/test.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-ds/resources/some/path?key=value", bytes.NewReader(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-Custom-Header", "custom-value")
 
@@ -300,7 +300,7 @@ func TestSubResourceREST_Connect(t *testing.T) {
 				handler, err := r.Connect(context.Background(), "test-ds", nil, &resourceMockResponder{})
 				require.NoError(t, err)
 
-				req := httptest.NewRequest(method, "http://localhost/apis/test/resource/path", nil)
+				req := httptest.NewRequest(method, "http://localhost/apis/test/resources/path", nil)
 				recorder := httptest.NewRecorder()
 				handler.ServeHTTP(recorder, req)
 
@@ -333,7 +333,7 @@ func TestSubResourceREST_Connect(t *testing.T) {
 		handler, err := r.Connect(context.Background(), "test-ds", nil, responder)
 		require.NoError(t, err)
 
-		req := httptest.NewRequest(http.MethodGet, "http://localhost/apis/test/resource/path", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/apis/test/resources/path", nil)
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
 
@@ -371,7 +371,7 @@ func TestSubResourceREST_Connect(t *testing.T) {
 		require.NoError(t, err)
 
 		requestBody := `{"key": "value", "nested": {"foo": "bar"}}`
-		req := httptest.NewRequest(http.MethodPost, "http://localhost/apis/test/resource/path", bytes.NewBufferString(requestBody))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost/apis/test/resources/path", bytes.NewBufferString(requestBody))
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
@@ -407,7 +407,7 @@ func TestSubResourceREST_Connect(t *testing.T) {
 		handler, err := r.Connect(context.Background(), "test-ds", nil, &resourceMockResponder{})
 		require.NoError(t, err)
 
-		req := httptest.NewRequest(http.MethodGet, "http://localhost/apis/test/resource/path", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/apis/test/resources/path", nil)
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
 
@@ -444,7 +444,7 @@ func TestSubResourceREST_Connect(t *testing.T) {
 		handler, err := r.Connect(context.Background(), "test-ds", nil, &resourceMockResponder{})
 		require.NoError(t, err)
 
-		req := httptest.NewRequest(http.MethodGet, "http://localhost/apis/test/resource/api/endpoint?foo=bar&baz=qux", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/apis/test/resources/api/endpoint?foo=bar&baz=qux", nil)
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
 

--- a/pkg/tests/apis/datasource/resources_test.go
+++ b/pkg/tests/apis/datasource/resources_test.go
@@ -76,7 +76,7 @@ func TestIntegrationDatasourceResources(t *testing.T) {
 		raw := apis.DoRequest[any](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources",
 		}, nil)
 
 		require.Equal(t, http.StatusOK, raw.Response.StatusCode, "expected OK status, got body: %s", string(raw.Body))
@@ -89,7 +89,7 @@ func TestIntegrationDatasourceResources(t *testing.T) {
 		raw := apis.DoRequest[testdataResponse](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/test/json",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/test/json",
 		}, &testdataResponse{})
 
 		require.Equal(t, http.StatusOK, raw.Response.StatusCode)
@@ -102,7 +102,7 @@ func TestIntegrationDatasourceResources(t *testing.T) {
 		raw := apis.DoRequest[testdataResponse](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodPost,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/test/json",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/test/json",
 			Body:   []byte(`{"foo": "bar", "count": 42}`),
 		}, &testdataResponse{})
 
@@ -122,7 +122,7 @@ func TestIntegrationDatasourceResourceHeaders(t *testing.T) {
 		raw := apis.DoRequest[testdataResponse](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodPost,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/test/json",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/test/json",
 			Headers: map[string]string{
 				"X-Custom-Header": "custom-value",
 			},
@@ -149,7 +149,7 @@ func TestIntegrationDatasourceResourceHeaders(t *testing.T) {
 		raw := apis.DoRequest[testdataResponse](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/test/json?param1=value1&param2=value2",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/test/json?param1=value1&param2=value2",
 		}, &testdataResponse{})
 
 		require.Equal(t, http.StatusOK, raw.Response.StatusCode)
@@ -173,7 +173,7 @@ func TestIntegrationDatasourceStreamingResource(t *testing.T) {
 		raw := apis.DoRequest[any](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/test/stream",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/test/stream",
 		}, nil)
 
 		require.NotNil(t, raw.Response.StatusCode)
@@ -190,7 +190,7 @@ func TestIntegrationDatasourceResourceAuthorization(t *testing.T) {
 		raw := apis.DoRequest[any](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/does-not-exist/resource",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/does-not-exist/resources",
 		}, nil)
 
 		require.NotNil(t, raw.Status)
@@ -202,7 +202,7 @@ func TestIntegrationDatasourceResourceAuthorization(t *testing.T) {
 		raw := apis.DoRequest[any](helper, apis.RequestParams{
 			User:   helper.Org1.None,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources",
 		}, nil)
 
 		require.NotNil(t, raw.Response)
@@ -214,7 +214,7 @@ func TestIntegrationDatasourceResourceAuthorization(t *testing.T) {
 		raw := apis.DoRequest[any](helper, apis.RequestParams{
 			User:   helper.OrgB.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources",
 		}, nil)
 
 		require.NotNil(t, raw.Status)
@@ -244,7 +244,7 @@ func TestIntegrationDatasourceResourcesMethods(t *testing.T) {
 			raw := apis.DoRequest[testdataResponse](helper, apis.RequestParams{
 				User:   helper.Org1.Admin,
 				Method: method,
-				Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/test/json",
+				Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/test/json",
 				Body:   body,
 			}, &testdataResponse{})
 
@@ -266,7 +266,7 @@ func TestIntegrationDatasourceResourcesScenarios(t *testing.T) {
 		raw := apis.DoRequest[[]map[string]any](helper, apis.RequestParams{
 			User:   helper.Org1.Admin,
 			Method: http.MethodGet,
-			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resource/scenarios",
+			Path:   "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-resource/resources/scenarios",
 		}, &[]map[string]any{})
 
 		require.Equal(t, http.StatusOK, raw.Response.StatusCode)

--- a/pkg/tests/apis/openapi_snapshots/grafana-testdata-datasource.datasource.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/grafana-testdata-datasource.datasource.grafana.app-v0alpha1.json
@@ -1005,13 +1005,163 @@
         }
       ]
     },
-    "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/{namespace}/datasources/{name}/resource": {
+    "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/{namespace}/datasources/{name}/resources": {
       "get": {
         "tags": [
           "DataSource"
         ],
-        "description": "Get resources in the datasource plugin. NOTE, additional routes may exist, but are not exposed via OpenAPI",
-        "operationId": "getDataSourceResource",
+        "description": "connect GET requests to resources of DataSource",
+        "operationId": "getDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "put": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect PUT requests to resources of DataSource",
+        "operationId": "replaceDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "post": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect POST requests to resources of DataSource",
+        "operationId": "createDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "delete": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect DELETE requests to resources of DataSource",
+        "operationId": "deleteDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "options": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect OPTIONS requests to resources of DataSource",
+        "operationId": "optionsDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "head": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect HEAD requests to resources of DataSource",
+        "operationId": "headDataSourceResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "patch": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect PATCH requests to resources of DataSource",
+        "operationId": "updateDataSourceResources",
         "responses": {
           "200": {
             "description": "OK",
@@ -1046,6 +1196,215 @@
           "name": "namespace",
           "in": "path",
           "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/grafana-testdata-datasource.datasource.grafana.app/v0alpha1/namespaces/{namespace}/datasources/{name}/resources/{path}": {
+      "get": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect GET requests to resources of DataSource",
+        "operationId": "getDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "put": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect PUT requests to resources of DataSource",
+        "operationId": "replaceDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "post": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect POST requests to resources of DataSource",
+        "operationId": "createDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "delete": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect DELETE requests to resources of DataSource",
+        "operationId": "deleteDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "options": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect OPTIONS requests to resources of DataSource",
+        "operationId": "optionsDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "head": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect HEAD requests to resources of DataSource",
+        "operationId": "headDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "patch": {
+        "tags": [
+          "DataSource"
+        ],
+        "description": "connect PATCH requests to resources of DataSource",
+        "operationId": "updateDataSourceResourcesWithPath",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "connect",
+        "x-kubernetes-group-version-kind": {
+          "group": "grafana-testdata-datasource.datasource.grafana.app",
+          "kind": "Status",
+          "version": "v0alpha1"
+        }
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the Status",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "path",
+          "in": "path",
+          "description": "path to the resource",
           "required": true,
           "schema": {
             "type": "string",


### PR DESCRIPTION
Based on internal discussion we decided to use `/resources/*` so that it matches the old endpoints exactly. 