### PR TITLE
chore: add eslint rule for config.panels to enterprise

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -659,13 +659,11 @@ module.exports = [
           message:
             'Usage of config.apps is not allowed. Use the function getAppPluginMetas or useAppPluginMetas from @grafana/runtime/internal instead',
         },
-        // FIXME: Remove once all enterprise issues are fixed (reports/dashboard/DashboardReportPage.test.tsx) -
-        // we don't have a suppressions file/approach for enterprise code yet
-        // {
-        //   selector: 'MemberExpression[object.name="config"][property.name="panels"]',
-        //   message:
-        //     'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
-        // },
+        {
+          selector: 'MemberExpression[object.name="config"][property.name="panels"]',
+          message:
+            'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
+        },
       ],
     },
   },


### PR DESCRIPTION
**What is this feature?**

This pull request re-enables an ESLint rule that disallows direct usage of `config.panels` in the codebase. Instead, developers are now required to use the recommended functions for accessing panel plugin metadata. This change helps enforce best practices and maintain consistency across the project.

**Why do we need this feature?**

So we don't add any new code with `config.panels` in the enterprise code

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
