### PR TITLE
Dashboard: Skip flaky "View a dashboard" e2e test

### DIFF
--- a/e2e-playwright/dashboard-cujs/dashboard-view.spec.ts
+++ b/e2e-playwright/dashboard-cujs/dashboard-view.spec.ts
@@ -19,7 +19,7 @@ test.describe(
     tag: ['@dashboard-cujs'],
   },
   () => {
-    test('View a dashboard', async ({ page, gotoDashboardPage, selectors }) => {
+    test.skip('View a dashboard', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboards = await getConfigDashboards();
       if (dashboards.length === 0) {
         dashboards.push(DASHBOARD_UNDER_TEST);


### PR DESCRIPTION
Skip the "View a dashboard" e2e Playwright test that is failing in CI.

https://github.com/grafana/grafana-enterprise/actions/runs/23545026712/job/68549959653?pr=11432#step:8:3862