### PR TITLE
Unified Storage: Multi-row INSERT for SQLKV Batch upserts

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -582,10 +582,9 @@ type batchSaveItem struct {
 	Value []byte
 }
 
-// batchSave saves multiple items to the DataSection.
-// For SqlKV it uses BulkInsertData (multi-row INSERT) for maximum throughput.
+// batchSave creates multiple new items in the DataSection.
 // The caller must ensure keys are new (e.g. by deleting the collection first).
-// For other KV implementations it falls back to the general Batch method.
+// Uses BatchOpCreate so the fast path (multi-row INSERT) is used for DataSection.
 func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error {
 	if len(items) == 0 {
 		return nil
@@ -598,7 +597,7 @@ func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error 
 			key = item.Key.StringWithGUID()
 		}
 		ops[i] = kvpkg.BatchOp{
-			Mode:  kvpkg.BatchOpPut,
+			Mode:  kvpkg.BatchOpCreate,
 			Key:   key,
 			Value: item.Value,
 		}

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -607,12 +607,7 @@ func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error 
 		}
 	}
 
-	// Use optimized multi-row INSERT for SqlKV (keys guaranteed new during bulk import).
-	if sqlkv, ok := d.kv.(*kvpkg.SqlKV); ok {
-		return sqlkv.BulkInsertData(ctx, ops)
-	}
-
-	return d.kv.Batch(ctx, dataSection, ops)
+	return d.kv.BulkInsertData(ctx, ops)
 }
 
 // ParseKey parses a string key into a DataKey struct

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"errors"
@@ -576,34 +577,50 @@ func (n *dataStore) batchDelete(ctx context.Context, keys []DataKey) error {
 	return nil
 }
 
