### PR TITLE
perf(unified-storage): batch sqlkv bulk writes

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -76,6 +76,11 @@ type DataObj struct {
 	Value io.ReadCloser
 }
 
+type dataSaveRequest struct {
+	Key   DataKey
+	Value []byte
+}
+
 // TODO: pull DataKey from kv/sqlkv into here once we don't need sql/backend backwards compatibility
 type DataKey = kvpkg.DataKey
 
@@ -545,6 +550,40 @@ func (d *dataStore) Save(ctx context.Context, key DataKey, value io.Reader) erro
 	}
 
 	return writer.Close()
+}
+
+func (d *dataStore) batchSave(ctx context.Context, requests []dataSaveRequest) error {
+	for len(requests) > 0 {
+		batch := requests
+		if len(batch) > kvpkg.MaxBatchOps {
+			batch = batch[:kvpkg.MaxBatchOps]
+		}
+
+		requests = requests[len(batch):]
+		ops := make([]kvpkg.BatchOp, 0, len(batch))
+		for _, req := range batch {
+			if err := validateDataKey(req.Key); err != nil {
+				return fmt.Errorf("invalid data key: %w", err)
+			}
+
+			key := req.Key.String()
+			if req.Key.GUID != "" {
+				key = req.Key.StringWithGUID()
+			}
+
+			ops = append(ops, kvpkg.BatchOp{
+				Mode:  kvpkg.BatchOpPut,
+				Key:   key,
+				Value: req.Value,
+			})
+		}
+
+		if err := d.kv.Batch(ctx, dataSection, ops); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (d *dataStore) Delete(ctx context.Context, key DataKey) error {

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -180,6 +180,8 @@ func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, 
 	return query, []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
 }
 
+// buildUpsertDatastoreQuery generates an UPSERT for datastore rows.
+// It preserves the existing guid and placeholder columns on conflict and only refreshes the stored value.
 // buildInsertDatastoreBackwardCompatQuery generates INSERT for backward-compatible mode
 // Inserts guid, value, and placeholder values for NOT NULL columns - these will be updated by applyBackwardsCompatibleChanges()
 func (qb *queryBuilder) buildInsertDatastoreBackwardCompatQuery(value []byte, guid, group, resource, namespace, name, folder string, action int64) (string, []interface{}) {

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -180,8 +180,6 @@ func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, 
 	return query, []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
 }
 
-// buildUpsertDatastoreQuery generates an UPSERT for datastore rows.
-// It preserves the existing guid and placeholder columns on conflict and only refreshes the stored value.
 // buildInsertDatastoreBackwardCompatQuery generates INSERT for backward-compatible mode
 // Inserts guid, value, and placeholder values for NOT NULL columns - these will be updated by applyBackwardsCompatibleChanges()
 func (qb *queryBuilder) buildInsertDatastoreBackwardCompatQuery(value []byte, guid, group, resource, namespace, name, folder string, action int64) (string, []interface{}) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -382,7 +382,72 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 }
 
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
-	return fmt.Errorf("Batch operation not implemented for sqlKV")
+	if len(ops) == 0 {
+		return nil
+	}
+	if len(ops) > MaxBatchOps {
+		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
+	}
+	if section == LastImportTimeSection {
+		return fmt.Errorf("batch operation not supported for section: %s", section)
+	}
+
+	qb, err := k.getQueryBuilder(section)
+	if err != nil {
+		return err
+	}
+
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin batch transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	for i, op := range ops {
+		if op.Key == "" {
+			return &BatchError{Err: fmt.Errorf("key is required"), Index: i, Op: op}
+		}
+
+		keyPath := getKeyPath(section, op.Key)
+
+		switch op.Mode {
+		case BatchOpPut:
+			if len(op.Value) == 0 {
+				return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+			}
+
+			var query string
+			var args []interface{}
+			if section == DataSection {
+				query, args = qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+			} else {
+				query, args = qb.buildUpsertQuery(keyPath, op.Value)
+			}
+
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		case BatchOpDelete:
+			query, args := qb.buildDeleteQuery(keyPath)
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		default:
+			return &BatchError{
+				Err:   fmt.Errorf("unsupported batch operation mode for sqlkv: %d", op.Mode),
+				Index: i,
+				Op:    op,
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit batch transaction: %w", err)
+	}
+
+	return nil
 }
 
 func (k *SqlKV) UnixTimestamp(ctx context.Context) (int64, error) {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1779,115 +1779,54 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	updatedResources := make(map[NamespacedResource]bool)
 	// Track the last micro RV per resource name for computing previous_resource_version in compat mode.
 	lastMicroRV := make(map[string]int64)
+	resourceExists := make(map[string]bool)
 
-	for iter.Next() {
-		if iter.RollbackRequested() {
+	batchIter, ok := iter.(BulkRequestBatchIterator)
+	if !ok {
+		batchIter = &singleRequestBatchIterator{iter: iter}
+	}
+
+	for batchIter.NextBatch() {
+		if batchIter.RollbackRequested() {
 			rollback()
 			break
 		}
 
-		req := iter.Request()
-		if req == nil {
+		batch := batchIter.Batch()
+		if len(batch) == 0 {
 			rollback()
-			rsp.Error = AsErrorResult(fmt.Errorf("missing request"))
+			rsp.Error = AsErrorResult(fmt.Errorf("missing request batch"))
 			break
 		}
 
-		rsp.Processed++
-
-		var action kv.DataAction
-		switch resourcepb.WatchEvent_Type(req.Action) {
-		case resourcepb.WatchEvent_ADDED:
-			action = DataActionCreated
-			// Check if resource already exists for create operations
-			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
-				Group:     req.Key.Group,
-				Resource:  req.Key.Resource,
-				Namespace: req.Key.Namespace,
-				Name:      req.Key.Name,
-			})
-			if err == nil {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  "resource already exists",
-				})
-				continue
-			}
-			if !errors.Is(err, ErrNotFound) {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
-				})
-				continue
-			}
-		case resourcepb.WatchEvent_MODIFIED:
-			action = DataActionUpdated
-		case resourcepb.WatchEvent_DELETED:
-			action = DataActionDeleted
-		default:
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  "invalid event type",
-			})
+		prepared := prepareBulkRequests(batch, bulkRvGenerator, rsp, resourceExists)
+		if len(prepared) == 0 {
 			continue
 		}
 
