### PR TITLE
Provisioning: make metadata missing/corrupted warnings not block folders check/cleanups

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -82,6 +82,17 @@ func isWarningError(err error) bool {
 	return ok
 }
 
+// isNonFailingWarning reports whether the warning represents an informational
+// issue where the underlying resource operation still succeeded (e.g. missing
+// or invalid folder metadata).
+func isNonFailingWarning(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, resources.ErrMissingFolderMetadata) ||
+		errors.Is(err, resources.ErrInvalidFolderMetadata)
+}
+
 // JobResourceResult represents the result of a resource operation in a job.
 type JobResourceResult struct {
 	name         string

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -382,3 +382,29 @@ func TestJobResourceResult_WarningReason(t *testing.T) {
 		assert.Equal(t, provisioning.ReasonFolderMetadataConflict, result.WarningReason())
 	})
 }
+
+func TestIsNonFailingWarning(t *testing.T) {
+	t.Run("nil is not a non-failing warning", func(t *testing.T) {
+		assert.False(t, isNonFailingWarning(nil))
+	})
+
+	t.Run("MissingFolderMetadata is a non-failing warning", func(t *testing.T) {
+		assert.True(t, isNonFailingWarning(resources.NewMissingFolderMetadata("folder/")))
+	})
+
+	t.Run("InvalidFolderMetadata is a non-failing warning", func(t *testing.T) {
+		assert.True(t, isNonFailingWarning(resources.NewInvalidFolderMetadata("folder/", errors.New("bad json"))))
+	})
+
+	t.Run("FolderMetadataConflict is not a non-failing warning", func(t *testing.T) {
+		assert.False(t, isNonFailingWarning(&resources.FolderMetadataConflict{Path: "folder/", Reason: "UID mismatch"}))
+	})
+
+	t.Run("ResourceValidationError is not a non-failing warning", func(t *testing.T) {
+		assert.False(t, isNonFailingWarning(resources.NewResourceValidationError(errors.New("invalid"))))
+	})
+
+	t.Run("generic error is not a non-failing warning", func(t *testing.T) {
+		assert.False(t, isNonFailingWarning(errors.New("something went wrong")))
+	})
+}

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -121,13 +121,17 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 	} else if result.Warning() != nil {
 		// Track failed deletions/updates/renames with warnings — these still represent
 		// operations that did not fully succeed and may block parent folder removal.
-		if result.Action() == repository.FileActionDeleted {
-			r.failedDeletions = append(r.failedDeletions, result.Path())
-		}
-		if result.Action() == repository.FileActionUpdated || result.Action() == repository.FileActionRenamed {
-			r.failedUpdates = append(r.failedUpdates, result.Path())
-			if result.Action() == repository.FileActionRenamed && result.PreviousPath() != "" {
-				r.failedUpdates = append(r.failedUpdates, result.PreviousPath())
+		// Non-failing warnings (e.g. missing/invalid folder metadata) are excluded
+		// because the underlying resource operation succeeded.
+		if !isNonFailingWarning(result.Warning()) {
+			if result.Action() == repository.FileActionDeleted {
+				r.failedDeletions = append(r.failedDeletions, result.Path())
+			}
+			if result.Action() == repository.FileActionUpdated || result.Action() == repository.FileActionRenamed {
+				r.failedUpdates = append(r.failedUpdates, result.Path())
+				if result.Action() == repository.FileActionRenamed && result.PreviousPath() != "" {
+					r.failedUpdates = append(r.failedUpdates, result.PreviousPath())
+				}
 			}
 		}
 

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -591,8 +591,7 @@ func TestJobProgressRecorderHasChildPathFailedUpdate(t *testing.T) {
 	assert.False(t, recorder.HasChildPathFailedUpdate("created/"), "creation failures are not tracked as update failures")
 
 	// Warning-level update failures ARE tracked (e.g. validation errors routed
-	// to warning via isWarningError). detectMissingFolderMetadata now runs after
-	// deleteFolders, so its benign warnings don't interfere with cleanup.
+	// to warning via isWarningError).
 	validationErr := resources.NewResourceValidationError(errors.New("invalid content"))
 	recorder.Record(ctx, NewResourceResult().
 		WithPath("warned/dash.json").
@@ -607,6 +606,22 @@ func TestJobProgressRecorderHasChildPathFailedUpdate(t *testing.T) {
 		WithWarning(errors.New("ownership conflict")).
 		Build())
 	assert.True(t, recorder.HasChildPathFailedUpdate("explicit-warn/"), "explicit WithWarning updates must be tracked")
+
+	// Non-failing warnings (missing/invalid folder metadata) are NOT tracked
+	// because the underlying folder operation succeeded.
+	recorder.Record(ctx, NewResourceResult().
+		WithPath("missing-meta/").
+		WithAction(repository.FileActionUpdated).
+		WithWarning(resources.NewMissingFolderMetadata("missing-meta/")).
+		Build())
+	assert.False(t, recorder.HasChildPathFailedUpdate("missing-meta/"), "missing folder metadata warnings must not be tracked as failed updates")
+
+	recorder.Record(ctx, NewResourceResult().
+		WithPath("invalid-meta/").
+		WithAction(repository.FileActionUpdated).
+		WithWarning(resources.NewInvalidFolderMetadata("invalid-meta/", errors.New("bad json"))).
+		Build())
+	assert.False(t, recorder.HasChildPathFailedUpdate("invalid-meta/"), "invalid folder metadata warnings must not be tracked as failed updates")
 
 	// Failed renames are tracked as update failures — a rename moves a child,
 	// so if it fails the child stays under the old folder.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Missing or corrupted metadata is marking folders as failed update, which may block future checks and cleanup operations in such folders. This PR treats these warnings as non-blocking the folder operation as the folder will still get updated in such cases.

**Why do we need this feature?**

The only reason this bug is not blocking folder deletion is the order in which we are detecting missing metadata (after the cleanup for incremental pulls). That is brittle as future changes (or other checks for updated folder problems) will experience false positive due to missing metadata situations.

**Who is this feature for?**

Provisioning feature.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1024

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x  ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
