### PR TITLE
Alerting: Protect /api/v2/status endpoint with dedicated permission

### DIFF
--- a/docs/sources/breaking-changes/breaking-changes-v13-0.md
+++ b/docs/sources/breaking-changes/breaking-changes-v13-0.md
@@ -72,3 +72,17 @@ Use the Kubernetes-style resource APIs under `notifications.alerting.grafana.app
 | Templates             | `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups`  |
 | Mute timings          | `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals`   |
 | Inhibition rules      | `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/inhibitionrules` |
+
+### Alertmanager status endpoint requires a new permission
+
+#### You are affected if
+
+You use the `GET /api/alertmanager/grafana/api/v2/status` endpoint and rely on the `alert.notifications:read` permission to access it.
+
+#### Description
+
+The `GET /api/alertmanager/grafana/api/v2/status` endpoint previously required the legacy `alert.notifications:read` permission. It now requires a dedicated `alert.notifications.system-status:read` permission. This new permission is included in the `fixed:alerting.notifications:writer` role, which is granted to Admin users by default.
+
+#### Migration
+
+If you have custom roles that need access to this endpoint, add the `alert.notifications.system-status:read` action to those roles. Admin users are unaffected as they receive this permission automatically through the built-in alerting notifications writer role.

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -457,6 +457,8 @@ const (
 	// (POST /config/history/{id}/_activate).
 	// Restricted to admin-only in v13; endpoint will be removed in v14.
 	ActionAlertingNotificationsConfigHistoryWrite = "alert.notifications.config-history:write"
+	// ActionAlertingNotificationsConfigHistoryDelete gates access to alertmanager status API
+	ActionAlertingNotificationSystemStatus = "alert.notifications.system-status:read"
 
 	// Alerting notifications template actions
 	ActionAlertingNotificationsTemplatesRead   = "alert.notifications.templates:read"

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -457,7 +457,7 @@ const (
 	// (POST /config/history/{id}/_activate).
 	// Restricted to admin-only in v13; endpoint will be removed in v14.
 	ActionAlertingNotificationsConfigHistoryWrite = "alert.notifications.config-history:write"
-	// ActionAlertingNotificationsConfigHistoryDelete gates access to alertmanager status API
+	// ActionAlertingNotificationSystemStatus gates access to alertmanager status API
 	ActionAlertingNotificationSystemStatus = "alert.notifications.system-status:read"
 
 	// Alerting notifications template actions

--- a/pkg/services/ngalert/accesscontrol/roles.go
+++ b/pkg/services/ngalert/accesscontrol/roles.go
@@ -342,6 +342,7 @@ var (
 				{Action: accesscontrol.ActionAlertingReceiversPermissionsWrite, Scope: models.ScopeReceiversAll},
 				{Action: accesscontrol.ActionAlertingReceiversReadSecrets, Scope: models.ScopeReceiversAll},
 				{Action: accesscontrol.ActionAlertingReceiversUpdateProtected, Scope: models.ScopeReceiversAll},
+				{Action: accesscontrol.ActionAlertingNotificationSystemStatus},
 			}),
 		},
 		Grants: []string{string(org.RoleAdmin)},

--- a/pkg/services/ngalert/accesscontrol/testdata/basic_role_grants.snapshot.json
+++ b/pkg/services/ngalert/accesscontrol/testdata/basic_role_grants.snapshot.json
@@ -103,6 +103,9 @@
         "action": "alert.notifications.routes:write"
       },
       {
+        "action": "alert.notifications.system-status:read"
+      },
+      {
         "action": "alert.notifications.templates.test:write"
       },
       {

--- a/pkg/services/ngalert/accesscontrol/testdata/fixed_roles.snapshot.json
+++ b/pkg/services/ngalert/accesscontrol/testdata/fixed_roles.snapshot.json
@@ -593,6 +593,9 @@
         "action": "alert.notifications.routes:write"
       },
       {
+        "action": "alert.notifications.system-status:read"
+      },
+      {
         "action": "alert.notifications.templates.test:write"
       },
       {

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -239,7 +239,7 @@ func (api *API) authorize(method, path string) web.Handler {
 	case http.MethodGet + "/api/alertmanager/grafana/config/history":
 		eval = ac.EvalPermission(ac.ActionAlertingNotificationsConfigHistoryRead)
 	case http.MethodGet + "/api/alertmanager/grafana/api/v2/status":
-		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationSystemStatus)
 	case http.MethodPost + "/api/alertmanager/grafana/config/history/{id}/_activate":
 		eval = ac.EvalPermission(ac.ActionAlertingNotificationsConfigHistoryWrite)
 	case http.MethodGet + "/api/alertmanager/grafana/config/api/v1/receivers":

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -568,14 +568,12 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 		{
 			desc:      "viewer request should succeed",
 			url:       "http://viewer:viewer@%s/api/alertmanager/grafana/api/v2/status",
-			expStatus: http.StatusUnauthorized,
-			expBody:   `{"extra":null,"message":"Unauthorized","messageId":"auth.unauthorized","statusCode":401,"traceID":""}`,
+			expStatus: http.StatusForbidden,
 		},
 		{
 			desc:      "editor request should succeed",
 			url:       "http://editor:editor@%s/api/alertmanager/grafana/api/v2/status",
-			expStatus: http.StatusUnauthorized,
-			expBody:   `{"extra":null,"message":"Unauthorized","messageId":"auth.unauthorized","statusCode":401,"traceID":""}`,
+			expStatus: http.StatusForbidden,
 		},
 		{
 			desc:      "admin request should succeed",
@@ -599,7 +597,9 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 				b = re.ReplaceAll(b, []byte(`"uid":""`))
 			}
 			require.NoError(t, err)
-			require.JSONEq(t, tc.expBody, string(b))
+			if tc.expBody != "" {
+				require.JSONEq(t, tc.expBody, string(b))
+			}
 		})
 	}
 }

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -544,10 +544,6 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 	}
 }
 `
