### PR TITLE
Provisioning: Fix default branch for fix metadata jobs when write is not allowed

### DIFF
--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -12,7 +12,11 @@ import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 import { DescendantCount } from 'app/features/browse-dashboards/components/BrowseActions/DescendantCount';
 import { collectSelectedItems } from 'app/features/browse-dashboards/utils/dashboards';
 import { JobStatus } from 'app/features/provisioning/Job/JobStatus';
-import { getCanPushToConfiguredBranch, getDefaultWorkflow } from 'app/features/provisioning/components/defaults';
+import {
+  getCanPushToConfiguredBranch,
+  getDefaultRef,
+  getDefaultWorkflow,
+} from 'app/features/provisioning/components/defaults';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 
@@ -24,7 +28,6 @@ import { MoveActionAvailableTargetWarning } from '../Shared/MoveActionAvailableT
 import { ProvisioningAwareFolderPicker } from '../Shared/ProvisioningAwareFolderPicker';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
-import { generateTimestamp } from '../utils/timestamp';
 
 import { MoveJobSpec, useBulkActionJob } from './useBulkActionJob';
 import { BulkActionFormData, BulkActionProvisionResourceProps, getTargetFolderPathInRepo } from './utils';
@@ -198,13 +201,11 @@ export function BulkMoveProvisionedResource({ folderUid, selectedItems, onDismis
 
   const canPushToConfiguredBranch = getCanPushToConfiguredBranch(repository);
   const folderPath = folder?.metadata?.annotations?.[AnnoKeySourcePath] || '';
-  const timestamp = generateTimestamp();
-  const defaultWorkflow = getDefaultWorkflow(repository);
 
   const initialValues = {
     comment: '',
-    ref: defaultWorkflow === 'branch' ? `bulk-move/${timestamp}` : (repository?.branch ?? ''),
-    workflow: defaultWorkflow,
+    ref: getDefaultRef(repository, 'bulk-move'),
+    workflow: getDefaultWorkflow(repository),
   };
 
   if (!repository || isReadOnlyRepo) {

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.test.tsx
@@ -82,9 +82,7 @@ describe('FixFolderMetadataDrawer', () => {
 
     const { user } = render(<FixFolderMetadataDrawer repositoryName={REPO_NAME} onDismiss={jest.fn()} />);
 
-    await screen.findByRole('button', { name: /fix folder ids/i });
-
-    await user.click(screen.getByRole('button', { name: /fix folder ids/i }));
+    await user.click(await screen.findByRole('button', { name: /fix folder ids/i }));
 
     await waitFor(() => {
       expect(capturedBody).toEqual(
@@ -92,6 +90,41 @@ describe('FixFolderMetadataDrawer', () => {
           action: 'fixFolderMetadata',
           fixFolderMetadata: expect.objectContaining({
             ref: 'main',
+          }),
+        })
+      );
+    });
+  });
+
+  it('defaults to a generated branch name when write workflow is not available', async () => {
+    server.use(
+      http.get(`${BASE}/settings`, () =>
+        HttpResponse.json({
+          ...defaultSettings,
+          items: [{ ...defaultSettings.items[0], workflows: ['branch'] }],
+        })
+      )
+    );
+
+    let capturedBody: unknown;
+    server.use(
+      http.post(`${BASE}/repositories/:name/jobs`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(jobResponse);
+      }),
+      http.get(`${BASE}/jobs`, () => HttpResponse.json({ items: [jobResponse] }))
+    );
+
+    const { user } = render(<FixFolderMetadataDrawer repositoryName={REPO_NAME} onDismiss={jest.fn()} />);
+
+    await user.click(await screen.findByRole('button', { name: /fix folder ids/i }));
+
+    await waitFor(() => {
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          action: 'fixFolderMetadata',
+          fixFolderMetadata: expect.objectContaining({
+            ref: expect.stringMatching(/^fix-folder-ids\//),
           }),
         })
       );
@@ -141,8 +174,7 @@ describe('FixFolderMetadataDrawer', () => {
 
     const { user } = render(<FixFolderMetadataDrawer repositoryName={REPO_NAME} onDismiss={jest.fn()} />);
 
-    await screen.findByRole('button', { name: /fix folder ids/i });
-    await user.click(screen.getByRole('button', { name: /fix folder ids/i }));
+    await user.click(await screen.findByRole('button', { name: /fix folder ids/i }));
 
     expect(await screen.findByRole('alert')).toBeInTheDocument();
     expect(screen.getByText(/error fixing folder metadata/i)).toBeInTheDocument();
@@ -157,8 +189,7 @@ describe('FixFolderMetadataDrawer', () => {
     const onDismiss = jest.fn();
     const { user } = render(<FixFolderMetadataDrawer repositoryName={REPO_NAME} onDismiss={onDismiss} />);
 
-    await screen.findByRole('button', { name: /fix folder ids/i });
-    await user.click(screen.getByRole('button', { name: /fix folder ids/i }));
+    await user.click(await screen.findByRole('button', { name: /fix folder ids/i }));
 
     // The drawer should remain open showing job status, not auto-dismiss
     expect(onDismiss).not.toHaveBeenCalled();
@@ -204,7 +235,6 @@ describe('FixFolderMetadataDrawer', () => {
 
     render(<FixFolderMetadataDrawer repositoryName={REPO_NAME} onDismiss={jest.fn()} />);
 
-    await screen.findByRole('button', { name: /fix folder ids/i });
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /fix folder ids/i })).toBeDisabled();
     });

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
@@ -14,7 +14,7 @@ import { BaseProvisionedFormData } from '../../types/form';
 import { useGetActiveJob } from '../../useGetActiveJob';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
-import { getCanPushToConfiguredBranch, getDefaultWorkflow } from '../defaults';
+import { getCanPushToConfiguredBranch, getDefaultRef, getDefaultWorkflow } from '../defaults';
 
 interface FixFolderMetadataDrawerProps {
   repositoryName: string;
@@ -80,7 +80,7 @@ export function FixFolderMetadataDrawer({ repositoryName, onDismiss }: FixFolder
   const defaultWorkflow = getDefaultWorkflow(repository);
 
   const defaultValues: BaseProvisionedFormData = {
-    ref: repository.branch ?? '',
+    ref: getDefaultRef(repository, 'fix-folder-ids'),
     path: '',
     comment: '',
     repo: repositoryName,

--- a/public/app/features/provisioning/components/defaults.ts
+++ b/public/app/features/provisioning/components/defaults.ts
@@ -1,5 +1,7 @@
 import { RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
+import { generateNewBranchName } from './utils/newBranchName';
+
 export function getDefaultWorkflow(config?: RepositoryView, loadedFromRef?: string) {
   if (loadedFromRef && loadedFromRef !== config?.branch) {
     return 'write'; // use write when the value targets an explicit ref
@@ -9,4 +11,9 @@ export function getDefaultWorkflow(config?: RepositoryView, loadedFromRef?: stri
 
 export function getCanPushToConfiguredBranch(repository?: RepositoryView) {
   return repository?.workflows?.includes('write') ?? false;
+}
+
+export function getDefaultRef(repository: RepositoryView | undefined, branchPrefix: string, loadedFromRef?: string) {
+  const workflow = getDefaultWorkflow(repository, loadedFromRef);
+  return workflow === 'branch' ? generateNewBranchName(branchPrefix) : (repository?.branch ?? '');
 }

--- a/public/app/features/provisioning/components/utils/newBranchName.ts
+++ b/public/app/features/provisioning/components/utils/newBranchName.ts
@@ -2,8 +2,8 @@ import { generateTimestamp } from './timestamp';
 
 /**
  * Generate a new branch name for provisioned resources.
- * Uses the resource type as a prefix and appends a timestamp.
+ * Uses the given prefix and appends a timestamp.
  */
-export function generateNewBranchName(resourceType: string): string {
-  return `${resourceType}/${generateTimestamp()}`;
+export function generateNewBranchName(prefix: string): string {
+  return `${prefix}/${generateTimestamp()}`;
 }

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.ts
@@ -9,8 +9,7 @@ import {
 import { getIsReadOnlyRepo } from 'app/features/provisioning/utils/repository';
 import { DashboardMeta } from 'app/types/dashboard';
 
-import { getCanPushToConfiguredBranch, getDefaultWorkflow } from '../components/defaults';
-import { generateNewBranchName } from '../components/utils/newBranchName';
+import { getCanPushToConfiguredBranch, getDefaultRef, getDefaultWorkflow } from '../components/defaults';
 import { generatePath } from '../components/utils/path';
 import { generateTimestamp } from '../components/utils/timestamp';
 import { ProvisionedDashboardFormData } from '../types/form';
@@ -72,11 +71,9 @@ export function useDefaultValues({
     folderPath,
   });
 
-  const defaultWorkflow = getDefaultWorkflow(repository, loadedFromRef);
-
   return {
     values: {
-      ref: defaultWorkflow === 'branch' ? generateNewBranchName('dashboard') : (repository?.branch ?? ''),
+      ref: getDefaultRef(repository, 'dashboard', loadedFromRef),
       path: dashboardPath,
       repo: managerIdentity || repository?.name || '',
       comment: '',

--- a/public/app/features/provisioning/hooks/useProvisionedFolderFormData.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedFolderFormData.ts
@@ -3,8 +3,11 @@ import { useMemo } from 'react';
 import { Folder } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
-import { getCanPushToConfiguredBranch, getDefaultWorkflow } from 'app/features/provisioning/components/defaults';
-import { generateNewBranchName } from 'app/features/provisioning/components/utils/newBranchName';
+import {
+  getCanPushToConfiguredBranch,
+  getDefaultRef,
+  getDefaultWorkflow,
+} from 'app/features/provisioning/components/defaults';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 
 import { BaseProvisionedFormData } from '../types/form';
@@ -38,12 +41,10 @@ export function useProvisionedFolderFormData({
     if (!repository || isLoading) {
       return undefined;
     }
-    const defaultWorkflow = getDefaultWorkflow(repository);
-
     return {
       title: title || '',
       comment: '',
-      ref: defaultWorkflow === 'branch' ? generateNewBranchName('folder') : (repository?.branch ?? ''),
+      ref: getDefaultRef(repository, 'folder'),
       repo: repository.name || '',
       path: folder?.metadata?.annotations?.[AnnoKeySourcePath] || '',
       workflow: getDefaultWorkflow(repository),


### PR DESCRIPTION
**What is this feature?**

Extracts a `getDefaultRef` helper that generates a new branch name when the default workflow is `branch` (no direct write access), and uses it consistently across all provisioning forms. Fixes the "Fix folder metadata" drawer which was incorrectly defaulting to the configured branch even when the user couldn't write to it.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1031