-// batchSaveItem represents a single item for batch save operations
-type batchSaveItem struct {
+// historyImportItem represents one authoritative history row produced by a
+// legacy migrator. The row has already been assigned its final DataKey.
+type historyImportItem struct {
 	Key   DataKey
 	Value []byte
 }
 
-// batchSave creates multiple new items in the DataSection.
-// The caller must ensure keys are new (e.g. by deleting the collection first).
-// Uses BatchOpCreate so the fast path (multi-row INSERT) is used for DataSection.
-func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error {
+// importHistoryBatch appends authoritative DataSection history rows for
+// migrator-driven bulk imports. This path is intentionally separate from
+// KV.Batch because migration imports append ordered history after wiping the
+// destination collection; they do not need generic Put/Create/Update/Delete
+// semantics, duplicate detection, or current-state validation.
+func (d *dataStore) importHistoryBatch(ctx context.Context, items []historyImportItem) error {
 	if len(items) == 0 {
 		return nil
 	}
 
-	ops := make([]kvpkg.BatchOp, len(items))
-	for i, item := range items {
-		key := item.Key.String()
-		if item.Key.GUID != "" {
-			key = item.Key.StringWithGUID()
-		}
-		ops[i] = kvpkg.BatchOp{
-			Mode:  kvpkg.BatchOpCreate,
-			Key:   key,
-			Value: item.Value,
+	for _, item := range items {
+		if err := validateDataKey(item.Key); err != nil {
+			return fmt.Errorf("invalid data key: %w", err)
 		}
 	}
 
-	return d.kv.Batch(ctx, dataSection, ops)
+	if importer, ok := d.kv.(kvpkg.HistoryImporter); ok {
+		rows := make([]kvpkg.HistoryImportRow, len(items))
+		for i, item := range items {
+			key := item.Key.String()
+			if item.Key.GUID != "" {
+				key = item.Key.StringWithGUID()
+			}
+			rows[i] = kvpkg.HistoryImportRow{
+				Key:   key,
+				Value: item.Value,
+			}
+		}
+		return importer.ImportHistory(ctx, rows)
+	}
+
+	for i, item := range items {
+		if err := d.Save(ctx, item.Key, bytes.NewReader(item.Value)); err != nil {
+			return fmt.Errorf("import history item %d: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // ParseKey parses a string key into a DataKey struct

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -582,7 +582,10 @@ type batchSaveItem struct {
 	Value []byte
 }
 
-// batchSave saves multiple items in a single Batch call to the KV store.
+// batchSave saves multiple items to the DataSection.
+// For SqlKV it uses BulkInsertData (multi-row INSERT) for maximum throughput.
+// The caller must ensure keys are new (e.g. by deleting the collection first).
+// For other KV implementations it falls back to the general Batch method.
 func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error {
 	if len(items) == 0 {
 		return nil
@@ -602,6 +605,11 @@ func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error 
 			Key:   key,
 			Value: item.Value,
 		}
+	}
+
+	// Use optimized multi-row INSERT for SqlKV (keys guaranteed new during bulk import).
+	if sqlkv, ok := d.kv.(*kvpkg.SqlKV); ok {
+		return sqlkv.BulkInsertData(ctx, ops)
 	}
 
 	return d.kv.Batch(ctx, dataSection, ops)

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -593,9 +593,6 @@ func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error 
 
 	ops := make([]kvpkg.BatchOp, len(items))
 	for i, item := range items {
-		if err := validateDataKey(item.Key); err != nil {
-			return fmt.Errorf("invalid data key at index %d: %w", i, err)
-		}
 		key := item.Key.String()
 		if item.Key.GUID != "" {
 			key = item.Key.StringWithGUID()

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"errors"
@@ -600,27 +599,18 @@ func (d *dataStore) importHistoryBatch(ctx context.Context, items []historyImpor
 		}
 	}
 
-	if importer, ok := d.kv.(kvpkg.HistoryImporter); ok {
-		rows := make([]kvpkg.HistoryImportRow, len(items))
-		for i, item := range items {
-			key := item.Key.String()
-			if item.Key.GUID != "" {
-				key = item.Key.StringWithGUID()
-			}
-			rows[i] = kvpkg.HistoryImportRow{
-				Key:   key,
-				Value: item.Value,
-			}
-		}
-		return importer.ImportHistory(ctx, rows)
-	}
-
+	rows := make([]kvpkg.HistoryImportRow, len(items))
 	for i, item := range items {
-		if err := d.Save(ctx, item.Key, bytes.NewReader(item.Value)); err != nil {
-			return fmt.Errorf("import history item %d: %w", i, err)
+		key := item.Key.String()
+		if item.Key.GUID != "" {
+			key = item.Key.StringWithGUID()
+		}
+		rows[i] = kvpkg.HistoryImportRow{
+			Key:   key,
+			Value: item.Value,
 		}
 	}
-	return nil
+	return d.kv.ImportHistory(ctx, rows)
 }
 
 // ParseKey parses a string key into a DataKey struct

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -576,6 +576,37 @@ func (n *dataStore) batchDelete(ctx context.Context, keys []DataKey) error {
 	return nil
 }
 
+// batchSaveItem represents a single item for batch save operations
+type batchSaveItem struct {
+	Key   DataKey
+	Value []byte
+}
+
+// batchSave saves multiple items in a single Batch call to the KV store.
+func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	ops := make([]kvpkg.BatchOp, len(items))
+	for i, item := range items {
+		if err := validateDataKey(item.Key); err != nil {
+			return fmt.Errorf("invalid data key at index %d: %w", i, err)
+		}
+		key := item.Key.String()
+		if item.Key.GUID != "" {
+			key = item.Key.StringWithGUID()
+		}
+		ops[i] = kvpkg.BatchOp{
+			Mode:  kvpkg.BatchOpPut,
+			Key:   key,
+			Value: item.Value,
+		}
+	}
+
+	return d.kv.Batch(ctx, dataSection, ops)
+}
+
 // ParseKey parses a string key into a DataKey struct
 func ParseKey(key string) (DataKey, error) {
 	parts := strings.Split(key, "/")

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -607,7 +607,7 @@ func (d *dataStore) batchSave(ctx context.Context, items []batchSaveItem) error 
 		}
 	}
 
-	return d.kv.BulkInsertData(ctx, ops)
+	return d.kv.Batch(ctx, dataSection, ops)
 }
 
 // ParseKey parses a string key into a DataKey struct

--- a/pkg/storage/unified/resource/kv/dialect.go
+++ b/pkg/storage/unified/resource/kv/dialect.go
@@ -90,7 +90,6 @@ func BatchInsertMaxRows(dialect Dialect, paramsPerRow int) int {
 		}
 		return maxByLimit
 	default:
-		// MySQL and PostgreSQL handle large batches well
-		return 1000
+		return MaxBatchOps
 	}
 }

--- a/pkg/storage/unified/resource/kv/dialect.go
+++ b/pkg/storage/unified/resource/kv/dialect.go
@@ -77,3 +77,20 @@ func (d sqliteDialect) QuoteIdent(name string) string {
 func (d sqliteDialect) Placeholder(n int) string {
 	return "?"
 }
+
+// BatchInsertMaxRows returns the maximum number of rows per multi-row INSERT
+// for the given dialect with the specified number of parameters per row.
+func BatchInsertMaxRows(dialect Dialect, paramsPerRow int) int {
+	switch dialect.Name() {
+	case "sqlite":
+		// SQLite has a 999 parameter limit
+		maxByLimit := 999 / paramsPerRow
+		if maxByLimit > 100 {
+			return 100
+		}
+		return maxByLimit
+	default:
+		// MySQL and PostgreSQL handle large batches well
+		return 1000
+	}
+}

--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -127,18 +127,14 @@ type KV interface {
 	//   - BatchOpUpdate: Fail with ErrNotFound if key doesn't exist
 	//   - BatchOpDelete: Idempotent, never fails on key state
 	Batch(ctx context.Context, section string, ops []BatchOp) error
-}
 
-// HistoryImporter is an optional fast path used only by ProcessBulk-style
-// migration imports. Unlike KV.Batch, it appends already-validated authoritative
-// history rows to DataSection and does not implement generic
-// Put/Create/Update/Delete semantics.
-type HistoryImporter interface {
+	// ImportHistory appends already-validated authoritative DataSection history
+	// rows for ProcessBulk-style migration imports. Unlike Batch, it does not
+	// implement generic Put/Create/Update/Delete semantics.
 	ImportHistory(ctx context.Context, rows []HistoryImportRow) error
 }
 
 var _ KV = &badgerKV{}
-var _ HistoryImporter = &badgerKV{}
 
 // Reference implementation of the KV interface using BadgerDB
 // This is only used for testing purposes, and will not work HA

--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -106,12 +106,6 @@ type KV interface {
 	// This is used to ensure the server and client are not too far apart in time.
 	UnixTimestamp(ctx context.Context) (int64, error)
 
-	// BulkInsertData performs optimized multi-row INSERT into the DataSection.
-	// Keys must be new — this does NOT upsert. The caller must ensure no
-	// duplicate key_paths exist (e.g. by deleting the collection first).
-	// Only BatchOpPut operations are supported.
-	BulkInsertData(ctx context.Context, ops []BatchOp) error
-
 	// Batch executes all operations atomically within a single transaction.
 	// If any operation fails, all operations are rolled back.
 	// Operations are executed in order; the batch stops on first failure.
@@ -497,8 +491,4 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 	}
 
 	return txn.Commit()
-}
-
-func (k *badgerKV) BulkInsertData(ctx context.Context, ops []BatchOp) error {
-	return k.Batch(ctx, DataSection, ops)
 }

--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -58,6 +58,16 @@ type BatchOp struct {
 	Value []byte // For Put/Create/Update operations, nil for Delete
 }
 
+// HistoryImportRow is a migration-only DataSection row.
+// The key is relative to DataSection and already includes the full history suffix
+// (resource version, action, folder, and optional GUID when applicable).
+// Callers provide rows in final write order after deciding collection scope and
+// any pre-import cleanup.
+type HistoryImportRow struct {
+	Key   string
+	Value []byte
+}
+
 // Maximum limit for batch operations
 const MaxBatchOps = 1000
 
@@ -119,7 +129,16 @@ type KV interface {
 	Batch(ctx context.Context, section string, ops []BatchOp) error
 }
 
+// HistoryImporter is an optional fast path used only by ProcessBulk-style
+// migration imports. Unlike KV.Batch, it appends already-validated authoritative
+// history rows to DataSection and does not implement generic
+// Put/Create/Update/Delete semantics.
+type HistoryImporter interface {
+	ImportHistory(ctx context.Context, rows []HistoryImportRow) error
+}
+
 var _ KV = &badgerKV{}
+var _ HistoryImporter = &badgerKV{}
 
 // Reference implementation of the KV interface using BadgerDB
 // This is only used for testing purposes, and will not work HA
@@ -487,6 +506,29 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 
 		default:
 			return &BatchError{Err: fmt.Errorf("unknown operation mode: %d", op.Mode), Index: i, Op: op}
+		}
+	}
+
+	return txn.Commit()
+}
+
+func (k *badgerKV) ImportHistory(ctx context.Context, rows []HistoryImportRow) error {
+	if k.db.IsClosed() {
+		return fmt.Errorf("database is closed")
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	txn := k.db.NewTransaction(true)
+	defer txn.Discard()
+
+	for _, row := range rows {
+		if len(row.Value) == 0 {
+			return ErrEmptyValue
+		}
+		if err := txn.Set([]byte(DataSection+"/"+row.Key), row.Value); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -59,7 +59,7 @@ type BatchOp struct {
 }
 
 // Maximum limit for batch operations
-const MaxBatchOps = 20
+const MaxBatchOps = 1000
 
 // BatchError wraps errors from Batch operations with context about which operation failed
 type BatchError struct {

--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -106,6 +106,12 @@ type KV interface {
 	// This is used to ensure the server and client are not too far apart in time.
 	UnixTimestamp(ctx context.Context) (int64, error)
 
+	// BulkInsertData performs optimized multi-row INSERT into the DataSection.
+	// Keys must be new — this does NOT upsert. The caller must ensure no
+	// duplicate key_paths exist (e.g. by deleting the collection first).
+	// Only BatchOpPut operations are supported.
+	BulkInsertData(ctx context.Context, ops []BatchOp) error
+
 	// Batch executes all operations atomically within a single transaction.
 	// If any operation fails, all operations are rolled back.
 	// Operations are executed in order; the batch stops on first failure.
@@ -491,4 +497,8 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 	}
 
 	return txn.Commit()
+}
+
+func (k *badgerKV) BulkInsertData(ctx context.Context, ops []BatchOp) error {
+	return k.Batch(ctx, DataSection, ops)
 }

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -152,18 +152,6 @@ func (qb *queryBuilder) buildBatchDeleteQuery(keyPaths []string) (string, []inte
 	return query, args
 }
 
-// buildInsertQuery generates a plain INSERT for non-DataSection tables (key_path + value only, no conflict handling).
-// Used by BatchOpCreate to ensure concurrent creates fail with a constraint violation rather than silently upserting.
-func (qb *queryBuilder) buildInsertQuery(keyPath string, value []byte) (string, []interface{}) {
-	query := fmt.Sprintf(
-		"INSERT INTO %s (%s, %s) VALUES (%s, %s)",
-		qb.dialect.QuoteIdent(qb.tableName),
-		qb.dialect.QuoteIdent("key_path"), qb.dialect.QuoteIdent("value"),
-		qb.dialect.Placeholder(1), qb.dialect.Placeholder(2),
-	)
-	return query, []interface{}{keyPath, value}
-}
-
 // buildInsertDatastoreQuery generates INSERT for datastore section for use in non-backwards compatible mode (without rvmanager)
 // Includes all required fields with empty string defaults for group, resource, namespace, name, folder, and 0 for action
 func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, guid string) (string, []interface{}) {

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -180,6 +180,50 @@ func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, 
 	return query, []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
 }
 
+// batchInsertRow represents a single row for batch INSERT into the datastore
+type batchInsertRow struct {
+	GUID    string
+	KeyPath string
+	Value   []byte
+}
+
+// buildBatchInsertDatastoreQuery generates a multi-row INSERT for the datastore section.
+// Same 9 columns as buildInsertDatastoreQuery. Legacy columns are set to empty/zero defaults.
+func (qb *queryBuilder) buildBatchInsertDatastoreQuery(rows []batchInsertRow) (string, []interface{}) {
+	if len(rows) == 0 {
+		return "", nil
+	}
+
+	cols := []string{"guid", "key_path", "value", "group", "resource", "namespace", "name", "action", "folder"}
+	quotedCols := make([]string, len(cols))
+	for i, col := range cols {
+		quotedCols[i] = qb.dialect.QuoteIdent(col)
+	}
+
+	paramsPerRow := len(cols)
+	valueParts := make([]string, 0, len(rows))
+	args := make([]interface{}, 0, len(rows)*paramsPerRow)
+
+	for i, row := range rows {
+		placeholders := make([]string, paramsPerRow)
+		base := i * paramsPerRow
+		for j := 0; j < paramsPerRow; j++ {
+			placeholders[j] = qb.dialect.Placeholder(base + j + 1)
+		}
+		valueParts = append(valueParts, "("+strings.Join(placeholders, ", ")+")")
+		args = append(args, row.GUID, row.KeyPath, row.Value, "", "", "", "", 0, "")
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES %s",
+		qb.dialect.QuoteIdent(qb.tableName),
+		strings.Join(quotedCols, ", "),
+		strings.Join(valueParts, ", "),
+	)
+
+	return query, args
+}
+
 // buildInsertDatastoreBackwardCompatQuery generates INSERT for backward-compatible mode
 // Inserts guid, value, and placeholder values for NOT NULL columns - these will be updated by applyBackwardsCompatibleChanges()
 func (qb *queryBuilder) buildInsertDatastoreBackwardCompatQuery(value []byte, guid, group, resource, namespace, name, folder string, action int64) (string, []interface{}) {

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -180,6 +180,43 @@ func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, 
 	return query, []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
 }
 
+// buildUpsertDatastoreQuery generates an upsert for the datastore section (9 columns).
+// On conflict with key_path, only value is updated; guid and legacy columns are left unchanged.
+func (qb *queryBuilder) buildUpsertDatastoreQuery(keyPath string, value []byte, guid string) (string, []interface{}) {
+	cols := []string{"guid", "key_path", "value", "group", "resource", "namespace", "name", "action", "folder"}
+	quoted := make([]string, len(cols))
+	for i, c := range cols {
+		quoted[i] = qb.dialect.QuoteIdent(c)
+	}
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = qb.dialect.Placeholder(i + 1)
+	}
+	baseArgs := []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
+
+	switch qb.dialect.Name() {
+	case "mysql":
+		query := fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s = %s",
+			qb.dialect.QuoteIdent(qb.tableName),
+			strings.Join(quoted, ", "),
+			strings.Join(placeholders, ", "),
+			qb.dialect.QuoteIdent("value"), qb.dialect.Placeholder(len(cols)+1),
+		)
+		return query, append(baseArgs, value)
+	default: // postgres, sqlite
+		query := fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s = %s",
+			qb.dialect.QuoteIdent(qb.tableName),
+			strings.Join(quoted, ", "),
+			strings.Join(placeholders, ", "),
+			qb.dialect.QuoteIdent("key_path"),
+			qb.dialect.QuoteIdent("value"), qb.dialect.Placeholder(len(cols)+1),
+		)
+		return query, append(baseArgs, value)
+	}
+}
+
 // batchInsertRow represents a single row for batch INSERT into the datastore
 type batchInsertRow struct {
 	GUID    string

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -152,6 +152,18 @@ func (qb *queryBuilder) buildBatchDeleteQuery(keyPaths []string) (string, []inte
 	return query, args
 }
 
+// buildInsertQuery generates a plain INSERT for non-DataSection tables (key_path + value only, no conflict handling).
+// Used by BatchOpCreate to ensure concurrent creates fail with a constraint violation rather than silently upserting.
+func (qb *queryBuilder) buildInsertQuery(keyPath string, value []byte) (string, []interface{}) {
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s, %s) VALUES (%s, %s)",
+		qb.dialect.QuoteIdent(qb.tableName),
+		qb.dialect.QuoteIdent("key_path"), qb.dialect.QuoteIdent("value"),
+		qb.dialect.Placeholder(1), qb.dialect.Placeholder(2),
+	)
+	return query, []interface{}{keyPath, value}
+}
+
 // buildInsertDatastoreQuery generates INSERT for datastore section for use in non-backwards compatible mode (without rvmanager)
 // Includes all required fields with empty string defaults for group, resource, namespace, name, folder, and 0 for action
 func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, guid string) (string, []interface{}) {

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -23,6 +23,17 @@ func (qb *queryBuilder) buildGetQuery(keyPath string) (string, []interface{}) {
 	return query, []interface{}{keyPath}
 }
 
+// buildExistsQuery generates a lightweight existence check for a single key.
+func (qb *queryBuilder) buildExistsQuery(keyPath string) (string, []interface{}) {
+	query := fmt.Sprintf(
+		"SELECT 1 FROM %s WHERE %s = %s",
+		qb.dialect.QuoteIdent(qb.tableName),
+		qb.dialect.QuoteIdent("key_path"),
+		qb.dialect.Placeholder(1),
+	)
+	return query, []interface{}{keyPath}
+}
+
 // buildKeysQuery generates SELECT query for listing keys
 func (qb *queryBuilder) buildKeysQuery(startKey, endKey string, sortAsc bool, limit int64) (string, []interface{}) {
 	order := "ASC"

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -180,43 +180,6 @@ func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, 
 	return query, []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
 }
 
-// buildUpsertDatastoreQuery generates an upsert for the datastore section (9 columns).
-// On conflict with key_path, only value is updated; guid and legacy columns are left unchanged.
-func (qb *queryBuilder) buildUpsertDatastoreQuery(keyPath string, value []byte, guid string) (string, []interface{}) {
-	cols := []string{"guid", "key_path", "value", "group", "resource", "namespace", "name", "action", "folder"}
-	quoted := make([]string, len(cols))
-	for i, c := range cols {
-		quoted[i] = qb.dialect.QuoteIdent(c)
-	}
-	placeholders := make([]string, len(cols))
-	for i := range cols {
-		placeholders[i] = qb.dialect.Placeholder(i + 1)
-	}
-	baseArgs := []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
-
-	switch qb.dialect.Name() {
-	case "mysql":
-		query := fmt.Sprintf(
-			"INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s = %s",
-			qb.dialect.QuoteIdent(qb.tableName),
-			strings.Join(quoted, ", "),
-			strings.Join(placeholders, ", "),
-			qb.dialect.QuoteIdent("value"), qb.dialect.Placeholder(len(cols)+1),
-		)
-		return query, append(baseArgs, value)
-	default: // postgres, sqlite
-		query := fmt.Sprintf(
-			"INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s = %s",
-			qb.dialect.QuoteIdent(qb.tableName),
-			strings.Join(quoted, ", "),
-			strings.Join(placeholders, ", "),
-			qb.dialect.QuoteIdent("key_path"),
-			qb.dialect.QuoteIdent("value"), qb.dialect.Placeholder(len(cols)+1),
-		)
-		return query, append(baseArgs, value)
-	}
-}
-
 // batchInsertRow represents a single row for batch INSERT into the datastore
 type batchInsertRow struct {
 	GUID    string

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -23,7 +23,6 @@ const (
 )
 
 var _ KV = &SqlKV{}
-var _ HistoryImporter = &SqlKV{}
 
 var batchSavepointCounter uint64
 

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -391,7 +391,170 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 }
 
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
-	return fmt.Errorf("Batch operation not implemented for sqlKV")
+	if section == "" {
+		return fmt.Errorf("section is required")
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	if len(ops) > MaxBatchOps {
+		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
+	}
+
+	qb, err := k.getQueryBuilder(section)
+	if err != nil {
+		return err
+	}
+
+	// Validate all ops upfront
+	for i, op := range ops {
+		switch op.Mode {
+		case BatchOpPut, BatchOpCreate, BatchOpUpdate:
+			if len(op.Value) == 0 {
+				return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+			}
+		case BatchOpDelete:
+			// OK
+		default:
+			return &BatchError{Err: fmt.Errorf("unknown operation mode: %d", op.Mode), Index: i, Op: op}
+		}
+	}
+
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Fast path: all BatchOpPut on DataSection → multi-row INSERT
+	if section == DataSection && allBatchOpPut(ops) {
+		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+
+	// General path: process ops in order within a single transaction
+	for i, op := range ops {
+		keyPath := getKeyPath(section, op.Key)
+		switch op.Mode {
+		case BatchOpPut:
+			if section == DataSection {
+				if err := putDataSectionTx(ctx, tx, qb, keyPath, op.Value); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			} else {
+				query, args := qb.buildUpsertQuery(keyPath, op.Value)
+				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			}
+		case BatchOpCreate:
+			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+			if err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if exists {
+				return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
+			}
+			if section == DataSection {
+				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			} else {
+				query, args := qb.buildUpsertQuery(keyPath, op.Value)
+				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			}
+		case BatchOpUpdate:
+			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+			if err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if !exists {
+				return &BatchError{Err: ErrNotFound, Index: i, Op: op}
+			}
+			query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		case BatchOpDelete:
+			query, args := qb.buildDeleteQuery(keyPath)
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
+func allBatchOpPut(ops []BatchOp) bool {
+	for _, op := range ops {
+		if op.Mode != BatchOpPut {
+			return false
+		}
+	}
+	return true
+}
+
+func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {
+	query, args := qb.buildGetQuery(keyPath)
+	row := tx.QueryRowContext(ctx, query, args...)
+	var value []byte
+	err := row.Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func putDataSectionTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string, value []byte) error {
+	exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		query, args := qb.buildUpdateDatastoreQuery(keyPath, value)
+		_, err = tx.ExecContext(ctx, query, args...)
+		return err
+	}
+	query, args := qb.buildInsertDatastoreQuery(keyPath, value, uuid.New().String())
+	_, err = tx.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {
+	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
+
+	for start := 0; start < len(ops); start += maxRows {
+		end := start + maxRows
+		if end > len(ops) {
+			end = len(ops)
+		}
+		chunk := ops[start:end]
+
+		rows := make([]batchInsertRow, len(chunk))
+		for i, op := range chunk {
+			rows[i] = batchInsertRow{
+				GUID:    uuid.New().String(),
+				KeyPath: getKeyPath(section, op.Key),
+				Value:   op.Value,
+			}
+		}
+
+		query, args := qb.buildBatchInsertDatastoreQuery(rows)
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("batch insert failed at rows %d-%d: %w", start, end-1, err)
+		}
+	}
+
+	return nil
 }
 
 func (k *SqlKV) UnixTimestamp(ctx context.Context) (int64, error) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -97,6 +97,23 @@ func (k *SqlKV) conn(ctx context.Context) dbtx {
 	return k.db
 }
 
+// borrowOrBeginTx returns a *sql.Tx for batch operations. When a migration tx
+// exists in the context (SQLite bulk import), it is returned directly with
+// owned=false so the caller does NOT commit/rollback. Otherwise a new tx is
+// started with owned=true and the caller must manage its lifecycle.
+func (k *SqlKV) borrowOrBeginTx(ctx context.Context) (tx *sql.Tx, owned bool, err error) {
+	if extTx, ok := dbtxFromCtx(ctx); ok {
+		if sqlTx, ok := extTx.(*sql.Tx); ok {
+			return sqlTx, false, nil
+		}
+	}
+	sqlTx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	return sqlTx, true, nil
+}
+
 func (k *SqlKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
 		if section == LastImportTimeSection {
@@ -462,11 +479,13 @@ func (k *SqlKV) batchUniform(ctx context.Context, qb *queryBuilder, section stri
 // in normal operation (ProcessBulk). Keys cannot collide with existing storage rows
 // because the collection is deleted before import and each key embeds a fresh RV.
 func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, err := k.db.BeginTx(ctx, nil)
+	tx, owned, err := k.borrowOrBeginTx(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if owned {
+		defer tx.Rollback() //nolint:errcheck
+	}
 
 	if section == DataSection && !hasDuplicateKeys(ops) {
 		// Fast path: multi-row INSERT. Safe because DataSection keys embed the
@@ -504,16 +523,21 @@ func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, 
 		}
 	}
 
-	return tx.Commit()
+	if owned {
+		return tx.Commit()
+	}
+	return nil
 }
 
 // batchCreate handles all-Create batches with existence checks.
 func (k *SqlKV) batchCreate(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, err := k.db.BeginTx(ctx, nil)
+	tx, owned, err := k.borrowOrBeginTx(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if owned {
+		defer tx.Rollback() //nolint:errcheck
+	}
 
 	for i, op := range ops {
 		keyPath := getKeyPath(section, op.Key)
@@ -537,16 +561,21 @@ func (k *SqlKV) batchCreate(ctx context.Context, qb *queryBuilder, section strin
 		}
 	}
 
-	return tx.Commit()
+	if owned {
+		return tx.Commit()
+	}
+	return nil
 }
 
 // batchUpdate handles all-Update batches with existence checks.
 func (k *SqlKV) batchUpdate(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, err := k.db.BeginTx(ctx, nil)
+	tx, owned, err := k.borrowOrBeginTx(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if owned {
+		defer tx.Rollback() //nolint:errcheck
+	}
 
 	for i, op := range ops {
 		keyPath := getKeyPath(section, op.Key)
@@ -563,16 +592,21 @@ func (k *SqlKV) batchUpdate(ctx context.Context, qb *queryBuilder, section strin
 		}
 	}
 
-	return tx.Commit()
+	if owned {
+		return tx.Commit()
+	}
+	return nil
 }
 
 // batchMixed handles batches with different op modes via sequential per-op processing.
 func (k *SqlKV) batchMixed(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, err := k.db.BeginTx(ctx, nil)
+	tx, owned, err := k.borrowOrBeginTx(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if owned {
+		defer tx.Rollback() //nolint:errcheck
+	}
 
 	for i, op := range ops {
 		keyPath := getKeyPath(section, op.Key)
@@ -639,7 +673,10 @@ func (k *SqlKV) batchMixed(ctx context.Context, qb *queryBuilder, section string
 		}
 	}
 
-	return tx.Commit()
+	if owned {
+		return tx.Commit()
+	}
+	return nil
 }
 
 func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {
@@ -671,11 +708,13 @@ func hasDuplicateKeys(ops []BatchOp) bool {
 // batchDelete handles all-Delete batches in a single transaction, chunking to
 // stay within dialect parameter limits (e.g. SQLite's 999).
 func (k *SqlKV) batchDelete(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, err := k.db.BeginTx(ctx, nil)
+	tx, owned, err := k.borrowOrBeginTx(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return err
 	}
-	defer tx.Rollback() //nolint:errcheck
+	if owned {
+		defer tx.Rollback() //nolint:errcheck
+	}
 
 	maxKeys := batchDeleteMaxKeys(k.dialect)
 	for start := 0; start < len(ops); start += maxKeys {
@@ -693,7 +732,10 @@ func (k *SqlKV) batchDelete(ctx context.Context, qb *queryBuilder, section strin
 		}
 	}
 
-	return tx.Commit()
+	if owned {
+		return tx.Commit()
+	}
+	return nil
 }
 
 // batchDeleteMaxKeys returns the max keys per DELETE WHERE IN chunk for the dialect.

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -484,8 +484,17 @@ func (k *SqlKV) batchPerItem(ctx context.Context, tx *sql.Tx, qb *queryBuilder, 
 		switch op.Mode {
 		case BatchOpPut:
 			if section == DataSection {
-				query, args := qb.buildUpsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-				_, err = tx.ExecContext(ctx, query, args...)
+				// key_path is not unique on resource_history, so ON CONFLICT
+				// cannot be used. Check existence and insert or update.
+				if exists, e := keyExistsTx(ctx, tx, qb, keyPath); e != nil {
+					return &BatchError{Err: e, Index: i, Op: op}
+				} else if exists {
+					query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
+					_, err = tx.ExecContext(ctx, query, args...)
+				} else {
+					query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+					_, err = tx.ExecContext(ctx, query, args...)
+				}
 			} else {
 				query, args := qb.buildUpsertQuery(keyPath, op.Value)
 				_, err = tx.ExecContext(ctx, query, args...)

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -426,14 +426,6 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Fast path: all BatchOpPut on DataSection → multi-row INSERT
-	if section == DataSection && allBatchOpPut(ops) {
-		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
-			return err
-		}
-		return tx.Commit()
-	}
-
 	// General path: process ops in order within a single transaction
 	for i, op := range ops {
 		keyPath := getKeyPath(section, op.Key)
@@ -491,15 +483,6 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 	return tx.Commit()
 }
 
-func allBatchOpPut(ops []BatchOp) bool {
-	for _, op := range ops {
-		if op.Mode != BatchOpPut {
-			return false
-		}
-	}
-	return true
-}
-
 func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {
 	query, args := qb.buildGetQuery(keyPath)
 	row := tx.QueryRowContext(ctx, query, args...)
@@ -529,9 +512,39 @@ func putDataSectionTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath
 	return err
 }
 
-func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {
-	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
+// BulkInsertData performs multi-row INSERT into the DataSection (resource_history).
+// Keys must be new — this does NOT upsert. It is the caller's responsibility to
+// ensure no duplicate key_paths exist (e.g. by deleting the collection first).
+// Used by dataStore.batchSave during bulk import for maximum throughput.
+func (k *SqlKV) BulkInsertData(ctx context.Context, ops []BatchOp) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	if len(ops) > MaxBatchOps {
+		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
+	}
 
+	for i, op := range ops {
+		if op.Mode != BatchOpPut {
+			return &BatchError{Err: fmt.Errorf("BulkInsertData only supports BatchOpPut"), Index: i, Op: op}
+		}
+		if len(op.Value) == 0 {
+			return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+		}
+	}
+
+	qb, err := k.getQueryBuilder(DataSection)
+	if err != nil {
+		return err
+	}
+
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
 	for start := 0; start < len(ops); start += maxRows {
 		end := start + maxRows
 		if end > len(ops) {
@@ -543,7 +556,7 @@ func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryB
 		for i, op := range chunk {
 			rows[i] = batchInsertRow{
 				GUID:    uuid.New().String(),
-				KeyPath: getKeyPath(section, op.Key),
+				KeyPath: getKeyPath(DataSection, op.Key),
 				Value:   op.Value,
 			}
 		}
@@ -554,7 +567,7 @@ func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryB
 		}
 	}
 
-	return nil
+	return tx.Commit()
 }
 
 func (k *SqlKV) UnixTimestamp(ctx context.Context) (int64, error) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -484,7 +484,7 @@ func (k *SqlKV) batchPerItem(ctx context.Context, tx *sql.Tx, qb *queryBuilder, 
 		switch op.Mode {
 		case BatchOpPut:
 			if section == DataSection {
-				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+				query, args := qb.buildUpsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
 				_, err = tx.ExecContext(ctx, query, args...)
 			} else {
 				query, args := qb.buildUpsertQuery(keyPath, op.Value)

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -448,8 +448,9 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		defer tx.Rollback() //nolint:errcheck
 	}
 
-	// Fast path: all-Put on DataSection uses multi-row INSERT.
-	if section == DataSection && allPut(ops) {
+	// Fast path: all-Create on DataSection uses multi-row INSERT.
+	// Keys are guaranteed unique by the caller (collection cleared, keys embed fresh RV).
+	if section == DataSection && allCreate(ops) {
 		if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
 			return err
 		}
@@ -466,10 +467,10 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 	return nil
 }
 
-// allPut returns true if every op is a BatchOpPut.
-func allPut(ops []BatchOp) bool {
+// allCreate returns true if every op is a BatchOpCreate.
+func allCreate(ops []BatchOp) bool {
 	for _, op := range ops {
-		if op.Mode != BatchOpPut {
+		if op.Mode != BatchOpCreate {
 			return false
 		}
 	}

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -407,10 +407,9 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 	return nil
 }
 
-// Batch executes all operations atomically. Currently only BatchOpPut is supported
-// for the importer (ProcessBulk) use case. DataSection uses multi-row INSERT for
-// maximum throughput; the caller must ensure keys are new (collection is deleted
-// before import and each key embeds a fresh resource version).
+// Batch executes all operations atomically within a single transaction.
+// All-Put batches on DataSection use multi-row INSERT for maximum throughput.
+// All other operations fall back to per-item execution within the transaction.
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
@@ -422,13 +421,17 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
 	}
 
-	// Validate all ops are BatchOpPut with non-empty values.
+	// Validate all ops upfront.
 	for i, op := range ops {
-		if op.Mode != BatchOpPut {
-			return &BatchError{Err: fmt.Errorf("only BatchOpPut is supported"), Index: i, Op: op}
-		}
-		if len(op.Value) == 0 {
-			return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+		switch op.Mode {
+		case BatchOpPut, BatchOpCreate, BatchOpUpdate:
+			if len(op.Value) == 0 {
+				return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+			}
+		case BatchOpDelete:
+			// OK
+		default:
+			return &BatchError{Err: fmt.Errorf("unknown operation mode: %d", op.Mode), Index: i, Op: op}
 		}
 	}
 
@@ -445,19 +448,15 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		defer tx.Rollback() //nolint:errcheck
 	}
 
-	if section == DataSection {
-		// Multi-row INSERT. Keys embed the resource version so they are unique
-		// both within the batch and in storage.
+	// Fast path: all-Put on DataSection uses multi-row INSERT.
+	if section == DataSection && allPut(ops) {
 		if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
 			return err
 		}
 	} else {
-		for i, op := range ops {
-			keyPath := getKeyPath(section, op.Key)
-			query, args := qb.buildUpsertQuery(keyPath, op.Value)
-			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
+		// Fallback: per-item execution for mixed modes or non-DataSection.
+		if err := k.batchPerItem(ctx, tx, qb, section, ops); err != nil {
+			return err
 		}
 	}
 
@@ -465,6 +464,81 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		return tx.Commit()
 	}
 	return nil
+}
+
+// allPut returns true if every op is a BatchOpPut.
+func allPut(ops []BatchOp) bool {
+	for _, op := range ops {
+		if op.Mode != BatchOpPut {
+			return false
+		}
+	}
+	return true
+}
+
+// batchPerItem executes each op individually within the given transaction.
+func (k *SqlKV) batchPerItem(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {
+	for i, op := range ops {
+		keyPath := getKeyPath(section, op.Key)
+		var err error
+		switch op.Mode {
+		case BatchOpPut:
+			if section == DataSection {
+				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+				_, err = tx.ExecContext(ctx, query, args...)
+			} else {
+				query, args := qb.buildUpsertQuery(keyPath, op.Value)
+				_, err = tx.ExecContext(ctx, query, args...)
+			}
+		case BatchOpCreate:
+			if exists, e := keyExistsTx(ctx, tx, qb, keyPath); e != nil {
+				return &BatchError{Err: e, Index: i, Op: op}
+			} else if exists {
+				return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
+			}
+			if section == DataSection {
+				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+				_, err = tx.ExecContext(ctx, query, args...)
+			} else {
+				query, args := qb.buildUpsertQuery(keyPath, op.Value)
+				_, err = tx.ExecContext(ctx, query, args...)
+			}
+		case BatchOpUpdate:
+			if exists, e := keyExistsTx(ctx, tx, qb, keyPath); e != nil {
+				return &BatchError{Err: e, Index: i, Op: op}
+			} else if !exists {
+				return &BatchError{Err: ErrNotFound, Index: i, Op: op}
+			}
+			if section == DataSection {
+				query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
+				_, err = tx.ExecContext(ctx, query, args...)
+			} else {
+				query, args := qb.buildUpsertQuery(keyPath, op.Value)
+				_, err = tx.ExecContext(ctx, query, args...)
+			}
+		case BatchOpDelete:
+			query, args := qb.buildDeleteQuery(keyPath)
+			_, err = tx.ExecContext(ctx, query, args...)
+		}
+		if err != nil {
+			return &BatchError{Err: err, Index: i, Op: op}
+		}
+	}
+	return nil
+}
+
+func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {
+	query, args := qb.buildGetQuery(keyPath)
+	row := tx.QueryRowContext(ctx, query, args...)
+	var value []byte
+	err := row.Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, ops []BatchOp) error {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"iter"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,6 +23,8 @@ const (
 )
 
 var _ KV = &SqlKV{}
+
+var batchSavepointCounter uint64
 
 type SqlKV struct {
 	db         *sql.DB
@@ -112,6 +115,49 @@ func (k *SqlKV) borrowOrBeginTx(ctx context.Context) (tx *sql.Tx, owned bool, er
 		return nil, false, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	return sqlTx, true, nil
+}
+
+func nextBatchSavepoint() string {
+	return fmt.Sprintf("sqlkv_batch_%d", atomic.AddUint64(&batchSavepointCounter, 1))
+}
+
+// withBatchTx runs fn inside a transaction and guarantees rollback on error.
+// When the context already carries an external *sql.Tx, a savepoint is used so
+// Batch remains atomic without owning the outer transaction.
+func (k *SqlKV) withBatchTx(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	tx, owned, err := k.borrowOrBeginTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	batchCtx := ContextWithDBTX(ctx, tx)
+	if owned {
+		defer tx.Rollback() //nolint:errcheck
+		if err := fn(batchCtx, tx); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+
+	savepoint := nextBatchSavepoint()
+	if _, err := tx.ExecContext(ctx, "SAVEPOINT "+savepoint); err != nil {
+		return fmt.Errorf("failed to create savepoint: %w", err)
+	}
+
+	if err := fn(batchCtx, tx); err != nil {
+		if _, rollbackErr := tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT "+savepoint); rollbackErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to rollback savepoint: %w", rollbackErr))
+		}
+		if _, releaseErr := tx.ExecContext(ctx, "RELEASE SAVEPOINT "+savepoint); releaseErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to release savepoint: %w", releaseErr))
+		}
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, "RELEASE SAVEPOINT "+savepoint); err != nil {
+		return fmt.Errorf("failed to release savepoint: %w", err)
+	}
+	return nil
 }
 
 func (k *SqlKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
@@ -407,6 +453,24 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 	return nil
 }
 
+func (k *SqlKV) keyExists(ctx context.Context, section string, key string) (bool, error) {
+	qb, err := k.getQueryBuilder(section)
+	if err != nil {
+		return false, err
+	}
+
+	query, args := qb.buildExistsQuery(getKeyPath(section, key))
+	var exists int
+	if err := k.conn(ctx).QueryRowContext(ctx, query, args...).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check key existence: %w", err)
+	}
+
+	return true, nil
+}
+
 // Batch executes a batch of operations. All-Create on DataSection uses multi-row
 // INSERT for maximum throughput. Everything else falls back to per-item Save/Delete.
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
@@ -439,54 +503,49 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		if err != nil {
 			return err
 		}
-		tx, owned, err := k.borrowOrBeginTx(ctx)
-		if err != nil {
-			return err
-		}
-		if owned {
-			defer tx.Rollback() //nolint:errcheck
-		}
-		if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
-			return err
-		}
-		if owned {
-			return tx.Commit()
-		}
-		return nil
+		return k.withBatchTx(ctx, func(batchCtx context.Context, tx *sql.Tx) error {
+			return k.batchInsertDatastore(batchCtx, tx, qb, ops)
+		})
 	}
 
-	// Fallback: per-item execution using existing Save/Delete methods.
-	for i, op := range ops {
-		switch op.Mode {
-		case BatchOpPut, BatchOpCreate:
-			w, err := k.Save(ctx, section, op.Key)
-			if err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if _, err := w.Write(op.Value); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if err := w.Close(); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-		case BatchOpUpdate:
-			w, err := k.Save(ctx, section, op.Key)
-			if err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if _, err := w.Write(op.Value); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if err := w.Close(); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-		case BatchOpDelete:
-			if err := k.Delete(ctx, section, op.Key); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
+	return k.withBatchTx(ctx, func(batchCtx context.Context, _ *sql.Tx) error {
+		// Fallback: execute per-item semantics via Save/Delete inside one tx.
+		for i, op := range ops {
+			switch op.Mode {
+			case BatchOpCreate:
+				exists, err := k.keyExists(batchCtx, section, op.Key)
+				if err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+				if exists {
+					return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
+				}
+				if err := k.batchWrite(batchCtx, section, op); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			case BatchOpUpdate:
+				exists, err := k.keyExists(batchCtx, section, op.Key)
+				if err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+				if !exists {
+					return &BatchError{Err: ErrNotFound, Index: i, Op: op}
+				}
+				if err := k.batchWrite(batchCtx, section, op); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			case BatchOpPut:
+				if err := k.batchWrite(batchCtx, section, op); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			case BatchOpDelete:
+				if err := k.Delete(batchCtx, section, op.Key); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
 			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // allCreate returns true if every op is a BatchOpCreate.
@@ -497,6 +556,17 @@ func allCreate(ops []BatchOp) bool {
 		}
 	}
 	return true
+}
+
+func (k *SqlKV) batchWrite(ctx context.Context, section string, op BatchOp) error {
+	w, err := k.Save(ctx, section, op.Key)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(op.Value); err != nil {
+		return err
+	}
+	return w.Close()
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, ops []BatchOp) error {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -466,12 +466,22 @@ func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, 
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	// Multi-row INSERT fast path: safe when all keys are unique both within the
+	// batch and in storage. This is the normal case for ProcessBulk where keys
+	// include resource version. Falls back to per-item upsert otherwise.
 	if section == DataSection && !hasDuplicateKeys(ops) {
-		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
+		hasExisting, err := anyKeyExistsTx(ctx, tx, qb, section, ops)
+		if err != nil {
 			return err
 		}
-	} else if section == DataSection {
-		// Duplicate keys in batch: fall back to per-item upsert for correct Put semantics.
+		if !hasExisting {
+			if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
+				return err
+			}
+			return tx.Commit()
+		}
+	}
+	if section == DataSection {
 		for i, op := range ops {
 			keyPath := getKeyPath(section, op.Key)
 			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
@@ -636,6 +646,39 @@ func (k *SqlKV) batchMixed(ctx context.Context, qb *queryBuilder, section string
 	}
 
 	return tx.Commit()
+}
+
+// anyKeyExistsTx checks whether any of the batch keys already exist in storage.
+// Uses a single SELECT ... IN query per chunk, returning as soon as a match is found.
+func anyKeyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) (bool, error) {
+	const maxParams = 999 // safe for all dialects including SQLite
+	for start := 0; start < len(ops); start += maxParams {
+		end := start + maxParams
+		if end > len(ops) {
+			end = len(ops)
+		}
+		chunk := ops[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]interface{}, len(chunk))
+		for i, op := range chunk {
+			placeholders[i] = qb.dialect.Placeholder(i + 1)
+			args[i] = getKeyPath(section, op.Key)
+		}
+		query := fmt.Sprintf("SELECT 1 FROM %s WHERE %s IN (%s) LIMIT 1",
+			qb.dialect.QuoteIdent(qb.tableName),
+			qb.dialect.QuoteIdent("key_path"),
+			strings.Join(placeholders, ", "),
+		)
+		var dummy int
+		err := tx.QueryRowContext(ctx, query, args...).Scan(&dummy)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("failed to check existing keys: %w", err)
+		}
+	}
+	return false, nil
 }
 
 func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -450,29 +450,15 @@ func (k *SqlKV) batchUniform(ctx context.Context, qb *queryBuilder, section stri
 	case BatchOpUpdate:
 		return k.batchUpdate(ctx, qb, section, ops)
 	case BatchOpDelete:
-		keys := make([]string, len(ops))
-		for i, op := range ops {
-			keys[i] = op.Key
-		}
-		// Chunk to stay within dialect parameter limits (e.g. SQLite's 999).
-		maxKeys := batchDeleteMaxKeys(k.dialect)
-		for start := 0; start < len(keys); start += maxKeys {
-			end := start + maxKeys
-			if end > len(keys) {
-				end = len(keys)
-			}
-			if err := k.BatchDelete(ctx, section, keys[start:end]); err != nil {
-				return err
-			}
-		}
-		return nil
+		return k.batchDelete(ctx, qb, section, ops)
 	default:
 		return fmt.Errorf("unknown operation mode: %d", mode)
 	}
 }
 
-// batchPut handles all-Put batches. DataSection uses multi-row INSERT (keys include
-// resource version, so they're unique by construction). Other sections use individual upserts.
+// batchPut handles all-Put batches. DataSection uses multi-row INSERT when all keys
+// are unique (the normal case — DataSection keys include resource version). If duplicate
+// keys are detected, falls back to sequential upsert to preserve Put semantics.
 func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
 	tx, err := k.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -480,9 +466,29 @@ func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, 
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	if section == DataSection {
+	if section == DataSection && !hasDuplicateKeys(ops) {
 		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
 			return err
+		}
+	} else if section == DataSection {
+		// Duplicate keys in batch: fall back to per-item upsert for correct Put semantics.
+		for i, op := range ops {
+			keyPath := getKeyPath(section, op.Key)
+			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+			if err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if exists {
+				query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
+				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			} else {
+				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+					return &BatchError{Err: err, Index: i, Op: op}
+				}
+			}
 		}
 	} else {
 		for i, op := range ops {
@@ -644,6 +650,46 @@ func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath stri
 		return false, err
 	}
 	return true, nil
+}
+
+// hasDuplicateKeys returns true if any two ops share the same key.
+func hasDuplicateKeys(ops []BatchOp) bool {
+	seen := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		if _, exists := seen[op.Key]; exists {
+			return true
+		}
+		seen[op.Key] = struct{}{}
+	}
+	return false
+}
+
+// batchDelete handles all-Delete batches in a single transaction, chunking to
+// stay within dialect parameter limits (e.g. SQLite's 999).
+func (k *SqlKV) batchDelete(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	maxKeys := batchDeleteMaxKeys(k.dialect)
+	for start := 0; start < len(ops); start += maxKeys {
+		end := start + maxKeys
+		if end > len(ops) {
+			end = len(ops)
+		}
+		keyPaths := make([]string, end-start)
+		for i, op := range ops[start:end] {
+			keyPaths[i] = getKeyPath(section, op.Key)
+		}
+		query, args := qb.buildBatchDeleteQuery(keyPaths)
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("batch delete failed at keys %d-%d: %w", start, end-1, err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 // batchDeleteMaxKeys returns the max keys per DELETE WHERE IN chunk for the dialect.

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -407,9 +407,9 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 	return nil
 }
 
-// Batch executes all operations atomically within a single transaction.
-// All-Put batches on DataSection use multi-row INSERT for maximum throughput.
-// All other operations fall back to per-item execution within the transaction.
+// Batch executes a batch of Create operations on DataSection using multi-row INSERT.
+// Keys must be unique and new (collection cleared before import, keys embed fresh RV).
+// All other operation modes or sections return an error.
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
@@ -421,18 +421,17 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
 	}
 
-	// Validate all ops upfront.
 	for i, op := range ops {
-		switch op.Mode {
-		case BatchOpPut, BatchOpCreate, BatchOpUpdate:
-			if len(op.Value) == 0 {
-				return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
-			}
-		case BatchOpDelete:
-			// OK
-		default:
-			return &BatchError{Err: fmt.Errorf("unknown operation mode: %d", op.Mode), Index: i, Op: op}
+		if op.Mode != BatchOpCreate {
+			return &BatchError{Err: fmt.Errorf("only BatchOpCreate is supported for sqlKV"), Index: i, Op: op}
 		}
+		if len(op.Value) == 0 {
+			return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+		}
+	}
+
+	if section != DataSection {
+		return fmt.Errorf("Batch only supports DataSection for sqlKV")
 	}
 
 	qb, err := k.getQueryBuilder(section)
@@ -448,107 +447,14 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		defer tx.Rollback() //nolint:errcheck
 	}
 
-	// Fast path: all-Create on DataSection uses multi-row INSERT.
-	// Keys are guaranteed unique by the caller (collection cleared, keys embed fresh RV).
-	if section == DataSection && allCreate(ops) {
-		if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
-			return err
-		}
-	} else {
-		// Fallback: per-item execution for mixed modes or non-DataSection.
-		if err := k.batchPerItem(ctx, tx, qb, section, ops); err != nil {
-			return err
-		}
+	if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
+		return err
 	}
 
 	if owned {
 		return tx.Commit()
 	}
 	return nil
-}
-
-// allCreate returns true if every op is a BatchOpCreate.
-func allCreate(ops []BatchOp) bool {
-	for _, op := range ops {
-		if op.Mode != BatchOpCreate {
-			return false
-		}
-	}
-	return true
-}
-
-// batchPerItem executes each op individually within the given transaction.
-func (k *SqlKV) batchPerItem(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {
-	for i, op := range ops {
-		keyPath := getKeyPath(section, op.Key)
-		var err error
-		switch op.Mode {
-		case BatchOpPut:
-			if section == DataSection {
-				// key_path is not unique on resource_history, so ON CONFLICT
-				// cannot be used. Check existence and insert or update.
-				if exists, e := keyExistsTx(ctx, tx, qb, keyPath); e != nil {
-					return &BatchError{Err: e, Index: i, Op: op}
-				} else if exists {
-					query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
-					_, err = tx.ExecContext(ctx, query, args...)
-				} else {
-					query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-					_, err = tx.ExecContext(ctx, query, args...)
-				}
-			} else {
-				query, args := qb.buildUpsertQuery(keyPath, op.Value)
-				_, err = tx.ExecContext(ctx, query, args...)
-			}
-		case BatchOpCreate:
-			if exists, e := keyExistsTx(ctx, tx, qb, keyPath); e != nil {
-				return &BatchError{Err: e, Index: i, Op: op}
-			} else if exists {
-				return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
-			}
-			if section == DataSection {
-				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-				_, err = tx.ExecContext(ctx, query, args...)
-			} else {
-				query, args := qb.buildUpsertQuery(keyPath, op.Value)
-				_, err = tx.ExecContext(ctx, query, args...)
-			}
-		case BatchOpUpdate:
-			if exists, e := keyExistsTx(ctx, tx, qb, keyPath); e != nil {
-				return &BatchError{Err: e, Index: i, Op: op}
-			} else if !exists {
-				return &BatchError{Err: ErrNotFound, Index: i, Op: op}
-			}
-			if section == DataSection {
-				query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
-				_, err = tx.ExecContext(ctx, query, args...)
-			} else {
-				query, args := qb.buildUpsertQuery(keyPath, op.Value)
-				_, err = tx.ExecContext(ctx, query, args...)
-			}
-		case BatchOpDelete:
-			query, args := qb.buildDeleteQuery(keyPath)
-			_, err = tx.ExecContext(ctx, query, args...)
-		}
-		if err != nil {
-			return &BatchError{Err: err, Index: i, Op: op}
-		}
-	}
-	return nil
-}
-
-func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {
-	query, args := qb.buildGetQuery(keyPath)
-	row := tx.QueryRowContext(ctx, query, args...)
-	var value []byte
-	err := row.Scan(&value)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, ops []BatchOp) error {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -23,6 +23,7 @@ const (
 )
 
 var _ KV = &SqlKV{}
+var _ HistoryImporter = &SqlKV{}
 
 var batchSavepointCounter uint64
 
@@ -453,6 +454,25 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 	return nil
 }
 
+// ImportHistory appends authoritative DataSection history rows for migrator-driven
+// bulk imports. It bypasses generic KV.Batch semantics and only performs raw
+// datastore inserts inside one transaction/savepoint scope, preserving the
+// caller's row order.
+func (k *SqlKV) ImportHistory(ctx context.Context, rows []HistoryImportRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	qb, err := k.getQueryBuilder(DataSection)
+	if err != nil {
+		return err
+	}
+
+	return k.withBatchTx(ctx, func(batchCtx context.Context, tx *sql.Tx) error {
+		return k.batchInsertDatastoreRows(batchCtx, tx, qb, rows)
+	})
+}
+
 func (k *SqlKV) keyExists(ctx context.Context, section string, key string) (bool, error) {
 	qb, err := k.getQueryBuilder(section)
 	if err != nil {
@@ -570,24 +590,35 @@ func (k *SqlKV) batchWrite(ctx context.Context, section string, op BatchOp) erro
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, ops []BatchOp) error {
-	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
-	for start := 0; start < len(ops); start += maxRows {
-		end := start + maxRows
-		if end > len(ops) {
-			end = len(ops)
+	rows := make([]HistoryImportRow, len(ops))
+	for i, op := range ops {
+		rows[i] = HistoryImportRow{
+			Key:   op.Key,
+			Value: op.Value,
 		}
-		chunk := ops[start:end]
+	}
+	return k.batchInsertDatastoreRows(ctx, tx, qb, rows)
+}
 
-		rows := make([]batchInsertRow, len(chunk))
-		for i, op := range chunk {
-			rows[i] = batchInsertRow{
+func (k *SqlKV) batchInsertDatastoreRows(ctx context.Context, tx *sql.Tx, qb *queryBuilder, rows []HistoryImportRow) error {
+	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
+	for start := 0; start < len(rows); start += maxRows {
+		end := start + maxRows
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunk := rows[start:end]
+
+		insertRows := make([]batchInsertRow, len(chunk))
+		for i, row := range chunk {
+			insertRows[i] = batchInsertRow{
 				GUID:    uuid.New().String(),
-				KeyPath: getKeyPath(DataSection, op.Key),
-				Value:   op.Value,
+				KeyPath: getKeyPath(DataSection, row.Key),
+				Value:   row.Value,
 			}
 		}
 
-		query, args := qb.buildBatchInsertDatastoreQuery(rows)
+		query, args := qb.buildBatchInsertDatastoreQuery(insertRows)
 		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return fmt.Errorf("batch insert failed at rows %d-%d: %w", start, end-1, err)
 		}

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -454,7 +454,18 @@ func (k *SqlKV) batchUniform(ctx context.Context, qb *queryBuilder, section stri
 		for i, op := range ops {
 			keys[i] = op.Key
 		}
-		return k.BatchDelete(ctx, section, keys)
+		// Chunk to stay within dialect parameter limits (e.g. SQLite's 999).
+		maxKeys := batchDeleteMaxKeys(k.dialect)
+		for start := 0; start < len(keys); start += maxKeys {
+			end := start + maxKeys
+			if end > len(keys) {
+				end = len(keys)
+			}
+			if err := k.BatchDelete(ctx, section, keys[start:end]); err != nil {
+				return err
+			}
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown operation mode: %d", mode)
 	}
@@ -633,6 +644,16 @@ func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath stri
 		return false, err
 	}
 	return true, nil
+}
+
+// batchDeleteMaxKeys returns the max keys per DELETE WHERE IN chunk for the dialect.
+func batchDeleteMaxKeys(dialect Dialect) int {
+	switch dialect.Name() {
+	case "sqlite":
+		return 999 // SQLITE_MAX_VARIABLE_NUMBER
+	default:
+		return MaxBatchOps
+	}
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -457,8 +457,10 @@ func (k *SqlKV) batchUniform(ctx context.Context, qb *queryBuilder, section stri
 }
 
 // batchPut handles all-Put batches. DataSection uses multi-row INSERT when all keys
-// are unique (the normal case — DataSection keys include resource version). If duplicate
-// keys are detected, falls back to sequential upsert to preserve Put semantics.
+// within the batch are unique, falling back to per-item upsert for duplicates.
+// DataSection keys include the resource version so they are unique by construction
+// in normal operation (ProcessBulk). Keys cannot collide with existing storage rows
+// because the collection is deleted before import and each key embeds a fresh RV.
 func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
 	tx, err := k.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -466,22 +468,14 @@ func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, 
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Multi-row INSERT fast path: safe when all keys are unique both within the
-	// batch and in storage. This is the normal case for ProcessBulk where keys
-	// include resource version. Falls back to per-item upsert otherwise.
 	if section == DataSection && !hasDuplicateKeys(ops) {
-		hasExisting, err := anyKeyExistsTx(ctx, tx, qb, section, ops)
-		if err != nil {
+		// Fast path: multi-row INSERT. Safe because DataSection keys embed the
+		// resource version, making them unique both within the batch and in storage.
+		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
 			return err
 		}
-		if !hasExisting {
-			if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
-				return err
-			}
-			return tx.Commit()
-		}
-	}
-	if section == DataSection {
+	} else if section == DataSection {
+		// Duplicate keys in batch: per-item upsert for correct Put semantics.
 		for i, op := range ops {
 			keyPath := getKeyPath(section, op.Key)
 			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
@@ -646,39 +640,6 @@ func (k *SqlKV) batchMixed(ctx context.Context, qb *queryBuilder, section string
 	}
 
 	return tx.Commit()
-}
-
-// anyKeyExistsTx checks whether any of the batch keys already exist in storage.
-// Uses a single SELECT ... IN query per chunk, returning as soon as a match is found.
-func anyKeyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) (bool, error) {
-	const maxParams = 999 // safe for all dialects including SQLite
-	for start := 0; start < len(ops); start += maxParams {
-		end := start + maxParams
-		if end > len(ops) {
-			end = len(ops)
-		}
-		chunk := ops[start:end]
-		placeholders := make([]string, len(chunk))
-		args := make([]interface{}, len(chunk))
-		for i, op := range chunk {
-			placeholders[i] = qb.dialect.Placeholder(i + 1)
-			args[i] = getKeyPath(section, op.Key)
-		}
-		query := fmt.Sprintf("SELECT 1 FROM %s WHERE %s IN (%s) LIMIT 1",
-			qb.dialect.QuoteIdent(qb.tableName),
-			qb.dialect.QuoteIdent("key_path"),
-			strings.Join(placeholders, ", "),
-		)
-		var dummy int
-		err := tx.QueryRowContext(ctx, query, args...).Scan(&dummy)
-		if err == nil {
-			return true, nil
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return false, fmt.Errorf("failed to check existing keys: %w", err)
-		}
-	}
-	return false, nil
 }
 
 func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -407,9 +407,8 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 	return nil
 }
 
-// Batch executes a batch of Create operations on DataSection using multi-row INSERT.
-// Keys must be unique and new (collection cleared before import, keys embed fresh RV).
-// All other operation modes or sections return an error.
+// Batch executes a batch of operations. All-Create on DataSection uses multi-row
+// INSERT for maximum throughput. Everything else falls back to per-item Save/Delete.
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
@@ -422,39 +421,82 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 	}
 
 	for i, op := range ops {
-		if op.Mode != BatchOpCreate {
-			return &BatchError{Err: fmt.Errorf("only BatchOpCreate is supported for sqlKV"), Index: i, Op: op}
+		switch op.Mode {
+		case BatchOpPut, BatchOpCreate, BatchOpUpdate:
+			if len(op.Value) == 0 {
+				return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+			}
+		case BatchOpDelete:
+			// OK
+		default:
+			return &BatchError{Err: fmt.Errorf("unknown operation mode: %d", op.Mode), Index: i, Op: op}
 		}
-		if len(op.Value) == 0 {
-			return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+	}
+
+	// Fast path: all-Create on DataSection uses multi-row INSERT.
+	if section == DataSection && allCreate(ops) {
+		qb, err := k.getQueryBuilder(section)
+		if err != nil {
+			return err
 		}
+		tx, owned, err := k.borrowOrBeginTx(ctx)
+		if err != nil {
+			return err
+		}
+		if owned {
+			defer tx.Rollback() //nolint:errcheck
+		}
+		if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
+			return err
+		}
+		if owned {
+			return tx.Commit()
+		}
+		return nil
 	}
 
-	if section != DataSection {
-		return fmt.Errorf("Batch only supports DataSection for sqlKV")
-	}
-
-	qb, err := k.getQueryBuilder(section)
-	if err != nil {
-		return err
-	}
-
-	tx, owned, err := k.borrowOrBeginTx(ctx)
-	if err != nil {
-		return err
-	}
-	if owned {
-		defer tx.Rollback() //nolint:errcheck
-	}
-
-	if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
-		return err
-	}
-
-	if owned {
-		return tx.Commit()
+	// Fallback: per-item execution using existing Save/Delete methods.
+	for i, op := range ops {
+		switch op.Mode {
+		case BatchOpPut, BatchOpCreate:
+			w, err := k.Save(ctx, section, op.Key)
+			if err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if _, err := w.Write(op.Value); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if err := w.Close(); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		case BatchOpUpdate:
+			w, err := k.Save(ctx, section, op.Key)
+			if err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if _, err := w.Write(op.Value); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+			if err := w.Close(); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		case BatchOpDelete:
+			if err := k.Delete(ctx, section, op.Key); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		}
 	}
 	return nil
+}
+
+// allCreate returns true if every op is a BatchOpCreate.
+func allCreate(ops []BatchOp) bool {
+	for _, op := range ops {
+		if op.Mode != BatchOpCreate {
+			return false
+		}
+	}
+	return true
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, ops []BatchOp) error {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -407,6 +407,10 @@ func (k *SqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 	return nil
 }
 
+// Batch executes all operations atomically. Currently only BatchOpPut is supported
+// for the importer (ProcessBulk) use case. DataSection uses multi-row INSERT for
+// maximum throughput; the caller must ensure keys are new (collection is deleted
+// before import and each key embeds a fresh resource version).
 func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
 	if section == "" {
 		return fmt.Errorf("section is required")
@@ -418,67 +422,21 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
 	}
 
+	// Validate all ops are BatchOpPut with non-empty values.
+	for i, op := range ops {
+		if op.Mode != BatchOpPut {
+			return &BatchError{Err: fmt.Errorf("only BatchOpPut is supported"), Index: i, Op: op}
+		}
+		if len(op.Value) == 0 {
+			return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+		}
+	}
+
 	qb, err := k.getQueryBuilder(section)
 	if err != nil {
 		return err
 	}
 
-	// Validate all ops upfront
-	for i, op := range ops {
-		switch op.Mode {
-		case BatchOpPut, BatchOpCreate, BatchOpUpdate:
-			if len(op.Value) == 0 {
-				return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
-			}
-		case BatchOpDelete:
-			// OK
-		default:
-			return &BatchError{Err: fmt.Errorf("unknown operation mode: %d", op.Mode), Index: i, Op: op}
-		}
-	}
-
-	// Detect homogeneous batch for optimized paths
-	if mode, ok := uniformMode(ops); ok {
-		return k.batchUniform(ctx, qb, section, ops, mode)
-	}
-
-	// Mixed modes: sequential per-op processing in a transaction
-	return k.batchMixed(ctx, qb, section, ops)
-}
-
-// uniformMode returns the common mode if all ops share it.
-func uniformMode(ops []BatchOp) (BatchOpMode, bool) {
-	mode := ops[0].Mode
-	for _, op := range ops[1:] {
-		if op.Mode != mode {
-			return 0, false
-		}
-	}
-	return mode, true
-}
-
-// batchUniform handles batches where all ops have the same mode, enabling bulk SQL optimizations.
-func (k *SqlKV) batchUniform(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp, mode BatchOpMode) error {
-	switch mode {
-	case BatchOpPut:
-		return k.batchPut(ctx, qb, section, ops)
-	case BatchOpCreate:
-		return k.batchCreate(ctx, qb, section, ops)
-	case BatchOpUpdate:
-		return k.batchUpdate(ctx, qb, section, ops)
-	case BatchOpDelete:
-		return k.batchDelete(ctx, qb, section, ops)
-	default:
-		return fmt.Errorf("unknown operation mode: %d", mode)
-	}
-}
-
-// batchPut handles all-Put batches. DataSection uses multi-row INSERT when all keys
-// within the batch are unique, falling back to per-item upsert for duplicates.
-// DataSection keys include the resource version so they are unique by construction
-// in normal operation (ProcessBulk). Keys cannot collide with existing storage rows
-// because the collection is deleted before import and each key embeds a fresh RV.
-func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
 	tx, owned, err := k.borrowOrBeginTx(ctx)
 	if err != nil {
 		return err
@@ -487,31 +445,11 @@ func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, 
 		defer tx.Rollback() //nolint:errcheck
 	}
 
-	if section == DataSection && !hasDuplicateKeys(ops) {
-		// Fast path: multi-row INSERT. Safe because DataSection keys embed the
-		// resource version, making them unique both within the batch and in storage.
-		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
+	if section == DataSection {
+		// Multi-row INSERT. Keys embed the resource version so they are unique
+		// both within the batch and in storage.
+		if err := k.batchInsertDatastore(ctx, tx, qb, ops); err != nil {
 			return err
-		}
-	} else if section == DataSection {
-		// Duplicate keys in batch: per-item upsert for correct Put semantics.
-		for i, op := range ops {
-			keyPath := getKeyPath(section, op.Key)
-			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-			if err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if exists {
-				query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return &BatchError{Err: err, Index: i, Op: op}
-				}
-			} else {
-				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return &BatchError{Err: err, Index: i, Op: op}
-				}
-			}
 		}
 	} else {
 		for i, op := range ops {
@@ -529,226 +467,7 @@ func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, 
 	return nil
 }
 
-// batchCreate handles all-Create batches with existence checks.
-func (k *SqlKV) batchCreate(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, owned, err := k.borrowOrBeginTx(ctx)
-	if err != nil {
-		return err
-	}
-	if owned {
-		defer tx.Rollback() //nolint:errcheck
-	}
-
-	for i, op := range ops {
-		keyPath := getKeyPath(section, op.Key)
-		exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-		if err != nil {
-			return &BatchError{Err: err, Index: i, Op: op}
-		}
-		if exists {
-			return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
-		}
-		if section == DataSection {
-			query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-		} else {
-			query, args := qb.buildInsertQuery(keyPath, op.Value)
-			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-		}
-	}
-
-	if owned {
-		return tx.Commit()
-	}
-	return nil
-}
-
-// batchUpdate handles all-Update batches with existence checks.
-func (k *SqlKV) batchUpdate(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, owned, err := k.borrowOrBeginTx(ctx)
-	if err != nil {
-		return err
-	}
-	if owned {
-		defer tx.Rollback() //nolint:errcheck
-	}
-
-	for i, op := range ops {
-		keyPath := getKeyPath(section, op.Key)
-		exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-		if err != nil {
-			return &BatchError{Err: err, Index: i, Op: op}
-		}
-		if !exists {
-			return &BatchError{Err: ErrNotFound, Index: i, Op: op}
-		}
-		query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			return &BatchError{Err: err, Index: i, Op: op}
-		}
-	}
-
-	if owned {
-		return tx.Commit()
-	}
-	return nil
-}
-
-// batchMixed handles batches with different op modes via sequential per-op processing.
-func (k *SqlKV) batchMixed(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, owned, err := k.borrowOrBeginTx(ctx)
-	if err != nil {
-		return err
-	}
-	if owned {
-		defer tx.Rollback() //nolint:errcheck
-	}
-
-	for i, op := range ops {
-		keyPath := getKeyPath(section, op.Key)
-		switch op.Mode {
-		case BatchOpPut:
-			if section == DataSection {
-				exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-				if err != nil {
-					return &BatchError{Err: err, Index: i, Op: op}
-				}
-				if exists {
-					query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
-					if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-						return &BatchError{Err: err, Index: i, Op: op}
-					}
-				} else {
-					query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-					if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-						return &BatchError{Err: err, Index: i, Op: op}
-					}
-				}
-			} else {
-				query, args := qb.buildUpsertQuery(keyPath, op.Value)
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return &BatchError{Err: err, Index: i, Op: op}
-				}
-			}
-		case BatchOpCreate:
-			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-			if err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if exists {
-				return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
-			}
-			if section == DataSection {
-				query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return &BatchError{Err: err, Index: i, Op: op}
-				}
-			} else {
-				query, args := qb.buildInsertQuery(keyPath, op.Value)
-				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-					return &BatchError{Err: err, Index: i, Op: op}
-				}
-			}
-		case BatchOpUpdate:
-			exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-			if err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-			if !exists {
-				return &BatchError{Err: ErrNotFound, Index: i, Op: op}
-			}
-			query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
-			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-		case BatchOpDelete:
-			query, args := qb.buildDeleteQuery(keyPath)
-			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-				return &BatchError{Err: err, Index: i, Op: op}
-			}
-		}
-	}
-
-	if owned {
-		return tx.Commit()
-	}
-	return nil
-}
-
-func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string) (bool, error) {
-	query, args := qb.buildGetQuery(keyPath)
-	row := tx.QueryRowContext(ctx, query, args...)
-	var value []byte
-	err := row.Scan(&value)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// hasDuplicateKeys returns true if any two ops share the same key.
-func hasDuplicateKeys(ops []BatchOp) bool {
-	seen := make(map[string]struct{}, len(ops))
-	for _, op := range ops {
-		if _, exists := seen[op.Key]; exists {
-			return true
-		}
-		seen[op.Key] = struct{}{}
-	}
-	return false
-}
-
-// batchDelete handles all-Delete batches in a single transaction, chunking to
-// stay within dialect parameter limits (e.g. SQLite's 999).
-func (k *SqlKV) batchDelete(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
-	tx, owned, err := k.borrowOrBeginTx(ctx)
-	if err != nil {
-		return err
-	}
-	if owned {
-		defer tx.Rollback() //nolint:errcheck
-	}
-
-	maxKeys := batchDeleteMaxKeys(k.dialect)
-	for start := 0; start < len(ops); start += maxKeys {
-		end := start + maxKeys
-		if end > len(ops) {
-			end = len(ops)
-		}
-		keyPaths := make([]string, end-start)
-		for i, op := range ops[start:end] {
-			keyPaths[i] = getKeyPath(section, op.Key)
-		}
-		query, args := qb.buildBatchDeleteQuery(keyPaths)
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			return fmt.Errorf("batch delete failed at keys %d-%d: %w", start, end-1, err)
-		}
-	}
-
-	if owned {
-		return tx.Commit()
-	}
-	return nil
-}
-
-// batchDeleteMaxKeys returns the max keys per DELETE WHERE IN chunk for the dialect.
-func batchDeleteMaxKeys(dialect Dialect) int {
-	switch dialect.Name() {
-	case "sqlite":
-		return 999 // SQLITE_MAX_VARIABLE_NUMBER
-	default:
-		return MaxBatchOps
-	}
-}
-
-func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {
+func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, ops []BatchOp) error {
 	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
 	for start := 0; start < len(ops); start += maxRows {
 		end := start + maxRows
@@ -761,7 +480,7 @@ func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryB
 		for i, op := range chunk {
 			rows[i] = batchInsertRow{
 				GUID:    uuid.New().String(),
-				KeyPath: getKeyPath(section, op.Key),
+				KeyPath: getKeyPath(DataSection, op.Key),
 				Value:   op.Value,
 			}
 		}

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -426,6 +426,15 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	// Fast path: all BatchOpPut on DataSection → multi-row INSERT.
+	// Safe because DataSection key_paths include the resource version, making them unique.
+	if section == DataSection && allBatchOpPut(ops) {
+		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+
 	// General path: process ops in order within a single transaction
 	for i, op := range ops {
 		keyPath := getKeyPath(section, op.Key)
@@ -512,38 +521,16 @@ func putDataSectionTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath
 	return err
 }
 
-// BulkInsertData performs multi-row INSERT into the DataSection (resource_history).
-// Keys must be new — this does NOT upsert. It is the caller's responsibility to
-// ensure no duplicate key_paths exist (e.g. by deleting the collection first).
-// Used by dataStore.batchSave during bulk import for maximum throughput.
-func (k *SqlKV) BulkInsertData(ctx context.Context, ops []BatchOp) error {
-	if len(ops) == 0 {
-		return nil
-	}
-	if len(ops) > MaxBatchOps {
-		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
-	}
-
-	for i, op := range ops {
+func allBatchOpPut(ops []BatchOp) bool {
+	for _, op := range ops {
 		if op.Mode != BatchOpPut {
-			return &BatchError{Err: fmt.Errorf("BulkInsertData only supports BatchOpPut"), Index: i, Op: op}
-		}
-		if len(op.Value) == 0 {
-			return &BatchError{Err: ErrEmptyValue, Index: i, Op: op}
+			return false
 		}
 	}
+	return true
+}
 
-	qb, err := k.getQueryBuilder(DataSection)
-	if err != nil {
-		return err
-	}
-
-	tx, err := k.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
+func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {
 	maxRows := BatchInsertMaxRows(k.dialect, 9) // 9 params per row
 	for start := 0; start < len(ops); start += maxRows {
 		end := start + maxRows
@@ -556,7 +543,7 @@ func (k *SqlKV) BulkInsertData(ctx context.Context, ops []BatchOp) error {
 		for i, op := range chunk {
 			rows[i] = batchInsertRow{
 				GUID:    uuid.New().String(),
-				KeyPath: getKeyPath(DataSection, op.Key),
+				KeyPath: getKeyPath(section, op.Key),
 				Value:   op.Value,
 			}
 		}
@@ -566,8 +553,7 @@ func (k *SqlKV) BulkInsertData(ctx context.Context, ops []BatchOp) error {
 			return fmt.Errorf("batch insert failed at rows %d-%d: %w", start, end-1, err)
 		}
 	}
-
-	return tx.Commit()
+	return nil
 }
 
 func (k *SqlKV) UnixTimestamp(ctx context.Context) (int64, error) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -420,29 +420,158 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 		}
 	}
 
+	// Detect homogeneous batch for optimized paths
+	if mode, ok := uniformMode(ops); ok {
+		return k.batchUniform(ctx, qb, section, ops, mode)
+	}
+
+	// Mixed modes: sequential per-op processing in a transaction
+	return k.batchMixed(ctx, qb, section, ops)
+}
+
+// uniformMode returns the common mode if all ops share it.
+func uniformMode(ops []BatchOp) (BatchOpMode, bool) {
+	mode := ops[0].Mode
+	for _, op := range ops[1:] {
+		if op.Mode != mode {
+			return 0, false
+		}
+	}
+	return mode, true
+}
+
+// batchUniform handles batches where all ops have the same mode, enabling bulk SQL optimizations.
+func (k *SqlKV) batchUniform(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp, mode BatchOpMode) error {
+	switch mode {
+	case BatchOpPut:
+		return k.batchPut(ctx, qb, section, ops)
+	case BatchOpCreate:
+		return k.batchCreate(ctx, qb, section, ops)
+	case BatchOpUpdate:
+		return k.batchUpdate(ctx, qb, section, ops)
+	case BatchOpDelete:
+		keys := make([]string, len(ops))
+		for i, op := range ops {
+			keys[i] = op.Key
+		}
+		return k.BatchDelete(ctx, section, keys)
+	default:
+		return fmt.Errorf("unknown operation mode: %d", mode)
+	}
+}
+
+// batchPut handles all-Put batches. DataSection uses multi-row INSERT (keys include
+// resource version, so they're unique by construction). Other sections use individual upserts.
+func (k *SqlKV) batchPut(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
 	tx, err := k.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Fast path: all BatchOpPut on DataSection → multi-row INSERT.
-	// Safe because DataSection key_paths include the resource version, making them unique.
-	if section == DataSection && allBatchOpPut(ops) {
+	if section == DataSection {
 		if err := k.batchInsertDatastore(ctx, tx, qb, section, ops); err != nil {
 			return err
 		}
-		return tx.Commit()
+	} else {
+		for i, op := range ops {
+			keyPath := getKeyPath(section, op.Key)
+			query, args := qb.buildUpsertQuery(keyPath, op.Value)
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		}
 	}
 
-	// General path: process ops in order within a single transaction
+	return tx.Commit()
+}
+
+// batchCreate handles all-Create batches with existence checks.
+func (k *SqlKV) batchCreate(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for i, op := range ops {
+		keyPath := getKeyPath(section, op.Key)
+		exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+		if err != nil {
+			return &BatchError{Err: err, Index: i, Op: op}
+		}
+		if exists {
+			return &BatchError{Err: ErrKeyAlreadyExists, Index: i, Op: op}
+		}
+		if section == DataSection {
+			query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		} else {
+			query, args := qb.buildInsertQuery(keyPath, op.Value)
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return &BatchError{Err: err, Index: i, Op: op}
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
+// batchUpdate handles all-Update batches with existence checks.
+func (k *SqlKV) batchUpdate(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for i, op := range ops {
+		keyPath := getKeyPath(section, op.Key)
+		exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+		if err != nil {
+			return &BatchError{Err: err, Index: i, Op: op}
+		}
+		if !exists {
+			return &BatchError{Err: ErrNotFound, Index: i, Op: op}
+		}
+		query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return &BatchError{Err: err, Index: i, Op: op}
+		}
+	}
+
+	return tx.Commit()
+}
+
+// batchMixed handles batches with different op modes via sequential per-op processing.
+func (k *SqlKV) batchMixed(ctx context.Context, qb *queryBuilder, section string, ops []BatchOp) error {
+	tx, err := k.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
 	for i, op := range ops {
 		keyPath := getKeyPath(section, op.Key)
 		switch op.Mode {
 		case BatchOpPut:
 			if section == DataSection {
-				if err := putDataSectionTx(ctx, tx, qb, keyPath, op.Value); err != nil {
+				exists, err := keyExistsTx(ctx, tx, qb, keyPath)
+				if err != nil {
 					return &BatchError{Err: err, Index: i, Op: op}
+				}
+				if exists {
+					query, args := qb.buildUpdateDatastoreQuery(keyPath, op.Value)
+					if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+						return &BatchError{Err: err, Index: i, Op: op}
+					}
+				} else {
+					query, args := qb.buildInsertDatastoreQuery(keyPath, op.Value, uuid.New().String())
+					if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+						return &BatchError{Err: err, Index: i, Op: op}
+					}
 				}
 			} else {
 				query, args := qb.buildUpsertQuery(keyPath, op.Value)
@@ -464,7 +593,7 @@ func (k *SqlKV) Batch(ctx context.Context, section string, ops []BatchOp) error 
 					return &BatchError{Err: err, Index: i, Op: op}
 				}
 			} else {
-				query, args := qb.buildUpsertQuery(keyPath, op.Value)
+				query, args := qb.buildInsertQuery(keyPath, op.Value)
 				if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 					return &BatchError{Err: err, Index: i, Op: op}
 				}
@@ -504,30 +633,6 @@ func keyExistsTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath stri
 		return false, err
 	}
 	return true, nil
-}
-
-func putDataSectionTx(ctx context.Context, tx *sql.Tx, qb *queryBuilder, keyPath string, value []byte) error {
-	exists, err := keyExistsTx(ctx, tx, qb, keyPath)
-	if err != nil {
-		return err
-	}
-	if exists {
-		query, args := qb.buildUpdateDatastoreQuery(keyPath, value)
-		_, err = tx.ExecContext(ctx, query, args...)
-		return err
-	}
-	query, args := qb.buildInsertDatastoreQuery(keyPath, value, uuid.New().String())
-	_, err = tx.ExecContext(ctx, query, args...)
-	return err
-}
-
-func allBatchOpPut(ops []BatchOp) bool {
-	for _, op := range ops {
-		if op.Mode != BatchOpPut {
-			return false
-		}
-	}
-	return true
 }
 
 func (k *SqlKV) batchInsertDatastore(ctx context.Context, tx *sql.Tx, qb *queryBuilder, section string, ops []BatchOp) error {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2012,8 +2012,6 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			action = DataActionUpdated
 		case resourcepb.WatchEvent_DELETED:
 			action = DataActionDeleted
-			createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
-			delete(seenCreates, createID)
 		default:
 			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
 				Key:    req.Key,
@@ -2053,11 +2051,13 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			continue
 		}
 
-		// Mark creates as seen only after all validation passes, so a rejected
-		// item doesn't block future valid ADDEDs for the same resource.
+		// Update seenCreates only after all validation passes, so a rejected
+		// item doesn't corrupt the duplicate-detection state.
+		createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
 		if action == DataActionCreated {
-			createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
 			seenCreates[createID] = true
+		} else if action == DataActionDeleted {
+			delete(seenCreates, createID)
 		}
 
 		pending = append(pending, pendingItem{dataKey: dataKey, value: req.Value, obj: obj, action: action})

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1786,6 +1786,16 @@ func (k *kvStorageBackend) GetResourceLastImportTimes(ctx context.Context) iter.
 	}
 }
 
+// ProcessBulk imports authoritative legacy history for one or more collections.
+// This path is only used by unified-storage migrators after they have selected a
+// namespace/group/resource collection and produced an ordered stream of
+// ADDED/MODIFIED/DELETED history records. ProcessBulk wipes the destination
+// collection first, then appends validated history rows in chunks. Rejections on
+// this path are limited to malformed requests (invalid action, invalid JSON,
+// invalid DataKey). It does not emulate generic "current resource existence"
+// semantics; migration validators are responsible for checking that the imported
+// history matches the legacy source of truth.
+//
 //nolint:gocyclo
 func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings, iter BulkRequestIterator) *resourcepb.BulkResponse {
 	// rvManagerDB is the database handle for rvManager and legacy compat operations.
@@ -1879,6 +1889,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			Resource:      key.Resource,
 			PreviousCount: previousCount,
 		}
+		rsp.Summary = append(rsp.Summary, summaries[NSGR(key)])
 	}
 
 	saved := make([]DataKey, 0)
@@ -1896,13 +1907,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	// Track the last micro RV per resource name for computing previous_resource_version in compat mode.
 	lastMicroRV := make(map[string]int64)
 
-	// Track ADDED resources accepted in the pending buffer to catch duplicates before flush.
-	seenCreates := make(map[string]bool)
-	// Track unflushed DELETEs so that a subsequent ADDED skips the storage check
-	// (the delete hasn't been persisted yet, so storage still shows the resource).
-	pendingDeletes := make(map[string]bool)
-
-	// Accumulate validated items for batch save instead of saving one at a time.
+	// Accumulate validated migrator history rows before importing them in chunks.
 	type pendingItem struct {
 		dataKey DataKey
 		value   []byte
@@ -1911,18 +1916,19 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	}
 	pending := make([]pendingItem, 0, kv.MaxBatchOps)
 
-	// flushPending batch-saves all accumulated items and runs post-save work (legacy updates).
+	// flushPending imports the accumulated history rows and runs post-import
+	// compatibility updates that keep the legacy SQL tables in sync.
 	flushPending := func() error {
 		if len(pending) == 0 {
 			return nil
 		}
 
-		items := make([]batchSaveItem, len(pending))
+		items := make([]historyImportItem, len(pending))
 		for i, p := range pending {
-			items[i] = batchSaveItem{Key: p.dataKey, Value: p.value}
+			items[i] = historyImportItem{Key: p.dataKey, Value: p.value}
 		}
 
-		if err := b.dataStore.batchSave(ctx, items); err != nil {
+		if err := b.dataStore.importHistoryBatch(ctx, items); err != nil {
 			return err
 		}
 
@@ -1956,7 +1962,6 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		}
 
 		pending = pending[:0]
-		clear(pendingDeletes)
 		return nil
 	}
 
@@ -1979,42 +1984,6 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		switch resourcepb.WatchEvent_Type(req.Action) {
 		case resourcepb.WatchEvent_ADDED:
 			action = DataActionCreated
-			createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
-			// Check pending buffer for duplicate creates not yet flushed
-			if seenCreates[createID] {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  "resource already exists",
-				})
-				continue
-			}
-			// Check if resource already exists in storage, but skip if a pending
-			// delete for this resource hasn't been flushed yet.
-			if !pendingDeletes[createID] {
-				_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
-					Group:     req.Key.Group,
-					Resource:  req.Key.Resource,
-					Namespace: req.Key.Namespace,
-					Name:      req.Key.Name,
-				})
-				if err == nil {
-					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-						Key:    req.Key,
-						Action: req.Action,
-						Error:  "resource already exists",
-					})
-					continue
-				}
-				if !errors.Is(err, ErrNotFound) {
-					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-						Key:    req.Key,
-						Action: req.Action,
-						Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
-					})
-					continue
-				}
-			}
 		case resourcepb.WatchEvent_MODIFIED:
 			action = DataActionUpdated
 		case resourcepb.WatchEvent_DELETED:
