### PR TITLE
Dashboards: Fix crash on settings page when GenAI buttons render without a dashboard

### DIFF
--- a/public/app/features/dashboard/components/GenAI/GenAIDashDescriptionButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIDashDescriptionButton.tsx
@@ -29,7 +29,12 @@ const DESCRIPTION_GENERATION_STANDARD_PROMPT =
   'Respond with only the description of the dashboard.';
 
 export const GenAIDashDescriptionButton = ({ onGenerate }: GenAIDashDescriptionButtonProps) => {
-  const dashboard = getDashboardSrv().getCurrent()!;
+  const dashboard = getDashboardSrv().getCurrent();
+
+  if (!dashboard) {
+    return null;
+  }
+
   const panelStrings = getPanelStrings(dashboard);
 
   return (

--- a/public/app/features/dashboard/components/GenAI/GenAIDashTitleButton.tsx
+++ b/public/app/features/dashboard/components/GenAI/GenAIDashTitleButton.tsx
@@ -29,7 +29,12 @@ const TITLE_GENERATION_STANDARD_PROMPT =
   'Respond with only the title of the dashboard.';
 
 export const GenAIDashTitleButton = ({ onGenerate }: GenAIDashTitleButtonProps) => {
-  const dashboard = getDashboardSrv().getCurrent()!;
+  const dashboard = getDashboardSrv().getCurrent();
+
+  if (!dashboard) {
+    return null;
+  }
+
   const panelStrings = getPanelStrings(dashboard);
 
   return (


### PR DESCRIPTION
**What is this feature?**
Adds a null guard to `GenAIDashDescriptionButton` and `GenAIDashTitleButton` so they gracefully render nothing when `getDashboardSrv().getCurrent()` returns [`undefined`](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/services/DashboardSrv.ts#L41-L43), instead of crashing.

**Why do we need this feature?**
Both components use `getDashboardSrv().getCurrent()!` with a non-null assertion, but `getCurrent()` explicitly returns [`DashboardModel | undefined`](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/services/DashboardSrv.ts#L41-L43).
