### PR TITLE
refactor(settings): Increase default settings service cache ttl

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -50,7 +50,7 @@ const LogPrefix = "setting.service"
 const DefaultPageSize = int64(500)
 const DefaultQPS = float32(200)
 const DefaultBurst = 300
-const DefaultCacheTTL = 1 * time.Second
+const DefaultCacheTTL = 5 * time.Second
 const DefaultCacheMaxEntries = 1000
 
 const (


### PR DESCRIPTION
**What is this feature?**

Increasing default `settings-service` cache `ttl` to 5 seconds

**Why do we need this feature?**


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
