### PR TITLE
Docs: clarify admin credentials env vars only apply on first startup

### DIFF
--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -211,6 +211,31 @@ You can input confidential data like login credentials and secrets into Grafana 
 
 You can apply this technique to any configuration options in `conf/grafana.ini` by setting `GF_<SectionName>_<KeyName>__FILE` to the file path that contains the secret information. For more information about Docker secret command usage, refer to [docker secret](https://docs.docker.com/engine/reference/commandline/secret/).
 
+{{< admonition type="note" >}}
+The `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD` environment variables (and their `__FILE` variants) are only used during the very first startup of Grafana, when no users exist in the database yet. If you use a persistent volume for `/var/lib/grafana`, changing these variables after the initial setup and restarting the container has no effect.
+
+To reset the admin password in a running container, use the Grafana CLI:
+
+```bash
+grafana cli admin reset-admin-password <new-password>
+```
+
+To automatically reset the admin password on every container startup, override the entrypoint:
+
+```yaml
+services:
+  grafana:
+    image: grafana/grafana-enterprise
+    entrypoint:
+      - "sh"
+      - "-c"
+      - "grafana cli admin reset-admin-password $${GF_SECURITY_ADMIN_PASSWORD} && /run.sh"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=mysecretpassword
+```
+
+{{< /admonition >}}
+
 The following example demonstrates how to set the admin password:
 
 - Admin password secret: `/run/secrets/admin_password`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -696,9 +696,23 @@ Disable creation of a Grafana Admin user on first start of Grafana. Default is `
 The name of the default Grafana Admin user, who has full permissions.
 Default is `admin`.
 
+This setting is only used during the initial startup when no users exist in the database. Changing it after the admin user has been created has no effect. To change the admin username after initial setup, use the Grafana UI or the [Admin API](/docs/grafana/latest/developers/http_api/admin/).
+
 #### `admin_password`
 
 The password of the default Grafana Admin. Set once on first-run. Default is `admin`.
+
+This setting is only used during the initial startup when no users exist in the database. Changing it after the admin user has been created has no effect, including when set through the `GF_SECURITY_ADMIN_PASSWORD` environment variable or Docker Secrets (`GF_SECURITY_ADMIN_PASSWORD__FILE`). To reset the admin password after initial setup, run:
+
+```bash
+grafana cli admin reset-admin-password <new-password>
+```
+
+In Docker or Kubernetes environments, you can override the container entrypoint to reset the password on every startup:
+
+```bash
+grafana cli admin reset-admin-password "$GF_SECURITY_ADMIN_PASSWORD" && /run.sh
+```
 
 #### `admin_email`
 


### PR DESCRIPTION
## Summary

- Clarify that `admin_user`, `admin_password` (and their `GF_SECURITY_*` env var overrides) are only used during Grafana's first startup when no users exist in the database
- Add the `grafana cli admin reset-admin-password` workaround to both the configuration reference and the Docker guide
- Add a Docker Compose example for automatically resetting the admin password on container startup

This is a common source of confusion, especially in Docker and Kubernetes deployments with persistent volumes where users expect env var changes to take effect on restart. The issue has 30+ comments from affected users.

## Test plan

- [ ] Verify the admonition renders correctly in the Grafana docs preview
- [ ] Confirm the `grafana cli admin reset-admin-password` command is accurate
- [ ] Verify the Docker Compose entrypoint example works

Fixes #49055