### PR TITLE
Scopes: Add CODEOWNERS entry for scope API client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -807,6 +807,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 # public folder
 /public/app/api/ @grafana/grafana-frontend-platform
 /public/app/api/clients/folder/ @grafana/grafana-frontend-navigation
+/public/app/api/clients/scope/ @grafana/grafana-operator-experience-squad
 /public/app/core/actions/ @grafana/grafana-frontend-platform
 /public/app/core/app_events.ts @grafana/grafana-frontend-platform
 /public/app/core/components/AccessControl/ @grafana/identity-access-team


### PR DESCRIPTION
## What this PR does / why we need it

Adds a CODEOWNERS entry for `/public/app/api/clients/scope/` so that PRs touching the scope API client route to `@grafana/grafana-operator-experience-squad` rather than falling through to the broader `@grafana/grafana-frontend-platform` catch-all.

Companion to grafana-enterprise#11420, which registers scope in the enterprise codegen pipeline.

## Test plan

- [x] CODEOWNERS entry follows the pattern established by `/public/app/api/clients/folder/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)