### PR TITLE
IAM: Add UserAuthorizer for teams subresource

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -71,7 +71,7 @@ func newIAMAuthorizer(
 	resourceAuthorizer[iamv0.ResourcePermissionInfo.GetName()] = allowAuthorizer // Handled by the backend wrapper
 	resourceAuthorizer[iamv0.RoleBindingInfo.GetName()] = authorizer
 	resourceAuthorizer[iamv0.ServiceAccountResourceInfo.GetName()] = authorizer
-	resourceAuthorizer[iamv0.UserResourceInfo.GetName()] = authorizer
+	resourceAuthorizer[iamv0.UserResourceInfo.GetName()] = newUserAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.ExternalGroupMappingResourceInfo.GetName()] = externalGroupMappingApiInstaller.GetAuthorizer()
 	resourceAuthorizer[iamv0.TeamResourceInfo.GetName()] = newTeamAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.TeamBindingResourceInfo.GetName()] = allowAuthorizer
@@ -131,6 +131,43 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 		}
 
 		// Delegate to the standard ResourceAuthorizer for non-members subresources
+		return delegate.Authorize(ctx, attr)
+	})
+}
+
+// newUserAuthorizer creates an authorizer for users that handles the "teams" subresource
+// with a get check on the parent user resource.
+func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	delegate := gfauthorizer.NewResourceAuthorizer(accessClient)
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if !attr.IsResourceRequest() {
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+
+		subresource := attr.GetSubresource()
+		if subresource == "teams" {
+			ident, ok := authlib.AuthInfoFrom(ctx)
+			if !ok {
+				return authorizer.DecisionDeny, "", errors.New("no identity found")
+			}
+
+			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+				Verb:      utils.VerbGet,
+				Group:     attr.GetAPIGroup(),
+				Resource:  attr.GetResource(),
+				Namespace: attr.GetNamespace(),
+				Name:      attr.GetName(),
+			}, "")
+			if err != nil {
+				return authorizer.DecisionDeny, "", err
+			}
+			if !res.Allowed {
+				return authorizer.DecisionDeny, "requires user get", nil
+			}
+			return authorizer.DecisionAllow, "", nil
+		}
+
+		// Delegate to the standard ResourceAuthorizer for non-teams subresources
 		return delegate.Authorize(ctx, attr)
 	})
 }

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -204,3 +204,174 @@ func TestNewTeamAuthorizer_DecisionMatrix(t *testing.T) {
 		})
 	}
 }
