### PR TITLE
Dashboard Import: Fix crash when importing dashboards with legacy string datasource format

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -588,7 +588,7 @@ describe('applyV1Inputs', () => {
     expect(dsVariable.current?.value).toBe('ds-uid');
   });
 
-  it('handles legacy string datasource format (e.g. Grafana 6.x dashboards)', () => {
+  it('handles legacy string datasource format', () => {
     const dashboard = {
       title: 'PostgreSQL Database',
       uid: '000000039',

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -588,6 +588,80 @@ describe('applyV1Inputs', () => {
     expect(dsVariable.current?.value).toBe('ds-uid');
   });
 
+  it('handles legacy string datasource format (e.g. Grafana 6.x dashboards)', () => {
+    const dashboard = {
+      title: 'PostgreSQL Database',
+      uid: '000000039',
+      schemaVersion: 19,
+      panels: [
+        {
+          datasource: '${DS_PROMETHEUS}',
+          targets: [{ expr: 'pg_static{instance="$instance"}', refId: 'A' }],
+        },
+        {
+          datasource: '${DS_PROMETHEUS}',
+          targets: [
+            { expr: 'rate(process_cpu_seconds_total[5m])', refId: 'A' },
+            { datasource: '${DS_PROMETHEUS}', expr: 'pg_up', refId: 'B' },
+          ],
+        },
+      ],
+      templating: {
+        list: [
+          {
+            type: 'datasource',
+            name: 'DS_PROMETHEUS',
+            query: 'prometheus',
+            current: { value: '${DS_PROMETHEUS}', text: '${DS_PROMETHEUS}', selected: true },
+          },
+          {
+            type: 'query',
+            name: 'namespace',
+            datasource: '${DS_PROMETHEUS}',
+            query: 'query_result(pg_exporter_last_scrape_duration_seconds)',
+          },
+        ],
+      },
+    } as unknown as Dashboard;
+
+    const inputs: DashboardInputs = {
+      dataSources: [
+        {
+          name: 'DS_PROMETHEUS',
+          label: 'DS_PROMETHEUS',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'prometheus',
+        },
+      ],
+      constants: [],
+      libraryPanels: [],
+    };
+
+    const form: ImportDashboardDTO = {
+      title: 'PostgreSQL Database',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'prom-uid', type: 'prometheus', name: 'grafanacloud-prom' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, inputs, form);
+
+    expect(result.panels?.[0].datasource?.uid).toBe('prom-uid');
+    expect(result.panels?.[1].datasource?.uid).toBe('prom-uid');
+
+    const panel2 = result.panels?.[1] as PanelWithTargets;
+    expect(panel2.targets?.[1].datasource?.uid).toBe('prom-uid');
+
+    const dsVariable = result.templating?.list?.[0] as DatasourceVariableModel;
+    expect(dsVariable.current?.value).toBe('prom-uid');
+  });
+
   it('replaces constant variable query, current, and options with user-provided values', () => {
     const dashboard = {
       title: 'old',

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -619,7 +619,7 @@ function processPanel(
   return {
     ...panel,
     ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
-    // nested panels of collapsed row panels
+    // nested panels of collapsed rows
     ...('panels' in panel && {
       panels: panel.panels.map((nestedPanel) => processPanel(nestedPanel, inputs, form)),
     }),

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -597,9 +597,9 @@ function resolveInputDatasource(
   inputs: { dataSources: DataSourceInput[] },
   form: ImportDashboardDTO
 ): Panel['datasource'] {
-  const templateUid = getDSUid(datasource);
-  if (templateUid) {
-    const userInput = checkUserInputMatch(templateUid, inputs.dataSources, form.dataSources);
+  const dsUid = getDSUid(datasource);
+  if (dsUid) {
+    const userInput = checkUserInputMatch(dsUid, inputs.dataSources, form.dataSources);
     if (userInput) {
       return { ...(isRecord(datasource) ? datasource : {}), uid: userInput.uid };
     }
@@ -614,9 +614,9 @@ function resolveInputTargets(
 ): Panel['targets'] {
   return targets?.map((target) => {
     const ds = target.datasource;
-    const templateUid = getDSUid(ds);
-    if (templateUid) {
-      const userInput = checkUserInputMatch(templateUid, inputs.dataSources, form.dataSources);
+    const dsUid = getDSUid(ds);
+    if (dsUid) {
+      const userInput = checkUserInputMatch(dsUid, inputs.dataSources, form.dataSources);
       if (userInput) {
         return {
           ...target,

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -601,7 +601,10 @@ function resolveInputDatasource(
   if (dsUid) {
     const userInput = checkUserInputMatch(dsUid, inputs.dataSources, form.dataSources);
     if (userInput) {
-      return { ...(isRecord(datasource) ? datasource : {}), uid: userInput.uid };
+      return {
+        ...(isRecord(datasource) ? datasource : {}),
+        uid: userInput.uid,
+      };
     }
   }
   return datasource;
@@ -620,7 +623,10 @@ function resolveInputTargets(
       if (userInput) {
         return {
           ...target,
-          datasource: { ...(isRecord(ds) ? ds : {}), uid: userInput.uid },
+          datasource: {
+            ...(isRecord(ds) ? ds : {}),
+            uid: userInput.uid,
+          },
         };
       }
     }

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -63,8 +63,8 @@ function isLibraryElementExport(value: unknown): value is LibraryElementExport {
   );
 }
 
-function hasUid(query: Record<string, unknown> | {}): query is { uid: string } {
-  return 'uid' in query && typeof query['uid'] === 'string';
+function hasUid(query: unknown): query is { uid: string } {
+  return isRecord(query) && typeof query['uid'] === 'string';
 }
 
 function getExportLabel(labels?: { [ExportLabel]?: string }): string | undefined {
@@ -582,18 +582,26 @@ function processAnnotation(
   return annotation;
 }
 
+function getDSUid(datasource: unknown): string | undefined {
+  if (typeof datasource === 'string' && datasource.startsWith('$')) {
+    return datasource;
+  }
+  if (hasUid(datasource) && datasource.uid.startsWith('$')) {
+    return datasource.uid;
+  }
+  return undefined;
+}
+
 function resolveInputDatasource(
   datasource: Panel['datasource'],
   inputs: { dataSources: DataSourceInput[] },
   form: ImportDashboardDTO
 ): Panel['datasource'] {
-  if (datasource && hasUid(datasource) && datasource.uid.startsWith('$')) {
-    const userInput = checkUserInputMatch(datasource.uid, inputs.dataSources, form.dataSources);
+  const templateUid = getDSUid(datasource);
+  if (templateUid) {
+    const userInput = checkUserInputMatch(templateUid, inputs.dataSources, form.dataSources);
     if (userInput) {
-      return {
-        ...datasource,
-        uid: userInput.uid,
-      };
+      return { ...(hasUid(datasource) ? datasource : {}), uid: userInput.uid, type: userInput.type };
     }
   }
   return datasource;
@@ -605,15 +613,14 @@ function resolveInputTargets(
   form: ImportDashboardDTO
 ): Panel['targets'] {
   return targets?.map((target) => {
-    if (target.datasource && hasUid(target.datasource) && target.datasource.uid.startsWith('$')) {
-      const userInput = checkUserInputMatch(target.datasource.uid, inputs.dataSources, form.dataSources);
+    const ds = target.datasource;
+    const templateUid = getDSUid(ds);
+    if (templateUid) {
+      const userInput = checkUserInputMatch(templateUid, inputs.dataSources, form.dataSources);
       if (userInput) {
         return {
           ...target,
-          datasource: {
-            ...target.datasource,
-            uid: userInput.uid,
-          },
+          datasource: { ...(hasUid(ds) ? ds : {}), uid: userInput.uid, type: userInput.type },
         };
       }
     }

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -610,30 +610,6 @@ function resolveInputDatasource(
   return datasource;
 }
 
-function resolveInputTargets(
-  targets: Panel['targets'],
-  inputs: { dataSources: DataSourceInput[] },
-  form: ImportDashboardDTO
-): Panel['targets'] {
-  return targets?.map((target) => {
-    const ds = target.datasource;
-    const dsUid = getDSUid(ds);
-    if (dsUid) {
-      const userInput = checkUserInputMatch(dsUid, inputs.dataSources, form.dataSources);
-      if (userInput) {
-        return {
-          ...target,
-          datasource: {
-            ...(isRecord(ds) ? ds : {}),
-            uid: userInput.uid,
-          },
-        };
-      }
-    }
-    return target;
-  });
-}
-
 function processPanel(
   panel: Panel | RowPanel,
   inputs: { dataSources: DataSourceInput[] },
@@ -652,7 +628,16 @@ function processPanel(
   return {
     ...panel,
     ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
-    ...(panel.targets && { targets: resolveInputTargets(panel.targets, inputs, form) }),
+    ...(panel.targets && {
+      targets: panel.targets.map((target) =>
+        target.datasource
+          ? {
+              ...target,
+              datasource: resolveInputDatasource(target.datasource, inputs, form),
+            }
+          : target
+      ),
+    }),
   };
 }
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -582,14 +582,14 @@ function processAnnotation(
   return annotation;
 }
 
-function getDSUid(datasource: unknown): string | undefined {
+function getDSUid(datasource: unknown): string | null {
   if (typeof datasource === 'string' && datasource.startsWith('$')) {
     return datasource;
   }
   if (hasUid(datasource) && datasource.uid.startsWith('$')) {
     return datasource.uid;
   }
-  return undefined;
+  return null;
 }
 
 function resolveInputDatasource(
@@ -598,6 +598,7 @@ function resolveInputDatasource(
   form: ImportDashboardDTO
 ): Panel['datasource'] {
   const dsUid = getDSUid(datasource);
+
   if (dsUid) {
     const userInput = checkUserInputMatch(dsUid, inputs.dataSources, form.dataSources);
     if (userInput) {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -616,29 +616,21 @@ function processPanel(
   inputs: { dataSources: DataSourceInput[] },
   form: ImportDashboardDTO
 ): Panel | RowPanel {
-  if ('panels' in panel) {
-    return {
-      ...panel,
-      ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
-      panels: panel.panels.map((nestedPanel) => {
-        return processPanel(nestedPanel, inputs, form);
-      }),
-    };
-  }
-
   return {
     ...panel,
     ...(panel.datasource && { datasource: resolveInputDatasource(panel.datasource, inputs, form) }),
-    ...(panel.targets && {
-      targets: panel.targets.map((target) =>
-        target.datasource
-          ? {
-              ...target,
-              datasource: resolveInputDatasource(target.datasource, inputs, form),
-            }
-          : target
-      ),
+    // nested panels of collapsed row panels
+    ...('panels' in panel && {
+      panels: panel.panels.map((nestedPanel) => processPanel(nestedPanel, inputs, form)),
     }),
+    ...('targets' in panel &&
+      panel.targets && {
+        targets: panel.targets.map((target) =>
+          target.datasource
+            ? { ...target, datasource: resolveInputDatasource(target.datasource, inputs, form) }
+            : target
+        ),
+      }),
   };
 }
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -601,7 +601,7 @@ function resolveInputDatasource(
   if (templateUid) {
     const userInput = checkUserInputMatch(templateUid, inputs.dataSources, form.dataSources);
     if (userInput) {
-      return { ...(hasUid(datasource) ? datasource : {}), uid: userInput.uid, type: userInput.type };
+      return { ...(isRecord(datasource) ? datasource : {}), uid: userInput.uid };
     }
   }
   return datasource;
@@ -620,7 +620,7 @@ function resolveInputTargets(
       if (userInput) {
         return {
           ...target,
-          datasource: { ...(hasUid(ds) ? ds : {}), uid: userInput.uid, type: userInput.type },
+          datasource: { ...(isRecord(ds) ? ds : {}), uid: userInput.uid },
         };
       }
     }


### PR DESCRIPTION
**What is this feature?**

Fixes the dashboard import crash that occurs when importing community dashboards from Grafana.com that use the legacy string datasource format (e.g. `"datasource": "${DS_PROMETHEUS}"` instead of `"datasource": { "uid": "${DS_PROMETHEUS}" }`).
