### PR TITLE
QueryEditor: Setup Intercom survey

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 
-import { QUERY_EDITOR_BANNER_FEEDBACK_URL } from '../../constants';
+import { startIntercomSurvey } from '../../tracking';
 import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
 export function ExperimentalFeedbackButton() {
@@ -27,14 +27,16 @@ export function ExperimentalFeedbackButton() {
     <Menu>
       <Menu.Item
         label={t('query-editor-next.experimental-button.give-feedback', 'Give feedback')}
-        icon="external-link-alt"
-        url={QUERY_EDITOR_BANNER_FEEDBACK_URL}
-        target="_blank"
+        icon="comment-alt-message"
+        onClick={() => startIntercomSurvey()}
       />
       <Menu.Item
         label={t('query-editor-next.experimental-button.back-to-classic', 'Go back to classic editor')}
         icon="arrow-left"
-        onClick={onSwitchToClassic}
+        onClick={() => {
+          startIntercomSurvey();
+          onSwitchToClassic?.();
+        }}
       />
     </Menu>
   );

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -30,7 +30,6 @@ export enum SidebarSize {
 export const QUERY_EDITOR_SIDEBAR_SIZE_KEY = 'grafana.dashboard.query-editor-next.sidebar-size';
 export const QUERY_EDITOR_BANNER_DISMISSED_KEY = 'grafana.dashboard.query-editor-next.banner-dismissed';
 export const QUERY_EDITOR_V2_PREFERENCE_KEY = 'grafana.dashboard.query-editor-next.v2-preference';
-export const QUERY_EDITOR_BANNER_FEEDBACK_URL = 'https://forms.gle/54uCfRjxzjcXVysp8';
 
 export function getQueryEditorBannerColors(theme: GrafanaTheme2) {
   return {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -141,3 +141,53 @@ export function trackRenameInitiated() {
     item_type: QueryEditorType.Query,
   });
 }
+
+const INTERCOM_APP_ID = 'agpb1wfw';
+const INTERCOM_SURVEY_ID = '59003702';
+
+function getIntercom(): ((command: string, ...args: unknown[]) => void) | undefined {
+  if ('Intercom' in window && typeof window.Intercom === 'function') {
+    return window.Intercom;
+  }
+  return undefined;
+}
+
+let intercomLoadPromise: Promise<void> | null = null;
+
+function ensureIntercomLoaded(): Promise<void> {
+  if (typeof getIntercom() === 'function') {
+    return Promise.resolve();
+  }
+
+  if (intercomLoadPromise) {
+    return intercomLoadPromise;
+  }
+
+  intercomLoadPromise = new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = `https://widget.intercom.io/widget/${INTERCOM_APP_ID}`;
+    script.async = true;
+    script.onload = () => {
+      getIntercom()?.('boot', { app_id: INTERCOM_APP_ID, hide_default_launcher: true });
+      resolve();
+    };
+    script.onerror = () => {
+      intercomLoadPromise = null;
+      reject(new Error('Failed to load Intercom'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return intercomLoadPromise;
+}
+
+export function startIntercomSurvey(): void {
+  ensureIntercomLoaded()
+    .then(() => {
+      getIntercom()?.('startSurvey', INTERCOM_SURVEY_ID);
+    })
+    .catch(() => {
+      // Intercom blocked or unavailable — silently ignore.
+      // The survey is non-critical; the editor remains fully functional.
+    });
+}

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
@@ -2,10 +2,10 @@ import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Button, Icon, IconButton, LinkButton, useStyles2 } from '@grafana/ui';
+import { Button, Icon, IconButton, useStyles2 } from '@grafana/ui';
 
-import { QUERY_EDITOR_BANNER_FEEDBACK_URL, getQueryEditorBannerColors } from './PanelEditNext/constants';
-import { trackBannerDismiss, trackFeedbackClick } from './PanelEditNext/tracking';
+import { getQueryEditorBannerColors } from './PanelEditNext/constants';
+import { startIntercomSurvey, trackBannerDismiss, trackFeedbackClick } from './PanelEditNext/tracking';
 
 interface Props {
   useQueryExperienceNext: boolean;
@@ -40,21 +40,30 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
       </div>
       <div className={styles.right}>
         {useQueryExperienceNext && (
-          <LinkButton
+          <Button
             variant="primary"
             fill="text"
             size="sm"
-            icon="external-link-alt"
-            href={QUERY_EDITOR_BANNER_FEEDBACK_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={trackFeedbackClick}
+            icon="comment-alt-message"
+            onClick={() => {
+              trackFeedbackClick();
+              startIntercomSurvey();
+            }}
           >
             {t('dashboard-scene.query-editor-banner.give-feedback', 'Give feedback')}
-          </LinkButton>
+          </Button>
         )}
         {useQueryExperienceNext ? (
-          <Button variant="secondary" fill="text" size="sm" icon="arrow-left" onClick={onToggle}>
+          <Button
+            variant="secondary"
+            fill="text"
+            size="sm"
+            icon="arrow-left"
+            onClick={() => {
+              startIntercomSurvey();
+              onToggle();
+            }}
+          >
             {t('dashboard-scene.query-editor-banner.go-back', 'Back to classic')}
           </Button>
         ) : (


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Move to Intercom survey instead of Google form.

## Changes
<!--- Describe your changes in detail -->
Intercom is already integrated into Grafana via Rudderstack (see `RudderstackBackend.ts` — the `identify()` call passes `user_hash` to Intercom's device-mode destination). However, that pipeline only handles user identification, not programmatic survey triggers.

This PR loads the Intercom Messenger script directly (lazy-loaded on first click) and boots it with our workspace's public `app_id`. This gives us access to `Intercom('startSurvey', id)` without adding any npm dependencies or backend changes. The script is only fetched when a user actually clicks a feedback/downgrade button — no impact on page load performance.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
https://github.com/user-attachments/assets/ba5d2a39-3221-4734-b26a-6aa9630d2162

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull down this branch locally and interact with the survey. I can share the Intercom dashboard if you want to see how the results are aggregated. 

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable