### PR TITLE
iam: support service accounts in K8s ResourcePermission API

### DIFF
--- a/pkg/registry/apis/iam/legacy/sql_test.go
+++ b/pkg/registry/apis/iam/legacy/sql_test.go
@@ -392,7 +392,7 @@ func TestIdentityQueries(t *testing.T) {
 					},
 				},
 			},
-			sqlQueryServiceAccountsTemplate: {
+		sqlQueryServiceAccountsTemplate: {
 				{
 					Name: "service_accounts",
 					Data: listServiceAccounts(&ListServiceAccountsQuery{

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -97,7 +97,7 @@ func RegisterAPIService(
 	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, externalGroupMappingApiInstaller)
 	registerMetrics(reg)
 
-	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider)
+	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, restConfig.GetRestConfig)
 
 	// When resourcepermissions are in Mode5 (unistore only), search must error; pass nil backend so the handler returns that error.
 	resourcePermsSearchBackend := resource.StorageBackend(rpStorage)
@@ -179,7 +179,7 @@ func NewAPIService(
 	tracingService tracing.Tracer,
 ) *IdentityAccessManagementAPIBuilder {
 	store := legacy.NewLegacySQLStores(dbProvider)
-	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider)
+	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider, nil)
 	registerMetrics(reg)
 
 	globalRoleAuthorizer := globalRoleApiInstaller.GetAuthorizer()

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -1,9 +1,19 @@
 package resourcepermission
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/grafana/authlib/types"
+
+	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 type Mapper interface {
@@ -13,18 +23,103 @@ type Mapper interface {
 	ScopePattern() string
 }
 
+// ResourceNameResolver translates between external names (UIDs used in the K8s API)
+// and internal names (e.g. numeric IDs used in legacy SQL scopes) for resource types
+// where the scope attribute differs from the API identifier.
+type ResourceNameResolver interface {
+	// ExternalToInternal converts an API-level name (e.g. SA UID) to the internal
+	// scope name (e.g. numeric ID string) used in RBAC permission rows.
+	ExternalToInternal(ctx context.Context, ns types.NamespaceInfo, externalName string) (string, error)
+	// InternalToExternal converts an internal scope name (e.g. numeric ID string)
+	// to the API-level name (e.g. SA UID) returned in K8s objects.
+	InternalToExternal(ctx context.Context, ns types.NamespaceInfo, internalName string) (string, error)
+}
+
+// APIServiceAccountNameResolver resolves service account UIDs ↔ internal numeric IDs
+// by querying the K8s ServiceAccount API via a dynamic client. This is mode-agnostic:
+// it works regardless of whether service accounts are stored in legacy SQL or unified storage,
+// because the K8s apiserver handles routing internally and always stores the legacy numeric ID
+// in the grafana.app/deprecatedInternalID label.
+type APIServiceAccountNameResolver struct {
+	configProvider func(ctx context.Context) (*rest.Config, error)
+}
+
+func NewAPIServiceAccountNameResolver(configProvider func(ctx context.Context) (*rest.Config, error)) ResourceNameResolver {
+	return &APIServiceAccountNameResolver{configProvider: configProvider}
+}
+
+// ExternalToInternal resolves a service account UID to its legacy numeric ID by
+// fetching the SA from the K8s API and reading the grafana.app/deprecatedInternalID label.
+func (r *APIServiceAccountNameResolver) ExternalToInternal(ctx context.Context, ns types.NamespaceInfo, uid string) (string, error) {
+	client, err := r.saClient(ctx, ns.Value)
+	if err != nil {
+		return "", fmt.Errorf("create service account client: %w", err)
+	}
+	obj, err := client.Get(ctx, uid, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get service account %q: %w", uid, err)
+	}
+	accessor, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return "", fmt.Errorf("meta accessor for service account %q: %w", uid, err)
+	}
+	id := accessor.GetDeprecatedInternalID()
+	if id == 0 {
+		return "", fmt.Errorf("service account %q has no deprecated internal ID", uid)
+	}
+	return fmt.Sprintf("%d", id), nil
+}
+
+// InternalToExternal resolves a legacy numeric ID to a service account UID by listing
+// SAs with the grafana.app/deprecatedInternalID label selector.
+func (r *APIServiceAccountNameResolver) InternalToExternal(ctx context.Context, ns types.NamespaceInfo, id string) (string, error) {
+	client, err := r.saClient(ctx, ns.Value)
+	if err != nil {
+		return "", fmt.Errorf("create service account client: %w", err)
+	}
+	list, err := client.List(ctx, metav1.ListOptions{
+		LabelSelector: utils.LabelKeyDeprecatedInternalID + "=" + id,
+		Limit:         1,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list service accounts with internal ID %s: %w", id, err)
+	}
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("service account with internal ID %s not found", id)
+	}
+	return list.Items[0].GetName(), nil
+}
+
+func (r *APIServiceAccountNameResolver) saClient(ctx context.Context, namespace string) (dynamic.ResourceInterface, error) {
+	cfg, err := r.configProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return client.Resource(v0alpha1.ServiceAccountResourceInfo.GroupVersionResource()).Namespace(namespace), nil
+}
+
 type mapper struct {
 	resource   string
+	attribute  string // "uid" or "id"
 	actionSets []string
 }
 
 func NewMapper(resource string, levels []string) Mapper {
+	return NewMapperWithAttribute(resource, levels, "uid")
+}
+
+func NewMapperWithAttribute(resource string, levels []string, attribute string) Mapper {
 	sets := make([]string, 0, len(levels))
 	for _, level := range levels {
 		sets = append(sets, resource+":"+level)
 	}
 	return mapper{
 		resource:   resource,
+		attribute:  attribute,
 		actionSets: sets,
 	}
 }
@@ -34,7 +129,7 @@ func (m mapper) ActionSets() []string {
 }
 
 func (m mapper) Scope(name string) string {
-	return m.resource + ":uid:" + name
+	return m.resource + ":" + m.attribute + ":" + name
 }
 
 func (m mapper) ActionSet(level string) (string, error) {
@@ -46,5 +141,5 @@ func (m mapper) ActionSet(level string) (string, error) {
 }
 
 func (m mapper) ScopePattern() string {
-	return m.resource + ":uid:%"
+	return m.resource + ":" + m.attribute + ":%"
 }

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -1,0 +1,67 @@
+package resourcepermission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMapper(t *testing.T) {
+	t.Run("default mapper uses uid attribute", func(t *testing.T) {
+		m := NewMapper("folders", []string{"view", "edit", "admin"})
+
+		require.Equal(t, "folders:uid:fold1", m.Scope("fold1"))
+		require.Equal(t, "folders:uid:%", m.ScopePattern())
+		require.Equal(t, []string{"folders:view", "folders:edit", "folders:admin"}, m.ActionSets())
+	})
+}
+
+func TestNewMapperWithAttribute(t *testing.T) {
+	t.Run("mapper with uid attribute", func(t *testing.T) {
+		m := NewMapperWithAttribute("folders", []string{"view", "edit", "admin"}, "uid")
+
+		require.Equal(t, "folders:uid:fold1", m.Scope("fold1"))
+		require.Equal(t, "folders:uid:%", m.ScopePattern())
+	})
+
+	t.Run("mapper with id attribute", func(t *testing.T) {
+		m := NewMapperWithAttribute("serviceaccounts", []string{"edit", "admin"}, "id")
+
+		require.Equal(t, "serviceaccounts:id:123", m.Scope("123"))
+		require.Equal(t, "serviceaccounts:id:%", m.ScopePattern())
+	})
+
+	t.Run("action sets are correctly generated for service accounts", func(t *testing.T) {
+		m := NewMapperWithAttribute("serviceaccounts", []string{"edit", "admin"}, "id")
+
+		actionSets := m.ActionSets()
+		require.Len(t, actionSets, 2)
+		require.Contains(t, actionSets, "serviceaccounts:edit")
+		require.Contains(t, actionSets, "serviceaccounts:admin")
+	})
+
+	t.Run("ActionSet returns correct action set for valid level", func(t *testing.T) {
+		m := NewMapperWithAttribute("serviceaccounts", []string{"edit", "admin"}, "id")
+
+		actionSet, err := m.ActionSet("edit")
+		require.NoError(t, err)
+		require.Equal(t, "serviceaccounts:edit", actionSet)
+
+		actionSet, err = m.ActionSet("admin")
+		require.NoError(t, err)
+		require.Equal(t, "serviceaccounts:admin", actionSet)
+	})
+
+	t.Run("ActionSet returns error for invalid level", func(t *testing.T) {
+		m := NewMapperWithAttribute("serviceaccounts", []string{"edit", "admin"}, "id")
+
+		// "view" is not valid for service accounts
+		_, err := m.ActionSet("view")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errInvalidSpec)
+
+		_, err = m.ActionSet("delete")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errInvalidSpec)
+	})
+}

--- a/pkg/registry/apis/iam/resourcepermission/models.go
+++ b/pkg/registry/apis/iam/resourcepermission/models.go
@@ -35,8 +35,9 @@ var (
 	errInvalidScope         = errors.New("invalid scope")
 	errInvalidNamespace     = errors.New("invalid namespace")
 
-	defaultLevels     = []string{"view", "edit", "admin"}
-	allowedBasicRoles = map[string]bool{"Viewer": true, "Editor": true, "Admin": true}
+	defaultLevels          = []string{"view", "edit", "admin"}
+	serviceAccountLevels   = []string{"edit", "admin"} // Service accounts don't have view level
+	allowedBasicRoles    = map[string]bool{"Viewer": true, "Editor": true, "Admin": true}
 )
 
 type IdentityStore interface {
@@ -129,7 +130,7 @@ func newV0ResourcePermission(grn *groupResourceName, specs []v0alpha1.ResourcePe
 
 // toV0ResourcePermissions translates a list of rbacAssignments into a list of v0alpha1.ResourcePermissions.
 // it is assumed that assignments are sorted by scope
-func (s *ResourcePermSqlBackend) toV0ResourcePermissions(assignments []rbacAssignment, namespace string) ([]v0alpha1.ResourcePermission, error) {
+func (s *ResourcePermSqlBackend) toV0ResourcePermissions(ctx context.Context, ns types.NamespaceInfo, assignments []rbacAssignment, namespace string) ([]v0alpha1.ResourcePermission, error) {
 	if len(assignments) == 0 {
 		return nil, nil
 	}
@@ -137,32 +138,32 @@ func (s *ResourcePermSqlBackend) toV0ResourcePermissions(assignments []rbacAssig
 	var (
 		created        = assignments[0].Created
 		updated        = assignments[0].Updated
+		currentScope   = assignments[0].Scope
 		permissionKind v0alpha1.ResourcePermissionSpecPermissionKind
 
 		resourcePermissions = make([]v0alpha1.ResourcePermission, 0, 8)
 		specs               = make([]v0alpha1.ResourcePermissionspecPermission, 0, 4)
 	)
 
-	grn, err := s.ParseScope(assignments[0].Scope)
+	grn, err := s.parseScopeExternal(ctx, ns, currentScope)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, assign := range assignments {
-		// Ensure all assignments belong to the same resource
-		parsedGrn, err := s.ParseScope(assign.Scope)
-		if err != nil {
-			return nil, err
-		}
-		// If it's a new resource, flush the current specs to a ResourcePermission and start a new one
-		if *parsedGrn != *grn {
+		// If it's a new scope/resource, flush the current specs and start a new one
+		if assign.Scope != currentScope {
 			resourcePermissions = append(
 				resourcePermissions,
 				newV0ResourcePermission(grn, specs, created, updated, namespace),
 			)
 
 			// Reset for the new resource
-			grn = parsedGrn
+			currentScope = assign.Scope
+			grn, err = s.parseScopeExternal(ctx, ns, currentScope)
+			if err != nil {
+				return nil, err
+			}
 			specs = make([]v0alpha1.ResourcePermissionspecPermission, 0, 4)
 			created = assign.Created
 			updated = assign.Updated
@@ -215,6 +216,20 @@ func (s *ResourcePermSqlBackend) toV0ResourcePermissions(assignments []rbacAssig
 	)
 
 	return resourcePermissions, nil
+}
+
+// parseScopeExternal parses a scope and resolves the resource name to the external (API) form.
+func (s *ResourcePermSqlBackend) parseScopeExternal(ctx context.Context, ns types.NamespaceInfo, scope string) (*groupResourceName, error) {
+	grn, err := s.ParseScope(scope)
+	if err != nil {
+		return nil, err
+	}
+	externalName, err := s.resolveToExternalName(ctx, ns, grn)
+	if err != nil {
+		return nil, err
+	}
+	grn.Name = externalName
+	return grn, nil
 }
 
 type groupResourceName struct {
@@ -277,4 +292,29 @@ func (s *ResourcePermSqlBackend) getResourceMapper(group, resource string) (Mapp
 	}
 
 	return mapper, nil
+}
+
+// getNameResolver returns the optional ResourceNameResolver for a group/resource, or nil if none is registered.
+func (s *ResourcePermSqlBackend) getNameResolver(group, resource string) ResourceNameResolver {
+	return s.nameResolvers[schema.GroupResource{Group: group, Resource: resource}]
+}
+
+// resolveToInternalName translates an external (API) name to the internal (scope) name.
+// Returns the name unchanged when no resolver is registered for the resource.
+func (s *ResourcePermSqlBackend) resolveToInternalName(ctx context.Context, ns types.NamespaceInfo, grn *groupResourceName) (string, error) {
+	resolver := s.getNameResolver(grn.Group, grn.Resource)
+	if resolver == nil {
+		return grn.Name, nil
+	}
+	return resolver.ExternalToInternal(ctx, ns, grn.Name)
+}
+
+// resolveToExternalName translates an internal (scope) name to the external (API) name.
+// Returns the name unchanged when no resolver is registered for the resource.
+func (s *ResourcePermSqlBackend) resolveToExternalName(ctx context.Context, ns types.NamespaceInfo, grn *groupResourceName) (string, error) {
+	resolver := s.getNameResolver(grn.Group, grn.Resource)
+	if resolver == nil {
+		return grn.Name, nil
+	}
+	return resolver.InternalToExternal(ctx, ns, grn.Name)
 }

--- a/pkg/registry/apis/iam/resourcepermission/models_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/models_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/authlib/types"
+
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/stretchr/testify/require"
@@ -15,14 +17,17 @@ func setupBackendNoDB(t *testing.T) *ResourcePermSqlBackend {
 	noProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
 		return nil, nil
 	}
-	return ProvideStorageBackend(noProvider)
+	return ProvideStorageBackend(noProvider, nil)
 }
 
 func TestToV0ResourcePermissions(t *testing.T) {
 	backend := setupBackendNoDB(t)
 
+	ctx := context.Background()
+	ns := types.NamespaceInfo{OrgID: 1, Value: "default"}
+
 	t.Run("empty permissions", func(t *testing.T) {
-		result, err := backend.toV0ResourcePermissions([]rbacAssignment{}, "default")
+		result, err := backend.toV0ResourcePermissions(ctx, ns, []rbacAssignment{}, "default")
 		require.NoError(t, err)
 		require.Nil(t, result)
 	})
@@ -76,7 +81,7 @@ func TestToV0ResourcePermissions(t *testing.T) {
 			},
 		}
 
-		result, err := backend.toV0ResourcePermissions(permissions, "default")
+		result, err := backend.toV0ResourcePermissions(ctx, ns, permissions, "default")
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result, 1)

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -89,7 +89,7 @@ func (s *ResourcePermSqlBackend) newRoleIterator(ctx context.Context, dbHelper *
 		return &listIterator{}, nil
 	}
 
-	v0ResourcePermissions, err := s.toV0ResourcePermissions(assignments, ns.Value)
+	v0ResourcePermissions, err := s.toV0ResourcePermissions(ctx, ns, assignments, ns.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -157,6 +157,8 @@ func (s *ResourcePermSqlBackend) getRbacAssignmentsWithTx(ctx context.Context, s
 }
 
 // getResourcePermission retrieves a single ResourcePermission by its name in the format <group>-<resource>-<name> (e.g. dashboard.grafana.app-dashboards-ad5rwqs)
+// The name component is the external (API) identifier (e.g. a UID), which is resolved to
+// the internal scope name (e.g. numeric ID) when the resource has a registered name resolver.
 func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql *legacysql.LegacyDatabaseHelper, tx *session.SessionTx, ns types.NamespaceInfo, name string) (*v0alpha1.ResourcePermission, error) {
 	grn, err := splitResourceName(name)
 	if err != nil {
@@ -168,8 +170,13 @@ func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql 
 		return nil, apierrors.NewInternalError(err)
 	}
 
+	internalName, err := s.resolveToInternalName(ctx, ns, grn)
+	if err != nil {
+		return nil, apierrors.NewInternalError(err)
+	}
+
 	resourceQuery := &ListResourcePermissionsQuery{
-		Scopes:     []string{mapper.Scope(grn.Name)},
+		Scopes:     []string{mapper.Scope(internalName)},
 		OrgID:      ns.OrgID,
 		ActionSets: mapper.ActionSets(),
 	}
@@ -183,7 +190,7 @@ func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql 
 		return nil, apierrors.NewNotFound(v0alpha1.ResourcePermissionInfo.GroupResource(), name)
 	}
 
-	resourcePermission, err := s.toV0ResourcePermissions(assignments, ns.Value)
+	resourcePermission, err := s.toV0ResourcePermissions(ctx, ns, assignments, ns.Value)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
@@ -376,14 +383,19 @@ func (s *ResourcePermSqlBackend) existsResourcePermission(ctx context.Context, t
 func (s *ResourcePermSqlBackend) createResourcePermission(
 	ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper, ns types.NamespaceInfo, mapper Mapper, grn *groupResourceName, v0ResourcePerm *v0alpha1.ResourcePermission,
 ) (int64, error) {
-	assignments, err := s.buildRbacAssignments(ctx, ns, mapper, v0ResourcePerm.Spec.Permissions, mapper.Scope(grn.Name))
+	internalName, err := s.resolveToInternalName(ctx, ns, grn)
+	if err != nil {
+		return 0, err
+	}
+	scope := mapper.Scope(internalName)
+
+	assignments, err := s.buildRbacAssignments(ctx, ns, mapper, v0ResourcePerm.Spec.Permissions, scope)
 	if err != nil {
 		return 0, err
 	}
 
 	err = dbHelper.DB.GetSqlxSession().WithTransaction(ctx, func(tx *session.SessionTx) error {
-		// Check if a resource permission for the same resource already exists
-		if err = s.existsResourcePermission(ctx, tx, dbHelper, ns.OrgID, mapper.Scope(grn.Name)); err != nil {
+		if err = s.existsResourcePermission(ctx, tx, dbHelper, ns.OrgID, scope); err != nil {
 			return err
 		}
 
@@ -400,12 +412,17 @@ func (s *ResourcePermSqlBackend) createResourcePermission(
 		return 0, err
 	}
 
-	// Return a timestamp as resource version
 	return timeNow().UnixMilli(), nil
 }
 
 func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper, ns types.NamespaceInfo, mapper Mapper, grn *groupResourceName, v0ResourcePerm *v0alpha1.ResourcePermission) (int64, error) {
-	err := dbHelper.DB.GetSqlxSession().WithTransaction(ctx, func(tx *session.SessionTx) error {
+	internalName, err := s.resolveToInternalName(ctx, ns, grn)
+	if err != nil {
+		return 0, err
+	}
+	scope := mapper.Scope(internalName)
+
+	err = dbHelper.DB.GetSqlxSession().WithTransaction(ctx, func(tx *session.SessionTx) error {
 		currentPerms, err := s.getResourcePermission(ctx, dbHelper, tx, ns, grn.string())
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -418,7 +435,7 @@ func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, d
 		permissionsToAdd, permissionsToRemove := diffPermissions(currentPerms.Spec.Permissions, v0ResourcePerm.Spec.Permissions)
 
 		if len(permissionsToRemove) > 0 {
-			permsToRemove, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToRemove, mapper.Scope(grn.Name))
+			permsToRemove, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToRemove, scope)
 			if err != nil {
 				return err
 			}
@@ -443,7 +460,7 @@ func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, d
 		}
 
 		if len(permissionsToAdd) > 0 {
-			permsToAdd, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToAdd, mapper.Scope(grn.Name))
+			permsToAdd, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToAdd, scope)
 			if err != nil {
 				return err
 			}
@@ -462,7 +479,6 @@ func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, d
 		return 0, err
 	}
 
-	// Return a timestamp as resource version
 	return timeNow().UnixMilli(), nil
 }
 
@@ -508,7 +524,12 @@ func (s *ResourcePermSqlBackend) deleteResourcePermission(ctx context.Context, s
 	if err != nil {
 		return err
 	}
-	scope := mapper.Scope(grn.Name)
+
+	internalName, err := s.resolveToInternalName(ctx, ns, grn)
+	if err != nil {
+		return err
+	}
+	scope := mapper.Scope(internalName)
 
 	resourceQuery := &DeleteResourcePermissionsQuery{
 		Scope: scope,

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -111,7 +111,7 @@ func setupBackend(t *testing.T) *ResourcePermSqlBackend {
 		return sqlHelper, nil
 	}
 
-	return ProvideStorageBackend(dbProvider)
+	return ProvideStorageBackend(dbProvider, nil)
 }
 
 func setupTestRoles(t *testing.T, store db.DB) {
@@ -203,6 +203,60 @@ func setupFineGrainedPermissions(t *testing.T, store db.DB) {
 		// Permissions for managed:users:2:permissions
 		2, "folders:read", "folders:uid:fold1", "2025-09-02", "2025-09-02",
 		2, "folders:create", "folders:uid:fold1", "2025-09-02", "2025-09-02",
+	)
+	require.NoError(t, err)
+}
+
+func setupServiceAccountPermissions(t *testing.T, store db.DB) {
+	sess := store.GetSqlxSession()
+
+	// Ensure org_user entries exist for the SA (ID=3, UID="sa-1") from setupTestRoles
+	// so the resolver can join user → org_user to look up SA by internal ID.
+	_, err := sess.Exec(context.Background(),
+		`INSERT INTO org_user (org_id, user_id, role, created, updated)
+		VALUES (?, ?, ?, ?, ?)`,
+		1, 3, "Viewer", "2025-09-02 00:00:00", "2025-09-02 00:00:00",
+	)
+	require.NoError(t, err)
+
+	// Insert service account managed role — uses SA ID=3 (UID "sa-1")
+	_, err = sess.Exec(context.Background(),
+		`INSERT INTO role (id, version, org_id, uid, name, display_name, description, group_name, hidden, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		6, 0, 1, "managed_serviceaccounts_3_permissions_org1", "managed:serviceaccounts:3:permissions", "", "", "", false, "2025-09-02", "2025-09-02",
+	)
+	require.NoError(t, err)
+
+	// Insert service account permissions with id-based scope (SA internal ID=3)
+	_, err = sess.Exec(context.Background(),
+		`INSERT INTO permission (role_id, action, scope, created, updated)
+		VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+		6, "serviceaccounts:edit", "serviceaccounts:id:3", "2025-09-02", "2025-09-02",
+		6, "serviceaccounts:admin", "serviceaccounts:id:3", "2025-09-02", "2025-09-02",
+	)
+	require.NoError(t, err)
+
+	// Insert a user who will have permissions on the service account
+	_, err = sess.Exec(context.Background(),
+		`INSERT INTO`+store.GetDialect().Quote("user")+`(id, org_id, uid, login, email, is_admin, is_service_account, created, updated, version)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		4, 1, "user-sa-admin", "user-sa-admin", "user-sa-admin@example.com", false, false, "2025-09-02 00:00:00", "2025-09-02 00:00:00", 0,
+	)
+	require.NoError(t, err)
+
+	// Org user for user-sa-admin so the SQL query finds them
+	_, err = sess.Exec(context.Background(),
+		`INSERT INTO org_user (org_id, user_id, role, created, updated)
+		VALUES (?, ?, ?, ?, ?)`,
+		1, 4, "Editor", "2025-09-02 00:00:00", "2025-09-02 00:00:00",
+	)
+	require.NoError(t, err)
+
+	// User role binding for service account permissions
+	_, err = sess.Exec(context.Background(),
+		`INSERT INTO user_role (org_id, user_id, role_id, created)
+		VALUES (?, ?, ?, ?)`,
+		1, 4, 6, "2025-09-02 00:00:00", // User-4 -> managed:serviceaccounts:3:permissions
 	)
 	require.NoError(t, err)
 }
@@ -646,7 +700,7 @@ func NewFakeIdentityStore(t *testing.T) *fakeIdentityStore {
 	}
 }
 
-// GetServiceAccountInternalID implements legacy.LegacyIdentityStore.
+// GetServiceAccountInternalID implements IdentityStore.
 func (f *fakeIdentityStore) GetServiceAccountInternalID(ctx context.Context, ns types.NamespaceInfo, query legacy.GetServiceAccountInternalIDQuery) (*legacy.GetServiceAccountInternalIDResult, error) {
 	require.Equal(f.t, f.expectedNs.Value, ns.Value)
 

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -12,6 +12,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
 
 	"github.com/grafana/authlib/types"
 
@@ -34,27 +35,40 @@ type ResourcePermSqlBackend struct {
 	identityStore IdentityStore
 	logger        log.Logger
 
-	mappers        map[schema.GroupResource]Mapper // group/resource -> rbac mapper
-	reverseMappers map[string]schema.GroupResource // rbac kind -> group/resource
+	mappers        map[schema.GroupResource]Mapper               // group/resource -> rbac mapper
+	reverseMappers map[string]schema.GroupResource               // rbac kind -> group/resource
+	nameResolvers  map[schema.GroupResource]ResourceNameResolver // optional per-resource name translation
 
 	subscribers []chan *resource.WrittenEvent
 	mutex       sync.Mutex
 }
 
-func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider) *ResourcePermSqlBackend {
+func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, configProvider func(ctx context.Context) (*rest.Config, error)) *ResourcePermSqlBackend {
+	identityStore := idStore.NewLegacySQLStores(dbProvider)
+
+	saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+
+	nameResolvers := map[schema.GroupResource]ResourceNameResolver{}
+	if configProvider != nil {
+		nameResolvers[saGR] = NewAPIServiceAccountNameResolver(configProvider)
+	}
+
 	return &ResourcePermSqlBackend{
 		dbProvider:    dbProvider,
-		identityStore: idStore.NewLegacySQLStores(dbProvider),
+		identityStore: identityStore,
 		logger:        log.New("resourceperm_storage_backend"),
 
 		mappers: map[schema.GroupResource]Mapper{
 			{Group: "folder.grafana.app", Resource: "folders"}:       NewMapper("folders", defaultLevels),
 			{Group: "dashboard.grafana.app", Resource: "dashboards"}: NewMapper("dashboards", defaultLevels),
+			saGR: NewMapperWithAttribute("serviceaccounts", serviceAccountLevels, "id"),
 		},
 		reverseMappers: map[string]schema.GroupResource{
-			"folders":    {Group: "folder.grafana.app", Resource: "folders"},
-			"dashboards": {Group: "dashboard.grafana.app", Resource: "dashboards"},
+			"folders":         {Group: "folder.grafana.app", Resource: "folders"},
+			"dashboards":      {Group: "dashboard.grafana.app", Resource: "dashboards"},
+			"serviceaccounts": saGR,
 		},
+		nameResolvers: nameResolvers,
 
 		subscribers: make([]chan *resource.WrittenEvent, 0),
 		mutex:       sync.Mutex{},

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -131,7 +135,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	}
 
 	t.Run("should error with invalid namespace", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 
 		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
 			Type: resourcepb.WatchEvent_ADDED,
@@ -144,7 +148,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should error if resource name is empty", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -180,7 +184,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should error if the resource is unknown", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -216,7 +220,7 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 
 	t.Run("should work with valid resource permission", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 		backend.identityStore = NewFakeIdentityStore(t)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
@@ -670,7 +674,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	}
 
 	t.Run("should error with invalid namespace", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 
 		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
 			Type: resourcepb.WatchEvent_MODIFIED,
@@ -683,7 +687,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should error if resource name is empty", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -719,7 +723,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should error if the resource is unknown", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
 			ObjectMeta: metav1.ObjectMeta{
@@ -755,7 +759,7 @@ func TestWriteEvent_Modify(t *testing.T) {
 	})
 
 	t.Run("should work with valid resource permission", func(t *testing.T) {
-		backend := ProvideStorageBackend(dbProvider)
+		backend := ProvideStorageBackend(dbProvider, nil)
 		backend.identityStore = NewFakeIdentityStore(t)
 
 		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
@@ -823,4 +827,144 @@ func TestWriteEvent_Modify(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, timeNow().UnixMilli(), rv)
 	})
+}
+
+func TestIntegration_ResourcePermSqlBackend_ReadResource_ServiceAccounts(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	backend := setupBackend(t)
+	backend.identityStore = NewFakeIdentityStore(t)
+	saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+	// SA internal ID=3 has UID "sa-1"; inject a test resolver that maps between them
+	backend.nameResolvers = map[schema.GroupResource]ResourceNameResolver{
+		saGR: newTestSAResolver(map[string]string{"sa-1": "3"}, map[string]string{"3": "sa-1"}),
+	}
+
+	sql, err := backend.dbProvider(context.Background())
+	require.NoError(t, err)
+	setupTestRoles(t, sql.DB)
+	setupServiceAccountPermissions(t, sql.DB)
+
+	t.Run("ReadResource - Get service account permissions by UID", func(t *testing.T) {
+		// SA with internal ID=3 has UID "sa-1" — the API uses UID in the key name
+		resp := backend.ReadResource(context.Background(), &resourcepb.ReadRequest{
+			Key: &resourcepb.ResourceKey{Name: "iam.grafana.app-serviceaccounts-sa-1", Namespace: "default"},
+		})
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.NotNil(t, resp.Value)
+
+		var permission v0alpha1.ResourcePermission
+		err := json.Unmarshal(resp.Value, &permission)
+		require.NoError(t, err)
+		require.Equal(t, "iam.grafana.app-serviceaccounts-sa-1", permission.Name)
+		require.Equal(t, "iam.grafana.app", permission.Spec.Resource.ApiGroup)
+		require.Equal(t, "serviceaccounts", permission.Spec.Resource.Resource)
+		require.Equal(t, "sa-1", permission.Spec.Resource.Name)
+
+		require.Len(t, permission.Spec.Permissions, 2)
+	})
+}
+
+func TestWriteEvent_ServiceAccounts(t *testing.T) {
+	store := db.InitTestDB(t)
+
+	timeNow = func() time.Time {
+		return time.Date(2025, 8, 28, 17, 13, 0, 0, time.UTC)
+	}
+
+	sqlHelper := &legacysql.LegacyDatabaseHelper{
+		DB:    store,
+		Table: func(name string) string { return name },
+	}
+
+	dbProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return sqlHelper, nil
+	}
+
+	t.Run("should work with valid service account resource permission using basic role", func(t *testing.T) {
+		backend := ProvideStorageBackend(dbProvider, nil)
+		backend.identityStore = NewFakeIdentityStore(t)
+		saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+		backend.nameResolvers = map[schema.GroupResource]ResourceNameResolver{
+			saGR: newTestSAResolver(map[string]string{"robot": "201"}, map[string]string{"201": "robot"}),
+		}
+
+		// "robot" UID maps to internal ID 201 in the fake store
+		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "iam.grafana.app-serviceaccounts-robot",
+				Namespace: "default",
+			},
+			Spec: v0alpha1.ResourcePermissionSpec{
+				Resource: v0alpha1.ResourcePermissionspecResource{
+					ApiGroup: "iam.grafana.app",
+					Resource: "serviceaccounts",
+					Name:     "robot",
+				},
+				Permissions: []v0alpha1.ResourcePermissionspecPermission{
+					{
+						Kind: v0alpha1.ResourcePermissionSpecPermissionKindBasicRole,
+						Name: "Editor",
+						Verb: "edit",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		gr := v0alpha1.ResourcePermissionInfo.GroupResource()
+		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
+			Type:   resourcepb.WatchEvent_ADDED,
+			Key:    &resourcepb.ResourceKey{Group: gr.Group, Resource: gr.Resource, Name: "iam.grafana.app-serviceaccounts-robot", Namespace: "default"},
+			Object: resourcePerm,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, timeNow().UnixMilli(), rv)
+
+		// Verify we can read it back — the response should use the SA UID, not the numeric ID
+		resp := backend.ReadResource(context.Background(), &resourcepb.ReadRequest{
+			Key: &resourcepb.ResourceKey{Name: "iam.grafana.app-serviceaccounts-robot", Namespace: "default"},
+		})
+
+		require.NotNil(t, resp)
+		require.Nil(t, resp.Error)
+		require.NotNil(t, resp.Value)
+
+		var permission v0alpha1.ResourcePermission
+		err = json.Unmarshal(resp.Value, &permission)
+		require.NoError(t, err)
+		require.Equal(t, "iam.grafana.app-serviceaccounts-robot", permission.Name)
+		require.Equal(t, "robot", permission.Spec.Resource.Name)
+		require.Len(t, permission.Spec.Permissions, 1)
+	})
+}
+
+// testSANameResolver is a simple in-process resolver for unit/integration tests,
+// bypassing the real K8s API used by APIServiceAccountNameResolver.
+type testSANameResolver struct {
+	uidToID map[string]string
+	idToUID map[string]string
+}
+
+func newTestSAResolver(uidToID, idToUID map[string]string) ResourceNameResolver {
+	return &testSANameResolver{uidToID: uidToID, idToUID: idToUID}
+}
+
+func (r *testSANameResolver) ExternalToInternal(_ context.Context, _ types.NamespaceInfo, uid string) (string, error) {
+	id, ok := r.uidToID[uid]
+	if !ok {
+		return "", fmt.Errorf("service account UID %q not found in test resolver", uid)
+	}
+	return id, nil
+}
+
+func (r *testSANameResolver) InternalToExternal(_ context.Context, _ types.NamespaceInfo, id string) (string, error) {
+	uid, ok := r.idToUID[id]
+	if !ok {
+		return "", fmt.Errorf("service account internal ID %q not found in test resolver", id)
+	}
+	return uid, nil
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/service_account.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/service_account.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
 var (
@@ -43,6 +45,7 @@ func ProvideServiceAccountPermissions(
 	options := resourcepermissions.Options{
 		Resource:           "serviceaccounts",
 		ResourceAttribute:  "id",
+		APIGroup:           iamv0.APIGroup,
 		ResourceTranslator: serviceaccounts.UIDToIDHandler(serviceAccountRetrieverService),
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
 			ctx, span := tracer.Start(ctx, "accesscontrol.ossaccesscontrol.ProvideServiceAccountPermissions.ResourceValidator")

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -178,7 +178,7 @@ func (s *Service) GetPermissions(ctx context.Context, user identity.Requester, r
 		actions := resourcePermissions[i].Actions
 		var expandedActions []string
 		for _, action := range actions {
-			if isFolderOrDashboardAction(action) {
+			if isActionSetEnabledResource(action) {
 				actionSetActions := s.actionSetSvc.ResolveActionSet(action)
 				if len(actionSetActions) > 0 {
 					// Add all actions for folder
@@ -359,8 +359,10 @@ func (s *Service) mapPermission(permission string) ([]string, error) {
 
 	var actions []string
 
-	// Write action sets for folders and dashboards
-	if s.options.Resource == dashboards.ScopeFoldersRoot || s.options.Resource == dashboards.ScopeDashboardsRoot {
+	// Write action sets for folders, dashboards, and service accounts
+	if s.options.Resource == dashboards.ScopeFoldersRoot ||
+		s.options.Resource == dashboards.ScopeDashboardsRoot ||
+		s.options.Resource == "serviceaccounts" {
 		actions = append(actions, GetActionSetName(s.options.Resource, permission))
 
 		// If we only want to store action sets, return now
@@ -520,9 +522,9 @@ func (a *ActionSetSvc) ResolveAction(action string) []string {
 	sets := a.store.ResolveAction(action)
 	filteredSets := make([]string, 0, len(sets))
 	for _, set := range sets {
-		// Only use action sets for folders and dashboards for now
+		// Only use action sets for folders, dashboards, and service accounts for now
 		// We need to verify that action sets for other resources do not share names with actions (eg, `datasources:read`)
-		if !isFolderOrDashboardAction(set) {
+		if !isActionSetEnabledResource(set) {
 			continue
 		}
 		filteredSets = append(filteredSets, set)
@@ -536,9 +538,9 @@ func (a *ActionSetSvc) ResolveActionPrefix(actionPrefix string) []string {
 	sets := a.store.ResolveActionPrefix(actionPrefix)
 	filteredSets := make([]string, 0, len(sets))
 	for _, set := range sets {
-		// Only use action sets for folders and dashboards for now
+		// Only use action sets for folders, dashboards, and service accounts for now
 		// We need to verify that action sets for other resources do not share names with actions (eg, `datasources:read`)
-		if !isFolderOrDashboardAction(set) {
+		if !isActionSetEnabledResource(set) {
 			continue
 		}
 		filteredSets = append(filteredSets, set)
@@ -549,9 +551,9 @@ func (a *ActionSetSvc) ResolveActionPrefix(actionPrefix string) []string {
 
 // ResolveActionSet resolves an action set to a list of corresponding actions.
 func (a *ActionSetSvc) ResolveActionSet(actionSet string) []string {
-	// Only use action sets for folders and dashboards for now
+	// Only use action sets for folders, dashboards, and service accounts for now
 	// We need to verify that action sets for other resources do not share names with actions (eg, `datasources:read`)
-	if !isFolderOrDashboardAction(actionSet) {
+	if !isActionSetEnabledResource(actionSet) {
 		return nil
 	}
 	return a.store.ResolveActionSet(actionSet)
@@ -600,8 +602,10 @@ func (a *ActionSetSvc) RegisterActionSets(ctx context.Context, pluginID string, 
 	return nil
 }
 
-func isFolderOrDashboardAction(action string) bool {
-	return strings.HasPrefix(action, dashboards.ScopeDashboardsRoot) || strings.HasPrefix(action, dashboards.ScopeFoldersRoot)
+func isActionSetEnabledResource(action string) bool {
+	return strings.HasPrefix(action, dashboards.ScopeDashboardsRoot) ||
+		strings.HasPrefix(action, dashboards.ScopeFoldersRoot) ||
+		strings.HasPrefix(action, "serviceaccounts")
 }
 
 // GetActionSetName function creates an action set from a list of actions and stores it inmemory.


### PR DESCRIPTION
This PR was just a test to see what it would take to cover service account resource permissions.

## Summary

- Adds CRUD support for service account resource permissions in the K8s IAM `ResourcePermission` API (`iam.grafana.app/v0alpha1`)
- Introduces a `ResourceNameResolver` interface to bridge between API-level SA UIDs and the legacy RBAC `serviceaccounts:id:{numeric_id}` scope format
- Implements `APIServiceAccountNameResolver` using a `dynamic.Client` against the K8s ServiceAccount API — reads the `grafana.app/deprecatedInternalID` label for UID↔ID translation, making it agnostic to storage mode (legacy SQL or unified storage / mode 5)
- Wires a `rest.Config` provider into `ProvideStorageBackend` so the resolver can create its dynamic client
- Extends action set resolution to include `serviceaccounts` alongside folders and dashboards

## Caveats

- The `InternalToExternal` direction (ID → UID) uses a label selector LIST on the SA API. This works in unified storage (mode 5), but the legacy `LegacyStore.List()` does not push label selectors down to SQL — a follow-up is needed to make the legacy store handle `grafana.app/deprecatedInternalID` label filtering.

## Test plan

- [x] Unit tests: `TestWriteEvent_ServiceAccounts` (write + read round-trip with fake resolver)
- [x] Integration test: `TestIntegration_ResourcePermSqlBackend_ReadResource_ServiceAccounts`
- [ ] Manual: verify SA resource permissions via the K8s API with a running Grafana instance

Made with [Cursor](https://cursor.com)