### PR TITLE
Dashboard: excluding the id field from the comparison in getDashboardChangesFromScene (#119358)

### DIFF
--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -195,8 +195,9 @@ export class V1DashboardSerializer
   ) {
     const changedSaveModel =
       options.rawJson && !isDashboardV2Spec(options.rawJson) ? options.rawJson : this.getSaveModel(scene);
+    const { id: _id, ...initialWithoutId } = (this.initialSaveModel ?? {}) as Dashboard;
     const changeInfo = getRawDashboardChanges(
-      this.initialSaveModel!,
+      initialWithoutId as Dashboard,
       changedSaveModel,
       options.saveTimeRange,
       options.saveVariables,


### PR DESCRIPTION

**What is this feature?**

When a new dashboard with panels is saved, the change tracker incorrectly detects a diff because the internal id field is present in initialSaveModel but is always removed by getSaveModel() via delete dashboard.id

**Why do we need this feature?**

Checking correctly if the dashboard has changed, removes the 2 pop-up for saving

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes #119358

**Replication before:**

https://github.com/user-attachments/assets/965e8fcd-e251-4bd1-a959-23fd4a48b525

**Replication After Fix:**

https://github.com/user-attachments/assets/8893ea00-6fb4-42e5-9068-e9b28d39502b


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
