### PR TITLE
Elastic esql timerange filter

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1549,4 +1549,160 @@ describe('ElasticDatasource', () => {
       });
     });
   });
+
+  describe('addTimeRangeToEsqlQuery', () => {
+    const fromISO = '2024-03-23T00:00:00.000Z';
+    const toISO = '2024-03-24T00:00:00.000Z';
+
+    function createDsWithTimeRange() {
+      const instanceSettings = {
+        meta: {
+          id: 'id',
+          name: 'name',
+          type: 'datasource' as const,
+          module: '',
+          baseUrl: '',
+          info: {
+            author: { name: 'Test' },
+            description: '',
+            links: [],
+            logos: { large: '', small: '' },
+            screenshots: [],
+            updated: '',
+            version: '',
+          },
+        },
+        readOnly: false,
+        name: 'test-elastic',
+        type: 'type',
+        uid: 'uid',
+        access: 'proxy' as const,
+        url: 'http://elasticsearch.local',
+        jsonData: {
+          timeField: '@timestamp',
+          timeInterval: '',
+          index: 'test-index',
+        },
+      };
+
+      const templateSrv = {
+        getVariables: () => [],
+        replace: (text?: string) => {
+          if (!text) {
+            return '';
+          }
+          return text
+            .replace(/\$\{__from:date:iso\}/g, fromISO)
+            .replace(/\$\{__to:date:iso\}/g, toISO);
+        },
+        containsTemplate: (text?: string) => text?.includes('$') ?? false,
+        updateTimeRange: () => {},
+      };
+
+      return new ElasticDatasource(instanceSettings as any, templateSrv as any);
+    }
+
+    it('should insert time filter right after FROM, before LIMIT', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables(
+        { refId: 'A', query: 'FROM test-index | LIMIT 10', queryType: 'esql' },
+        {}
+      );
+      expect(result.query).toMatch(/FROM test-index \| WHERE @timestamp >=.*AND @timestamp <=.*\| LIMIT 10/);
+    });
+
+    it('should insert time filter after FROM when WHERE exists on a different field', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables(
+        { refId: 'A', query: 'FROM test-index | WHERE status == 200 | LIMIT 10', queryType: 'esql' },
+        {}
+      );
+      expect(result.query).toMatch(/FROM test-index \| WHERE @timestamp >=.*\| WHERE status == 200/);
+    });
+
+    it('should NOT add time filter when WHERE clause references the time field', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables(
+        {
+          refId: 'A',
+          query: 'FROM test-index | WHERE @timestamp >= "2024-01-01T00:00:00Z"',
+          queryType: 'esql',
+        },
+        {}
+      );
+      const whereCount = (result.query!.match(/WHERE/g) || []).length;
+      expect(whereCount).toBe(1);
+    });
+
+    it('should append time filter when query has only FROM and no pipe commands', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables({ refId: 'A', query: 'FROM test-index', queryType: 'esql' }, {});
+      expect(result.query).toContain('WHERE @timestamp >=');
+    });
+
+    it('should return empty query unchanged', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables({ refId: 'A', query: '', queryType: 'esql' }, {});
+      expect(result.query).toBe('');
+    });
+
+    it('should return malformed query unchanged when parsing fails', () => {
+      const testDs = createDsWithTimeRange();
+      const input = '}{}{][';
+      const result = testDs.applyTemplateVariables({ refId: 'A', query: input, queryType: 'esql' }, {});
+      expect(result.query).toBe(input);
+    });
+
+    it('should contain the time macro placeholders before templateSrv resolves them', () => {
+      const instanceSettings = {
+        meta: {
+          id: 'id',
+          name: 'name',
+          type: 'datasource' as const,
+          module: '',
+          baseUrl: '',
+          info: {
+            author: { name: 'Test' },
+            description: '',
+            links: [],
+            logos: { large: '', small: '' },
+            screenshots: [],
+            updated: '',
+            version: '',
+          },
+        },
+        readOnly: false,
+        name: 'test-elastic',
+        type: 'type',
+        uid: 'uid',
+        access: 'proxy' as const,
+        url: 'http://elasticsearch.local',
+        jsonData: {
+          timeField: '@timestamp',
+          timeInterval: '',
+          index: 'test-index',
+        },
+      };
+
+      const replaceCalls: string[] = [];
+      const templateSrv = {
+        getVariables: () => [],
+        replace: (text?: string) => {
+          replaceCalls.push(text || '');
+          return text || '';
+        },
+        containsTemplate: (text?: string) => text?.includes('$') ?? false,
+        updateTimeRange: () => {},
+      };
+
+      const testDs = new ElasticDatasource(instanceSettings as any, templateSrv as any);
+      testDs.applyTemplateVariables(
+        { refId: 'A', query: 'FROM test-index | LIMIT 10', queryType: 'esql' },
+        {}
+      );
+      const finalReplaceCall = replaceCalls[replaceCalls.length - 1];
+      expect(finalReplaceCall).toContain('${__from:date:iso}');
+      expect(finalReplaceCall).toContain('${__to:date:iso}');
+    });
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1640,6 +1640,33 @@ describe('ElasticDatasource', () => {
       expect(result.query).toContain('WHERE @timestamp >=');
     });
 
