### PR TITLE
Provisioning: Fix double slashes in nested folder path construction

### DIFF
--- a/public/app/features/provisioning/components/BulkActions/utils.test.ts
+++ b/public/app/features/provisioning/components/BulkActions/utils.test.ts
@@ -1,6 +1,6 @@
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 
-import { getTargetFolderPathInRepo, getNestedFolderPath } from './utils';
+import { getTargetFolderPathInRepo, getNestedFolderPath, getResourceTargetPath } from './utils';
 
 const MOCK_FOLDER = {
   metadata: { annotations: { [AnnoKeySourcePath]: 'path/to/folder' } },
@@ -55,5 +55,42 @@ describe('getNestedFolderPath', () => {
     // @ts-expect-error
     const result = getNestedFolderPath({});
     expect(result).toBe('/');
+  });
+
+  it('should not produce double slashes when sourcePath has trailing slash', () => {
+    const result = getNestedFolderPath({
+      metadata: { annotations: { [AnnoKeySourcePath]: 'path/to/folder/' } },
+      spec: { title: 'folder title' },
+    });
+    expect(result).toBe('path/to/folder/');
+  });
+
+  it('should normalize path without trailing slash', () => {
+    const result = getNestedFolderPath({
+      metadata: { annotations: { [AnnoKeySourcePath]: 'path/to/folder' } },
+      spec: { title: 'folder title' },
+    });
+    expect(result).toBe('path/to/folder/');
+  });
+});
+
+describe('getResourceTargetPath', () => {
+  it('should not produce double slashes when targetFolderPath has trailing slash', () => {
+    const result = getResourceTargetPath('old/path/dashboard.json', 'new/path/');
+    expect(result).toBe('new/path/dashboard.json');
+  });
+
+  it('should handle folder paths', () => {
+    const result = getResourceTargetPath('old/path/folder/', 'new/path/');
+    expect(result).toBe('new/path/folder/');
+  });
+
+  it('should handle targetFolderPath without trailing slash', () => {
+    const result = getResourceTargetPath('old/path/dashboard.json', 'new/path');
+    expect(result).toBe('new/path/dashboard.json');
+  });
+
+  it('should throw for invalid path', () => {
+    expect(() => getResourceTargetPath('/', 'new/path')).toThrow('Invalid path');
   });
 });

--- a/public/app/features/provisioning/components/BulkActions/utils.ts
+++ b/public/app/features/provisioning/components/BulkActions/utils.ts
@@ -3,6 +3,8 @@ import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 import { DashboardTreeSelection } from 'app/features/browse-dashboards/types';
 import { WorkflowOption } from 'app/features/provisioning/types';
 
+import { joinPath } from '../utils/path';
+
 export type BulkActionFormData = {
   comment: string;
   ref: string;
@@ -76,8 +78,7 @@ export function getNestedFolderPath(targetFolder?: Folder): string | undefined {
   const folderAnnotations = targetFolder?.metadata?.annotations || {};
   const sourcePath = folderAnnotations[AnnoKeySourcePath] || '';
 
-  // Ensure path ends with slash
-  return sourcePath ? `${sourcePath}/` : '/';
+  return sourcePath ? joinPath(sourcePath, '') : '/';
 }
 
 export function getResourceTargetPath(currentPath: string, targetFolderPath: string): string {
@@ -89,7 +90,7 @@ export function getResourceTargetPath(currentPath: string, targetFolderPath: str
     throw new Error(`Invalid path: ${currentPath}`);
   }
 
-  // For folders, add back the trailing slash
   const isFolder = currentPath.endsWith('/');
-  return isFolder ? `${targetFolderPath}/${filename}/` : `${targetFolderPath}/${filename}`;
+  const basePath = joinPath(targetFolderPath, filename);
+  return isFolder ? `${basePath}/` : basePath;
 }

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
@@ -27,6 +27,7 @@ import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { useBulkActionJob } from '../BulkActions/useBulkActionJob';
 import { getTargetFolderPathInRepo } from '../BulkActions/utils';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
+import { joinPath } from '../utils/path';
 
 export interface Props {
   dashboard: DashboardScene;
@@ -92,7 +93,7 @@ export function MoveProvisionedDashboardForm({
       repoName: repository?.name,
       hidePrependSlash: true,
     });
-    const newPath = `${targetFolderPath}${filename}`;
+    const newPath = joinPath(targetFolderPath ?? '', filename ?? '');
     setTargetPath(newPath);
   }, [currentFileData, targetFolder, targetFolderUID, targetFolderTitle, repository]);
 

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.test.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.test.tsx
@@ -112,7 +112,7 @@ const mockHookData: ProvisionedFolderFormDataResult = {
   folder: {
     metadata: {
       annotations: {
-        'grafana.app/sourcePath': '/dashboards',
+        'grafana.app/sourcePath': 'dashboards',
       },
     },
     spec: {
@@ -234,6 +234,49 @@ describe('NewProvisionedFolderForm', () => {
     expect(request.url.pathname).toContain('New%20Test%20Folder');
     expect(request.url.searchParams.get('message')).toBe('Creating a new test folder');
     expect(request.body).toEqual({ title: 'New Test Folder', type: 'folder' });
+  });
+
+  it('should not produce double slashes when folder annotation has trailing slash', async () => {
+    server.use(
+      http.post(`${BASE}/repositories/:name/files/*`, async ({ request }) => {
+        const url = new URL(request.url);
+        capturedRequest = { url, body: await request.json() };
+        return HttpResponse.json({
+          resource: { upsert: { metadata: { name: 'new-folder' } } },
+        });
+      })
+    );
+
+    const hookDataWithTrailingSlash = {
+      ...mockHookData,
+      folder: {
+        metadata: {
+          annotations: {
+            'grafana.app/sourcePath': 'dashboards/',
+          },
+        },
+        spec: {
+          title: '',
+        },
+      },
+    };
+
+    const { user } = setup({}, hookDataWithTrailingSlash);
+
+    const folderNameInput = await screen.findByRole('textbox', { name: /folder name/i });
+    await user.clear(folderNameInput);
+    await user.type(folderNameInput, 'New Folder');
+
+    const submitButton = screen.getByRole('button', { name: /^create$/i });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(capturedRequest).not.toBeNull();
+    });
+
+    const request = requireCapturedRequest(capturedRequest);
+    expect(request.url.pathname).not.toContain('//');
+    expect(request.url.pathname).toContain('/dashboards/New%20Folder/');
   });
 
   it('should create folder with branch workflow', async () => {

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -20,6 +20,7 @@ import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 import { getProvisionedRequestError } from '../utils/errors';
+import { joinPath } from '../utils/path';
 
 interface FormProps extends Props {
   initialValues: BaseProvisionedFormData;
@@ -123,8 +124,7 @@ function FormContent({ initialValues, repository, canPushToConfiguredBranch, fol
     }
 
     const basePath = folder?.metadata?.annotations?.[AnnoKeySourcePath] ?? '';
-    const prefix = basePath ? `${basePath}/` : '';
-    const path = `${prefix}${title}/`;
+    const path = joinPath(basePath, `${title}/`);
 
     const folderModel = {
       title,


### PR DESCRIPTION
**What is this feature?**

Fixes path construction for nested provisioned folders to use the existing `joinPath` utility instead of manual string concatenation. This prevents double slashes (e.g., `dashboards//New Folder/`) when the `AnnoKeySourcePath` annotation already ends with a trailing slash.

Follow up to https://github.com/grafana/grafana/pull/121098