### PR TITLE
Alerting: Add opt-in provenance support to TimeInterval k8s API

### DIFF
--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert"
 	ac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -115,7 +116,11 @@ func (a AppInstaller) GetLegacyStorage(gvr schema.GroupVersionResource) grafanar
 	case receiver.ResourceInfo.GroupResource().Resource:
 		return receiver.NewStorage(api.ReceiverService, namespacer, api.ReceiverService)
 	case timeinterval.ResourceInfo.GroupResource().Resource:
-		srv := api.MuteTimings
+		// The k8s API enforces its own SetProvisioningStatus permission check before
+		// any provenance change reaches the service, so the service-level transition
+		// validator can be permissive — ValidateProvenanceRelaxed would otherwise
+		// block valid transitions like api→none for callers with explicit permission.
+		srv := api.MuteTimings.WithProvenanceValidator(validation.ValidateProvenancePermissive)
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if a.ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingImportAlertmanagerAPI) {
 			srv = srv.WithIncludeImported()

--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -116,16 +116,12 @@ func (a AppInstaller) GetLegacyStorage(gvr schema.GroupVersionResource) grafanar
 	case receiver.ResourceInfo.GroupResource().Resource:
 		return receiver.NewStorage(api.ReceiverService, namespacer, api.ReceiverService)
 	case timeinterval.ResourceInfo.GroupResource().Resource:
-		// The k8s API enforces its own SetProvisioningStatus permission check before
-		// any provenance change reaches the service, so the service-level transition
-		// validator can be permissive — ValidateProvenanceRelaxed would otherwise
-		// block valid transitions like api→none for callers with explicit permission.
-		srv := api.MuteTimings.WithProvenanceValidator(validation.ValidateProvenancePermissive)
+		srv := api.MuteTimings.WithProvenanceValidator(validation.NewPermissionAwareValidator(api.AccessControl))
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if a.ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingImportAlertmanagerAPI) {
 			srv = srv.WithIncludeImported()
 		}
-		return timeinterval.NewStorage(srv, namespacer, api.AccessControl)
+		return timeinterval.NewStorage(srv, namespacer)
 	case templategroup.ResourceInfo.GroupResource().Resource:
 		srv := api.Templates
 		//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -120,7 +120,7 @@ func (a AppInstaller) GetLegacyStorage(gvr schema.GroupVersionResource) grafanar
 		if a.ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingImportAlertmanagerAPI) {
 			srv = srv.WithIncludeImported()
 		}
-		return timeinterval.NewStorage(srv, namespacer)
+		return timeinterval.NewStorage(srv, namespacer, api.AccessControl)
 	case templategroup.ResourceInfo.GroupResource().Resource:
 		srv := api.Templates
 		//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
