### PR TITLE
Storage: improve broadcaster resilience to write bursts

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"time"
 )
 
 type Broadcaster[T any] interface {
@@ -16,13 +17,20 @@ type Broadcaster[T any] interface {
 // for closing it when no more data will be sent. The broadcaster terminates
 // when either ctx is cancelled or input is closed.
 func NewBroadcaster[T any](ctx context.Context, input <-chan T) Broadcaster[T] {
+	return newBroadcasterWithSizes[T](ctx, input, watchChanSize, defaultOverflowCap)
+}
+
+// newBroadcasterWithSizes creates a broadcaster with configurable buffer sizes for testing.
+func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufSize, ovfCap int) *broadcaster[T] {
 	b := &broadcaster[T]{
 		shouldTerminate: ctx.Done(),
-		cache:           newRingBuffer[T](100),
-		subscribe:       make(chan subscription[T], chanBufferLen),
-		unsubscribe:     make(chan (<-chan T), chanBufferLen),
-		subs:            make(map[<-chan T]subscription[T]),
+		cache:           newRingBuffer[T](defaultCacheSize),
+		subscribe:       make(chan *subscription[T], internalChanSize),
+		unsubscribe:     make(chan (<-chan T), internalChanSize),
+		subs:            make(map[<-chan T]*subscription[T]),
 		terminated:      make(chan struct{}),
+		watchBufSize:    subBufSize,
+		overflowCap:     ovfCap,
 	}
 
 	go b.stream(input)
@@ -31,8 +39,9 @@ func NewBroadcaster[T any](ctx context.Context, input <-chan T) Broadcaster[T] {
 }
 
 type subscription[T any] struct {
-	name string
-	ch   chan T
+	name     string
+	ch       chan T
+	overflow []T // pending items when channel is full, nil when not overflowing
 }
 
 type broadcaster[T any] struct {
@@ -44,13 +53,44 @@ type broadcaster[T any] struct {
 	// subscription management
 
 	cache       ringBuffer[T]
-	subscribe   chan subscription[T]
+	subscribe   chan *subscription[T]
 	unsubscribe chan (<-chan T)
-	subs        map[<-chan T]subscription[T]
+	subs        map[<-chan T]*subscription[T]
+
+	// configuration
+
+	watchBufSize    int
+	overflowCap     int
+	lastOverflowLog time.Time
+	overflowCount   int64 // overflow events since last log
 }
 
+const (
+	// internalChanSize is the buffer for internal subscribe/unsubscribe coordination channels.
+	internalChanSize = 100
+
+	// defaultCacheSize is the ring buffer size for replaying recent events to new subscribers.
+	defaultCacheSize = 500
+
+	// watchChanSize is the per-subscriber event delivery channel buffer.
+	// Must be larger than defaultCacheSize so that readInto never fills the
+	// channel completely, leaving headroom for new events.
+	watchChanSize = 1000
+
+	// defaultOverflowCap is the maximum number of items in a subscriber's overflow
+	// buffer before the subscriber is disconnected.
+	defaultOverflowCap = 50_000
+
+	// drainInterval controls how often the stream loop drains overflow buffers
+	// during idle periods (no incoming events).
+	drainInterval = 100 * time.Millisecond
+
+	// overflowLogInterval rate-limits "overflow started" log messages.
+	overflowLogInterval = 10 * time.Second
+)
+
 func (b *broadcaster[T]) Subscribe(ctx context.Context, name string) (<-chan T, error) {
-	sub := subscription[T]{name: name, ch: make(chan T, 100)}
+	sub := &subscription[T]{name: name, ch: make(chan T, b.watchBufSize)}
 
 	select {
 	case <-ctx.Done(): // client canceled
@@ -73,7 +113,24 @@ func (b *broadcaster[T]) Unsubscribe(sub <-chan T) {
 	}
 }
 
-const chanBufferLen = 100
+// drainOverflow moves items from sub.overflow into sub.ch without blocking.
+// Nils the overflow slice when fully drained to release memory.
+func (b *broadcaster[T]) drainOverflow(sub *subscription[T]) {
+	if len(sub.overflow) == 0 {
+		return
+	}
+	i := 0
+	for i < len(sub.overflow) {
+		select {
+		case sub.ch <- sub.overflow[i]:
+			i++
+		default:
+			sub.overflow = sub.overflow[i:]
+			return
+		}
+	}
+	sub.overflow = nil
+}
 
 // stream acts a message broker between the watch implementation that receives a
 // raw stream of events and the individual clients watching for those events.
@@ -83,12 +140,16 @@ const chanBufferLen = 100
 // (as with any other channel) will always be of the sending side. Hence, the
 // watch implementation should do it.
 func (b *broadcaster[T]) stream(input <-chan T) {
+	drainTicker := time.NewTicker(drainInterval)
+	defer drainTicker.Stop()
+
 	// make sure we unconditionally cleanup upon return
 	defer func() {
 		// prevent new subscriptions and make sure to discard unsubscriptions
 		close(b.terminated)
 		// terminate all subscriptions
 		for recv, sub := range b.subs {
+			sub.overflow = nil
 			close(sub.ch)
 			delete(b.subs, recv)
 		}
@@ -96,12 +157,13 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 
 	unsubscribe := func(recv <-chan T) {
 		if sub, ok := b.subs[recv]; ok {
+			sub.overflow = nil
 			close(sub.ch)
 			delete(b.subs, recv)
 		}
 	}
 
-	addSubscriber := func(sub subscription[T]) {
+	addSubscriber := func(sub *subscription[T]) {
 		// send initial batch of cached items
 		if !b.cache.readInto(sub.ch) {
 			close(sub.ch)
@@ -140,20 +202,47 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 
 			var slow []<-chan T
 			for _, sub := range b.subs {
-				select {
-				case sub.ch <- item:
-				default:
-					slow = append(slow, sub.ch)
+				b.drainOverflow(sub)
+
+				if len(sub.overflow) > 0 {
+					// Still overflowing — append to overflow
+					sub.overflow = append(sub.overflow, item)
+					b.overflowCount++
+					if len(sub.overflow) > b.overflowCap {
+						slog.Warn("disconnecting subscriber: overflow cap exceeded",
+							"subscriber", sub.name,
+							"overflowSize", len(sub.overflow))
+						slow = append(slow, sub.ch)
+					}
+				} else {
+					// Try direct send
+					select {
+					case sub.ch <- item:
+					default:
+						sub.overflow = append(sub.overflow, item)
+						b.overflowCount++
+						now := time.Now()
+						if now.Sub(b.lastOverflowLog) > overflowLogInterval {
+							slog.Warn("subscriber overflow",
+								"subscriber", sub.name,
+								"overflowSize", len(sub.overflow),
+								"overflowsSinceLastLog", b.overflowCount)
+							b.lastOverflowLog = now
+							b.overflowCount = 0
+						}
+					}
 				}
 			}
 			// Instead of sending subscribers to b.unsubscribe channel, we unsubscribe directly.
 			// Sending to b.unsubscribe could lead to deadlock, if there are too many elements in the
 			// channel buffer already.
 			for _, recv := range slow {
-				if sub, ok := b.subs[recv]; ok {
-					slog.Warn("unsubscribing slow consumer", "subscriber", sub.name)
-				}
 				unsubscribe(recv)
+			}
+
+		case <-drainTicker.C: // periodically drain overflow for idle periods
+			for _, sub := range b.subs {
+				b.drainOverflow(sub)
 			}
 		}
 	}
@@ -169,7 +258,7 @@ type ringBuffer[T any] struct {
 
 func newRingBuffer[T any](size int) ringBuffer[T] {
 	if size <= 0 {
-		size = 100
+		size = defaultCacheSize
 	}
 	return ringBuffer[T]{
 		buf: make([]T, size),

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -133,27 +133,28 @@ func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
 	defer cancel()
 
 	ch := make(chan int)
-	b := NewBroadcaster(ctx, ch)
 
-	// Create 101 subscribers that never read — more than the
-	// unsubscribe channel buffer (100) in the original code.
-	const numSubs = chanBufferLen + 1
+	// Use small overflow cap so slow consumers get disconnected quickly.
+	const subBuf = 10
+	const ovfCap = 20
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+
+	// Create 101 subscribers that never read — enough to exceed the
+	// internal unsubscribe channel buffer and exercise bulk disconnect.
+	const numSubs = internalChanSize + 1
 	for i := 0; i < numSubs; i++ {
 		_, err := b.Subscribe(ctx, "test")
 		require.NoError(t, err)
 	}
 
-	// Fill all subscriber buffers (each buffered at 100), and keep sending more elements.
-	//
-	// Since all subscribers are slow, they should get unsubscribed
-	// eventually. In the original code, unsubscribing buf size + 1 subscribers would deadlock.
-	// Use a timeout to detect the deadlock.
+	// Fill all subscriber buffers + overflow until cap is exceeded.
+	// All subscribers are slow, so they all get disconnected on the same
+	// event. Use a timeout to detect deadlock.
 	done := make(chan struct{})
 	go func() {
-		for i := 0; i < 10*chanBufferLen; i++ {
+		for i := 0; i < subBuf+ovfCap+1; i++ {
 			ch <- i
 		}
-
 		close(done)
 	}()
 
@@ -163,4 +164,183 @@ func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("deadlock: stream() blocked trying to unsubscribe slow consumers")
 	}
+}
+
+func TestBroadcasterOverflowSpoolsInsteadOfDisconnecting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	t.Cleanup(func() { close(ch) })
+
+	const subBuf = 10
+	const ovfCap = 100
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+
+	sub, err := b.Subscribe(ctx, "test")
+	require.NoError(t, err)
+
+	// Send more items than the subscriber buffer can hold.
+	// With overflow, the subscriber should NOT be disconnected.
+	const totalItems = subBuf + 20
+	go func() {
+		for i := 0; i < totalItems; i++ {
+			ch <- i
+		}
+	}()
+
+	// Read all items — they should arrive in order.
+	for i := 0; i < totalItems; i++ {
+		select {
+		case v, ok := <-sub:
+			require.True(t, ok, "subscriber channel closed prematurely at item %d", i)
+			require.Equal(t, i, v)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for item %d", i)
+		}
+	}
+}
+
+func TestBroadcasterDisconnectsOnOverflowCapExceeded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	t.Cleanup(func() { close(ch) })
+
+	const subBuf = 10
+	const ovfCap = 20
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+
+	sub, err := b.Subscribe(ctx, "test")
+	require.NoError(t, err)
+
+	// Send enough items to fill buffer + exceed overflow cap.
+	// The subscriber never reads, so it should be disconnected.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < subBuf+ovfCap+10; i++ {
+			ch <- i
+		}
+		close(done)
+	}()
+
+	// Wait for all sends to complete — stream() processes them, subscriber
+	// gets disconnected after overflow cap exceeded.
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out: sender blocked")
+	}
+
+	// Drain any buffered items; channel should be closed.
+	for {
+		select {
+		case _, ok := <-sub:
+			if !ok {
+				return
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out: subscriber was not disconnected after overflow cap exceeded")
+		}
+	}
+}
+
+func TestBroadcasterReadIntoDoesNotFillChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	t.Cleanup(func() { close(ch) })
+
+	// Subscriber buffer (defaultCacheSize + 100) > defaultCacheSize,
+	// so readInto should leave headroom.
+	const subBuf = defaultCacheSize + 100
+	const ovfCap = 1000
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+
+	// Fill the cache to capacity by sending items through the input channel
+	// (no subscribers yet, so items only go to cache).
+	for i := 0; i < defaultCacheSize; i++ {
+		ch <- i
+	}
+
+	// Subscribe — readInto sends all cached items into the subscriber channel.
+	sub, err := b.Subscribe(ctx, "test")
+	require.NoError(t, err)
+
+	// Read one cached item to confirm the subscription is active.
+	select {
+	case _, ok := <-sub:
+		require.True(t, ok)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first cached item")
+	}
+
+	// Send additional events. The channel has headroom (buffer > cache)
+	// so these arrive without overflowing.
+	const extra = 10
+	for i := 0; i < extra; i++ {
+		ch <- 1000 + i
+	}
+
+	// Read all remaining items — subscriber should still be alive.
+	for i := 0; i < extra; i++ {
+		select {
+		case _, ok := <-sub:
+			require.True(t, ok, "subscriber disconnected at item %d", i)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out at item %d of %d", i, extra)
+		}
+	}
+}
+
+func TestBroadcasterOverflowMemoryReleasedWhenCaughtUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan int)
+	t.Cleanup(func() { close(ch) })
+
+	const subBuf = 10
+	const ovfCap = 100
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+
+	sub, err := b.Subscribe(ctx, "test")
+	require.NoError(t, err)
+
+	// Send more items than the channel buffer can hold, causing overflow.
+	const totalItems = subBuf + 15
+	go func() {
+		for i := 0; i < totalItems; i++ {
+			ch <- i
+		}
+	}()
+
+	// Read all items to catch up.
+	for i := 0; i < totalItems; i++ {
+		select {
+		case _, ok := <-sub:
+			require.True(t, ok)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for item %d", i)
+		}
+	}
+
+	// Send one more event to confirm the subscriber is still alive
+	// and the overflow path is not active.
+	ch <- 999
+	select {
+	case v, ok := <-sub:
+		require.True(t, ok)
+		require.Equal(t, 999, v)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out: subscriber not responsive after overflow recovery")
+	}
+
+	// Verify overflow is nil by checking internal state.
+	// The subscriber should have no overflow since it caught up.
+	s := b.subs[sub]
+	require.NotNil(t, s, "subscriber should still exist")
+	require.Nil(t, s.overflow, "overflow should be nil after subscriber caught up")
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1439,6 +1439,10 @@ func parseTrashItem(value []byte) (utils.GrafanaMetaAccessor, error) {
 	return utils.MetaAccessor(partial)
 }
 
+// producerChanSize is the buffer for the channel that feeds events into the
+// broadcaster. Controls backpressure on the event-writing (producer) side.
+const producerChanSize = 100
+
 // Start the server.broadcaster (requires that the backend storage services are enabled)
 func (s *server) initWatcher() error {
 	events, err := s.backend.WatchWriteEvents(s.ctx)
@@ -1446,7 +1450,7 @@ func (s *server) initWatcher() error {
 		return err
 	}
 
-	out := make(chan *WrittenEvent, 100)
+	out := make(chan *WrittenEvent, producerChanSize)
 	go func() {
 		defer close(out)
 		for v := range events {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1446,7 +1446,7 @@ func (s *server) initWatcher() error {
 		return err
 	}
 
-	out := make(chan *WrittenEvent, chanBufferLen)
+	out := make(chan *WrittenEvent, 100)
 	go func() {
 		defer close(out)
 		for v := range events {


### PR DESCRIPTION
## Summary

The broadcaster disconnects "slow consumers" when their channel buffer is full. Under burst write load, this causes cascading failure: disconnected watchers reconnect with `sendInitialEvents=true`, triggering full LIST replays that overload the database.

**Root cause**: ring buffer cache size (100) == subscriber channel buffer (100). When a new subscriber joins and the cache is full, `readInto` fills the channel completely, leaving zero headroom. The next event triggers immediate disconnect.

**Changes**:
- Increase cache size to 500 and subscriber channel buffer to 1000, so `readInto` never fills the channel completely
- Add per-subscriber overflow slice that absorbs bursts instead of immediately disconnecting. Uses a slice rather than a larger channel because most subscribers keep up — allocating a 50k-deep channel per subscriber would waste memory, while a nil slice costs nothing until actually needed
- Disconnect only when overflow exceeds cap (50,000 items)
- Drain overflow inline during event dispatch + via a 100ms ticker for idle periods, keeping `stream()` as the sole owner of subscriber state (no extra goroutines, no ordering issues)
- Add rate-limited overflow logging with event counter

Relates to https://github.com/grafana/search-and-storage-team/issues/724

## Test plan
- [x] All existing broadcaster tests pass
- [x] New test: overflow spools instead of disconnecting (`TestBroadcasterOverflowSpoolsInsteadOfDisconnecting`)
- [x] New test: disconnect only on overflow cap exceeded (`TestBroadcasterDisconnectsOnOverflowCapExceeded`)
- [x] New test: readInto from full cache doesn't fill channel (`TestBroadcasterReadIntoDoesNotFillChannel`)
- [x] New test: overflow memory released when caught up (`TestBroadcasterOverflowMemoryReleasedWhenCaughtUp`)
- [x] All tests pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)