### PR TITLE
Folders API: Add validation for owner reference name field

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	teamservice "github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -64,6 +65,7 @@ type FolderAPIBuilder struct {
 	folderPermissionsSvc   accesscontrol.FolderPermissionsService // TODO: Remove this once kubernetesAuthzResourcePermissionApis is removed and the frontend is calling /apis directly to create root level folders
 	acService              accesscontrol.Service
 	ac                     accesscontrol.AccessControl
+	teamSvc                teamservice.Service
 }
 
 func RegisterAPIService(cfg *setting.Cfg,
@@ -77,6 +79,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 	registerer prometheus.Registerer,
 	unified resource.ResourceClient,
 	zanzanaClient zanzana.Client,
+	teamSvc teamservice.Service,
 ) *FolderAPIBuilder {
 	builder := &FolderAPIBuilder{
 		features:             features,
@@ -90,6 +93,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 		searcher:             unified,
 		permissionStore:      NewZanzanaPermissionStore(zanzanaClient),
 		maxNestedFolderDepth: cfg.MaxNestedFolderDepth,
+		teamSvc:              teamSvc,
 	}
 	apiregistration.RegisterAPI(builder)
 	return builder
@@ -361,7 +365,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		if err := validateOwnerReferencesOnManagedFolder(f, nil); err != nil {
 			return err
 		}
-		return validateOnCreate(ctx, f, b.parents, b.maxNestedFolderDepth)
+		return validateOnCreate(ctx, f, b.parents, b.maxNestedFolderDepth, b.teamSvc)
 	case admission.Delete:
 		return validateOnDelete(ctx, f, b.searcher)
 	case admission.Update:

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -2,6 +2,7 @@ package folders
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -10,13 +11,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
+	teamservice "github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util"
@@ -57,7 +61,7 @@ func validateOwnerReferencesOnManagedFolder(obj *folders.Folder, old *folders.Fo
 	return nil
 }
 
-func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGetter, maxDepth int) error {
+func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGetter, maxDepth int, teamSvc teamservice.Service) error {
 	id := f.Name
 
 	if slices.Contains([]string{
@@ -84,6 +88,10 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return dashboards.ErrFolderTitleEmpty
 	}
 
+	if err := validateTeamOwnerReferences(ctx, f, teamSvc); err != nil {
+		return err
+	}
+
 	parentName := meta.GetFolder()
 	if parentName == "" {
 		return nil // OK, we do not need to validate the tree
@@ -103,6 +111,60 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	// We need to add +1 as we also have the root folder as part of the parents.
 	if len(parents.Items) > maxDepth+1 {
 		return fmt.Errorf("folder max depth exceeded, max depth is %d", maxDepth)
+	}
+
+	return nil
+}
+
+// validateTeamOwnerReferences checks if the owner reference we are trying to save, references some existing resource
+// (right now only teams are allowed).
+func validateTeamOwnerReferences(ctx context.Context, f *folders.Folder, teamSvc teamservice.Service) error {
+	if len(f.OwnerReferences) == 0 {
+		return nil
+	}
+
+	requester, err := identity.GetRequester(ctx)
+	if err != nil {
+		return apierrors.NewUnauthorized("no identity found")
+	}
+
+	// We check all the references to be nice and give all the info, but maybe it would be better to just fail quickly
+	// and not spend resources on it.
+	var errs field.ErrorList
+	for i, ref := range f.OwnerReferences {
+		refPath := field.NewPath("metadata", "ownerReferences").Index(i)
+
+		// For now, we only allow teams to be owners of folders, but that may change in the future
+		if ref.Kind != "Team" {
+			errs = append(errs, field.NotSupported(refPath.Child("kind"), ref.Kind, []string{"Team"}))
+			continue
+		}
+
+		if ref.Name == "" {
+			errs = append(errs, field.Required(refPath.Child("name"), "team owner reference name is required"))
+			continue
+		}
+		teamDTO, err := teamSvc.GetTeamByID(ctx, &teamservice.GetTeamByIDQuery{
+			OrgID: requester.GetOrgID(),
+			// This mapping looks weird, but the UID is eventually mapped to a resource name. We also have UID in the
+			// ownerRef which on FE we fill with the same value, so ref.UID but this should be ref.Name nevertheless.
+			UID: ref.Name,
+		})
+		if err != nil {
+			if errors.Is(err, teamservice.ErrTeamNotFound) {
+				errs = append(errs, field.NotFound(refPath.Child("name"), ref.Name))
+				continue
+			}
+			return fmt.Errorf("failed to validate team owner reference %q: %w", ref.Name, err)
+		}
+		if teamDTO == nil {
+			// This should not happen if we didn't have an error but just in case
+			return fmt.Errorf("team service returned empty result for owner reference name %q", ref.Name)
+		}
+	}
+
+	if len(errs) > 0 {
+		return apierrors.NewInvalid(folders.FolderResourceInfo.GroupVersionKind().GroupKind(), f.Name, errs)
 	}
 
 	return nil

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -5,14 +5,18 @@ import (
 	"fmt"
 	"testing"
 
+	claims "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/team"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -264,7 +268,7 @@ func TestValidateCreate(t *testing.T) {
 
 			getter := newParentsGetter(mockStorage, maxDepth)
 
-			err := validateOnCreate(context.Background(), tt.folder, getter, maxDepth)
+			err := validateOnCreate(context.Background(), tt.folder, getter, maxDepth, nil)
 
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
@@ -272,6 +276,81 @@ func TestValidateCreate(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedErr)
 			}
+		})
+	}
+}
+
+func TestValidateCreateTeamOwnerReferences(t *testing.T) {
+	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
+		Type:      claims.TypeUser,
+		OrgID:     1,
+		Namespace: "stacks-1",
+	})
+
+	tests := []struct {
+		name        string
+		ownerRef    metav1.OwnerReference
+		teamSvc     team.Service
+		expectedErr string
+	}{
+		{
+			name: "accepts existing team owner reference",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: "iam.grafana.app/v0alpha1",
+				Kind:       "Team",
+				Name:       "engineering",
+				UID:        "team-1",
+			},
+			teamSvc: teamtest.NewFakeServiceWithTeamDTO(&team.TeamDTO{
+				UID:  "team-1",
+				Name: "engineering",
+			}),
+		},
+		{
+			name: "rejects missing team owner reference",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: "iam.grafana.app/v0alpha1",
+				Kind:       "Team",
+				Name:       "ghost-team",
+				UID:        "missing-team",
+			},
+			teamSvc:     &teamtest.FakeService{ExpectedError: team.ErrTeamNotFound},
+			expectedErr: "metadata.ownerReferences[0].name",
+		},
+		{
+			name: "rejects non-team owner reference",
+			ownerRef: metav1.OwnerReference{
+				APIVersion: "iam.grafana.app/v0alpha1",
+				Kind:       "User",
+				Name:       "alice",
+				UID:        "user-1",
+			},
+			teamSvc:     teamtest.NewFakeService(),
+			expectedErr: "Unsupported value: \"User\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "folder-1",
+				},
+				Spec: folders.FolderSpec{
+					Title: "Folder 1",
+				},
+			}
+			f.SetOwnerReferences([]metav1.OwnerReference{tt.ownerRef})
+
+			err := validateOnCreate(ctx, f, nil, 5, tt.teamSvc)
+
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectedErr)
 		})
 	}
 }

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -912,7 +912,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderimplService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient)
+	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderimplService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient, teamimplService)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
 	globalRoleApiInstaller := iam.ProvideNoopGlobalRoleApiInstaller()
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()
@@ -1616,7 +1616,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderimplService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient)
+	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderimplService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient, teamimplService)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
 	globalRoleApiInstaller := iam.ProvideNoopGlobalRoleApiInstaller()
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	k8srest "k8s.io/client-go/rest"
 
