### PR TITLE
Provisioning: fix flaky ownership protection integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"sync"
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -397,40 +396,27 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()
 
-	// create both repos concurrently to reduce duration of this test
-	// Create first repository targeting "folder-1" with its own subdirectory
 	const repo1 = "ownership-repo-1"
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		helper.CreateRepo(t, common.TestRepo{
-			Name:   repo1,
-			Path:   path.Join(helper.ProvisioningPath, "repo1"),
-			Target: "folder",
-			Copies: map[string]string{
-				"testdata/all-panels.json": "dashboard1.json",
-			},
-			SkipResourceAssertions: true, // will check both at the same time below to reduce duration of this test
-		})
-	}()
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo1,
+		Path:   path.Join(helper.ProvisioningPath, "repo1"),
+		Target: "folder",
+		Copies: map[string]string{
+			"testdata/all-panels.json": "dashboard1.json",
+		},
+		SkipResourceAssertions: true, // will check both at the same time below
+	})
 
-	// Create second repository targeting "folder-2" with its own subdirectory
 	const repo2 = "ownership-repo-2"
-	path2 := path.Join(helper.ProvisioningPath, "repo2")
-	go func() {
-		defer wg.Done()
-		helper.CreateRepo(t, common.TestRepo{
-			Name:   repo2,
-			Path:   path2,
-			Target: "folder",
-			Copies: map[string]string{
-				"testdata/timeline-demo.json": "dashboard2.json",
-			},
-			SkipResourceAssertions: true, // will check both at the same time below to reduce duration of this test
-		})
-	}()
-	wg.Wait()
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo2,
+		Path:   path.Join(helper.ProvisioningPath, "repo2"),
+		Target: "folder",
+		Copies: map[string]string{
+			"testdata/timeline-demo.json": "dashboard2.json",
+		},
+		SkipResourceAssertions: true, // will check both at the same time below
+	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})

--- a/pkg/tests/apis/provisioning/jobs/pulljob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_test.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,38 +23,27 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()
 
-	// Create two repositories with folder targets and separate paths to avoid file conflicts
 	const repo1 = "pulljob-repo-1"
 	const repo2 = "pulljob-repo-2"
 
-	// create both repos concurrently to reduce duration of this test
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		helper.CreateRepo(t, common.TestRepo{
-			Name:   repo1,
-			Path:   path.Join(helper.ProvisioningPath, "repo1"),
-			Target: "folder",
-			Copies: map[string]string{
-				"../testdata/all-panels.json": "dashboard1.json",
-			},
-			SkipResourceAssertions: true, // will check both at the same time below to reduce duration of this test
-		})
-	}()
-	go func() {
-		defer wg.Done()
-		helper.CreateRepo(t, common.TestRepo{
-			Name:   repo2,
-			Path:   path.Join(helper.ProvisioningPath, "repo2"),
-			Target: "folder",
-			Copies: map[string]string{
-				"../testdata/timeline-demo.json": "dashboard2.json",
-			},
-			SkipResourceAssertions: true, // will check both at the same time below to reduce duration of this test
-		})
-	}()
-	wg.Wait()
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo1,
+		Path:   path.Join(helper.ProvisioningPath, "repo1"),
+		Target: "folder",
+		Copies: map[string]string{
+			"../testdata/all-panels.json": "dashboard1.json",
+		},
+		SkipResourceAssertions: true, // will check both at the same time below
+	})
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo2,
+		Path:   path.Join(helper.ProvisioningPath, "repo2"),
+		Target: "folder",
+		Copies: map[string]string{
+			"../testdata/timeline-demo.json": "dashboard2.json",
+		},
+		SkipResourceAssertions: true, // will check both at the same time below
+	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})


### PR DESCRIPTION
## What

Fix two flaky integration tests that intermittently fail in CI:

- `TestIntegrationProvisioning_FilesOwnershipProtection` — expects 2 dashboards after sync but only finds 1, times out after 60s.
- `TestIntegrationProvisioning_PullJobOwnershipProtection` — `AwaitJobs` fails with "expect at least one job" because historic job records are missing.

## Why

Both tests create two repositories concurrently using goroutines + `sync.WaitGroup`, then assert that both repos' dashboards were provisioned. This pattern is unreliable for two reasons:

1. **Concurrent sync race condition** — When both repos trigger `SyncAndWait` simultaneously, the sync jobs interfere with each other. Observed symptoms include one repo's dashboard never being created, files failing to parse mid-write (`resource validation failed: file does not contain a valid resource`), and `AwaitJobs` unable to find historic job records.

2. **`testing.T` misuse from goroutines** — `require` functions call `t.FailNow()`, which invokes `runtime.Goexit()`. Per [Go's testing contract](https://pkg.go.dev/testing#T.FailNow), this must only be called from the goroutine running the test. When called from a spawned goroutine, it only exits *that* goroutine — the deferred `wg.Done()` still fires, `wg.Wait()` returns, and the test continues with incomplete state.

## How

Replace the concurrent goroutine pattern with sequential `CreateRepo` calls. Both repos still use `SkipResourceAssertions: true` with a combined `EventuallyWithT` check afterward, so there is no change in what the tests validate — only the setup ordering.

## Test plan
- [ ] CI passes for `pkg/tests/apis/provisioning` and `pkg/tests/apis/provisioning/jobs`
- [ ] Both previously flaky tests pass reliably across multiple runs