### PR TITLE
FS: Fix SSO auto-login redirection not working

### DIFF
--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -225,7 +225,7 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 		body := recorder.Body.String()
 
 		// Check that the generic error message is in the response
-		assert.Contains(t, body, "loginError", "Should contain loginError when cookie is present")
+		assert.Contains(t, body, `"loginError"`, "Should contain loginError when cookie is present")
 		assert.Contains(t, body, "oauth.login.error", "Should contain the generic OAuth error message")
 
 		// Check that the cookie was deleted (MaxAge=-1)
@@ -261,8 +261,10 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 		// The page should render but without the login error
 		assert.Contains(t, body, "window.grafanaBootData")
 		// Check that loginError is not set (or is empty/omitted in JSON)
-		// Since it's omitempty, it shouldn't appear at all
-		assert.NotContains(t, body, "loginError", "Should not contain loginError when cookie is absent")
+		// Since it's omitempty, it shouldn't appear at all.
+		// Note: the static JS in the template contains "loginError" as a property accessor,
+		// so we check for the JSON-quoted form which only appears when the value is serialized.
+		assert.NotContains(t, body, `"loginError":`, "Should not contain loginError when cookie is absent")
 	})
 
 	t.Run("should handle custom OAuth error message from config", func(t *testing.T) {

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -290,15 +290,15 @@
           }
 
           // Handle SSO auto-login redirection from /bootdata.
-          if (rawBootData.autoLoginRedirectURL) {
+          // Only redirect if there's no login error to avoid redirect loops.
+          if (rawBootData.autoLoginRedirectURL && !rawBootData.settings.loginError) {
             // Copied from context_srv.setRedirectToUrl
             window.sessionStorage.setItem(
               'redirectTo',
               encodeURIComponent(window.location.href.substring(window.location.origin.length))
             );
 
-            window.location.href = rawBootData.autoLoginRedirectURL;
-            return;
+            return { redirect: rawBootData.autoLoginRedirectURL };
           }
 
           return rawBootData;
@@ -358,7 +358,14 @@
           // - nav tree and user info come from the backend
           // - merge settings from both. FS settings contains less values
           // - build info edition comes from the backend
-          const { navTree, settings, user } = await loadBootData();
+          const { navTree, settings, user, redirect } = await loadBootData();
+
+          // If the backend indicates a redirect is needed (for SSO auto-login, or custom domain) do that
+          // only if there's no SSO login error to avoid redirect loops
+          if (redirect) {
+            window.location.href = redirect;
+            return;
+          }
 
           window.grafanaBootData.settings = {
             ...settings,

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -21,8 +21,6 @@
     <script nonce="[[.Nonce]]">
       performance.mark('frontend_boot_css_time_seconds');
     </script>
-
-
   </head>
 
   <body>
@@ -289,6 +287,18 @@
 
           if (!resp.ok) {
             throw new Error("Unexpected response body: " + textResponse);
+          }
+
+          // Handle SSO auto-login redirection from /bootdata.
+          if (rawBootData.autoLoginRedirectURL) {
+            // Copied from context_srv.setRedirectToUrl
+            window.sessionStorage.setItem(
+              'redirectTo',
+              encodeURIComponent(window.location.href.substring(window.location.origin.length))
+            );
+
+            window.location.href = rawBootData.autoLoginRedirectURL;
+            return;
           }
 
           return rawBootData;

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -360,11 +360,9 @@
           // - build info edition comes from the backend
           const { navTree, settings, user, redirect } = await loadBootData();
 
-          // If the backend indicates a redirect is needed (for SSO auto-login, or custom domain) do that
-          // only if there's no SSO login error to avoid redirect loops
+          // If the backend wants us to redirect, we reject this promise to avoid booting the rest of the app.
           if (redirect) {
-            window.location.href = redirect;
-            return;
+            return Promise.reject({ redirect });
           }
 
           window.grafanaBootData.settings = {
@@ -414,6 +412,12 @@
 
         window.__grafana_boot_data_promise = initGrafana()
         window.__grafana_boot_data_promise.catch((err) => {
+          // initGrafana can throw a `{ redirect: string }` object to indicate that the frontend should redirect without booting the app.
+          if (err && err.redirect && typeof err.redirect === 'string') {
+            window.location.href = err.redirect;
+            return;
+          }
+
           console.error("__grafana_boot_data_promise rejected", err);
           window.__grafana_load_failed(err);
         });

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -29,6 +29,10 @@ async function bootstrapWindowData() {
 }
 
 bootstrapWindowData().catch((error) => {
-  console.error('Error bootstrapping Grafana', error);
-  window.__grafana_load_failed();
+  const isRedirect = error && error.redirect && typeof error.redirect === 'string';
+  // If a redirect was thrown, just ignore this. The index.html will handle the redirect
+  if (!isRedirect) {
+    console.error('Error bootstrapping Grafana', error);
+    window.__grafana_load_failed();
+  }
 });


### PR DESCRIPTION
Part of grafana/grafana-frontend-platform/issues/141

Other part of https://github.com/grafana/grafana/pull/121000, this consumes the new property and issues the redirect.

It also saves the current location into session storage so the user is sent back to the correct page when they return back to Grafana.