### PR TITLE
OpenAPI: Regenerate report settings schema for footer fields

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -5380,9 +5380,19 @@ export type ReportBrandingOptions = {
   emailLogoUrl?: string;
   reportLogoUrl?: string;
 };
+export type FooterItem = {
+  color?: string;
+  fontSize?: string;
+  fontStyle?: string;
+  fontWeight?: string;
+  type?: string;
+  value?: string;
+};
 export type ReportSettings = {
   branding?: ReportBrandingOptions;
   embeddedImageTheme?: string;
+  footerFontFamily?: string;
+  footerItems?: FooterItem[];
   id?: number;
   orgId?: number;
   pdfDashboardTitleEnabled?: boolean;

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -5597,6 +5597,29 @@
         },
         "type": "object"
       },
+      "FooterItem": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "fontSize": {
+            "type": "string"
+          },
+          "fontStyle": {
+            "type": "string"
+          },
+          "fontWeight": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ForbiddenError": {
         "properties": {
           "body": {
@@ -9881,6 +9904,15 @@
           },
           "embeddedImageTheme": {
             "type": "string"
+          },
+          "footerFontFamily": {
+            "type": "string"
+          },
+          "footerItems": {
+            "items": {
+              "$ref": "#/components/schemas/FooterItem"
+            },
+            "type": "array"
           },
           "id": {
             "format": "int64",

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4960,6 +4960,29 @@
         }
       }
     },
+    "FooterItem": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "fontSize": {
+          "type": "string"
+        },
+        "fontStyle": {
+          "type": "string"
+        },
+        "fontWeight": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
     "Frame": {
       "description": "Each Field is well typed by its FieldType and supports optional Labels.\n\nA Frame is a general data container for Grafana. A Frame can be table data\nor time series data depending on its content and field types.",
       "type": "object",
@@ -7064,6 +7087,15 @@
         },
         "embeddedImageTheme": {
           "type": "string"
+        },
+        "footerFontFamily": {
+          "type": "string"
+        },
+        "footerItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FooterItem"
+          }
         },
         "id": {
           "type": "integer",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15956,6 +15956,29 @@
         }
       }
     },
+    "FooterItem": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "fontSize": {
+          "type": "string"
+        },
+        "fontStyle": {
+          "type": "string"
+        },
+        "fontWeight": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
     "ForbiddenError": {
       "type": "object",
       "properties": {
@@ -20307,6 +20330,15 @@
         },
         "embeddedImageTheme": {
           "type": "string"
+        },
+        "footerFontFamily": {
+          "type": "string"
+        },
+        "footerItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FooterItem"
+          }
         },
         "id": {
           "type": "integer",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -5725,6 +5725,29 @@
         },
         "type": "object"
       },
+      "FooterItem": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "fontSize": {
+            "type": "string"
+          },
+          "fontStyle": {
+            "type": "string"
+          },
+          "fontWeight": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ForbiddenError": {
         "properties": {
           "body": {
@@ -10075,6 +10098,15 @@
           },
           "embeddedImageTheme": {
             "type": "string"
+          },
+          "footerFontFamily": {
+            "type": "string"
+          },
+          "footerItems": {
+            "items": {
+              "$ref": "#/components/schemas/FooterItem"
+            },
+            "type": "array"
           },
           "id": {
             "format": "int64",


### PR DESCRIPTION
## Summary
- regenerate the report settings schema artifacts after adding `footerItems` and `footerFontFamily`
- update the merged and OpenAPI outputs consumed by downstream tooling
- keep generated schema updates isolated from the functional footer implementation

**More details including screenshots in parent issue:**
Reporting - Enable new footer customisation options [#1780](https://github.com/grafana/grafana-operator-experience-squad/issues/1780)

**All PRs related to this feature**:
- PR2a Reporting: Add configurable PDF footer backend support: [#11447](https://github.com/grafana/grafana-enterprise/pull/11447)
- PR2b Reporting: Add configurable PDF footer settings UI [#11448](https://github.com/grafana/grafana-enterprise/pull/11448)
- PR2c FeatureToggles: Add reportingFooterSettings [#121174](https://github.com/grafana/grafana/pull/121174))
- PR2d OpenAPI: Regenerate report settings schema for footer fields [#121175](https://github.com/grafana/grafana/pull/121175))

## Notes
- Generated output for this branch currently comes from the repo's existing OpenAPI pipeline
- Review after PR2a (Reporting: Add configurable PDF footer backend support: https://github.com/grafana/grafana-enterprise/pull/11447), since it reflects the backend contract added there


Made with [Cursor](https://cursor.com)