### PR TITLE
Presets: Add thresholds badge

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.test.tsx
@@ -285,14 +285,14 @@ describe('PanelStylesSection', () => {
       mockGetPluginPresets.mockReturnValue([...mockPresets, thresholdPreset]);
       render(<PanelStylesSection panel={buildPanel()} onApplyPreset={onApplyPreset} />);
 
-      expect(screen.getByLabelText('Modifies thresholds')).toBeInTheDocument();
+      expect(screen.getByLabelText('This preset will modify thresholds')).toBeInTheDocument();
     });
 
     it('does not render a badge for presets that do not modify thresholds', () => {
       mockGetPluginPresets.mockReturnValue(mockPresets);
       render(<PanelStylesSection panel={buildPanel()} onApplyPreset={onApplyPreset} />);
 
-      expect(screen.queryByLabelText('Modifies thresholds')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('This preset will modify thresholds')).not.toBeInTheDocument();
     });
 
     it('renders one badge per threshold-modifying preset', () => {
@@ -304,7 +304,7 @@ describe('PanelStylesSection', () => {
       mockGetPluginPresets.mockReturnValue([...mockPresets, thresholdPreset, anotherThresholdPreset]);
       render(<PanelStylesSection panel={buildPanel()} onApplyPreset={onApplyPreset} />);
 
-      expect(screen.getAllByLabelText('Modifies thresholds')).toHaveLength(2);
+      expect(screen.getAllByLabelText('This preset will modify thresholds')).toHaveLength(2);
     });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 import {
   FieldConfigSource,
@@ -9,6 +9,7 @@ import {
   PanelData,
   PanelPlugin,
   PanelPluginVisualizationSuggestion,
+  ThresholdsMode,
   getDefaultTimeRange,
   toDataFrame,
 } from '@grafana/data';
@@ -51,21 +52,25 @@ jest.mock('app/features/panel/components/VizTypePicker/VisualizationCardGrid', (
     items,
     onItemClick,
     selectedKey,
+    getBadge,
   }: {
     items: PanelPluginVisualizationSuggestion[];
     onItemClick: (item: PanelPluginVisualizationSuggestion, index: number) => void;
     selectedKey?: string;
+    getBadge?: (item: PanelPluginVisualizationSuggestion) => React.ReactNode;
   }) => (
     <div>
       {items.map((item, index) => (
-        <button
-          key={item.hash}
-          data-testid={`preset-${item.hash}`}
-          data-selected={selectedKey === item.hash ? 'true' : 'false'}
-          onClick={() => onItemClick(item, index)}
-        >
-          {item.name}
-        </button>
+        <div key={item.hash} style={{ position: 'relative' }}>
+          <button
+            data-testid={`preset-${item.hash}`}
+            data-selected={selectedKey === item.hash ? 'true' : 'false'}
+            onClick={() => onItemClick(item, index)}
+          >
+            {item.name}
+          </button>
+          {getBadge?.(item)}
+        </div>
       ))}
     </div>
   ),
@@ -76,6 +81,26 @@ const mockSceneGraph = jest.mocked(sceneGraph);
 const mockReportInteraction = jest.mocked(reportInteraction);
 
 const fakePlugin = {} as PanelPlugin;
+
+const thresholdPreset: PanelPluginVisualizationSuggestion = {
+  pluginId: 'gauge',
+  name: 'Standard',
+  hash: 'threshold-hash',
+  options: {},
+  fieldConfig: {
+    defaults: {
+      thresholds: {
+        mode: ThresholdsMode.Percentage,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        steps: [
+          { value: null as unknown as number, color: 'green' },
+          { value: 80, color: 'red' },
+        ],
+      },
+    },
+    overrides: [],
+  },
+};
 
 const mockPresets: PanelPluginVisualizationSuggestion[] = [
   {
@@ -253,5 +278,33 @@ describe('PanelStylesSection', () => {
 
     expect(screen.getByTestId('preset-table-preset-hash')).toBeInTheDocument();
     expect(screen.queryByTestId('preset-smooth-hash')).not.toBeInTheDocument();
+  });
+
+  describe('threshold badge', () => {
+    it('renders a badge for presets that modify thresholds', () => {
+      mockGetPluginPresets.mockReturnValue([...mockPresets, thresholdPreset]);
+      render(<PanelStylesSection panel={buildPanel()} onApplyPreset={onApplyPreset} />);
+
+      expect(screen.getByLabelText('Modifies thresholds')).toBeInTheDocument();
+    });
+
+    it('does not render a badge for presets that do not modify thresholds', () => {
+      mockGetPluginPresets.mockReturnValue(mockPresets);
+      render(<PanelStylesSection panel={buildPanel()} onApplyPreset={onApplyPreset} />);
+
+      expect(screen.queryByLabelText('Modifies thresholds')).not.toBeInTheDocument();
+    });
+
+    it('renders one badge per threshold-modifying preset', () => {
+      const anotherThresholdPreset: PanelPluginVisualizationSuggestion = {
+        ...thresholdPreset,
+        name: 'Segmented',
+        hash: 'threshold-hash-2',
+      };
+      mockGetPluginPresets.mockReturnValue([...mockPresets, thresholdPreset, anotherThresholdPreset]);
+      render(<PanelStylesSection panel={buildPanel()} onApplyPreset={onApplyPreset} />);
+
+      expect(screen.getAllByLabelText('Modifies thresholds')).toHaveLength(2);
+    });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.tsx
@@ -1,9 +1,10 @@
+import { css } from '@emotion/css';
 import { useCallback, useMemo, useState } from 'react';
 
-import { FeatureState, FieldConfigSource, PanelPluginVisualizationSuggestion } from '@grafana/data';
+import { FeatureState, FieldConfigSource, GrafanaTheme2, PanelPluginVisualizationSuggestion } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { sceneGraph, VizPanel } from '@grafana/scenes';
-import { FeatureBadge, Stack } from '@grafana/ui';
+import { FeatureBadge, Icon, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { OptionsPaneCategory } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategory';
 import { VisualizationCardGrid } from 'app/features/panel/components/VizTypePicker/VisualizationCardGrid';
 import { VizSuggestionsInteractions } from 'app/features/panel/components/VizTypePicker/interactions';
@@ -16,6 +17,7 @@ export interface PanelStylesSectionProps {
 }
 
 export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionProps) {
+  const styles = useStyles2(getStyles);
   const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
   const { data } = sceneGraph.getData(panel).useState();
 
@@ -35,6 +37,32 @@ export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionP
       }
     },
     [onApplyPreset, panel]
+  );
+
+  const presetModifiesThresholds = (preset: PanelPluginVisualizationSuggestion): boolean => {
+    return Boolean(preset.fieldConfig?.defaults?.thresholds);
+  };
+
+  const getThresholdBadge = useCallback(
+    (preset: PanelPluginVisualizationSuggestion) => {
+      return (
+        <>
+          {presetModifiesThresholds(preset) && (
+            <Tooltip
+              content={t('dashboard-scene.panel-styles.threshold-badge-tooltip', 'This preset will modify thresholds')}
+            >
+              <div
+                className={styles.thresholdBadge}
+                aria-label={t('dashboard-scene.panel-styles.threshold-badge-label', 'Modifies thresholds')}
+              >
+                <Icon name="sliders-v-alt" size="xs" />
+              </div>
+            </Tooltip>
+          )}
+        </>
+      );
+    },
+    [styles.thresholdBadge]
   );
 
   if (!presets || presets.length === 0 || !data || data.series.length === 0) {
@@ -61,7 +89,31 @@ export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionP
         selectedKey={selectedPreset}
         minColumnWidth={120}
         maxCardWidth={MIN_MULTI_COLUMN_SIZE}
+        getBadge={getThresholdBadge}
       />
     </OptionsPaneCategory>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  thresholdBadge: css({
+    position: 'absolute',
+    top: theme.spacing(0.5),
+    right: theme.spacing(0.5),
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: theme.spacing(2.5),
+    height: theme.spacing(2.5),
+    borderRadius: theme.shape.radius.circle,
+    background: theme.colors.background.canvas,
+    border: `1px solid ${theme.colors.border.medium}`,
+    color: theme.colors.text.secondary,
+    pointerEvents: 'auto',
+    zIndex: 1,
+    '&:hover': {
+      color: theme.colors.text.primary,
+      borderColor: theme.colors.border.strong,
+    },
+  }),
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.tsx
@@ -16,6 +16,10 @@ export interface PanelStylesSectionProps {
   onApplyPreset: (preset: PanelPluginVisualizationSuggestion, prevFieldConfig: FieldConfigSource) => void;
 }
 
+function presetModifiesThresholds(preset: PanelPluginVisualizationSuggestion): boolean {
+  return Boolean(preset.fieldConfig?.defaults?.thresholds);
+}
+
 export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionProps) {
   const styles = useStyles2(getStyles);
   const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
@@ -39,27 +43,22 @@ export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionP
     [onApplyPreset, panel]
   );
 
-  const presetModifiesThresholds = (preset: PanelPluginVisualizationSuggestion): boolean => {
-    return Boolean(preset.fieldConfig?.defaults?.thresholds);
-  };
-
   const getThresholdBadge = useCallback(
     (preset: PanelPluginVisualizationSuggestion) => {
+      if (!presetModifiesThresholds(preset)) {
+        return null;
+      }
       return (
-        <>
-          {presetModifiesThresholds(preset) && (
-            <Tooltip
-              content={t('dashboard-scene.panel-styles.threshold-badge-tooltip', 'This preset will modify thresholds')}
-            >
-              <div
-                className={styles.thresholdBadge}
-                aria-label={t('dashboard-scene.panel-styles.threshold-badge-label', 'Modifies thresholds')}
-              >
-                <Icon name="sliders-v-alt" size="xs" />
-              </div>
-            </Tooltip>
-          )}
-        </>
+        <Tooltip
+          content={t('dashboard-scene.panel-styles.threshold-badge-tooltip', 'This preset will modify thresholds')}
+        >
+          <div
+            className={styles.thresholdBadge}
+            aria-label={t('dashboard-scene.panel-styles.threshold-badge-label', 'Modifies thresholds')}
+          >
+            <Icon name="sliders-v-alt" size="xs" />
+          </div>
+        </Tooltip>
       );
     },
     [styles.thresholdBadge]

--- a/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelStylesSection.tsx
@@ -43,26 +43,23 @@ export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionP
     [onApplyPreset, panel]
   );
 
-  const getThresholdBadge = useCallback(
-    (preset: PanelPluginVisualizationSuggestion) => {
-      if (!presetModifiesThresholds(preset)) {
-        return null;
-      }
-      return (
-        <Tooltip
-          content={t('dashboard-scene.panel-styles.threshold-badge-tooltip', 'This preset will modify thresholds')}
+  const getThresholdBadge = (preset: PanelPluginVisualizationSuggestion) => {
+    if (!presetModifiesThresholds(preset)) {
+      return null;
+    }
+    return (
+      <Tooltip
+        content={t('dashboard-scene.panel-styles.threshold-badge-tooltip', 'This preset will modify thresholds')}
+      >
+        <div
+          className={styles.thresholdBadge}
+          aria-label={t('dashboard-scene.panel-styles.threshold-badge-tooltip', 'This preset will modify thresholds')}
         >
-          <div
-            className={styles.thresholdBadge}
-            aria-label={t('dashboard-scene.panel-styles.threshold-badge-label', 'Modifies thresholds')}
-          >
-            <Icon name="sliders-v-alt" size="xs" />
-          </div>
-        </Tooltip>
-      );
-    },
-    [styles.thresholdBadge]
-  );
+          <Icon name="sliders-v-alt" size="xs" />
+        </div>
+      </Tooltip>
+    );
+  };
 
   if (!presets || presets.length === 0 || !data || data.series.length === 0) {
     return null;
@@ -97,7 +94,7 @@ export function PanelStylesSection({ panel, onApplyPreset }: PanelStylesSectionP
 const getStyles = (theme: GrafanaTheme2) => ({
   thresholdBadge: css({
     position: 'absolute',
-    top: theme.spacing(0.5),
+    top: theme.spacing(1),
     right: theme.spacing(0.5),
     display: 'flex',
     alignItems: 'center',
@@ -108,11 +105,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     background: theme.colors.background.canvas,
     border: `1px solid ${theme.colors.border.medium}`,
     color: theme.colors.text.secondary,
-    pointerEvents: 'auto',
+    cursor: 'default',
     zIndex: 1,
-    '&:hover': {
-      color: theme.colors.text.primary,
-      borderColor: theme.colors.border.strong,
-    },
   }),
 });

--- a/public/app/features/panel/components/VizTypePicker/VisualizationCardGrid.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationCardGrid.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { Fragment, useMemo } from 'react';
+import { Fragment, ReactNode, useMemo } from 'react';
 import { useMeasure } from 'react-use';
 
 import { GrafanaTheme2, PanelData, PanelPluginMeta, PanelPluginVisualizationSuggestion } from '@grafana/data';
@@ -23,6 +23,7 @@ export interface Props {
   selectedKey?: string;
   minColumnWidth?: number;
   maxCardWidth?: number;
+  getBadge?: (item: PanelPluginVisualizationSuggestion) => ReactNode;
 }
 
 export function VisualizationCardGrid({
@@ -34,6 +35,7 @@ export function VisualizationCardGrid({
   selectedKey,
   minColumnWidth,
   maxCardWidth,
+  getBadge,
 }: Props) {
   const styles = useStyles2(getStyles, minColumnWidth, maxCardWidth);
   const [firstCardRef, { width }] = useMeasure<HTMLDivElement>();
@@ -60,6 +62,7 @@ export function VisualizationCardGrid({
   const renderCard = (item: PanelPluginVisualizationSuggestion, isFirst: boolean) => {
     const itemKey = getItemKey(item);
     const itemIndex = itemIndexMap.get(itemKey) ?? -1;
+    const badge = getBadge?.(item);
 
     return (
       <div
@@ -82,6 +85,7 @@ export function VisualizationCardGrid({
           isSelected={getItemKey(item) === selectedKey}
           onClick={() => onItemClick(item, itemIndex)}
         />
+        {badge}
       </div>
     );
   };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7252,7 +7252,6 @@
       }
     },
     "panel-styles": {
-      "threshold-badge-label": "Modifies thresholds",
       "threshold-badge-tooltip": "This preset will modify thresholds",
       "title": "Panel styles"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7252,6 +7252,8 @@
       }
     },
     "panel-styles": {
+      "threshold-badge-label": "Modifies thresholds",
+      "threshold-badge-tooltip": "This preset will modify thresholds",
       "title": "Panel styles"
     },
     "panel-viz-type-picker": {


### PR DESCRIPTION
This PR adds a thresholds badge to `VisualizationCardGrid` to indicate when a preset modifies thresholds.


https://github.com/user-attachments/assets/6ada636a-9766-43cd-8f69-abfc4beca755




Fixes https://github.com/grafana/grafana/issues/121026

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