-		obj := &unstructured.Unstructured{}
-		err := obj.UnmarshalJSON(req.Value)
-		if err != nil {
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  "unable to unmarshal json",
-			})
+		if err := b.dataStore.batchSave(ctx, buildDataSaveRequests(prepared)); err != nil {
+			for _, entry := range prepared {
+				if err := b.dataStore.Save(ctx, entry.dataKey, bytes.NewReader(entry.req.Value)); err != nil {
+					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+						Key:    entry.req.Key,
+						Action: entry.req.Action,
+						Error:  fmt.Sprintf("failed to save resource: %s", err),
+					})
+					continue
+				}
+				saved = append(saved, entry.dataKey)
+				if !b.recordBulkSave(ctx, entry, updatedResources, lastMicroRV, resourceExists) {
+					return rsp
+				}
+			}
 			continue
 		}
 
-		dataKey := DataKey{
-			Group:           req.Key.Group,
-			Resource:        req.Key.Resource,
-			Namespace:       req.Key.Namespace,
-			Name:            req.Key.Name,
-			ResourceVersion: bulkRvGenerator.next(obj),
-			Action:          action,
-			Folder:          req.Folder,
-		}
-		err = b.dataStore.Save(ctx, dataKey, bytes.NewReader(req.Value))
-		if err != nil {
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  fmt.Sprintf("failed to save resource: %s", err),
-			})
-			continue
-		}
-
-		saved = append(saved, dataKey)
-		updatedResources[NamespacedResource{Namespace: dataKey.Namespace, Group: dataKey.Group, Resource: dataKey.Resource}] = true
-
-		// Fill in legacy columns on the resource_history row that was just inserted with only key_path and value.
-		if b.rvManager != nil {
-			microRV := rvmanager.RVFromBulkSnowflake(dataKey.ResourceVersion)
-			generation := obj.GetGeneration()
-			if action == DataActionDeleted {
-				generation = 0
-			}
-
-			// For creates, previous RV is 0. For updates/deletes, it's the RV of the previous event for this resource.
-			nameKey := dataKey.Group + "/" + dataKey.Resource + "/" + dataKey.Namespace + "/" + dataKey.Name
-			var previousRV int64
-			if action != DataActionCreated {
-				previousRV = lastMicroRV[nameKey]
-			}
-
-			if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, b.rvManager.DB(), dataKey, microRV, previousRV, generation); err != nil {
-				b.log.Error("failed to update legacy resource_history for bulk", "error", err)
+		for _, entry := range prepared {
+			saved = append(saved, entry.dataKey)
+			if !b.recordBulkSave(ctx, entry, updatedResources, lastMicroRV, resourceExists) {
 				return rsp
 			}
-			lastMicroRV[nameKey] = microRV
 		}
 	}
 
