### PR TITLE
Pyroscope: Improve the alignment between the call tree and the flame …

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.tsx
@@ -312,7 +312,6 @@ const getStylesNew = (theme: GrafanaTheme2) => ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: theme.spacing(1),
   }),
   controls: css({
     label: 'controls',


### PR DESCRIPTION
A minor improvement to the alignment between the call tree table and the flame graph, when there are pills visible (focus or sandwich mode).

Context: https://github.com/grafana/profiles-drilldown/pull/862#pullrequestreview-3997228323

I opted to remove the bottom margin for the flame graph header, as I don't see a good reason to have it. Alternatively we could apply the margin to the call tree header if that looks better.

Before

<img width="2199" height="742" alt="Screenshot 2026-03-25 at 09 54 15" src="https://github.com/user-attachments/assets/dc3b706e-8cae-44bf-9265-3c5bcaff80f5" />

---

After

<img width="2209" height="806" alt="Screenshot 2026-03-25 at 09 50 49" src="https://github.com/user-attachments/assets/48ce7243-3955-4523-abce-e2a39fbf4575" />

