### PR TITLE
Provisioning: fix double-slash paths when saving new dashboards

### DIFF
--- a/public/app/features/provisioning/components/utils/path.test.ts
+++ b/public/app/features/provisioning/components/utils/path.test.ts
@@ -68,6 +68,16 @@ describe('generatePath', () => {
 
     expect(result).toBe('my-dashboard.json');
   });
+
+  it('should normalize folderPath with trailing slash', () => {
+    const result = generatePath({
+      timestamp,
+      slug: 'my-dashboard',
+      folderPath: 'team-alpha/',
+    });
+
+    expect(result).toBe('team-alpha/my-dashboard.json');
+  });
 });
 
 describe('splitPath', () => {

--- a/public/app/features/provisioning/components/utils/path.ts
+++ b/public/app/features/provisioning/components/utils/path.ts
@@ -25,9 +25,9 @@ export function generatePath({ timestamp, pathFromAnnotation, slug, folderPath =
   const pathSlug = slug || `new-dashboard-${timestamp}`;
   path = `${pathSlug}.json`;
 
-  // Add folder path if it exists
+  // Add folder path if it exists (folder annotations may use trailing slashes; avoid "//" in repo paths)
   if (folderPath) {
-    return `${folderPath}/${path}`;
+    return joinPath(folderPath, path);
   }
 
   return path;


### PR DESCRIPTION
**What is this feature?**

generatePath concatenated folderPath with a slash; folder source paths from annotations can end with /. Use joinPath so team-alpha/ + file.json does not produce team-alpha//file.json (safepath validation error).


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1033

