### PR TITLE
Pyroscope: Add support for heatmap query API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/grafana/nanogit/gittest v0.10.2 // @grafana/grafana-git-ui-sync-team
 	github.com/grafana/otel-profiling-go v0.5.1 // @grafana/grafana-backend-group
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // @grafana/data-sources-plugins
-	github.com/grafana/pyroscope/api v1.2.1-0.20251202111406-6c67b876b686 // @grafana/data-sources-plugins
+	github.com/grafana/pyroscope/api v1.3.0 // @grafana/data-sources-plugins
 	github.com/grafana/schemads v0.0.8 // @grafana/data-sources
 	github.com/grafana/tempo v1.5.1-0.20250529124718-87c2dc380cec // @grafana/data-sources-plugins
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // @grafana/grafana-search-and-storage

--- a/go.sum
+++ b/go.sum
@@ -1656,8 +1656,8 @@ github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c/go.mod h1:sWX4vzxYuH91qFCd2Khubo61VjbksxRcb7SDHs5SDig=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasnuOY813tbMN8i/a3Og=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
-github.com/grafana/pyroscope/api v1.2.1-0.20251202111406-6c67b876b686 h1:igFpQWVqTfyMF3LISKcteXkUBNI3fLf9nxb1ZWAm0Fw=
-github.com/grafana/pyroscope/api v1.2.1-0.20251202111406-6c67b876b686/go.mod h1:ga4rxVfVsvUKEbmwx4/dryIRwHBYpuwP0mDB81aMR2Y=
+github.com/grafana/pyroscope/api v1.3.0 h1:wzOC+3k9Yn247E3rftOaHlO0MG7mQL48eab/EOFujsU=
+github.com/grafana/pyroscope/api v1.3.0/go.mod h1:K4BU7r29UGWJfAF29ySzQQ9wvVvWsEU7IaRXIa89ZwA=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56 h1:SDGrP81Vcd102L3UJEryRd1eestRw73wt+b8vnVEFe0=

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1722,6 +1722,11 @@ export interface FeatureToggles {
   */
   queryFetchConfigFromSettingsService?: boolean;
   /**
+  * Enables heatmap visualization support for Pyroscope profiles
+  * @default false
+  */
+  profilesHeatmap?: boolean;
+  /**
   * Enables the query service to do query caching
   * @default false
   */

--- a/packages/grafana-schema/src/raw/composable/grafanapyroscope/dataquery/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/grafanapyroscope/dataquery/x/types.gen.ts
@@ -18,6 +18,8 @@ export type PyroscopeQueryType = ('metrics' | 'profile' | 'both');
 
 export const defaultPyroscopeQueryType: PyroscopeQueryType = 'both';
 
+export type HeatmapQueryType = ('individual' | 'span');
+
 export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
   /**
    * If set to true, the response will contain annotations
@@ -28,9 +30,17 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
    */
   groupBy: Array<string>;
   /**
+   * Specifies the type of heatmap query
+   */
+  heatmapType: (HeatmapQueryType | 'individual');
+  /**
    * If set to true, exemplars will be requested
    */
   includeExemplars: boolean;
+  /**
+   * If set to true, heatmap data will be requested
+   */
+  includeHeatmap: boolean;
   /**
    * Specifies the query label selectors.
    */
@@ -59,7 +69,9 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
 
 export const defaultGrafanaPyroscopeDataQuery: Partial<GrafanaPyroscopeDataQuery> = {
   groupBy: [],
+  heatmapType: 'individual',
   includeExemplars: false,
+  includeHeatmap: false,
   labelSelector: '{}',
   profileIdSelector: [],
   spanSelector: [],

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2947,6 +2947,14 @@ var (
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:        "profilesHeatmap",
+			Description: "Enables heatmap visualization support for Pyroscope profiles",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaObservabilityTracesAndProfilingSquad,
+			Expression:  "false",
+			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:        "queryServiceQueryCaching",
 			Description: "Enables the query service to do query caching",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -343,6 +343,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-27,streamingForwardTeamHeadersTempo,privatePreview,@grafana/data-sources-plugins,false,false,false
 2026-03-19,lokiAlignedQuerySplitting,experimental,@grafana/observability-logs,false,false,false
 2026-03-16,queryFetchConfigFromSettingsService,experimental,@grafana/grafana-datasources-core-services,false,false,false
+2026-04-16,profilesHeatmap,experimental,@grafana/observability-traces-and-profiling,false,false,false
 2026-03-28,queryServiceQueryCaching,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-04-01,tracesDrilldownTimeSeeker,experimental,@grafana/observability-traces-and-profiling,false,false,true
 2026-04-01,clearPreviousFieldValues,experimental,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -930,6 +930,10 @@ const (
 	// Enables the query service to fetch the configuration from the settings service
 	FlagQueryFetchConfigFromSettingsService = "queryFetchConfigFromSettingsService"
 
+	// FlagProfilesHeatmap
+	// Enables heatmap visualization support for Pyroscope profiles
+	FlagProfilesHeatmap = "profilesHeatmap"
+
 	// FlagQueryServiceQueryCaching
 	// Enables the query service to do query caching
 	FlagQueryServiceQueryCaching = "queryServiceQueryCaching"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4371,6 +4371,19 @@
     },
     {
       "metadata": {
+        "name": "profilesHeatmap",
+        "resourceVersion": "1776332619529",
+        "creationTimestamp": "2026-04-16T09:43:39Z"
+      },
+      "spec": {
+        "description": "Enables heatmap visualization support for Pyroscope profiles",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "prometheusAzureOverrideAudience",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2022-05-30T15:43:32Z",

--- a/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar.go
@@ -2,37 +2,49 @@ package exemplar
 
 import (
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 type Exemplar struct {
-	Id        string
+	ProfileId string
+	SpanId    string
 	Value     float64
 	Timestamp int64
 	Labels    map[string]string
 }
 
-func CreateExemplarFrame(labels map[string]string, exemplars []*Exemplar, units string) *data.Frame {
+type ExemplarType string
+
+const (
+	ExemplarTypeProfile ExemplarType = "profile"
+	ExemplarTypeSpan    ExemplarType = "span"
+)
+
+func CreateExemplarFrame(labels map[string]string, exemplars []*Exemplar, exemplarType ExemplarType, units string) *data.Frame {
 	frame := data.NewFrame("exemplar")
 	frame.Meta = &data.FrameMeta{
 		DataTopic: data.DataTopicAnnotations,
 	}
+
+	// Determine display name and which ID to use based on exemplar type
+	displayName := "Profile ID"
+	if exemplarType == ExemplarTypeSpan {
+		displayName = "Span ID"
+	}
+
 	// Collect all unique label names across all exemplars
 	uniqLabelNames := make(map[string]struct{})
 	for _, e := range exemplars {
 		for name := range e.Labels {
-			if strings.HasPrefix(name, "__") {
-				continue
-			}
 			uniqLabelNames[name] = struct{}{}
 		}
 	}
 	for name := range labels {
 		uniqLabelNames[name] = struct{}{}
 	}
+
 	sortedLabelNames := make([]string, 0, len(uniqLabelNames))
 	for name := range uniqLabelNames {
 		sortedLabelNames = append(sortedLabelNames, name)
@@ -53,7 +65,7 @@ func CreateExemplarFrame(labels map[string]string, exemplars []*Exemplar, units 
 	}
 
 	fields[2].Config = &data.FieldConfig{
-		DisplayName: "Profile ID",
+		DisplayName: displayName,
 	}
 
 	// Create fields for all label names
@@ -67,7 +79,15 @@ func CreateExemplarFrame(labels map[string]string, exemplars []*Exemplar, units 
 	for _, e := range exemplars {
 		row[0] = time.UnixMilli(e.Timestamp)
 		row[1] = e.Value
-		row[2] = e.Id
+
+		// Use the appropriate ID based on exemplar type
+		switch exemplarType {
+		case ExemplarTypeSpan:
+			row[2] = e.SpanId
+		case ExemplarTypeProfile:
+			row[2] = e.ProfileId
+		}
+
 		// Append label values: prefer exemplar-specific values over series values
 		for idx, name := range sortedLabelNames {
 			// Check if this exemplar has this label

--- a/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar.go
@@ -2,6 +2,7 @@ package exemplar
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -38,13 +39,15 @@ func CreateExemplarFrame(labels map[string]string, exemplars []*Exemplar, exempl
 	uniqLabelNames := make(map[string]struct{})
 	for _, e := range exemplars {
 		for name := range e.Labels {
+			if strings.HasPrefix(name, "__") {
+				continue
+			}
 			uniqLabelNames[name] = struct{}{}
 		}
 	}
 	for name := range labels {
 		uniqLabelNames[name] = struct{}{}
 	}
-
 	sortedLabelNames := make([]string, 0, len(uniqLabelNames))
 	for name := range uniqLabelNames {
 		sortedLabelNames = append(sortedLabelNames, name)

--- a/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar_test.go
@@ -78,7 +78,7 @@ func TestCreateExemplarFrame_SpanType(t *testing.T) {
 	require.Equal(t, "span-abc123", row[2]) // Should use SpanId for span type
 }
 
-func TestCreateExemplarFrame_AllLabelsIncluded(t *testing.T) {
+func TestCreateExemplarFrame_FiltersPrivateLabels(t *testing.T) {
 	exemplars := []*Exemplar{
 		{
 			ProfileId: "profile-1",
@@ -97,7 +97,7 @@ func TestCreateExemplarFrame_AllLabelsIncluded(t *testing.T) {
 	}
 	frame := CreateExemplarFrame(labels, exemplars, ExemplarTypeSpan, "count")
 
-	// Verify all fields are created (including private labels)
+	// Verify non-private fields are created, and private (__) labels are excluded
 	fieldNames := make([]string, 0, len(frame.Fields))
 	for _, field := range frame.Fields {
 		fieldNames = append(fieldNames, field.Name)
@@ -108,8 +108,8 @@ func TestCreateExemplarFrame_AllLabelsIncluded(t *testing.T) {
 	require.Contains(t, fieldNames, "Id")
 	require.Contains(t, fieldNames, "service")
 	require.Contains(t, fieldNames, "pod")
-	require.Contains(t, fieldNames, "__profile_type__")
-	require.Contains(t, fieldNames, "__name__")
+	require.NotContains(t, fieldNames, "__profile_type__")
+	require.NotContains(t, fieldNames, "__name__")
 }
 
 func TestCreateExemplarFrame_NoDuplicateFields(t *testing.T) {

--- a/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/exemplar/exemplar_test.go
@@ -6,42 +6,221 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateExemplarFrame(t *testing.T) {
+func TestCreateExemplarFrame_ProfileType(t *testing.T) {
 	exemplars := []*Exemplar{
-		{Id: "1", Value: 1.0, Timestamp: 100, Labels: map[string]string{"__private_label__": "omitted"}},
-		{Id: "2", Value: 2.0, Timestamp: 200, Labels: map[string]string{"label1": "value1", "label2": "value2"}},
+		{ProfileId: "profile-1", SpanId: "span-1", Value: 1.0, Timestamp: 100, Labels: map[string]string{"pod": "pod-1"}},
+		{ProfileId: "profile-2", SpanId: "span-2", Value: 2.0, Timestamp: 200, Labels: map[string]string{"pod": "pod-2"}},
 	}
 	labels := map[string]string{
-		"foo": "bar",
+		"service": "api",
 	}
-	unit := "short"
-	frame := CreateExemplarFrame(labels, exemplars, unit)
+	frame := CreateExemplarFrame(labels, exemplars, ExemplarTypeProfile, "short")
 
 	require.Equal(t, "exemplar", frame.Name)
-	require.Equal(t, 6, len(frame.Fields))
+	// Time, Value, Id, service (from labels), pod (from exemplar labels)
+	require.Equal(t, 5, len(frame.Fields))
 	require.Equal(t, "Time", frame.Fields[0].Name)
 	require.Equal(t, "Value", frame.Fields[1].Name)
 	require.Equal(t, "short", frame.Fields[1].Config.Unit)
 	require.Equal(t, "Id", frame.Fields[2].Name)
-	require.Equal(t, "foo", frame.Fields[3].Name)
-	require.Equal(t, "label1", frame.Fields[4].Name)
-	require.Equal(t, "label2", frame.Fields[5].Name)
+
+	// Check that Id field shows Profile ID
+	require.Equal(t, "Profile ID", frame.Fields[2].Config.DisplayName)
 
 	rows, err := frame.RowLen()
 	require.NoError(t, err)
 	require.Equal(t, 2, rows)
+
 	row := frame.RowCopy(0)
-	require.Equal(t, 6, len(row))
+	require.Equal(t, 5, len(row))
 	require.Equal(t, 1.0, row[1])
-	require.Equal(t, "1", row[2])
-	require.Equal(t, "bar", row[3])
-	require.Equal(t, "", row[4])
-	require.Equal(t, "", row[5])
-	row = frame.RowCopy(1)
-	require.Equal(t, 6, len(row))
-	require.Equal(t, 2.0, row[1])
-	require.Equal(t, "2", row[2])
-	require.Equal(t, "bar", row[3])
-	require.Equal(t, "value1", row[4])
-	require.Equal(t, "value2", row[5])
+	require.Equal(t, "profile-1", row[2]) // Should use ProfileId for profile type
+}
+
+func TestCreateExemplarFrame_SpanType(t *testing.T) {
+	exemplars := []*Exemplar{
+		{
+			ProfileId: "profile-1",
+			SpanId:    "span-abc123",
+			Value:     100.0,
+			Timestamp: 1000,
+			Labels: map[string]string{
+				"pod":       "pod-xyz",
+				"namespace": "prod",
+				"__name__":  "cpu",
+			},
+		},
+	}
+	labels := map[string]string{
+		"service": "api",
+	}
+	frame := CreateExemplarFrame(labels, exemplars, ExemplarTypeSpan, "nanoseconds")
+
+	require.Equal(t, "exemplar", frame.Name)
+
+	// Check Value field configuration
+	valueField := frame.Fields[1]
+	require.Equal(t, "Value", valueField.Name)
+	require.Equal(t, "Value", valueField.Config.DisplayName)
+	require.Equal(t, "nanoseconds", valueField.Config.Unit)
+
+	// Check Id field configuration
+	idField := frame.Fields[2]
+	require.Equal(t, "Id", idField.Name)
+	require.Equal(t, "Span ID", idField.Config.DisplayName)
+
+	// Verify span ID is used for span type
+	rows, err := frame.RowLen()
+	require.NoError(t, err)
+	require.Equal(t, 1, rows)
+
+	row := frame.RowCopy(0)
+	require.Equal(t, "span-abc123", row[2]) // Should use SpanId for span type
+}
+
+func TestCreateExemplarFrame_AllLabelsIncluded(t *testing.T) {
+	exemplars := []*Exemplar{
+		{
+			ProfileId: "profile-1",
+			SpanId:    "span-1",
+			Value:     1.0,
+			Timestamp: 100,
+			Labels: map[string]string{
+				"pod":              "pod-1",
+				"__profile_type__": "cpu",
+				"__name__":         "process_cpu",
+			},
+		},
+	}
+	labels := map[string]string{
+		"service": "api",
+	}
+	frame := CreateExemplarFrame(labels, exemplars, ExemplarTypeSpan, "count")
+
+	// Verify all fields are created (including private labels)
+	fieldNames := make([]string, 0, len(frame.Fields))
+	for _, field := range frame.Fields {
+		fieldNames = append(fieldNames, field.Name)
+	}
+
+	require.Contains(t, fieldNames, "Time")
+	require.Contains(t, fieldNames, "Value")
+	require.Contains(t, fieldNames, "Id")
+	require.Contains(t, fieldNames, "service")
+	require.Contains(t, fieldNames, "pod")
+	require.Contains(t, fieldNames, "__profile_type__")
+	require.Contains(t, fieldNames, "__name__")
+}
+
+func TestCreateExemplarFrame_NoDuplicateFields(t *testing.T) {
+	// Test that labels in both series labels and exemplar labels don't create duplicate fields
+	exemplars := []*Exemplar{
+		{
+			ProfileId: "profile-1",
+			SpanId:    "span-1",
+			Value:     1.0,
+			Timestamp: 100,
+			Labels: map[string]string{
+				"pod":       "exemplar-pod-123", // Different value than series label
+				"namespace": "prod",             // This is only in exemplar labels
+			},
+		},
+	}
+	labels := map[string]string{
+		"service": "api",
+		"pod":     "series-pod-456", // This is also in exemplar labels but with different value
+	}
+	frame := CreateExemplarFrame(labels, exemplars, ExemplarTypeSpan, "short")
+
+	// Count how many fields have each name
+	fieldCounts := make(map[string]int)
+	for _, field := range frame.Fields {
+		fieldCounts[field.Name]++
+	}
+
+	// Each field name should appear exactly once
+	require.Equal(t, 1, fieldCounts["Time"])
+	require.Equal(t, 1, fieldCounts["Value"])
+	require.Equal(t, 1, fieldCounts["Id"])
+	require.Equal(t, 1, fieldCounts["service"])
+	require.Equal(t, 1, fieldCounts["pod"], "pod field should appear exactly once, not duplicated")
+	require.Equal(t, 1, fieldCounts["namespace"])
+
+	// Verify the exemplar-specific pod value is used (not the series value)
+	rows, err := frame.RowLen()
+	require.NoError(t, err)
+	require.Equal(t, 1, rows)
+
+	podField, _ := frame.FieldByName("pod")
+	require.NotNil(t, podField)
+	require.Equal(t, "exemplar-pod-123", podField.At(0), "Should use exemplar-specific pod value, not series value")
+
+	// Verify series label is used when exemplar doesn't have the label
+	serviceField, _ := frame.FieldByName("service")
+	require.NotNil(t, serviceField)
+	require.Equal(t, "api", serviceField.At(0))
+
+	// Verify exemplar-only label
+	namespaceField, _ := frame.FieldByName("namespace")
+	require.NotNil(t, namespaceField)
+	require.Equal(t, "prod", namespaceField.At(0))
+}
+
+func TestCreateExemplarFrame_ExemplarValueTakesPrecedence(t *testing.T) {
+	// Test that exemplar label values take precedence over series label values
+	exemplars := []*Exemplar{
+		{
+			ProfileId: "profile-1",
+			SpanId:    "span-1",
+			Value:     1.0,
+			Timestamp: 100,
+			Labels: map[string]string{
+				"pod":       "pod-abc",
+				"node":      "node-xyz",
+				"span_name": "my-span",
+			},
+		},
+		{
+			ProfileId: "profile-2",
+			SpanId:    "span-2",
+			Value:     2.0,
+			Timestamp: 200,
+			Labels: map[string]string{
+				"pod":       "pod-def",
+				"node":      "node-uvw",
+				"span_name": "another-span",
+			},
+		},
+	}
+	labels := map[string]string{
+		"service": "api",
+	}
+	frame := CreateExemplarFrame(labels, exemplars, ExemplarTypeSpan, "bytes")
+
+	// Verify we have the correct number of rows
+	rows, err := frame.RowLen()
+	require.NoError(t, err)
+	require.Equal(t, 2, rows)
+
+	// Verify each exemplar has its own pod, node, and span_name values
+	podField, _ := frame.FieldByName("pod")
+	require.NotNil(t, podField)
+	require.Equal(t, "pod-abc", podField.At(0))
+	require.Equal(t, "pod-def", podField.At(1))
+
+	nodeField, _ := frame.FieldByName("node")
+	require.NotNil(t, nodeField)
+	require.Equal(t, "node-xyz", nodeField.At(0))
+	require.Equal(t, "node-uvw", nodeField.At(1))
+
+	spanNameField, _ := frame.FieldByName("span_name")
+	require.NotNil(t, spanNameField)
+	require.Equal(t, "my-span", spanNameField.At(0))
+	require.Equal(t, "another-span", spanNameField.At(1))
+
+	// Verify series label is the same for both
+	serviceField, _ := frame.FieldByName("service")
+	require.NotNil(t, serviceField)
+	require.Equal(t, "api", serviceField.At(0))
+	require.Equal(t, "api", serviceField.At(1))
 }

--- a/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-// Point represents a single heatmap point with timestamp, bucket minimums, and counts
-type Point struct {
+// Slot represents a single heatmap slot with timestamp, bucket minimums, and counts
+type Slot struct {
 	Timestamp int64
 	YMin      []float64
 	Counts    []int64
@@ -40,153 +40,70 @@ func generateFrameName(labels map[string]string) string {
 	return fmt.Sprintf("heatmap{%s}", strings.Join(pairs, ","))
 }
 
-// fillMissingTimeSlices ensures continuous time coverage by filling gaps between data points.
-// This prevents visual gaps in the heatmap. Points are assumed to be in increasing timestamp order.
-func fillMissingTimeSlices(points []*Point, stepSeconds float64) []*Point {
-	if len(points) == 0 {
-		return points
-	}
-
-	// Determine the common bucket structure (YMin values)
-	// Find the most complete bucket structure across all points
-	templateYMin := points[0].YMin
-	for _, point := range points {
-		if len(point.YMin) > len(templateYMin) {
-			templateYMin = point.YMin
-		}
-	}
-
-	stepMs := int64(stepSeconds * 1000)
-	filled := make([]*Point, 0, len(points)*2) // Estimate: assume some gaps
-	zeroCounts := make([]int64, len(templateYMin))
-
-	// Process first point, normalizing bucket structure if needed
-	firstPoint := points[0] //nolint:gosec // bounds checked by len(points) == 0 guard above
-	if len(firstPoint.YMin) < len(templateYMin) {
-		paddedCounts := make([]int64, len(templateYMin))
-		copy(paddedCounts, firstPoint.Counts)
-		filled = append(filled, &Point{
-			Timestamp: firstPoint.Timestamp,
-			YMin:      templateYMin,
-			Counts:    paddedCounts,
-		})
-	} else {
-		filled = append(filled, firstPoint)
-	}
-
-	// Iterate through remaining points and fill gaps as we find them
-	for i := 1; i < len(points); i++ {
-		prevTimestamp := filled[len(filled)-1].Timestamp //nolint:gosec // filled is guaranteed non-empty: at least one element appended before loop
-		currTimestamp := points[i].Timestamp             //nolint:gosec // i is bounded by loop condition i < len(points)
-
-		// Fill any gaps between previous and current point
-		expectedTimestamp := prevTimestamp + stepMs
-		for expectedTimestamp < currTimestamp {
-			filled = append(filled, &Point{
-				Timestamp: expectedTimestamp,
-				YMin:      templateYMin,
-				Counts:    append([]int64(nil), zeroCounts...), // Copy to avoid sharing
-			})
-			expectedTimestamp += stepMs
-		}
-
-		// Add current point, normalizing bucket structure if needed
-		currPoint := points[i] //nolint:gosec // i is bounded by loop condition i < len(points)
-		if len(currPoint.YMin) < len(templateYMin) {
-			paddedCounts := make([]int64, len(templateYMin))
-			copy(paddedCounts, currPoint.Counts)
-			filled = append(filled, &Point{
-				Timestamp: currTimestamp,
-				YMin:      templateYMin,
-				Counts:    paddedCounts,
-			})
-		} else {
-			filled = append(filled, currPoint)
-		}
-	}
-
-	return filled
-}
-
-// CreateHeatmapFrame converts heatmap points to a DataFrame in HeatmapCells format
-// This creates a sparse representation where each cell is explicitly defined by:
-// - xMax: time value (timestamp)
-// - yMin: bucket minimum value
-// - yMax: bucket maximum value
-// - count: number of matches in that bucket
-// - yLayout: bucket layout (0 for linear buckets)
+// CreateHeatmapFrame converts heatmap slots to a DataFrame in HeatmapCells sparse format.
+// Only non-zero cells are emitted; absent cells are implicitly zero.
+// Fields (in order): xMax (Time), yMin (Number), yMax (Number), count (Number).
+// Having both yMin and yMax signals a sparse heatmap to the frontend.
 //
-// Parameters:
-// - labels: metric labels for the heatmap series
-// - points: data points in increasing timestamp order (may have gaps in time coverage)
-// - units: unit string for Y-axis values
-// - stepSeconds: duration of each time bucket in seconds
-//
-// The function ensures continuous time coverage by filling gaps between points with zero counts.
-func CreateHeatmapFrame(labels map[string]string, points []*Point, units string, stepSeconds float64) *data.Frame {
+// The contract for this can be found here: https://github.com/grafana/dataplane/blob/main/docs/contract/heatmap.md
+func CreateHeatmapFrame(labels map[string]string, slots []*Slot, units string, stepSeconds float64) *data.Frame {
 	frameName := generateFrameName(labels)
 	frame := data.NewFrame(frameName)
 	frame.Meta = &data.FrameMeta{
 		Type: "heatmap-cells",
 	}
 
-	// Calculate total number of cells across all points
-	totalCells := 0
-	for _, point := range points {
-		totalCells += len(point.Counts)
-	}
-
-	// Create data fields in the order expected by heatmap-cells format
-	// Set interval (in milliseconds) on xMax field so frontend can calculate xMin for bucket boundaries
-	intervalMs := int64(stepSeconds * 1000)
+	stepMs := int64(stepSeconds * 1000)
 	frame.Fields = data.Fields{
-		data.NewField("xMax", nil, make([]time.Time, 0, totalCells)).SetConfig(&data.FieldConfig{
-			Interval: float64(intervalMs),
-		}),
-		data.NewField("yMin", nil, make([]float64, 0, totalCells)).SetConfig(&data.FieldConfig{
+		data.NewField("xMax", nil, []time.Time{}).SetConfig(&data.FieldConfig{}),
+		data.NewField("yMin", nil, []float64{}).SetConfig(&data.FieldConfig{
 			Unit: units,
 		}),
-		data.NewField("yMax", nil, make([]float64, 0, totalCells)).SetConfig(&data.FieldConfig{
+		data.NewField("yMax", nil, []float64{}).SetConfig(&data.FieldConfig{
 			Unit: units,
 		}),
-		data.NewField("count", labels, make([]int64, 0, totalCells)),
-		data.NewField("yLayout", nil, make([]int8, 0, totalCells)),
+		data.NewField("count", labels, []int64{}),
 	}
 
-	if totalCells == 0 {
-		return frame
-	}
+	for i, slot := range slots {
+		xMax := time.UnixMilli(slot.Timestamp)
+		nBuckets := len(slot.Counts)
+		for j := 0; j < nBuckets; j++ {
+			if slot.Counts[j] == 0 {
+				continue
+			}
 
-	// Fill missing time slices and normalize bucket structures
-	points = fillMissingTimeSlices(points, stepSeconds)
-
-	// Populate cells: for each time point, create a cell for each bucket
-	for _, point := range points {
-		timestamp := time.UnixMilli(point.Timestamp)
-		for i := 0; i < len(point.Counts); i++ {
-			// Calculate yMax: for bucket i, yMax is yMin of bucket i+1
-			// For the last bucket, use a large value or calculate based on bucket width
 			var yMax float64
-			if i < len(point.YMin)-1 {
-				yMax = point.YMin[i+1]
+			if j < len(slot.YMin)-1 {
+				yMax = slot.YMin[j+1]
+			} else if j > 0 {
+				yMax = slot.YMin[j] + (slot.YMin[j] - slot.YMin[j-1])
 			} else {
-				// For the last bucket, calculate based on the previous bucket width
-				if i > 0 {
-					bucketWidth := point.YMin[i] - point.YMin[i-1]
-					yMax = point.YMin[i] + bucketWidth
-				} else {
-					// Single bucket case: use a reasonable default
-					yMax = point.YMin[i] * 2
-				}
+				yMax = slot.YMin[j] * 2
 			}
 
 			frame.AppendRow(
-				timestamp,
-				point.YMin[i],
+				xMax,
+				slot.YMin[j],
 				yMax,
-				point.Counts[i],
-				int8(0), // 0 indicates linear bucket layout
+				slot.Counts[j],
 			)
+		}
+
+		// Unlike the contract the panel doesn't respect xMin, instead it infers the correct bucket
+		// width from the size of the first gap in xMax.
+		// So if the next slot is more than one step away, insert a zero-count calibration
+		// row at timestamp+stepMs so the panel sees the correct bucket width.
+		if i == 0 && len(slots) > 1 && slots[1].Timestamp != slot.Timestamp+stepMs {
+			calTs := time.UnixMilli(slot.Timestamp + stepMs)
+			var calYMin, calYMax float64
+			if len(slot.YMin) > 1 {
+				calYMin, calYMax = slot.YMin[0], slot.YMin[1]
+			} else if len(slot.YMin) == 1 {
+				calYMin = slot.YMin[0]
+				calYMax = slot.YMin[0] * 2
+			}
+			frame.AppendRow(calTs, calYMin, calYMax, int64(0))
 		}
 	}
 

--- a/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap.go
@@ -1,0 +1,194 @@
+package heatmap
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// Point represents a single heatmap point with timestamp, bucket minimums, and counts
+type Point struct {
+	Timestamp int64
+	YMin      []float64
+	Counts    []int64
+}
+
+// generateFrameName creates a unique frame name from labels
+// If labels are empty, returns "heatmap"
+// Otherwise returns "heatmap{label1=value1,label2=value2,...}"
+func generateFrameName(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "heatmap"
+	}
+
+	// Sort label keys for consistent ordering
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Build label string
+	pairs := make([]string, 0, len(labels))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, labels[k]))
+	}
+
+	return fmt.Sprintf("heatmap{%s}", strings.Join(pairs, ","))
+}
+
+// fillMissingTimeSlices ensures continuous time coverage by filling gaps between data points.
+// This prevents visual gaps in the heatmap. Points are assumed to be in increasing timestamp order.
+func fillMissingTimeSlices(points []*Point, stepSeconds float64) []*Point {
+	if len(points) == 0 {
+		return points
+	}
+
+	// Determine the common bucket structure (YMin values)
+	// Find the most complete bucket structure across all points
+	templateYMin := points[0].YMin
+	for _, point := range points {
+		if len(point.YMin) > len(templateYMin) {
+			templateYMin = point.YMin
+		}
+	}
+
+	stepMs := int64(stepSeconds * 1000)
+	filled := make([]*Point, 0, len(points)*2) // Estimate: assume some gaps
+	zeroCounts := make([]int64, len(templateYMin))
+
+	// Process first point, normalizing bucket structure if needed
+	firstPoint := points[0] //nolint:gosec // bounds checked by len(points) == 0 guard above
+	if len(firstPoint.YMin) < len(templateYMin) {
+		paddedCounts := make([]int64, len(templateYMin))
+		copy(paddedCounts, firstPoint.Counts)
+		filled = append(filled, &Point{
+			Timestamp: firstPoint.Timestamp,
+			YMin:      templateYMin,
+			Counts:    paddedCounts,
+		})
+	} else {
+		filled = append(filled, firstPoint)
+	}
+
+	// Iterate through remaining points and fill gaps as we find them
+	for i := 1; i < len(points); i++ {
+		prevTimestamp := filled[len(filled)-1].Timestamp //nolint:gosec // filled is guaranteed non-empty: at least one element appended before loop
+		currTimestamp := points[i].Timestamp             //nolint:gosec // i is bounded by loop condition i < len(points)
+
+		// Fill any gaps between previous and current point
+		expectedTimestamp := prevTimestamp + stepMs
+		for expectedTimestamp < currTimestamp {
+			filled = append(filled, &Point{
+				Timestamp: expectedTimestamp,
+				YMin:      templateYMin,
+				Counts:    append([]int64(nil), zeroCounts...), // Copy to avoid sharing
+			})
+			expectedTimestamp += stepMs
+		}
+
+		// Add current point, normalizing bucket structure if needed
+		currPoint := points[i] //nolint:gosec // i is bounded by loop condition i < len(points)
+		if len(currPoint.YMin) < len(templateYMin) {
+			paddedCounts := make([]int64, len(templateYMin))
+			copy(paddedCounts, currPoint.Counts)
+			filled = append(filled, &Point{
+				Timestamp: currTimestamp,
+				YMin:      templateYMin,
+				Counts:    paddedCounts,
+			})
+		} else {
+			filled = append(filled, currPoint)
+		}
+	}
+
+	return filled
+}
+
+// CreateHeatmapFrame converts heatmap points to a DataFrame in HeatmapCells format
+// This creates a sparse representation where each cell is explicitly defined by:
+// - xMax: time value (timestamp)
+// - yMin: bucket minimum value
+// - yMax: bucket maximum value
+// - count: number of matches in that bucket
+// - yLayout: bucket layout (0 for linear buckets)
+//
+// Parameters:
+// - labels: metric labels for the heatmap series
+// - points: data points in increasing timestamp order (may have gaps in time coverage)
+// - units: unit string for Y-axis values
+// - stepSeconds: duration of each time bucket in seconds
+//
+// The function ensures continuous time coverage by filling gaps between points with zero counts.
+func CreateHeatmapFrame(labels map[string]string, points []*Point, units string, stepSeconds float64) *data.Frame {
+	frameName := generateFrameName(labels)
+	frame := data.NewFrame(frameName)
+	frame.Meta = &data.FrameMeta{
+		Type: "heatmap-cells",
+	}
+
+	// Calculate total number of cells across all points
+	totalCells := 0
+	for _, point := range points {
+		totalCells += len(point.Counts)
+	}
+
+	// Create data fields in the order expected by heatmap-cells format
+	// Set interval (in milliseconds) on xMax field so frontend can calculate xMin for bucket boundaries
+	intervalMs := int64(stepSeconds * 1000)
+	frame.Fields = data.Fields{
+		data.NewField("xMax", nil, make([]time.Time, 0, totalCells)).SetConfig(&data.FieldConfig{
+			Interval: float64(intervalMs),
+		}),
+		data.NewField("yMin", nil, make([]float64, 0, totalCells)).SetConfig(&data.FieldConfig{
+			Unit: units,
+		}),
+		data.NewField("yMax", nil, make([]float64, 0, totalCells)).SetConfig(&data.FieldConfig{
+			Unit: units,
+		}),
+		data.NewField("count", labels, make([]int64, 0, totalCells)),
+		data.NewField("yLayout", nil, make([]int8, 0, totalCells)),
+	}
+
+	if totalCells == 0 {
+		return frame
+	}
+
+	// Fill missing time slices and normalize bucket structures
+	points = fillMissingTimeSlices(points, stepSeconds)
+
+	// Populate cells: for each time point, create a cell for each bucket
+	for _, point := range points {
+		timestamp := time.UnixMilli(point.Timestamp)
+		for i := 0; i < len(point.Counts); i++ {
+			// Calculate yMax: for bucket i, yMax is yMin of bucket i+1
+			// For the last bucket, use a large value or calculate based on bucket width
+			var yMax float64
+			if i < len(point.YMin)-1 {
+				yMax = point.YMin[i+1]
+			} else {
+				// For the last bucket, calculate based on the previous bucket width
+				if i > 0 {
+					bucketWidth := point.YMin[i] - point.YMin[i-1]
+					yMax = point.YMin[i] + bucketWidth
+				} else {
+					// Single bucket case: use a reasonable default
+					yMax = point.YMin[i] * 2
+				}
+			}
+
+			frame.AppendRow(
+				timestamp,
+				point.YMin[i],
+				yMax,
+				point.Counts[i],
+				int8(0), // 0 indicates linear bucket layout
+			)
+		}
+	}
+
+	return frame
+}

--- a/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap_test.go
@@ -1,0 +1,398 @@
+package heatmap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateFrameName(t *testing.T) {
+	t.Run("empty labels returns default name", func(t *testing.T) {
+		name := generateFrameName(map[string]string{})
+		require.Equal(t, "heatmap", name)
+	})
+
+	t.Run("single label", func(t *testing.T) {
+		name := generateFrameName(map[string]string{"service": "api"})
+		require.Equal(t, "heatmap{service=api}", name)
+	})
+
+	t.Run("multiple labels sorted", func(t *testing.T) {
+		name := generateFrameName(map[string]string{
+			"service": "api",
+			"env":     "prod",
+			"region":  "us-west",
+		})
+		// Labels should be sorted alphabetically
+		require.Equal(t, "heatmap{env=prod,region=us-west,service=api}", name)
+	})
+}
+
+func TestCreateHeatmapFrame(t *testing.T) {
+	t.Run("creates frame with correct metadata", func(t *testing.T) {
+		now := time.Now()
+		points := []*Point{
+			{
+				Timestamp: now.UnixMilli(),
+				YMin:      []float64{0, 100, 200},
+				Counts:    []int64{5, 10, 3},
+			},
+		}
+		labels := map[string]string{"service": "api"}
+
+		frame := CreateHeatmapFrame(labels, points, "ns", 15.0)
+
+		require.NotNil(t, frame)
+		require.Equal(t, "heatmap{service=api}", frame.Name)
+		require.NotNil(t, frame.Meta)
+		require.Equal(t, data.FrameType("heatmap-cells"), frame.Meta.Type)
+	})
+
+	t.Run("creates correct fields structure", func(t *testing.T) {
+		timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		points := []*Point{
+			{
+				Timestamp: timestamp.UnixMilli(),
+				YMin:      []float64{0, 100, 200},
+				Counts:    []int64{5, 10, 3},
+			},
+		}
+
+		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", 15.0)
+
+		require.Len(t, frame.Fields, 5)
+		require.Equal(t, "xMax", frame.Fields[0].Name)
+		require.Equal(t, "yMin", frame.Fields[1].Name)
+		require.Equal(t, "yMax", frame.Fields[2].Name)
+		require.Equal(t, "count", frame.Fields[3].Name)
+		require.Equal(t, "yLayout", frame.Fields[4].Name)
+	})
+
+	t.Run("correctly expands multiple time points into cells", func(t *testing.T) {
+		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		timestamp2 := time.Date(2024, 1, 1, 0, 0, 15, 0, time.UTC) // 15 seconds later (1 step)
+		stepDuration := 15.0                                       // 15 seconds
+
+		points := []*Point{
+			{
+				Timestamp: timestamp1.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{5, 10},
+			},
+			{
+				Timestamp: timestamp2.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{7, 12},
+			},
+		}
+
+		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", stepDuration)
+
+		// Should create 4 cells total (2 time points × 2 buckets, no gaps to fill)
+		require.Equal(t, 4, frame.Fields[0].Len())
+		require.Equal(t, 4, frame.Fields[1].Len())
+		require.Equal(t, 4, frame.Fields[2].Len())
+		require.Equal(t, 4, frame.Fields[3].Len())
+		require.Equal(t, 4, frame.Fields[4].Len())
+
+		// Check xMax values (timestamps) - compare Unix millis to avoid timezone issues
+		xMaxField := frame.Fields[0]
+		require.Equal(t, timestamp1.UnixMilli(), xMaxField.At(0).(time.Time).UnixMilli())
+		require.Equal(t, timestamp1.UnixMilli(), xMaxField.At(1).(time.Time).UnixMilli())
+		require.Equal(t, timestamp2.UnixMilli(), xMaxField.At(2).(time.Time).UnixMilli())
+		require.Equal(t, timestamp2.UnixMilli(), xMaxField.At(3).(time.Time).UnixMilli())
+
+		// Check yMin values (bucket minimums)
+		yMinField := frame.Fields[1]
+		require.Equal(t, float64(0), yMinField.At(0))
+		require.Equal(t, float64(100), yMinField.At(1))
+		require.Equal(t, float64(0), yMinField.At(2))
+		require.Equal(t, float64(100), yMinField.At(3))
+
+		// Check yMax values (bucket maximums)
+		yMaxField := frame.Fields[2]
+		require.Equal(t, float64(100), yMaxField.At(0)) // yMax for bucket [0-100)
+		require.Equal(t, float64(200), yMaxField.At(1)) // yMax for bucket [100-200)
+		require.Equal(t, float64(100), yMaxField.At(2)) // yMax for bucket [0-100)
+		require.Equal(t, float64(200), yMaxField.At(3)) // yMax for bucket [100-200)
+
+		// Check count values
+		countField := frame.Fields[3]
+		require.Equal(t, int64(5), countField.At(0))
+		require.Equal(t, int64(10), countField.At(1))
+		require.Equal(t, int64(7), countField.At(2))
+		require.Equal(t, int64(12), countField.At(3))
+
+		// Check yLayout values (should all be 0 for linear)
+		yLayoutField := frame.Fields[4]
+		require.Equal(t, int8(0), yLayoutField.At(0))
+		require.Equal(t, int8(0), yLayoutField.At(1))
+		require.Equal(t, int8(0), yLayoutField.At(2))
+		require.Equal(t, int8(0), yLayoutField.At(3))
+	})
+
+	t.Run("attaches labels to count field", func(t *testing.T) {
+		now := time.Now()
+		points := []*Point{
+			{
+				Timestamp: now.UnixMilli(),
+				YMin:      []float64{0},
+				Counts:    []int64{5},
+			},
+		}
+		labels := map[string]string{"service": "api", "env": "prod"}
+
+		frame := CreateHeatmapFrame(labels, points, "ns", 15.0)
+
+		countField := frame.Fields[3]
+		require.NotNil(t, countField.Labels)
+		require.Equal(t, "api", countField.Labels["service"])
+		require.Equal(t, "prod", countField.Labels["env"])
+	})
+
+	t.Run("creates unique frame name based on labels", func(t *testing.T) {
+		now := time.Now()
+		points := []*Point{
+			{
+				Timestamp: now.UnixMilli(),
+				YMin:      []float64{0},
+				Counts:    []int64{5},
+			},
+		}
+		labels := map[string]string{"service": "api", "env": "prod"}
+
+		frame := CreateHeatmapFrame(labels, points, "ns", 15.0)
+
+		// Frame name should include labels in sorted order
+		require.Equal(t, "heatmap{env=prod,service=api}", frame.Name)
+	})
+
+	t.Run("sets unit on yMin and yMax fields", func(t *testing.T) {
+		now := time.Now()
+		points := []*Point{
+			{
+				Timestamp: now.UnixMilli(),
+				YMin:      []float64{0},
+				Counts:    []int64{5},
+			},
+		}
+
+		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", 15.0)
+
+		// yMin field should have units
+		yMinField := frame.Fields[1]
+		require.NotNil(t, yMinField.Config)
+		require.Equal(t, "ns", yMinField.Config.Unit)
+
+		// yMax field should have units
+		yMaxField := frame.Fields[2]
+		require.NotNil(t, yMaxField.Config)
+		require.Equal(t, "ns", yMaxField.Config.Unit)
+
+		// count field should NOT have units (or have empty unit)
+		countField := frame.Fields[3]
+		if countField.Config != nil {
+			require.Empty(t, countField.Config.Unit)
+		}
+	})
+
+	t.Run("handles empty points", func(t *testing.T) {
+		frame := CreateHeatmapFrame(map[string]string{}, []*Point{}, "ns", 15.0)
+
+		require.NotNil(t, frame)
+		require.Len(t, frame.Fields, 5)
+		require.Equal(t, 0, frame.Fields[0].Len())
+		require.Equal(t, 0, frame.Fields[1].Len())
+		require.Equal(t, 0, frame.Fields[2].Len())
+		require.Equal(t, 0, frame.Fields[3].Len())
+		require.Equal(t, 0, frame.Fields[4].Len())
+	})
+
+	t.Run("handles varying bucket counts per time point", func(t *testing.T) {
+		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		timestamp2 := time.Date(2024, 1, 1, 0, 0, 15, 0, time.UTC) // 15 seconds later (1 step)
+
+		points := []*Point{
+			{
+				Timestamp: timestamp1.UnixMilli(),
+				YMin:      []float64{0, 100, 200},
+				Counts:    []int64{5, 10, 3},
+			},
+			{
+				Timestamp: timestamp2.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{7, 12},
+			},
+		}
+
+		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", 15.0)
+
+		// Should use the most complete bucket structure (3 buckets from first point)
+		// 2 time points × 3 buckets = 6 cells
+		require.Equal(t, 6, frame.Fields[0].Len())
+	})
+
+	t.Run("fills missing time slices with zero counts", func(t *testing.T) {
+		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		timestamp2 := time.Date(2024, 1, 1, 0, 0, 45, 0, time.UTC) // 45 seconds later (3 steps of 15s)
+		stepDuration := 15.0                                       // 15 seconds
+
+		points := []*Point{
+			{
+				Timestamp: timestamp1.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{5, 10},
+			},
+			{
+				Timestamp: timestamp2.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{7, 12},
+			},
+		}
+
+		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", stepDuration)
+
+		// Should fill gaps: original 2 points + 2 gap points = 4 points
+		// Each point has 2 buckets, so 4 * 2 = 8 cells total
+		require.Equal(t, 8, frame.Fields[0].Len())
+
+		// Check timestamps are continuous
+		xMaxField := frame.Fields[0]
+		expectedTimestamps := []int64{
+			timestamp1.UnixMilli(),                       // Original point
+			timestamp1.Add(15 * time.Second).UnixMilli(), // Gap fill
+			timestamp1.Add(30 * time.Second).UnixMilli(), // Gap fill
+			timestamp2.UnixMilli(),                       // Original point
+		}
+
+		for i, expected := range expectedTimestamps {
+			// Each timestamp should appear twice (once per bucket)
+			require.Equal(t, expected, xMaxField.At(i*2).(time.Time).UnixMilli())
+			require.Equal(t, expected, xMaxField.At(i*2+1).(time.Time).UnixMilli())
+		}
+
+		// Check that gap-filled cells have zero counts
+		countField := frame.Fields[3]
+		require.Equal(t, int64(5), countField.At(0))  // Original
+		require.Equal(t, int64(10), countField.At(1)) // Original
+		require.Equal(t, int64(0), countField.At(2))  // Gap fill
+		require.Equal(t, int64(0), countField.At(3))  // Gap fill
+		require.Equal(t, int64(0), countField.At(4))  // Gap fill
+		require.Equal(t, int64(0), countField.At(5))  // Gap fill
+		require.Equal(t, int64(7), countField.At(6))  // Original
+		require.Equal(t, int64(12), countField.At(7)) // Original
+	})
+}
+
+func TestFillMissingTimeSlices(t *testing.T) {
+	t.Run("no gaps returns original points", func(t *testing.T) {
+		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		timestamp2 := time.Date(2024, 1, 1, 0, 0, 15, 0, time.UTC)
+		stepDuration := 15.0
+
+		points := []*Point{
+			{
+				Timestamp: timestamp1.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{5, 10},
+			},
+			{
+				Timestamp: timestamp2.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{7, 12},
+			},
+		}
+
+		filled := fillMissingTimeSlices(points, stepDuration)
+
+		require.Len(t, filled, 2)
+		require.Equal(t, timestamp1.UnixMilli(), filled[0].Timestamp)
+		require.Equal(t, timestamp2.UnixMilli(), filled[1].Timestamp)
+	})
+
+	t.Run("fills single gap", func(t *testing.T) {
+		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		timestamp2 := time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC) // 2 steps later
+		stepDuration := 15.0
+
+		points := []*Point{
+			{
+				Timestamp: timestamp1.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{5, 10},
+			},
+			{
+				Timestamp: timestamp2.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{7, 12},
+			},
+		}
+
+		filled := fillMissingTimeSlices(points, stepDuration)
+
+		require.Len(t, filled, 3)
+		require.Equal(t, timestamp1.UnixMilli(), filled[0].Timestamp)
+		require.Equal(t, timestamp1.Add(15*time.Second).UnixMilli(), filled[1].Timestamp)
+		require.Equal(t, timestamp2.UnixMilli(), filled[2].Timestamp)
+
+		// Check gap point has zero counts
+		require.Equal(t, []int64{0, 0}, filled[1].Counts)
+		require.Equal(t, []float64{0, 100}, filled[1].YMin)
+	})
+
+	t.Run("fills multiple gaps", func(t *testing.T) {
+		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		timestamp2 := time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC) // 4 steps later
+		stepDuration := 15.0
+
+		points := []*Point{
+			{
+				Timestamp: timestamp1.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{5, 10},
+			},
+			{
+				Timestamp: timestamp2.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{7, 12},
+			},
+		}
+
+		filled := fillMissingTimeSlices(points, stepDuration)
+
+		require.Len(t, filled, 5)
+		require.Equal(t, timestamp1.UnixMilli(), filled[0].Timestamp)
+		require.Equal(t, timestamp1.Add(15*time.Second).UnixMilli(), filled[1].Timestamp)
+		require.Equal(t, timestamp1.Add(30*time.Second).UnixMilli(), filled[2].Timestamp)
+		require.Equal(t, timestamp1.Add(45*time.Second).UnixMilli(), filled[3].Timestamp)
+		require.Equal(t, timestamp2.UnixMilli(), filled[4].Timestamp)
+
+		// Check all gap points have zero counts
+		for i := 1; i <= 3; i++ {
+			require.Equal(t, []int64{0, 0}, filled[i].Counts)
+		}
+	})
+
+	t.Run("handles empty points", func(t *testing.T) {
+		filled := fillMissingTimeSlices([]*Point{}, 15.0)
+		require.Len(t, filled, 0)
+	})
+
+	t.Run("handles single point", func(t *testing.T) {
+		timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		points := []*Point{
+			{
+				Timestamp: timestamp.UnixMilli(),
+				YMin:      []float64{0, 100},
+				Counts:    []int64{5, 10},
+			},
+		}
+
+		filled := fillMissingTimeSlices(points, 15.0)
+
+		require.Len(t, filled, 1)
+		require.Equal(t, timestamp.UnixMilli(), filled[0].Timestamp)
+	})
+}

--- a/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/heatmap/heatmap_test.go
@@ -33,7 +33,7 @@ func TestGenerateFrameName(t *testing.T) {
 func TestCreateHeatmapFrame(t *testing.T) {
 	t.Run("creates frame with correct metadata", func(t *testing.T) {
 		now := time.Now()
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: now.UnixMilli(),
 				YMin:      []float64{0, 100, 200},
@@ -42,7 +42,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 		}
 		labels := map[string]string{"service": "api"}
 
-		frame := CreateHeatmapFrame(labels, points, "ns", 15.0)
+		frame := CreateHeatmapFrame(labels, slots, "ns", 15.0)
 
 		require.NotNil(t, frame)
 		require.Equal(t, "heatmap{service=api}", frame.Name)
@@ -51,8 +51,9 @@ func TestCreateHeatmapFrame(t *testing.T) {
 	})
 
 	t.Run("creates correct fields structure", func(t *testing.T) {
+		stepDuration := 15.0 // 15 seconds
 		timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: timestamp.UnixMilli(),
 				YMin:      []float64{0, 100, 200},
@@ -60,14 +61,13 @@ func TestCreateHeatmapFrame(t *testing.T) {
 			},
 		}
 
-		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", 15.0)
+		frame := CreateHeatmapFrame(map[string]string{}, slots, "ns", stepDuration)
 
-		require.Len(t, frame.Fields, 5)
+		require.Len(t, frame.Fields, 4)
 		require.Equal(t, "xMax", frame.Fields[0].Name)
 		require.Equal(t, "yMin", frame.Fields[1].Name)
 		require.Equal(t, "yMax", frame.Fields[2].Name)
 		require.Equal(t, "count", frame.Fields[3].Name)
-		require.Equal(t, "yLayout", frame.Fields[4].Name)
 	})
 
 	t.Run("correctly expands multiple time points into cells", func(t *testing.T) {
@@ -75,7 +75,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 		timestamp2 := time.Date(2024, 1, 1, 0, 0, 15, 0, time.UTC) // 15 seconds later (1 step)
 		stepDuration := 15.0                                       // 15 seconds
 
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: timestamp1.UnixMilli(),
 				YMin:      []float64{0, 100},
@@ -88,14 +88,13 @@ func TestCreateHeatmapFrame(t *testing.T) {
 			},
 		}
 
-		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", stepDuration)
+		frame := CreateHeatmapFrame(map[string]string{}, slots, "ns", stepDuration)
 
 		// Should create 4 cells total (2 time points × 2 buckets, no gaps to fill)
 		require.Equal(t, 4, frame.Fields[0].Len())
 		require.Equal(t, 4, frame.Fields[1].Len())
 		require.Equal(t, 4, frame.Fields[2].Len())
 		require.Equal(t, 4, frame.Fields[3].Len())
-		require.Equal(t, 4, frame.Fields[4].Len())
 
 		// Check xMax values (timestamps) - compare Unix millis to avoid timezone issues
 		xMaxField := frame.Fields[0]
@@ -124,18 +123,11 @@ func TestCreateHeatmapFrame(t *testing.T) {
 		require.Equal(t, int64(10), countField.At(1))
 		require.Equal(t, int64(7), countField.At(2))
 		require.Equal(t, int64(12), countField.At(3))
-
-		// Check yLayout values (should all be 0 for linear)
-		yLayoutField := frame.Fields[4]
-		require.Equal(t, int8(0), yLayoutField.At(0))
-		require.Equal(t, int8(0), yLayoutField.At(1))
-		require.Equal(t, int8(0), yLayoutField.At(2))
-		require.Equal(t, int8(0), yLayoutField.At(3))
 	})
 
 	t.Run("attaches labels to count field", func(t *testing.T) {
 		now := time.Now()
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: now.UnixMilli(),
 				YMin:      []float64{0},
@@ -144,7 +136,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 		}
 		labels := map[string]string{"service": "api", "env": "prod"}
 
-		frame := CreateHeatmapFrame(labels, points, "ns", 15.0)
+		frame := CreateHeatmapFrame(labels, slots, "ns", 15.0)
 
 		countField := frame.Fields[3]
 		require.NotNil(t, countField.Labels)
@@ -154,7 +146,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 
 	t.Run("creates unique frame name based on labels", func(t *testing.T) {
 		now := time.Now()
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: now.UnixMilli(),
 				YMin:      []float64{0},
@@ -163,7 +155,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 		}
 		labels := map[string]string{"service": "api", "env": "prod"}
 
-		frame := CreateHeatmapFrame(labels, points, "ns", 15.0)
+		frame := CreateHeatmapFrame(labels, slots, "ns", 15.0)
 
 		// Frame name should include labels in sorted order
 		require.Equal(t, "heatmap{env=prod,service=api}", frame.Name)
@@ -171,7 +163,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 
 	t.Run("sets unit on yMin and yMax fields", func(t *testing.T) {
 		now := time.Now()
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: now.UnixMilli(),
 				YMin:      []float64{0},
@@ -179,7 +171,7 @@ func TestCreateHeatmapFrame(t *testing.T) {
 			},
 		}
 
-		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", 15.0)
+		frame := CreateHeatmapFrame(map[string]string{}, slots, "ns", 15.0)
 
 		// yMin field should have units
 		yMinField := frame.Fields[1]
@@ -199,22 +191,21 @@ func TestCreateHeatmapFrame(t *testing.T) {
 	})
 
 	t.Run("handles empty points", func(t *testing.T) {
-		frame := CreateHeatmapFrame(map[string]string{}, []*Point{}, "ns", 15.0)
+		frame := CreateHeatmapFrame(map[string]string{}, []*Slot{}, "ns", 15.0)
 
 		require.NotNil(t, frame)
-		require.Len(t, frame.Fields, 5)
+		require.Len(t, frame.Fields, 4)
 		require.Equal(t, 0, frame.Fields[0].Len())
 		require.Equal(t, 0, frame.Fields[1].Len())
 		require.Equal(t, 0, frame.Fields[2].Len())
 		require.Equal(t, 0, frame.Fields[3].Len())
-		require.Equal(t, 0, frame.Fields[4].Len())
 	})
 
 	t.Run("handles varying bucket counts per time point", func(t *testing.T) {
 		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		timestamp2 := time.Date(2024, 1, 1, 0, 0, 15, 0, time.UTC) // 15 seconds later (1 step)
 
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: timestamp1.UnixMilli(),
 				YMin:      []float64{0, 100, 200},
@@ -227,172 +218,121 @@ func TestCreateHeatmapFrame(t *testing.T) {
 			},
 		}
 
-		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", 15.0)
+		frame := CreateHeatmapFrame(map[string]string{}, slots, "ns", 15.0)
 
-		// Should use the most complete bucket structure (3 buckets from first point)
-		// 2 time points × 3 buckets = 6 cells
-		require.Equal(t, 6, frame.Fields[0].Len())
+		// Each point is rendered with its own bucket count (no padding).
+		// 3 buckets (point 1) + 2 buckets (point 2) = 5 cells
+		require.Equal(t, 5, frame.Fields[0].Len())
 	})
 
-	t.Run("fills missing time slices with zero counts", func(t *testing.T) {
+	t.Run("skips zero-count cells (sparse)", func(t *testing.T) {
 		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		timestamp2 := time.Date(2024, 1, 1, 0, 0, 45, 0, time.UTC) // 45 seconds later (3 steps of 15s)
-		stepDuration := 15.0                                       // 15 seconds
+		timestamp2 := time.Date(2024, 1, 1, 0, 0, 45, 0, time.UTC) // 3 steps later
 
-		points := []*Point{
+		slots := []*Slot{
 			{
 				Timestamp: timestamp1.UnixMilli(),
 				YMin:      []float64{0, 100},
-				Counts:    []int64{5, 10},
+				Counts:    []int64{5, 0},
 			},
 			{
 				Timestamp: timestamp2.UnixMilli(),
 				YMin:      []float64{0, 100},
-				Counts:    []int64{7, 12},
+				Counts:    []int64{0, 12},
 			},
 		}
 
-		frame := CreateHeatmapFrame(map[string]string{}, points, "ns", stepDuration)
+		frame := CreateHeatmapFrame(map[string]string{}, slots, "ns", 15.0)
 
-		// Should fill gaps: original 2 points + 2 gap points = 4 points
-		// Each point has 2 buckets, so 4 * 2 = 8 cells total
-		require.Equal(t, 8, frame.Fields[0].Len())
+		// 1 non-zero cell from point1 + 1 calibration row (gap > stepMs) + 1 non-zero cell from point2
+		require.Equal(t, 3, frame.Fields[0].Len())
 
-		// Check timestamps are continuous
 		xMaxField := frame.Fields[0]
-		expectedTimestamps := []int64{
-			timestamp1.UnixMilli(),                       // Original point
-			timestamp1.Add(15 * time.Second).UnixMilli(), // Gap fill
-			timestamp1.Add(30 * time.Second).UnixMilli(), // Gap fill
-			timestamp2.UnixMilli(),                       // Original point
-		}
+		calibrationTs := timestamp1.Add(15 * time.Second)
+		require.Equal(t, timestamp1.UnixMilli(), xMaxField.At(0).(time.Time).UnixMilli())
+		require.Equal(t, calibrationTs.UnixMilli(), xMaxField.At(1).(time.Time).UnixMilli())
+		require.Equal(t, timestamp2.UnixMilli(), xMaxField.At(2).(time.Time).UnixMilli())
 
-		for i, expected := range expectedTimestamps {
-			// Each timestamp should appear twice (once per bucket)
-			require.Equal(t, expected, xMaxField.At(i*2).(time.Time).UnixMilli())
-			require.Equal(t, expected, xMaxField.At(i*2+1).(time.Time).UnixMilli())
-		}
-
-		// Check that gap-filled cells have zero counts
 		countField := frame.Fields[3]
-		require.Equal(t, int64(5), countField.At(0))  // Original
-		require.Equal(t, int64(10), countField.At(1)) // Original
-		require.Equal(t, int64(0), countField.At(2))  // Gap fill
-		require.Equal(t, int64(0), countField.At(3))  // Gap fill
-		require.Equal(t, int64(0), countField.At(4))  // Gap fill
-		require.Equal(t, int64(0), countField.At(5))  // Gap fill
-		require.Equal(t, int64(7), countField.At(6))  // Original
-		require.Equal(t, int64(12), countField.At(7)) // Original
+		require.Equal(t, int64(5), countField.At(0))
+		require.Equal(t, int64(0), countField.At(1)) // calibration row
+		require.Equal(t, int64(12), countField.At(2))
 	})
 }
 
-func TestFillMissingTimeSlices(t *testing.T) {
-	t.Run("no gaps returns original points", func(t *testing.T) {
-		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		timestamp2 := time.Date(2024, 1, 1, 0, 0, 15, 0, time.UTC)
-		stepDuration := 15.0
+// TestCreateHeatmapFrameFromRealAPIData tests CreateHeatmapFrame against a real
+// Pyroscope SelectHeatmap API response (pyroscope-api.json at the repo root).
+//
+// The response contains 4 slots with two gaps of 3 steps each:
+//
+//	slot 1: ts=1774522307000  counts[0]=5
+//	slot 2: ts=1774522352000  counts[19]=1
+//	slot 3: ts=1774522367000  counts[0]=1
+//	slot 4: ts=1774522412000  counts[0]=17, counts[14]=1
+//
+// Sparse output: only 5 non-zero cells emitted (gaps and zero buckets are omitted).
+func TestCreateHeatmapFrameFromRealAPIData(t *testing.T) {
+	yMin := []float64{
+		10000000, 176500000, 343000000, 509500000, 676000000,
+		842500000, 1009000000, 1175500000, 1342000000, 1508500000,
+		1675000000, 1841500000, 2008000000, 2174500000, 2341000000,
+		2507500000, 2674000000, 2840500000, 3007000000, 3173500000,
+	}
+	slot1Counts := make([]int64, 20)
+	slot1Counts[0] = 5
+	slot2Counts := make([]int64, 20)
+	slot2Counts[19] = 1
+	slot3Counts := make([]int64, 20)
+	slot3Counts[0] = 1
+	slot4Counts := make([]int64, 20)
+	slot4Counts[0] = 17
+	slot4Counts[14] = 1
 
-		points := []*Point{
-			{
-				Timestamp: timestamp1.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{5, 10},
-			},
-			{
-				Timestamp: timestamp2.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{7, 12},
-			},
-		}
+	slots := []*Slot{
+		{Timestamp: 1774522307000, YMin: yMin, Counts: slot1Counts},
+		{Timestamp: 1774522352000, YMin: yMin, Counts: slot2Counts},
+		{Timestamp: 1774522367000, YMin: yMin, Counts: slot3Counts},
+		{Timestamp: 1774522412000, YMin: yMin, Counts: slot4Counts},
+	}
 
-		filled := fillMissingTimeSlices(points, stepDuration)
+	frame := CreateHeatmapFrame(map[string]string{}, slots, "ns", 15.0)
 
-		require.Len(t, filled, 2)
-		require.Equal(t, timestamp1.UnixMilli(), filled[0].Timestamp)
-		require.Equal(t, timestamp2.UnixMilli(), filled[1].Timestamp)
-	})
+	// 5 non-zero cells + 1 calibration row inserted after slot1 (gap to slot2 is 3 steps).
+	require.Equal(t, 6, frame.Fields[0].Len())
+	xMax := frame.Fields[0]
+	yMinField := frame.Fields[1]
+	yMaxField := frame.Fields[2]
+	counts := frame.Fields[3]
 
-	t.Run("fills single gap", func(t *testing.T) {
-		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		timestamp2 := time.Date(2024, 1, 1, 0, 0, 30, 0, time.UTC) // 2 steps later
-		stepDuration := 15.0
+	// cell 0: slot1, bucket 0
+	require.Equal(t, int64(1774522307000), xMax.At(0).(time.Time).UnixMilli())
+	require.Equal(t, float64(10000000), yMinField.At(0))
+	require.Equal(t, float64(176500000), yMaxField.At(0))
+	require.Equal(t, int64(5), counts.At(0))
 
-		points := []*Point{
-			{
-				Timestamp: timestamp1.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{5, 10},
-			},
-			{
-				Timestamp: timestamp2.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{7, 12},
-			},
-		}
+	// cell 1: calibration row at slot1+stepMs — ensures panel sees correct bucket width
+	require.Equal(t, int64(1774522322000), xMax.At(1).(time.Time).UnixMilli()) // 1774522307000 + 15000
+	require.Equal(t, float64(10000000), yMinField.At(1))
+	require.Equal(t, float64(176500000), yMaxField.At(1))
+	require.Equal(t, int64(0), counts.At(1))
 
-		filled := fillMissingTimeSlices(points, stepDuration)
+	// cell 2: slot2, bucket 19 (last bucket — yMax extrapolated)
+	require.Equal(t, int64(1774522352000), xMax.At(2).(time.Time).UnixMilli())
+	require.Equal(t, float64(3173500000), yMinField.At(2))
+	require.Equal(t, float64(3340000000), yMaxField.At(2)) // yMin[19] + (yMin[19]-yMin[18])
+	require.Equal(t, int64(1), counts.At(2))
 
-		require.Len(t, filled, 3)
-		require.Equal(t, timestamp1.UnixMilli(), filled[0].Timestamp)
-		require.Equal(t, timestamp1.Add(15*time.Second).UnixMilli(), filled[1].Timestamp)
-		require.Equal(t, timestamp2.UnixMilli(), filled[2].Timestamp)
+	// cell 3: slot3, bucket 0
+	require.Equal(t, int64(1774522367000), xMax.At(3).(time.Time).UnixMilli())
+	require.Equal(t, int64(1), counts.At(3))
 
-		// Check gap point has zero counts
-		require.Equal(t, []int64{0, 0}, filled[1].Counts)
-		require.Equal(t, []float64{0, 100}, filled[1].YMin)
-	})
+	// cell 4: slot4, bucket 0
+	require.Equal(t, int64(1774522412000), xMax.At(4).(time.Time).UnixMilli())
+	require.Equal(t, int64(17), counts.At(4))
 
-	t.Run("fills multiple gaps", func(t *testing.T) {
-		timestamp1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		timestamp2 := time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC) // 4 steps later
-		stepDuration := 15.0
-
-		points := []*Point{
-			{
-				Timestamp: timestamp1.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{5, 10},
-			},
-			{
-				Timestamp: timestamp2.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{7, 12},
-			},
-		}
-
-		filled := fillMissingTimeSlices(points, stepDuration)
-
-		require.Len(t, filled, 5)
-		require.Equal(t, timestamp1.UnixMilli(), filled[0].Timestamp)
-		require.Equal(t, timestamp1.Add(15*time.Second).UnixMilli(), filled[1].Timestamp)
-		require.Equal(t, timestamp1.Add(30*time.Second).UnixMilli(), filled[2].Timestamp)
-		require.Equal(t, timestamp1.Add(45*time.Second).UnixMilli(), filled[3].Timestamp)
-		require.Equal(t, timestamp2.UnixMilli(), filled[4].Timestamp)
-
-		// Check all gap points have zero counts
-		for i := 1; i <= 3; i++ {
-			require.Equal(t, []int64{0, 0}, filled[i].Counts)
-		}
-	})
-
-	t.Run("handles empty points", func(t *testing.T) {
-		filled := fillMissingTimeSlices([]*Point{}, 15.0)
-		require.Len(t, filled, 0)
-	})
-
-	t.Run("handles single point", func(t *testing.T) {
-		timestamp := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		points := []*Point{
-			{
-				Timestamp: timestamp.UnixMilli(),
-				YMin:      []float64{0, 100},
-				Counts:    []int64{5, 10},
-			},
-		}
-
-		filled := fillMissingTimeSlices(points, 15.0)
-
-		require.Len(t, filled, 1)
-		require.Equal(t, timestamp.UnixMilli(), filled[0].Timestamp)
-	})
+	// cell 5: slot4, bucket 14
+	require.Equal(t, int64(1774522412000), xMax.At(5).(time.Time).UnixMilli())
+	require.Equal(t, float64(2341000000), yMinField.At(5))
+	require.Equal(t, float64(2507500000), yMaxField.At(5))
+	require.Equal(t, int64(1), counts.At(5))
 }

--- a/pkg/tsdb/grafana-pyroscope-datasource/instance.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
@@ -36,6 +37,7 @@ type ProfilingClient interface {
 	GetSeries(ctx context.Context, profileTypeID string, labelSelector string, start int64, end int64, groupBy []string, limit *int64, step float64, exemplarType typesv1.ExemplarType) (*SeriesResponse, error)
 	GetProfile(ctx context.Context, profileTypeID string, labelSelector string, start int64, end int64, maxNodes *int64, profileIdSelector []string) (*ProfileResponse, error)
 	GetSpanProfile(ctx context.Context, profileTypeID string, labelSelector string, spanSelector []string, start int64, end int64, maxNodes *int64) (*ProfileResponse, error)
+	GetHeatmap(ctx context.Context, profileTypeID string, labelSelector string, start int64, end int64, groupBy []string, step float64, queryType querierv1.HeatmapQueryType, limit *int64, includeExemplars bool) (*HeatmapResponse, error)
 }
 
 // PyroscopeDatasource is a datasource for querying application performance profiles.

--- a/pkg/tsdb/grafana-pyroscope-datasource/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/kinds/dataquery/types_dataquery_gen.go
@@ -19,6 +19,13 @@ const (
 	PyroscopeQueryTypeBoth    PyroscopeQueryType = "both"
 )
 
+type HeatmapQueryType string
+
+const (
+	HeatmapQueryTypeIndividual HeatmapQueryType = "individual"
+	HeatmapQueryTypeSpan       HeatmapQueryType = "span"
+)
+
 type GrafanaPyroscopeDataQuery struct {
 	// Specifies the query label selectors.
 	LabelSelector string `json:"labelSelector"`
@@ -36,6 +43,12 @@ type GrafanaPyroscopeDataQuery struct {
 	Annotations *bool `json:"annotations,omitempty"`
 	// If set to true, exemplars will be requested
 	IncludeExemplars bool `json:"includeExemplars"`
+	// Specifies the query profile id selectors.
+	ProfileIdSelector []string `json:"profileIdSelector,omitempty"`
+	// If set to true, heatmap data will be requested
+	IncludeHeatmap bool `json:"includeHeatmap"`
+	// Specifies the type of heatmap query
+	HeatmapType string `json:"heatmapType"`
 	// A unique identifier for the query within the list of targets.
 	// In server side expressions, the refId is used as a variable name to identify results.
 	// By default, the UI will assign A->Z; however setting meaningful names may be useful.
@@ -45,8 +58,6 @@ type GrafanaPyroscopeDataQuery struct {
 	// Specify the query flavor
 	// TODO make this required and give it a default
 	QueryType *string `json:"queryType,omitempty"`
-	// Specifies the query profile id selectors.
-	ProfileIdSelector []string `json:"profileIdSelector,omitempty"`
 	// For mixed data sources the selected datasource is on the query level.
 	// For non mixed scenarios this is undefined.
 	// TODO find a better way to do this ^ that's friendly to schema
@@ -60,5 +71,7 @@ func NewGrafanaPyroscopeDataQuery() *GrafanaPyroscopeDataQuery {
 		LabelSelector:    "{}",
 		GroupBy:          []string{},
 		IncludeExemplars: false,
+		IncludeHeatmap:   false,
+		HeatmapType:      "individual",
 	}
 }

--- a/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
@@ -55,8 +55,9 @@ type Point struct {
 }
 
 type Exemplar struct {
-	Id        string
-	Value     uint64
+	ProfileId string
+	SpanId    string
+	Value     int64
 	Timestamp int64
 	Labels    []*LabelPair
 }
@@ -70,6 +71,23 @@ type SeriesResponse struct {
 	Series []*Series
 	Units  string
 	Label  string
+}
+
+type HeatmapPoint struct {
+	Timestamp int64
+	YMin      []float64
+	Counts    []int64
+	Exemplars []*Exemplar
+}
+
+type HeatmapSeries struct {
+	Labels []*LabelPair
+	Points []*HeatmapPoint
+}
+
+type HeatmapResponse struct {
+	Series []*HeatmapSeries
+	Units  string
 }
 
 type PyroscopeClient struct {
@@ -160,7 +178,8 @@ func (c *PyroscopeClient) GetSeries(ctx context.Context, profileTypeID string, l
 						}
 					}
 					points[i].Exemplars[j] = &Exemplar{
-						Id:        e.ProfileId,
+						ProfileId: e.ProfileId,
+						SpanId:    e.SpanId,
 						Value:     e.Value,
 						Timestamp: e.Timestamp,
 						Labels:    exemplarLabels,
@@ -181,6 +200,100 @@ func (c *PyroscopeClient) GetSeries(ctx context.Context, profileTypeID string, l
 		Series: series,
 		Units:  getUnits(profileTypeID),
 		Label:  parts[1],
+	}, nil
+}
+
+func (c *PyroscopeClient) GetHeatmap(ctx context.Context, profileTypeID string, labelSelector string, start int64, end int64, groupBy []string, step float64, queryType querierv1.HeatmapQueryType, limit *int64, includeExemplars bool) (*HeatmapResponse, error) {
+	ctx, span := tracing.DefaultTracer().Start(ctx, "datasource.pyroscope.GetHeatmap", trace.WithAttributes(attribute.String("profileTypeID", profileTypeID), attribute.String("labelSelector", labelSelector)))
+	defer span.End()
+
+	// Determine exemplar type based on includeExemplars flag and query type
+	exemplarType := typesv1.ExemplarType_EXEMPLAR_TYPE_NONE
+	if includeExemplars {
+		switch queryType {
+		case querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_SPAN:
+			exemplarType = typesv1.ExemplarType_EXEMPLAR_TYPE_SPAN
+		case querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_INDIVIDUAL:
+			exemplarType = typesv1.ExemplarType_EXEMPLAR_TYPE_INDIVIDUAL
+		case querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_UNSPECIFIED:
+			// default to no exemplars for unspecified query type
+		}
+	}
+
+	req := connect.NewRequest(&querierv1.SelectHeatmapRequest{
+		ProfileTypeID: profileTypeID,
+		LabelSelector: labelSelector,
+		Start:         start,
+		End:           end,
+		Step:          step,
+		GroupBy:       groupBy,
+		QueryType:     queryType,
+		Limit:         limit,
+		ExemplarType:  exemplarType,
+	})
+
+	resp, err := c.connectClient.SelectHeatmap(ctx, req)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, backend.DownstreamErrorf("received error from client while getting heatmap: %w", err)
+	}
+
+	series := make([]*HeatmapSeries, len(resp.Msg.Series))
+	for i, s := range resp.Msg.Series {
+		labels := make([]*LabelPair, len(s.Labels))
+		for j, l := range s.Labels {
+			labels[j] = &LabelPair{
+				Name:  l.Name,
+				Value: l.Value,
+			}
+		}
+
+		points := make([]*HeatmapPoint, len(s.Slots))
+		for j, slot := range s.Slots {
+			// Convert []int32 to []int64
+			counts := make([]int64, len(slot.Counts))
+			for k, c := range slot.Counts {
+				counts[k] = int64(c)
+			}
+
+			// Process exemplars if present
+			exemplars := make([]*Exemplar, len(slot.Exemplars))
+			for k, e := range slot.Exemplars {
+				// Convert API labels to our LabelPair type
+				exemplarLabels := make([]*LabelPair, len(e.Labels))
+				for i, l := range e.Labels {
+					exemplarLabels[i] = &LabelPair{
+						Name:  l.Name,
+						Value: l.Value,
+					}
+				}
+				exemplars[k] = &Exemplar{
+					ProfileId: e.ProfileId,
+					SpanId:    e.SpanId,
+					Value:     e.Value,
+					Timestamp: e.Timestamp,
+					Labels:    exemplarLabels,
+				}
+			}
+
+			points[j] = &HeatmapPoint{
+				Timestamp: slot.Timestamp,
+				YMin:      slot.YMin,
+				Counts:    counts,
+				Exemplars: exemplars,
+			}
+		}
+
+		series[i] = &HeatmapSeries{
+			Labels: labels,
+			Points: points,
+		}
+	}
+
+	return &HeatmapResponse{
+		Series: series,
+		Units:  getUnits(profileTypeID),
 	}, nil
 }
 

--- a/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient_test.go
@@ -40,7 +40,7 @@ func Test_PyroscopeClient(t *testing.T) {
 
 		series := &SeriesResponse{
 			Series: []*Series{
-				{Labels: []*LabelPair{{Name: "foo", Value: "bar"}}, Points: []*Point{{Timestamp: int64(1000), Value: 30, Exemplars: []*Exemplar{{Id: "id1", Value: 3, Timestamp: 1000, Labels: make([]*LabelPair, 0)}}}, {Timestamp: int64(2000), Value: 10, Exemplars: []*Exemplar{{Id: "id2", Value: 1, Timestamp: 2000, Labels: make([]*LabelPair, 0)}}}}},
+				{Labels: []*LabelPair{{Name: "foo", Value: "bar"}}, Points: []*Point{{Timestamp: int64(1000), Value: 30, Exemplars: []*Exemplar{{ProfileId: "id1", SpanId: "", Value: 3, Timestamp: 1000, Labels: []*LabelPair{}}}}, {Timestamp: int64(2000), Value: 10, Exemplars: []*Exemplar{{ProfileId: "id2", SpanId: "", Value: 1, Timestamp: 2000, Labels: []*LabelPair{}}}}}},
 			},
 			Units: "short",
 			Label: "alloc_objects",
@@ -163,6 +163,22 @@ func (f *FakePyroscopeConnectClient) SelectSeries(ctx context.Context, req *conn
 				{
 					Labels: []*typesv1.LabelPair{{Name: "foo", Value: "bar"}},
 					Points: []*typesv1.Point{{Timestamp: int64(1000), Value: 30}, {Timestamp: int64(2000), Value: 10}},
+				},
+			},
+		},
+	}, nil
+}
+
+func (f *FakePyroscopeConnectClient) SelectHeatmap(ctx context.Context, req *connect.Request[querierv1.SelectHeatmapRequest]) (*connect.Response[querierv1.SelectHeatmapResponse], error) {
+	f.Req = req
+	return &connect.Response[querierv1.SelectHeatmapResponse]{
+		Msg: &querierv1.SelectHeatmapResponse{
+			Series: []*typesv1.HeatmapSeries{
+				{
+					Labels: []*typesv1.LabelPair{{Name: "foo", Value: "bar"}},
+					Slots: []*typesv1.HeatmapSlot{
+						{Timestamp: int64(1000), YMin: []float64{0, 100, 200}, Counts: []int32{5, 10, 3}},
+					},
 				},
 			},
 		},

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/live"
 	"github.com/grafana/grafana/pkg/tsdb/grafana-pyroscope-datasource/exemplar"
+	"github.com/grafana/grafana/pkg/tsdb/grafana-pyroscope-datasource/heatmap"
 	"github.com/xlab/treeprint"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -23,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/grafana-pyroscope-datasource/annotation"
 	"github.com/grafana/grafana/pkg/tsdb/grafana-pyroscope-datasource/kinds/dataquery"
 
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
@@ -41,6 +43,7 @@ const (
 	queryTypeBoth    = string(dataquery.PyroscopeQueryTypeBoth)
 
 	exemplarsFeatureToggle = "profilesExemplars"
+	heatmapFeatureToggle   = "profilesHeatmap"
 )
 
 var identityTransformation = func(value float64) float64 { return value }
@@ -84,6 +87,20 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 					logger.Error("Failed to parse the MinStep using default", "MinStep", dsJson.MinStep, "function", logEntrypoint())
 				}
 			}
+
+			// Heatmap handling
+			if qm.IncludeHeatmap && backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled(heatmapFeatureToggle) {
+				stepDuration := math.Max(query.Interval.Seconds(), parsedInterval.Seconds())
+				frames, err := d.queryHeatmap(gCtx, span, profileTypeId, labelSelector, query, qm, stepDuration)
+				if err != nil {
+					return err
+				}
+				responseMutex.Lock()
+				defer responseMutex.Unlock()
+				response.Frames = append(response.Frames, frames...)
+				return nil
+			}
+
 			exemplarType := typesv1.ExemplarType_EXEMPLAR_TYPE_NONE
 			if qm.IncludeExemplars && backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled(exemplarsFeatureToggle) {
 				exemplarType = typesv1.ExemplarType_EXEMPLAR_TYPE_INDIVIDUAL
@@ -107,6 +124,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 			}
 			// add the frames to the response.
 			responseMutex.Lock()
+			defer responseMutex.Unlock()
 			withAnnotations := qm.Annotations != nil && *qm.Annotations
 			stepDuration := math.Max(query.Interval.Seconds(), parsedInterval.Seconds())
 			frames, err := seriesToDataFrames(seriesResp, withAnnotations, stepDuration, profileTypeId)
@@ -117,7 +135,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 				return err
 			}
 			response.Frames = append(response.Frames, frames...)
-			responseMutex.Unlock()
+
 			return nil
 		})
 	}
@@ -198,6 +216,78 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 	}
 
 	return response
+}
+
+// queryHeatmap handles heatmap query execution and frame construction.
+func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span, profileTypeId string, labelSelector string, query backend.DataQuery, qm queryModel, stepDuration float64) ([]*data.Frame, error) {
+	heatmapType := querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_INDIVIDUAL
+	if qm.HeatmapType == "span" {
+		heatmapType = querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_SPAN
+	}
+
+	includeExemplars := qm.IncludeExemplars && backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled(exemplarsFeatureToggle)
+
+	heatmapResp, err := d.client.GetHeatmap(
+		ctx,
+		profileTypeId,
+		labelSelector,
+		query.TimeRange.From.UnixMilli(),
+		query.TimeRange.To.UnixMilli(),
+		qm.GroupBy,
+		stepDuration,
+		heatmapType,
+		qm.Limit,
+		includeExemplars,
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.Error("Querying SelectHeatmap()", "err", err, "function", logEntrypoint())
+		return nil, err
+	}
+
+	exemplarType := exemplar.ExemplarTypeProfile
+	if heatmapType == querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_SPAN {
+		exemplarType = exemplar.ExemplarTypeSpan
+	}
+
+	frames := make([]*data.Frame, 0, len(heatmapResp.Series)*2)
+	for _, series := range heatmapResp.Series {
+		labels := make(map[string]string)
+		for _, label := range series.Labels {
+			labels[label.Name] = label.Value
+		}
+		points := make([]*heatmap.Point, len(series.Points))
+		exemplars := []*exemplar.Exemplar{}
+		for i, p := range series.Points {
+			points[i] = &heatmap.Point{
+				Timestamp: p.Timestamp,
+				YMin:      p.YMin,
+				Counts:    p.Counts,
+			}
+			for _, e := range p.Exemplars {
+				exemplarLabels := make(map[string]string)
+				for _, l := range e.Labels {
+					exemplarLabels[l.Name] = l.Value
+				}
+				exemplars = append(exemplars, &exemplar.Exemplar{
+					ProfileId: e.ProfileId,
+					SpanId:    e.SpanId,
+					Value:     float64(e.Value),
+					Timestamp: e.Timestamp,
+					Labels:    exemplarLabels,
+				})
+			}
+		}
+		heatmapFrame := heatmap.CreateHeatmapFrame(labels, points, heatmapResp.Units, stepDuration)
+		frames = append(frames, heatmapFrame)
+
+		if len(exemplars) > 0 {
+			exemplarFrame := exemplar.CreateExemplarFrame(labels, exemplars, exemplarType, heatmapResp.Units)
+			frames = append(frames, exemplarFrame)
+		}
+	}
+	return frames, nil
 }
 
 // responseToDataFrames turns Pyroscope response to data.Frame. We encode the data into a nested set format where we have
@@ -559,7 +649,8 @@ func seriesToDataFrames(resp *SeriesResponse, withAnnotations bool, stepDuration
 					exemplarLabels[l.Name] = l.Value
 				}
 				exemplars = append(exemplars, &exemplar.Exemplar{
-					Id:        e.Id,
+					ProfileId: e.ProfileId,
+					SpanId:    e.SpanId,
 					Value:     transformation(float64(e.Value)),
 					Timestamp: e.Timestamp,
 					Labels:    exemplarLabels,
@@ -571,7 +662,8 @@ func seriesToDataFrames(resp *SeriesResponse, withAnnotations bool, stepDuration
 		frames = append(frames, frame)
 
 		if len(exemplars) > 0 {
-			frame := exemplar.CreateExemplarFrame(labels, exemplars, displayUnit)
+			// Series queries always use individual profiles
+			frame := exemplar.CreateExemplarFrame(labels, exemplars, exemplar.ExemplarTypeProfile, displayUnit)
 			frames = append(frames, frame)
 		}
 	}

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -257,10 +257,10 @@ func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span,
 		for _, label := range series.Labels {
 			labels[label.Name] = label.Value
 		}
-		points := make([]*heatmap.Point, len(series.Points))
+		slots := make([]*heatmap.Slot, len(series.Points))
 		exemplars := []*exemplar.Exemplar{}
 		for i, p := range series.Points {
-			points[i] = &heatmap.Point{
+			slots[i] = &heatmap.Slot{
 				Timestamp: p.Timestamp,
 				YMin:      p.YMin,
 				Counts:    p.Counts,
@@ -279,7 +279,7 @@ func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span,
 				})
 			}
 		}
-		heatmapFrame := heatmap.CreateHeatmapFrame(labels, points, heatmapResp.Units, stepDuration)
+		heatmapFrame := heatmap.CreateHeatmapFrame(labels, slots, heatmapResp.Units, stepDuration)
 		frames = append(frames, heatmapFrame)
 
 		if len(exemplars) > 0 {

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -90,8 +90,11 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 
 			// Heatmap handling
 			if qm.IncludeHeatmap && backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled(heatmapFeatureToggle) {
-				stepDuration := math.Max(query.Interval.Seconds(), parsedInterval.Seconds())
-				frames, err := d.queryHeatmap(gCtx, span, profileTypeId, labelSelector, query, qm, stepDuration)
+				const maxHeatmapPoints = 64
+				timeRangeSec := query.TimeRange.To.Sub(query.TimeRange.From).Seconds()
+				minStepFromRange := timeRangeSec / maxHeatmapPoints
+				stepDuration := math.Max(math.Max(query.Interval.Seconds(), parsedInterval.Seconds()), minStepFromRange)
+				frames, err := d.queryHeatmap(gCtx, span, profileTypeId, labelSelector, query, qm, stepDuration, pCtx.DataSourceInstanceSettings.UID)
 				if err != nil {
 					return err
 				}

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -222,7 +222,7 @@ func (d *PyroscopeDatasource) query(ctx context.Context, pCtx backend.PluginCont
 }
 
 // queryHeatmap handles heatmap query execution and frame construction.
-func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span, profileTypeId string, labelSelector string, query backend.DataQuery, qm queryModel, stepDuration float64) ([]*data.Frame, error) {
+func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span, profileTypeId string, labelSelector string, query backend.DataQuery, qm queryModel, stepDuration float64, datasourceUID string) ([]*data.Frame, error) {
 	heatmapType := querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_INDIVIDUAL
 	if qm.HeatmapType == "span" {
 		heatmapType = querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_SPAN
@@ -287,6 +287,9 @@ func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span,
 
 		if len(exemplars) > 0 {
 			exemplarFrame := exemplar.CreateExemplarFrame(labels, exemplars, exemplarType, heatmapResp.Units)
+			exemplarFrame.Meta.Custom = map[string]interface{}{
+				"datasourceUID": datasourceUID,
+			}
 			frames = append(frames, exemplarFrame)
 		}
 	}

--- a/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 
 	"github.com/grafana/grafana/pkg/tsdb/grafana-pyroscope-datasource/annotation"
@@ -658,5 +659,19 @@ func (f *FakeClient) GetSeries(ctx context.Context, profileTypeID, labelSelector
 		},
 		Units: "count",
 		Label: "test",
+	}, nil
+}
+
+func (f *FakeClient) GetHeatmap(ctx context.Context, profileTypeID, labelSelector string, start, end int64, groupBy []string, step float64, queryType querierv1.HeatmapQueryType, limit *int64, includeExemplars bool) (*HeatmapResponse, error) {
+	return &HeatmapResponse{
+		Series: []*HeatmapSeries{
+			{
+				Labels: []*LabelPair{{Name: "foo", Value: "bar"}},
+				Points: []*HeatmapPoint{
+					{Timestamp: start, YMin: []float64{0, 100, 200}, Counts: []int64{5, 10, 3}},
+				},
+			},
+		},
+		Units: "nanoseconds",
 	}, nil
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanFlameGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanFlameGraph.tsx
@@ -133,6 +133,8 @@ export default function SpanFlameGraph(props: SpanFlameGraphProps) {
               uid: profilesDataSourceSettings.uid,
             },
             includeExemplars: false,
+            heatmapType: 'individual' as const,
+            includeHeatmap: false,
           },
         ],
       };

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
@@ -39,6 +39,8 @@ describe('QueryEditor', () => {
           maxNodes: 1000,
           groupBy: [],
           includeExemplars: false,
+          includeHeatmap: false,
+          heatmapType: 'individual',
         },
       },
     });
@@ -131,6 +133,8 @@ function setup(options: { props: Partial<Props> } = { props: {} }) {
         groupBy: [],
         limit: 42,
         includeExemplars: false,
+        includeHeatmap: false,
+        heatmapType: 'individual',
       }}
       datasource={setupDs()}
       onChange={onChange}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
@@ -5,6 +5,7 @@ import { CoreApp, type GrafanaTheme2, type SelectableValue } from '@grafana/data
 import { config } from '@grafana/runtime';
 import { useStyles2, RadioButtonGroup, MultiSelect, Input, InlineSwitch } from '@grafana/ui';
 
+import type { HeatmapQueryType } from '../dataquery.gen';
 import { type Query } from '../types';
 
 import { EditorField } from './EditorField';
@@ -59,6 +60,9 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
   }
   if (query.includeExemplars) {
     collapsedInfo.push(`With exemplars`);
+  }
+  if (query.includeHeatmap) {
+    collapsedInfo.push(`Heatmap: ${query.heatmapType || 'individual'}`);
   }
 
   return (
@@ -155,6 +159,30 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
                 }}
               />
             </EditorField>
+          )}
+          {config.featureToggles.profilesHeatmap && (
+            <>
+              <EditorField label={'Heatmap'} tooltip={<>Include heatmap visualization of profile data over time.</>}>
+                <InlineSwitch
+                  value={query.includeHeatmap || false}
+                  onChange={(event: React.SyntheticEvent<HTMLInputElement>) => {
+                    onQueryChange({ ...query, includeHeatmap: event.currentTarget.checked });
+                  }}
+                />
+              </EditorField>
+              {query.includeHeatmap && (
+                <EditorField label={'Heatmap Type'} tooltip={<>Select the type of heatmap aggregation.</>}>
+                  <RadioButtonGroup
+                    options={[
+                      { value: 'individual', label: 'Individual', description: 'Show individual profile samples' },
+                      { value: 'span', label: 'Span', description: 'Aggregate by span duration' },
+                    ]}
+                    value={query.heatmapType || 'individual'}
+                    onChange={(value: HeatmapQueryType) => onQueryChange({ ...query, heatmapType: value })}
+                  />
+                </EditorField>
+              )}
+            </>
           )}
         </div>
       </QueryOptionGroup>

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.cue
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.cue
@@ -49,6 +49,11 @@ composableKinds: DataQuery: {
 				includeExemplars: bool | *false
 				// Specifies the query profile id selectors.
 				profileIdSelector?: [...string]
+				// If set to true, heatmap data will be requested
+				includeHeatmap: bool | *false
+				// Specifies the type of heatmap query
+				heatmapType:       #HeatmapQueryType | *"individual"
+				#HeatmapQueryType: "individual" | "span" @cuetsy(kind="type")
 			}
 		}]
 		lenses: []

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.gen.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.gen.ts
@@ -16,6 +16,8 @@ export type PyroscopeQueryType = ('metrics' | 'profile' | 'both');
 
 export const defaultPyroscopeQueryType: PyroscopeQueryType = 'both';
 
+export type HeatmapQueryType = ('individual' | 'span');
+
 export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
   /**
    * If set to true, the response will contain annotations
@@ -26,9 +28,17 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
    */
   groupBy: Array<string>;
   /**
+   * Specifies the type of heatmap query
+   */
+  heatmapType: (HeatmapQueryType | 'individual');
+  /**
    * If set to true, exemplars will be requested
    */
   includeExemplars: boolean;
+  /**
+   * If set to true, heatmap data will be requested
+   */
+  includeHeatmap: boolean;
   /**
    * Specifies the query label selectors.
    */
@@ -57,7 +67,9 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
 
 export const defaultGrafanaPyroscopeDataQuery: Partial<GrafanaPyroscopeDataQuery> = {
   groupBy: [],
+  heatmapType: 'individual',
   includeExemplars: false,
+  includeHeatmap: false,
   labelSelector: '{}',
   profileIdSelector: [],
   spanSelector: [],

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
@@ -44,6 +44,8 @@ describe('Pyroscope data source', () => {
           profileTypeId: '',
           groupBy: [''],
           includeExemplars: false,
+          includeHeatmap: false,
+          heatmapType: 'individual',
         },
       ]);
       expect(queries).toMatchObject([
@@ -120,6 +122,8 @@ describe('normalizeQuery', () => {
       profileTypeId: 'cpu',
       refId: '',
       includeExemplars: false,
+      includeHeatmap: false,
+      heatmapType: 'individual',
     });
     expect(normalized).toMatchObject({
       labelSelector: '{app="myapp"}',
@@ -148,6 +152,8 @@ const defaultQuery = (query: Partial<Query>): Query => {
     profileTypeId: '',
     queryType: defaultPyroscopeQueryType,
     includeExemplars: false,
+    includeHeatmap: false,
+    heatmapType: 'individual',
     ...query,
   };
 };

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -130,6 +130,8 @@ export class PyroscopeDataSource extends DataSourceWithBackend<Query, PyroscopeD
       profileTypeId: '',
       groupBy: [],
       includeExemplars: false,
+      includeHeatmap: false,
+      heatmapType: 'individual',
     };
   }
 


### PR DESCRIPTION
## Summary

This adds Grafana support for the Pyroscope heatmap query API. (This has been added to Pyroscope in https://github.com/grafana/pyroscope/pull/4736).

Heatmaps can be retrieved either on a per individual profile or if you have trace integration enabled per span basis.

- New `heatmap` package with gap-filling and bucket normalization logic for heatmap series data
- Updated `exemplar` package for creating profile/span exemplar data frames
- Updated `pyroscopeClient` and query handling to support heatmap requests
- Adds `profilesHeatmap` feature toggle to the registry
- Updates `pyroscope/api` dependency to v1.3.0 (adds heatmap RPC support)
- Updates generated CUE types (`types_dataquery_gen.go`) with `includeHeatmap`, `heatmapType`, and `profileIdSelector` fields

**Note:**: I have tried to adhere to the mt-service-compatiblilty but I was not sucessful to split it: By adding the feature flag I always had autogenerated changes in both paths. (See the related frontend only PR: #121052). Unsure if this will cause problems or not.

Once this merges, I plan to add support for Explore as per this PR #116052  
