### PR TITLE
Provisioning: Add `SharedGitEnv` in integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/git/common/testing.go
+++ b/pkg/tests/apis/provisioning/git/common/testing.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/grafana/nanogit/gittest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +27,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+
+	"github.com/grafana/grafana/pkg/infra/db"
 )
 
 // GrafanaOpt is a functional option applied to GrafanaOpts before starting Grafana.
@@ -68,6 +74,22 @@ type GitTestHelper struct {
 	FoldersV1    *apis.K8sResourceClient
 }
 
+// SharedGitEnv lazily starts and reuses one GitTestHelper across tests.
+// Tests still create fresh repositories and local clones; only the Grafana
+// server and gittest server are shared.
+type SharedGitEnv struct {
+	Helper       *GitTestHelper
+	shutdownFunc func()
+	once         sync.Once
+	initErr      string
+	options      []GrafanaOpt
+}
+
+// NewSharedGitEnv creates a lazily initialized shared Git test environment.
+func NewSharedGitEnv(options ...GrafanaOpt) *SharedGitEnv {
+	return &SharedGitEnv{options: options}
+}
+
 // runGrafanaWithGitServer starts both a Grafana test instance and a git server.
 // Pass functional options to override any GrafanaOpts defaults before startup,
 // e.g. to set ProvisioningMaxResourcesPerRepository for quota tests.
@@ -85,79 +107,105 @@ func RunGrafanaWithGitServer(t *testing.T, options ...GrafanaOpt) *GitTestHelper
 		}
 	})
 
-	// Start Grafana with provisioning enabled
-	opts := testinfra.GrafanaOpts{
-		EnableFeatureToggles: []string{
-			featuremgmt.FlagProvisioning,
-			featuremgmt.FlagProvisioningExport,
-		},
-		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-			"dashboards.dashboard.grafana.app": {
-				DualWriterMode:  grafanarest.Mode5,
-				EnableMigration: true,
-			},
-			"folders.folder.grafana.app": {
-				DualWriterMode:  grafanarest.Mode5,
-				EnableMigration: true,
-			},
-		},
-		ProvisioningAllowedTargets:  []string{"folder", "instance"},
-		ProvisioningRepositoryTypes: []string{"git"},
-	}
-	for _, o := range options {
-		o(&opts)
-	}
+	return newGitTestHelper(t, apis.NewK8sTestHelper(t, gitGrafanaOpts(options...)), gitServer)
+}
 
