### PR TITLE
Provisioning: authorize fix metadata job based ref write permissions

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -233,6 +233,10 @@ func (c *jobsConnector) validateWriteAccess(cfg *provisioning.Repository, spec p
 		if spec.Push != nil {
 			targetRef = spec.Push.Branch
 		}
+	case provisioning.JobActionFixFolderMetadata:
+		if spec.FixFolderMetadata != nil {
+			targetRef = spec.FixFolderMetadata.Ref
+		}
 	case provisioning.JobActionMigrate:
 		// no ref needed
 	default:

--- a/pkg/registry/apis/provisioning/jobs_test.go
+++ b/pkg/registry/apis/provisioning/jobs_test.go
@@ -107,6 +107,106 @@ func TestFixFolderMetadataFeatureGate(t *testing.T) {
 	})
 }
 
+func TestValidateWriteAccess_FixFolderMetadata(t *testing.T) {
+	c := &jobsConnector{}
+
+	t.Run("allowed with write workflow and no ref", func(t *testing.T) {
+		cfg := &provisioning.Repository{
+			Spec: provisioning.RepositorySpec{
+				Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+			},
+		}
+		spec := provisioning.JobSpec{
+			Action:            provisioning.JobActionFixFolderMetadata,
+			FixFolderMetadata: &provisioning.FixFolderMetadataJobOptions{},
+		}
+		err := c.validateWriteAccess(cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("allowed with branch workflow and feature branch ref", func(t *testing.T) {
+		cfg := &provisioning.Repository{
+			Spec: provisioning.RepositorySpec{
+				Type:      provisioning.GitHubRepositoryType,
+				Workflows: []provisioning.Workflow{provisioning.BranchWorkflow},
+				GitHub:    &provisioning.GitHubRepositoryConfig{Branch: "main"},
+			},
+		}
+		spec := provisioning.JobSpec{
+			Action: provisioning.JobActionFixFolderMetadata,
+			FixFolderMetadata: &provisioning.FixFolderMetadataJobOptions{
+				Ref: "add-folder-metadata",
+			},
+		}
+		err := c.validateWriteAccess(cfg, spec)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejected with branch-only workflow and no ref", func(t *testing.T) {
+		cfg := &provisioning.Repository{
+			Spec: provisioning.RepositorySpec{
+				Type:      provisioning.GitHubRepositoryType,
+				Workflows: []provisioning.Workflow{provisioning.BranchWorkflow},
+				GitHub:    &provisioning.GitHubRepositoryConfig{Branch: "main"},
+			},
+		}
+		spec := provisioning.JobSpec{
+			Action:            provisioning.JobActionFixFolderMetadata,
+			FixFolderMetadata: &provisioning.FixFolderMetadataJobOptions{},
+		}
+		err := c.validateWriteAccess(cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("rejected with no workflows", func(t *testing.T) {
+		cfg := &provisioning.Repository{
+			Spec: provisioning.RepositorySpec{
+				Workflows: []provisioning.Workflow{},
+			},
+		}
+		spec := provisioning.JobSpec{
+			Action:            provisioning.JobActionFixFolderMetadata,
+			FixFolderMetadata: &provisioning.FixFolderMetadataJobOptions{},
+		}
+		err := c.validateWriteAccess(cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("rejected with branch-only workflow and ref matching configured branch", func(t *testing.T) {
+		cfg := &provisioning.Repository{
+			Spec: provisioning.RepositorySpec{
+				Type:      provisioning.GitHubRepositoryType,
+				Workflows: []provisioning.Workflow{provisioning.BranchWorkflow},
+				GitHub:    &provisioning.GitHubRepositoryConfig{Branch: "main"},
+			},
+		}
+		spec := provisioning.JobSpec{
+			Action: provisioning.JobActionFixFolderMetadata,
+			FixFolderMetadata: &provisioning.FixFolderMetadataJobOptions{
+				Ref: "main",
+			},
+		}
+		err := c.validateWriteAccess(cfg, spec)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err))
+	})
+
+	t.Run("nil options treated as empty ref", func(t *testing.T) {
+		cfg := &provisioning.Repository{
+			Spec: provisioning.RepositorySpec{
+				Workflows: []provisioning.Workflow{provisioning.WriteWorkflow},
+			},
+		}
+		spec := provisioning.JobSpec{
+			Action: provisioning.JobActionFixFolderMetadata,
+		}
+		err := c.validateWriteAccess(cfg, spec)
+		require.NoError(t, err)
+	})
+}
+
 func TestAuthorizeResourceJob(t *testing.T) {
 	ctx := context.Background()
 	cfg := newTestRepo("my-repo", "default")

--- a/pkg/tests/apis/provisioning/git/foldermetadata_fix/fixfoldermetadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_fix/fixfoldermetadata_test.go
@@ -153,6 +153,45 @@ func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch(t *testing.T) {
 	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
 }
 
+// TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch_WithRef verifies
+// that when the repository only has the "branch" workflow (default branch is
+// read-only), the fix-folder-metadata job succeeds if a Ref targeting a feature
+// branch is provided. The _folder.json files are committed to the feature
+// branch and the default branch stays untouched.
+func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch_WithRef(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+	ctx := context.Background()
+
+	const repoName = "fix-meta-readonly-branch"
+	const featureBranch = "fix-folders"
+
+	helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"parent/child/dashboard.json": gitcommon.DashboardJSON("git-ro-branch-dash", "Git ReadOnly Branch Dashboard", 1),
+	}, "branch")
+
+	job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+		Action: provisioning.JobActionFixFolderMetadata,
+		FixFolderMetadata: &provisioning.FixFolderMetadataJobOptions{
+			Ref: featureBranch,
+		},
+	})
+
+	state, _, _ := unstructured.NestedString(job.Object, "status", "state")
+	require.Equal(t, string(provisioning.JobStateSuccess), state,
+		"fix-folder-metadata job on branch %q should succeed even when the default branch is read-only", featureBranch)
+
+	parentUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/_folder.json", featureBranch)
+	childUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/child/_folder.json", featureBranch)
+
+	require.NotEqual(t, parentUID, childUID,
+		"parent and child folders should have different UIDs")
+
+	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
+}
+
 // requireFolderMetadataOnRef reads the _folder.json at filePath from the given
 // branch via the repository files API and asserts it is a valid Folder resource.
 // It returns the folder UID so callers can compare across files.

--- a/pkg/tests/apis/provisioning/git/foldermetadata_fix/fixfoldermetadata_test.go
+++ b/pkg/tests/apis/provisioning/git/foldermetadata_fix/fixfoldermetadata_test.go
@@ -112,6 +112,47 @@ func TestIntegrationGit_FixFolderMetadata_ExistingBranch(t *testing.T) {
 	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
 }
 
+// TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch verifies that the
+// fix-folder-metadata job is rejected when the repository only has the "branch"
+// workflow (no "write"). Without a Ref targeting a feature branch, the job
+// would push directly to main, which is not allowed.
+func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := gitcommon.RunGrafanaWithGitServer(t, common.WithProvisioningFolderMetadata)
+	ctx := context.Background()
+
+	const repoName = "fix-meta-readonly-main"
+
+	// Create a repo with only the "branch" workflow — no "write" means the
+	// default branch (main) is read-only and the worker must not push there.
+	helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"parent/child/dashboard.json": gitcommon.DashboardJSON("git-ro-dash", "Git ReadOnly Dashboard", 1),
+	}, "branch")
+
+	// Submitting a fix-folder-metadata job WITHOUT a Ref should be rejected
+	// because the repo does not have the "write" workflow, so targeting the
+	// default branch is forbidden.
+	body := common.AsJSON(provisioning.JobSpec{
+		Action: provisioning.JobActionFixFolderMetadata,
+	})
+	result := helper.AdminREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repoName).
+		SubResource("jobs").
+		Body(body).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+
+	require.True(t, apierrors.IsForbidden(result.Error()),
+		"job targeting the default branch on a read-only repo should be forbidden; got: %v", result.Error())
+
+	// The default branch (main) must remain untouched.
+	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
+}
+
 // requireFolderMetadataOnRef reads the _folder.json at filePath from the given
 // branch via the repository files API and asserts it is a valid Folder resource.
 // It returns the folder UID so callers can compare across files.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix metadata job should not create direct pushes to branches that are not meant to be directly written. This PR adds the job the same auth sequence than the other jobs, getting the same "forbidden" response as other job runs with similar characteristics. This solved the backend part of https://github.com/grafana/git-ui-sync-project/issues/1028

**Why do we need this feature?**

Without it, fix metadata jobs may run against read-only branch (e.g. main branch on a repository configured with branch workflow), which is unintended and undesired behavior.

**Who is this feature for?**

Provisioning feature users, related to folder permissions.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1032

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
