### PR TITLE
Dashboard assistant popover: fix mobile, intrusiveness, and repeated panel issues

### DIFF
--- a/public/app/features/dashboard-scene/assistant/AssistantPopoverContext.tsx
+++ b/public/app/features/dashboard-scene/assistant/AssistantPopoverContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+import { VizPanel } from '@grafana/scenes';
+
+export interface PopoverTarget {
+  panel: VizPanel;
+  anchorEl: HTMLElement;
+}
+
+/**
+ * Context that lets the sparkle hint button trigger the popover
+ * without going through the element selection system.
+ */
+export const AssistantPopoverContext = createContext<{
+  openPopover: (panel: VizPanel, anchorEl: HTMLElement) => void;
+} | null>(null);

--- a/public/app/features/dashboard-scene/assistant/AssistantPopoverContext.tsx
+++ b/public/app/features/dashboard-scene/assistant/AssistantPopoverContext.tsx
@@ -10,7 +10,11 @@ export interface PopoverTarget {
 /**
  * Context that lets the sparkle hint button trigger the popover
  * without going through the element selection system.
+ *
+ * Supports multi-panel selection: once the popover is open, clicking
+ * another sparkle adds that panel to the context. Clicking the same
+ * sparkle again removes it (toggle).
  */
 export const AssistantPopoverContext = createContext<{
-  openPopover: (panel: VizPanel, anchorEl: HTMLElement) => void;
+  openPopover: (panel: VizPanel, anchorEl: HTMLElement, multi: boolean) => void;
 } | null>(null);

--- a/public/app/features/dashboard-scene/assistant/DashboardAssistantViewMode.tsx
+++ b/public/app/features/dashboard-scene/assistant/DashboardAssistantViewMode.tsx
@@ -4,65 +4,42 @@ import { useEffect } from 'react';
 import { useAssistant } from '@grafana/assistant';
 import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { SceneObject, VizPanel } from '@grafana/scenes';
+import { SceneObject } from '@grafana/scenes';
+import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 
-import { ElementSelection } from '../edit-pane/ElementSelection';
-import { EditPaneSelectionActions } from '../edit-pane/types';
-
-import { panelHasData, useAssistantPanelHints } from './PanelAssistantHint';
+import { useAssistantPanelHints } from './PanelAssistantHint';
 
 interface DashboardAssistantViewModeProps {
   dashboard: SceneObject;
-  editPane: EditPaneSelectionActions;
   isEditing: boolean | undefined;
-  selection: ElementSelection | undefined;
 }
 
 /**
- * Manages all assistant-related behavior in dashboard view mode:
+ * Manages assistant-related behavior in dashboard view mode:
  * - Checks assistant availability and feature toggle
- * - Enables panel selection in view mode
  * - Injects AI sparkle hint icons on panels with data
- * - Clears selection on non-data panels
- * - Renders the floating prompt card on panel selection
- * - Provides CSS class names for view mode selection styling
+ *
+ * The popover is now triggered exclusively via the sparkle button (AssistantPopoverContext),
+ * not through the element selection system. This prevents panel body clicks,
+ * table column resizes, and other interactions from opening the popover.
  */
-export function useDashboardAssistantViewMode({
-  dashboard,
-  editPane,
-  isEditing,
-  selection,
-}: DashboardAssistantViewModeProps) {
-  const { isAvailable: isAssistantAvailable } = useAssistant();
+export function useDashboardAssistantViewMode({ dashboard, isEditing }: DashboardAssistantViewModeProps) {
+  const { isAvailable: isAssistantAvailable, openAssistant } = useAssistant();
+  // Disable on small screens: the 380px floating card doesn't fit, and the
+  // auto-focused input inside AssistantPromptCard triggers the mobile keyboard.
+  const isLargeScreen = useMediaQueryMinWidth('md');
   const isEnabled =
-    !!config.featureToggles.dashboardAssistantPopover && config.bootData.user.isSignedIn && isAssistantAvailable;
+    !!config.featureToggles.dashboardAssistantPopover &&
+    config.bootData.user.isSignedIn &&
+    isAssistantAvailable &&
+    isLargeScreen;
 
   useAssistantPanelHints(dashboard, isEditing, isEnabled);
 
-  useEffect(() => {
-    if (!isEditing && isEnabled && selection && !hasSelectedVizPanelsWithData(selection)) {
-      editPane.clearSelection(true);
-    }
-  }, [isEditing, isEnabled, selection, editPane]);
-
-  const isViewModeWithPanelSelected = !isEditing && isEnabled && hasSelectedVizPanelsWithData(selection);
-
   return {
     isEnabled,
-    isViewModeWithPanelSelected,
+    openAssistant,
   };
-}
-
-function hasSelectedVizPanelsWithData(selection: ElementSelection | undefined): boolean {
-  if (!selection) {
-    return false;
-  }
-
-  const selected = selection.getSelection();
-  if (Array.isArray(selected)) {
-    return selected.length > 0 && selected.every((obj) => obj instanceof VizPanel && panelHasData(obj));
-  }
-  return selected instanceof VizPanel && panelHasData(selected);
 }
 
 // Register a custom CSS property so the browser can interpolate the angle natively,
@@ -85,35 +62,56 @@ const selectionBorderAnimation = keyframes({
   '100%': { '--border-angle': '360deg' },
 });
 
-export function getAssistantViewModeStyles(theme: GrafanaTheme2) {
+/**
+ * Returns a CSS class that applies an animated gradient border to the given element.
+ * Used by ViewModePanelPromptCard to highlight the active panel.
+ */
+export function getAnimatedBorderClass(theme: GrafanaTheme2) {
   const bg = theme.colors.background.canvas;
   const c1 = 'rgb(168, 85, 247)';
   const c2 = 'rgb(249, 115, 22)';
 
-  return {
-    viewModeHoverOverride: css({
-      '.dashboard-selectable-element:not(.dashboard-selected-element):hover': {
-        outline: 'none',
-        backgroundColor: theme.colors.background.primary,
-      },
-      '.dashboard-selected-element': {
-        outline: 'none',
-      },
-    }),
-    viewModeAnimatedBorder: css({
-      '.dashboard-selected-element': {
-        outline: 'none',
-        border: '1px solid transparent',
-        backgroundImage: `
-          linear-gradient(${bg}, ${bg}),
-          conic-gradient(from var(--border-angle), transparent 60%, ${c1} 80%, ${c2} 100%, transparent 15%)
-        `,
-        backgroundOrigin: 'border-box',
-        backgroundClip: 'padding-box, border-box',
-        [theme.transitions.handleMotion('no-preference')]: {
-          animation: `${selectionBorderAnimation} 2s linear infinite`,
-        },
-      },
-    }),
-  };
+  return css({
+    label: 'assistant-animated-border',
+    outline: 'none',
+    border: '1px solid transparent',
+    backgroundImage: `
+      linear-gradient(${bg}, ${bg}),
+      conic-gradient(from var(--border-angle), transparent 60%, ${c1} 80%, ${c2} 100%, transparent 15%)
+    `,
+    backgroundOrigin: 'border-box',
+    backgroundClip: 'padding-box, border-box',
+    [theme.transitions.handleMotion('no-preference')]: {
+      animation: `${selectionBorderAnimation} 2s linear infinite`,
+    },
+  });
+}
+
+/**
+ * Registers a global click-outside listener that calls `onDismiss` when the user
+ * clicks anywhere except the popover or the sparkle hint buttons.
+ */
+export function usePopoverDismissOnClickOutside(isActive: unknown, onDismiss: () => void) {
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const handler = (evt: PointerEvent) => {
+      if (!(evt.target instanceof Element)) {
+        return;
+      }
+      // Don't dismiss when clicking inside the popover or the sparkle hint
+      if (
+        evt.target.closest('[data-testid="view-mode-panel-prompt-card"]') ||
+        evt.target.closest('[data-testid="panel-assistant-hint"]')
+      ) {
+        return;
+      }
+      onDismiss();
+    };
+
+    document.addEventListener('pointerdown', handler);
+    return () => document.removeEventListener('pointerdown', handler);
+  }, [isActive, onDismiss]);
 }

--- a/public/app/features/dashboard-scene/assistant/PanelAssistantHint.tsx
+++ b/public/app/features/dashboard-scene/assistant/PanelAssistantHint.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/css';
-import { useEffect } from 'react';
+import { type MouseEvent, useCallback, useContext, useEffect } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import {
   isSceneObject,
   SceneComponentProps,
@@ -13,6 +14,8 @@ import {
 } from '@grafana/scenes';
 import { Icon, useStyles2 } from '@grafana/ui';
 
+import { AssistantPopoverContext } from './AssistantPopoverContext';
+
 const HINT_KEY_PREFIX = 'assistant-hint-';
 
 export function panelHasData(panel: VizPanel): boolean {
@@ -23,14 +26,44 @@ export class PanelAssistantHintItem extends SceneObjectBase<SceneObjectState> {
   static Component = PanelAssistantHintRenderer;
 }
 
-function PanelAssistantHintRenderer(_props: SceneComponentProps<PanelAssistantHintItem>) {
+function PanelAssistantHintRenderer({ model }: SceneComponentProps<PanelAssistantHintItem>) {
   const styles = useStyles2(getHintStyles);
+  const popoverContext = useContext(AssistantPopoverContext);
+
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+
+      // Walk up the scene object tree to find the parent VizPanel
+      let current: SceneObject | undefined = model.parent;
+      while (current && !(current instanceof VizPanel)) {
+        current = current.parent;
+      }
+
+      if (current instanceof VizPanel && popoverContext) {
+        // Pass the button element — ViewModePanelPromptCard will walk up the DOM
+        // from it to find the panel container for positioning.
+        const target: HTMLElement | null = e.currentTarget instanceof HTMLElement ? e.currentTarget : null;
+        if (target) {
+          popoverContext.openPopover(current, target);
+        }
+      }
+    },
+    [model, popoverContext]
+  );
 
   return (
-    <span className={styles.hintIcon} data-testid="panel-assistant-hint">
+    <button
+      className={styles.hintButton}
+      onClick={handleClick}
+      data-testid="panel-assistant-hint"
+      aria-label={t('dashboard.panel-assistant.hint.aria-label', 'Open assistant for this panel')}
+      type="button"
+    >
       <span className={styles.hintCircle} />
       <Icon name="ai-sparkle" size="xs" className={styles.hintSparkle} />
-    </span>
+    </button>
   );
 }
 
@@ -111,7 +144,7 @@ export function useAssistantPanelHints(dashboard: SceneObject, isEditing: boolea
 
 function getHintStyles(theme: GrafanaTheme2) {
   return {
-    hintIcon: css({
+    hintButton: css({
       label: 'panel-assistant-hint',
       display: 'inline-flex',
       alignItems: 'center',
@@ -121,11 +154,19 @@ function getHintStyles(theme: GrafanaTheme2) {
       height: 20,
       cursor: 'pointer',
       opacity: 0,
+      // Reset button styles
+      background: 'none',
+      border: 'none',
+      padding: 0,
+      margin: 0,
       [theme.transitions.handleMotion('no-preference')]: {
         transition: 'opacity 150ms ease-in-out',
       },
 
-      '.dashboard-selectable-element:hover &, [class*="panel-container"]:hover &': {
+      // Only show when the individual panel's <section> is hovered.
+      // Using `section[class*="panel-container"]` prevents matching parent
+      // wrappers in repeated rows/panels that may also contain "panel-container".
+      'section[class*="panel-container"]:hover &': {
         opacity: 1,
       },
     }),

--- a/public/app/features/dashboard-scene/assistant/PanelAssistantHint.tsx
+++ b/public/app/features/dashboard-scene/assistant/PanelAssistantHint.tsx
@@ -46,7 +46,7 @@ function PanelAssistantHintRenderer({ model }: SceneComponentProps<PanelAssistan
         // from it to find the panel container for positioning.
         const target: HTMLElement | null = e.currentTarget instanceof HTMLElement ? e.currentTarget : null;
         if (target) {
-          popoverContext.openPopover(current, target);
+          popoverContext.openPopover(current, target, e.shiftKey);
         }
       }
     },

--- a/public/app/features/dashboard-scene/assistant/ViewModePanelPromptCard.tsx
+++ b/public/app/features/dashboard-scene/assistant/ViewModePanelPromptCard.tsx
@@ -7,51 +7,65 @@ import { AssistantPromptCard, createAssistantContextItem } from '@grafana/assist
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { VizPanel } from '@grafana/scenes';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 
+import { type PopoverTarget } from './AssistantPopoverContext';
 import { getAnimatedBorderClass } from './DashboardAssistantViewMode';
 
 interface ViewModePanelPromptCardProps {
-  panel: VizPanel;
-  /** A DOM element inside the panel (e.g. the sparkle button). Used to locate the panel container. */
-  hintEl: HTMLElement;
+  targets: PopoverTarget[];
   onClose: () => void;
 }
 
 /**
- * Renders a floating AssistantPromptCard below a VizPanel in dashboard view mode.
- * Uses Floating UI for positioning and creates a portal to render outside the panel DOM hierarchy.
- * Applies an animated gradient border to the active panel.
+ * Renders a floating AssistantPromptCard below selected VizPanels in dashboard view mode.
+ * Supports multi-panel selection: the popover anchors to the last selected panel,
+ * and all selected panels get an animated gradient border.
  */
-export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePanelPromptCardProps) {
+export function ViewModePanelPromptCard({ targets, onClose }: ViewModePanelPromptCardProps) {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
 
+  // Anchor to the last selected panel
+  const lastTarget = targets[targets.length - 1];
+  const hintEl = lastTarget.anchorEl;
+
   // Walk up from the sparkle button to find the panel's <section> element.
-  // PanelChrome renders: <div> → <section class="...-panel-container"> → header → titleItems → button.
-  // Using `section[class*="panel-container"]` targets the individual panel precisely,
-  // even inside repeated rows/panels where a parent wrapper may also exist.
   const anchorEl = useMemo(() => {
     const section = hintEl.closest<HTMLElement>('section[class*="panel-container"]');
     return section ?? hintEl;
   }, [hintEl]);
 
-  // Apply animated border to the active panel's DOM element
+  // Resolve all panel <section> elements for border styling
+  const allAnchorEls = useMemo(
+    () =>
+      targets.map((t) => {
+        const section = t.anchorEl.closest<HTMLElement>('section[class*="panel-container"]');
+        return section ?? t.anchorEl;
+      }),
+    [targets]
+  );
+
+  // Apply animated border to ALL selected panels
   const borderClass = useMemo(() => getAnimatedBorderClass(theme), [theme]);
   useEffect(() => {
-    anchorEl.classList.add(borderClass);
-    return () => anchorEl.classList.remove(borderClass);
-  }, [anchorEl, borderClass]);
+    for (const el of allAnchorEls) {
+      el.classList.add(borderClass);
+    }
+    return () => {
+      for (const el of allAnchorEls) {
+        el.classList.remove(borderClass);
+      }
+    };
+  }, [allAnchorEls, borderClass]);
 
-  // Close the popover when the anchor element is removed from the DOM
-  // (e.g. when a row is collapsed). Polls via rAF because MutationObserver
-  // on the parent won't fire when a grandparent is removed, and the scene
-  // object may not deactivate when its React component unmounts.
+  // Close the popover when any anchor element is removed from the DOM
+  // (e.g. when a row is collapsed).
   useEffect(() => {
     let rafId: number;
     const check = () => {
-      if (!anchorEl.isConnected) {
+      const anyDisconnected = allAnchorEls.some((el) => !el.isConnected);
+      if (anyDisconnected) {
         onClose();
         return;
       }
@@ -59,7 +73,7 @@ export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePane
     };
     rafId = requestAnimationFrame(check);
     return () => cancelAnimationFrame(rafId);
-  }, [anchorEl, onClose]);
+  }, [allAnchorEls, onClose]);
 
   const { refs, floatingStyles, isPositioned } = useFloating({
     placement: 'bottom',
@@ -75,7 +89,7 @@ export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePane
 
   useEffect(() => {
     setVisible(false);
-  }, [panel]);
+  }, [anchorEl]);
 
   useEffect(() => {
     if (!isPositioned) {
@@ -86,32 +100,37 @@ export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePane
       requestAnimationFrame(() => setVisible(true));
     });
     return () => cancelAnimationFrame(raf);
-  }, [isPositioned, panel]);
+  }, [isPositioned, anchorEl]);
 
   const context = useMemo(
-    () => [
-      createAssistantContextItem('structured', {
-        title: panel.state.title || 'Panel',
-        data: {
-          panelKey: panel.state.key,
-          panelTitle: panel.state.title,
-          pluginId: panel.state.pluginId,
-        },
-      }),
-    ],
-    [panel]
+    () =>
+      targets.map((t) =>
+        createAssistantContextItem('structured', {
+          title: t.panel.state.title || 'Panel',
+          data: {
+            panelKey: t.panel.state.key,
+            panelTitle: t.panel.state.title,
+            pluginId: t.panel.state.pluginId,
+          },
+        })
+      ),
+    [targets]
   );
 
-  const promptPlaceholder = t('dashboard.panel-assistant.prompt-card.placeholder', 'Ask Assistant about this panel...');
+  const promptPlaceholder =
+    targets.length > 1
+      ? t('dashboard.panel-assistant.prompt-card.placeholder-multi', 'Ask Assistant about these panels...')
+      : t('dashboard.panel-assistant.prompt-card.placeholder', 'Ask Assistant about this panel...');
 
   const closedExplicitlyRef = useRef(false);
+  const targetKeys = useMemo(() => targets.map((t) => t.panel.state.key).join(','), [targets]);
 
   useEffect(() => {
     if (visible) {
       closedExplicitlyRef.current = false;
       reportInteraction('dashboards_assistant_popover_displayed', {
-        panelCount: 1,
-        pluginIds: [panel.state.pluginId],
+        panelCount: targets.length,
+        pluginIds: targets.map((t) => t.panel.state.pluginId),
       });
 
       return () => {
@@ -122,7 +141,7 @@ export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePane
     }
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, panel]);
+  }, [visible, targetKeys]);
 
   const handleClose = useCallback(() => {
     closedExplicitlyRef.current = true;
@@ -134,12 +153,12 @@ export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePane
     (prompt: string) => {
       closedExplicitlyRef.current = true;
       reportInteraction('dashboards_assistant_popover_prompt_submitted', {
-        panelCount: 1,
+        panelCount: targets.length,
         promptLength: prompt.length,
       });
       onClose();
     },
-    [onClose]
+    [onClose, targets.length]
   );
 
   const hiddenStyle = {
@@ -150,11 +169,13 @@ export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePane
     pointerEvents: 'none' as const,
   };
 
+  const isVisible = visible && anchorEl.isConnected;
+
   return createPortal(
     <div
       ref={refs.setFloating}
-      style={visible ? floatingStyles : hiddenStyle}
-      className={visible ? styles.floatingContainer : undefined}
+      style={isVisible ? floatingStyles : hiddenStyle}
+      className={isVisible ? styles.floatingContainer : undefined}
       data-testid="view-mode-panel-prompt-card"
     >
       <AssistantPromptCard

--- a/public/app/features/dashboard-scene/assistant/ViewModePanelPromptCard.tsx
+++ b/public/app/features/dashboard-scene/assistant/ViewModePanelPromptCard.tsx
@@ -7,39 +7,59 @@ import { AssistantPromptCard, createAssistantContextItem } from '@grafana/assist
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { SceneObject, VizPanel, sceneGraph } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { VizPanel } from '@grafana/scenes';
+import { useStyles2, useTheme2 } from '@grafana/ui';
 
-import { ElementSelection } from '../edit-pane/ElementSelection';
-import { EditPaneSelectionActions } from '../edit-pane/types';
-
-import { panelHasData } from './PanelAssistantHint';
+import { getAnimatedBorderClass } from './DashboardAssistantViewMode';
 
 interface ViewModePanelPromptCardProps {
-  selection: ElementSelection | undefined;
-  editPane: EditPaneSelectionActions;
-  dashboard: SceneObject;
+  panel: VizPanel;
+  /** A DOM element inside the panel (e.g. the sparkle button). Used to locate the panel container. */
+  hintEl: HTMLElement;
+  onClose: () => void;
 }
 
 /**
- * Renders a floating AssistantPromptCard below a selected VizPanel in dashboard view mode.
+ * Renders a floating AssistantPromptCard below a VizPanel in dashboard view mode.
  * Uses Floating UI for positioning and creates a portal to render outside the panel DOM hierarchy.
+ * Applies an animated gradient border to the active panel.
  */
-export function ViewModePanelPromptCard({ selection, editPane, dashboard }: ViewModePanelPromptCardProps) {
-  const selectedPanels = useSelectedVizPanels(selection);
-  const firstPanel = selectedPanels.length > 0 ? selectedPanels[0] : null;
+export function ViewModePanelPromptCard({ panel, hintEl, onClose }: ViewModePanelPromptCardProps) {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
 
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  // Walk up from the sparkle button to find the panel's <section> element.
+  // PanelChrome renders: <div> → <section class="...-panel-container"> → header → titleItems → button.
+  // Using `section[class*="panel-container"]` targets the individual panel precisely,
+  // even inside repeated rows/panels where a parent wrapper may also exist.
+  const anchorEl = useMemo(() => {
+    const section = hintEl.closest<HTMLElement>('section[class*="panel-container"]');
+    return section ?? hintEl;
+  }, [hintEl]);
 
-  useLayoutEffect(() => {
-    if (!firstPanel?.state.key) {
-      setAnchorEl(null);
-      return;
-    }
-    const el = findPanelDomElement(firstPanel.state.key, dashboard);
-    setAnchorEl(el);
-  }, [firstPanel, dashboard]);
+  // Apply animated border to the active panel's DOM element
+  const borderClass = useMemo(() => getAnimatedBorderClass(theme), [theme]);
+  useEffect(() => {
+    anchorEl.classList.add(borderClass);
+    return () => anchorEl.classList.remove(borderClass);
+  }, [anchorEl, borderClass]);
+
+  // Close the popover when the anchor element is removed from the DOM
+  // (e.g. when a row is collapsed). Polls via rAF because MutationObserver
+  // on the parent won't fire when a grandparent is removed, and the scene
+  // object may not deactivate when its React component unmounts.
+  useEffect(() => {
+    let rafId: number;
+    const check = () => {
+      if (!anchorEl.isConnected) {
+        onClose();
+        return;
+      }
+      rafId = requestAnimationFrame(check);
+    };
+    rafId = requestAnimationFrame(check);
+    return () => cancelAnimationFrame(rafId);
+  }, [anchorEl, onClose]);
 
   const { refs, floatingStyles, isPositioned } = useFloating({
     placement: 'bottom',
@@ -55,10 +75,10 @@ export function ViewModePanelPromptCard({ selection, editPane, dashboard }: View
 
   useEffect(() => {
     setVisible(false);
-  }, [anchorEl]);
+  }, [panel]);
 
   useEffect(() => {
-    if (!anchorEl || !isPositioned) {
+    if (!isPositioned) {
       setVisible(false);
       return;
     }
@@ -66,23 +86,32 @@ export function ViewModePanelPromptCard({ selection, editPane, dashboard }: View
       requestAnimationFrame(() => setVisible(true));
     });
     return () => cancelAnimationFrame(raf);
-  }, [anchorEl, isPositioned]);
+  }, [isPositioned, panel]);
 
-  const context = usePanelsContext(selectedPanels);
-  const promptPlaceholder =
-    selectedPanels.length > 1
-      ? t('dashboard.panel-assistant.prompt-card.placeholder-multi', 'Ask Assistant about these panels...')
-      : t('dashboard.panel-assistant.prompt-card.placeholder', 'Ask Assistant about this panel...');
+  const context = useMemo(
+    () => [
+      createAssistantContextItem('structured', {
+        title: panel.state.title || 'Panel',
+        data: {
+          panelKey: panel.state.key,
+          panelTitle: panel.state.title,
+          pluginId: panel.state.pluginId,
+        },
+      }),
+    ],
+    [panel]
+  );
+
+  const promptPlaceholder = t('dashboard.panel-assistant.prompt-card.placeholder', 'Ask Assistant about this panel...');
 
   const closedExplicitlyRef = useRef(false);
-  const selectedPanelKeys = useMemo(() => selectedPanels.map((p) => p.state.key).join(','), [selectedPanels]);
 
   useEffect(() => {
-    if (visible && selectedPanels.length > 0) {
+    if (visible) {
       closedExplicitlyRef.current = false;
       reportInteraction('dashboards_assistant_popover_displayed', {
-        panelCount: selectedPanels.length,
-        pluginIds: selectedPanels.map((p) => p.state.pluginId),
+        panelCount: 1,
+        pluginIds: [panel.state.pluginId],
       });
 
       return () => {
@@ -93,24 +122,24 @@ export function ViewModePanelPromptCard({ selection, editPane, dashboard }: View
     }
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, selectedPanelKeys]);
+  }, [visible, panel]);
 
   const handleClose = useCallback(() => {
     closedExplicitlyRef.current = true;
     reportInteraction('dashboards_assistant_popover_closed', { action: 'escape' });
-    editPane.clearSelection(true);
-  }, [editPane]);
+    onClose();
+  }, [onClose]);
 
   const handleSubmit = useCallback(
     (prompt: string) => {
       closedExplicitlyRef.current = true;
       reportInteraction('dashboards_assistant_popover_prompt_submitted', {
-        panelCount: selectedPanels.length,
+        panelCount: 1,
         promptLength: prompt.length,
       });
-      editPane.clearSelection(true);
+      onClose();
     },
-    [editPane, selectedPanels]
+    [onClose]
   );
 
   const hiddenStyle = {
@@ -128,76 +157,18 @@ export function ViewModePanelPromptCard({ selection, editPane, dashboard }: View
       className={visible ? styles.floatingContainer : undefined}
       data-testid="view-mode-panel-prompt-card"
     >
-      {firstPanel && anchorEl && (
-        <AssistantPromptCard
-          origin="grafana/dashboard/panel-popover"
-          context={context}
-          placeholder={promptPlaceholder}
-          animated={false}
-          onClose={handleClose}
-          onSubmit={handleSubmit}
-          className={styles.card}
-        />
-      )}
+      <AssistantPromptCard
+        origin="grafana/dashboard/panel-popover"
+        context={context}
+        placeholder={promptPlaceholder}
+        animated={false}
+        onClose={handleClose}
+        onSubmit={handleSubmit}
+        className={styles.card}
+      />
     </div>,
     document.body
   );
-}
-
-function useSelectedVizPanels(selection: ElementSelection | undefined): VizPanel[] {
-  return useMemo(() => {
-    if (!selection) {
-      return [];
-    }
-
-    const selected = selection.getSelection();
-    if (Array.isArray(selected)) {
-      return selected.filter((obj): obj is VizPanel => obj instanceof VizPanel && panelHasData(obj));
-    }
-    if (selected instanceof VizPanel && panelHasData(selected)) {
-      return [selected];
-    }
-    return [];
-  }, [selection]);
-}
-
-function findPanelDomElement(panelKey: string, dashboard: SceneObject): HTMLElement | null {
-  try {
-    const panel = sceneGraph.findByKey(dashboard, panelKey);
-    if (!panel) {
-      return null;
-    }
-
-    let current: SceneObject | undefined = panel;
-    while (current) {
-      if (hasContainerRef(current) && current.containerRef?.current) {
-        return current.containerRef.current;
-      }
-      current = current.parent;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function usePanelsContext(panels: VizPanel[]) {
-  return useMemo(() => {
-    if (panels.length === 0) {
-      return undefined;
-    }
-
-    return panels.map((panel) =>
-      createAssistantContextItem('structured', {
-        title: panel.state.title || 'Panel',
-        data: {
-          panelKey: panel.state.key,
-          panelTitle: panel.state.title,
-          pluginId: panel.state.pluginId,
-        },
-      })
-    );
-  }, [panels]);
 }
 
 const popIn = keyframes({
@@ -220,12 +191,4 @@ function getStyles(theme: GrafanaTheme2) {
       width: '100%',
     }),
   };
-}
-
-interface WithContainerRef {
-  containerRef?: { current: HTMLElement | null };
-}
-
-function hasContainerRef(obj: SceneObject): obj is SceneObject & WithContainerRef {
-  return 'containerRef' in obj;
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -45,6 +45,17 @@ jest.mock('@grafana/assistant', () => ({
   }),
 }));
 
+jest.mock('app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider', () => ({
+  useExtensionSidebarContext: jest.fn().mockReturnValue({
+    isOpen: false,
+    dockedComponentId: undefined,
+    setDockedComponentId: jest.fn(),
+    availableComponents: new Map(),
+    extensionSidebarWidth: 400,
+    setExtensionSidebarWidth: jest.fn(),
+  }),
+}));
+
 export function buildTestScene() {
   const testScene = new DashboardScene({
     $variables: new SceneVariableSet({ variables: [] }),

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -78,26 +78,41 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   });
 
   // --- Assistant popover state (decoupled from selection system) ---
-  // Stores both the VizPanel reference and the panel's DOM element directly,
-  // avoiding findByKey/containerRef ambiguity with repeated/cloned panels.
-  const [popoverTarget, setPopoverTarget] = useState<PopoverTarget | null>(null);
+  // Stores an array of PopoverTargets to support multi-panel context.
+  // Once the popover is open, clicking another sparkle adds that panel;
+  // clicking the same sparkle again removes it (toggle).
+  const [popoverTargets, setPopoverTargets] = useState<PopoverTarget[]>([]);
 
   // Close popover when entering edit mode
   useEffect(() => {
     if (isEditing) {
-      setPopoverTarget(null);
+      setPopoverTargets([]);
     }
   }, [isEditing]);
 
-  const clearPopover = useCallback(() => setPopoverTarget(null), []);
-  usePopoverDismissOnClickOutside(popoverTarget, clearPopover);
+  const clearPopover = useCallback(() => setPopoverTargets([]), []);
+  usePopoverDismissOnClickOutside(popoverTargets.length > 0, clearPopover);
 
   const popoverContextValue = useMemo(
     () => ({
-      openPopover: (panel: VizPanel, anchorEl: HTMLElement) => {
-        // Always show the popover — clicking the sparkle button is an intentional action.
-        // The AssistantPromptCard will send the prompt to the already-open sidebar if present.
-        setPopoverTarget((prev) => (prev?.panel === panel ? null : { panel, anchorEl }));
+      openPopover: (panel: VizPanel, anchorEl: HTMLElement, multi: boolean) => {
+        setPopoverTargets((prev) => {
+          const exists = prev.findIndex((t) => t.panel === panel);
+
+          if (multi) {
+            // Shift+click: toggle panel in/out of the selection
+            if (exists >= 0) {
+              return prev.filter((_, i) => i !== exists);
+            }
+            return [...prev, { panel, anchorEl }];
+          }
+
+          // Plain click: replace selection, or toggle off if already the only one
+          if (exists >= 0 && prev.length === 1) {
+            return [];
+          }
+          return [{ panel, anchorEl }];
+        });
       },
     }),
     []
@@ -204,7 +219,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     );
   }
 
-  const showPopover = !isEditing && isAssistantEnabled && popoverTarget !== null;
+  const showPopover = !isEditing && isAssistantEnabled && popoverTargets.length > 0;
 
   return (
     <AssistantPopoverContext.Provider value={popoverContextValue}>
@@ -214,13 +229,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
             {controls}
           </div>
           {renderBody()}
-          {showPopover && (
-            <ViewModePanelPromptCard
-              panel={popoverTarget.panel}
-              hintEl={popoverTarget.anchorEl}
-              onClose={clearPopover}
-            />
-          )}
+          {showPopover && <ViewModePanelPromptCard targets={popoverTargets} onClose={clearPopover} />}
         </ElementSelectionContext.Provider>
       </div>
     </AssistantPopoverContext.Provider>

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -1,10 +1,10 @@
 import { css, cx } from '@emotion/css';
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, useChromeHeaderHeight } from '@grafana/runtime';
-import { useSceneObjectState } from '@grafana/scenes';
+import { VizPanel, useSceneObjectState } from '@grafana/scenes';
 import { ElementSelectionContext, useSidebar, useStyles2, Sidebar } from '@grafana/ui';
 import NativeScrollbar, { DivScrollElement } from 'app/core/components/NativeScrollbar';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -12,7 +12,11 @@ import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { KioskMode } from 'app/types/dashboard';
 
-import { getAssistantViewModeStyles, useDashboardAssistantViewMode } from '../assistant/DashboardAssistantViewMode';
+import { type PopoverTarget, AssistantPopoverContext } from '../assistant/AssistantPopoverContext';
+import {
+  useDashboardAssistantViewMode,
+  usePopoverDismissOnClickOutside,
+} from '../assistant/DashboardAssistantViewMode';
 import { ViewModePanelPromptCard } from '../assistant/ViewModePanelPromptCard';
 import { DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
@@ -57,7 +61,6 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   const headerHeight = useChromeHeaderHeight();
   const { editPane } = dashboard.state;
   const styles = useStyles2(getStyles, headerHeight ?? 0);
-  const assistantStyles = useStyles2(getAssistantViewModeStyles);
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
   const { isPlaying } = playlistSrv.useState();
@@ -67,25 +70,52 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
    */
   useUpdateAppChromeActions(dashboard);
 
-  const { selectionContext, openPane, selection } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
+  const { selectionContext, openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
 
-  const { isEnabled: isAssistantEnabled, isViewModeWithPanelSelected } = useDashboardAssistantViewMode({
+  const { isEnabled: isAssistantEnabled } = useDashboardAssistantViewMode({
     dashboard,
-    editPane,
     isEditing,
-    selection,
   });
+
+  // --- Assistant popover state (decoupled from selection system) ---
+  // Stores both the VizPanel reference and the panel's DOM element directly,
+  // avoiding findByKey/containerRef ambiguity with repeated/cloned panels.
+  const [popoverTarget, setPopoverTarget] = useState<PopoverTarget | null>(null);
+
+  // Close popover when entering edit mode
+  useEffect(() => {
+    if (isEditing) {
+      setPopoverTarget(null);
+    }
+  }, [isEditing]);
+
+  const clearPopover = useCallback(() => setPopoverTarget(null), []);
+  usePopoverDismissOnClickOutside(popoverTarget, clearPopover);
+
+  const popoverContextValue = useMemo(
+    () => ({
+      openPopover: (panel: VizPanel, anchorEl: HTMLElement) => {
+        // Always show the popover — clicking the sparkle button is an intentional action.
+        // The AssistantPromptCard will send the prompt to the already-open sidebar if present.
+        setPopoverTarget((prev) => (prev?.panel === panel ? null : { panel, anchorEl }));
+      },
+    }),
+    []
+  );
 
   const CODE_PANE_MIN_WIDTH = 700;
   const originalPaneWidthRef = useRef<number | null>(null);
   const previousPaneRef = useRef<DashboardSidebarPaneName | undefined>(undefined);
+
+  // Selection is only needed in edit mode — the assistant popover is triggered
+  // exclusively via the sparkle button, not through the selection system.
   useEffect(() => {
-    if (isEditing || isAssistantEnabled) {
+    if (isEditing) {
       editPane.enableSelection();
     } else {
       editPane.disableSelection();
     }
-  }, [isEditing, isAssistantEnabled, editPane]);
+  }, [isEditing, editPane]);
 
   const sidebarContext = useSidebar({
     hasOpenPane: Boolean(openPane) && Boolean(isEditing),
@@ -174,24 +204,26 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     );
   }
 
+  const showPopover = !isEditing && isAssistantEnabled && popoverTarget !== null;
+
   return (
-    <div
-      className={cx(
-        styles.container,
-        !isEditing && isAssistantEnabled && assistantStyles.viewModeHoverOverride,
-        isViewModeWithPanelSelected && assistantStyles.viewModeAnimatedBorder
-      )}
-    >
-      <ElementSelectionContext.Provider value={selectionContext}>
-        <div className={styles.controlsWrapperSticky} onPointerDown={onClearSelection}>
-          {controls}
-        </div>
-        {renderBody()}
-        {isViewModeWithPanelSelected && (
-          <ViewModePanelPromptCard selection={selection} editPane={editPane} dashboard={dashboard} />
-        )}
-      </ElementSelectionContext.Provider>
-    </div>
+    <AssistantPopoverContext.Provider value={popoverContextValue}>
+      <div className={styles.container}>
+        <ElementSelectionContext.Provider value={selectionContext}>
+          <div className={styles.controlsWrapperSticky} onPointerDown={onClearSelection}>
+            {controls}
+          </div>
+          {renderBody()}
+          {showPopover && (
+            <ViewModePanelPromptCard
+              panel={popoverTarget.panel}
+              hintEl={popoverTarget.anchorEl}
+              onClose={clearPopover}
+            />
+          )}
+        </ElementSelectionContext.Provider>
+      </div>
+    </AssistantPopoverContext.Provider>
   );
 }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5999,7 +5999,8 @@
         "aria-label": "Open assistant for this panel"
       },
       "prompt-card": {
-        "placeholder": "Ask Assistant about this panel..."
+        "placeholder": "Ask Assistant about this panel...",
+        "placeholder-multi": "Ask Assistant about these panels..."
       }
     },
     "panel-edit": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5995,9 +5995,11 @@
       }
     },
     "panel-assistant": {
+      "hint": {
+        "aria-label": "Open assistant for this panel"
+      },
       "prompt-card": {
-        "placeholder": "Ask Assistant about this panel...",
-        "placeholder-multi": "Ask Assistant about these panels..."
+        "placeholder": "Ask Assistant about this panel..."
       }
     },
     "panel-edit": {


### PR DESCRIPTION
## Fix assistant popover mobile UX and interaction issues

  Follow-up to #120051 addressing community feedback on the dashboard assistant popover.

  ### Problems

  1. **Mobile**: Clicking panels opens the popover and auto-focuses the input, triggering the virtual keyboard and taking over the screen
  2. **Overzealous trigger**: Any panel body click (including table column resizes) opens the popover
  3. **Row hover**: Hovering a row shows sparkle icons on ALL panels inside it, not just the hovered panel
  4. **Esc persistence**: Pressing Escape while the kebab menu is open causes the popover to persist
  5. **Repeated panels**: Clicking a sparkle in a repeated row/panel targets the wrong panel (first instance)

  ### Solution

  **Decouple the popover from the element selection system.** The popover is now triggered exclusively via the sparkle button, not through
  panel body clicks.

  - **Mobile**: Popover disabled below `md` breakpoint (768px) via `useMediaQueryMinWidth`. The `AssistantPromptCard` (from
  `@grafana/assistant`) auto-focuses its text input on mount, which triggers the virtual keyboard on mobile and takes over the screen. The card is also hardcoded to 380px wide, which doesn't fit mobile viewports. Since we can't control the auto-focus from the consumer side, disabling on small screens is the simplest fix. A better long-term solution would be adding an `autoFocus` prop to `AssistantPromptCard`.
  - **Sparkle-only trigger**: New `AssistantPopoverContext` lets the hint button open the popover directly, bypassing element selection. Panel body clicks, table resizes, and other interactions no longer interfere.
  - **Row hover fix**: CSS scoped to `section[class*="panel-container"]:hover` — only the individual PanelChrome `<section>` triggers the sparkle, not parent row wrappers.
  - **Repeated panels**: VizPanel reference + DOM element passed directly from the clicked sparkle button (via
  `closest('section[class*="panel-container"]')`), avoiding `sceneGraph.findByKey` ambiguity with cloned panels that share keys.
  - **Accessibility**: Sparkle hint changed from `<span>` to `<button>` with `aria-label`.
  - **Dismiss**: Click-outside handler via `usePopoverDismissOnClickOutside`, Escape via `AssistantPromptCard.onClose`, toggle on re-click.


  ### How to test

  Enable: `dashboardNewLayouts`, `dashboardAssistantPopover`, `extensionSidebar`, `externalServiceAccounts`. Assistant plugin installed, user  signed in.

  1. **Sparkle button only** — click panel body → nothing happens; click sparkle → popover appears
  2. **Table column resize** — drag table column headers → no popover
  3. **Row hover** — hover row header → no sparkle on nested panels; hover individual panel → sparkle appears
  4. **Dismiss** — Escape closes; click outside closes; click same sparkle toggles off
  5. **Repeated panels** — sparkle targets the exact panel clicked, not the first instance
  6. **Mobile** — Chrome DevTools device toolbar, viewport < 768px → no sparkle, no popover
  7. **Edit mode** — normal panel selection works, no popover interference