-	k8s := apis.NewK8sTestHelper(t, opts)
+// RunGrafanaWithGitServerShared is like RunGrafanaWithGitServer but keeps the
+// servers alive until the returned shutdown function is called.
+func RunGrafanaWithGitServerShared(t *testing.T, options ...GrafanaOpt) (*GitTestHelper, func()) {
+	t.Helper()
 
-	// Set up K8s resource clients
-	repositories := k8s.GetResourceClient(apis.ResourceClientArgs{
-		User:      k8s.Org1.Admin,
-		Namespace: "default",
-		GVR:       provisioning.RepositoryResourceInfo.GroupVersionResource(),
+	ctx := context.Background()
+	gitServer, err := gittest.NewServer(ctx, gittest.WithLogger(gittest.NewWriterLogger(os.Stderr)))
+	require.NoError(t, err, "failed to start git server")
+
+	k8s, serverShutdown := apis.NewK8sTestHelperShared(t, apis.K8sTestHelperOpts{
+		GrafanaOpts: gitGrafanaOpts(options...),
 	})
-
-	jobsClient := k8s.GetResourceClient(apis.ResourceClientArgs{
-		User:      k8s.Org1.Admin,
-		Namespace: "default",
-		GVR:       provisioning.JobResourceInfo.GroupVersionResource(),
-	})
-
-	dashboardsV1 := k8s.GetResourceClient(apis.ResourceClientArgs{
-		User:      k8s.Org1.Admin,
-		Namespace: "default",
-		GVR:       dashboardV1.DashboardResourceInfo.GroupVersionResource(),
-	})
-
-	foldersV1 := k8s.GetResourceClient(apis.ResourceClientArgs{
-		User:      k8s.Org1.Admin,
-		Namespace: "default",
-		GVR:       folderV1beta1.FolderResourceInfo.GroupVersionResource(),
-	})
-
-	// Get REST clients for different roles
-	gv := &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"}
-	adminClient := k8s.Org1.Admin.RESTClient(t, gv)
-	editorClient := k8s.Org1.Editor.RESTClient(t, gv)
-	viewerClient := k8s.Org1.Viewer.RESTClient(t, gv)
-
-	helper := &GitTestHelper{
-		K8sTestHelper: k8s,
-		gitServer:     gitServer,
-		Repositories:  repositories,
-		Jobs:          jobsClient,
-		DashboardsV1:  dashboardsV1,
-		FoldersV1:     foldersV1,
-		AdminREST:     adminClient,
-		EditorREST:    editorClient,
-		ViewerREST:    viewerClient,
+	shutdown := func() {
+		if err := gitServer.Cleanup(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "failed to cleanup git server: %v\n", err)
+		}
+		serverShutdown()
 	}
 
-	return helper
+	return newGitTestHelper(t, k8s, gitServer), shutdown
+}
+
+// GetHelper returns the shared helper, starting it on first use.
+func (e *SharedGitEnv) GetHelper(t *testing.T) *GitTestHelper {
+	t.Helper()
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	e.once.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				e.initErr = fmt.Sprintf("shared git server init panicked: %v", r)
+			} else if e.Helper == nil && e.initErr == "" {
+				e.initErr = "shared git server init failed (FailNow/Goexit called; see first test output)"
+			}
+		}()
+		e.Helper, e.shutdownFunc = RunGrafanaWithGitServerShared(t, e.options...)
+	})
+
+	if e.initErr != "" {
+		t.Fatalf("SharedGitEnv: %s", e.initErr)
+	}
+
+	return e.Helper
+}
+
+// GetCleanHelper returns the shared helper after removing resources left by a
+// previous test from Grafana. Git server state is intentionally not reset.
+func (e *SharedGitEnv) GetCleanHelper(t *testing.T) *GitTestHelper {
+	t.Helper()
+	h := e.GetHelper(t)
+	h.CleanupAllResources(t, context.Background())
+	return h
+}
+
+// Shutdown stops the shared servers if they were started.
+func (e *SharedGitEnv) Shutdown() {
+	if e.shutdownFunc != nil {
+		e.shutdownFunc()
+	}
+}
+
+// RunTestMain replaces testsuite.Run(m) for packages that share one Git test
+// environment. It handles DB setup, executes the package tests, shuts down the
+// shared servers, cleans the DB, and exits.
+func (e *SharedGitEnv) RunTestMain(m *testing.M) {
+	db.SetupTestDB()
+	code := m.Run()
+	e.Shutdown()
+	db.CleanupTestDB()
+	os.Exit(code)
 }
 
 func (h *GitTestHelper) GitServer() *gittest.Server {
 	return h.gitServer
+}
+
+// CleanupAllResources removes Grafana-managed resources left by a previous
+// test. Remote git repositories are not deleted because the shared gittest
+// server does not expose repo/user cleanup and tests already isolate by using
+// fresh users and local clones per repository.
+func (h *GitTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
+	t.Helper()
+	h.waitForNoActiveJobs(t)
+
+	for _, c := range []struct {
+		name   string
+		client dynamic.ResourceInterface
+	}{
+		{"repositories", h.Repositories.Resource},
+		{"dashboards", h.DashboardsV1.Resource},
+		{"folders", h.FoldersV1.Resource},
+	} {
+		if err := deleteAndWait(ctx, c.client, 10*time.Second); err != nil {
+			t.Fatalf("CleanupAllResources(%s): %v", c.name, err)
+		}
+	}
 }
 
 // CreateGitRepo creates a git repository with sync target "instance" and registers
@@ -386,6 +434,137 @@ func (h *GitTestHelper) waitForJobsComplete(t *testing.T, repoName string) {
 
 		assert.False(collect, hasActiveJobs, "jobs still active for repository %s", repoName)
 	}, WaitTimeoutDefault, WaitIntervalDefault, "jobs should complete for repository %s", repoName)