@@ -2056,20 +2025,6 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 				Error:  fmt.Sprintf("invalid data key: %s", err),
 			})
 			continue
-		}
-
-		// Update seenCreates only after all validation passes, so a rejected
-		// item doesn't corrupt the duplicate-detection state.
-		createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
-		switch action {
-		case DataActionCreated:
-			seenCreates[createID] = true
-			delete(pendingDeletes, createID)
-		case DataActionDeleted:
-			delete(seenCreates, createID)
-			pendingDeletes[createID] = true
-		case DataActionUpdated:
-			// no-op for duplicate tracking
 		}
 
 		pending = append(pending, pendingItem{dataKey: dataKey, value: req.Value, obj: obj, action: action})

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1896,6 +1896,9 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	// Track the last micro RV per resource name for computing previous_resource_version in compat mode.
 	lastMicroRV := make(map[string]int64)
 
+	// Track ADDED resources accepted in the pending buffer to catch duplicates before flush.
+	seenCreates := make(map[string]bool)
+
 	// Accumulate validated items for batch save instead of saving one at a time.
 	type pendingItem struct {
 		dataKey DataKey
@@ -1972,7 +1975,17 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		switch resourcepb.WatchEvent_Type(req.Action) {
 		case resourcepb.WatchEvent_ADDED:
 			action = DataActionCreated
-			// Check if resource already exists for create operations
+			createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
+			// Check pending buffer for duplicate creates not yet flushed
+			if seenCreates[createID] {
+				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+					Key:    req.Key,
+					Action: req.Action,
+					Error:  "resource already exists",
+				})
+				continue
+			}
+			// Check if resource already exists in storage
 			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
 				Group:     req.Key.Group,
 				Resource:  req.Key.Resource,
