### PR TITLE
Feature Toggles: Fix doc redundancy introduced in #114047

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2920,10 +2920,6 @@ For more information about Grafana Enterprise, refer to [Grafana Enterprise](../
 
 ### `[feature_toggles]`
 
-#### `feature_name = true|false`
-
-Set each feature toggle to `true` to enable it or `false` to disable it. Some feature toggles are on by default, so set the toggle to `false` to disable that default behavior, for example, `exploreMixedDatasource = false`.
-
 #### `FEATURE_NAME = <value>`
 
 Use a key-value pair to set feature flag values explicitly, overriding any default values. A few different types are supported, following the OpenFeature specification. See the defaults.ini file for more details.


### PR DESCRIPTION
During a rebase in #114047 I incorrectly resolved a merge conflict, leaving an old reference behind.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