@@ -2,8 +2,6 @@ package timeinterval
 
 import (
 	"encoding/json"
-	"fmt"
-	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -16,29 +14,6 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
-
-// provenanceFromAnnotation maps the grafana.com/provenance annotation value
-// from a k8s API request to a Provenance for use in the service layer.
-//
-// Provenance is opt-in for the k8s API: callers must explicitly set
-// grafana.com/provenance: api to mark a resource as externally managed.
-// If the annotation is absent or "none", ProvenanceNone is returned and the
-// resource remains freely editable by all callers (including the Grafana UI).
-//
-// Contrast with the HTTP provisioning API (/api/v1/provisioning/...) which is
-// opt-out: it sets ProvenanceAPI on every write unless the caller sends the
-// X-Disable-Provenance header.
-func provenanceFromAnnotation(annotationVal string) (definitions.Provenance, error) {
-	// ngmodels.ProvenanceNone is an empty string so explicitly check for "none" as well
-	if annotationVal != model.ProvenanceStatusNone && !slices.Contains(ngmodels.KnownProvenances, ngmodels.Provenance(annotationVal)) {
-		return definitions.Provenance(""), fmt.Errorf("invalid provenance status: %s", annotationVal)
-	}
-
-	if annotationVal == "" || annotationVal == model.ProvenanceStatusNone {
-		return definitions.Provenance(ngmodels.ProvenanceNone), nil
-	}
-	return definitions.Provenance(annotationVal), nil
-}
 
 func ConvertToK8sResources(orgID int64, intervals []definitions.MuteTimeInterval, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TimeIntervalList, error) {
 	data, err := json.Marshal(intervals)
@@ -113,10 +88,13 @@ func convertToDomainModel(interval *model.TimeInterval) (definitions.MuteTimeInt
 	}
 	result.Version = interval.ResourceVersion
 	result.UID = interval.Name
-	result.Provenance, err = provenanceFromAnnotation(interval.GetProvenanceStatus())
+
+	prov, err := ngmodels.ProvenanceFromString(interval.GetProvenanceStatus())
 	if err != nil {
 		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
 	}
+	result.Provenance = definitions.Provenance(prov)
+
 	err = result.Validate()
 	if err != nil {
 		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)

--- a/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
@@ -2,6 +2,8 @@ package timeinterval
 
 import (
 	"encoding/json"
+	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -14,6 +16,29 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
+
+// provenanceFromAnnotation maps the grafana.com/provenance annotation value
+// from a k8s API request to a Provenance for use in the service layer.
+//
+// Provenance is opt-in for the k8s API: callers must explicitly set
+// grafana.com/provenance: api to mark a resource as externally managed.
+// If the annotation is absent or "none", ProvenanceNone is returned and the
+// resource remains freely editable by all callers (including the Grafana UI).
+//
+// Contrast with the HTTP provisioning API (/api/v1/provisioning/...) which is
+// opt-out: it sets ProvenanceAPI on every write unless the caller sends the
+// X-Disable-Provenance header.
+func provenanceFromAnnotation(annotationVal string) (definitions.Provenance, error) {
+	// ngmodels.ProvenanceNone is an empty string so explicitly check for "none" as well
+	if annotationVal != model.ProvenanceStatusNone && !slices.Contains(ngmodels.KnownProvenances, ngmodels.Provenance(annotationVal)) {
+		return definitions.Provenance(""), fmt.Errorf("invalid provenance status: %s", annotationVal)
+	}
+
+	if annotationVal == "" || annotationVal == model.ProvenanceStatusNone {
+		return definitions.Provenance(ngmodels.ProvenanceNone), nil
+	}
+	return definitions.Provenance(annotationVal), nil
+}
 
 func ConvertToK8sResources(orgID int64, intervals []definitions.MuteTimeInterval, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TimeIntervalList, error) {
 	data, err := json.Marshal(intervals)
@@ -88,7 +113,10 @@ func convertToDomainModel(interval *model.TimeInterval) (definitions.MuteTimeInt
 	}
 	result.Version = interval.ResourceVersion
 	result.UID = interval.Name
-	result.Provenance = definitions.Provenance(ngmodels.ProvenanceNone)
+	result.Provenance, err = provenanceFromAnnotation(interval.GetProvenanceStatus())
+	if err != nil {
+		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
+	}
 	err = result.Validate()
 	if err != nil {
 		return definitions.MuteTimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)

--- a/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
@@ -37,9 +37,8 @@ type legacyStorage struct {
 
 // checkProvisioningStatusPermission verifies the caller holds
 // alert.provisioning.provenance:write. This is required whenever a write
-// involves a non-None provenance — either because the resource is already
-// provisioned (old provenance != None) or because the caller is explicitly
-// claiming provenance ownership (new provenance != None).
+// changes the provenance value (new != old), including claiming ownership
+// (None → api) and transferring or releasing it (api → other).
 func (s *legacyStorage) checkProvisioningStatusPermission(ctx context.Context, user identity.Requester) error {
 	ok, err := s.ac.Evaluate(ctx, user, accesscontrol.EvalPermission(accesscontrol.ActionAlertingProvisioningSetStatus))
 	if err != nil {
@@ -197,11 +196,11 @@ func (s *legacyStorage) Update(ctx context.Context,
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	// Gate on either side being non-None:
-	//   old != None — resource is already provisioned; protect it from unintentional overwrites.
-	//   new != None — caller is (re-)claiming provenance ownership; requires explicit permission.
-	// If both are None the resource is unprovisioned and freely editable by all callers.
-	if interval.Provenance != definitions.Provenance(ngmodels.ProvenanceNone) || oldProv != definitions.Provenance(ngmodels.ProvenanceNone) {
+	// Only gate on permission when provenance is changing. Callers that are not
+	// touching provenance (new == old) do not need SetProvisioningStatus — the
+	// service-level validator (ValidateProvenanceRelaxed) still enforces which
+	// transitions are valid for the resource itself.
+	if interval.Provenance != oldProv {
 		user, err := identity.GetRequester(ctx)
 		if err != nil {
 			return nil, false, err

--- a/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
@@ -11,15 +11,14 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-var _ grafanarest.Storage = (*legacyStorage)(nil)
+var (
+	_ grafanarest.Storage = (*legacyStorage)(nil)
+)
 
 type TimeIntervalService interface {
 	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error)
@@ -32,23 +31,6 @@ type legacyStorage struct {
 	service        TimeIntervalService
 	namespacer     request.NamespaceMapper
 	tableConverter rest.TableConvertor
-	ac             accesscontrol.AccessControl
-}
-
-// checkProvisioningStatusPermission verifies the caller holds
-// alert.provisioning.provenance:write. This is required whenever a write
-// changes the provenance value (new != old), including claiming ownership
-// (None → api) and transferring or releasing it (api → other).
-func (s *legacyStorage) checkProvisioningStatusPermission(ctx context.Context, user identity.Requester) error {
-	ok, err := s.ac.Evaluate(ctx, user, accesscontrol.EvalPermission(accesscontrol.ActionAlertingProvisioningSetStatus))
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return errors.NewForbidden(ResourceInfo.GroupResource(), "",
-			fmt.Errorf("missing permission: %s", accesscontrol.ActionAlertingProvisioningSetStatus))
-	}
-	return nil
 }
 
 func (s *legacyStorage) New() runtime.Object {
@@ -127,22 +109,11 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if p.Name != "" { // TODO remove when metadata.name can be defined by user
 		return nil, errors.NewBadRequest("object's metadata.name should be empty")
 	}
-	mt, err := convertToDomainModel(p)
+	model, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, err
 	}
-	// Provenance is opt-in: callers must explicitly set grafana.com/provenance: api
-	// to claim ownership. If set, require SetProvisioningStatus permission
-	if mt.Provenance != definitions.Provenance(ngmodels.ProvenanceNone) {
-		user, err := identity.GetRequester(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if err := s.checkProvisioningStatusPermission(ctx, user); err != nil {
-			return nil, err
-		}
-	}
-	out, err := s.service.CreateMuteTiming(ctx, mt, info.OrgID)
+	out, err := s.service.CreateMuteTiming(ctx, model, info.OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -188,28 +159,6 @@ func (s *legacyStorage) Update(ctx context.Context,
 		return nil, false, errors.NewBadRequest("title of cannot be changed. Consider creating a new resource.")
 	}
 
-	oldInterval, ok := old.(*model.TimeInterval)
-	if !ok {
-		return nil, false, fmt.Errorf("expected time-interval but got %s", old.GetObjectKind().GroupVersionKind())
-	}
-	oldProv, err := provenanceFromAnnotation(oldInterval.GetProvenanceStatus())
-	if err != nil {
-		return nil, false, errors.NewBadRequest(err.Error())
-	}
-	// Only gate on permission when provenance is changing. Callers that are not
-	// touching provenance (new == old) do not need SetProvisioningStatus — the
-	// service-level validator (ValidateProvenanceRelaxed) still enforces which
-	// transitions are valid for the resource itself.
-	if interval.Provenance != oldProv {
-		user, err := identity.GetRequester(ctx)
-		if err != nil {
-			return nil, false, err
-		}
-		if err := s.checkProvisioningStatusPermission(ctx, user); err != nil {
-			return nil, false, err
-		}
-	}
-
 	updated, err := s.service.UpdateMuteTiming(ctx, interval, info.OrgID)
 	if err != nil {
 		return nil, false, err
@@ -243,23 +192,8 @@ func (s *legacyStorage) Delete(ctx context.Context, uid string, deleteValidation
 		return nil, false, fmt.Errorf("expected time-interval but got %s", old.GetObjectKind().GroupVersionKind())
 	}
 
-	storedProv, err := provenanceFromAnnotation(p.GetProvenanceStatus())
-	if err != nil {
-		return nil, false, errors.NewBadRequest(err.Error())
-	}
-	// Prevent deletion of provisioned resources by callers without explicit permission.
-	if storedProv != definitions.Provenance(ngmodels.ProvenanceNone) {
-		user, err := identity.GetRequester(ctx)
-		if err != nil {
-			return nil, false, err
-		}
-		if err := s.checkProvisioningStatusPermission(ctx, user); err != nil {
-			return nil, false, err
-		}
-	}
-
-	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, storedProv, version) // TODO add support for dry-run option
-	return old, false, err                                                         // false - will be deleted async
+	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, definitions.Provenance(p.GetProvenanceStatus()), version) // TODO add support for dry-run option
+	return old, false, err                                                                                              // false - will be deleted async
 }
 
 func (s *legacyStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *internalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
@@ -14,6 +14,7 @@ import (
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 var (
@@ -192,8 +193,12 @@ func (s *legacyStorage) Delete(ctx context.Context, uid string, deleteValidation
 		return nil, false, fmt.Errorf("expected time-interval but got %s", old.GetObjectKind().GroupVersionKind())
 	}
 
-	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, definitions.Provenance(p.GetProvenanceStatus()), version) // TODO add support for dry-run option
-	return old, false, err                                                                                              // false - will be deleted async
+	prov, err := ngmodels.ProvenanceFromString(p.GetProvenanceStatus())
+	if err != nil {
+		return nil, false, errors.NewBadRequest(err.Error())
+	}
+	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, definitions.Provenance(prov), version) // TODO add support for dry-run option
+	return old, false, err                                                                           // false - will be deleted async
 }
 
 func (s *legacyStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *internalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
@@ -11,15 +11,15 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-var (
-	_ grafanarest.Storage = (*legacyStorage)(nil)
-)
+var _ grafanarest.Storage = (*legacyStorage)(nil)
 
 type TimeIntervalService interface {
 	GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error)
@@ -32,6 +32,24 @@ type legacyStorage struct {
 	service        TimeIntervalService
 	namespacer     request.NamespaceMapper
 	tableConverter rest.TableConvertor
+	ac             accesscontrol.AccessControl
+}
+
+// checkProvisioningStatusPermission verifies the caller holds
+// alert.provisioning.provenance:write. This is required whenever a write
+// involves a non-None provenance — either because the resource is already
+// provisioned (old provenance != None) or because the caller is explicitly
+// claiming provenance ownership (new provenance != None).
+func (s *legacyStorage) checkProvisioningStatusPermission(ctx context.Context, user identity.Requester) error {
+	ok, err := s.ac.Evaluate(ctx, user, accesscontrol.EvalPermission(accesscontrol.ActionAlertingProvisioningSetStatus))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.NewForbidden(ResourceInfo.GroupResource(), "",
+			fmt.Errorf("missing permission: %s", accesscontrol.ActionAlertingProvisioningSetStatus))
+	}
+	return nil
 }
 
 func (s *legacyStorage) New() runtime.Object {
@@ -110,11 +128,22 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if p.Name != "" { // TODO remove when metadata.name can be defined by user
 		return nil, errors.NewBadRequest("object's metadata.name should be empty")
 	}
-	model, err := convertToDomainModel(p)
+	mt, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.service.CreateMuteTiming(ctx, model, info.OrgID)
+	// Provenance is opt-in: callers must explicitly set grafana.com/provenance: api
+	// to claim ownership. If set, require SetProvisioningStatus permission
+	if mt.Provenance != definitions.Provenance(ngmodels.ProvenanceNone) {
+		user, err := identity.GetRequester(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.checkProvisioningStatusPermission(ctx, user); err != nil {
+			return nil, err
+		}
+	}
+	out, err := s.service.CreateMuteTiming(ctx, mt, info.OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +189,28 @@ func (s *legacyStorage) Update(ctx context.Context,
 		return nil, false, errors.NewBadRequest("title of cannot be changed. Consider creating a new resource.")
 	}
 
+	oldInterval, ok := old.(*model.TimeInterval)
+	if !ok {
+		return nil, false, fmt.Errorf("expected time-interval but got %s", old.GetObjectKind().GroupVersionKind())
+	}
+	oldProv, err := provenanceFromAnnotation(oldInterval.GetProvenanceStatus())
+	if err != nil {
+		return nil, false, errors.NewBadRequest(err.Error())
+	}
+	// Gate on either side being non-None:
+	//   old != None — resource is already provisioned; protect it from unintentional overwrites.
+	//   new != None — caller is (re-)claiming provenance ownership; requires explicit permission.
+	// If both are None the resource is unprovisioned and freely editable by all callers.
+	if interval.Provenance != definitions.Provenance(ngmodels.ProvenanceNone) || oldProv != definitions.Provenance(ngmodels.ProvenanceNone) {
+		user, err := identity.GetRequester(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := s.checkProvisioningStatusPermission(ctx, user); err != nil {
+			return nil, false, err
+		}
+	}
+
 	updated, err := s.service.UpdateMuteTiming(ctx, interval, info.OrgID)
 	if err != nil {
 		return nil, false, err
@@ -193,8 +244,23 @@ func (s *legacyStorage) Delete(ctx context.Context, uid string, deleteValidation
 		return nil, false, fmt.Errorf("expected time-interval but got %s", old.GetObjectKind().GroupVersionKind())
 	}
 
-	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, definitions.Provenance(ngmodels.ProvenanceNone), version) // TODO add support for dry-run option
-	return old, false, err                                                                                              // false - will be deleted async
+	storedProv, err := provenanceFromAnnotation(p.GetProvenanceStatus())
+	if err != nil {
+		return nil, false, errors.NewBadRequest(err.Error())
+	}
+	// Prevent deletion of provisioned resources by callers without explicit permission.
+	if storedProv != definitions.Provenance(ngmodels.ProvenanceNone) {
+		user, err := identity.GetRequester(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := s.checkProvisioningStatusPermission(ctx, user); err != nil {
+			return nil, false, err
+		}
+	}
+
+	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, storedProv, version) // TODO add support for dry-run option
+	return old, false, err                                                         // false - will be deleted async
 }
 
 func (s *legacyStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *internalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/registry/apps/alerting/notifications/timeinterval/storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/storage.go
@@ -2,19 +2,16 @@ package timeinterval
 
 import (
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 )
 
 func NewStorage(
 	legacySvc TimeIntervalService,
 	namespacer request.NamespaceMapper,
-	ac accesscontrol.AccessControl,
 ) grafanarest.Storage {
 	return &legacyStorage{
 		service:        legacySvc,
 		namespacer:     namespacer,
 		tableConverter: ResourceInfo.TableConverter(),
-		ac:             ac,
 	}
 }

--- a/pkg/registry/apps/alerting/notifications/timeinterval/storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/storage.go
@@ -2,16 +2,19 @@ package timeinterval
 
 import (
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 )
 
 func NewStorage(
 	legacySvc TimeIntervalService,
 	namespacer request.NamespaceMapper,
+	ac accesscontrol.AccessControl,
 ) grafanarest.Storage {
 	return &legacyStorage{
 		service:        legacySvc,
 		namespacer:     namespacer,
 		tableConverter: ResourceInfo.TableConverter(),
+		ac:             ac,
 	}
 }

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"fmt"
+	"slices"
+)
+
 type Provenance string
 
 const (
@@ -10,14 +15,30 @@ const (
 	ProvenanceFile Provenance = "file"
 	// ProvenanceConvertedPrometheus is used for objects converted from Prometheus definitions.
 	ProvenanceConvertedPrometheus Provenance = "converted_prometheus"
+
+	// k8sProvenanceNone is the textual representation of ProvenanceNone used in Kubernetes annotations.
+	// https://github.com/grafana/grafana/blob/main/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/ext.go#L5-L5
+	k8sProvenanceNone = "none"
 )
 
-var (
-	KnownProvenances = []Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile, ProvenanceConvertedPrometheus}
-)
+var KnownProvenances = []Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile, ProvenanceConvertedPrometheus}
 
 // Provisionable represents a resource that can be created through a provisioning mechanism, such as Terraform or config file.
 type Provisionable interface {
 	ResourceType() string
 	ResourceID() string
+}
+
+// ProvenanceFromString converts a string to a Provenance type, validating that it is one of the known provenances.
+func ProvenanceFromString(s string) (Provenance, error) {
+	if s == k8sProvenanceNone {
+		return ProvenanceNone, nil
+	}
+
+	p := Provenance(s)
+	if !slices.Contains(KnownProvenances, p) {
+		return Provenance(""), fmt.Errorf("invalid provenance status: %s", s)
+	}
+
+	return p, nil
 }

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -25,7 +25,7 @@ type MuteTimingService struct {
 	provenanceStore        ProvisioningStore
 	xact                   TransactionManager
 	log                    log.Logger
-	validator              validation.ProvenanceStatusTransitionValidator
+	validator              validation.ContextualProvenanceValidator
 	ruleNotificationsStore AlertRuleNotificationSettingsStore
 	routeService           timeIntervalRouteRefService
 	includeImported        bool
@@ -44,11 +44,13 @@ func NewMuteTimingService(
 	routeService timeIntervalRouteRefService,
 ) *MuteTimingService {
 	return &MuteTimingService{
-		configStore:            config,
-		provenanceStore:        prov,
-		xact:                   xact,
-		log:                    log,
-		validator:              validation.ValidateProvenanceRelaxed,
+		configStore:     config,
+		provenanceStore: prov,
+		xact:            xact,
+		log:             log,
+		validator: func(_ context.Context, from, to models.Provenance) error {
+			return validation.ValidateProvenanceRelaxed(from, to)
+		},
 		ruleNotificationsStore: ns,
 		routeService:           routeService,
 		includeImported:        false,
@@ -68,7 +70,7 @@ func (svc *MuteTimingService) WithIncludeImported() *MuteTimingService {
 	}
 }
 
-func (svc *MuteTimingService) WithProvenanceValidator(v validation.ProvenanceStatusTransitionValidator) *MuteTimingService {
+func (svc *MuteTimingService) WithProvenanceValidator(v validation.ContextualProvenanceValidator) *MuteTimingService {
 	return &MuteTimingService{
 		configStore:            svc.configStore,
 		provenanceStore:        svc.provenanceStore,
@@ -242,7 +244,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 	}
 
 	// check that provenance is not changed in an invalid way
-	if err := svc.validator(models.Provenance(existing.Provenance), models.Provenance(mt.Provenance)); err != nil {
+	if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(mt.Provenance)); err != nil {
 		return definitions.MuteTimeInterval{}, err
 	}
 
@@ -306,7 +308,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID st
 	existingInterval := existing.MuteTimeInterval
 	target := definitions.MuteTimeInterval{MuteTimeInterval: existingInterval, Provenance: provenance}
 
-	if err := svc.validator(models.Provenance(existing.Provenance), models.Provenance(provenance)); err != nil {
+	if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(provenance)); err != nil {
 		return err
 	}
 

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -68,6 +68,19 @@ func (svc *MuteTimingService) WithIncludeImported() *MuteTimingService {
 	}
 }
 
+func (svc *MuteTimingService) WithProvenanceValidator(v validation.ProvenanceStatusTransitionValidator) *MuteTimingService {
+	return &MuteTimingService{
+		configStore:            svc.configStore,
+		provenanceStore:        svc.provenanceStore,
+		xact:                   svc.xact,
+		log:                    svc.log,
+		validator:              v,
+		ruleNotificationsStore: svc.ruleNotificationsStore,
+		routeService:           svc.routeService,
+		includeImported:        svc.includeImported,
+	}
+}
+
 // GetMuteTimings returns a slice of all mute timings within the specified org.
 func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error) {
 	rev, err := svc.configStore.Get(ctx, orgID)

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -625,7 +625,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
 		expectedErr := errors.New("test")
-		sut.validator = func(from, to models.Provenance) error {
+		sut.validator = func(_ context.Context, from, to models.Provenance) error {
 			return expectedErr
 		}
 		timing := definitions.MuteTimeInterval{
@@ -645,7 +645,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
 		}
-		sut.validator = func(from, to models.Provenance) error {
+		sut.validator = func(_ context.Context, from, to models.Provenance) error {
 			return nil
 		}
 		timing := definitions.MuteTimeInterval{
@@ -1123,7 +1123,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 	t.Run("fails if provenance check fails", func(t *testing.T) {
 		sut, store, prov := createMuteTimingSvcSut()
 		expectedErr := errors.New("test")
-		sut.validator = func(from, to models.Provenance) error {
+		sut.validator = func(_ context.Context, from, to models.Provenance) error {
 			return expectedErr
 		}
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
@@ -1403,7 +1403,7 @@ func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerC
 		provenanceStore: prov,
 		xact:            newNopTransactionManager(),
 		log:             log.NewNopLogger(),
-		validator: func(from, to models.Provenance) error {
+		validator: func(_ context.Context, from, to models.Provenance) error {
 			return nil
 		},
 		ruleNotificationsStore: &fakeAlertRuleNotificationStore{},

--- a/pkg/services/ngalert/provisioning/validation/provenance.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance.go
@@ -1,6 +1,10 @@
 package validation
 
 import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -28,6 +32,33 @@ func CanUpdateProvenanceInRuleGroup(storedProvenance, provenance models.Provenan
 
 type ProvenanceStatusTransitionValidator = func(from, to models.Provenance) error
 
+// ContextualProvenanceValidator is like ProvenanceStatusTransitionValidator but
+// receives ctx so it can check caller permissions.
+type ContextualProvenanceValidator = func(ctx context.Context, from, to models.Provenance) error
+
+// NewPermissionAwareValidator returns a ContextualProvenanceValidator that allows any
+// provenance transition when the caller holds ActionAlertingProvisioningSetStatus,
+// and blocks any transition where from != to otherwise.
+func NewPermissionAwareValidator(ac accesscontrol.AccessControl) ContextualProvenanceValidator {
+	return func(ctx context.Context, from, to models.Provenance) error {
+		if from == to {
+			return nil
+		}
+		user, err := identity.GetRequester(ctx)
+		if err != nil {
+			return err
+		}
+		ok, err := ac.Evaluate(ctx, user, accesscontrol.EvalPermission(accesscontrol.ActionAlertingProvisioningSetStatus))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return MakeErrProvenanceChangeNotAllowed(from, to)
+		}
+		return nil
+	}
+}
+
 // ValidateProvenanceRelaxed checks if the transition of provenance status from `from` to `to` is allowed.
 // Applies relaxed checks that prevents only transition from any status to `none`.
 // Returns ErrProvenanceChangeNotAllowed if transition is not allowed
@@ -38,13 +69,6 @@ func ValidateProvenanceRelaxed(from, to models.Provenance) error {
 	if to == models.ProvenanceNone { // allow any transition to none unless it's from "none" either
 		return MakeErrProvenanceChangeNotAllowed(from, to)
 	}
-	return nil
-}
-
-// ValidateProvenancePermissive allows any provenance transition. Use this when the caller has already
-// verified that the user holds the SetProvisioningStatus permission and should be free to set or
-// reset provenance (e.g. via the k8s API which enforces its own permission check).
-func ValidateProvenancePermissive(_, _ models.Provenance) error {
 	return nil
 }
 

--- a/pkg/services/ngalert/provisioning/validation/provenance.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance.go
@@ -41,6 +41,13 @@ func ValidateProvenanceRelaxed(from, to models.Provenance) error {
 	return nil
 }
 
+// ValidateProvenancePermissive allows any provenance transition. Use this when the caller has already
+// verified that the user holds the SetProvisioningStatus permission and should be free to set or
+// reset provenance (e.g. via the k8s API which enforces its own permission check).
+func ValidateProvenancePermissive(_, _ models.Provenance) error {
+	return nil
+}
+
 // ValidateProvenanceOfDependentResources returns a list of allowed provenance statuses for dependent resources
 // in the case when they need to be updated when the resource they depend on is changed.
 func ValidateProvenanceOfDependentResources(parentProvenance models.Provenance) func(childProvenance models.Provenance) bool {

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -197,7 +197,7 @@ func TestIntegrationTimeIntervalAccessControl(t *testing.T) {
 		t.Run(fmt.Sprintf("user '%s'", tc.user.Identity.GetLogin()), func(t *testing.T) {
 			client, err := v1beta1.NewTimeIntervalClientFromGenerator(tc.user.GetClientRegistry())
 			require.NoError(t, err)
-			var expected = &v1beta1.TimeInterval{
+			expected := &v1beta1.TimeInterval{
 				ObjectMeta: v1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -393,16 +393,12 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, string(ngmodels.ProvenanceAPI), got.GetProvenanceStatus())
 	})
+
 	t.Run("should not let update if provisioned without set-status permission", func(t *testing.T) {
 		updated := created.Copy().(*v1beta1.TimeInterval)
 		updated.Spec.TimeIntervals = fakes.IntervalGenerator{}.GenerateMany(2)
 
 		_, err := writerClient.Update(ctx, updated, resource.UpdateOptions{})
-		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
-	})
-
-	t.Run("should not let delete if provisioned without set-status permission", func(t *testing.T) {
-		err := writerClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 
@@ -415,8 +411,8 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("should let delete if provisioned with set-status permission", func(t *testing.T) {
-		err := adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+	t.Run("should let delete without set-status permission", func(t *testing.T) {
+		err := writerClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -347,7 +347,6 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	admin := helper.Org1.Admin
 	adminClient, err := v1beta1.NewTimeIntervalClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
 	require.NoError(t, err)
 
@@ -365,11 +364,6 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 	writerClient, err := v1beta1.NewTimeIntervalClientFromGenerator(writer.GetClientRegistry())
 	require.NoError(t, err)
 
-	env := helper.GetEnv()
-	ac := acimpl.ProvideAccessControl(env.FeatureToggles)
-	db, err := store.ProvideDBStore(env.Cfg, env.FeatureToggles, env.SQLStore, &foldertest.FakeService{}, &dashboards.FakeDashboardService{}, ac, bus.ProvideBus(tracing.InitializeTracerForTest()))
-	require.NoError(t, err)
-
 	created, err := adminClient.Create(ctx, &v1beta1.TimeInterval{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: "default",
@@ -382,36 +376,41 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "none", created.GetProvenanceStatus())
 
-	t.Run("should provide provenance status", func(t *testing.T) {
-		require.NoError(t, db.SetProvenance(ctx, &definitions.MuteTimeInterval{
-			MuteTimeInterval: config.MuteTimeInterval{
-				Name: created.Spec.Name,
-			},
-		}, admin.Identity.GetOrgID(), ngmodels.ProvenanceAPI))
-
-		got, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
-		require.NoError(t, err)
-		require.Equal(t, string(ngmodels.ProvenanceAPI), got.GetProvenanceStatus())
-	})
-
-	t.Run("should not let update if provisioned without set-status permission", func(t *testing.T) {
+	t.Run("should not let update provenance if provisioned without set-status permission", func(t *testing.T) {
 		updated := created.Copy().(*v1beta1.TimeInterval)
-		updated.Spec.TimeIntervals = fakes.IntervalGenerator{}.GenerateMany(2)
+		updated.SetProvenanceStatus(string(ngmodels.ProvenanceAPI))
 
 		_, err := writerClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 
-	t.Run("should let update if provisioned with set-status permission", func(t *testing.T) {
+	t.Run("should let update provenance if provisioned with set-status permission", func(t *testing.T) {
 		updated := created.Copy().(*v1beta1.TimeInterval)
-		updated.Spec.TimeIntervals = fakes.IntervalGenerator{}.GenerateMany(2)
 		updated.SetProvenanceStatus(string(ngmodels.ProvenanceAPI))
 
-		_, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
+		got, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
+		require.NoError(t, err)
+		require.Equal(t, string(ngmodels.ProvenanceAPI), got.GetProvenanceStatus())
+	})
+
+	t.Run("should let update spec if provisioned without set-status permission", func(t *testing.T) {
+		updated := created.Copy().(*v1beta1.TimeInterval)
+		updated.SetProvenanceStatus(string(ngmodels.ProvenanceAPI))
+		updated.Spec.TimeIntervals = fakes.IntervalGenerator{}.GenerateMany(2)
+
+		_, err := writerClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.NoError(t, err)
 	})
 
-	t.Run("should let delete without set-status permission", func(t *testing.T) {
+	t.Run("should not let update provenance if provisioned without set-status permission", func(t *testing.T) {
+		updated := created.Copy().(*v1beta1.TimeInterval)
+		updated.SetProvenanceStatus(string(ngmodels.ProvenanceNone))
+
+		_, err := writerClient.Update(ctx, updated, resource.UpdateOptions{})
+		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
+	})
+
+	t.Run("should let delete if provisioned without set-status permission", func(t *testing.T) {
 		err := writerClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.NoError(t, err)
 	})

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -347,10 +347,22 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 	ctx := context.Background()
 	helper := getTestHelper(t)
 
-	org := helper.Org1
-
-	admin := org.Admin
+	admin := helper.Org1.Admin
 	adminClient, err := v1beta1.NewTimeIntervalClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+
+	// A user with write permissions but without alert.provisioning.provenance:write.
+	// Used to verify that provisioned resources are protected from callers that lack the permission.
+	writer := helper.CreateUser("IntervalsWriter", apis.Org1, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions: []string{
+				accesscontrol.ActionAlertingNotificationsTimeIntervalsRead,
+				accesscontrol.ActionAlertingNotificationsTimeIntervalsWrite,
+				accesscontrol.ActionAlertingNotificationsTimeIntervalsDelete,
+			},
+		},
+	})
+	writerClient, err := v1beta1.NewTimeIntervalClientFromGenerator(writer.GetClientRegistry())
 	require.NoError(t, err)
 
 	env := helper.GetEnv()
@@ -375,23 +387,37 @@ func TestIntegrationTimeIntervalProvisioning(t *testing.T) {
 			MuteTimeInterval: config.MuteTimeInterval{
 				Name: created.Spec.Name,
 			},
-		}, admin.Identity.GetOrgID(), "API"))
+		}, admin.Identity.GetOrgID(), ngmodels.ProvenanceAPI))
 
 		got, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
 		require.NoError(t, err)
-		require.Equal(t, "API", got.GetProvenanceStatus())
+		require.Equal(t, string(ngmodels.ProvenanceAPI), got.GetProvenanceStatus())
 	})
-	t.Run("should not let update if provisioned", func(t *testing.T) {
+	t.Run("should not let update if provisioned without set-status permission", func(t *testing.T) {
 		updated := created.Copy().(*v1beta1.TimeInterval)
 		updated.Spec.TimeIntervals = fakes.IntervalGenerator{}.GenerateMany(2)
 
-		_, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
+		_, err := writerClient.Update(ctx, updated, resource.UpdateOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
 	})
 
-	t.Run("should not let delete if provisioned", func(t *testing.T) {
-		err := adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+	t.Run("should not let delete if provisioned without set-status permission", func(t *testing.T) {
+		err := writerClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
 		require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
+	})
+
+	t.Run("should let update if provisioned with set-status permission", func(t *testing.T) {
+		updated := created.Copy().(*v1beta1.TimeInterval)
+		updated.Spec.TimeIntervals = fakes.IntervalGenerator{}.GenerateMany(2)
+		updated.SetProvenanceStatus(string(ngmodels.ProvenanceAPI))
+
+		_, err := adminClient.Update(ctx, updated, resource.UpdateOptions{})
+		require.NoError(t, err)
+	})
+
+	t.Run("should let delete if provisioned with set-status permission", func(t *testing.T) {
+		err := adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## What

Adds provenance support to the Kubernetes-style `TimeInterval` alerting notification API. Previously, all writes through this API hardcoded `ProvenanceNone`, meaning provisioned resources had no protection against accidental overwrites.

## How

**Opt-in model** _ callers explicitly set `grafana.com/provenance: api` to declare a resource as externally managed. If the annotation is absent or `"none"`, the resource is stored with `ProvenanceNone` and remains freely editable by all callers, including the Grafana UI.

This is a deliberate contrast with the HTTP provisioning API (`/api/v1/provisioning/...`), which is opt-out (sets provenance on every write unless `X-Disable-Provenance` is sent). Opt-in allows us to push this without breaking existing clients (e.g. UI).

**Internal provenance value** _ k8s API writes with `grafana.com/provenance: api` store `ProvenanceAPI` (`"api"`) in the DB, the same value used by the HTTP provisioning API. The two write paths are intentionally indistinguishable at the provenance level.

**Permission gate** _ `alert.provisioning.provenance:write` is required whenever a write touches a provisioned resource, regardless of whether provenance itself is changing:

- **Create**: new provenance != `none` _ caller is claiming ownership
- **Update**: old _or_ new provenance != `none` _ either the resource is already provisioned (protect it from content changes even if the caller echoes back the same provenance), or the caller is trying to claim ownership
- **Delete**: stored provenance != `none` _ resource is provisioned

Callers that hold the permission and consistently send `grafana.com/provenance: api` (e.g. Terraform) can freely create, update, and delete their own resources - `ValidateProvenanceRelaxed` allows same-provenance transitions.

## Scope

This PR covers `TimeInterval` only. The same pattern will be extended to the remaining 4 notification resource types (templates, contact points, notification policies, inhibition rules) in follow-up PRs.