### PR TITLE
chore: Fix broken TemplateDashboardModal test query for View template button

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.test.tsx
@@ -339,10 +339,10 @@ describe('TemplateDashboardModal', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: 'View template' })).toHaveLength(2);
+      expect(screen.getAllByRole('button', { name: /^View template:/i })).toHaveLength(2);
     });
 
-    await user.click(screen.getAllByRole('button', { name: 'View template' })[0]);
+    await user.click(screen.getAllByRole('button', { name: /^View template:/i })[0]);
 
     expect(mockNewItemClicked).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
**What is this feature?**

Fix test that was querying for `{ name: 'View template' }` (exact match) when buttons have `aria-label="View template: <dashboard name>"`