@@ -2175,6 +2177,8 @@ func TestIntegrationFolderSearchWithOwner(t *testing.T) {
 		User: helper.Org1.Admin,
 		GVR:  gvr,
 	})
+	engineering := helper.CreateTeam("engineering", "engineering@example.com", helper.Org1.OrgID)
+	testingTeam := helper.CreateTeam("testing", "testing@example.com", helper.Org1.OrgID)
 
 	// Without owner
 	folder := &unstructured.Unstructured{
@@ -2201,17 +2205,36 @@ func TestIntegrationFolderSearchWithOwner(t *testing.T) {
 	folder.SetOwnerReferences([]metav1.OwnerReference{{
 		APIVersion: "iam.grafana.app/v0alpha1",
 		Kind:       "Team",
-		Name:       "engineering",
-		UID:        "123456", // required by k8s
+		Name:       engineering.Name,
+		UID:        types.UID(engineering.UID),
 	}, {
 		APIVersion: "iam.grafana.app/v0alpha1",
 		Kind:       "Team",
-		Name:       "testing",
-		UID:        "123457", // required by k8s
+		Name:       testingTeam.Name,
+		UID:        types.UID(testingTeam.UID),
 	}})
 	out, err = client.Resource.Create(context.Background(), folder, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.Equal(t, folder.GetName(), out.GetName())
+
+	invalidOwnerFolder := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"title": "Folder with invalid owner",
+			},
+		},
+	}
+	invalidOwnerFolder.SetName("folder-invalid-owner")
+	invalidOwnerFolder.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: "iam.grafana.app/v0alpha1",
+		Kind:       "Team",
+		Name:       "marketing",
+		UID:        types.UID(engineering.UID),
+	}})
+	_, err = client.Resource.Create(context.Background(), invalidOwnerFolder, metav1.CreateOptions{})
+	require.Error(t, err)
+	require.True(t, apierrors.IsInvalid(err), "expected invalid status error, got: %v", err)
+	require.Contains(t, err.Error(), "metadata.ownerReferences[0].name")
 
 	// Get everything
 	results, err := client.Resource.List(context.Background(), metav1.ListOptions{})
