### PR TITLE
IAM: Add team authorizer for members subresource

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	authlib "github.com/grafana/authlib/types"
@@ -72,7 +73,7 @@ func newIAMAuthorizer(
 	resourceAuthorizer[iamv0.ServiceAccountResourceInfo.GetName()] = authorizer
 	resourceAuthorizer[iamv0.UserResourceInfo.GetName()] = authorizer
 	resourceAuthorizer[iamv0.ExternalGroupMappingResourceInfo.GetName()] = externalGroupMappingApiInstaller.GetAuthorizer()
-	resourceAuthorizer[iamv0.TeamResourceInfo.GetName()] = authorizer
+	resourceAuthorizer[iamv0.TeamResourceInfo.GetName()] = newTeamAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.TeamBindingResourceInfo.GetName()] = allowAuthorizer
 	resourceAuthorizer["searchUsers"] = serviceAuthorizer
 	resourceAuthorizer["searchTeams"] = serviceAuthorizer
@@ -95,6 +96,43 @@ func (s *iamAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribute
 	}
 
 	return authz.Authorize(ctx, attr)
+}
+
+// newTeamAuthorizer creates an authorizer for teams that handles the "members" subresource
+// with a get_permissions check on the parent team resource.
+func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	delegate := gfauthorizer.NewResourceAuthorizer(accessClient)
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if !attr.IsResourceRequest() {
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+
+		subresource := attr.GetSubresource()
+		if subresource == "members" {
+			ident, ok := authlib.AuthInfoFrom(ctx)
+			if !ok {
+				return authorizer.DecisionDeny, "", errors.New("no identity found")
+			}
+
+			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+				Verb:      utils.VerbGetPermissions,
+				Group:     attr.GetAPIGroup(),
+				Resource:  attr.GetResource(),
+				Namespace: attr.GetNamespace(),
+				Name:      attr.GetName(),
+			}, "")
+			if err != nil {
+				return authorizer.DecisionDeny, "", err
+			}
+			if !res.Allowed {
+				return authorizer.DecisionDeny, "requires team getpermissions", nil
+			}
+			return authorizer.DecisionAllow, "", nil
+		}
+
+		// Delegate to the standard ResourceAuthorizer for non-members subresources
+		return delegate.Authorize(ctx, attr)
+	})
 }
 
 func newLegacyAccessClient(ac accesscontrol.AccessControl, store legacy.LegacyIdentityStore) authlib.AccessClient {

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -1,0 +1,206 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/authlib/authn"
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+)
+
+// fakeAccessClient is a mock implementation of types.AccessClient for testing
+type fakeAccessClient struct {
+	checkFunc func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
+}
+
+func (f *fakeAccessClient) Check(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+	if f.checkFunc != nil {
+		return f.checkFunc(ctx, id, req, folder)
+	}
+	return types.CheckResponse{Allowed: false}, nil
+}
+
+func (f *fakeAccessClient) Compile(ctx context.Context, id types.AuthInfo, req types.ListRequest) (types.ItemChecker, types.Zookie, error) {
+	return nil, types.NoopZookie{}, nil
+}
+
+func (f *fakeAccessClient) BatchCheck(ctx context.Context, id types.AuthInfo, req types.BatchCheckRequest) (types.BatchCheckResponse, error) {
+	return types.BatchCheckResponse{}, nil
+}
+
+// TestNewTeamAuthorizer_MembersSubresource_CheckRequest verifies that the authorizer
+// builds the correct CheckRequest for the members subresource.
+func TestNewTeamAuthorizer_MembersSubresource_CheckRequest(t *testing.T) {
+	var capturedReq *types.CheckRequest
+	fakeClient := &fakeAccessClient{
+		checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+			capturedReq = &req
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	teamAuth := newTeamAuthorizer(fakeClient)
+
+	authInfo := authn.NewIDTokenAuthInfo(
+		authn.Claims[authn.AccessTokenClaims]{},
+		&authn.Claims[authn.IDTokenClaims]{},
+	)
+	ctx := types.WithAuthInfo(context.Background(), authInfo)
+
+	attr := authorizer.AttributesRecord{
+		ResourceRequest: true,
+		APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
+		Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
+		Subresource:     "members",
+		Name:            "team-abc",
+		Verb:            "get",
+		Namespace:       "org-1",
+	}
+
+	_, _, err := teamAuth.Authorize(ctx, attr)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	assert.Equal(t, "get_permissions", capturedReq.Verb)
+	assert.Equal(t, iamv0.TeamResourceInfo.GroupResource().Group, capturedReq.Group)
+	assert.Equal(t, iamv0.TeamResourceInfo.GroupResource().Resource, capturedReq.Resource)
+	assert.Equal(t, "team-abc", capturedReq.Name)
+	assert.Equal(t, "org-1", capturedReq.Namespace)
+}
+
+// TestNewTeamAuthorizer_DecisionMatrix covers all decision paths with table-driven tests.
+func TestNewTeamAuthorizer_DecisionMatrix(t *testing.T) {
+	tests := []struct {
+		name            string
+		subresource     string
+		resourceRequest bool
+		checkFunc       func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
+		wantDecision    authorizer.Decision
+		wantReason      string
+		wantErr         bool
+		wantCheckCalled bool
+	}{
+		{
+			name:            "members subresource - allowed",
+			subresource:     "members",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				return types.CheckResponse{Allowed: true}, nil
+			},
+			wantDecision:    authorizer.DecisionAllow,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "members subresource - denied",
+			subresource:     "members",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				return types.CheckResponse{Allowed: false}, nil
+			},
+			wantDecision:    authorizer.DecisionDeny,
+			wantReason:      "requires team getpermissions",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "members subresource - error",
+			subresource:     "members",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				return types.CheckResponse{}, errors.New("database error")
+			},
+			wantDecision:    authorizer.DecisionDeny,
+			wantReason:      "",
+			wantErr:         true,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "no subresource - delegates to ResourceAuthorizer",
+			subresource:     "",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				// Verify the subresource is NOT passed through to the delegate
+				assert.Empty(t, req.Subresource)
+				return types.CheckResponse{Allowed: true}, nil
+			},
+			wantDecision:    authorizer.DecisionAllow,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "other subresource (groups) - delegates to ResourceAuthorizer",
+			subresource:     "groups",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				// The subresource should be passed through to the delegate
+				assert.Equal(t, "groups", req.Subresource)
+				return types.CheckResponse{Allowed: true}, nil
+			},
+			wantDecision:    authorizer.DecisionAllow,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "non-resource request - no opinion",
+			subresource:     "",
+			resourceRequest: false,
+			checkFunc:       nil, // Should not be called
+			wantDecision:    authorizer.DecisionNoOpinion,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkCalled := false
+			wrappedCheckFunc := func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				checkCalled = true
+				if tt.checkFunc != nil {
+					return tt.checkFunc(ctx, id, req, folder)
+				}
+				return types.CheckResponse{Allowed: false}, nil
+			}
+
+			fakeClient := &fakeAccessClient{checkFunc: wrappedCheckFunc}
+			teamAuth := newTeamAuthorizer(fakeClient)
+
+			authInfo := authn.NewIDTokenAuthInfo(
+				authn.Claims[authn.AccessTokenClaims]{},
+				&authn.Claims[authn.IDTokenClaims]{},
+			)
+			ctx := types.WithAuthInfo(context.Background(), authInfo)
+
+			attr := authorizer.AttributesRecord{
+				ResourceRequest: tt.resourceRequest,
+				APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
+				Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
+				Subresource:     tt.subresource,
+				Name:            "team-abc",
+				Verb:            "get",
+			}
+
+			decision, reason, err := teamAuth.Authorize(ctx, attr)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantDecision, decision)
+			assert.Equal(t, tt.wantReason, reason)
+			assert.Equal(t, tt.wantCheckCalled, checkCalled, "Check call mismatch")
+		})
+	}
+}

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -464,8 +464,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamsAPIGroup(opts builder.AP
 			b.features,
 		)
 
