### PR TITLE
Provisioning: fix folder creation on new branch with folder metadata

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -189,7 +189,7 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 				stableUID = existing.Name
 				return nil
 			}
-			if !errors.Is(readErr, repository.ErrFileNotFound) {
+			if !errors.Is(readErr, repository.ErrFileNotFound) && !errors.Is(readErr, repository.ErrRefNotFound) {
 				return fmt.Errorf("failed to read folder metadata for %q: %w", folderPath, readErr)
 			}
 			// Not found: write a new folder metadata file

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -454,6 +454,40 @@ func TestCreateFolder(t *testing.T) {
 			errContains: "failed to read folder metadata",
 		},
 		{
+			name: "flag enabled: ref not found is treated as file not found (new branch)",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				config := &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+					Spec: provisioning.RepositorySpec{
+						Type:      provisioning.GitRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow, provisioning.BranchWorkflow},
+						Sync:      provisioning.SyncOptions{Enabled: false},
+					},
+				}
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(config)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "new-branch").Return(nil, repository.ErrRefNotFound)
+				rw.On("Create", mock.Anything, "newfolder/_folder.json", "new-branch", mock.MatchedBy(func(b []byte) bool {
+					var res folders.Folder
+					if err := json.Unmarshal(b, &res); err != nil {
+						return false
+					}
+					return res.APIVersion == "folder.grafana.app/v1beta1" &&
+						res.Kind == "Folder" &&
+						res.Name != "" &&
+						res.Spec.Title == "newfolder"
+				}), "").Return(nil)
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				dw := &DualReadWriter{repo: rw, authorizer: NewAuthorizer(config, rw, accessMock, false), folderMetadataEnabled: true}
+				return dw, DualWriteOptions{Path: "newfolder/", Ref: "new-branch"}
+			},
+			check: func(t *testing.T, result *provisioning.ResourceWrapper) {
+				assert.Equal(t, "newfolder/", result.Path)
+				assert.Equal(t, "new-branch", result.Ref)
+			},
+		},
+		{
 			name: "sync enabled, flag disabled: GetFolder not found → no Upsert",
 			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
 				config := newSyncEnabledConfig("test-repo")

--- a/pkg/tests/apis/provisioning/git/foldermetadata_files/create_folder_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_files/create_folder_test.go
@@ -1,0 +1,127 @@
+package foldermetadatafiles
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	repoName := "test-folder-metadata-files"
+	_, _ = helper.CreateGitRepo(t, repoName, nil, "write", "branch")
+
+	t.Run("create folder on default branch writes _folder.json", func(t *testing.T) {
+		resp := postFolderViaFilesAPI(t, helper, repoName, "meta-folder/", "", "Create folder with metadata")
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "should create folder on default branch: %s", string(body))
+
+		result := helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "meta-folder", "_folder.json").
+			Do(ctx)
+		require.NoError(t, result.Error(), "_folder.json should exist in the folder")
+	})
+
+	t.Run("create folder on new branch writes _folder.json", func(t *testing.T) {
+		branchName := "metadata-branch"
+
+		resp := postFolderViaFilesAPI(t, helper, repoName, "branch-meta-folder/", branchName, "Create folder with metadata on branch")
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "should create folder on new branch: %s", string(body))
+
+		result := helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "branch-meta-folder", "_folder.json").
+			Param("ref", branchName).
+			Do(ctx)
+		require.NoError(t, result.Error(), "_folder.json should exist on the branch")
+
+		result = helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "branch-meta-folder", "_folder.json").
+			Do(ctx)
+		require.True(t, apierrors.IsNotFound(result.Error()), "_folder.json should not exist on the default branch")
+	})
+
+	t.Run("create nested folder on new branch writes _folder.json for every segment", func(t *testing.T) {
+		branchName := "nested-metadata-branch"
+
+		resp := postFolderViaFilesAPI(t, helper, repoName, "outer/inner/", branchName, "Create nested folder on branch")
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "should create nested folder on new branch: %s", string(body))
+
+		result := helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "outer", "_folder.json").
+			Param("ref", branchName).
+			Do(ctx)
+		require.NoError(t, result.Error(), "parent _folder.json should exist on the branch")
+
+		result = helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "outer", "inner", "_folder.json").
+			Param("ref", branchName).
+			Do(ctx)
+		require.NoError(t, result.Error(), "child _folder.json should exist on the branch")
+	})
+}
+
+// postFolderViaFilesAPI makes a raw HTTP POST to the files endpoint to create a folder.
+// We build the URL manually because the K8s REST client may strip the trailing
+// slash that the files endpoint needs to distinguish folders from files.
+func postFolderViaFilesAPI(t *testing.T, helper *gitcommon.GitTestHelper, repoName, folderPath, ref, message string) *http.Response {
+	t.Helper()
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	rawURL := fmt.Sprintf(
+		"http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/%s",
+		addr, repoName, folderPath,
+	)
+
+	parsedURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	params := parsedURL.Query()
+	if message != "" {
+		params.Set("message", message)
+	}
+	if ref != "" {
+		params.Set("ref", ref)
+	}
+	parsedURL.RawQuery = params.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, parsedURL.String(), nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	return resp
+}