@@ -2223,12 +2246,12 @@ func TestIntegrationFolderSearchWithOwner(t *testing.T) {
 	require.NoError(t, err)
 	owners := folderB.GetOwnerReferences()
 	require.Len(t, owners, 2, "folderB should have 2 owner references")
-	require.Equal(t, "engineering", owners[0].Name)
+	require.Equal(t, engineering.Name, owners[0].Name)
 	require.Equal(t, "Team", owners[0].Kind)
 
 	// Find results with a specific owner (with trimming suffix)
 	suffixToTrim := " "
-	sr := callSearch(t, helper.Org1.Admin, "ownerReference=iam.grafana.app/Team/engineering"+suffixToTrim)
+	sr := callSearch(t, helper.Org1.Admin, "ownerReference=iam.grafana.app/Team/"+engineering.Name+suffixToTrim)
 	require.Len(t, sr.Hits, 1)
 	require.Equal(t, "folderB", sr.Hits[0].Name)
 
@@ -2237,7 +2260,7 @@ func TestIntegrationFolderSearchWithOwner(t *testing.T) {
 	require.Len(t, sr.Hits, 0)
 
 	// Find results using OR conditions and search by second owner reference
-	sr = callSearch(t, helper.Org1.Admin, "ownerReference=iam.grafana.app/Team/marketing&ownerReference=iam.grafana.app/Team/testing")
+	sr = callSearch(t, helper.Org1.Admin, "ownerReference=iam.grafana.app/Team/marketing&ownerReference=iam.grafana.app/Team/"+testingTeam.Name)
 	require.Len(t, sr.Hits, 1)
 	require.Equal(t, "folderB", sr.Hits[0].Name)
 }


### PR DESCRIPTION
Adds validation which checks if the ownerRef.name references existing resource. At this moment only valid resource is a team so it needs to match some existing team name.