### PR TITLE
Provisioning: metadata fix job cleans .keep files

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker.go
@@ -2,7 +2,9 @@ package fixfoldermetadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -17,9 +19,13 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+const keepFileName = ".keep"
+
 // Worker implements the fix-folder-metadata job type.
 // It scans the repository tree and writes a _folder.json metadata file for
 // every directory that does not already have one, using a hash-derived UID.
+// It also removes legacy .keep files from folders that have (or receive)
+// a _folder.json, since the metadata file supersedes the keep marker.
 type Worker struct{}
 
 func NewWorker() *Worker {
@@ -77,13 +83,16 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 
 		repoName := rw.Config().GetName()
 
-		// Collect dirs with existing metadata and parse all folder entries.
+		// Collect dirs with existing metadata, track .keep files, and parse all folder entries.
 		hasMetadata := make(map[string]struct{}, len(entries))
+		hasKeepFile := make(map[string]string, len(entries))
 		folders := make([]resources.Folder, 0, len(entries))
 		for _, entry := range entries {
 			if entry.Blob {
 				if resources.IsFolderMetadataFile(entry.Path) {
 					hasMetadata[safepath.Dir(entry.Path)] = struct{}{}
+				} else if isKeepFile(entry.Path) {
+					hasKeepFile[safepath.Dir(entry.Path)] = entry.Path
 				}
 				continue
 			}
@@ -99,6 +108,10 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 
 		for _, folder := range folders {
 			if _, ok := hasMetadata[folder.Path]; ok {
+				// Folder already has _folder.json; remove stale .keep if present.
+				if keepPath, ok := hasKeepFile[folder.Path]; ok {
+					deleteKeepFile(ctx, rw, keepPath, ref, logger)
+				}
 				continue
 			}
 
@@ -115,6 +128,12 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 				progress.Record(ctx, rb.Build())
 				return wrappedErr
 			}
+
+			// _folder.json now exists; remove the legacy .keep if present.
+			if keepPath, ok := hasKeepFile[folder.Path]; ok {
+				deleteKeepFile(ctx, rw, keepPath, ref, logger)
+			}
+
 			progress.Record(ctx, rb.Build())
 		}
 
@@ -158,4 +177,19 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 	}
 
 	return nil
+}
+
+func isKeepFile(path string) bool {
+	return strings.HasSuffix(path, keepFileName)
+}
+
+// deleteKeepFile removes a .keep file, logging but not failing on errors
+// (the .keep may already be absent in certain edge cases).
+func deleteKeepFile(ctx context.Context, rw repository.ReaderWriter, keepPath, ref string, logger logging.Logger) {
+	if err := rw.Delete(ctx, keepPath, ref, "Remove legacy .keep replaced by _folder.json"); err != nil {
+		if errors.Is(err, repository.ErrFileNotFound) {
+			return
+		}
+		logger.Warn("failed to delete .keep file", "path", keepPath, "error", err)
+	}
 }

--- a/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/fixfoldermetadata/worker_test.go
@@ -396,4 +396,152 @@ func TestWorker_Process(t *testing.T) {
 		err := w.Process(ctx, mockRepo, job, mockProgress)
 		require.NoError(t, err)
 	})