@@ -1995,6 +2008,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 				})
 				continue
 			}
+			seenCreates[createID] = true
 		case resourcepb.WatchEvent_MODIFIED:
 			action = DataActionUpdated
 		case resourcepb.WatchEvent_DELETED:
@@ -2027,6 +2041,15 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			ResourceVersion: bulkRvGenerator.next(obj),
 			Action:          action,
 			Folder:          req.Folder,
+		}
+
+		if err := validateDataKey(dataKey); err != nil {
+			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+				Key:    req.Key,
+				Action: req.Action,
+				Error:  fmt.Sprintf("invalid data key: %s", err),
+			})
+			continue
 		}
 
 		pending = append(pending, pendingItem{dataKey: dataKey, value: req.Value, obj: obj, action: action})

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1894,6 +1894,59 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	// Track the last micro RV per resource name for computing previous_resource_version in compat mode.
 	lastMicroRV := make(map[string]int64)
 
+	// Accumulate validated items for batch save instead of saving one at a time.
+	type pendingItem struct {
+		dataKey DataKey
+		value   []byte
+		obj     *unstructured.Unstructured
+		action  kv.DataAction
+	}
+	pending := make([]pendingItem, 0, kv.MaxBatchOps)
+
+	// flushPending batch-saves all accumulated items and runs post-save work (legacy updates).
+	flushPending := func() error {
+		if len(pending) == 0 {
+			return nil
+		}
+
+		items := make([]batchSaveItem, len(pending))
+		for i, p := range pending {
+			items[i] = batchSaveItem{Key: p.dataKey, Value: p.value}
+		}
+
+		if err := b.dataStore.batchSave(ctx, items); err != nil {
+			return err
+		}
+
+		for _, p := range pending {
+			saved = append(saved, p.dataKey)
+			updatedResources[NamespacedResource{Namespace: p.dataKey.Namespace, Group: p.dataKey.Group, Resource: p.dataKey.Resource}] = true
+
+			// Fill in legacy columns on the resource_history row that was just inserted with only key_path and value.
+			if b.rvManager != nil {
+				microRV := rvmanager.RVFromBulkSnowflake(p.dataKey.ResourceVersion)
+				generation := p.obj.GetGeneration()
+				if p.action == DataActionDeleted {
+					generation = 0
+				}
+
+				nameKey := p.dataKey.Group + "/" + p.dataKey.Resource + "/" + p.dataKey.Namespace + "/" + p.dataKey.Name
+				var previousRV int64
+				if p.action != DataActionCreated {
+					previousRV = lastMicroRV[nameKey]
+				}
+
+				if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, b.rvManager.DB(), p.dataKey, microRV, previousRV, generation); err != nil {
+					return fmt.Errorf("failed to update legacy resource_history for bulk: %w", err)
+				}
+				lastMicroRV[nameKey] = microRV
+			}
+		}
+
+		pending = pending[:0]
+		return nil
+	}
+
 	for iter.Next() {
 		if iter.RollbackRequested() {
 			rollback()
@@ -1969,39 +2022,23 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			Action:          action,
 			Folder:          req.Folder,
 		}
-		err = b.dataStore.Save(ctx, dataKey, bytes.NewReader(req.Value))
-		if err != nil {
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  fmt.Sprintf("failed to save resource: %s", err),
-			})
-			continue
+
+		pending = append(pending, pendingItem{dataKey: dataKey, value: req.Value, obj: obj, action: action})
+
+		if len(pending) >= kv.MaxBatchOps {
+			if err := flushPending(); err != nil {
+				rollback()
+				rsp.Error = AsErrorResult(err)
+				break
+			}
 		}
