### PR TITLE
Org switching: preserve ?orgId in programmatic navigation

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -3,6 +3,7 @@ import { LegacyGraphHoverClearEvent, SetPanelAttentionEvent, locationUtil } from
 import { LocationService, config } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
+import { appendOrgId } from 'app/core/utils/navigationUrl';
 import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
 import { ShareModal } from 'app/features/dashboard/components/ShareModal/ShareModal';
@@ -101,23 +102,23 @@ export class KeybindingSrv {
   }
 
   private openAlerting() {
-    this.locationService.push('/alerting');
+    this.locationService.push(appendOrgId('/alerting'));
   }
 
   private goToDashboards() {
-    this.locationService.push('/dashboards');
+    this.locationService.push(appendOrgId('/dashboards'));
   }
 
   private goToHome() {
-    this.locationService.push('/');
+    this.locationService.push(appendOrgId('/'));
   }
 
   private goToProfile() {
-    this.locationService.push('/profile');
+    this.locationService.push(appendOrgId('/profile'));
   }
 
   private goToExplore() {
-    this.locationService.push('/explore');
+    this.locationService.push(appendOrgId('/explore'));
   }
 
   private showHelpModal() {

--- a/public/app/core/utils/navigationUrl.ts
+++ b/public/app/core/utils/navigationUrl.ts
@@ -1,0 +1,14 @@
+import { contextSrv } from '../services/context_srv';
+
+/**
+ * Appends the current orgId as a query param if not already present.
+ * Used to keep ?orgId in the URL after programmatic navigation so links
+ * remain shareable and reloadable when the user is in a non-default org.
+ */
+export function appendOrgId(path: string): string {
+  const orgId = contextSrv.user.orgId;
+  if (!orgId || path.includes('orgId=')) {
+    return path;
+  }
+  return path + (path.includes('?') ? '&' : '?') + `orgId=${orgId}`;
+}

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -21,6 +21,7 @@ import { appEvents } from 'app/core/app_events';
 import { ScrollRefElement } from 'app/core/components/NativeScrollbar';
 import { LS_PANEL_COPY_KEY, LS_STYLES_COPY_KEY } from 'app/core/constants';
 import { getNavModel } from 'app/core/selectors/navModel';
+import { appendOrgId } from 'app/core/utils/navigationUrl';
 import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
@@ -991,7 +992,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   public async onDashboardDelete() {
     // Need to mark it non dirty to navigate away without unsaved changes warning
     this.setState({ isDirty: false });
-    locationService.replace('/');
+    locationService.replace(appendOrgId('/'));
   }
 
   public getDashboardPanels() {

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -4,6 +4,7 @@ import useAsyncFn from 'react-use/lib/useAsyncFn';
 
 import { Trans, t } from '@grafana/i18n';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
+import { appendOrgId } from 'app/core/utils/navigationUrl';
 import { Modal, Button, Text, Space, TextLink } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { cleanUpDashboardAndVariables } from 'app/features/dashboard/state/actions';
@@ -39,7 +40,7 @@ const DeleteDashboardModalUnconnected = ({ hideModal, cleanUpDashboardAndVariabl
     await deleteDashboards({ dashboardUIDs: [dashboard.uid] });
     cleanUpDashboardAndVariables();
     hideModal();
-    locationService.replace('/');
+    locationService.replace(appendOrgId('/'));
   }, [hideModal]);
 
   if (isProvisioned) {


### PR DESCRIPTION
Keyboard shortcuts (`g h`, `g d`, `g e`, `g a`, `g p`) and post-delete redirects called `locationService.push/replace` with hardcoded paths, silently dropping `?orgId` from the URL. For users in a non-default org, this made those URLs non-shareable and non-reloadable (a refresh in the wrong tab would show the wrong org to a recipient).

## Changes

- New `appendOrgId(path)` helper in `public/app/core/utils/navigationUrl.ts` — appends `?orgId=<current>` if not already present, no-ops for single-org deployments
- `keybindingSrv.ts`: 5 keyboard navigation shortcuts now use `appendOrgId`
- `DeleteDashboardModal.tsx`: redirect after delete now preserves orgId
- `DashboardScene.tsx`: `onDashboardDelete` redirect now preserves orgId

API calls are unaffected — `backend_srv.ts` already sends `X-Grafana-Org-Id` on every request so org context is never lost there.

## Related PRs

- #120942 — backend: JWT auth `?orgId` infinite redirect loop fix
- #120967 — frontend: `interceptLinkClicks` `<a>`-tag orgId injection + `OrganizationSwitcher` dispatch fix