--- a/pkg/tests/apis/provisioning/git/foldermetadata_files/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_files/helper_test.go
@@ -1,0 +1,21 @@
+package foldermetadatafiles
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
+)
+
+var (
+	sharedGitEnvWithFolderMetadata = gitcommon.NewSharedGitEnv(common.WithProvisioningFolderMetadata)
+)
+
+func TestMain(m *testing.M) {
+	sharedGitEnvWithFolderMetadata.RunTestMain(m)
+}
+
+func sharedGitHelper(t *testing.T) *gitcommon.GitTestHelper {
+	t.Helper()
+	return sharedGitEnvWithFolderMetadata.GetCleanHelper(t)
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/1025

## What

Fixes a **"ref not found"** error when creating a folder via the provisioning files endpoint using the **branch workflow** with the `provisioningFolderMetadata` feature flag enabled.

## Why

When `CreateFolder` runs with folder metadata enabled, it first calls `ReadFolderMetadata` → `repo.Read()` to check whether the folder already exists. If the target branch doesn't exist yet (the normal case when a user creates a folder on a brand-new feature branch), `Read` fails with `ErrRefNotFound`.

The error guard only accepted `ErrFileNotFound` as the "not found, proceed to create" signal:

```go
// before
if !errors.Is(readErr, repository.ErrFileNotFound) {
    return fmt.Errorf("failed to read folder metadata for %q: %w", folderPath, readErr)
}
```

`ErrRefNotFound` fell through and surfaced as an HTTP 404 `"ref not found"` to the caller.

## How

Accept `ErrRefNotFound` alongside `ErrFileNotFound` so the code proceeds to `WriteFolderMetadata`, which calls `repo.Create` → `ensureBranchExists` and creates the branch automatically:

```go
// after
if !errors.Is(readErr, repository.ErrFileNotFound) && !errors.Is(readErr, repository.ErrRefNotFound) {
    return fmt.Errorf("failed to read folder metadata for %q: %w", folderPath, readErr)
}
```

The non-metadata code path (`folderMetadataEnabled = false`) was **not** affected because it calls `repo.Create` directly, which already handles branch creation via `ensureBranchExists`.

## Test plan

**Unit test** (new, in `dualwriter_test.go`):
- `TestCreateFolder/flag_enabled:_ref_not_found_is_treated_as_file_not_found_(new_branch)` — mocks `Read` returning `ErrRefNotFound` on a branch-workflow repo and asserts `_folder.json` is written to the new branch.

**Integration tests** (new package `foldermetadata_files`):
- Create folder on default branch → `_folder.json` exists
- Create folder on a **new branch** → `_folder.json` exists on the branch but not on the default branch (the bug scenario)
- Create nested folder on a new branch → `_folder.json` for both parent and child segments