### PR TITLE
FeatureToggles: Add reportingFooterSettings

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -214,6 +214,11 @@ export interface FeatureToggles {
   */
   reportingHeaderSettings?: boolean;
   /**
+  * Enables the configurable footer settings for PDF reports
+  * @default false
+  */
+  reportingFooterSettings?: boolean;
+  /**
   * Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -322,6 +322,14 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "reportingFooterSettings",
+			Description:  "Enables the configurable footer settings for PDF reports",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaOperatorExperienceSquad,
+			Expression:   "false",
+		},
+		{
 			Name:        "sseGroupByDatasource",
 			Description: "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -38,6 +38,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-03-05,aiGeneratedDashboardChanges,experimental,@grafana/dashboards-squad,false,false,true
 2026-01-08,reportingCsvEncodingOptions,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-03-17,reportingHeaderSettings,experimental,@grafana/grafana-operator-experience-squad,false,false,true
+2026-03-25,reportingFooterSettings,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2023-09-07,sseGroupByDatasource,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-09-19,lokiRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4444,6 +4444,20 @@
     },
     {
       "metadata": {
+        "name": "reportingFooterSettings",
+        "resourceVersion": "1774457609263",
+        "creationTimestamp": "2026-03-25T16:53:29Z"
+      },
+      "spec": {
+        "description": "Enables the configurable footer settings for PDF reports",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "reportingHeaderSettings",
         "resourceVersion": "1773744562248",
         "creationTimestamp": "2026-03-17T10:49:22Z"


### PR DESCRIPTION
## Summary
- register the `reportingFooterSettings` feature toggle in the OSS registry
- regenerate the feature toggle artifacts consumed by the frontend type system
- keep footer settings rollout independent from the existing header settings toggle

**More details including screenshots in parent issue:**
Reporting - Enable new footer customisation options [#1780](https://github.com/grafana/grafana-operator-experience-squad/issues/1780)

**All PRs related to this feature**:
- PR2a Reporting: Add configurable PDF footer backend support: [#11447](https://github.com/grafana/grafana-enterprise/pull/11447)
- PR2b Reporting: Add configurable PDF footer settings UI [#11448](https://github.com/grafana/grafana-enterprise/pull/11448)
- PR2c FeatureToggles: Add reportingFooterSettings [#121174](https://github.com/grafana/grafana/pull/121174))
- PR2d OpenAPI: Regenerate report settings schema for footer fields [#121175](https://github.com/grafana/grafana/pull/121175))

Made with [Cursor](https://cursor.com)