+    it('should insert time filter right after TS command', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables(
+        {
+          refId: 'A',
+          query: 'TS metrics-generic.otel-default | STATS AVG(cpu) BY BUCKET(@timestamp, 100, "${__from:date:iso}", "${__to:date:iso}")',
+          queryType: 'esql',
+        },
+        {}
+      );
+      expect(result.query).toMatch(/TS metrics-generic.otel-default \| WHERE @timestamp >=.*\| STATS/);
+    });
+
+    it('should NOT add time filter to TS query when WHERE on time field already exists', () => {
+      const testDs = createDsWithTimeRange();
+      const result = testDs.applyTemplateVariables(
+        {
+          refId: 'A',
+          query: 'TS metrics-generic.otel-default | WHERE @timestamp >= "2024-01-01T00:00:00Z" | STATS AVG(cpu)',
+          queryType: 'esql',
+        },
+        {}
+      );
+      const whereCount = (result.query!.match(/WHERE/g) || []).length;
+      expect(whereCount).toBe(1);
+    });
+
     it('should return empty query unchanged', () => {
       const testDs = createDsWithTimeRange();
       const result = testDs.applyTemplateVariables({ refId: 'A', query: '', queryType: 'esql' }, {});

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1201,8 +1201,8 @@ export class ElasticDatasource
         }
       }
 
-      const fromCmdIndex = root.commands.findIndex((cmd) => cmd.name === 'from');
-      if (fromCmdIndex === -1) {
+      const headerCmdIndex = root.commands.findIndex((cmd) => cmd.name === 'from' || cmd.name === 'ts');
+      if (headerCmdIndex === -1) {
         return esqlQuery;
       }
 
@@ -1210,8 +1210,8 @@ export class ElasticDatasource
         `WHERE ${this.timeField} >= "\${__from:date:iso}" AND ${this.timeField} <= "\${__to:date:iso}"`
       );
 
-      // Insert right after FROM so the time filter runs before LIMIT or other commands
-      mutate.generic.commands.insert(root, whereCmd, fromCmdIndex + 1);
+      // Insert right after FROM/TS so the time filter runs before LIMIT or other commands
+      mutate.generic.commands.insert(root, whereCmd, headerCmdIndex + 1);
 
       return BasicPrettyPrinter.print(root);
     } catch {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1,3 +1,4 @@
+import { BasicPrettyPrinter, mutate, Parser, Walker } from '@elastic/esql';
 import { cloneDeep, first as _first, isNumber, isString, map as _map, isObject } from 'lodash';
 import { from, generate, lastValueFrom, Observable, of } from 'rxjs';
 import { catchError, first, map, mergeMap, skipWhile, throwIfEmpty, tap } from 'rxjs/operators';
@@ -1162,7 +1163,10 @@ export class ElasticDatasource
       datasource: this.getRef(),
       query:
         query.queryType === 'esql'
-          ? this.addAdHocFilters(this.interpolateEsqlQuery(query.query || '', scopedVars), filters)
+          ? this.addAdHocFilters(
+              this.interpolateEsqlQuery(this.addTimeRangeToEsqlQuery(query.query || ''), scopedVars),
+              filters
+            )
           : this.addAdHocFilters(this.interpolateLuceneQuery(query.query || '', scopedVars), filters),
       bucketAggs: query.bucketAggs?.map(interpolateBucketAgg),
     };
@@ -1173,6 +1177,46 @@ export class ElasticDatasource
 
   private interpolateEsqlQuery(esqlQuery: string, scopedVars?: ScopedVars): string {
     return this.templateSrv.replace(esqlQuery, scopedVars);
+  }
+
+  private addTimeRangeToEsqlQuery(esqlQuery: string): string {
+    if (!esqlQuery || !this.timeField) {
+      return esqlQuery;
+    }
+
+    try {
+      const { root } = Parser.parse(esqlQuery);
+
+      const whereCommands = Walker.matchAll(root, {
+        type: 'command',
+        name: 'where',
+      });
+
+      for (const whereCmd of whereCommands) {
+        const columns = Walker.matchAll(whereCmd, {
+          type: 'column',
+        });
+        if (columns.some((col) => col.name === this.timeField)) {
+          return esqlQuery;
+        }
+      }
+
+      const fromCmdIndex = root.commands.findIndex((cmd) => cmd.name === 'from');
+      if (fromCmdIndex === -1) {
+        return esqlQuery;
+      }
+
+      const { root: whereCmd } = Parser.parseCommand(
+        `WHERE ${this.timeField} >= "\${__from:date:iso}" AND ${this.timeField} <= "\${__to:date:iso}"`
+      );
+
+      // Insert right after FROM so the time filter runs before LIMIT or other commands
+      mutate.generic.commands.insert(root, whereCmd, fromCmdIndex + 1);
+
+      return BasicPrettyPrinter.print(root);
+    } catch {
+      return esqlQuery;
+    }
   }
 
   // Private method used in the `getDatabaseVersion` to get the database version from the Elasticsearch API.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Automatically add a time range filter on ESQL queries when it's not provided

**Why do we need this feature?**

To avoid going over many documents.

**Who is this feature for?**

User's using the ES|QL feature

**Which issue(s) does this PR fix?**:

## When time range filter is not provided by the user, it's automatically added to the query:
<img width="2516" height="1358" alt="Screenshot 2026-03-24 at 13 49 38" src="https://github.com/user-attachments/assets/41b7f97b-5d52-468e-b594-8d69c07a6667" />

## When time range filter is  provided by the user it does NOT override it"
<img width="2606" height="1368" alt="Screenshot 2026-03-24 at 13 49 54" src="https://github.com/user-attachments/assets/07d94c25-cce3-4711-a9c6-efc45c65c61a" />


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