+	}
 
-		saved = append(saved, dataKey)
-		updatedResources[NamespacedResource{Namespace: dataKey.Namespace, Group: dataKey.Group, Resource: dataKey.Resource}] = true
-
-		// Fill in legacy columns on the resource_history row that was just inserted with only key_path and value.
-		if rvManagerDB != nil {
-			microRV := rvmanager.RVFromBulkSnowflake(dataKey.ResourceVersion)
-			generation := obj.GetGeneration()
-			if action == DataActionDeleted {
-				generation = 0
-			}
-
-			// For creates, previous RV is 0. For updates/deletes, it's the RV of the previous event for this resource.
-			nameKey := dataKey.Group + "/" + dataKey.Resource + "/" + dataKey.Namespace + "/" + dataKey.Name
-			var previousRV int64
-			if action != DataActionCreated {
-				previousRV = lastMicroRV[nameKey]
-			}
-
-			if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, rvManagerDB, dataKey, microRV, previousRV, generation); err != nil {
-				b.log.Error("failed to update legacy resource_history for bulk", "error", err)
-				return rsp
-			}
-			lastMicroRV[nameKey] = microRV
+	// Flush any remaining items
+	if rsp.Error == nil {
+		if err := flushPending(); err != nil {
+			rollback()
+			rsp.Error = AsErrorResult(err)
 		}
 	}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2013,6 +2013,8 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			action = DataActionUpdated
 		case resourcepb.WatchEvent_DELETED:
 			action = DataActionDeleted
