### PR TITLE
Zanzana: Fix check request with wildcard as object name

### DIFF
--- a/pkg/services/authz/zanzana/common/info.go
+++ b/pkg/services/authz/zanzana/common/info.go
@@ -152,7 +152,9 @@ func (r ResourceInfo) GroupResourceIdent() string {
 }
 
 func (r ResourceInfo) ResourceIdent() string {
-	if r.name == "" {
+	// Treat "*" the same as "". Wildcard access ("can access all resources of this type")
+	// is handled at the group-resource level.
+	if r.name == "" || r.name == "*" {
 		return ""
 	}
 

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -230,4 +230,12 @@ func TestIntegrationServerCheck(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, true, res.GetAllowed())
 	})
+
+	t.Run("wildcard name for typed resource should be allowed when subject has group_resource get_permissions and returns no error", func(t *testing.T) {
+		// user:19 has get_permissions on the group_resource for users — they can manage
+		// permissions for all users. A check with name="*" must succeed via group_resource only.
+		res, err := server.Check(newContextWithNamespace(), newReq("user:19", utils.VerbGetPermissions, userGroup, userResource, "", "", "*"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 }

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -70,6 +70,7 @@ func setup(t *testing.T, srv *Server) *Server {
 		common.NewFolderTuple("user:17", common.RelationSetView, "4"),
 		common.NewFolderTuple("user:18", common.RelationCreate, "general"),
 		common.NewFolderResourceTuple("user:18", common.RelationCreate, dashboardGroup, dashboardResource, "", "general"),
+		common.NewGroupResourceTuple("user:19", common.RelationGetPermissions, userGroup, userResource, ""),
 	}
 
 	return setupOpenFGADatabase(t, srv, tuples)


### PR DESCRIPTION
**What is this feature?**

Fixes regression introduced in https://github.com/grafana/grafana/pull/120477

```
logger=zanzana.server t=2026-03-24T14:14:02.037184955Z level=error msg="failed to perform check request" error="failed to check typed resource: failed to perform openfga Check request: rpc error: code = Code(2000) desc = the 'object' field cannot reference a typed wildcard" namespace=stacks-13
error logger=zanzana.server t=2026-03-24T14:14:02.03715651Z level=error msg="failed to perform check" error=null subject=service-account:ce4ltewlm04cgb relation=get_permissions object=user:*
```

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
