### PR TITLE
PageNotFound: Use custom branding link in EntityNotFound component

### DIFF
--- a/public/app/core/components/PageNotFound/EntityNotFound.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.tsx
@@ -22,7 +22,13 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
   const communityLink = useMemo(() => {
     const footerLinks = getFooterLinks();
     const link = footerLinks.find((l) => l.id === 'community');
-    return link?.url ?? 'https://community.grafana.com/?utm_source=entity_not_found';
+    const url = link?.url ?? 'https://community.grafana.com';
+
+    // Override the default footer UTM attribution with one specific to this component
+    if (url.includes('utm_source=grafana_footer')) {
+      return url.replace('utm_source=grafana_footer', 'utm_source=entity_not_found');
+    }
+    return url;
   }, []);
 
   return (

--- a/public/app/core/components/PageNotFound/EntityNotFound.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.tsx
@@ -1,9 +1,12 @@
 import { css } from '@emotion/css';
+import { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Stack, EmptyState, LinkButton, useStyles2 } from '@grafana/ui';
+
+import { getFooterLinks } from '../Footer/Footer';
 
 export interface Props {
   /**
@@ -15,6 +18,12 @@ export interface Props {
 export function EntityNotFound({ entity = 'Page' }: Props) {
   const styles = useStyles2(getStyles);
   const lowerCaseEntity = entity.toLowerCase();
+
+  const communityLink = useMemo(() => {
+    const footerLinks = getFooterLinks();
+    const link = footerLinks.find((l) => l.id === 'community');
+    return link?.url ?? 'https://community.grafana.com/?utm_source=entity_not_found';
+  }, []);
 
   return (
     <div className={styles.container} data-testid={selectors.components.EntityNotFound.container}>
@@ -29,7 +38,7 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
 
             <LinkButton
               icon="question-circle"
-              href="https://community.grafana.com"
+              href={communityLink}
               target="_blank"
               rel="noreferrer"
               variant="secondary"

--- a/public/app/core/components/PageNotFound/EntityNotFound.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.tsx
@@ -19,7 +19,7 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
   const styles = useStyles2(getStyles);
   const lowerCaseEntity = entity.toLowerCase();
 
-  const communityLink = useMemo(() => {
+  const communityLinkInfo = useMemo(() => {
     const footerLinks = getFooterLinks();
     const link = footerLinks.find((l) => l.id === 'community');
     const url = link?.url;
@@ -28,11 +28,19 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
       return undefined;
     }
 
+    const defaultText = t('nav.help/community', 'Community');
+    const isCustomText = link?.text && link.text !== defaultText;
+
     // Override the default footer UTM attribution with one specific to this component
+    let finalUrl = url;
     if (url.includes('utm_source=grafana_footer')) {
-      return url.replace('utm_source=grafana_footer', 'utm_source=entity_not_found');
+      finalUrl = url.replace('utm_source=grafana_footer', 'utm_source=entity_not_found');
     }
-    return url;
+
+    return {
+      url: finalUrl,
+      text: isCustomText ? link.text : undefined,
+    };
   }, []);
 
   return (
@@ -46,15 +54,15 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
               <Trans i18nKey="entity-not-found.home-link">Back to Home</Trans>
             </LinkButton>
 
-            {communityLink && (
+            {communityLinkInfo && (
               <LinkButton
                 icon="question-circle"
-                href={communityLink}
+                href={communityLinkInfo.url}
                 target="_blank"
                 rel="noreferrer"
                 variant="secondary"
               >
-                <Trans i18nKey="entity-not-found.community-link">Community Help</Trans>
+                {communityLinkInfo.text ?? <Trans i18nKey="entity-not-found.community-link">Community Help</Trans>}
               </LinkButton>
             )}
           </Stack>

--- a/public/app/core/components/PageNotFound/EntityNotFound.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.tsx
@@ -22,7 +22,11 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
   const communityLink = useMemo(() => {
     const footerLinks = getFooterLinks();
     const link = footerLinks.find((l) => l.id === 'community');
-    const url = link?.url ?? 'https://community.grafana.com';
+    const url = link?.url;
+
+    if (!url) {
+      return undefined;
+    }
 
     // Override the default footer UTM attribution with one specific to this component
     if (url.includes('utm_source=grafana_footer')) {
@@ -42,15 +46,17 @@ export function EntityNotFound({ entity = 'Page' }: Props) {
               <Trans i18nKey="entity-not-found.home-link">Back to Home</Trans>
             </LinkButton>
 
-            <LinkButton
-              icon="question-circle"
-              href={communityLink}
-              target="_blank"
-              rel="noreferrer"
-              variant="secondary"
-            >
-              <Trans i18nKey="entity-not-found.community-link">Community Help</Trans>
-            </LinkButton>
+            {communityLink && (
+              <LinkButton
+                icon="question-circle"
+                href={communityLink}
+                target="_blank"
+                rel="noreferrer"
+                variant="secondary"
+              >
+                <Trans i18nKey="entity-not-found.community-link">Community Help</Trans>
+              </LinkButton>
+            )}
           </Stack>
         }
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Updates the `EntityNotFound` component to use the custom branding community link from the footer configuration instead of a hardcoded URL.

**Why do we need this feature?**

Currently, the `EntityNotFound` component has a hardcoded link to `https://community.grafana.com` for the "Community Help" button. This doesn't respect custom branding settings that can be configured for the footer links. Organizations using custom branding would expect the same community link to be used consistently across the application.

**Who is this feature for?**

Organizations using Grafana's custom branding features who want consistent links across their Grafana instance.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/hyperion-planning/issues/536

**Special notes for your reviewer:**

- The component now imports `getFooterLinks` from the Footer component
- It looks for a link with `id: 'community'` in the footer links
- If the URL contains the default footer UTM attribution (`utm_source=grafana_footer`), it replaces it with `utm_source=entity_not_found` for proper tracking
- Custom branding URLs are used as-is without modification
- If no community link URL is defined, the Community Help button is not rendered
- If custom branding text is configured (different from the default "Community"), that text is used; otherwise falls back to "Community Help"

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a20c3a5-3e59-4ece-890a-5c67227b9b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a20c3a5-3e59-4ece-890a-5c67227b9b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