+			createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
+			delete(seenCreates, createID)
 		default:
 			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
 				Key:    req.Key,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2059,6 +2059,8 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			seenCreates[createID] = true
 		case DataActionDeleted:
 			delete(seenCreates, createID)
+		case DataActionUpdated:
+			// no-op for duplicate tracking
 		}
 
 		pending = append(pending, pendingItem{dataKey: dataKey, value: req.Value, obj: obj, action: action})

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1898,6 +1898,9 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 
 	// Track ADDED resources accepted in the pending buffer to catch duplicates before flush.
 	seenCreates := make(map[string]bool)
+	// Track unflushed DELETEs so that a subsequent ADDED skips the storage check
+	// (the delete hasn't been persisted yet, so storage still shows the resource).
+	pendingDeletes := make(map[string]bool)
 
 	// Accumulate validated items for batch save instead of saving one at a time.
 	type pendingItem struct {
@@ -1953,6 +1956,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		}
 
 		pending = pending[:0]
+		clear(pendingDeletes)
 		return nil
 	}
 
@@ -1985,28 +1989,31 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 				})
 				continue
 			}
-			// Check if resource already exists in storage
-			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
-				Group:     req.Key.Group,
-				Resource:  req.Key.Resource,
-				Namespace: req.Key.Namespace,
-				Name:      req.Key.Name,
-			})
-			if err == nil {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  "resource already exists",
+			// Check if resource already exists in storage, but skip if a pending
+			// delete for this resource hasn't been flushed yet.
+			if !pendingDeletes[createID] {
+				_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
+					Group:     req.Key.Group,
+					Resource:  req.Key.Resource,
+					Namespace: req.Key.Namespace,
+					Name:      req.Key.Name,
 				})
