### PR TITLE
Log level toggle: refactor out of "fields" title

### DIFF
--- a/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
@@ -74,76 +74,79 @@ export const ActiveFields = ({
     [toggle]
   );
 
-  if (active.length || suggested.length) {
-    return (
-      <>
-        <div className={styles.columnHeader}>
-          <Trans i18nKey="explore.logs-table-multi-select.selected-fields">Selected fields</Trans>
-          {active.length > 0 && (
-            <button onClick={clear} className={styles.columnHeaderButton}>
-              <Trans i18nKey="explore.logs-table-multi-select.reset">Reset</Trans>
-            </button>
-          )}
+  return (
+    <>
+      {logLevelActive !== undefined && toggleLevel && (
+        <div className={styles.columnWrapper}>
+          <LogLevelField active={Boolean(logLevelActive)} toggle={toggleLevel} />
         </div>
-        <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="order-fields" direction="vertical">
-            {(provided) => (
-              <div className={styles.columnWrapper} {...provided.droppableProps} ref={provided.innerRef}>
-                {logLevelActive && toggleLevel && <LogLevelField active toggle={toggleLevel} />}
-                {active.map((field, index) => (
-                  <Draggable
-                    draggableId={field.name}
-                    key={field.name}
-                    index={index}
-                    isDragDisabled={!activeFields.includes(field.name)}
-                  >
-                    {(provided: DraggableProvided, snapshot) => (
-                      <div
-                        className={cx(styles.wrap, snapshot.isDragging ? styles.dragging : undefined)}
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        title={t(
-                          'logs.field-selector.label-title',
-                          `{{fieldName}} appears in {{percentage}}% of log lines`,
-                          { fieldName: field.name, percentage: field.stats.percentOfLinesWithLabel }
-                        )}
-                      >
-                        <Field
-                          active={activeFields.includes(field.name)}
-                          field={field}
-                          toggle={toggle}
-                          draggable={activeFields.includes(field.name)}
-                        />
-                      </div>
-                    )}
-                  </Draggable>
-                ))}
-                {provided.placeholder}
-              </div>
+      )}
+      {(active.length || suggested.length) && (
+        <>
+          <div className={styles.columnHeader}>
+            <Trans i18nKey="explore.logs-table-multi-select.selected-fields">Selected fields</Trans>
+            {active.length > 0 && (
+              <button onClick={clear} className={styles.columnHeaderButton}>
+                <Trans i18nKey="explore.logs-table-multi-select.reset">Reset</Trans>
+              </button>
             )}
-          </Droppable>
-        </DragDropContext>
-        {suggested.length > 0 && (
-          <>
-            <div className={styles.columnSubHeader}>
-              <Trans i18nKey="explore.logs-table-multi-select.suggested-fields">Suggested</Trans>
-            </div>
-            <div className={styles.columnWrapper}>
-              {logLevelActive === false && toggleLevel && <LogLevelField active={false} toggle={toggleLevel} />}
-              {suggested.map((field) => (
-                <div className={styles.wrap} key={field.name}>
-                  <Field field={field} toggle={toggleSelectedField} />
+          </div>
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="order-fields" direction="vertical">
+              {(provided) => (
+                <div className={styles.columnWrapper} {...provided.droppableProps} ref={provided.innerRef}>
+                  {active.map((field, index) => (
+                    <Draggable
+                      draggableId={field.name}
+                      key={field.name}
+                      index={index}
+                      isDragDisabled={!activeFields.includes(field.name)}
+                    >
+                      {(provided: DraggableProvided, snapshot) => (
+                        <div
+                          className={cx(styles.wrap, snapshot.isDragging ? styles.dragging : undefined)}
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          title={t(
+                            'logs.field-selector.label-title',
+                            `{{fieldName}} appears in {{percentage}}% of log lines`,
+                            { fieldName: field.name, percentage: field.stats.percentOfLinesWithLabel }
+                          )}
+                        >
+                          <Field
+                            active={activeFields.includes(field.name)}
+                            field={field}
+                            toggle={toggle}
+                            draggable={activeFields.includes(field.name)}
+                          />
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
                 </div>
-              ))}
-            </div>
-          </>
-        )}
-      </>
-    );
-  }
-
-  return null;
+              )}
+            </Droppable>
+          </DragDropContext>
+          {suggested.length > 0 && (
+            <>
+              <div className={styles.columnSubHeader}>
+                <Trans i18nKey="explore.logs-table-multi-select.suggested-fields">Suggested</Trans>
+              </div>
+              <div className={styles.columnWrapper}>
+                {suggested.map((field) => (
+                  <div className={styles.wrap} key={field.name}>
+                    <Field field={field} toggle={toggleSelectedField} />
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
 };
 
 export function getLogsFieldsStyles(theme: GrafanaTheme2) {

--- a/public/app/features/logs/components/fieldSelector/LogLevelField.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogLevelField.tsx
@@ -26,7 +26,7 @@ export function LogLevelField({ active, toggle }: Props): React.JSX.Element | un
     <div className={styles.contentWrap}>
       <Checkbox
         className={styles.checkboxLabel}
-        label={t('logs.field-selector.log-level', 'Log level')}
+        label={t('logs.field-selector.log-level', 'Show log level')}
         onChange={handleChange}
         checked={active}
       />

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -577,7 +577,7 @@ describe('LogList', () => {
       expect(screen.getByText('debug')).toBeInTheDocument();
 
       // Click the "Log Level" checkbox in the field selector to hide log level
-      const logLevelCheckbox = screen.getByRole('checkbox', { name: 'Log level' });
+      const logLevelCheckbox = screen.getByRole('checkbox', { name: 'Show log level' });
       expect(logLevelCheckbox).toBeChecked();
       await userEvent.click(logLevelCheckbox);
 
@@ -589,13 +589,13 @@ describe('LogList', () => {
       expect(screen.getByText('backend')).toBeInTheDocument();
 
       // Click again to show log level (checkbox is now in Suggested section)
-      const logLevelCheckboxAfter = screen.getByRole('checkbox', { name: 'Log level' });
+      const logLevelCheckboxAfter = screen.getByRole('checkbox', { name: 'Show log level' });
       await userEvent.click(logLevelCheckboxAfter);
 
       // Level is shown again (wait for list to re-render)
       expect(await screen.findByText('info')).toBeInTheDocument();
       expect(screen.getByText('debug')).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Log level' })).toBeChecked();
+      expect(screen.getByRole('checkbox', { name: 'Show log level' })).toBeChecked();
     });
   });
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -29,6 +29,7 @@ import {
   LoadingState,
   rangeUtil,
   transformDataFrame,
+  store,
 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -631,7 +632,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
               showControls={Boolean(showControls)}
               showFieldSelector={showFieldSelector}
               showLogAttributes={showLogAttributes}
-              showLevel={showLevel}
+              showLevel={storageKey ? store.getBool(`${storageKey}.showLevel`, showLevel ?? true) : showLevel}
               showTime={showTime}
               showUniqueLabels={showLabels}
               sortOrder={sortOrder}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11038,7 +11038,7 @@
       "collapse": "Collapse sidebar",
       "expand": "Expand sidebar",
       "label-title": "{{fieldName}} appears in {{percentage}}% of log lines",
-      "log-level": "Log level",
+      "log-level": "Show log level",
       "placeholder-search-fields-by-name": "Search fields by name",
       "title-drag-and-drop-to-reorder": "Drag and drop to reorder"
     },


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/119475
Follow up of https://github.com/grafana/grafana/pull/120667

While doing a demo I noticed that if the active fields matched the suggested fields, it was not possible to set the level visibility. 

Additionally, even if stored in local storage, because of the default value set in [the module.tsx file ](https://github.com/grafana/grafana/blob/e775bda9ca5d3bb7234d7f373ccd37b9a185f72b/public/app/plugins/panel/logs/module.tsx#L43), the stored preference was being ignored.

Lastly, Log level is not a displayed field, and I think it was potentially confusing inside "Selected fields", so it's been extracted out of the title.

Demo:

https://github.com/user-attachments/assets/9b0f25c1-aa5f-480b-ba84-0205848b9741

