### PR TITLE
chore(unified-storage): log every bulk insert timing

### DIFF
--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -391,7 +391,7 @@ func (b *backend) insertHistoryBatch(ctx context.Context, tx db.ContextExecer, b
 
 	if insertDuration > 500*time.Millisecond {
 		b.log.Warn("slow bulk insert", "processed", rsp.Processed, "batch_size", len(batch), "inserted", len(rows), "payload_bytes", payloadBytes, "insert", insertDuration)
-	} else if rsp.Processed%10 == 0 {
+	} else {
 		b.log.Debug("bulk insert timing", "processed", rsp.Processed, "batch_size", len(batch), "inserted", len(rows), "payload_bytes", payloadBytes, "insert", insertDuration)
 	}
 


### PR DESCRIPTION
This removes the %10 gate from the SQL bulk import debug log in pkg/storage/unified/sql/backend_bulk.go, so bulk insert timing is emitted for every non-slow batch instead of every tenth processed item. Slow inserts still log at warn level, so this only changes debug visibility for the normal path.

This is a logging-only change intended to make it easier to inspect per-batch timing while validating bulk import behavior and performance.

## Testing
- go test ./pkg/storage/unified/sql