-				continue
-			}
-			if !errors.Is(err, ErrNotFound) {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
-				})
-				continue
+				if err == nil {
+					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+						Key:    req.Key,
+						Action: req.Action,
+						Error:  "resource already exists",
+					})
+					continue
+				}
+				if !errors.Is(err, ErrNotFound) {
+					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+						Key:    req.Key,
+						Action: req.Action,
+						Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
+					})
+					continue
+				}
 			}
 		case resourcepb.WatchEvent_MODIFIED:
 			action = DataActionUpdated
@@ -2057,8 +2064,10 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		switch action {
 		case DataActionCreated:
 			seenCreates[createID] = true
+			delete(pendingDeletes, createID)
 		case DataActionDeleted:
 			delete(seenCreates, createID)
+			pendingDeletes[createID] = true
 		case DataActionUpdated:
 			// no-op for duplicate tracking
 		}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1882,7 +1882,9 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	}
 
 	saved := make([]DataKey, 0)
+	rolledBack := false
 	rollback := func() {
+		rolledBack = true
 		// we don't have transactions in the kv store, so we simply delete everything we created
 		err = b.dataStore.batchDelete(ctx, saved)
 		if err != nil {
@@ -1918,12 +1920,16 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			return err
 		}
 
+		// Track all keys for rollback BEFORE legacy updates so a mid-loop
+		// failure in updateLegacyResourceHistoryBulk doesn't leave orphan rows.
 		for _, p := range pending {
 			saved = append(saved, p.dataKey)
 			updatedResources[NamespacedResource{Namespace: p.dataKey.Namespace, Group: p.dataKey.Group, Resource: p.dataKey.Resource}] = true
+		}
 
-			// Fill in legacy columns on the resource_history row that was just inserted with only key_path and value.
-			if b.rvManager != nil {
+		// Fill in legacy columns on the resource_history rows that were just inserted.
+		if b.rvManager != nil {
+			for _, p := range pending {
 				microRV := rvmanager.RVFromBulkSnowflake(p.dataKey.ResourceVersion)
 				generation := p.obj.GetGeneration()
 				if p.action == DataActionDeleted {
@@ -2034,8 +2040,8 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		}
 	}
 
-	// Flush any remaining items
-	if rsp.Error == nil {
+	// Flush any remaining items (skip if rollback was triggered)
+	if rsp.Error == nil && !rolledBack {
 		if err := flushPending(); err != nil {
 			rollback()
 			rsp.Error = AsErrorResult(err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1931,7 +1931,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		}
 
 		// Fill in legacy columns on the resource_history rows that were just inserted.
-		if b.rvManager != nil {
+		if rvManagerDB != nil {
 			for _, p := range pending {
 				microRV := rvmanager.RVFromBulkSnowflake(p.dataKey.ResourceVersion)
 				generation := p.obj.GetGeneration()
@@ -1945,7 +1945,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 					previousRV = lastMicroRV[nameKey]
 				}
 
-				if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, b.rvManager.DB(), p.dataKey, microRV, previousRV, generation); err != nil {
+				if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, rvManagerDB, p.dataKey, microRV, previousRV, generation); err != nil {
 					return fmt.Errorf("failed to update legacy resource_history for bulk: %w", err)
 				}
 				lastMicroRV[nameKey] = microRV
@@ -2054,9 +2054,10 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		// Update seenCreates only after all validation passes, so a rejected
 		// item doesn't corrupt the duplicate-detection state.
 		createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
-		if action == DataActionCreated {
+		switch action {
+		case DataActionCreated:
 			seenCreates[createID] = true
-		} else if action == DataActionDeleted {
+		case DataActionDeleted:
 			delete(seenCreates, createID)
 		}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2008,7 +2008,6 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 				})
 				continue
 			}
-			seenCreates[createID] = true
 		case resourcepb.WatchEvent_MODIFIED:
 			action = DataActionUpdated
 		case resourcepb.WatchEvent_DELETED:
@@ -2052,6 +2051,13 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 				Error:  fmt.Sprintf("invalid data key: %s", err),
 			})
 			continue
+		}
+
+		// Mark creates as seen only after all validation passes, so a rejected
+		// item doesn't block future valid ADDEDs for the same resource.
+		if action == DataActionCreated {
+			createID := req.Key.Group + "/" + req.Key.Resource + "/" + req.Key.Namespace + "/" + req.Key.Name
+			seenCreates[createID] = true
 		}
 
 		pending = append(pending, pendingItem{dataKey: dataKey, value: req.Value, obj: obj, action: action})

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -1194,6 +1194,36 @@ func runTestKVBatch(t *testing.T, kv resource.KV, nsPrefix string) {
 		require.NoError(t, err)
 	})
 
+	t.Run("batch respects earlier operations on the same key", func(t *testing.T) {
+		saveKVHelper(t, kv, ctx, section, "replace-in-batch", strings.NewReader("old"))
+
+		ops := []resource.BatchOp{
+			{Mode: kvpkg.BatchOpCreate, Key: "create-then-update", Value: []byte("created")},
+			{Mode: kvpkg.BatchOpUpdate, Key: "create-then-update", Value: []byte("updated")},
+			{Mode: kvpkg.BatchOpDelete, Key: "replace-in-batch"},
+			{Mode: kvpkg.BatchOpCreate, Key: "replace-in-batch", Value: []byte("recreated")},
+		}
+
+		err := kv.Batch(ctx, section, ops)
+		require.NoError(t, err)
+
+		reader, err := kv.Get(ctx, section, "create-then-update")
+		require.NoError(t, err)
+		value, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, "updated", string(value))
+		err = reader.Close()
+		require.NoError(t, err)
+
+		reader, err = kv.Get(ctx, section, "replace-in-batch")
+		require.NoError(t, err)
+		value, err = io.ReadAll(reader)
+		require.NoError(t, err)
+		require.Equal(t, "recreated", string(value))
+		err = reader.Close()
+		require.NoError(t, err)
+	})
+
 	t.Run("batch too many operations", func(t *testing.T) {
 		ops := make([]kvpkg.BatchOp, kvpkg.MaxBatchOps+1)
 		for i := range ops {

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -952,7 +952,7 @@ func saveKVHelper(t *testing.T, kv resource.KV, ctx context.Context, section, ke
 
 func runTestKVBatch(t *testing.T, kv resource.KV, nsPrefix string) {
 	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
-	section := nsPrefix + "-batch"
+	section := testSection
 
 	t.Run("batch with empty section", func(t *testing.T) {
 		err := kv.Batch(ctx, "", nil)

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -952,7 +952,7 @@ func saveKVHelper(t *testing.T, kv resource.KV, ctx context.Context, section, ke
 
 func runTestKVBatch(t *testing.T, kv resource.KV, nsPrefix string) {
 	ctx := testutil.NewTestContext(t, time.Now().Add(30*time.Second))
-	section := testSection
+	section := nsPrefix + "-batch"
 
 	t.Run("batch with empty section", func(t *testing.T) {
 		err := kv.Batch(ctx, "", nil)

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -48,8 +48,5 @@ func TestSQLKV(t *testing.T) {
 		return kv
 	}, &KVTestOptions{
 		NSPrefix: "sql-kv-test",
-		SkipTests: map[string]bool{
-			TestKVBatch: true, // Batch operations not yet implemented for sqlKV
-		},
 	})
 }

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -48,8 +48,5 @@ func TestSQLKV(t *testing.T) {
 		return kv
 	}, &KVTestOptions{
 		NSPrefix: "sql-kv-test",
-		SkipTests: map[string]bool{
-			TestKVBatch: true, // SqlKV Batch only supports BatchOpCreate on DataSection
-		},
 	})
 }

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -48,5 +48,8 @@ func TestSQLKV(t *testing.T) {
 		return kv
 	}, &KVTestOptions{
 		NSPrefix: "sql-kv-test",
+		SkipTests: map[string]bool{
+			TestKVBatch: true, // SqlKV Batch only supports BatchOpCreate on DataSection
+		},
 	})
 }

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -50,3 +50,35 @@ func TestSQLKV(t *testing.T) {
 		NSPrefix: "sql-kv-test",
 	})
 }
+
+func TestSQLKVBatchWithExternalTxRollsBackOnFailure(t *testing.T) {
+	ctx := context.Background()
+
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+
+	dbConn, err := eDB.Init(ctx)
+	require.NoError(t, err)
+
+	store, err := kv.NewSQLKV(dbConn.SqlDB(), dbConn.DriverName())
+	require.NoError(t, err)
+
+	tx, err := dbConn.SqlDB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tx.Rollback()
+	})
+
+	txCtx := kv.ContextWithDBTX(ctx, tx)
+	err = store.Batch(txCtx, kv.EventsSection, []resource.BatchOp{
+		{Mode: kv.BatchOpPut, Key: "rolled-back-put", Value: []byte("value")},
+		{Mode: kv.BatchOpUpdate, Key: "missing-key", Value: []byte("should-fail")},
+	})
+	require.ErrorIs(t, err, resource.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	_, err = store.Get(ctx, kv.EventsSection, "rolled-back-put")
+	require.ErrorIs(t, err, resource.ErrNotFound)
+}

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -48,5 +48,8 @@ func TestSQLKV(t *testing.T) {
 		return kv
 	}, &KVTestOptions{
 		NSPrefix: "sql-kv-test",
+		SkipTests: map[string]bool{
+			TestKVBatch: true, // Batch operations not yet implemented for sqlKV
+		},
 	})
 }