+
+	t.Run("deletes .keep file after creating _folder.json", func(t *testing.T) {
+		ctx := context.Background()
+		w := NewWorker()
+
+		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
+		mockStaged := repository.NewMockStagedRepository(t)
+		mockProgress := jobs.NewMockJobProgressRecorder(t)
+
+		job := makeTestJob("")
+
+		tree := []repository.FileTreeEntry{
+			treeEntry("myfolder", false),
+			treeEntry("myfolder/.keep", true),
+		}
+
+		myFolder := resources.ParseFolder("myfolder/", "test-repo")
+
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.Anything).Return(mockStaged, nil)
+
+		mockStaged.EXPECT().ReadTree(mock.Anything, "").Return(tree, nil)
+		mockStaged.EXPECT().Config().Return(repoConfig("test-repo"))
+		mockStaged.EXPECT().Create(mock.Anything, "myfolder/_folder.json", "", mock.Anything, mock.Anything).Return(nil)
+		mockStaged.EXPECT().Delete(mock.Anything, "myfolder/.keep", "", mock.Anything).Return(nil)
+
+		mockProgress.EXPECT().SetMessage(mock.Anything, "Writing folder metadata files on default branch").Return()
+		mockProgress.EXPECT().SetTotal(mock.Anything, 1).Return()
+		mockProgress.EXPECT().Record(mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+			return r.Action() == repository.FileActionCreated && r.Name() == myFolder.ID
+		})).Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, "Folder metadata fixed on default branch").Return()
+
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
+
+		err := w.Process(ctx, mockRepo, job, mockProgress)
+		require.NoError(t, err)
+	})
+
+	t.Run("deletes .keep file from folder that already has _folder.json", func(t *testing.T) {
+		ctx := context.Background()
+		w := NewWorker()
+
+		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
+		mockStaged := repository.NewMockStagedRepository(t)
+		mockProgress := jobs.NewMockJobProgressRecorder(t)
+
+		job := makeTestJob("")
+
+		tree := []repository.FileTreeEntry{
+			treeEntry("myfolder", false),
+			treeEntry("myfolder/_folder.json", true),
+			treeEntry("myfolder/.keep", true),
+		}
+
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.Anything).Return(mockStaged, nil)
+
+		mockStaged.EXPECT().ReadTree(mock.Anything, "").Return(tree, nil)
+		mockStaged.EXPECT().Config().Return(repoConfig("test-repo"))
+		// No Create expected — _folder.json already exists
+		mockStaged.EXPECT().Delete(mock.Anything, "myfolder/.keep", "", mock.Anything).Return(nil)
+
+		mockProgress.EXPECT().SetMessage(mock.Anything, "Writing folder metadata files on default branch").Return()
+		mockProgress.EXPECT().SetTotal(mock.Anything, 0).Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, "Folder metadata fixed on default branch").Return()
+
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
+
+		err := w.Process(ctx, mockRepo, job, mockProgress)
+		require.NoError(t, err)
+	})
+
+	t.Run("tolerates .keep file already absent when deleting", func(t *testing.T) {
+		ctx := context.Background()
+		w := NewWorker()
+
+		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
+		mockStaged := repository.NewMockStagedRepository(t)
+		mockProgress := jobs.NewMockJobProgressRecorder(t)
+
+		job := makeTestJob("")
+
+		tree := []repository.FileTreeEntry{
+			treeEntry("myfolder", false),
+			treeEntry("myfolder/.keep", true),
+		}
+
+		myFolder := resources.ParseFolder("myfolder/", "test-repo")
+
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.Anything).Return(mockStaged, nil)
+
+		mockStaged.EXPECT().ReadTree(mock.Anything, "").Return(tree, nil)
+		mockStaged.EXPECT().Config().Return(repoConfig("test-repo"))
+		mockStaged.EXPECT().Create(mock.Anything, "myfolder/_folder.json", "", mock.Anything, mock.Anything).Return(nil)
+		mockStaged.EXPECT().Delete(mock.Anything, "myfolder/.keep", "", mock.Anything).Return(repository.ErrFileNotFound)
+
+		mockProgress.EXPECT().SetMessage(mock.Anything, "Writing folder metadata files on default branch").Return()
+		mockProgress.EXPECT().SetTotal(mock.Anything, 1).Return()
+		mockProgress.EXPECT().Record(mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+			return r.Action() == repository.FileActionCreated && r.Name() == myFolder.ID
+		})).Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, "Folder metadata fixed on default branch").Return()
+
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
+
+		err := w.Process(ctx, mockRepo, job, mockProgress)
+		require.NoError(t, err)
+	})
+
+	t.Run("does not attempt .keep deletion when folder has no .keep", func(t *testing.T) {
+		ctx := context.Background()
+		w := NewWorker()
+
+		mockRepo := &mockStageableRepo{MockStageableRepository: repository.NewMockStageableRepository(t)}
+		mockStaged := repository.NewMockStagedRepository(t)
+		mockProgress := jobs.NewMockJobProgressRecorder(t)
+
+		job := makeTestJob("")
+
+		tree := []repository.FileTreeEntry{
+			treeEntry("myfolder", false),
+			treeEntry("myfolder/dashboard.json", true),
+		}
+
+		myFolder := resources.ParseFolder("myfolder/", "test-repo")
+
+		mockRepo.MockStageableRepository.EXPECT().Stage(mock.Anything, mock.Anything).Return(mockStaged, nil)
+
+		mockStaged.EXPECT().ReadTree(mock.Anything, "").Return(tree, nil)
+		mockStaged.EXPECT().Config().Return(repoConfig("test-repo"))
+		mockStaged.EXPECT().Create(mock.Anything, "myfolder/_folder.json", "", mock.Anything, mock.Anything).Return(nil)
+		// No Delete expected — there is no .keep file
+
+		mockProgress.EXPECT().SetMessage(mock.Anything, "Writing folder metadata files on default branch").Return()
+		mockProgress.EXPECT().SetTotal(mock.Anything, 1).Return()
+		mockProgress.EXPECT().Record(mock.Anything, mock.MatchedBy(func(r jobs.JobResourceResult) bool {
+			return r.Action() == repository.FileActionCreated && r.Name() == myFolder.ID
+		})).Return()
+		mockProgress.EXPECT().SetFinalMessage(mock.Anything, "Folder metadata fixed on default branch").Return()
+
+		mockStaged.EXPECT().Push(mock.Anything).Return(nil)
+		mockStaged.EXPECT().Remove(mock.Anything).Return(nil)
+
+		err := w.Process(ctx, mockRepo, job, mockProgress)
+		require.NoError(t, err)
+	})
 }

