### PR TITLE
feat: Add heatmap support to Pyroscope datasource (frontend)

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1740,4 +1740,9 @@ export interface FeatureToggles {
   * @default false
   */
   useMTPluginSettings?: boolean;
+  /**
+  * Enables heatmap visualization support for Pyroscope profiles
+  * @default false
+  */
+  profilesHeatmap?: boolean;
 }

--- a/packages/grafana-schema/src/raw/composable/grafanapyroscope/dataquery/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/grafanapyroscope/dataquery/x/types.gen.ts
@@ -18,6 +18,8 @@ export type PyroscopeQueryType = ('metrics' | 'profile' | 'both');
 
 export const defaultPyroscopeQueryType: PyroscopeQueryType = 'both';
 
+export type HeatmapQueryType = ('individual' | 'span');
+
 export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
   /**
    * If set to true, the response will contain annotations
@@ -28,9 +30,17 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
    */
   groupBy: Array<string>;
   /**
+   * Specifies the type of heatmap query
+   */
+  heatmapType: (HeatmapQueryType | 'individual');
+  /**
    * If set to true, exemplars will be requested
    */
   includeExemplars: boolean;
+  /**
+   * If set to true, heatmap data will be requested
+   */
+  includeHeatmap: boolean;
   /**
    * Specifies the query label selectors.
    */
@@ -59,7 +69,9 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
 
 export const defaultGrafanaPyroscopeDataQuery: Partial<GrafanaPyroscopeDataQuery> = {
   groupBy: [],
+  heatmapType: 'individual',
   includeExemplars: false,
+  includeHeatmap: false,
   labelSelector: '{}',
   profileIdSelector: [],
   spanSelector: [],

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanFlameGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanFlameGraph.tsx
@@ -133,6 +133,8 @@ export default function SpanFlameGraph(props: SpanFlameGraphProps) {
               uid: profilesDataSourceSettings.uid,
             },
             includeExemplars: false,
+            heatmapType: 'individual' as const,
+            includeHeatmap: false,
           },
         ],
       };

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryEditor.test.tsx
@@ -39,6 +39,8 @@ describe('QueryEditor', () => {
           maxNodes: 1000,
           groupBy: [],
           includeExemplars: false,
+          includeHeatmap: false,
+          heatmapType: 'individual',
         },
       },
     });
@@ -131,6 +133,8 @@ function setup(options: { props: Partial<Props> } = { props: {} }) {
         groupBy: [],
         limit: 42,
         includeExemplars: false,
+        includeHeatmap: false,
+        heatmapType: 'individual',
       }}
       datasource={setupDs()}
       onChange={onChange}

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/QueryOptions.tsx
@@ -5,6 +5,7 @@ import { CoreApp, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { useStyles2, RadioButtonGroup, MultiSelect, Input, InlineSwitch } from '@grafana/ui';
 
+import { HeatmapQueryType } from '../dataquery.gen';
 import { Query } from '../types';
 
 import { EditorField } from './EditorField';
@@ -59,6 +60,9 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
   }
   if (query.includeExemplars) {
     collapsedInfo.push(`With exemplars`);
+  }
+  if (query.includeHeatmap) {
+    collapsedInfo.push(`Heatmap: ${query.heatmapType || 'individual'}`);
   }
 
   return (
@@ -155,6 +159,30 @@ export function QueryOptions({ query, onQueryChange, app, labels }: Props) {
                 }}
               />
             </EditorField>
