### PR TITLE
Provisioning: fix flaky namespace quota token refresh test

### DIFF
--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/util/retry"
+	"k8s.io/apimachinery/pkg/types"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -225,42 +227,34 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 	// about to expire.
 	//
 	// The controller reconciler runs concurrently and may update the repo's
-	// status between our Get and UpdateStatus, bumping resourceVersion and
-	// causing a conflict error. We use two layers of retry:
-	//   - Inner RetryOnConflict: tight backoff (~10ms) for bursts of conflicts,
-	//     much faster than EventuallyWithT's poll interval.
-	//   - Outer EventuallyWithT: 60s deadline that survives sustained controller
-	//     activity (e.g. periodic resync, quota re-evaluation).
+	// status between our Get and UpdateStatus, causing optimistic-locking
+	// conflicts. On fast backends (SQLite) the reconciler outpaces even
+	// tight retry loops. A merge patch on the status subresource avoids
+	// this entirely — it doesn't require a specific resourceVersion, so it
+	// can never conflict.
 	now := time.Now()
-	var staledHealthChecked, staledTokenLastUpdated int64
+	staledHealthChecked := now.Add(-2 * time.Minute).UnixMilli()
+	staledTokenLastUpdated := now.Add(-1 * time.Hour).UnixMilli()
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		innerErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			repoUnstr, err := helper.Repositories.Resource.Get(ctx, repoName1, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			repo1 := common.UnstructuredToRepository(t, repoUnstr)
-
-			// Token lastUpdated far in the past (not "recently created") and expiration
-			// soon (within the 2*resyncInterval+10s refresh buffer).
-			repo1.Status.Token = provisioning.TokenStatus{
-				LastUpdated: now.Add(-1 * time.Hour).UnixMilli(),
-				Expiration:  now.Add(30 * time.Second).UnixMilli(),
-			}
-			// Age the health.checked beyond recentUnhealthyDuration (1 min) so the
-			// health checker considers it stale. This also ensures health.checked will
-			// visibly advance after the next reconciliation.
-			repo1.Status.Health.Checked = now.Add(-2 * time.Minute).UnixMilli()
-			staledHealthChecked = repo1.Status.Health.Checked
-			staledTokenLastUpdated = repo1.Status.Token.LastUpdated
-
-			updatedUnstr := common.RepositoryToUnstructured(t, repo1)
-			_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedUnstr, metav1.UpdateOptions{})
-			return err
-		})
-		assert.NoError(c, innerErr, "failed to update repo1 status with near-expiry token")
-	}, common.WaitTimeoutDefault, 200*time.Millisecond, "should update repo1 status with near-expiry token")
+	// Token lastUpdated far in the past (not "recently created") and expiration
+	// soon (within the 2*resyncInterval+10s refresh buffer).
+	// Age the health.checked beyond recentUnhealthyDuration (1 min) so the
+	// health checker considers it stale.
+	statusPatch, err := json.Marshal(map[string]any{
+		"status": map[string]any{
+			"token": map[string]any{
+				"lastUpdated": staledTokenLastUpdated,
+				"expiration":  now.Add(30 * time.Second).UnixMilli(),
+			},
+			"health": map[string]any{
+				"checked": staledHealthChecked,
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = helper.Repositories.Resource.Patch(ctx, repoName1,
+		types.MergePatchType, statusPatch, metav1.PatchOptions{}, "status")
+	require.NoError(t, err, "failed to patch repo1 status with near-expiry token")
 
 	// --- Step 5: verify health check AND token refresh happened, repo still blocked
 	require.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
## Summary

Fixes a flaky integration test `TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota` that consistently fails on SQLite but rarely on PostgreSQL/MySQL.

**Root cause:** Step 4 of the test uses a Get → Modify → `UpdateStatus` pattern to manufacture a near-expiry token on a repo. `UpdateStatus` requires a specific `resourceVersion` and fails with an optimistic-locking conflict when the reconciler updates the object in between. On fast backends (SQLite) the reconciler runs in a tight loop, outpacing even aggressive retry strategies — both a 20-attempt no-delay loop and a 60s `EventuallyWithT` with 10ms polling consistently fail across every single attempt.

With PostgreSQL/MySQL the added I/O latency widens the window enough for the test to occasionally win the race.

**Fix:** Replace the Get → Modify → `UpdateStatus` pattern with a **merge patch** on the status subresource. A `MergePatchType` patch does not carry a `resourceVersion`, so the apiserver applies it to the latest version regardless of concurrent updates — there is no conflict possible.

## Test plan

- [ ] CI passes on SQLite (the backend where this flake reproduced)
- [ ] The existing Step 5 assertions (`health.checked` advanced, `token.lastUpdated` advanced, quota still exceeded) continue to pass, confirming the near-expiry token state was successfully written before the reconciler picked it up