+}
+
+func (h *GitTestHelper) waitForNoActiveJobs(t *testing.T) {
+	t.Helper()
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		jobs, err := h.Jobs.Resource.List(context.Background(), metav1.ListOptions{})
+		if !assert.NoError(collect, err, "failed to list jobs") {
+			return
+		}
+		assert.Empty(collect, jobs.Items, "jobs still active from previous test")
+	}, WaitTimeoutDefault, WaitIntervalDefault, "jobs should complete before cleanup")
+}
+
+func gitGrafanaOpts(options ...GrafanaOpt) testinfra.GrafanaOpts {
+	opts := testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagProvisioning,
+			featuremgmt.FlagProvisioningExport,
+		},
+		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+			"dashboards.dashboard.grafana.app": {
+				DualWriterMode:  grafanarest.Mode5,
+				EnableMigration: true,
+			},
+			"folders.folder.grafana.app": {
+				DualWriterMode:  grafanarest.Mode5,
+				EnableMigration: true,
+			},
+		},
+		ProvisioningAllowedTargets:  []string{"folder", "instance"},
+		ProvisioningRepositoryTypes: []string{"git"},
+	}
+	for _, o := range options {
+		o(&opts)
+	}
+	return opts
+}
+
+func newGitTestHelper(t *testing.T, k8s *apis.K8sTestHelper, gitServer *gittest.Server) *GitTestHelper {
+	repositories := k8s.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8s.Org1.Admin,
+		Namespace: "default",
+		GVR:       provisioning.RepositoryResourceInfo.GroupVersionResource(),
+	})
+
+	jobsClient := k8s.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8s.Org1.Admin,
+		Namespace: "default",
+		GVR:       provisioning.JobResourceInfo.GroupVersionResource(),
+	})
+
+	dashboardsV1 := k8s.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8s.Org1.Admin,
+		Namespace: "default",
+		GVR:       dashboardV1.DashboardResourceInfo.GroupVersionResource(),
+	})
+
+	foldersV1 := k8s.GetResourceClient(apis.ResourceClientArgs{
+		User:      k8s.Org1.Admin,
+		Namespace: "default",
+		GVR:       folderV1beta1.FolderResourceInfo.GroupVersionResource(),
+	})
+
+	gv := &schema.GroupVersion{Group: "provisioning.grafana.app", Version: "v0alpha1"}
+
+	return &GitTestHelper{
+		K8sTestHelper: k8s,
+		gitServer:     gitServer,
+		Repositories:  repositories,
+		Jobs:          jobsClient,
+		DashboardsV1:  dashboardsV1,
+		FoldersV1:     foldersV1,
+		AdminREST:     k8s.Org1.Admin.RESTClient(t, gv),
+		EditorREST:    k8s.Org1.Editor.RESTClient(t, gv),
+		ViewerREST:    k8s.Org1.Viewer.RESTClient(t, gv),
+	}
+}
+
+func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeout time.Duration) error {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("deleteAndWait: initial list: %w", err)
+	}
+	if len(list.Items) == 0 {
+		return nil
+	}
+
+	var firstErr error
+	for _, item := range list.Items {
+		if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
+			}
+		}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		remaining, err := client.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("deleteAndWait: list while polling: %w", err)
+		}
+		if len(remaining.Items) == 0 {
+			return nil
+		}
+		for _, item := range remaining.Items {
+			if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			if firstErr != nil {
+				return fmt.Errorf("deleteAndWait: context cancelled (first delete error: %v): %w", firstErr, ctx.Err())
+			}
+			return fmt.Errorf("deleteAndWait: context cancelled: %w", ctx.Err())
+		case <-timer.C:
+			if firstErr != nil {
+				return fmt.Errorf("deleteAndWait: timed out with %d items remaining (first delete error: %v)", len(remaining.Items), firstErr)
+			}
+			return fmt.Errorf("deleteAndWait: timed out with %d items remaining", len(remaining.Items))
+		case <-ticker.C:
+		}
+	}
 }
 
 // asJSON serialises v to a JSON byte slice, panicking on encoding errors

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/helper_test.go
@@ -19,8 +19,3 @@ func sharedGitHelper(t *testing.T) *gitcommon.GitTestHelper {
 	t.Helper()
 	return sharedGitEnvWithFolderMetadata.GetCleanHelper(t)
 }
