### PR TITLE
Alerting: Fix Alert Activity group-by showing same firing count for all groups

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/dataTransform.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/dataTransform.test.ts
@@ -1508,7 +1508,7 @@ describe('convertToWorkbenchRows', () => {
       ]);
     });
 
-    it('should use global rule counts when same rule appears in multiple groups', () => {
+    it('should use per-group rule counts when same rule appears in multiple groups', () => {
       const result = convertToWorkbenchRows(
         [
           {
@@ -1552,7 +1552,7 @@ describe('convertToWorkbenchRows', () => {
         ['team']
       );
 
-      // Both groups get the global summed counts for uid1: firing=5+8=13, pending=2+3=5
+      // Each group gets its own scoped count: backend firing=5,pending=2; frontend firing=8,pending=3
       expect(result).toEqual([
         {
           type: 'group',
@@ -1561,10 +1561,10 @@ describe('convertToWorkbenchRows', () => {
             {
               type: 'alertRule',
               metadata: { title: 'Alert1', folder: 'Folder1', ruleUID: 'uid1' },
-              instanceCounts: { firing: 13, pending: 5 },
+              instanceCounts: { firing: 5, pending: 2 },
             },
           ],
-          instanceCounts: { firing: 13, pending: 5 },
+          instanceCounts: { firing: 5, pending: 2 },
         },
         {
           type: 'group',
@@ -1573,10 +1573,10 @@ describe('convertToWorkbenchRows', () => {
             {
               type: 'alertRule',
               metadata: { title: 'Alert1', folder: 'Folder1', ruleUID: 'uid1' },
-              instanceCounts: { firing: 13, pending: 5 },
+              instanceCounts: { firing: 8, pending: 3 },
             },
           ],
-          instanceCounts: { firing: 13, pending: 5 },
+          instanceCounts: { firing: 8, pending: 3 },
         },
       ]);
     });

--- a/public/app/features/alerting/unified/triage/scene/dataTransform.ts
+++ b/public/app/features/alerting/unified/triage/scene/dataTransform.ts
@@ -17,16 +17,20 @@ function sumCounts(rows: WorkbenchRow[]): InstanceCounts {
 }
 
 /**
- * Pre-computes a map of ruleUID → InstanceCounts by summing Values per (ruleUID, alertstate).
+ * Pre-computes a map of (ruleUID[+groupValues]) → InstanceCounts by summing Values per
+ * (ruleUID, alertstate[, groupValue…]).
  *
  * Expects single-timestamp instant query data where deduplication has already been done
  * at the PromQL level. When groupBy labels are active the query produces multiple rows
- * per (ruleUID, alertstate) — one per group value — which are summed together.
+ * per (ruleUID, alertstate) — one per group value combination. The composite key
+ * `ruleUID:groupVal1:groupVal2:…` preserves the per-group breakdown so that each group
+ * can display its own count rather than a global total.
  */
 function buildRuleCountsMap(
   frame: DataFrame,
   fieldIndex: Map<string, number>,
-  ruleUIDValues: DataFrame['fields'][number]['values']
+  ruleUIDValues: DataFrame['fields'][number]['values'],
+  groupByValueArrays: Array<DataFrame['fields'][number]['values'] | undefined>
 ): Map<string, InstanceCounts> {
   const alertstateIdx = fieldIndex.get(FIELD_NAMES.alertstate);
   const valueIdx = fieldIndex.get(FIELD_NAMES.value);
@@ -49,10 +53,15 @@ function buildRuleCountsMap(
       continue;
     }
 
-    let counts = result.get(ruleUID);
+    const key =
+      groupByValueArrays.length > 0
+        ? `${ruleUID}:${groupByValueArrays.map((arr) => arr?.[i] ?? '').join(':')}`
+        : ruleUID;
+
+    let counts = result.get(key);
     if (!counts) {
       counts = { firing: 0, pending: 0 };
-      result.set(ruleUID, counts);
+      result.set(key, counts);
     }
 
     if (alertstate === 'firing') {
@@ -126,18 +135,19 @@ export function convertToWorkbenchRows(series: DataFrame[], groupBy: string[] = 
 
   const { alertname: alertnameValues, folder: folderValues, ruleUID: ruleUIDValues } = fields;
 
-  // Pre-compute instance counts per rule
-  const ruleCountsMap = buildRuleCountsMap(frame, fieldIndex, ruleUIDValues);
-
-  function getRuleCounts(ruleUID: string): InstanceCounts {
-    return ruleCountsMap.get(ruleUID) ?? EMPTY_COUNTS;
-  }
-
   // Get groupBy field value arrays
   const groupByValueArrays = groupBy.map((key) => {
     const index = fieldIndex.get(key);
     return index !== undefined ? frame.fields[index]?.values : undefined;
   });
+
+  // Pre-compute instance counts per rule (keyed by ruleUID[:groupVal…] when groupBy is active)
+  const ruleCountsMap = buildRuleCountsMap(frame, fieldIndex, ruleUIDValues, groupByValueArrays);
+
+  function getRuleCounts(ruleUID: string, groupPath: string[] = []): InstanceCounts {
+    const key = groupPath.length > 0 ? `${ruleUID}:${groupPath.join(':')}` : ruleUID;
+    return ruleCountsMap.get(key) ?? EMPTY_COUNTS;
+  }
 
   // Fast path: no grouping - just dedupe alert rules
   if (groupBy.length === 0) {
@@ -200,9 +210,9 @@ export function convertToWorkbenchRows(series: DataFrame[], groupBy: string[] = 
   }
 
   // Convert tree to WorkbenchRow format
-  function nodeToRows(node: GroupNode, depth: number): WorkbenchRow[] {
+  function nodeToRows(node: GroupNode, depth: number, groupPath: string[] = []): WorkbenchRow[] {
     if (depth >= groupBy.length) {
-      // Leaf level - create alert rule rows
+      // Leaf level - create alert rule rows with per-group counts
       const seen = new Set<string>();
       const result: AlertRuleRow[] = [];
 
@@ -217,7 +227,7 @@ export function convertToWorkbenchRows(series: DataFrame[], groupBy: string[] = 
               folder: folderValues[rowIdx],
               ruleUID: ruleUID,
             },
-            instanceCounts: getRuleCounts(ruleUID),
+            instanceCounts: getRuleCounts(ruleUID, groupPath),
           });
         }
       }
@@ -230,7 +240,8 @@ export function convertToWorkbenchRows(series: DataFrame[], groupBy: string[] = 
     const emptyGroups: GenericGroupedRow[] = [];
 
     for (const [value, childNode] of node.children.entries()) {
-      const childRows = nodeToRows(childNode, depth + 1);
+      const rawGroupValue = value === EmptyLabelValue ? '' : String(value);
+      const childRows = nodeToRows(childNode, depth + 1, [...groupPath, rawGroupValue]);
       const group: GenericGroupedRow = {
         type: 'group',
         metadata: {


### PR DESCRIPTION
**What is this feature?**

Bug fix for the Alert Activity page: when using **Group by**, all group rows were displaying the same total firing count instead of a per-group count.

**Why do we need this feature?**

A customer reported that grouping by `k8s_cluster_name` showed the same count (e.g. 56) under both `hcp-rosa-nonprod2` and `hcp-rosa-prod1`, rather than the correct split counts per cluster.

The root cause was in `buildRuleCountsMap()`: it used only `ruleUID` as its map key, so when the same alert rule had instances across multiple group values, all counts were collapsed into a single global total per rule. Every group then received that same total.

The fix uses a composite key (`ruleUID:groupVal1:groupVal2:…`) when groupBy is active, and threads the current group path through the `nodeToRows` recursion so each leaf node looks up its own scoped count.

**Who is this feature for?**

Users of the Alert Activity page who use the Group by feature.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The fix is entirely in `dataTransform.ts` — no query or scene changes needed. The PromQL query was already producing correctly split rows per group; it was the count aggregation step that was losing the per-group breakdown.
- One existing test explicitly asserted the buggy behaviour ("should use global rule counts when same rule appears in multiple groups") — it has been updated to expect the correct per-group split counts.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.