### PR TITLE
App Platform: Use util for error handling

### DIFF
--- a/public/app/api/clients/collections/v1alpha1/index.ts
+++ b/public/app/api/clients/collections/v1alpha1/index.ts
@@ -1,6 +1,7 @@
 import { generatedAPI } from '@grafana/api-clients/rtkq/collections/v1alpha1';
 import { t } from '@grafana/i18n';
-import { createSuccessNotification, createErrorNotification } from 'app/core/copy/appNotification';
+import { handleError } from 'app/api/utils';
+import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 
 export const collectionsAPIv1alpha1 = generatedAPI.enhanceEndpoints({
@@ -11,11 +12,7 @@ export const collectionsAPIv1alpha1 = generatedAPI.enhanceEndpoints({
           await queryFulfilled;
           dispatch(notifyApp(createSuccessNotification(t('dashboard.toolbar.star-added', 'Added to starred'))));
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(createErrorNotification(t('dashboard.toolbar.star-add-error', 'Failed to add to starred'), e))
-            );
-          }
+          handleError(e, dispatch, t('dashboard.toolbar.star-add-error', 'Failed to add to starred'));
         }
       },
     },
@@ -25,13 +22,7 @@ export const collectionsAPIv1alpha1 = generatedAPI.enhanceEndpoints({
           await queryFulfilled;
           dispatch(notifyApp(createSuccessNotification(t('dashboard.toolbar.star-removed', 'Removed from starred'))));
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(t('dashboard.toolbar.star-remove-error', 'Failed to remove from starred'), e)
-              )
-            );
-          }
+          handleError(e, dispatch, t('dashboard.toolbar.star-remove-error', 'Failed to remove from starred'));
         }
       },
     },

--- a/public/app/api/clients/correlations/v0alpha1/index.ts
+++ b/public/app/api/clients/correlations/v0alpha1/index.ts
@@ -1,6 +1,7 @@
 import { generatedAPI } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { t } from '@grafana/i18n';
-import { createErrorNotification, createSuccessNotification } from 'app/core/copy/appNotification';
+import { handleError } from 'app/api/utils';
+import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 
 export const correlationsAPIv0alpha1 = generatedAPI.enhanceEndpoints({
@@ -30,9 +31,7 @@ export const correlationsAPIv0alpha1 = generatedAPI.enhanceEndpoints({
 
           dispatch(notifyApp(createSuccessNotification(t('correlation.edit-success', 'Correlation updated'))));
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(notifyApp(createErrorNotification(t('correlation.edit-error', 'Error updating correlation'), e)));
-          }
+          handleError(e, dispatch, t('correlation.edit-error', 'Error updating correlation'));
         }
       },
     },

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -140,16 +140,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             )
           );
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(
-                  t('provisioning.delete-repository-button.error-repository-delete', 'Failed to delete repository'),
-                  e
-                )
-              )
-            );
-          }
+          handleError(
+            e,
+            dispatch,
+            t('provisioning.delete-repository-button.error-repository-delete', 'Failed to delete repository')
+          );
         }
         // Refetch dashboards and folders after deleting a provisioned repository.
         // We need to add timeout to ensure that the deletion is processed before refetching since the deletion is done
@@ -171,16 +166,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             )
           );
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(
-                  t('provisioning.home-page.error-delete-all-repositories', 'Failed to delete all repositories'),
-                  e
-                )
-              )
-            );
-          }
+          handleError(
+            e,
+            dispatch,
+            t('provisioning.home-page.error-delete-all-repositories', 'Failed to delete all repositories')
+          );
         }
         setTimeout(() => {
           dispatch(refetchChildren({ parentUID: undefined, pageSize: PAGE_SIZE }));
@@ -208,16 +198,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             );
           }
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(
-                  t('provisioning.sync-repository.error-pulling-resources', 'Error pulling resources'),
-                  e
-                )
-              )
-            );
-          }
+          handleError(
+            e,
+            dispatch,
+            t('provisioning.sync-repository.error-pulling-resources', 'Error pulling resources')
+          );
         }
       },
     },
@@ -233,16 +218,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             )
           );
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(
-                  t('provisioning.config-form.error-save-repository', 'Failed to save repository settings'),
-                  e
-                )
-              )
-            );
-          }
+          handleError(
+            e,
+            dispatch,
+            t('provisioning.config-form.error-save-repository', 'Failed to save repository settings')
+          );
         }
       },
     },
@@ -258,16 +238,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             )
           );
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(
-                  t('provisioning.config-form.error-save-repository', 'Failed to save repository settings'),
-                  e
-                )
-              )
-            );
-          }
+          handleError(
+            e,
+            dispatch,
+            t('provisioning.config-form.error-save-repository', 'Failed to save repository settings')
+          );
         }
         // Refetch dashboards and folders after creating/updating a provisioned repository
         dispatch(refetchChildren({ parentUID: undefined, pageSize: PAGE_SIZE }));
@@ -357,16 +332,11 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             )
           );
         } catch (e) {
-          if (e instanceof Error) {
-            dispatch(
-              notifyApp(
-                createErrorNotification(
-                  t('provisioning.connection-form.error-delete-connection', 'Failed to delete connection'),
-                  e
-                )
-              )
-            );
-          }
+          handleError(
+            e,
+            dispatch,
+            t('provisioning.connection-form.error-delete-connection', 'Failed to delete connection')
+          );
         }
       },
     },


### PR DESCRIPTION
**What is this feature?**

During the investigation of a bug found in #119979, I discovered the error was not surfacing the app notifications as expected. I found the error was getting caught, but an if statement checking that the error was `instanceOf Error` was evaluating to false so the notification was not showing. I found that this pattern is repeated in this section of the codebase, and a utility function had already been created to surface errors as expected.

This PR replaces the pattern with the utility function in other clients. I did not individually test each replacement, but it did work with correlations. I'd appreciate it if the owners could test it - Throwing an error from the equivalent `[pkg/services/*/database.go` should do it, if that exists.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
