### PR TITLE
Annotations: Allow datasource-provided color on annotation events

### DIFF
--- a/public/app/features/query/state/DashboardQueryRunner/utils.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.test.ts
@@ -1,0 +1,62 @@
+import { AnnotationEvent, AnnotationQuery } from '@grafana/data';
+
+import { translateQueryResult } from './utils';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    theme2: {
+      visualization: {
+        getColorByName: (color: string) => color ?? 'default-color',
+      },
+    },
+  },
+}));
+
+describe('translateQueryResult', () => {
+  const annotation: AnnotationQuery = {
+    name: 'Test',
+    enable: true,
+    iconColor: 'purple',
+    datasource: { uid: 'test', type: 'test' },
+  };
+
+  it('should use iconColor as fallback when event has no color and no newState', () => {
+    const results: AnnotationEvent[] = [{ time: 1 }];
+    const translated = translateQueryResult(annotation, results);
+    expect(translated[0].color).toBe('purple');
+  });
+
+  it('should preserve event-level color from datasource when no newState is set', () => {
+    const results: AnnotationEvent[] = [{ time: 1, color: 'blue' }];
+    const translated = translateQueryResult(annotation, results);
+    expect(translated[0].color).toBe('blue');
+  });
+
+  it('should override event color with newState color when newState is set', () => {
+    const results: AnnotationEvent[] = [{ time: 1, color: 'blue', newState: 'alerting' }];
+    const translated = translateQueryResult(annotation, results);
+    expect(translated[0].color).toBe('red');
+  });
+
+  it.each([
+    ['pending', 'yellow'],
+    ['alerting', 'red'],
+    ['ok', 'green'],
+    ['normal', 'green'],
+    ['no_data', 'gray'],
+    ['nodata', 'gray'],
+  ])('should map newState "%s" to color "%s"', (newState, expectedColor) => {
+    const results: AnnotationEvent[] = [{ time: 1, newState }];
+    const translated = translateQueryResult(annotation, results);
+    expect(translated[0].color).toBe(expectedColor);
+  });
+
+  it('should set source, type, and isRegion correctly', () => {
+    const results: AnnotationEvent[] = [{ time: 1, timeEnd: 2 }];
+    const translated = translateQueryResult(annotation, results);
+    expect(translated[0].source).toBe(annotation);
+    expect(translated[0].type).toBe('Test');
+    expect(translated[0].isRegion).toBe(true);
+  });
+});

--- a/public/app/features/query/state/DashboardQueryRunner/utils.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.test.ts
@@ -27,9 +27,16 @@ describe('translateQueryResult', () => {
     expect(translated[0].color).toBe('purple');
   });
 
-  it('should preserve event-level color from datasource when no newState is set', () => {
+  it('should prefer iconColor over event-level color from datasource', () => {
     const results: AnnotationEvent[] = [{ time: 1, color: 'blue' }];
     const translated = translateQueryResult(annotation, results);
+    expect(translated[0].color).toBe('purple');
+  });
+
+  it('should use event-level color from datasource when no iconColor is set', () => {
+    const noIconColor: AnnotationQuery = { ...annotation, iconColor: '' };
+    const results: AnnotationEvent[] = [{ time: 1, color: 'blue' }];
+    const translated = translateQueryResult(noIconColor, results);
     expect(translated[0].color).toBe('blue');
   });
 

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -88,7 +88,7 @@ export function translateQueryResult(annotation: AnnotationQuery, results: Annot
     item.type = annotation.name;
     item.isRegion = Boolean(item.timeEnd && item.time !== item.timeEnd);
 
-    // Color priority: newState mapping > event-level color from datasource > annotation iconColor fallback
+    // Color priority: newState mapping > annotation iconColor > event-level color from datasource
     switch (item.newState?.toLowerCase()) {
       case 'pending':
         item.color = 'yellow';
@@ -105,9 +105,10 @@ export function translateQueryResult(annotation: AnnotationQuery, results: Annot
         item.color = 'gray';
         break;
       default:
-        if (!item.color) {
+        if (annotation.iconColor) {
           item.color = config.theme2.visualization.getColorByName(annotation.iconColor);
         }
+        // otherwise keep item.color from the datasource if present
         break;
     }
   }

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -85,10 +85,10 @@ export function translateQueryResult(annotation: AnnotationQuery, results: Annot
 
   for (const item of results) {
     item.source = annotation;
-    item.color = config.theme2.visualization.getColorByName(annotation.iconColor);
     item.type = annotation.name;
     item.isRegion = Boolean(item.timeEnd && item.time !== item.timeEnd);
 
+    // Color priority: newState mapping > event-level color from datasource > annotation iconColor fallback
     switch (item.newState?.toLowerCase()) {
       case 'pending':
         item.color = 'yellow';
@@ -97,16 +97,17 @@ export function translateQueryResult(annotation: AnnotationQuery, results: Annot
         item.color = 'red';
         break;
       case 'ok':
-        item.color = 'green';
-        break;
       case 'normal': // ngalert ("normal" instead of "ok")
         item.color = 'green';
         break;
       case 'no_data':
-        item.color = 'gray';
-        break;
       case 'nodata': // ngalert
         item.color = 'gray';
+        break;
+      default:
+        if (!item.color) {
+          item.color = config.theme2.visualization.getColorByName(annotation.iconColor);
+        }
         break;
     }
   }


### PR DESCRIPTION
## Summary
- Reorder color resolution in `translateQueryResult` so that annotation events/dataframes can specify a custom `color` field (e.g. `'blue'`) that is respected at render time
- Previously, event-level color was unconditionally overwritten by `annotation.iconColor`, meaning datasources could never control annotation color programmatically
- Color priority is now: `newState` mapping > `iconColor` > event-level `color` fallback

## Test plan
- [ ] Verify annotations with `newState` (alerting, ok, pending, etc.) still render with expected colors
- [ ] Verify annotations without `newState` or event color fall back to the configured `iconColor`
- [ ] Verify a datasource returning `color: 'blue'` on an annotation event renders blue when no `iconColor` is set
- [ ] Run new unit tests in `utils.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)