### PR TITLE
Logs: Add summary display mode for structured JSON logs

### DIFF
--- a/apps/logsdrilldown/definitions/logsdrilldown-manifest.json
+++ b/apps/logsdrilldown/definitions/logsdrilldown-manifest.json
@@ -68,6 +68,10 @@
                   "interceptDismissed": {
                     "type": "boolean"
                   },
+                  "logLineDisplayMode": {
+                    "enum": ["full", "summary"],
+                    "type": "string"
+                  },
                   "prettifyJSON": {
                     "type": "boolean"
                   },
@@ -157,6 +161,10 @@
                   },
                   "interceptDismissed": {
                     "type": "boolean"
+                  },
+                  "logLineDisplayMode": {
+                    "enum": ["full", "summary"],
+                    "type": "string"
                   },
                   "prettifyJSON": {
                     "type": "boolean"

--- a/apps/logsdrilldown/definitions/logsdrilldown.logsdrilldown.grafana.app.json
+++ b/apps/logsdrilldown/definitions/logsdrilldown.logsdrilldown.grafana.app.json
@@ -25,6 +25,10 @@
                   "interceptDismissed": {
                     "type": "boolean"
                   },
+                  "logLineDisplayMode": {
+                    "enum": ["full", "summary"],
+                    "type": "string"
+                  },
                   "prettifyJSON": {
                     "type": "boolean"
                   },

--- a/apps/logsdrilldown/definitions/logsdrilldowndefaults.logsdrilldown.grafana.app.json
+++ b/apps/logsdrilldown/definitions/logsdrilldowndefaults.logsdrilldown.grafana.app.json
@@ -25,6 +25,10 @@
                   "interceptDismissed": {
                     "type": "boolean"
                   },
+                  "logLineDisplayMode": {
+                    "enum": ["full", "summary"],
+                    "type": "string"
+                  },
                   "prettifyJSON": {
                     "type": "boolean"
                   },

--- a/apps/logsdrilldown/kinds/logsdrilldown.cue
+++ b/apps/logsdrilldown/kinds/logsdrilldown.cue
@@ -6,6 +6,7 @@ import (
 
 LogsDrilldownSpecv1alpha1: {
 	defaultFields: [...string] | *[]
+	logLineDisplayMode?: "full" | "summary"
 	prettifyJSON:       bool
 	wrapLogMessage:     bool
 	interceptDismissed: bool

--- a/apps/logsdrilldown/pkg/apis/logsdrilldown/v1alpha1/logsdrilldown_spec_gen.go
+++ b/apps/logsdrilldown/pkg/apis/logsdrilldown/v1alpha1/logsdrilldown_spec_gen.go
@@ -5,6 +5,7 @@ package v1alpha1
 // +k8s:openapi-gen=true
 type LogsDrilldownSpec struct {
 	DefaultFields      []string `json:"defaultFields"`
+	LogLineDisplayMode *string  `json:"logLineDisplayMode,omitempty"`
 	PrettifyJSON       bool     `json:"prettifyJSON"`
 	WrapLogMessage     bool     `json:"wrapLogMessage"`
 	InterceptDismissed bool     `json:"interceptDismissed"`

--- a/apps/logsdrilldown/pkg/apis/logsdrilldown/v1alpha1/logsdrilldowndefaults_spec_gen.go
+++ b/apps/logsdrilldown/pkg/apis/logsdrilldown/v1alpha1/logsdrilldowndefaults_spec_gen.go
@@ -5,6 +5,7 @@ package v1alpha1
 // +k8s:openapi-gen=true
 type LogsDrilldownDefaultsSpec struct {
 	DefaultFields      []string `json:"defaultFields"`
+	LogLineDisplayMode *string  `json:"logLineDisplayMode,omitempty"`
 	PrettifyJSON       bool     `json:"prettifyJSON"`
 	WrapLogMessage     bool     `json:"wrapLogMessage"`
 	InterceptDismissed bool     `json:"interceptDismissed"`

--- a/apps/logsdrilldown/plugin/src/generated/logsdrilldown/v1alpha1/types.spec.gen.ts
+++ b/apps/logsdrilldown/plugin/src/generated/logsdrilldown/v1alpha1/types.spec.gen.ts
@@ -2,6 +2,7 @@
 
 export interface Spec {
 	defaultFields: string[];
+	logLineDisplayMode?: 'full' | 'summary';
 	prettifyJSON: boolean;
 	wrapLogMessage: boolean;
 	interceptDismissed: boolean;

--- a/apps/logsdrilldown/plugin/src/generated/logsdrilldowndefaults/v1alpha1/types.spec.gen.ts
+++ b/apps/logsdrilldown/plugin/src/generated/logsdrilldowndefaults/v1alpha1/types.spec.gen.ts
@@ -2,6 +2,7 @@
 
 export interface Spec {
 	defaultFields: string[];
+	logLineDisplayMode?: 'full' | 'summary';
 	prettifyJSON: boolean;
 	wrapLogMessage: boolean;
 	interceptDismissed: boolean;

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1306,6 +1306,11 @@ export interface FeatureToggles {
   */
   otelLogsFormatting?: boolean;
   /**
+  * Enables summary display mode for JSON logs, showing auto-detected message field instead of full JSON
+  * @default false
+  */
+  logsSummaryDisplay?: boolean;
+  /**
   * Enables the notification history feature
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2059,6 +2059,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "logsSummaryDisplay",
+			Description:  "Enables summary display mode for JSON logs, showing auto-detected message field instead of full JSON",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaObservabilityLogsSquad,
+			Expression:   "false",
+		},
+		{
 			Name:         "alertingNotificationHistory",
 			Description:  "Enables the notification history feature",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles-gitlog.csv
+++ b/pkg/services/featuremgmt/toggles-gitlog.csv
@@ -496,6 +496,7 @@ provisioningSecretsService,2025-07-15T13:43:17Z,2025-07-31T22:56:50Z,d39a47a89b9
 sharingDashboardImage,2025-07-15T21:07:39Z,,b691b3288d5d18366e405ad4e881e7e9d9d6de96,Nathan Marrs
 enablePluginImporter,2025-07-16T04:42:28Z,2025-10-23T04:18:23Z,5b82e056972f959908cd42c9934ba56e8adbf143,Hugo Häggmark
 otelLogsFormatting,2025-07-16T15:42:14Z,,974103c6fa20701c5467c67fb24f173aea9113fb,Matias Chomicki
+logsSummaryDisplay,2026-03-24T00:00:00Z,,,
 alertingAIAnalyzeCentralStateHistory,2025-07-16T16:42:42Z,,9c15662cf6337b37f2932cf7b20fe5e05d310153,Sonia Aguilar
 alertingAIGenAlertRules,2025-07-16T16:42:42Z,,9c15662cf6337b37f2932cf7b20fe5e05d310153,Sonia Aguilar
 alertingAIGenTemplates,2025-07-16T16:42:42Z,,9c15662cf6337b37f2932cf7b20fe5e05d310153,Sonia Aguilar

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -256,6 +256,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-10-13,enableDashboardEmptyExtensions,experimental,@grafana/dashboards-squad,false,false,true
 2025-07-03,foldersAppPlatformAPI,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2025-07-16,otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true
+2026-03-24,logsSummaryDisplay,experimental,@grafana/observability-logs,false,false,true
 2025-07-17,alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
 2025-07-18,unifiedStorageSearchDualReaderEnabled,experimental,@grafana/search-and-storage,false,false,false
 2025-07-31,dashboardLevelTimeMacros,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3762,6 +3762,20 @@
     },
     {
       "metadata": {
+        "name": "logsSummaryDisplay",
+        "resourceVersion": "1771434338561",
+        "creationTimestamp": "2026-03-24T00:00:00Z"
+      },
+      "spec": {
+        "description": "Enables summary display mode for JSON logs, showing auto-detected message field instead of full JSON",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "panelFilterVariable",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2023-11-03T12:15:54Z"

--- a/public/app/features/explore/Logs/utils/logs.ts
+++ b/public/app/features/explore/Logs/utils/logs.ts
@@ -4,6 +4,7 @@ export const SETTINGS_KEYS = {
   wrapLogMessage: 'grafana.explore.logs.wrapLogMessage',
   prettifyLogMessage: 'grafana.explore.logs.prettifyLogMessage',
   logsSortOrder: 'grafana.explore.logs.sortOrder',
+  logLineDisplayMode: 'grafana.explore.logs.logLineDisplayMode',
   logContextWrapLogMessage: 'grafana.explore.logs.logContext.wrapLogMessage',
   commonLabels: 'grafana.explore.logs.commonLabels',
 };

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DataFrameType, DataSourceApi, GrafanaTheme2, hasLogsLabelTypesSupport, store, TimeRange } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { Box, ControlledCollapse, useStyles2 } from '@grafana/ui';
 
 import { getLabelTypeFromRow } from '../../utils';
@@ -31,8 +31,14 @@ interface LogLineDetailsComponentProps {
 
 export const LogLineDetailsComponent = memo(
   ({ log, logs, search = '', timeRange, timeZone }: LogLineDetailsComponentProps) => {
-    const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
-      useLogListContext();
+    const {
+      displayedFields,
+      logLineDisplayMode,
+      noInteractions,
+      logOptionsStorageKey,
+      setDisplayedFields,
+      syntaxHighlighting,
+    } = useLogListContext();
 
     const [ds, setDs] = useState<DataSourceApi | null | undefined>(undefined);
     const styles = useStyles2(getStyles);
@@ -121,11 +127,31 @@ export const LogLineDetailsComponent = memo(
       [logOptionsStorageKey, noInteractions]
     );
 
+    const parsedFieldLabels: LabelWithLinks[] = useMemo(() => {
+      if (!config.featureToggles.logsSummaryDisplay || logLineDisplayMode !== 'summary') {
+        return [];
+      }
+      const parsed = log.parsedFields;
+      if (!parsed) {
+        return [];
+      }
+      return Object.entries(parsed).map(([key, value]) => ({
+        key,
+        value,
+        links: undefined,
+      }));
+    }, [log, logLineDisplayMode]);
+
+    const parsedFieldsOpen = logOptionsStorageKey
+      ? store.getBool(`${logOptionsStorageKey}.log-details.parsedFieldsOpen`, true)
+      : true;
+
     const noDetails =
       !fieldsWithLinks.links.length &&
       !fieldsWithLinks.linksFromVariableMap.length &&
       !labelGroups.length &&
-      !fieldsWithoutLinks.length;
+      !fieldsWithoutLinks.length &&
+      !parsedFieldLabels.length;
 
     const allLinks = useMemo(
       () => [...fieldsWithLinks.links, ...fieldsWithLinks.linksFromVariableMap],
@@ -230,6 +256,16 @@ export const LogLineDetailsComponent = memo(
             onToggle={(isOpen: boolean) => handleToggle('fieldsOpen', isOpen)}
           >
             <LogLineDetailsFields log={log} logs={logs} fields={fieldsWithoutLinks} search={search} />
+          </ControlledCollapse>
+        )}
+        {parsedFieldLabels.length > 0 && (
+          <ControlledCollapse
+            className={styles.collapsable}
+            label={t('logs.log-line-details.parsed-fields-section', 'Parsed')}
+            isOpen={parsedFieldsOpen}
+            onToggle={(isOpen: boolean) => handleToggle('parsedFieldsOpen', isOpen)}
+          >
+            <LogLineDetailsLabelFields log={log} logs={logs} fields={parsedFieldLabels} search={search} />
           </ControlledCollapse>
         )}
         {noDetails && (

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -58,6 +58,7 @@ export interface Props {
   isLabelFilterActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   loading?: boolean;
   loadMore?: LoadMoreLogsType;
+  logLineDisplayMode?: LogLineDisplayMode;
   logLineMenuCustomItems?: LogLineMenuCustomItem[];
   logOptionsStorageKey?: string;
   logs: LogRowModel[];
@@ -101,8 +102,9 @@ export interface Props {
 }
 
 export type LogListFontSize = 'default' | 'small';
+export type LogLineDisplayMode = 'full' | 'summary';
 
-export type LogListOptions = keyof LogListState | 'wrapLogMessage' | 'prettifyLogMessage' | 'defaultDisplayedFields';
+export type LogListOptions = keyof LogListState | 'wrapLogMessage' | 'prettifyLogMessage' | 'logLineDisplayMode' | 'defaultDisplayedFields';
 
 type LogListComponentProps = Omit<
   Props,
@@ -140,6 +142,7 @@ export const LogList = ({
   isLabelFilterActive,
   loading,
   loadMore,
+  logLineDisplayMode,
   logLineMenuCustomItems,
   logs,
   logsMeta,
@@ -189,6 +192,7 @@ export const LogList = ({
       isLabelFilterActive={isLabelFilterActive}
       logs={logs}
       logsMeta={logsMeta}
+      logLineDisplayMode={logLineDisplayMode}
       logLineMenuCustomItems={logLineMenuCustomItems}
       logOptionsStorageKey={logOptionsStorageKey}
       logSupportsContext={logSupportsContext}
@@ -280,6 +284,7 @@ const LogListComponent = ({
     hasSampledLogs,
     onClickFilterString,
     onClickFilterOutString,
+    logLineDisplayMode,
     permalinkedLogId,
     prettifyJSON,
     showLevel,
@@ -379,6 +384,7 @@ const LogListComponent = ({
         {
           getFieldLinks,
           escape: forceEscape ?? false,
+          logLineDisplayMode,
           prettifyJSON,
           order: sortOrder,
           timeZone,
@@ -390,7 +396,7 @@ const LogListComponent = ({
     );
     virtualization.resetLogLineSizes();
     listRef.current?.resetAfterIndex(0);
-  }, [forceEscape, getFieldLinks, grammar, logs, prettifyJSON, sortOrder, timeZone, virtualization, wrapLogMessage]);
+  }, [forceEscape, getFieldLinks, grammar, logLineDisplayMode, logs, prettifyJSON, sortOrder, timeZone, virtualization, wrapLogMessage]);
 
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -33,7 +33,7 @@ import { getDisplayedFieldsForLogs } from '../otel/formats';
 import { getDefaultDetailsMode, getDetailsWidth } from './LogDetailsContext';
 import { LogLineTimestampResolution } from './LogLine';
 import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
-import { LogListOptions, LogListFontSize } from './LogList';
+import { LogLineDisplayMode, LogListOptions, LogListFontSize } from './LogList';
 import { collectInsights } from './analytics';
 import { LogListModel } from './processing';
 
@@ -54,6 +54,7 @@ export interface LogListContextData
   setForceEscape: (forceEscape: boolean) => void;
   setLogListState: Dispatch<SetStateAction<LogListState>>;
   setPinnedLogs: (pinnedlogs: string[]) => void;
+  setLogLineDisplayMode: (mode: LogLineDisplayMode) => void;
   setPrettifyJSON: (prettifyJSON: boolean) => void;
   setSyntaxHighlighting: (syntaxHighlighting: boolean) => void;
   setShowLevel: (showLevel: boolean) => void;
@@ -63,6 +64,7 @@ export interface LogListContextData
   setTimestampResolution: (format: LogLineTimestampResolution) => void;
   setUnwrappedColumns: (unwrappedColumns: boolean) => void;
   setWrapLogMessage: (showTime: boolean) => void;
+  logLineDisplayMode: LogLineDisplayMode;
   showLevel: boolean;
   timestampResolution: LogLineTimestampResolution;
   isAssistantAvailable: boolean;
@@ -86,6 +88,7 @@ export const LogListContext = createContext<LogListContextData>({
   setFilterLevels: () => {},
   setFontSize: () => {},
   setForceEscape: () => {},
+  setLogLineDisplayMode: () => {},
   setLogListState: () => {},
   setPinnedLogs: () => {},
   setPrettifyJSON: () => {},
@@ -97,6 +100,7 @@ export const LogListContext = createContext<LogListContextData>({
   setTimestampResolution: () => {},
   setUnwrappedColumns: () => {},
   setWrapLogMessage: () => {},
+  logLineDisplayMode: 'full',
   showLevel: true,
   showTime: true,
   sortOrder: LogsSortOrder.Ascending,
@@ -174,6 +178,7 @@ export interface Props {
   permalinkedLogId?: string;
   pinLineButtonTooltipTitle?: PopoverContent;
   pinnedLogs?: string[];
+  logLineDisplayMode?: LogLineDisplayMode;
   prettifyJSON?: boolean;
   setDisplayedFields?: (displayedFields: string[]) => void;
   showControls: boolean;
@@ -219,6 +224,7 @@ export const LogListContextProvider = ({
   onUnpinLine,
   permalinkedLogId,
   pinLineButtonTooltipTitle,
+  logLineDisplayMode: logLineDisplayModeProp,
   pinnedLogs,
   prettifyJSON: prettifyJSONProp,
   setDisplayedFields,
@@ -249,6 +255,12 @@ export const LogListContextProvider = ({
     timestampResolution,
   });
   const { isAvailable: isAssistantAvailable, openAssistant } = useAssistant();
+  const storedDisplayMode = logOptionsStorageKey
+    ? (store.get(`${logOptionsStorageKey}.logLineDisplayMode`) ?? 'full')
+    : 'full';
+  const [logLineDisplayMode, setLogLineDisplayModeState] = useState<LogLineDisplayMode>(
+    logLineDisplayModeProp ?? (storedDisplayMode === 'summary' ? 'summary' : 'full')
+  );
   const [prettifyJSON, setPrettifyJSONState] = useState(prettifyJSONProp);
   const [wrapLogMessage, setWrapLogMessageState] = useState(wrapLogMessageProp);
   const [unwrappedColumns, setUnwrappedColumnsState] = useState(unwrappedColumnsProp);
@@ -345,6 +357,13 @@ export const LogListContextProvider = ({
       setLogListState({ ...logListState, pinnedLogs });
     }
   }, [logListState, pinnedLogs]);
+
+  // Sync logLineDisplayMode
+  useEffect(() => {
+    if (logLineDisplayModeProp !== undefined) {
+      setLogLineDisplayModeState(logLineDisplayModeProp);
+    }
+  }, [logLineDisplayModeProp]);
 
   // Sync prettifyJSON
   useEffect(() => {
@@ -468,6 +487,17 @@ export const LogListContextProvider = ({
       }
     },
     [logListState, logOptionsStorageKey, onLogOptionsChange]
+  );
+
+  const setLogLineDisplayMode = useCallback(
+    (mode: LogLineDisplayMode) => {
+      setLogLineDisplayModeState(mode);
+      if (logOptionsStorageKey) {
+        store.set(`${logOptionsStorageKey}.logLineDisplayMode`, mode);
+      }
+      onLogOptionsChange?.('logLineDisplayMode', mode);
+    },
+    [logOptionsStorageKey, onLogOptionsChange]
   );
 
   const setPrettifyJSON = useCallback(
@@ -623,10 +653,12 @@ export const LogListContextProvider = ({
         permalinkedLogId,
         pinLineButtonTooltipTitle,
         pinnedLogs: logListState.pinnedLogs,
+        logLineDisplayMode,
         prettifyJSON,
         setControlsExpanded,
         setDedupStrategy,
         setDisplayedFields,
+        setLogLineDisplayMode,
         setFilterLevels,
         setFontSize,
         setForceEscape,

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -57,6 +57,7 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
     fontSize,
     forceEscape,
     hasUnescapedContent,
+    logLineDisplayMode,
     logOptionsStorageKey,
     prettifyJSON,
     setControlsExpanded,
@@ -64,6 +65,7 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
     setFilterLevels,
     setFontSize,
     setForceEscape,
+    setLogLineDisplayMode,
     setPrettifyJSON,
     setShowTime,
     setShowUniqueLabels,
@@ -162,6 +164,14 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
     });
     setPrettifyJSON(!prettifyJSON);
   }, [prettifyJSON, setPrettifyJSON]);
+
+  const onLogLineDisplayModeClick = useCallback(() => {
+    const newMode = logLineDisplayMode === 'summary' ? 'full' : 'summary';
+    reportInteraction('logs_log_list_controls_summary_display_clicked', {
+      state: newMode,
+    });
+    setLogLineDisplayMode(newMode);
+  }, [logLineDisplayMode, setLogLineDisplayMode]);
 
   const onSyntaxHightlightingClick = useCallback(() => {
     reportInteraction('logs_log_list_controls_syntax_clicked', {
@@ -478,6 +488,26 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
                     syntaxHighlighting
                       ? t('logs.logs-controls.tooltip.disable-highlighting', 'Disable highlighting')
                       : t('logs.logs-controls.tooltip.enable-highlighting', 'Enable highlighting')
+                  }
+                  size="lg"
+                />
+              )}
+              {config.featureToggles.logsSummaryDisplay && (
+                <LogListControlsOption
+                  expanded={controlsExpanded}
+                  name="file-alt"
+                  aria-pressed={logLineDisplayMode === 'summary'}
+                  className={logLineDisplayMode === 'summary' ? styles.controlButtonActive : styles.controlButton}
+                  onClick={onLogLineDisplayModeClick}
+                  label={
+                    logLineDisplayMode === 'summary'
+                      ? t('logs.logs-controls.label.full-view', 'Full view')
+                      : t('logs.logs-controls.label.summary-view', 'Summary view')
+                  }
+                  tooltip={
+                    logLineDisplayMode === 'summary'
+                      ? t('logs.logs-controls.tooltip.full-view', 'Show full log line')
+                      : t('logs.logs-controls.tooltip.summary-view', 'Show summary of JSON logs')
                   }
                   size="lg"
                 />

--- a/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
@@ -50,6 +50,8 @@ export const LogListContext = createContext<LogListContextData>({
   openAssistantByLog: () => {},
   controlsExpanded: false,
   setControlsExpanded: () => {},
+  logLineDisplayMode: 'full',
+  setLogLineDisplayMode: () => {},
 });
 
 export const useLogListContextData = (key: keyof LogListContextData) => {
@@ -105,6 +107,8 @@ export const defaultValue: LogListContextData = {
   timestampResolution: 'ns',
   controlsExpanded: false,
   setControlsExpanded: jest.fn(),
+  logLineDisplayMode: 'full',
+  setLogLineDisplayMode: jest.fn(),
 };
 
 export const defaultProps: Props = {

--- a/public/app/features/logs/components/panel/messageExtraction.test.ts
+++ b/public/app/features/logs/components/panel/messageExtraction.test.ts
@@ -5,6 +5,7 @@ describe('extractMessageFromJSON', () => {
     const raw = JSON.stringify({ level: 'info', message: 'HTTP request completed', method: 'GET' });
     const result = extractMessageFromJSON(raw);
     expect(result.message).toBe('HTTP request completed');
+    expect(result.messageFieldName).toBe('message');
     expect(result.parsed).toEqual({ level: 'info', message: 'HTTP request completed', method: 'GET' });
   });
 
@@ -60,6 +61,7 @@ describe('extractMessageFromJSON', () => {
     const raw = JSON.stringify({ level: 'info', status: 200, path: '/api/users' });
     const result = extractMessageFromJSON(raw);
     expect(result.message).toBeNull();
+    expect(result.messageFieldName).toBeNull();
     expect(result.parsed).toEqual({ level: 'info', status: 200, path: '/api/users' });
   });
 
@@ -91,6 +93,7 @@ describe('extractMessageFromJSON', () => {
     const raw = JSON.stringify({ event: { message: 'Nested event message', code: 42 }, ts: 123 });
     const result = extractMessageFromJSON(raw);
     expect(result.message).toBe('Nested event message');
+    expect(result.messageFieldName).toBe('event');
   });
 
   it('does NOT use nested lookup when parent is a string', () => {

--- a/public/app/features/logs/components/panel/messageExtraction.test.ts
+++ b/public/app/features/logs/components/panel/messageExtraction.test.ts
@@ -1,0 +1,144 @@
+import { extractMessageFromJSON } from './messageExtraction';
+
+describe('extractMessageFromJSON', () => {
+  it('extracts "message" field (winston, ECS, zerolog)', () => {
+    const raw = JSON.stringify({ level: 'info', message: 'HTTP request completed', method: 'GET' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('HTTP request completed');
+    expect(result.parsed).toEqual({ level: 'info', message: 'HTTP request completed', method: 'GET' });
+  });
+
+  it('extracts "msg" field (pino, Go slog/zap)', () => {
+    const raw = JSON.stringify({ level: 30, msg: 'Server started', port: 3000 });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Server started');
+  });
+
+  it('extracts "event" field (Python structlog)', () => {
+    const raw = JSON.stringify({ event: 'user_login', user_id: 42 });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('user_login');
+  });
+
+  it('extracts "@m" field (Serilog CompactJsonFormatter)', () => {
+    const raw = JSON.stringify({ '@t': '2024-01-01T00:00:00Z', '@m': 'Processing request', '@l': 'Information' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Processing request');
+  });
+
+  it('extracts "@mt" field (Serilog template)', () => {
+    const raw = JSON.stringify({ '@t': '2024-01-01T00:00:00Z', '@mt': 'Processing {RequestId}', '@l': 'Information' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Processing {RequestId}');
+  });
+
+  it('extracts "RenderedMessage" field (Serilog JsonFormatter)', () => {
+    const raw = JSON.stringify({ Timestamp: '2024-01-01', RenderedMessage: 'Request processed', Level: 'Info' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Request processed');
+  });
+
+  it('extracts "log" field (Docker container logs)', () => {
+    const raw = JSON.stringify({ log: 'Container started successfully', stream: 'stdout' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Container started successfully');
+  });
+
+  it('extracts "text" field (generic)', () => {
+    const raw = JSON.stringify({ text: 'Something happened', code: 200 });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Something happened');
+  });
+
+  it('respects priority order: "message" before "msg"', () => {
+    const raw = JSON.stringify({ msg: 'lower priority', message: 'higher priority' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('higher priority');
+  });
+
+  it('returns null for JSON without a known message field', () => {
+    const raw = JSON.stringify({ level: 'info', status: 200, path: '/api/users' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBeNull();
+    expect(result.parsed).toEqual({ level: 'info', status: 200, path: '/api/users' });
+  });
+
+  it('returns null for plain text (non-JSON)', () => {
+    const result = extractMessageFromJSON('Just a plain log line');
+    expect(result.message).toBeNull();
+    expect(result.parsed).toBeNull();
+  });
+
+  it('returns null for logfmt', () => {
+    const result = extractMessageFromJSON('level=info msg="hello world" ts=1234567890');
+    expect(result.message).toBeNull();
+    expect(result.parsed).toBeNull();
+  });
+
+  it('returns null for invalid JSON', () => {
+    const result = extractMessageFromJSON('{ broken json');
+    expect(result.message).toBeNull();
+    expect(result.parsed).toBeNull();
+  });
+
+  it('returns null for JSON arrays', () => {
+    const result = extractMessageFromJSON('[1, 2, 3]');
+    expect(result.message).toBeNull();
+    expect(result.parsed).toBeNull();
+  });
+
+  it('extracts nested event.message (structlog object parent)', () => {
+    const raw = JSON.stringify({ event: { message: 'Nested event message', code: 42 }, ts: 123 });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('Nested event message');
+  });
+
+  it('does NOT use nested lookup when parent is a string', () => {
+    const raw = JSON.stringify({ event: 'login', ts: 123 });
+    const result = extractMessageFromJSON(raw);
+    // "event" as string is valid for top-level lookup
+    expect(result.message).toBe('login');
+  });
+
+  it('returns null for empty/short message strings', () => {
+    const raw = JSON.stringify({ message: 'x' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBeNull();
+  });
+
+  it('returns null for empty string message', () => {
+    const raw = JSON.stringify({ message: '' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBeNull();
+  });
+
+  it('coerces numeric message to string', () => {
+    const raw = JSON.stringify({ message: 42 });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('42');
+  });
+
+  it('ignores object/array message values', () => {
+    const raw = JSON.stringify({ message: { nested: true }, msg: 'fallback' });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('fallback');
+  });
+
+  it('ignores array message values', () => {
+    const raw = JSON.stringify({ message: [1, 2, 3] });
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBeNull();
+  });
+
+  it('handles JSON with leading whitespace', () => {
+    const raw = '  {"message": "with whitespace"}';
+    const result = extractMessageFromJSON(raw);
+    expect(result.message).toBe('with whitespace');
+  });
+
+  it('returns null for empty string input', () => {
+    const result = extractMessageFromJSON('');
+    expect(result.message).toBeNull();
+    expect(result.parsed).toBeNull();
+  });
+});

--- a/public/app/features/logs/components/panel/messageExtraction.ts
+++ b/public/app/features/logs/components/panel/messageExtraction.ts
@@ -21,10 +21,11 @@ const NESTED_MESSAGE_PATHS: Array<{ parent: string; child: string }> = [{ parent
 
 export interface MessageExtractionResult {
   message: string | null;
+  messageFieldName: string | null;
   parsed: Record<string, unknown> | null;
 }
 
-const NULL_RESULT: MessageExtractionResult = { message: null, parsed: null };
+const NULL_RESULT: MessageExtractionResult = { message: null, messageFieldName: null, parsed: null };
 
 export function extractMessageFromJSON(raw: string): MessageExtractionResult {
   // Pre-check: skip parse if it doesn't look like JSON
@@ -52,7 +53,7 @@ export function extractMessageFromJSON(raw: string): MessageExtractionResult {
     const value = obj[fieldName];
     const message = coerceToMessage(value);
     if (message !== null) {
-      return { message, parsed: obj };
+      return { message, messageFieldName: fieldName, parsed: obj };
     }
   }
 
@@ -63,7 +64,7 @@ export function extractMessageFromJSON(raw: string): MessageExtractionResult {
       const nested: unknown = Object(parentValue)[child];
       const message = coerceToMessage(nested);
       if (message !== null) {
-        return { message, parsed: obj };
+        return { message, messageFieldName: parent, parsed: obj };
       }
     }
   }

--- a/public/app/features/logs/components/panel/messageExtraction.ts
+++ b/public/app/features/logs/components/panel/messageExtraction.ts
@@ -1,0 +1,82 @@
+/**
+ * Priority-ordered list of common message field names across logging frameworks.
+ * 'body' excluded — collides with OTLP where body is already the raw content.
+ */
+const MESSAGE_FIELD_NAMES = [
+  'message', // winston, zerolog, Python, Log4j2, Logback, ECS/Kibana, Datadog, Better Stack
+  'msg', // pino, bunyan, Go slog, Go zap
+  'event', // Python structlog
+  '@m', // .NET Serilog CompactJsonFormatter (rendered)
+  '@mt', // .NET Serilog CompactJsonFormatter (template)
+  'RenderedMessage', // .NET Serilog JsonFormatter
+  'log', // Docker container logs, Fluentd/Fluent Bit
+  'text', // generic variant
+];
+
+/**
+ * Nested lookup: only event.message (structlog pattern),
+ * and only when the parent is an object (avoids { "event": "login" } false positive).
+ */
+const NESTED_MESSAGE_PATHS: Array<{ parent: string; child: string }> = [{ parent: 'event', child: 'message' }];
+
+export interface MessageExtractionResult {
+  message: string | null;
+  parsed: Record<string, unknown> | null;
+}
+
+const NULL_RESULT: MessageExtractionResult = { message: null, parsed: null };
+
+export function extractMessageFromJSON(raw: string): MessageExtractionResult {
+  // Pre-check: skip parse if it doesn't look like JSON
+  const trimmed = raw.trimStart();
+  if (trimmed.length === 0 || (trimmed[0] !== '{' && trimmed[0] !== '[')) {
+    return NULL_RESULT;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return NULL_RESULT;
+  }
+
+  // Must be a non-null object (not an array)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return NULL_RESULT;
+  }
+
+  const obj: Record<string, unknown> = Object(parsed);
+
+  // Top-level field lookup (deterministic priority order)
+  for (const fieldName of MESSAGE_FIELD_NAMES) {
+    const value = obj[fieldName];
+    const message = coerceToMessage(value);
+    if (message !== null) {
+      return { message, parsed: obj };
+    }
+  }
+
+  // Nested lookup (conservative: only known patterns)
+  for (const { parent, child } of NESTED_MESSAGE_PATHS) {
+    const parentValue = obj[parent];
+    if (typeof parentValue === 'object' && parentValue !== null && !Array.isArray(parentValue)) {
+      const nested: unknown = Object(parentValue)[child];
+      const message = coerceToMessage(nested);
+      if (message !== null) {
+        return { message, parsed: obj };
+      }
+    }
+  }
+
+  return { ...NULL_RESULT, parsed: obj };
+}
+
+function coerceToMessage(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value.length >= 2 ? value : null;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return null;
+}

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -584,6 +584,15 @@ Value"
       });
     });
 
+    test('parsedFields excludes message field by key, not by value', () => {
+      const entry = '{"message":"User logged in","description":"User logged in","status":200}';
+      const log = createLogLine({ entry }, summaryOptions);
+      expect(log.parsedFields).toEqual({
+        description: 'User logged in',
+        status: '200',
+      });
+    });
+
     test('parsedFields returns null for non-JSON or when no fields remain', () => {
       const plainText = createLogLine({ entry: 'plain text' }, summaryOptions);
       expect(plainText.parsedFields).toBeNull();

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -5,7 +5,7 @@ import { LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '.
 import { createLogLine, createLogRow } from '../mocks/logRow';
 import { OTEL_PROBE_FIELD } from '../otel/formats';
 
-import { LogListFontSize } from './LogList';
+import { LogLineDisplayMode, LogListFontSize } from './LogList';
 import { LogListModel, preProcessLogs } from './processing';
 import { LogLineVirtualization } from './virtualization';
 
@@ -518,6 +518,79 @@ Value"
     expect(processedLogs[0].getDisplayedFieldValue(LOG_LINE_BODY_FIELD_NAME)).toBe(processedLogs[0].body);
     expect(processedLogs[1].getDisplayedFieldValue(LOG_LINE_BODY_FIELD_NAME)).toBe(processedLogs[1].body);
     expect(processedLogs[2].getDisplayedFieldValue(LOG_LINE_BODY_FIELD_NAME)).toBe(processedLogs[2].body);
+  });
+
+  describe('Summary display mode', () => {
+    const summaryOptions = {
+      escape: false,
+      order: LogsSortOrder.Descending,
+      timeZone: 'browser',
+      wrapLogMessage: true,
+      logLineDisplayMode: 'summary' as LogLineDisplayMode,
+    };
+
+    test('Body shows extracted message instead of full JSON', () => {
+      const entry = '{"level":"info","message":"HTTP request completed","status":200}';
+      const log = createLogLine({ entry }, summaryOptions);
+      expect(log.body).toBe('HTTP request completed');
+      expect(log.isJSON).toBe(false);
+    });
+
+    test('Body falls back to full display when no message field or non-JSON', () => {
+      const noMsgField = createLogLine({ entry: '{"status":200,"path":"/api"}' }, summaryOptions);
+      expect(noMsgField.body).toBe('{"status":200,"path":"/api"}');
+
+      const plainText = createLogLine({ entry: 'level=info msg="logfmt"' }, summaryOptions);
+      expect(plainText.body).toBe('level=info msg="logfmt"');
+    });
+
+    test('Default mode and full mode show full JSON', () => {
+      const entry = '{"level":"info","message":"HTTP request completed","status":200}';
+      const defaultMode = createLogLine({ entry }, {
+        escape: false,
+        order: LogsSortOrder.Descending,
+        timeZone: 'browser',
+        wrapLogMessage: true,
+      });
+      expect(defaultMode.body).toBe(entry);
+      expect(defaultMode.isJSON).toBe(true);
+    });
+
+    test('Summary mode respects wrapLogMessage for newlines', () => {
+      const entry = '{"message":"line1\\nline2"}';
+      const wrapped = createLogLine({ entry }, summaryOptions);
+      expect(wrapped.body).toBe('line1\nline2');
+
+      const unwrapped = createLogLine({ entry }, { ...summaryOptions, wrapLogMessage: false });
+      expect(unwrapped.body).not.toContain('\n');
+    });
+
+    test('Clone forces full mode for details view', () => {
+      const entry = '{"level":"info","message":"HTTP request completed","status":200}';
+      const log = createLogLine({ entry }, summaryOptions);
+      expect(log.body).toBe('HTTP request completed');
+
+      const cloned = log.clone();
+      expect(cloned.body).toBe(entry);
+      expect(cloned.isJSON).toBe(true);
+    });
+
+    test('parsedFields excludes metadata, message field, and existing labels', () => {
+      const entry = '{"level":"info","time":123,"message":"test","method":"GET","app":"myapp","count":42}';
+      const log = createLogLine({ entry, labels: { app: 'myapp' } }, summaryOptions);
+      expect(log.parsedFields).toEqual({
+        method: 'GET',
+        count: '42',
+      });
+    });
+
+    test('parsedFields returns null for non-JSON or when no fields remain', () => {
+      const plainText = createLogLine({ entry: 'plain text' }, summaryOptions);
+      expect(plainText.parsedFields).toBeNull();
+
+      const onlyMeta = createLogLine({ entry: '{"message":"test","level":"info","time":123}' }, summaryOptions);
+      expect(onlyMeta.parsedFields).toBeNull();
+    });
   });
 
   describe.each(fontSizes)('Collapsible log lines', (fontSize: LogListFontSize) => {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -20,7 +20,9 @@ import { LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '.
 import { FieldDef, getAllFields } from '../logParser';
 import { identifyOTelLanguage, getOtelAttributesField } from '../otel/formats';
 
+import { LogLineDisplayMode } from './LogList';
 import { generateLogGrammar, generateTextMatchGrammar } from './grammar';
+import { extractMessageFromJSON } from './messageExtraction';
 import { LogLineVirtualization } from './virtualization';
 
 const TRUNCATION_DEFAULT_LENGTH = 50000;
@@ -65,14 +67,26 @@ export class LogListModel implements LogRowModel {
   private _escapeUnescapedString = false;
   private _fields: FieldDef[] | undefined = undefined;
   private _getFieldLinks: GetFieldLinksFn | undefined = undefined;
+  private _logLineDisplayMode: LogLineDisplayMode;
   private _prettifyJSON: boolean;
   private _virtualization?: LogLineVirtualization;
   private _wrapLogMessage: boolean;
   private _json = false;
+  private _summaryMessage: string | null | undefined = undefined;
+  private _parsedJSON: Record<string, unknown> | null | undefined = undefined;
 
   constructor(
     log: LogRowModel,
-    { escape, getFieldLinks, grammar, prettifyJSON, timeZone, virtualization, wrapLogMessage }: PreProcessLogOptions
+    {
+      escape,
+      getFieldLinks,
+      grammar,
+      logLineDisplayMode,
+      prettifyJSON,
+      timeZone,
+      virtualization,
+      wrapLogMessage,
+    }: PreProcessLogOptions
   ) {
     // LogRowModel
     this.datasourceType = log.datasourceType;
@@ -103,6 +117,7 @@ export class LogListModel implements LogRowModel {
     this.displayLevel = logLevelToDisplayLevel(log.logLevel);
     this._getFieldLinks = getFieldLinks;
     this._grammar = grammar;
+    this._logLineDisplayMode = logLineDisplayMode ?? 'full';
     this._prettifyJSON = Boolean(prettifyJSON);
     this.timestamp = dateTimeFormat(log.timeEpochMs, {
       timeZone,
@@ -126,6 +141,7 @@ export class LogListModel implements LogRowModel {
     const clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     // Unless this function is required outside of <LogLineDetailsLog />, we create a wrapped clone, so new lines are not stripped.
     clone._wrapLogMessage = true;
+    clone._logLineDisplayMode = 'full';
     clone._body = undefined;
     clone._highlightTokens = undefined;
     clone.collapsed = false;
@@ -134,6 +150,23 @@ export class LogListModel implements LogRowModel {
 
   get body(): string {
     if (this._body === undefined) {
+      // Summary mode: show extracted message instead of full JSON
+      if (this._logLineDisplayMode === 'summary') {
+        const summary = this.summaryMessage;
+        if (summary !== null) {
+          let body = summary;
+          if (this._escapeUnescapedString) {
+            body = escapeUnescapedString(body);
+          }
+          if (!this._wrapLogMessage) {
+            body = body.replace(NEWLINES_REGEX, '');
+          }
+          this._body = body;
+          return this._body;
+        }
+        // Fallback: no message extracted, proceed with full display
+      }
+
       try {
         const parsed = parse(this.raw, undefined, {
           onDuplicateKey: ({ newValue }) => newValue,
@@ -160,6 +193,43 @@ export class LogListModel implements LogRowModel {
       }
     }
     return this._body;
+  }
+
+  get summaryMessage(): string | null {
+    if (this._summaryMessage === undefined) {
+      const result = extractMessageFromJSON(this.raw);
+      this._summaryMessage = result.message;
+      this._parsedJSON = result.parsed;
+    }
+    return this._summaryMessage;
+  }
+
+  get parsedFields(): Record<string, string> | null {
+    // Trigger extraction if not done yet
+    if (this._parsedJSON === undefined) {
+      this.summaryMessage; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    }
+    const parsed = this._parsedJSON;
+    if (parsed === null || parsed === undefined || this._summaryMessage === null) {
+      return null;
+    }
+    const result: Record<string, string> = {};
+    const excludeKeys = new Set(['level', 'time', 'timestamp', 'severity', 'ts', '@t', '@l']);
+    // Find the message field key to exclude it
+    for (const [key, value] of Object.entries(parsed)) {
+      if (excludeKeys.has(key)) {
+        continue;
+      }
+      if (typeof value === 'string' && value === this._summaryMessage) {
+        continue;
+      }
+      // Skip fields already in labels
+      if (this.labels[key] != null) {
+        continue;
+      }
+      result[key] = typeof value === 'string' ? value : JSON.stringify(value);
+    }
+    return Object.keys(result).length > 0 ? result : null;
   }
 
   get errorMessage(): string | undefined {
@@ -284,6 +354,7 @@ export class LogListModel implements LogRowModel {
 export interface PreProcessOptions {
   escape: boolean;
   getFieldLinks?: GetFieldLinksFn;
+  logLineDisplayMode?: LogLineDisplayMode;
   order: LogsSortOrder;
   prettifyJSON?: boolean;
   timeZone: string;
@@ -293,7 +364,16 @@ export interface PreProcessOptions {
 
 export const preProcessLogs = (
   logs: LogRowModel[],
-  { escape, getFieldLinks, order, prettifyJSON, timeZone, virtualization, wrapLogMessage }: PreProcessOptions,
+  {
+    escape,
+    getFieldLinks,
+    logLineDisplayMode,
+    order,
+    prettifyJSON,
+    timeZone,
+    virtualization,
+    wrapLogMessage,
+  }: PreProcessOptions,
   grammar?: Grammar
 ): LogListModel[] => {
   const orderedLogs = sortLogRows(logs, order);
@@ -302,6 +382,7 @@ export const preProcessLogs = (
       escape,
       getFieldLinks,
       grammar,
+      logLineDisplayMode,
       prettifyJSON,
       timeZone,
       virtualization,
@@ -314,6 +395,7 @@ interface PreProcessLogOptions {
   escape: boolean;
   getFieldLinks?: GetFieldLinksFn;
   grammar?: Grammar;
+  logLineDisplayMode?: LogLineDisplayMode;
   prettifyJSON?: boolean;
   timeZone: string;
   virtualization?: LogLineVirtualization;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -73,6 +73,7 @@ export class LogListModel implements LogRowModel {
   private _wrapLogMessage: boolean;
   private _json = false;
   private _summaryMessage: string | null | undefined = undefined;
+  private _messageFieldName: string | null = null;
   private _parsedJSON: Record<string, unknown> | null | undefined = undefined;
 
   constructor(
@@ -199,6 +200,7 @@ export class LogListModel implements LogRowModel {
     if (this._summaryMessage === undefined) {
       const result = extractMessageFromJSON(this.raw);
       this._summaryMessage = result.message;
+      this._messageFieldName = result.messageFieldName;
       this._parsedJSON = result.parsed;
     }
     return this._summaryMessage;
@@ -215,16 +217,17 @@ export class LogListModel implements LogRowModel {
     }
     const result: Record<string, string> = {};
     const excludeKeys = new Set(['level', 'time', 'timestamp', 'severity', 'ts', '@t', '@l']);
-    // Find the message field key to exclude it
+    if (this._messageFieldName) {
+      excludeKeys.add(this._messageFieldName);
+    }
+    // Build set of datasource-provided field names to avoid duplicates
+    const dsFieldKeys = new Set(this.fields.map((f) => f.keys[0]));
     for (const [key, value] of Object.entries(parsed)) {
       if (excludeKeys.has(key)) {
         continue;
       }
-      if (typeof value === 'string' && value === this._summaryMessage) {
-        continue;
-      }
-      // Skip fields already in labels
-      if (this.labels[key] != null) {
+      // Skip fields already in labels or datasource fields
+      if (this.labels[key] != null || dsFieldKeys.has(key)) {
         continue;
       }
       result[key] = typeof value === 'string' ? value : JSON.stringify(value);

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -173,6 +173,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     fontSize,
     syntaxHighlighting,
     detailsMode: detailsModeProp,
+    logLineDisplayMode,
     noInteractions,
     timestampResolution,
     showLogAttributes,
@@ -601,6 +602,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
               getFieldLinks={getFieldLinks}
               grammar={isGrammar(grammar) ? grammar : undefined}
               isLabelFilterActive={isIsFilterLabelActive(isFilterLabelActive) ? isFilterLabelActive : undefined}
+              logLineDisplayMode={logLineDisplayMode}
               initialScrollPosition={initialScrollPosition}
               loading={infiniteScrolling}
               logLineMenuCustomItems={

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -46,6 +46,7 @@ composableKinds: PanelCfg: {
 					showLogAttributes?:       bool
 					fontSize?:                "default" | "small"  @cuetsy(kind="enum", memberNames="default|small")
 					detailsMode?:             "inline" | "sidebar" @cuetsy(kind="enum", memberNames="inline|sidebar")
+					logLineDisplayMode?:      "full" | "summary"   @cuetsy(kind="enum", memberNames="full|summary")
 					timestampResolution?:     "ms" | "ns"          @cuetsy(kind="enum", memberNames="ms|ns")
 					// TODO: figure out how to define callbacks
 					onClickFilterLabel?:     _

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -17,6 +17,7 @@ export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
   detailsMode?: ('inline' | 'sidebar');
   displayedFields?: Array<string>;
+  logLineDisplayMode?: ('full' | 'summary');
   enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   fontSize?: ('default' | 'small');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11160,6 +11160,7 @@
       "move-displayed-field-up": "Move up",
       "no-details": "No fields to display.",
       "open-assistant": "Explain log line in Assistant",
+      "parsed-fields-section": "Parsed",
       "pin-line": "Pin log",
       "remove-displayed-field": "Remove field",
       "remove-log": "Remove log",
@@ -11267,7 +11268,9 @@
         "disable-highlighting": "Highlight text",
         "enable-highlighting": "Plain text",
         "escape-newlines": "Escape newlines",
-        "expand": "Collapsed"
+        "expand": "Collapsed",
+        "full-view": "Full view",
+        "summary-view": "Summary view"
       },
       "labels": {
         "font-large": "Large font",
@@ -11313,7 +11316,9 @@
         "disable-highlighting": "Disable highlighting",
         "download": "Download",
         "enable-highlighting": "Enable highlighting",
-        "filter-level": "Filter logs result by level"
+        "filter-level": "Filter logs result by level",
+        "full-view": "Show full log line",
+        "summary-view": "Show summary of JSON logs"
       },
       "unwrap-lines": "Unwrap lines",
       "unwrapped-columns": {


### PR DESCRIPTION
<!--
Thank you for your contribution! Please see https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md
for our contribution guide.
-->

**What is this feature?**

An opt-in summary display mode for JSON logs that auto-detects the message field and shows only the extracted message instead of the full JSON blob, improving readability for structured log data.

**Why do we need this feature?**

Structured JSON logs are verbose and hard to scan visually. A single log line like:
```json
{"level":"info","time":"2026-03-25T18:10:35.917Z","service":"api","message":"(GET) /session | Status: 200 | Time: 26ms","method":"GET","status":200,"responseTimeInMS":26}
```
becomes:
```
(GET) /session | Status: 200 | Time: 26ms
```
The full JSON is still available in the details view with parsed fields displayed as individual key-value pairs.

**Who is this feature for?**

Users who work with structured JSON logs from common logging frameworks (winston, pino, zerolog, slog, Serilog, structlog, Log4j2, Fluentd, Docker).

**Which issue(s) does this PR fix?**

<!--
- Automatically closes linked issue when the Pull Request is merged.
Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
-->

N/A — new feature proposal

**Special notes for your reviewer:**

- Gated behind the `logsSummaryDisplay` feature toggle (experimental, disabled by default)
- No changes to stored log data — rendering-only change
- Falls back to full mode when extraction fails (non-JSON, no matching field)
- Tested with real Loki JSON logs in Explore and Logs Drilldown