+          )}
+          {config.featureToggles.profilesHeatmap && (
+            <>
+              <EditorField label={'Heatmap'} tooltip={<>Include heatmap visualization of profile data over time.</>}>
+                <InlineSwitch
+                  value={query.includeHeatmap || false}
+                  onChange={(event: React.SyntheticEvent<HTMLInputElement>) => {
+                    onQueryChange({ ...query, includeHeatmap: event.currentTarget.checked });
+                  }}
+                />
+              </EditorField>
+              {query.includeHeatmap && (
+                <EditorField label={'Heatmap Type'} tooltip={<>Select the type of heatmap aggregation.</>}>
+                  <RadioButtonGroup
+                    options={[
+                      { value: 'individual', label: 'Individual', description: 'Show individual profile samples' },
+                      { value: 'span', label: 'Span', description: 'Aggregate by span duration' },
+                    ]}
+                    value={query.heatmapType || 'individual'}
+                    onChange={(value: HeatmapQueryType) => onQueryChange({ ...query, heatmapType: value })}
+                  />
+                </EditorField>
+              )}
+            </>
           )}
         </div>
       </QueryOptionGroup>

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.cue
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.cue
@@ -48,6 +48,11 @@ composableKinds: DataQuery: {
 				includeExemplars: bool | *false
 				// Specifies the query profile id selectors.
 				profileIdSelector?: [...string]
+				// If set to true, heatmap data will be requested
+				includeHeatmap: bool | *false
+				// Specifies the type of heatmap query
+				heatmapType: #HeatmapQueryType | *"individual"
+				#HeatmapQueryType: "individual" | "span" @cuetsy(kind="type")
 			}
 		}]
 		lenses: []

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.gen.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/dataquery.gen.ts
@@ -16,6 +16,8 @@ export type PyroscopeQueryType = ('metrics' | 'profile' | 'both');
 
 export const defaultPyroscopeQueryType: PyroscopeQueryType = 'both';
 
+export type HeatmapQueryType = ('individual' | 'span');
+
 export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
   /**
    * If set to true, the response will contain annotations
@@ -26,9 +28,17 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
    */
   groupBy: Array<string>;
   /**
+   * Specifies the type of heatmap query
+   */
+  heatmapType: (HeatmapQueryType | 'individual');
+  /**
    * If set to true, exemplars will be requested
    */
   includeExemplars: boolean;
+  /**
+   * If set to true, heatmap data will be requested
+   */
+  includeHeatmap: boolean;
   /**
    * Specifies the query label selectors.
    */
@@ -57,7 +67,9 @@ export interface GrafanaPyroscopeDataQuery extends common.DataQuery {
 
 export const defaultGrafanaPyroscopeDataQuery: Partial<GrafanaPyroscopeDataQuery> = {
   groupBy: [],
+  heatmapType: 'individual',
   includeExemplars: false,
+  includeHeatmap: false,
   labelSelector: '{}',
   profileIdSelector: [],
   spanSelector: [],

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
@@ -44,6 +44,8 @@ describe('Pyroscope data source', () => {
           profileTypeId: '',
           groupBy: [''],
           includeExemplars: false,
+          includeHeatmap: false,
+          heatmapType: 'individual',
         },
       ]);
       expect(queries).toMatchObject([
@@ -120,6 +122,8 @@ describe('normalizeQuery', () => {
       profileTypeId: 'cpu',
       refId: '',
       includeExemplars: false,
+      includeHeatmap: false,
+      heatmapType: 'individual',
     });
     expect(normalized).toMatchObject({
       labelSelector: '{app="myapp"}',
@@ -148,6 +152,8 @@ const defaultQuery = (query: Partial<Query>): Query => {
     profileTypeId: '',
     queryType: defaultPyroscopeQueryType,
     includeExemplars: false,
+    includeHeatmap: false,
+    heatmapType: 'individual',
     ...query,
   };
 };

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -130,6 +130,8 @@ export class PyroscopeDataSource extends DataSourceWithBackend<Query, PyroscopeD
       profileTypeId: '',
       groupBy: [],
       includeExemplars: false,
+      includeHeatmap: false,
+      heatmapType: 'individual',
     };
   }
 


### PR DESCRIPTION
## Summary

- Adds `heatmapType` and `includeHeatmap` fields to the Pyroscope `DataQuery` CUE schema and generated TypeScript types
- Updates `QueryOptions` UI to expose heatmap type selection
- Updates `datasource.ts` to request heatmap data when the feature is enabled
- Fixes `SpanFlameGraph.tsx` for compatibility with the updated `Query` type
- Adds `profilesHeatmap` feature toggle TypeScript type (generated from backend registry)

## Related

Backend PR: #120995

> **Note**: This PR should be merged after the backend PR (#120995) since it depends on the `profilesHeatmap` feature toggle being available server-side.

## Test plan

- [ ] Verify TypeScript typecheck passes
- [ ] Verify frontend lint passes
- [ ] Verify QueryOptions renders heatmap controls when feature flag is enabled