@@ -1924,6 +1863,177 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	}
 
 	return rsp
+}
+
+type preparedBulkRequest struct {
+	req         *resourcepb.BulkRequest
+	obj         *unstructured.Unstructured
+	dataKey     DataKey
+	resourceKey string
+	existsAfter bool
+}
+
+func prepareBulkRequests(batch []*resourcepb.BulkRequest, bulkRvGenerator *bulkRV, rsp *resourcepb.BulkResponse, resourceExists map[string]bool) []preparedBulkRequest {
+	nextExists := make(map[string]bool, len(resourceExists))
+	for key, exists := range resourceExists {
+		nextExists[key] = exists
+	}
+
+	prepared := make([]preparedBulkRequest, 0, len(batch))
+	for _, req := range batch {
+		rsp.Processed++
+
+		entry, reject := prepareBulkRequest(req, bulkRvGenerator, nextExists)
+		if reject != nil {
+			rsp.Rejected = append(rsp.Rejected, reject)
+			continue
+		}
+
+		prepared = append(prepared, entry)
+	}
+
+	return prepared
+}
+
+func prepareBulkRequest(req *resourcepb.BulkRequest, bulkRvGenerator *bulkRV, resourceExists map[string]bool) (preparedBulkRequest, *resourcepb.BulkResponse_Rejected) {
+	resourceKey := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
+
+	var action kv.DataAction
+	switch resourcepb.WatchEvent_Type(req.Action) {
+	case resourcepb.WatchEvent_ADDED:
+		action = DataActionCreated
+		if resourceExists[resourceKey] {
+			return preparedBulkRequest{}, &resourcepb.BulkResponse_Rejected{
+				Key:    req.Key,
+				Action: req.Action,
+				Error:  "resource already exists",
+			}
+		}
+	case resourcepb.WatchEvent_MODIFIED:
+		action = DataActionUpdated
+	case resourcepb.WatchEvent_DELETED:
+		action = DataActionDeleted
+	default:
+		return preparedBulkRequest{}, &resourcepb.BulkResponse_Rejected{
+			Key:    req.Key,
+			Action: req.Action,
+			Error:  "invalid event type",
+		}
+	}
+
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(req.Value); err != nil {
+		return preparedBulkRequest{}, &resourcepb.BulkResponse_Rejected{
+			Key:    req.Key,
+			Action: req.Action,
+			Error:  "unable to unmarshal json",
+		}
+	}
+
+	dataKey := DataKey{
+		Group:           req.Key.Group,
+		Resource:        req.Key.Resource,
+		Namespace:       req.Key.Namespace,
+		Name:            req.Key.Name,
+		ResourceVersion: bulkRvGenerator.next(obj),
+		Action:          action,
+		Folder:          req.Folder,
+	}
+	if err := validateDataKey(dataKey); err != nil {
+		return preparedBulkRequest{}, &resourcepb.BulkResponse_Rejected{
+			Key:    req.Key,
+			Action: req.Action,
+			Error:  fmt.Sprintf("failed to save resource: invalid data key: %s", err),
+		}
+	}
+
+	existsAfter := action != DataActionDeleted
+	resourceExists[resourceKey] = existsAfter
+
+	return preparedBulkRequest{
+		req:         req,
+		obj:         obj,
+		dataKey:     dataKey,
+		resourceKey: resourceKey,
+		existsAfter: existsAfter,
+	}, nil
+}
+
+func buildDataSaveRequests(prepared []preparedBulkRequest) []dataSaveRequest {
+	requests := make([]dataSaveRequest, 0, len(prepared))
+	for _, entry := range prepared {
+		requests = append(requests, dataSaveRequest{
+			Key:   entry.dataKey,
+			Value: entry.req.Value,
+		})
+	}
+	return requests
+}
+
+func (b *kvStorageBackend) recordBulkSave(
+	ctx context.Context,
+	entry preparedBulkRequest,
+	updatedResources map[NamespacedResource]bool,
+	lastMicroRV map[string]int64,
+	resourceExists map[string]bool,
+) bool {
+	resourceExists[entry.resourceKey] = entry.existsAfter
+	updatedResources[NamespacedResource{
+		Namespace: entry.dataKey.Namespace,
+		Group:     entry.dataKey.Group,
+		Resource:  entry.dataKey.Resource,
+	}] = true
+
+	if b.rvManager == nil {
+		return true
+	}
+
+	microRV := rvmanager.RVFromBulkSnowflake(entry.dataKey.ResourceVersion)
+	generation := entry.obj.GetGeneration()
+	if entry.dataKey.Action == DataActionDeleted {
+		generation = 0
+	}
+
+	var previousRV int64
+	if entry.dataKey.Action != DataActionCreated {
+		previousRV = lastMicroRV[entry.resourceKey]
+	}
+
+	if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, b.rvManager.DB(), entry.dataKey, microRV, previousRV, generation); err != nil {
+		b.log.Error("failed to update legacy resource_history for bulk", "error", err)
+		return false
+	}
+	lastMicroRV[entry.resourceKey] = microRV
+
+	return true
+}
+
+type singleRequestBatchIterator struct {
+	iter  BulkRequestIterator
+	batch []*resourcepb.BulkRequest
+}
+
+func (s *singleRequestBatchIterator) NextBatch() bool {
+	if !s.iter.Next() {
+		return false
+	}
+	if req := s.iter.Request(); req != nil {
+		if len(s.batch) == 0 {
+			s.batch = make([]*resourcepb.BulkRequest, 1)
+		}
+		s.batch[0] = req
+	} else {
+		s.batch = nil
+	}
+	return true
+}
+
+func (s *singleRequestBatchIterator) Batch() []*resourcepb.BulkRequest {
+	return s.batch
+}
+
+func (s *singleRequestBatchIterator) RollbackRequested() bool {
+	return s.iter.RollbackRequested()
 }
 
 // readAndClose reads all data from a ReadCloser and ensures it's closed,

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
+	kvpkg "github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -71,6 +72,52 @@ func TestNewKvStorageBackend(t *testing.T) {
 	assert.NotNil(t, backend.eventStore)
 	assert.NotNil(t, backend.notifier)
 	assert.NotNil(t, backend.snowflake)
