### PR TITLE
Adhoc: Rename customer-facing ad hoc terminology to Filter

### DIFF
--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -320,7 +320,7 @@ The following data sources support ad hoc filters:
 To create an ad hoc filter, follow these steps:
 
 1. [Enter general options](#enter-general-options).
-1. Under the **Ad-hoc options** section of the page, select a target data source in the **Data source** drop-down list.
+1. Under the **Filter options** section of the page, select a target data source in the **Data source** drop-down list.
 
    You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
    For more information about data sources, refer to [Add a data source](ref:add-a-data-source).

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
@@ -17,8 +17,9 @@ function openAddFilterPane(dashboard: DashboardScene) {
     return;
   }
 
+  const name = 'filter';
   const type = 'adhoc';
-  const newVar = getVariableScene(type, { name: getNextAvailableId(type, variablesSet.state.variables ?? []) });
+  const newVar = getVariableScene(type, { name: getNextAvailableId(name, variablesSet.state.variables ?? []) });
   dashboardEditActions.addVariable({ source: variablesSet, addedObject: newVar });
   dashboard.state.editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
   DashboardInteractions.newVariableTypeSelected({ type });

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -362,11 +362,7 @@ export const adhocVariableKindSchema = z
     spec: z.object({
       ...commonVariableSpecFields,
       baseFilters: z.array(adHocFilterSchema).optional().default([]).describe('Base filters always applied to queries'),
-      filters: z
-        .array(adHocFilterSchema)
-        .optional()
-        .default([])
-        .describe('User-configured ad-hoc filters applied to queries'),
+      filters: z.array(adHocFilterSchema).optional().default([]).describe('User-configured filters applied to queries'),
       defaultKeys: z
         .array(metricFindValueSchema)
         .optional()
@@ -380,7 +376,7 @@ export const adhocVariableKindSchema = z
     }),
   })
   .describe(
-    'AdhocVariable: Ad-hoc filter builder that adds key/value filters to all queries for a data source. Has top-level group and datasource fields for data source binding.'
+    'AdhocVariable: Filter builder that adds key/value filters to all queries for a data source. Has top-level group and datasource fields for data source binding.'
   );
 
 export const switchVariableKindSchema = z

--- a/public/app/features/dashboard-scene/scene/dashboard-filters-overview/DashboardFiltersOverview.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-filters-overview/DashboardFiltersOverview.tsx
@@ -49,7 +49,7 @@ export const DashboardFiltersOverview = ({
   });
 
   if (!hasAdhocFilters) {
-    return <div>{t('dashboard.filters-overview.missing-adhoc', 'No ad hoc filters available')}</div>;
+    return <div>{t('dashboard.filters-overview.missing-adhoc', 'No filters available')}</div>;
   }
 
   if (loading) {

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -62,7 +62,7 @@ export function AdHocVariableForm({
     <Stack direction="column" gap={2}>
       {!inline && (
         <VariableLegend>
-          <Trans i18nKey="dashboard-scene.ad-hoc-variable-form.adhoc-options">Ad-hoc options</Trans>
+          <Trans i18nKey="dashboard-scene.ad-hoc-variable-form.adhoc-options">Filter options</Trans>
         </VariableLegend>
       )}
 
@@ -85,7 +85,7 @@ export function AdHocVariableForm({
         <Alert
           title={t(
             'dashboard-scene.ad-hoc-variable-form.alert-not-supported',
-            'This data source does not support ad hoc filters'
+            'This data source does not support filters'
           )}
           severity="warning"
           bottomSpacing={0}
@@ -168,7 +168,7 @@ export function AdHocVariableForm({
             label={t('dashboard-scene.ad-hoc-variable-form.name-enable-group-by', 'Enable group by')}
             description={t(
               'dashboard-scene.ad-hoc-variable-form.description-enable-group-by',
-              'Enables group by operator in the ad hoc filter combobox'
+              'Enables group by operator in the filter combobox'
             )}
             noMargin
           >

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -229,7 +229,7 @@ async function setup(props?: React.ComponentProps<typeof AdHocFiltersVariableEdi
   const variable = new AdHocFiltersVariable({
     name: 'adhocVariable',
     type: 'adhoc',
-    label: 'Filters',
+    label: 'Filter',
     description: 'Filters are applied automatically to all queries that target this data source',
     datasource: { uid: defaultDatasource.uid, type: defaultDatasource.type },
     filters: [

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -229,8 +229,8 @@ async function setup(props?: React.ComponentProps<typeof AdHocFiltersVariableEdi
   const variable = new AdHocFiltersVariable({
     name: 'adhocVariable',
     type: 'adhoc',
-    label: 'Ad hoc filters',
-    description: 'Ad hoc filters are applied automatically to all queries that target this data source',
+    label: 'Filters',
+    description: 'Filters are applied automatically to all queries that target this data source',
     datasource: { uid: defaultDatasource.uid, type: defaultDatasource.type },
     filters: [
       {

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -60,8 +60,8 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
   }, [datasourceRef]);
 
   const message = datasourceSettings?.getTagKeys
-    ? 'Ad hoc filters are applied automatically to all queries that target this data source'
-    : 'This data source does not support ad hoc filters.';
+    ? 'Filters are applied automatically to all queries that target this data source'
+    : 'This data source does not support filters.';
 
   const onDataSourceChange = async (ds: DataSourceInstanceSettings) => {
     const dsRef = getDataSourceRef(ds);

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -3,6 +3,7 @@ import { FormEvent, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { DataSourceInstanceSettings, MetricFindValue, getDataSourceRef } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariable, AdHocFilterWithLabels, SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -60,8 +61,14 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
   }, [datasourceRef]);
 
   const message = datasourceSettings?.getTagKeys
-    ? 'Filters are applied automatically to all queries that target this data source'
-    : 'This data source does not support filters.';
+    ? t(
+        'dashboard-scene.ad-hoc-filters-variable-editor.message-supported',
+        'Filters are applied automatically to all queries that target this data source'
+      )
+    : t(
+        'dashboard-scene.ad-hoc-filters-variable-editor.message-not-supported',
+        'This data source does not support filters.'
+      );
 
   const onDataSourceChange = async (ds: DataSourceInstanceSettings) => {
     const dsRef = getDataSourceRef(ds);

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -97,7 +97,7 @@ export const getEditableVariables: () => Record<EditableVariableType, EditableVa
     getOptions: getDataSourceVariableOptions,
   },
   adhoc: {
-    name: t('dashboard-scene.get-editable-variables.name.ad-hoc-filters', 'Filters'),
+    name: t('dashboard-scene.get-editable-variables.name.ad-hoc-filters', 'Filter'),
     description: t(
       'dashboard-scene.get-editable-variables.description.add-keyvalue-filters-on-the-fly',
       'Add key/value filters on the fly'

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -97,7 +97,7 @@ export const getEditableVariables: () => Record<EditableVariableType, EditableVa
     getOptions: getDataSourceVariableOptions,
   },
   adhoc: {
-    name: t('dashboard-scene.get-editable-variables.name.ad-hoc-filters', 'Ad hoc filters'),
+    name: t('dashboard-scene.get-editable-variables.name.ad-hoc-filters', 'Filters'),
     description: t(
       'dashboard-scene.get-editable-variables.description.add-keyvalue-filters-on-the-fly',
       'Add key/value filters on the fly'
@@ -226,7 +226,10 @@ export function getVariableDefault(variables: Array<SceneVariable<SceneVariableS
   return getVariableScene('query', { name: nextVariableIdName });
 }
 
-export function getNextAvailableId(type: VariableType, variables: Array<SceneVariable<SceneVariableState>>): string {
+export function getNextAvailableId(
+  type: VariableType | string,
+  variables: Array<SceneVariable<SceneVariableState>>
+): string {
   let counter = 0;
   let nextId = `${type}${counter}`;
 

--- a/public/app/features/variables/adhoc/adapter.ts
+++ b/public/app/features/variables/adhoc/adapter.ts
@@ -22,7 +22,7 @@ export const createAdHocVariableAdapter = (): VariableAdapter<AdHocVariableModel
       'variables.create-ad-hoc-variable-adapter.description.add-keyvalue-filters-on-the-fly',
       'Add key/value filters on the fly.'
     ),
-    name: 'Ad hoc filters',
+    name: 'Filters',
     initialState: initialAdHocVariableModelState,
     reducer: adHocVariableReducer,
     picker: AdHocPicker,

--- a/public/app/features/variables/adhoc/adapter.ts
+++ b/public/app/features/variables/adhoc/adapter.ts
@@ -22,7 +22,7 @@ export const createAdHocVariableAdapter = (): VariableAdapter<AdHocVariableModel
       'variables.create-ad-hoc-variable-adapter.description.add-keyvalue-filters-on-the-fly',
       'Add key/value filters on the fly.'
     ),
-    name: 'Filters',
+    name: 'Filter',
     initialState: initialAdHocVariableModelState,
     reducer: adHocVariableReducer,
     picker: AdHocPicker,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6633,6 +6633,10 @@
     }
   },
   "dashboard-scene": {
+    "ad-hoc-filters-variable-editor": {
+      "message-not-supported": "This data source does not support filters.",
+      "message-supported": "Filters are applied automatically to all queries that target this data source"
+    },
     "ad-hoc-variable-form": {
       "adhoc-options": "Filter options",
       "alert-not-supported": "This data source does not support filters",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6999,7 +6999,7 @@
         "values-timespans": "Values are timespans, ex 1m, 1h, 1d"
       },
       "name": {
-        "ad-hoc-filters": "Filters",
+        "ad-hoc-filters": "Filter",
         "constant": "Constant",
         "custom": "Custom",
         "data-source": "Data source",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5668,7 +5668,7 @@
       "close": "Close",
       "empty": "No labels available",
       "groupby": "GroupBy",
-      "missing-adhoc": "No ad hoc filters available",
+      "missing-adhoc": "No filters available",
       "multi": {
         "value": {
           "aria-label": "Value",
@@ -6634,9 +6634,9 @@
   },
   "dashboard-scene": {
     "ad-hoc-variable-form": {
-      "adhoc-options": "Ad-hoc options",
-      "alert-not-supported": "This data source does not support ad hoc filters",
-      "description-enable-group-by": "Enables group by operator in the ad hoc filter combobox",
+      "adhoc-options": "Filter options",
+      "alert-not-supported": "This data source does not support filters",
+      "description-enable-group-by": "Enables group by operator in the filter combobox",
       "description-enables-users-custom-values": "Enables users to add custom values to the list",
       "description-provide-dimensions-as-csv-dimension-name-dimension-id": "Provide dimensions as CSV: {{name}}, {{value}}",
       "label-data-source": "Data source",
@@ -6999,7 +6999,7 @@
         "values-timespans": "Values are timespans, ex 1m, 1h, 1d"
       },
       "name": {
-        "ad-hoc-filters": "Ad hoc filters",
+        "ad-hoc-filters": "Filters",
         "constant": "Constant",
         "custom": "Custom",
         "data-source": "Data source",


### PR DESCRIPTION
**What is this feature?**
Renames all customer-facing "ad hoc" / "Ad-hoc" terminology to "Filter" across the dashboard

Affected strings include the variable type name, editor section headers, info text messages, alert messages, and Zod schema descriptions.


Fixes: https://github.com/grafana/grafana/issues/120596