-	cfgWithoutAutogen := fmt.Sprintf(cfgTemplate, `{
-			"receiver": "empty",
-			"group_by": ["grafana_folder", "alertname"]
-		}`)
 	cfgWithAutogen := fmt.Sprintf(cfgTemplate, `{
 					"receiver": "empty",
 					"routes": [{
@@ -572,14 +568,14 @@ func TestIntegrationAlertmanagerStatus(t *testing.T) {
 		{
 			desc:      "viewer request should succeed",
 			url:       "http://viewer:viewer@%s/api/alertmanager/grafana/api/v2/status",
-			expStatus: http.StatusOK,
-			expBody:   cfgWithoutAutogen,
+			expStatus: http.StatusUnauthorized,
+			expBody:   `{"extra":null,"message":"Unauthorized","messageId":"auth.unauthorized","statusCode":401,"traceID":""}`,
 		},
 		{
 			desc:      "editor request should succeed",
 			url:       "http://editor:editor@%s/api/alertmanager/grafana/api/v2/status",
-			expStatus: http.StatusOK,
-			expBody:   cfgWithoutAutogen,
+			expStatus: http.StatusUnauthorized,
+			expBody:   `{"extra":null,"message":"Unauthorized","messageId":"auth.unauthorized","statusCode":401,"traceID":""}`,
 		},
 		{
 			desc:      "admin request should succeed",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a dedicated permission `alert.notifications.system-status:read` to protect the `/api/v2/status` endpoint, which by default is granted only to Admin roles.

**Why do we need this feature?**

Disaggregate `alert.notifications:read` and remove it in the future.

This ensures tighter security by restricting access to the endpoint to users with specific permissions.


# Release notice breaking change

The `GET /api/alertmanager/grafana/api/v2/status` endpoint previously required the legacy `alert.notifications:read` permission. It now requires a dedicated `alert.notifications.system-status:read` permission. This new permission is included in the `fixed:alerting.notifications:writer` role, which is granted to Admin users by default.

#### Migration
If you have custom roles that need access to this endpoint, add the `alert.notifications.system-status:read` action to those roles. Admin users are unaffected as they receive this permission automatically through the built-in alerting notifications writer role.