+}
+
+func TestKvStorageBackendProcessBulkUsesBatchSaveForSQLKV(t *testing.T) {
+	countingKV := newCountingKV(setupSqlKV(t))
+	backend := setupTestStorageBackend(t, withKV(countingKV))
+	t.Cleanup(backend.Stop)
+
+	ns := NamespacedResource{
+		Namespace: "default",
+		Group:     "playlist.grafana.app",
+		Resource:  "playlists",
+	}
+
+	requests := make([]*resourcepb.BulkRequest, 0, 3)
+	for i := 1; i <= 3; i++ {
+		name := fmt.Sprintf("bulk-item-%d", i)
+		obj, err := createTestObjectWithName(name, ns, fmt.Sprintf("data-%d", i))
+		require.NoError(t, err)
+
+		requests = append(requests, &resourcepb.BulkRequest{
+			Key: &resourcepb.ResourceKey{
+				Namespace: ns.Namespace,
+				Group:     ns.Group,
+				Resource:  ns.Resource,
+				Name:      name,
+			},
+			Action: resourcepb.BulkRequest_ADDED,
+			Value:  objectToJSONBytes(t, obj),
+		})
+	}
+
+	resp := backend.ProcessBulk(context.Background(), BulkSettings{
+		Collection: []*resourcepb.ResourceKey{
+			{
+				Namespace: ns.Namespace,
+				Group:     ns.Group,
+				Resource:  ns.Resource,
+			},
+		},
+	}, &testBulkBatchIterator{batches: [][]*resourcepb.BulkRequest{requests}})
+
+	require.Nil(t, resp.Error)
+	require.Empty(t, resp.Rejected)
+	require.Equal(t, int64(len(requests)), resp.Processed)
+	require.Equal(t, 1, countingKV.batchCalls(kvpkg.DataSection))
+	require.Zero(t, countingKV.saveCalls(kvpkg.DataSection), "sqlkv batch error: %s", countingKV.batchErr(kvpkg.DataSection))
 }
 
 func TestKvStorageBackend_WriteEvent_Success(t *testing.T) {
@@ -2367,6 +2414,106 @@ func testClusterScopedResources(t *testing.T, backend *kvStorageBackend) {
 			t.Fatalf("Timeout waiting for event %d", i)
 		}
 	}