### PR DESCRIPTION
This started as a performance change for SQLKV batch writes, but review surfaced a layering problem: the branch was weakening the generic `KV.Batch` contract to make `ProcessBulk` fast. `ProcessBulk` is only used by unified-storage migrators, which import an authoritative ordered history stream after wiping a collection, so it should not depend on generic create/update semantics. This PR keeps the SQL multi-row INSERT optimization, restores the documented `KV.Batch` behavior, and routes migrator imports through a dedicated history-import path.

## Summary

- keep the SQL multi-row INSERT fast path for `DataSection` history rows
- restore `SqlKV.Batch()` semantics for `Create`/`Update` and single-transaction rollback behavior
- document `kvStorageBackend.ProcessBulk()` as a migrator-only history import path
- add `HistoryImporter` so migrator imports no longer translate authoritative history into generic `KV.Batch` operations
- implement the history-import fast path for both `SqlKV` and `BadgerKV`
- preserve legacy sync, RV bumping, rollback bookkeeping, and last-import timestamps during bulk import

## Review Notes

- review `pkg/storage/unified/resource/kv/sqlkv.go` for the generic batch semantics and the SQL history-import path
- review `pkg/storage/unified/resource/storage_backend.go` and `pkg/storage/unified/resource/datastore.go` for the `ProcessBulk` contract narrowing
- the key design change is that bulk import now appends already-validated history rows directly instead of asking `KV.Batch` to emulate current-resource existence checks

## Test plan

- [x] `go test -count=1 -run 'TestSQLKV/batch_operations|TestSQLKVBatchWithExternalTxRollsBackOnFailure' ./pkg/storage/unified/testing/`
- [x] `go test -count=1 -run 'TestIntegrationSQLKVStorageBackend/(Without_RvManager|With_RvManager)/get_resource_last_import_time' ./pkg/storage/unified/testing/`
- [x] `go test -count=1 -run 'TestIntegrationSQLStorageAndSQLKVCompatibilityTests/(IsHA \(polling notifier\)|NotHA \(in process notifier\))/(bulk import compatibility|last import time cross backend)' ./pkg/storage/unified/sql/test/`