-
-func sharedDefaultGitHelper(t *testing.T) *gitcommon.GitTestHelper {
-	t.Helper()
-	return gitcommon.RunGrafanaWithGitServer(t)
-}

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/helper_test.go
@@ -3,9 +3,24 @@ package foldermetadataincremental
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
+)
+
+var (
+	sharedGitEnvWithFolderMetadata = gitcommon.NewSharedGitEnv(common.WithProvisioningFolderMetadata)
 )
 
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	sharedGitEnvWithFolderMetadata.RunTestMain(m)
+}
+
+func sharedGitHelper(t *testing.T) *gitcommon.GitTestHelper {
+	t.Helper()
+	return sharedGitEnvWithFolderMetadata.GetCleanHelper(t)
+}
+
+func sharedDefaultGitHelper(t *testing.T) *gitcommon.GitTestHelper {
+	t.Helper()
+	return gitcommon.RunGrafanaWithGitServer(t)
 }

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_folder_metadata_test.go
@@ -22,7 +22,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("detects missing folder metadata after adding file to folder", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 
 		const repoName = "incr-missing-meta-add"
 
@@ -60,7 +60,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 	})
 
 	t.Run("noop incremental sync still detects missing metadata", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 
 		const repoName = "incr-missing-meta-noop"
 
@@ -101,7 +101,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := gitcommon.RunGrafanaWithGitServer(t) // no withProvisioningFolderMetadata
+	helper := sharedDefaultGitHelper(t) // no withProvisioningFolderMetadata
 
 	const repoName = "incr-missing-meta-disabled"
 
@@ -163,7 +163,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("folder uses spec.title from _folder.json", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title"
@@ -192,7 +192,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 	})
 
 	t.Run("folder falls back to directory name when spec.title is empty", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title-empty"
@@ -219,7 +219,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 	})
 
 	t.Run("folder uses directory name when no _folder.json exists", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title-absent"
@@ -245,7 +245,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 	})
 
 	t.Run("nested folders use respective spec.title from _folder.json", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title-nested"
@@ -278,7 +278,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("adding _folder.json clears prior missing metadata warnings", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-create-clears-warning"
@@ -322,7 +322,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 	})
 
 	t.Run("new _folder.json creates a brand-new empty folder", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-create-empty-folder"
@@ -349,7 +349,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 	})
 
 	t.Run("new _folder.json transitions existing folder to stable uid", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-create-existing"
@@ -381,7 +381,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 	})
 
 	t.Run("new _folder.json transitions existing folder to stable uid and re-parents children", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-create-existing"
@@ -420,7 +420,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 	})
 
 	t.Run("new _folder.json with direct child rename does not replay the old child path", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-create-child-rename"
@@ -454,7 +454,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 	})
 
 	t.Run("new nested _folder.json files transition both parent and child to stable uids", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-create-nested"
@@ -505,7 +505,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("updates folder title when _folder.json spec.title changes", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title-update"
@@ -532,7 +532,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 	})
 
 	t.Run("updates nested folder title", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title-nested-upd"
@@ -562,7 +562,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 	})
 
 	t.Run("updates title alongside dashboard changes", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-title-with-dash"
@@ -601,7 +601,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("root to root rename", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-rename-root-root"
@@ -653,7 +653,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 	})
 
 	t.Run("nested to nested rename within same parent", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-rename-nested-nested"
@@ -707,7 +707,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 	})
 
 	t.Run("root to nested rename", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-rename-root-nested"
@@ -762,7 +762,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 	})
 
 	t.Run("nested to root rename", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-rename-nested-root"
@@ -816,7 +816,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 	})
 
 	t.Run("rename folder with both resources and folder children", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-rename-mixed"
@@ -897,7 +897,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 	})
 
 	t.Run("non-metadata folder rename still works via delete and create", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-graceful-rename-nometa"
@@ -934,7 +934,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("simple UID change re-parents dashboard", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-uid-change-simple"
@@ -980,7 +980,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 	})
 
 	t.Run("UID change with nested child folder", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-uid-change-nested"
@@ -1035,7 +1035,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 	})
 
 	t.Run("UID change alongside dashboard update in same commit", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-uid-change-combo"
@@ -1077,7 +1077,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 	})
 
 	t.Run("chained UID changes never accumulate orphans", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-uid-chained"
@@ -1132,7 +1132,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 	})
 
 	t.Run("full sync after incremental UID changes cleans up any remaining orphans", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-uid-full-cleanup"
@@ -1179,7 +1179,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("simple metadata deletion re-parents dashboard", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-simple"
@@ -1228,7 +1228,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 	})
 
 	t.Run("metadata deletion with nested child folder", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-nested"
@@ -1284,7 +1284,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 	})
 
 	t.Run("metadata deletion re-parents all direct children", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-children"
@@ -1354,7 +1354,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 	})
 
 	t.Run("metadata deletion alongside dashboard update in same commit", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-combo"
@@ -1406,7 +1406,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("metadata-only folder rename cleans up old folder", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-orphan"
@@ -1449,7 +1449,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 	})
 
 	t.Run("metadata moved to folder with dashboard but no metadata", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-to-existing"
@@ -1498,7 +1498,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 	})
 
 	t.Run("metadata moved to folder with dashboard and pre-existing metadata", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-over"
@@ -1551,7 +1551,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 	})
 
 	t.Run("metadata-only empty folder rename cleans up old folder", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+		helper := sharedGitHelper(t)
 		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-empty"

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_folder_metadata_test.go
@@ -98,49 +98,6 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 	})
 }
 
