### PR TITLE
SqlExpressions: Remove preview badges from UI

### DIFF
--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
 import { lazy, Suspense, useCallback, useEffect, useRef } from 'react';
 
-import { DataSourceApi, FeatureState, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
+import { DataSourceApi, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Button, FeatureBadge, IconButton, InlineField, PopoverContent, useStyles2 } from '@grafana/ui';
+import { Button, IconButton, InlineField, PopoverContent, useStyles2 } from '@grafana/ui';
 
 import { ClassicConditions } from './components/ClassicConditions';
 import { ExpressionTypeDropdown } from './components/ExpressionTypeDropdown';
@@ -31,9 +31,7 @@ type ExpressionTypeConfigStorage = Partial<Record<NonClassicExpressionType, stri
  * @param type - The expression type.
  * @returns The configuration for the expression type.
  */
-const getExpressionTypeConfig = (
-  type: ExpressionQueryType
-): { helperText: PopoverContent; featureState: FeatureState | undefined } => {
+const getExpressionTypeConfig = (type: ExpressionQueryType): { helperText: PopoverContent } => {
   const description = expressionTypes.find(({ value }) => value === type)?.description;
 
   switch (type) {
@@ -46,12 +44,10 @@ const getExpressionTypeConfig = (
             columns, as returned from the data source.
           </Trans>
         ),
-        featureState: FeatureState.preview,
       };
     default:
       return {
         helperText: description ?? '',
-        featureState: undefined,
       };
   }
 };
@@ -149,7 +145,7 @@ export function ExpressionQueryEditor(props: ExpressionQueryEditorProps) {
     }
   };
 
-  const { helperText, featureState } = getExpressionTypeConfig(query.type);
+  const { helperText } = getExpressionTypeConfig(query.type);
 
   return (
     <div>
@@ -165,7 +161,6 @@ export function ExpressionQueryEditor(props: ExpressionQueryEditorProps) {
           </ExpressionTypeDropdown>
         </InlineField>
         <div className={styles.fieldContainer}>
-          {featureState && <FeatureBadge featureState={featureState} />}
           {helperText && <IconButton name="info-circle" tooltip={helperText} />}
         </div>
       </div>

--- a/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
+++ b/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
@@ -1,8 +1,8 @@
 import { css, cx } from '@emotion/css';
 import { memo, ReactElement, useCallback, useMemo } from 'react';
 
-import { FeatureState, GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Dropdown, FeatureBadge, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Dropdown, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
 import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
 
 const EXPRESSION_ICON_MAP = {
@@ -46,7 +46,6 @@ const ExpressionMenuItem = memo<ExpressionMenuItemProps>(({ item, onSelect, disa
           >
             <Icon className={styles.icon} name={EXPRESSION_ICON_MAP[value!]} aria-hidden="true" />
             {label}
-            {value === ExpressionQueryType.sql && <FeatureBadge featureState={FeatureState.preview} />}
           </div>
           <Tooltip placement="right" content={tooltipContent!}>
             <Icon className={styles.infoIcon} name="info-circle" />


### PR DESCRIPTION
## Motivation

This PR closes #121080. It supports https://github.com/grafana/grafana/pull/120986 by having the front end reflect SQL Expressions' status promotion to GA.

## What does this PR do?

Removes **Preview** badges for SQL Expressions, both in the query editor and in the expression type selector.

## Demo

Not the lack of Preview badge in the screenshots below.

<img width="77" height="33" alt="Screenshot 2026-03-26 at 3 08 30 AM" src="https://github.com/user-attachments/assets/c4ac4130-6894-4241-83ff-2c57ed4aaddb" />


### Query editor

<img width="1149" height="365" alt="demo no preview badge in query editor" src="https://github.com/user-attachments/assets/07d8bfad-ea42-44c9-96d8-a0a20c3135ce" />

### Expression picker

#### Classic query editor

<img width="280" height="260" alt="expressions selector classic query editor" src="https://github.com/user-attachments/assets/d69cfb56-2757-4cf7-8d22-28d9d48b739d" />

#### Query editor v2

<img width="848" height="339" alt="expressions selector qev2" src="https://github.com/user-attachments/assets/4812e0c2-8406-4780-8a0b-0d4ce5b52c79" />
