### PR TITLE
Dashboard: Suppress error alert on API version discovery failure

### DIFF
--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -51,6 +51,19 @@ describe('DashboardAPIVersionResolver', () => {
       expect(result).toEqual(expected);
     });
 
+    it('should call discovery endpoint with showErrorAlert disabled', async () => {
+      mockDiscoveryResponse(['v2beta1', 'v1beta1']);
+      await dashboardAPIVersionResolver.resolve();
+
+      const mockGet = mockGetBackendSrv()?.get as jest.Mock;
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/'),
+        undefined,
+        undefined,
+        expect.objectContaining({ showErrorAlert: false })
+      );
+    });
+
     it('should retry discovery after a transient failure', async () => {
       mockDiscoveryFailure();
       expect(await dashboardAPIVersionResolver.resolve()).toEqual(BETA_FALLBACK);

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
@@ -69,7 +69,9 @@ class DashboardAPIVersionResolver {
   }
 
   private async discover(): Promise<ResolvedDashboardVersions> {
-    const group = await getBackendSrv().get<K8sAPIGroup>(`/apis/${DASHBOARD_API_GROUP}/`);
+    const group = await getBackendSrv().get<K8sAPIGroup>(`/apis/${DASHBOARD_API_GROUP}/`, undefined, undefined, {
+      showErrorAlert: false,
+    });
     const availableVersions = new Set(group.versions.map((v) => v.version));
 
     const v1: DashboardV1Version = availableVersions.has('v1') ? 'v1' : BETA_V1;


### PR DESCRIPTION
The DashboardAPIVersionResolver calls the k8s discovery endpoint to negotiate API versions. When users lack access to this endpoint, the request fails and getBackendSrv() shows an error toast. Since the resolver already handles failures gracefully by falling back to beta versions, suppress the error alert with showErrorAlert: false.