-func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := sharedDefaultGitHelper(t) // no withProvisioningFolderMetadata
-
-	const repoName = "incr-missing-meta-disabled"
-
-	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
-		"dashboard.json": gitcommon.DashboardJSON("disabled-dash", "Root Dashboard", 1),
-	})
-
-	// Full sync.
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
-
-	// Add a dashboard inside a folder with no _folder.json.
-	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(gitcommon.DashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))
-	_, err := local.Git("add", ".")
-	require.NoError(t, err)
-	_, err = local.Git("commit", "-m", "add dashboard in folder without metadata")
-	require.NoError(t, err)
-	_, err = local.Git("push")
-	require.NoError(t, err)
-
-	// Trigger incremental sync.
-	job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{Incremental: true},
-	})
-	jobObj := &provisioning.Job{}
-	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
-
-	require.Empty(t, jobObj.Status.Errors,
-		"incremental sync with flag disabled should produce no errors")
-	require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State,
-		"incremental sync should succeed without warnings when flag is disabled")
-
-	// Ensure no warning about missing folder metadata.
-	for _, w := range jobObj.Status.Warnings {
-		require.False(t, strings.Contains(w, "missing folder metadata"),
-			"should not warn about missing folder metadata when flag is disabled, got: %s", w)
-	}
-}
-
 // folderMetadataJSON generates a valid _folder.json payload with a stable UID and title.
 func folderMetadataJSON(uid, title string) []byte {
 	folder := map[string]any{

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
@@ -21,12 +21,12 @@ import (
 func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-    helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+	helper := sharedGitHelper(t)
 
 	t.Run("invalid metadata creation on existing folder keeps unstable uid and reconciles changed child", func(t *testing.T) {
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-existing"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -67,7 +67,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	t.Run("invalid metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-new"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -109,7 +109,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-update"
 		const stableUID = "team-stable-uid"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -151,7 +151,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-follow-up-child"
 		const stableUID = "team-stable-uid"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -210,7 +210,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		const repoName = "incr-invalid-meta-with-valid-replaced"
 		const parentStableUID = "parent-stable-uid"
 		const childUID = "child-stable-uid"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -263,7 +263,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	t.Run("moving a resource into an existing folder with invalid metadata still works", func(t *testing.T) {
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-move-into-existing"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -303,7 +303,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	t.Run("moving a resource into a new folder with invalid metadata falls back to unstable uid", func(t *testing.T) {
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-move-into-new"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -345,7 +345,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		ctx := context.Background()
 		const repoName = "incr-invalid-meta-folder-move"
 		const stableUID = "team-stable-uid"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 
@@ -395,7 +395,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		const repoName = "incr-invalid-meta-with-valid-rename"
 		const parentStableUID = "parent-stable-uid"
 		const childUID = "child-stable-uid"
-		t.Cleanup(func ()  {
+		t.Cleanup(func() {
 			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
 		})
 

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_invalid_folder_metadata_test.go
@@ -21,11 +21,14 @@ import (
 func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	t.Run("invalid metadata creation on existing folder keeps unstable uid and reconciles changed child", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
-		ctx := context.Background()
+    helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 
+	t.Run("invalid metadata creation on existing folder keeps unstable uid and reconciles changed child", func(t *testing.T) {
+		ctx := context.Background()
 		const repoName = "incr-invalid-meta-existing"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"team/dashboard.json": gitcommon.DashboardJSON("team-dash", "Team Dashboard", 1),
@@ -62,10 +65,11 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("invalid metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-new"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"root.json": gitcommon.DashboardJSON("root-dash", "Root Dashboard", 1),
@@ -102,11 +106,12 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("invalid metadata update on stable folder keeps stable uid and reconciles changed child", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-update"
 		const stableUID = "team-stable-uid"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"team/_folder.json":   folderMetadataJSON(stableUID, "Team"),
@@ -143,11 +148,12 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("follow-up child update under already-invalid metadata keeps the existing stable uid", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-follow-up-child"
 		const stableUID = "team-stable-uid"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"team/_folder.json":   folderMetadataJSON(stableUID, "Team"),
@@ -200,12 +206,13 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("invalid metadata creation on existing folder does not break valid folder meta creation on another folder in the same incremental sync", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-with-valid-replaced"
 		const parentStableUID = "parent-stable-uid"
 		const childUID = "child-stable-uid"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"broken/dashboard.json":         gitcommon.DashboardJSON("broken-dash", "Broken Dashboard", 1),
@@ -254,10 +261,11 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("moving a resource into an existing folder with invalid metadata still works", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-move-into-existing"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"team/_folder.json": invalidFolderMetadataJSON("Broken Team"),
@@ -293,10 +301,11 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("moving a resource into a new folder with invalid metadata falls back to unstable uid", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-move-into-new"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"root.json": gitcommon.DashboardJSON("root-dash", "Root Dashboard", 1),
@@ -333,11 +342,12 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("moving a folder with invalid metadata falls back to delete and recreate", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-folder-move"
 		const stableUID = "team-stable-uid"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"team/_folder.json":   folderMetadataJSON(stableUID, "Team"),
@@ -381,12 +391,13 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	})
 
 	t.Run("invalid metadata creation does not break valid metadata-backed folder rename in the same incremental sync", func(t *testing.T) {
-		helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
 		ctx := context.Background()
-
 		const repoName = "incr-invalid-meta-with-valid-rename"
 		const parentStableUID = "parent-stable-uid"
 		const childUID = "child-stable-uid"
+		t.Cleanup(func ()  {
+			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"old-parent/_folder.json":         folderMetadataJSON(parentStableUID, "Parent"),

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/incremental_permissions_move_test.go
@@ -26,7 +26,7 @@ import (
 func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+	helper := sharedGitHelper(t)
 	ctx := context.Background()
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 

--- a/pkg/tests/apis/provisioning/git/foldermetadata_incremental/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_incremental/metadata_name_change_test.go
@@ -21,7 +21,7 @@ import (
 func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := gitcommon.RunGrafanaWithGitServer(t)
+	helper := sharedDefaultGitHelper(t)
 	ctx := context.Background()
 
 	const repoName = "git-incremental-name-change"

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -1,4 +1,4 @@
-package foldermetadataincremental
+package git
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := sharedDefaultGitHelper(t)
+	helper := gitcommon.RunGrafanaWithGitServer(t)
 	ctx := context.Background()
 
 	const repoName = "git-incremental-name-change"

--- a/pkg/tests/apis/provisioning/git/missing_metadata_incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/missing_metadata_incremental_test.go
@@ -1,0 +1,56 @@
+package git
+
+import (
+	"strings"
+	"testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisabled(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := gitcommon.RunGrafanaWithGitServer(t) // no withProvisioningFolderMetadata
+
+	const repoName = "incr-missing-meta-disabled"
+
+	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard.json": gitcommon.DashboardJSON("disabled-dash", "Root Dashboard", 1),
+	})
+
+	// Full sync.
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+	// Add a dashboard inside a folder with no _folder.json.
+	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(gitcommon.DashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))
+	_, err := local.Git("add", ".")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "add dashboard in folder without metadata")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	// Trigger incremental sync.
+	job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+	})
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+	require.Empty(t, jobObj.Status.Errors,
+		"incremental sync with flag disabled should produce no errors")
+	require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State,
+		"incremental sync should succeed without warnings when flag is disabled")
+
+	// Ensure no warning about missing folder metadata.
+	for _, w := range jobObj.Status.Warnings {
+		require.False(t, strings.Contains(w, "missing folder metadata"),
+			"should not warn about missing folder metadata when flag is disabled, got: %s", w)
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Adding `SharedGitEnv` in integration tests and using it in `foldermetadata_incremental` package

**Why do we need this feature?**

This should speed up integration tests run time 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
