### PR TITLE
Provisioning: Add full sync UID takeover recovery test

### DIFF
--- a/pkg/tests/apis/provisioning/git/sourcepath_guard/helper_test.go
+++ b/pkg/tests/apis/provisioning/git/sourcepath_guard/helper_test.go
@@ -3,9 +3,16 @@ package sourcepathguard
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/tests/testsuite"
+	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
 )
 
+var env = gitcommon.NewSharedGitEnv()
+
+func sharedGitHelper(t *testing.T) *gitcommon.GitTestHelper {
+	t.Helper()
+	return env.GetCleanHelper(t)
+}
+
 func TestMain(m *testing.M) {
-	testsuite.Run(m)
+	env.RunTestMain(m)
 }

--- a/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
+++ b/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
@@ -8,25 +8,17 @@ import (
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	gitcommon "github.com/grafana/grafana/pkg/tests/apis/provisioning/git/common"
-	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
 // TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover verifies
 // the deleteOldResource sourcePath guard during an incremental sync. File A
 // takes file B's UID while file B moves to a brand-new UID. Incremental sync
 // processes changes serially in alphabetical order, so A's write updates
-// swap-incr-uid-b's sourcePath annotation to dashboard_a.json before B's
+// takeover-uid-b's sourcePath annotation to dashboard_a.json before B's
 // deleteOldResource runs. The guard detects the mismatch and skips the delete,
 // preserving the resource that A just claimed.
-//
-// This scenario is tested only with incremental sync because full sync
-// processes files in parallel, making it impossible to guarantee that A's write
-// completes before B's deleteOldResource runs. A unit test in
-// resources_test.go covers the guard logic directly.
 func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
-
-	helper := gitcommon.RunGrafanaWithGitServer(t)
+	helper := sharedGitHelper(t)
 	ctx := context.Background()
 
 	const repoName = "git-incr-uid-takeover"
@@ -62,5 +54,65 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"takeover-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
 		"takeover-uid-new": {Title: "Dashboard B New UID", SourcePath: "dashboard_b.json"},
+	})
+}
+
+// TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery verifies
+// that a second full sync recovers the correct dashboard state after a
+// multi-file UID takeover.
+//
+// FIXME: Full sync processes file changes in parallel (applyResourcesInParallel),
+// so there is no ordering guarantee between goroutines. During a UID takeover
+// (file A claims file B's old UID while file B moves to a new UID), a race
+// exists: if B's goroutine completes its write+delete cycle before A's write
+// starts, B deletes the old UID before A can claim it. A's subsequent
+// create-after-delete then fails against the storage layer, leaving one
+// dashboard missing. This is a known bug — the first full sync may produce an
+// inconsistent state.
+//
+// The second full sync recovers because it compares the git tree against the
+// current Grafana resources and re-creates any missing dashboards. This test
+// exists to document the bug and verify the recovery path.
+func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const repoName = "git-full-uid-takeover-recovery"
+
+	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard_a.json": gitcommon.DashboardJSON("full-uid-a", "Dashboard A", 1),
+		"dashboard_b.json": gitcommon.DashboardJSON("full-uid-b", "Dashboard B", 1),
+	}, "write", "branch")
+
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		"full-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
+		"full-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
+	})
+
+	// File A takes B's UID; file B gets a brand-new UID.
+	require.NoError(t, local.UpdateFile("dashboard_a.json", string(gitcommon.DashboardJSON("full-uid-b", "Dashboard A Took B", 2))))
+	require.NoError(t, local.UpdateFile("dashboard_b.json", string(gitcommon.DashboardJSON("full-uid-new", "Dashboard B New UID", 2))))
+	_, err := local.Git("add", ".")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "file A takes B's UID, B gets new UID")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	// FIXME: The first full sync is non-deterministic due to parallel
+	// processing. Depending on goroutine scheduling, the UID takeover race
+	// may cause one dashboard to be lost. We intentionally do not assert
+	// dashboard state here because the outcome varies between runs.
+	helper.SyncAndWait(t, repoName)
+
+	// A second full sync compares the git tree against the current Grafana
+	// state and re-creates any resources that went missing in the first sync.
+	// After this, the state must converge to the correct result.
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		"full-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
+		"full-uid-new": {Title: "Dashboard B New UID", SourcePath: "dashboard_b.json"},
 	})
 }

--- a/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
+++ b/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
@@ -57,6 +57,55 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 	})
 }
 
+// TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap verifies the
+// deleteOldResource sourcePath guard during a symmetric UID swap in incremental
+// sync. File A takes B's UID and file B takes A's UID simultaneously.
+//
+// Incremental sync processes files alphabetically, so the execution is
+// deterministic:
+//  1. A runs first: writes swap-uid-b (UPDATE → sourcePath becomes
+//     dashboard_a.json), then deletes swap-uid-a (sourcePath still points to
+//     dashboard_a.json → match → delete proceeds).
+//  2. B runs next: writes swap-uid-a (CREATE, since A just deleted it), then
+//     tries to delete swap-uid-b — but its sourcePath is now dashboard_a.json
+//     (set by A's write), which ≠ dashboard_b.json → guard fires, skip delete.
+//
+// Both dashboards survive with their UIDs swapped.
+func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const repoName = "git-incr-uid-swap"
+
+	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard_a.json": gitcommon.DashboardJSON("swap-uid-a", "Dashboard A", 1),
+		"dashboard_b.json": gitcommon.DashboardJSON("swap-uid-b", "Dashboard B", 1),
+	}, "write", "branch")
+
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		"swap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
+		"swap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
+	})
+
+	// Symmetric swap: A gets B's UID, B gets A's UID.
+	require.NoError(t, local.UpdateFile("dashboard_a.json", string(gitcommon.DashboardJSON("swap-uid-b", "Dashboard A Swapped", 2))))
+	require.NoError(t, local.UpdateFile("dashboard_b.json", string(gitcommon.DashboardJSON("swap-uid-a", "Dashboard B Swapped", 2))))
+	_, err := local.Git("add", ".")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "swap UIDs between A and B")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	helper.SyncAndWaitIncremental(t, repoName)
+
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		"swap-uid-a": {Title: "Dashboard B Swapped", SourcePath: "dashboard_b.json"},
+		"swap-uid-b": {Title: "Dashboard A Swapped", SourcePath: "dashboard_a.json"},
+	})
+}
+
 // TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery verifies
 // that a second full sync recovers the correct dashboard state after a
 // multi-file UID takeover.
@@ -114,5 +163,60 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"full-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
 		"full-uid-new": {Title: "Dashboard B New UID", SourcePath: "dashboard_b.json"},
+	})
+}
+
+// TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery verifies that
+// a second full sync recovers the correct dashboard state after a symmetric UID
+// swap (file A takes B's UID, file B takes A's UID).
+//
+// FIXME: The same parallel-processing race described in
+// TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery applies
+// here. With a symmetric swap, the race is even more pronounced: whichever
+// goroutine completes its write+delete first destroys the UID the other
+// goroutine needs. The first full sync may leave one or both dashboards in an
+// inconsistent state. This is a known bug.
+//
+// The second full sync recovers because it compares the git tree against the
+// current Grafana resources and re-creates any missing dashboards.
+func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const repoName = "git-full-uid-swap-recovery"
+
+	_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard_a.json": gitcommon.DashboardJSON("fswap-uid-a", "Dashboard A", 1),
+		"dashboard_b.json": gitcommon.DashboardJSON("fswap-uid-b", "Dashboard B", 1),
+	}, "write", "branch")
+
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		"fswap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
+		"fswap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
+	})
+
+	// Symmetric swap: A gets B's UID, B gets A's UID.
+	require.NoError(t, local.UpdateFile("dashboard_a.json", string(gitcommon.DashboardJSON("fswap-uid-b", "Dashboard A Swapped", 2))))
+	require.NoError(t, local.UpdateFile("dashboard_b.json", string(gitcommon.DashboardJSON("fswap-uid-a", "Dashboard B Swapped", 2))))
+	_, err := local.Git("add", ".")
+	require.NoError(t, err)
+	_, err = local.Git("commit", "-m", "swap UIDs between A and B")
+	require.NoError(t, err)
+	_, err = local.Git("push")
+	require.NoError(t, err)
+
+	// FIXME: The first full sync is non-deterministic due to parallel
+	// processing. The symmetric swap race may cause one or both dashboards
+	// to be lost. We do not assert state here.
+	helper.SyncAndWait(t, repoName)
+
+	// A second full sync re-compares the git tree and recovers any missing
+	// resources, converging to the correct state.
+	common.SyncAndWaitWithSuccess(t, helper, repoName)
+
+	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		"fswap-uid-a": {Title: "Dashboard B Swapped", SourcePath: "dashboard_b.json"},
+		"fswap-uid-b": {Title: "Dashboard A Swapped", SourcePath: "dashboard_a.json"},
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #120962. Adds integration tests covering UID changes across multiple files during provisioning sync — both **one-directional takeover** (A claims B's UID, B gets a new one) and **symmetric swap** (A↔B exchange UIDs).

### The bug (FIXME)

Full sync processes file changes in parallel via `applyResourcesInParallel`. During a UID takeover or swap, a race exists between goroutines: if one goroutine completes its write+delete cycle before the other's write starts, it deletes the UID the other goroutine needs. The subsequent create-after-delete fails against the storage layer, leaving a dashboard missing. The first full sync is therefore **non-deterministic** and may produce an inconsistent state.

A **second full sync** recovers because it compares the git tree against the current Grafana resources and re-creates any missing dashboards.

### Test matrix

| Test | Sync type | Scenario | Deterministic? |
|---|---|---|---|
| `IncrementalGitSync_MultiFileUIDTakeover` | Incremental | A takes B's UID, B gets new UID | Yes (alphabetical order) |
| `IncrementalGitSync_MultiFileUIDSwap` | Incremental | A↔B symmetric UID swap | Yes (alphabetical order) |
| `FullSync_MultiFileUIDTakeover_Recovery` | Full (×2) | A takes B's UID, B gets new UID | Recovery sync is deterministic |
| `FullSync_MultiFileUIDSwap_Recovery` | Full (×2) | A↔B symmetric UID swap | Recovery sync is deterministic |

### Other changes

- Migrates the `sourcepath_guard` test package to use `SharedGitEnv` so all four tests share a single Grafana + Git server instance, reducing startup cost.

## Test plan

- [ ] `TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover`
- [ ] `TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap`
- [ ] `TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery`
- [ ] `TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery`