### PR TITLE
Provisioning: Fix root folder incorrectly showing missing metadata warning

### DIFF
--- a/public/app/features/provisioning/hooks/useFolderMetadataStatus.test.ts
+++ b/public/app/features/provisioning/hooks/useFolderMetadataStatus.test.ts
@@ -114,6 +114,58 @@ describe('useFolderMetadataStatus', () => {
     });
   });
 
+  describe('root folder of folder-targeted repo', () => {
+    it('returns ok without querying _folder.json (root identity is stable)', () => {
+      setupMocks({
+        repoViewOverrides: {
+          repository: { name: 'my-repo', target: 'folder', title: 'Repo', type: 'github', workflows: ['branch'] },
+        },
+        fileQueryOverrides: {
+          data: undefined,
+          error: undefined,
+          isLoading: false,
+        },
+      });
+
+      // folderUID matches repo name -- this is the root folder
+      const { result } = renderHook(() => useFolderMetadataStatus('my-repo'));
+      expect(result.current.status).toBe('ok');
+      expect(mockUseGetRepositoryFilesWithPathQuery).toHaveBeenCalledWith(expect.any(Symbol));
+    });
+
+    it('still checks metadata for nested folders of folder-targeted repos', () => {
+      setupMocks({
+        repoViewOverrides: {
+          repository: { name: 'my-repo', target: 'folder', title: 'Repo', type: 'github', workflows: ['branch'] },
+        },
+      });
+
+      // folderUID does NOT match repo name -- this is a nested folder
+      renderHook(() => useFolderMetadataStatus('nested-folder-uid'));
+      expect(mockUseGetRepositoryFilesWithPathQuery).toHaveBeenCalledWith({
+        name: 'my-repo',
+        path: 'folders/my-folder/_folder.json',
+      });
+    });
+  });
+
+  describe('instance-targeted repo', () => {
+    it('still checks _folder.json even when folderUID matches repo name', () => {
+      setupMocks({
+        repoViewOverrides: {
+          repository: { name: 'my-repo', target: 'instance', title: 'Repo', type: 'github', workflows: ['branch'] },
+        },
+      });
+
+      // Same UID as repo name, but target is 'instance' -- root shortcut must not apply
+      renderHook(() => useFolderMetadataStatus('my-repo'));
+      expect(mockUseGetRepositoryFilesWithPathQuery).toHaveBeenCalledWith({
+        name: 'my-repo',
+        path: 'folders/my-folder/_folder.json',
+      });
+    });
+  });
+
   describe('path construction', () => {
     it('queries the correct path for nested folders', () => {
       setupMocks();

--- a/public/app/features/provisioning/hooks/useFolderMetadataStatus.ts
+++ b/public/app/features/provisioning/hooks/useFolderMetadataStatus.ts
@@ -32,8 +32,12 @@ export function useFolderMetadataStatus(folderUID: string): FolderMetadataResult
   const repoName = repository?.name ?? '';
   const folderJsonPath = getFolderMetadataPath(sourcePath);
 
+  // Root folders of folder-targeted repos have stable identity (UID = repo name)
+  // and never have a _folder.json file. Skip the metadata check for them.
+  const isRootRepoFolder = repository?.target === 'folder' && repoName === folderUID;
+
   const { error, isLoading: isFileLoading } = useGetRepositoryFilesWithPathQuery(
-    repoName ? { name: repoName, path: folderJsonPath } : skipToken
+    repoName && !isRootRepoFolder ? { name: repoName, path: folderJsonPath } : skipToken
   );
 
   if (isRepoViewLoading || isFileLoading) {


### PR DESCRIPTION
**What is this feature?**

Fixes the permissions drawer for root folders of folder-targeted provisioned repositories. Previously, navigating to the root folder and opening the permissions drawer showed "This folder is missing metadata," preventing users from editing permissions. The root folder now correctly reports its metadata status as ok.

**Why do we need this feature?**

Root folders of folder-targeted repos never have a `_folder.json` file by design -- their identity is inherently stable (UID = repo name). The `useFolderMetadataStatus` hook did not account for this, so it queried for the nonexistent file, got a 404, and incorrectly flagged the metadata as missing. Nested folders were unaffected because they do have `_folder.json` files.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1030
