### PR TITLE
E2E: Mark i18n language verification test as slow

### DIFF
--- a/e2e-playwright/various-suite/verify-i18n.spec.ts
+++ b/e2e-playwright/various-suite/verify-i18n.spec.ts
@@ -34,6 +34,7 @@ test.describe(
     // Basic test which loops through the defined languages in the picker
     // and verifies that the corresponding label is translated correctly
     test('loads all the languages correctly', async ({ page, selectors, createUser }) => {
+      test.slow();
       await createUser();
       // login manually for now
       await page.getByTestId(selectors.pages.Login.username).fill(I18N_USER);


### PR DESCRIPTION
**What is this feature?**

Adds `test.slow()` to the i18n language verification e2e test, tripling the default Playwright timeout.

**Why do we need this feature?**

The `verify-i18n` test loops through multiple languages, changing the language preference and verifying the translation each time. This takes longer than the default test timeout allows, causing flaky timeouts in CI.

**Who is this feature for?**

Developers running e2e tests.

**Which issue(s) does this PR fix?**:

Fixes #121078

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.