+
+// TestNewUserAuthorizer_TeamsSubresource_CheckRequest verifies that the authorizer
+// builds the correct CheckRequest for the teams subresource.
+func TestNewUserAuthorizer_TeamsSubresource_CheckRequest(t *testing.T) {
+	var capturedReq *types.CheckRequest
+	fakeClient := &fakeAccessClient{
+		checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+			capturedReq = &req
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	userAuth := newUserAuthorizer(fakeClient)
+
+	authInfo := authn.NewIDTokenAuthInfo(
+		authn.Claims[authn.AccessTokenClaims]{},
+		&authn.Claims[authn.IDTokenClaims]{},
+	)
+	ctx := types.WithAuthInfo(context.Background(), authInfo)
+
+	attr := authorizer.AttributesRecord{
+		ResourceRequest: true,
+		APIGroup:        iamv0.UserResourceInfo.GroupResource().Group,
+		Resource:        iamv0.UserResourceInfo.GroupResource().Resource,
+		Subresource:     "teams",
+		Name:            "user-xyz",
+		Verb:            "get",
+		Namespace:       "org-1",
+	}
+
+	_, _, err := userAuth.Authorize(ctx, attr)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	assert.Equal(t, "get", capturedReq.Verb)
+	assert.Equal(t, iamv0.UserResourceInfo.GroupResource().Group, capturedReq.Group)
+	assert.Equal(t, iamv0.UserResourceInfo.GroupResource().Resource, capturedReq.Resource)
+	assert.Equal(t, "user-xyz", capturedReq.Name)
+	assert.Equal(t, "org-1", capturedReq.Namespace)
+}
+
+// TestNewUserAuthorizer_DecisionMatrix covers all decision paths with table-driven tests.
+func TestNewUserAuthorizer_DecisionMatrix(t *testing.T) {
+	tests := []struct {
+		name            string
+		subresource     string
+		resourceRequest bool
+		checkFunc       func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
+		wantDecision    authorizer.Decision
+		wantReason      string
+		wantErr         bool
+		wantCheckCalled bool
+	}{
+		{
+			name:            "teams subresource - allowed",
+			subresource:     "teams",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				return types.CheckResponse{Allowed: true}, nil
+			},
+			wantDecision:    authorizer.DecisionAllow,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "teams subresource - denied",
+			subresource:     "teams",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				return types.CheckResponse{Allowed: false}, nil
+			},
+			wantDecision:    authorizer.DecisionDeny,
+			wantReason:      "requires user get",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "teams subresource - error",
+			subresource:     "teams",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				return types.CheckResponse{}, errors.New("database error")
+			},
+			wantDecision:    authorizer.DecisionDeny,
+			wantReason:      "",
+			wantErr:         true,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "no subresource - delegates to ResourceAuthorizer",
+			subresource:     "",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				// Verify the subresource is NOT passed through to the delegate
+				assert.Empty(t, req.Subresource)
+				return types.CheckResponse{Allowed: true}, nil
+			},
+			wantDecision:    authorizer.DecisionAllow,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "other subresource (status) - delegates to ResourceAuthorizer",
+			subresource:     "status",
+			resourceRequest: true,
+			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				// The subresource should be passed through to the delegate
+				assert.Equal(t, "status", req.Subresource)
+				return types.CheckResponse{Allowed: true}, nil
+			},
+			wantDecision:    authorizer.DecisionAllow,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: true,
+		},
+		{
+			name:            "non-resource request - no opinion",
+			subresource:     "",
+			resourceRequest: false,
+			checkFunc:       nil, // Should not be called
+			wantDecision:    authorizer.DecisionNoOpinion,
+			wantReason:      "",
+			wantErr:         false,
+			wantCheckCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkCalled := false
+			wrappedCheckFunc := func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+				checkCalled = true
+				if tt.checkFunc != nil {
+					return tt.checkFunc(ctx, id, req, folder)
+				}
+				return types.CheckResponse{Allowed: false}, nil
+			}
+
+			fakeClient := &fakeAccessClient{checkFunc: wrappedCheckFunc}
+			userAuth := newUserAuthorizer(fakeClient)
+
+			authInfo := authn.NewIDTokenAuthInfo(
+				authn.Claims[authn.AccessTokenClaims]{},
+				&authn.Claims[authn.IDTokenClaims]{},
+			)
+			ctx := types.WithAuthInfo(context.Background(), authInfo)
+
+			attr := authorizer.AttributesRecord{
+				ResourceRequest: tt.resourceRequest,
+				APIGroup:        iamv0.UserResourceInfo.GroupResource().Group,
+				Resource:        iamv0.UserResourceInfo.GroupResource().Resource,
+				Subresource:     tt.subresource,
+				Name:            "user-xyz",
+				Verb:            "get",
+			}
+
+			decision, reason, err := userAuth.Authorize(ctx, attr)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantDecision, decision)
+			assert.Equal(t, tt.wantReason, reason)
+			assert.Equal(t, tt.wantCheckCalled, checkCalled, "Check call mismatch")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `newUserAuthorizer()` that delegates to `ResourceAuthorizer` for all subresources except `teams`
- For the `teams` subresource, explicitly check `get` permission on the parent user resource
- Add comprehensive tests for all decision paths (allowed, denied, error, delegation cases)

## Why
Pre-requisite for https://github.com/grafana/grafana/pull/118377

**Problem:** The generic `ResourceAuthorizer` passes all subresources to the RBAC service. I plan to change the AuthZ Service check so when a subresource lacks a mapper entry (like `users/teams`), the RBAC service denies access. This will break authorization for existing subresources.

**Solution:** Create a dedicated `UserAuthorizer` that intercepts the `teams` subresource and explicitly checks `get` on the parent user (*which is what was currently happening*). This matches the current access control logic where viewing a user's teams requires `users:read` on that user (legacy endpoint: `/api/users/:id/teams`).

## Consistency with legacy access control
| Endpoint | Legacy Permission | New K8s Check |
|----------|------------------|---------------|
| `/api/users/:id/teams` | `users:read` scoped to user | `get` on `users/{name}` |

## Test plan
- [ ] Run `go test ./pkg/registry/apis/iam/... -run "UserAuthorizer"` to verify new tests pass
- [ ] Verify `TestNewUserAuthorizer_TeamsSubresource_CheckRequest` validates correct CheckRequest is built
- [ ] Verify `TestNewUserAuthorizer_DecisionMatrix` covers all decision paths (allowed, denied, error, delegation, no-opinion)