### PR TITLE
API Discovery: Allow none users to view

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/role.go
+++ b/pkg/services/apiserver/auth/authorizer/role.go
@@ -51,6 +51,10 @@ func (auth roleAuthorizer) Authorize(ctx context.Context, a authorizer.Attribute
 			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
 		}
 	case org.RoleNone:
+		// allow api discovery endpoints (i.e. non resource requests)
+		if !a.IsResourceRequest() && a.GetVerb() == "get" {
+			return authorizer.DecisionAllow, "", nil
+		}
 		// HOTFIX: granting Viewer actions to None roles to a fixed group of APIs,
 		//  while we work on a proper fix.
 		if slices.Contains(orgRoleNoneAsViewerAPIGroups, a.GetAPIGroup()) {

--- a/pkg/services/apiserver/auth/authorizer/role_test.go
+++ b/pkg/services/apiserver/auth/authorizer/role_test.go
@@ -1,0 +1,55 @@
+package authorizer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+type roleAttributes struct {
+	authorizer.Attributes
+	verb              string
+	isResourceRequest bool
+}
+
+func (a roleAttributes) GetVerb() string         { return a.verb }
+func (a roleAttributes) IsResourceRequest() bool { return a.isResourceRequest }
+func (a roleAttributes) GetAPIGroup() string     { return "" }
+func (a roleAttributes) GetResource() string     { return "" }
+func (a roleAttributes) GetPath() string         { return "" }
+
+func ctxWithRole(role org.RoleType) context.Context {
+	return identity.WithRequester(context.Background(), &identity.StaticRequester{
+		OrgRole: role,
+	})
+}
+
+func TestRoleAuthorizer_NoneRole_DiscoveryEndpoints(t *testing.T) {
+	auth := roleAuthorizer{}
+
+	t.Run("non-resource GET is allowed for RoleNone (api discovery)", func(t *testing.T) {
+		attrs := &roleAttributes{verb: "get", isResourceRequest: false}
+		decision, _, err := auth.Authorize(ctxWithRole(org.RoleNone), attrs)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionAllow, decision)
+	})
+
+	t.Run("non-resource POST is denied for RoleNone", func(t *testing.T) {
+		attrs := &roleAttributes{verb: "post", isResourceRequest: false}
+		decision, _, err := auth.Authorize(ctxWithRole(org.RoleNone), attrs)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionDeny, decision)
+	})
+
+	t.Run("resource request is denied for RoleNone", func(t *testing.T) {
+		attrs := &roleAttributes{verb: "get", isResourceRequest: true}
+		decision, _, err := auth.Authorize(ctxWithRole(org.RoleNone), attrs)
+		require.NoError(t, err)
+		require.Equal(t, authorizer.DecisionDeny, decision)
+	})
+}


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/120511

We need to allow any signed in user to be able to view api discovery endpoints.

IsResourceRequest [will return true if there are more than 4 parts](https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/request/requestinfo.go#L150) (`/apis/<group>/<version>` ....)

Closes https://github.com/grafana/support-escalations/issues/21383