### PR TITLE
datasources: querier: optional raw output mode

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -344,6 +344,11 @@ export interface FeatureToggles {
   */
   datasourcesApiserverEnableResourceEndpointRedirect?: boolean;
   /**
+  * use raw output mode for the data source querier
+  * @default false
+  */
+  datasourcesQuerierRawOutput?: boolean;
+  /**
   * Runs CloudWatch metrics queries as separate batches
   * @default false
   */

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -31,9 +31,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	ds_service "github.com/grafana/grafana/pkg/services/datasources/service"
 	"github.com/grafana/grafana/pkg/services/dsquerierclient"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	service "github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
+	"github.com/open-feature/go-sdk/openfeature"
 )
 
 type queryREST struct {
@@ -136,57 +139,68 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 			"caller", getCaller(ctx),
 		)
 		connectLogger.Debug("received query-service request")
-		responder := newResponderWrapper(incomingResponder,
-			func(statusCode *int, obj runtime.Object) {
-				if *statusCode/100 == 4 {
-					span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
-				}
+		responderOnObjectFn := func(statusCode *int, obj runtime.Object) {
+			if *statusCode/100 == 4 {
+				span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+			}
 
-				if *statusCode >= 500 {
-					o, ok := obj.(*query.QueryDataResponse)
-					if ok && o.Responses != nil {
-						for refId, response := range o.Responses {
-							if response.ErrorSource == backend.ErrorSourceDownstream {
-								*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
-								span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
-								span.SetAttributes(attribute.String("error.source", "downstream"))
-								break
-							} else if response.Error != nil {
-								connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
-								span.SetStatus(codes.Error, "500 error without downstream error source")
-							} else {
-								span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
-								span.SetAttributes(attribute.String("error.ref_id", refId))
-							}
+			if *statusCode >= 500 {
+				o, ok := obj.(*query.QueryDataResponse)
+				if ok && o.Responses != nil {
+					for refId, response := range o.Responses {
+						if response.ErrorSource == backend.ErrorSourceDownstream {
+							*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
+							span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+							span.SetAttributes(attribute.String("error.source", "downstream"))
+							break
+						} else if response.Error != nil {
+							connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
+							span.SetStatus(codes.Error, "500 error without downstream error source")
+						} else {
+							span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
+							span.SetAttributes(attribute.String("error.ref_id", refId))
 						}
 					}
 				}
-				connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
-				b.reportStatus(ctx, *statusCode)
-			},
+			}
+			connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
+			b.reportStatus(ctx, *statusCode)
+		}
+		responderOnErrorFn := func(err error) {
+			connectLogger.Error("error caught in handler", "err", err, "caller", getCaller(ctx))
+			span.SetStatus(codes.Error, "query error")
 
-			func(err error) {
-				connectLogger.Error("error caught in handler", "err", err, "caller", getCaller(ctx))
-				span.SetStatus(codes.Error, "query error")
+			if err == nil {
+				return
+			}
 
-				if err == nil {
-					return
-				}
+			span.RecordError(err)
 
-				span.RecordError(err)
+			statusCode := 0
+			var k8sErr *errorsK8s.StatusError
+			if errors.As(err, &k8sErr) {
+				statusCode = int(k8sErr.Status().Code)
+			} else {
+				// we do not know what kind of error it is,
+				// we do not know what status code will get assigned to it,
+				// so we use the zero to indicate the unknown.
+				connectLogger.Debug("Connect: unknown error returned", "error", err)
+			}
+			b.reportStatus(ctx, statusCode)
+		}
 
-				statusCode := 0
-				var k8sErr *errorsK8s.StatusError
-				if errors.As(err, &k8sErr) {
-					statusCode = int(k8sErr.Status().Code)
-				} else {
-					// we do not know what kind of error it is,
-					// we do not know what status code will get assigned to it,
-					// so we use the zero to indicate the unknown.
-					connectLogger.Debug("Connect: unknown error returned", "error", err)
-				}
-				b.reportStatus(ctx, statusCode)
-			})
+		var responder rest.Responder
+		rawOutputMode := openfeature.NewDefaultClient().Boolean(
+			ctx,
+			featuremgmt.FlagDatasourcesQuerierRawOutput,
+			false,
+			openfeature.TransactionContext(ctx),
+		)
+		if rawOutputMode {
+			responder = newRawResponderWrapper(ctx, w, responderOnObjectFn, responderOnErrorFn)
+		} else {
+			responder = newConnectResponderWrapper(incomingResponder, responderOnObjectFn, responderOnErrorFn)
+		}
 
 		raw := &query.QueryDataRequest{}
 		err := web.Bind(httpreq, raw)
@@ -202,7 +216,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 			return
 		}
 
-		qdr, err := handleQuery(ctx, *raw, *b, httpreq, *responder, connectLogger)
+		qdr, err := handleQuery(ctx, *raw, *b, httpreq, responder, connectLogger)
 
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -382,7 +396,7 @@ func handleQuery(
 	raw query.QueryDataRequest,
 	b QueryAPIBuilder,
 	httpreq *http.Request,
-	responder responderWrapper,
+	responder rest.Responder,
 	connectLogger log.Logger,
 ) (*backend.QueryDataResponse, error) {
 	pq, err := prepareQuery(ctx, raw, b, httpreq, connectLogger)
@@ -393,21 +407,21 @@ func handleQuery(
 	return handlePreparedQuery(ctx, pq, b.concurrentQueryLimit)
 }
 
-type responderWrapper struct {
+type connectResponderWrapper struct {
 	wrapped    rest.Responder
 	onObjectFn func(statusCode *int, obj runtime.Object)
 	onErrorFn  func(err error)
 }
 
-func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
-	return &responderWrapper{
+func newConnectResponderWrapper(responder rest.Responder, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) rest.Responder {
+	return &connectResponderWrapper{
 		wrapped:    responder,
 		onObjectFn: onObjectFn,
 		onErrorFn:  onErrorFn,
 	}
 }
 
-func (r responderWrapper) Object(statusCode int, obj runtime.Object) {
+func (r connectResponderWrapper) Object(statusCode int, obj runtime.Object) {
 	if r.onObjectFn != nil {
 		r.onObjectFn(&statusCode, obj)
 	}
@@ -415,12 +429,55 @@ func (r responderWrapper) Object(statusCode int, obj runtime.Object) {
 	r.wrapped.Object(statusCode, obj)
 }
 
-func (r responderWrapper) Error(err error) {
+func (r connectResponderWrapper) Error(err error) {
 	if r.onErrorFn != nil {
 		r.onErrorFn(err)
 	}
 
 	r.wrapped.Error(err)
+}
+
+type rawResponderWrapper struct {
+	w          http.ResponseWriter
+	ctx        context.Context
+	onObjectFn func(statusCode *int, obj runtime.Object)
+	onErrorFn  func(err error)
+}
+
+func newRawResponderWrapper(ctx context.Context, w http.ResponseWriter, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) rest.Responder {
+	return &rawResponderWrapper{
+		w:          w,
+		ctx:        ctx,
+		onObjectFn: onObjectFn,
+		onErrorFn:  onErrorFn,
+	}
+}
+
+func (r rawResponderWrapper) Object(statusCode int, obj runtime.Object) {
+	if r.onObjectFn != nil {
+		r.onObjectFn(&statusCode, obj)
+	}
+
+	// a marker so we can see in the browser that this mode was chosen
+	r.w.Header().Set("X-Ds-Querier-Raw", "1")
+
+	// Write the value as JSON
+	r.w.Header().Set("Content-Type", "application/json")
+	r.w.WriteHeader(statusCode)
+	if err := json.NewEncoder(r.w).Encode(obj); err != nil {
+		http.Error(r.w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (r rawResponderWrapper) Error(err error) {
+	if r.onErrorFn != nil {
+		r.onErrorFn(err)
+	}
+
+	// a marker so we can see in the browser that this mode was chosen
+	r.w.Header().Set("X-Ds-Querier-Raw", "1")
+
+	errhttp.Write(r.ctx, err, r.w)
 }
 
 func logEmptyRefids(queries []v0alpha1.DataQuery, logger log.Logger) {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
 )
 
 func loadTestdataFrames(t *testing.T, filename string) *backend.QueryDataResponse {
@@ -167,8 +170,26 @@ func TestQueryAPI(t *testing.T) {
 		},
 	}
 
+	testProvider := oftesting.NewTestProvider()
+	err := openfeature.SetProviderAndWait(testProvider)
+	if err != nil {
+		t.Errorf("unable to set openfeature provider")
+	}
+
+	// first we test the responder-based output mode
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name+"-responder", func(t *testing.T) {
+			defer testProvider.Cleanup()
+			testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagDatasourcesQuerierRawOutput: {
+					State:          memprovider.Enabled,
+					DefaultVariant: "disabled",
+					Variants: map[string]any{
+						"disabled": false,
+					},
+				},
+			})
+
 			builder := &QueryAPIBuilder{
 				converter: &expr.ResultConverter{
 					Features: featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),
@@ -245,9 +266,107 @@ func TestQueryAPI(t *testing.T) {
 			t.Logf("Test case '%s' completed successfully", tc.name)
 		})
 	}
+
+	// next we test the raw output mode
+	for _, tc := range testCases {
+		t.Run(tc.name+"raw-output", func(t *testing.T) {
+			defer testProvider.Cleanup()
+			testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagDatasourcesQuerierRawOutput: {
+					State:          memprovider.Enabled,
+					DefaultVariant: "enabled",
+					Variants: map[string]any{
+						"enabled": true,
+					},
+				},
+			})
+			builder := &QueryAPIBuilder{
+				converter: &expr.ResultConverter{
+					Features: featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),
+					Tracer:   tracing.InitializeTracerForTest(),
+				},
+				instanceProvider: mockClient{
+					stubbedFrame: tc.stubbedFrame,
+				},
+				tracer:                 tracing.InitializeTracerForTest(),
+				log:                    log.New("test"),
+				legacyDatasourceLookup: &mockLegacyDataSourceLookup{},
+				reportStatus:           func(context.Context, int) {},
+			}
+
+			reqCtx := claims.WithAuthInfo(identity.WithRequester(context.Background(), mockUser{}), &mockAuthInfo{})
+
+			req := httptest.NewRequestWithContext(reqCtx, http.MethodPost, "/some-path", bytes.NewReader([]byte(tc.queryJSON)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set optional headers
+			for key, value := range tc.headers {
+				req.Header.Set(key, value)
+			}
+
+			ctx := context.Background()
+			mr := &mockResponder{}
+			qr := newQueryREST(builder)
+
+			handler, err := qr.Connect(ctx, "name", nil, mr)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			result := rr.Result()
+			defer func() {
+				_ = result.Body.Close()
+			}()
+
+			require.False(t, mr.used, "Responder should be unused")
+
+			require.Equal(t, tc.expectedStatus, result.StatusCode, "Should return expected status code")
+
+			// Verify the response is the expected type
+			qdr := &queryapi.QueryDataResponse{}
+			err = json.NewDecoder(result.Body).Decode(qdr)
+			require.NoError(t, err, "Failed to decode response body")
+
+			require.NotNil(t, qdr.Responses, "Should have responses")
+
+			// Load expected frames from testdata if provided
+			if tc.testdataFile != "" {
+				expectedResponse := loadTestdataFrames(t, tc.testdataFile)
+
+				// get refids from expected response
+				expectedRefIds := make([]string, 0, len(expectedResponse.Responses))
+				for refID := range expectedResponse.Responses {
+					expectedRefIds = append(expectedRefIds, refID)
+				}
+
+				// Verify all expected refIDs are present
+				for _, refID := range expectedRefIds {
+					require.Contains(t, qdr.Responses, refID, "Should contain response for refId %s", refID)
+
+					actualResponse := qdr.Responses[refID]
+					expectedFrameResponse := expectedResponse.Responses[refID]
+
+					// Verify frame structure matches testdata
+					require.Len(t, actualResponse.Frames, len(expectedFrameResponse.Frames), "Frame count should match testdata for refId %s", refID)
+
+					for i, actualFrame := range actualResponse.Frames {
+						expectedFrame := expectedFrameResponse.Frames[i]
+						if diff := cmp.Diff(expectedFrame, actualFrame, data.FrameTestCompareOptions()...); diff != "" {
+							require.FailNowf(t, "Result mismatch (-want +got):%s", diff)
+						}
+					}
+				}
+			} else {
+				t.Fatalf("No testdata file provided for test case %s", tc.name)
+			}
+
+			t.Logf("Test case '%s' completed successfully", tc.name)
+		})
+	}
 }
 
 type mockResponder struct {
+	used       bool
 	statusCode int
 	response   runtime.Object
 	err        error
@@ -257,11 +376,13 @@ type mockResponder struct {
 func (m *mockResponder) Object(statusCode int, obj runtime.Object) {
 	m.statusCode = statusCode
 	m.response = obj
+	m.used = true
 }
 
 // Error writes the provided error to the response. This method may only be invoked once.
 func (m *mockResponder) Error(err error) {
 	m.err = err
+	m.used = true
 }
 
 type mockClient struct {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -525,6 +525,14 @@ var (
 			Expression:      "false",
 		},
 		{
+			Name:            "datasourcesQuerierRawOutput",
+			Description:     "use raw output mode for the data source querier",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaDatasourcesCoreServicesSquad,
+			RequiresRestart: false,
+			Expression:      "false",
+		},
+		{
 			Name:        "cloudWatchBatchQueries",
 			Description: "Runs CloudWatch metrics queries as separate batches",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -64,6 +64,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,datasourcesRerouteLegacyCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-02-18,datasourcesApiServerEnableResourceEndpoint,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-03-16,datasourcesApiserverEnableResourceEndpointRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
+2026-03-30,datasourcesQuerierRawOutput,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-10-20,cloudWatchBatchQueries,GA,@grafana/aws-datasources,false,false,false
 2023-10-12,cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2023-10-30,alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -207,6 +207,10 @@ const (
 	// redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.
 	FlagDatasourcesApiserverEnableResourceEndpointRedirect = "datasourcesApiserverEnableResourceEndpointRedirect"
 
+	// FlagDatasourcesQuerierRawOutput
+	// use raw output mode for the data source querier
+	FlagDatasourcesQuerierRawOutput = "datasourcesQuerierRawOutput"
+
 	// FlagCloudWatchBatchQueries
 	// Runs CloudWatch metrics queries as separate batches
 	FlagCloudWatchBatchQueries = "cloudWatchBatchQueries"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1760,6 +1760,19 @@
     },
     {
       "metadata": {
+        "name": "datasourcesQuerierRawOutput",
+        "resourceVersion": "1774855676428",
+        "creationTimestamp": "2026-03-30T07:27:56Z"
+      },
+      "spec": {
+        "description": "use raw output mode for the data source querier",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-datasources-core-services",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "datasourcesRerouteLegacyCRUDAPIs",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"


### PR DESCRIPTION
(part of https://github.com/grafana/grafana/issues/120663)

currently the query service's output is done using a `rest.Responder`. we want to switch writing the response manually through the `http.ResponseWriter`, this has the advantage that we control exactly what bytes we output and exactly what http response code we produce.

this PR introduces this change using a feature flag ( `datasourcesQuerierRawOutput` ), when disabled (the default) it uses the old way, and when enabled, it uses the new way.

when using the new way, we also emit a http-header ( `X-Ds-Querier-Raw=1`), so one can check in the browser's dev-tools if we got the response through the new path.