-		storage[teamResource.StoragePath("members")] = team.NewTeamMembersREST(teamBindingSearchClient, b.tracing,
-			b.features, b.accessClient)
+		storage[teamResource.StoragePath("members")] = team.NewTeamMembersREST(teamBindingSearchClient, b.tracing, b.features)
 	}
 
 	if enableExternalGroupMappingsApi && b.teamGroupsHandler != nil {

--- a/pkg/registry/apis/iam/team/rest_members.go
+++ b/pkg/registry/apis/iam/team/rest_members.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/authlib/types"
+
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -32,23 +32,20 @@ var (
 	_ rest.Connecter       = (*TeamMembersREST)(nil)
 )
 
-func NewTeamMembersREST(client resourcepb.ResourceIndexClient, tracer trace.Tracer, features featuremgmt.FeatureToggles,
-	accessClient types.AccessClient) *TeamMembersREST {
+func NewTeamMembersREST(client resourcepb.ResourceIndexClient, tracer trace.Tracer, features featuremgmt.FeatureToggles) *TeamMembersREST {
 	return &TeamMembersREST{
-		log:          log.New("grafana-apiserver.team.members"),
-		client:       client,
-		tracer:       tracer,
-		features:     features,
-		accessClient: accessClient,
+		log:      log.New("grafana-apiserver.team.members"),
+		client:   client,
+		tracer:   tracer,
+		features: features,
 	}
 }
 
 type TeamMembersREST struct {
-	accessClient types.AccessClient
-	log          log.Logger
-	client       resourcepb.ResourceIndexClient
-	tracer       trace.Tracer
-	features     featuremgmt.FeatureToggles
+	log      log.Logger
+	client   resourcepb.ResourceIndexClient
+	tracer   trace.Tracer
+	features featuremgmt.FeatureToggles
 }
 
 // New implements rest.Storage.
@@ -87,25 +84,8 @@ func (s *TeamMembersREST) Connect(ctx context.Context, name string, options runt
 		ctx, span := s.tracer.Start(r.Context(), "team.members")
 		defer span.End()
 
-		authInfo, ok := types.AuthInfoFrom(ctx)
-		if !ok {
-			responder.Error(apierrors.NewUnauthorized("no identity found"))
-			return
-		}
-
-		// https://github.com/grafana/grafana/blob/8649534e37b4c3520af538e311fb3a84c7b9f29f/public/app/features/teams/TeamPages.tsx#L74
-		checkTeamAccess, err := s.accessClient.Check(ctx, authInfo, types.CheckRequest{
-			Namespace: authInfo.GetNamespace(),
-			Group:     iamv0alpha1.TeamResourceInfo.GroupResource().Group,
-			Resource:  iamv0alpha1.TeamResourceInfo.GroupResource().Resource,
-			Verb:      utils.VerbGetPermissions,
-			Name:      name,
-		}, "")
-		if err != nil || !checkTeamAccess.Allowed {
-			responder.Error(apierrors.NewForbidden(iamv0alpha1.TeamResourceInfo.GroupResource(),
-				name, errors.New("you'll need additional permissions to perform this action. Permissions needed: \"GetPermissions\" on the \"Team\" resource")))
-			return
-		}
+		// Authorization is handled by the TeamAuthorizer at the K8s authorizer level.
+		// This handler assumes the request has already been authorized.
 
 		queryParams, err := url.ParseQuery(r.URL.RawQuery)
 		if err != nil {
@@ -127,6 +107,13 @@ func (s *TeamMembersREST) Connect(ctx context.Context, name string, options runt
 		} else if queryParams.Has("page") {
 			page, _ = strconv.Atoi(queryParams.Get("page"))
 			offset = (page - 1) * limit
+		}
+
+		// Get namespace from the request context
+		authInfo, ok := types.AuthInfoFrom(ctx)
+		if !ok {
+			responder.Error(apierrors.NewUnauthorized("no identity found"))
+			return
 		}
 
 		searchRequest := &resourcepb.ResourceSearchRequest{

--- a/pkg/registry/apis/iam/team/rest_members_test.go
+++ b/pkg/registry/apis/iam/team/rest_members_test.go
@@ -322,7 +322,6 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 		require.NotNil(t, responder.err)
 		require.Contains(t, responder.err.Error(), "functionality not available")
 	})
-
 }
 
 func TestTeamMembersREST_parseResults(t *testing.T) {

--- a/pkg/registry/apis/iam/team/rest_members_test.go
+++ b/pkg/registry/apis/iam/team/rest_members_test.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/grafana/authlib/types"
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -24,7 +23,7 @@ import (
 func TestTeamMembersREST_Connect(t *testing.T) {
 	t.Run("should create handler with default pagination", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -51,7 +50,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should parse limit query parameter", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -72,7 +71,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should parse offset query parameter and calculate page", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -95,7 +94,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should parse page query parameter and calculate offset", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -118,7 +117,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should parse explain query parameter", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -139,7 +138,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should not enable explain when explain=false", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -160,7 +159,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should return error when identity is missing", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := context.Background()
 		responder := &mockResponder{}
@@ -183,7 +182,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 		mockClient := &MockClient{
 			MockError: errors.New("search failed"),
 		}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -237,7 +236,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 				},
 			},
 		}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -271,7 +270,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should include correct fields in search request", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings))
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -303,7 +302,7 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 
 	t.Run("should return 403 when feature flag is disabled", func(t *testing.T) {
 		mockClient := &MockClient{}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(), types.FixedAccessClient(true))
+		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures())
 
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Namespace: "test-namespace",
@@ -324,41 +323,6 @@ func TestTeamMembersREST_Connect(t *testing.T) {
 		require.Contains(t, responder.err.Error(), "functionality not available")
 	})
 
-	t.Run("should return 403 when user doesn't have the required action on team", func(t *testing.T) {
-		mockClient := &MockClient{}
-		accessClient := &fakeAccessClient{
-			checkFunc: func(id types.AuthInfo, req *types.CheckRequest, folder string) (types.CheckResponse, error) {
-				// First call is for team access check
-				require.Equal(t, "test-namespace", req.Namespace)
-				require.Equal(t, iamv0alpha1.TeamResourceInfo.GroupResource().Group, req.Group)
-				require.Equal(t, iamv0alpha1.TeamResourceInfo.GroupResource().Resource, req.Resource)
-				require.Equal(t, "get_permissions", req.Verb)
-				require.Equal(t, "testteam", req.Name)
-				return types.CheckResponse{Allowed: false}, nil
-			},
-		}
-		handler := NewTeamMembersREST(mockClient, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(featuremgmt.FlagKubernetesTeamBindings), accessClient)
-
-		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
-			Namespace: "test-namespace",
-		})
-		responder := &mockResponder{}
-
-		httpHandler, err := handler.Connect(ctx, "testteam", nil, responder)
-		require.NoError(t, err)
-
-		req := httptest.NewRequest(http.MethodGet, "/members", nil)
-		req = req.WithContext(ctx)
-		w := httptest.NewRecorder()
-
-		httpHandler.ServeHTTP(w, req)
-
-		require.True(t, responder.called)
-		require.NotNil(t, responder.err)
-		require.Contains(t, responder.err.Error(), "forbidden")
-		require.True(t, accessClient.checkCalled)
-		require.Equal(t, 1, accessClient.checkCallCount)
-	})
 }
 
 func TestTeamMembersREST_parseResults(t *testing.T) {
@@ -622,27 +586,4 @@ func (m *MockClient) GetStats(ctx context.Context, in *resourcepb.ResourceStatsR
 
 func (m *MockClient) RebuildIndexes(ctx context.Context, in *resourcepb.RebuildIndexesRequest, opts ...grpc.CallOption) (*resourcepb.RebuildIndexesResponse, error) {
 	return nil, nil
-}
-
-var _ types.AccessClient = (*fakeAccessClient)(nil)
-
-// fakeAccessClient is a mock implementation of types.AccessClient for testing access control
-type fakeAccessClient struct {
-	checkCalled    bool
-	checkCallCount int
-	checkFunc      func(id types.AuthInfo, req *types.CheckRequest, folder string) (types.CheckResponse, error)
-}
-
-func (m *fakeAccessClient) Check(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-	m.checkCalled = true
-	m.checkCallCount++
-	return m.checkFunc(id, &req, folder)
-}
-
-func (m *fakeAccessClient) Compile(ctx context.Context, id types.AuthInfo, req types.ListRequest) (types.ItemChecker, types.Zookie, error) {
-	return nil, types.NoopZookie{}, nil
-}
-
-func (m *fakeAccessClient) BatchCheck(ctx context.Context, id types.AuthInfo, req types.BatchCheckRequest) (types.BatchCheckResponse, error) {
-	return types.BatchCheckResponse{}, nil
 }


### PR DESCRIPTION
## Summary

Pre-requisite for https://github.com/grafana/grafana/pull/118377

**Problem:** The generic `ResourceAuthorizer` passes all subresources to the RBAC service. 
I plan to change the AuthZ Service check so when a subresource lacks a mapper entry (like `teams/members`), the RBAC service denies access. This will break authorization for existing subresources.

**Solution:** Create a dedicated `TeamAuthorizer` that intercepts the `members` subresource and explicitly checks `get_permissions` on the parent team. This matches the existing access control logic in the handler while moving it to the proper K8s authorizer layer.

## Changes
- Create `newTeamAuthorizer()` that wraps `ResourceAuthorizer`
- For `members` subresource: check `get_permissions` on the team
- For other subresources: delegate to standard `ResourceAuthorizer`
- Remove redundant auth check from `TeamMembersREST.Connect()` handler
- Add unit tests with table-driven decision matrix
## Test plan
- [ ] Unit tests pass: `go test ./pkg/registry/apis/iam/... -run TestNewTeamAuthorizer`
- [ ] Existing team members tests pass: `go test ./pkg/registry/apis/iam/team/...`
- [ ] Manual test: verify team/members endpoint enforces get_permissions check