--- a/pkg/tests/apis/provisioning/jobs/foldermetadata/fixfoldermetadatajob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/foldermetadata/fixfoldermetadatajob_test.go
@@ -1,10 +1,14 @@
 package foldermetadata
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -65,4 +69,73 @@ func TestIntegrationProvisioning_FixFolderMetadataJob(t *testing.T) {
 		state := common.MustNestedString(job.Object, "status", "state")
 		require.Equal(t, "success", state, "fix-folder-metadata job with empty options should complete with success")
 	})
+}
+
+// TestIntegrationProvisioning_FixFolderMetadataJob_RemovesKeepFiles verifies
+// that running the fix-folder-metadata job removes legacy .keep files from
+// folders once they have a _folder.json (whether pre-existing or newly created).
+func TestIntegrationProvisioning_FixFolderMetadataJob_RemovesKeepFiles(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "fix-folder-metadata-keep-files"
+	testRepo := common.TestRepo{
+		Name:                   repo,
+		Target:                 "folder",
+		SkipResourceAssertions: true,
+	}
+	helper.CreateRepo(t, testRepo)
+
+	// Plant .keep files in both folder directories, mimicking legacy state
+	// where folders were tracked via .keep instead of _folder.json.
+	helper.WriteToProvisioningPath(t, "parent/.keep", []byte{})
+	helper.WriteToProvisioningPath(t, "parent/child/.keep", []byte{})
+
+	// Plant a valid _folder.json in the parent folder only.
+	// The child folder intentionally has no _folder.json so the job must create one.
+	parentMeta := marshalFolderMetadata(t, "pre-existing-parent-uid", "parent")
+	helper.WriteToProvisioningPath(t, "parent/_folder.json", parentMeta)
+
+	spec := provisioning.JobSpec{
+		Action: provisioning.JobActionFixFolderMetadata,
+	}
+	job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
+	state := common.MustNestedString(job.Object, "status", "state")
+	require.Equal(t, "success", state, "fix-folder-metadata job should complete with success")
+
+	t.Run("keep file removed from folder with existing _folder.json", func(t *testing.T) {
+		_, err := os.Stat(filepath.Join(helper.ProvisioningPath, "parent", ".keep"))
+		require.True(t, os.IsNotExist(err), ".keep must be removed from parent folder that already had _folder.json")
+	})
+
+	t.Run("keep file removed from folder where job creates _folder.json", func(t *testing.T) {
+		_, err := os.Stat(filepath.Join(helper.ProvisioningPath, "parent", "child", ".keep"))
+		require.True(t, os.IsNotExist(err), ".keep must be removed from child folder where job created _folder.json")
+	})
+
+	t.Run("existing _folder.json is not overwritten", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(helper.ProvisioningPath, "parent", "_folder.json")) //nolint:gosec
+		require.NoError(t, err)
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &obj))
+		meta, _ := obj["metadata"].(map[string]interface{})
+		require.Equal(t, "pre-existing-parent-uid", meta["name"],
+			"pre-existing parent _folder.json must not be overwritten by the job")
+	})
+
+	t.Run("_folder.json is created for folder without metadata", func(t *testing.T) {
+		_, err := os.Stat(filepath.Join(helper.ProvisioningPath, "parent", "child", "_folder.json"))
+		require.NoError(t, err, "_folder.json must be created for child folder that had no metadata")
+	})
+}
+
+// marshalFolderMetadata builds a valid _folder.json payload with the given UID and title.
+func marshalFolderMetadata(t *testing.T, uid, title string) []byte {
+	t.Helper()
+	f := folders.NewFolder()
+	f.SetGroupVersionKind(folders.FolderResourceInfo.GroupVersionKind())
+	f.Name = uid
+	f.Spec.Title = title
+	data, err := json.Marshal(f)
+	require.NoError(t, err)
+	return data
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Metadata fix job would create _folder.json metadata files but left .keep files in empty folders. With this change, the job will also cleanup .keep files for folders that already had a _folders.json file and for the ones that the actual run creates the metadata file. 

**Why do we need this feature?**

Without it, a repository may get polluted witih uneeded .keep files. For example a repository may end with:
- folderA/
- folderA/_folder.json
- folderA/.keep

The end result should only contain:
- folderA/
- folderA/_folder.json

**Who is this feature for?**

Provisioning feature repos.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1027

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