+}
+
+type countingKV struct {
+	KV
+	mu              sync.Mutex
+	batchCallsBySec map[string]int
+	batchErrBySec   map[string]string
+	saveCallsBySec  map[string]int
+}
+
+func newCountingKV(inner KV) *countingKV {
+	return &countingKV{
+		KV:              inner,
+		batchCallsBySec: make(map[string]int),
+		batchErrBySec:   make(map[string]string),
+		saveCallsBySec:  make(map[string]int),
+	}
+}
+
+func (k *countingKV) Save(ctx context.Context, section string, key string) (io.WriteCloser, error) {
+	k.mu.Lock()
+	k.saveCallsBySec[section]++
+	k.mu.Unlock()
+	return k.KV.Save(ctx, section, key)
+}
+
+func (k *countingKV) Batch(ctx context.Context, section string, ops []kvpkg.BatchOp) error {
+	k.mu.Lock()
+	k.batchCallsBySec[section]++
+	k.mu.Unlock()
+	err := k.KV.Batch(ctx, section, ops)
+	if err != nil {
+		k.mu.Lock()
+		k.batchErrBySec[section] = err.Error()
+		k.mu.Unlock()
+	}
+	return err
+}
+
+func (k *countingKV) batchCalls(section string) int {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.batchCallsBySec[section]
+}
+
+func (k *countingKV) saveCalls(section string) int {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.saveCallsBySec[section]
+}
+
+func (k *countingKV) batchErr(section string) string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.batchErrBySec[section]
+}
+
+type testBulkBatchIterator struct {
+	batches  [][]*resourcepb.BulkRequest
+	idx      int
+	batchIdx int
+	current  *resourcepb.BulkRequest
+}
+
+func (t *testBulkBatchIterator) NextBatch() bool {
+	if t.idx >= len(t.batches) {
+		return false
+	}
+	t.idx++
+	t.batchIdx = 0
+	return true
+}
+
+func (t *testBulkBatchIterator) Batch() []*resourcepb.BulkRequest {
+	if t.idx == 0 || t.idx > len(t.batches) {
+		return nil
+	}
+	return t.batches[t.idx-1]
+}
+
+func (t *testBulkBatchIterator) Next() bool {
+	if t.idx == 0 || t.idx > len(t.batches) {
+		return false
+	}
+	batch := t.batches[t.idx-1]
+	if t.batchIdx >= len(batch) {
+		t.current = nil
+		return false
+	}
+	t.current = batch[t.batchIdx]
+	t.batchIdx++
+	return true
+}
+
+func (t *testBulkBatchIterator) Request() *resourcepb.BulkRequest {
+	return t.current
+}
+
+func (t *testBulkBatchIterator) RollbackRequested() bool {
+	return false
 }
 
 func TestKvStorageBackend_prunerHistoryLimit(t *testing.T) {


### PR DESCRIPTION
This follows up on the merged bulk-batching work by extending the KV backend bulk import path when it is backed by SQLKV. The goal is to stop issuing one resource_history write per item and instead flush bulk-import history rows through SQLKV batches while keeping the existing per-request rejection behavior.

The change adds batched datastore writes for bulk imports, implements SqlKV batch support for the operations this path needs, and falls back to sequential saves only if a batch write fails. Coverage includes a SQLKV-specific bulk test that asserts data writes go through Batch, plus existing KV write and cluster-scoped tests.