### PR TITLE
IAM: Add ServiceAccount authorizer for tokens subresource

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -70,7 +70,7 @@ func newIAMAuthorizer(
 	resourceAuthorizer[iamv0.TeamLBACRuleInfo.GetName()] = teamLbacApiInstaller.GetAuthorizer()
 	resourceAuthorizer[iamv0.ResourcePermissionInfo.GetName()] = allowAuthorizer // Handled by the backend wrapper
 	resourceAuthorizer[iamv0.RoleBindingInfo.GetName()] = authorizer
-	resourceAuthorizer[iamv0.ServiceAccountResourceInfo.GetName()] = authorizer
+	resourceAuthorizer[iamv0.ServiceAccountResourceInfo.GetName()] = newServiceAccountAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.UserResourceInfo.GetName()] = newUserAuthorizer(accessClient)
 	resourceAuthorizer[iamv0.ExternalGroupMappingResourceInfo.GetName()] = externalGroupMappingApiInstaller.GetAuthorizer()
 	resourceAuthorizer[iamv0.TeamResourceInfo.GetName()] = newTeamAuthorizer(accessClient)
@@ -98,22 +98,42 @@ func (s *iamAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribute
 	return authz.Authorize(ctx, attr)
 }
 
-// newTeamAuthorizer creates an authorizer for teams that handles the "members" subresource
-// with a get_permissions check on the parent team resource.
-func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+// subresourceCheck is a function that performs authorization check for a specific subresource.
+// It receives the context, identity, and attributes, and returns the authorization decision.
+type subresourceCheck func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error)
+
+// newAuthorizerWithCustomSubCheck creates an authorizer that handles specific subresources
+// with custom permission checks, delegating to the standard ResourceAuthorizer for all other subresources.
+func newAuthorizerWithCustomSubCheck(
+	accessClient authlib.AccessClient,
+	checks map[string]subresourceCheck,
+) authorizer.Authorizer {
 	delegate := gfauthorizer.NewResourceAuthorizer(accessClient)
 	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 		if !attr.IsResourceRequest() {
 			return authorizer.DecisionNoOpinion, "", nil
 		}
 
-		subresource := attr.GetSubresource()
-		if subresource == "members" {
-			ident, ok := authlib.AuthInfoFrom(ctx)
-			if !ok {
-				return authorizer.DecisionDeny, "", errors.New("no identity found")
-			}
+		check, ok := checks[attr.GetSubresource()]
+		if !ok {
+			// Delegate to the standard ResourceAuthorizer for non-matching subresources
+			return delegate.Authorize(ctx, attr)
+		}
 
+		ident, ok := authlib.AuthInfoFrom(ctx)
+		if !ok {
+			return authorizer.DecisionDeny, "", errors.New("no identity found")
+		}
+
+		return check(ctx, ident, attr)
+	})
+}
+
+// newTeamAuthorizer creates an authorizer for teams that handles the "members" subresource
+// with a get_permissions check on the parent team resource.
+func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
+		"members": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
 				Verb:      utils.VerbGetPermissions,
 				Group:     attr.GetAPIGroup(),
@@ -128,29 +148,15 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 				return authorizer.DecisionDeny, "requires team getpermissions", nil
 			}
 			return authorizer.DecisionAllow, "", nil
-		}
-
-		// Delegate to the standard ResourceAuthorizer for non-members subresources
-		return delegate.Authorize(ctx, attr)
+		},
 	})
 }
 
 // newUserAuthorizer creates an authorizer for users that handles the "teams" subresource
 // with a get check on the parent user resource.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	delegate := gfauthorizer.NewResourceAuthorizer(accessClient)
-	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		if !attr.IsResourceRequest() {
-			return authorizer.DecisionNoOpinion, "", nil
-		}
-
-		subresource := attr.GetSubresource()
-		if subresource == "teams" {
-			ident, ok := authlib.AuthInfoFrom(ctx)
-			if !ok {
-				return authorizer.DecisionDeny, "", errors.New("no identity found")
-			}
-
+	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
+		"teams": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
 				Verb:      utils.VerbGet,
 				Group:     attr.GetAPIGroup(),
@@ -165,10 +171,31 @@ func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 				return authorizer.DecisionDeny, "requires user get", nil
 			}
 			return authorizer.DecisionAllow, "", nil
-		}
+		},
+	})
+}
 
-		// Delegate to the standard ResourceAuthorizer for non-teams subresources
-		return delegate.Authorize(ctx, attr)
+// newServiceAccountAuthorizer creates an authorizer for service accounts that handles the "tokens" subresource
+// with a get check on the parent service account resource.
+// This follows the legacy permission pattern where viewing tokens requires serviceaccounts:read on serviceaccounts:id:<id>.
+func newServiceAccountAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
+		"tokens": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+				Verb:      utils.VerbGet,
+				Group:     attr.GetAPIGroup(),
+				Resource:  attr.GetResource(),
+				Namespace: attr.GetNamespace(),
+				Name:      attr.GetName(),
+			}, "")
+			if err != nil {
+				return authorizer.DecisionDeny, "", err
+			}
+			if !res.Allowed {
+				return authorizer.DecisionDeny, "requires serviceaccount get", nil
+			}
+			return authorizer.DecisionAllow, "", nil
+		},
 	})
 }
 

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -14,7 +14,7 @@ import (
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
-// fakeAccessClient is a mock implementation of types.AccessClient for testing
+// fakeAccessClient is a mock implementation of types.AccessClient for testing.
 type fakeAccessClient struct {
 	checkFunc func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
 }
@@ -34,344 +34,210 @@ func (f *fakeAccessClient) BatchCheck(ctx context.Context, id types.AuthInfo, re
 	return types.BatchCheckResponse{}, nil
 }
 
-// TestNewTeamAuthorizer_MembersSubresource_CheckRequest verifies that the authorizer
-// builds the correct CheckRequest for the members subresource.
-func TestNewTeamAuthorizer_MembersSubresource_CheckRequest(t *testing.T) {
-	var capturedReq *types.CheckRequest
-	fakeClient := &fakeAccessClient{
-		checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-			capturedReq = &req
-			return types.CheckResponse{Allowed: true}, nil
-		},
-	}
+// authorizerScenario captures the per-resource configuration used to drive the shared test logic.
+type authorizerScenario struct {
+	name               string
+	newAuthorizer      func(types.AccessClient) authorizer.Authorizer
+	group              string
+	resource           string
+	resourceName       string
+	specialSubresource string // subresource that triggers the custom check
+	otherSubresource   string // unrelated subresource that should delegate to ResourceAuthorizer
+	deniedReason       string // reason string returned when the custom check denies
+	checkRequestVerb   string // verb expected in the CheckRequest built for the custom check
+}
 
-	teamAuth := newTeamAuthorizer(fakeClient)
+var authorizerScenarios = []authorizerScenario{
+	{
+		name:               "team",
+		newAuthorizer:      newTeamAuthorizer,
+		group:              iamv0.TeamResourceInfo.GroupResource().Group,
+		resource:           iamv0.TeamResourceInfo.GroupResource().Resource,
+		resourceName:       "team-abc",
+		specialSubresource: "members",
+		otherSubresource:   "groups",
+		deniedReason:       "requires team getpermissions",
+		checkRequestVerb:   "get_permissions",
+	},
+	{
+		name:               "user",
+		newAuthorizer:      newUserAuthorizer,
+		group:              iamv0.UserResourceInfo.GroupResource().Group,
+		resource:           iamv0.UserResourceInfo.GroupResource().Resource,
+		resourceName:       "user-xyz",
+		specialSubresource: "teams",
+		otherSubresource:   "status",
+		deniedReason:       "requires user get",
+		checkRequestVerb:   "get",
+	},
+	{
+		name:               "serviceaccount",
+		newAuthorizer:      newServiceAccountAuthorizer,
+		group:              iamv0.ServiceAccountResourceInfo.GroupResource().Group,
+		resource:           iamv0.ServiceAccountResourceInfo.GroupResource().Resource,
+		resourceName:       "sa-abc",
+		specialSubresource: "tokens",
+		otherSubresource:   "status",
+		deniedReason:       "requires serviceaccount get",
+		checkRequestVerb:   "get",
+	},
+}
 
-	authInfo := authn.NewIDTokenAuthInfo(
+// newTestAuthInfo returns a minimal AuthInfo for use in authorization tests.
+func newTestAuthInfo() types.AuthInfo {
+	return authn.NewIDTokenAuthInfo(
 		authn.Claims[authn.AccessTokenClaims]{},
 		&authn.Claims[authn.IDTokenClaims]{},
 	)
-	ctx := types.WithAuthInfo(context.Background(), authInfo)
-
-	attr := authorizer.AttributesRecord{
-		ResourceRequest: true,
-		APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
-		Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
-		Subresource:     "members",
-		Name:            "team-abc",
-		Verb:            "get",
-		Namespace:       "org-1",
-	}
-
-	_, _, err := teamAuth.Authorize(ctx, attr)
-	require.NoError(t, err)
-	require.NotNil(t, capturedReq)
-
-	assert.Equal(t, "get_permissions", capturedReq.Verb)
-	assert.Equal(t, iamv0.TeamResourceInfo.GroupResource().Group, capturedReq.Group)
-	assert.Equal(t, iamv0.TeamResourceInfo.GroupResource().Resource, capturedReq.Resource)
-	assert.Equal(t, "team-abc", capturedReq.Name)
-	assert.Equal(t, "org-1", capturedReq.Namespace)
 }
 
-// TestNewTeamAuthorizer_DecisionMatrix covers all decision paths with table-driven tests.
-func TestNewTeamAuthorizer_DecisionMatrix(t *testing.T) {
-	tests := []struct {
-		name            string
-		subresource     string
-		resourceRequest bool
-		checkFunc       func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
-		wantDecision    authorizer.Decision
-		wantReason      string
-		wantErr         bool
-		wantCheckCalled bool
-	}{
-		{
-			name:            "members subresource - allowed",
-			subresource:     "members",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				return types.CheckResponse{Allowed: true}, nil
-			},
-			wantDecision:    authorizer.DecisionAllow,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "members subresource - denied",
-			subresource:     "members",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				return types.CheckResponse{Allowed: false}, nil
-			},
-			wantDecision:    authorizer.DecisionDeny,
-			wantReason:      "requires team getpermissions",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "members subresource - error",
-			subresource:     "members",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				return types.CheckResponse{}, errors.New("database error")
-			},
-			wantDecision:    authorizer.DecisionDeny,
-			wantReason:      "",
-			wantErr:         true,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "no subresource - delegates to ResourceAuthorizer",
-			subresource:     "",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				// Verify the subresource is NOT passed through to the delegate
-				assert.Empty(t, req.Subresource)
-				return types.CheckResponse{Allowed: true}, nil
-			},
-			wantDecision:    authorizer.DecisionAllow,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "other subresource (groups) - delegates to ResourceAuthorizer",
-			subresource:     "groups",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				// The subresource should be passed through to the delegate
-				assert.Equal(t, "groups", req.Subresource)
-				return types.CheckResponse{Allowed: true}, nil
-			},
-			wantDecision:    authorizer.DecisionAllow,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "non-resource request - no opinion",
-			subresource:     "",
-			resourceRequest: false,
-			checkFunc:       nil, // Should not be called
-			wantDecision:    authorizer.DecisionNoOpinion,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			checkCalled := false
-			wrappedCheckFunc := func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				checkCalled = true
-				if tt.checkFunc != nil {
-					return tt.checkFunc(ctx, id, req, folder)
-				}
-				return types.CheckResponse{Allowed: false}, nil
+// TestAuthorizerCheckRequest verifies that each authorizer builds the correct
+// CheckRequest when its custom subresource is accessed.
+func TestAuthorizerCheckRequest(t *testing.T) {
+	for _, sc := range authorizerScenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			var capturedReq *types.CheckRequest
+			fakeClient := &fakeAccessClient{
+				checkFunc: func(_ context.Context, _ types.AuthInfo, req types.CheckRequest, _ string) (types.CheckResponse, error) {
+					capturedReq = &req
+					return types.CheckResponse{Allowed: true}, nil
+				},
 			}
 
-			fakeClient := &fakeAccessClient{checkFunc: wrappedCheckFunc}
-			teamAuth := newTeamAuthorizer(fakeClient)
-
-			authInfo := authn.NewIDTokenAuthInfo(
-				authn.Claims[authn.AccessTokenClaims]{},
-				&authn.Claims[authn.IDTokenClaims]{},
-			)
-			ctx := types.WithAuthInfo(context.Background(), authInfo)
+			auth := sc.newAuthorizer(fakeClient)
+			ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
 
 			attr := authorizer.AttributesRecord{
-				ResourceRequest: tt.resourceRequest,
-				APIGroup:        iamv0.TeamResourceInfo.GroupResource().Group,
-				Resource:        iamv0.TeamResourceInfo.GroupResource().Resource,
-				Subresource:     tt.subresource,
-				Name:            "team-abc",
+				ResourceRequest: true,
+				APIGroup:        sc.group,
+				Resource:        sc.resource,
+				Subresource:     sc.specialSubresource,
+				Name:            sc.resourceName,
 				Verb:            "get",
+				Namespace:       "org-1",
 			}
 
-			decision, reason, err := teamAuth.Authorize(ctx, attr)
+			_, _, err := auth.Authorize(ctx, attr)
+			require.NoError(t, err)
+			require.NotNil(t, capturedReq)
 
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.wantDecision, decision)
-			assert.Equal(t, tt.wantReason, reason)
-			assert.Equal(t, tt.wantCheckCalled, checkCalled, "Check call mismatch")
+			assert.Equal(t, sc.checkRequestVerb, capturedReq.Verb)
+			assert.Equal(t, sc.group, capturedReq.Group)
+			assert.Equal(t, sc.resource, capturedReq.Resource)
+			assert.Equal(t, sc.resourceName, capturedReq.Name)
+			assert.Equal(t, "org-1", capturedReq.Namespace)
 		})
 	}
 }
 
-// TestNewUserAuthorizer_TeamsSubresource_CheckRequest verifies that the authorizer
-// builds the correct CheckRequest for the teams subresource.
-func TestNewUserAuthorizer_TeamsSubresource_CheckRequest(t *testing.T) {
-	var capturedReq *types.CheckRequest
-	fakeClient := &fakeAccessClient{
-		checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-			capturedReq = &req
-			return types.CheckResponse{Allowed: true}, nil
-		},
-	}
-
-	userAuth := newUserAuthorizer(fakeClient)
-
-	authInfo := authn.NewIDTokenAuthInfo(
-		authn.Claims[authn.AccessTokenClaims]{},
-		&authn.Claims[authn.IDTokenClaims]{},
-	)
-	ctx := types.WithAuthInfo(context.Background(), authInfo)
-
-	attr := authorizer.AttributesRecord{
-		ResourceRequest: true,
-		APIGroup:        iamv0.UserResourceInfo.GroupResource().Group,
-		Resource:        iamv0.UserResourceInfo.GroupResource().Resource,
-		Subresource:     "teams",
-		Name:            "user-xyz",
-		Verb:            "get",
-		Namespace:       "org-1",
-	}
-
-	_, _, err := userAuth.Authorize(ctx, attr)
-	require.NoError(t, err)
-	require.NotNil(t, capturedReq)
-
-	assert.Equal(t, "get", capturedReq.Verb)
-	assert.Equal(t, iamv0.UserResourceInfo.GroupResource().Group, capturedReq.Group)
-	assert.Equal(t, iamv0.UserResourceInfo.GroupResource().Resource, capturedReq.Resource)
-	assert.Equal(t, "user-xyz", capturedReq.Name)
-	assert.Equal(t, "org-1", capturedReq.Namespace)
-}
-
-// TestNewUserAuthorizer_DecisionMatrix covers all decision paths with table-driven tests.
-func TestNewUserAuthorizer_DecisionMatrix(t *testing.T) {
-	tests := []struct {
-		name            string
-		subresource     string
-		resourceRequest bool
-		checkFunc       func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
-		wantDecision    authorizer.Decision
-		wantReason      string
-		wantErr         bool
-		wantCheckCalled bool
-	}{
-		{
-			name:            "teams subresource - allowed",
-			subresource:     "teams",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				return types.CheckResponse{Allowed: true}, nil
-			},
-			wantDecision:    authorizer.DecisionAllow,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "teams subresource - denied",
-			subresource:     "teams",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				return types.CheckResponse{Allowed: false}, nil
-			},
-			wantDecision:    authorizer.DecisionDeny,
-			wantReason:      "requires user get",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "teams subresource - error",
-			subresource:     "teams",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				return types.CheckResponse{}, errors.New("database error")
-			},
-			wantDecision:    authorizer.DecisionDeny,
-			wantReason:      "",
-			wantErr:         true,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "no subresource - delegates to ResourceAuthorizer",
-			subresource:     "",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				// Verify the subresource is NOT passed through to the delegate
-				assert.Empty(t, req.Subresource)
-				return types.CheckResponse{Allowed: true}, nil
-			},
-			wantDecision:    authorizer.DecisionAllow,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "other subresource (status) - delegates to ResourceAuthorizer",
-			subresource:     "status",
-			resourceRequest: true,
-			checkFunc: func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				// The subresource should be passed through to the delegate
-				assert.Equal(t, "status", req.Subresource)
-				return types.CheckResponse{Allowed: true}, nil
-			},
-			wantDecision:    authorizer.DecisionAllow,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: true,
-		},
-		{
-			name:            "non-resource request - no opinion",
-			subresource:     "",
-			resourceRequest: false,
-			checkFunc:       nil, // Should not be called
-			wantDecision:    authorizer.DecisionNoOpinion,
-			wantReason:      "",
-			wantErr:         false,
-			wantCheckCalled: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			checkCalled := false
-			wrappedCheckFunc := func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
-				checkCalled = true
-				if tt.checkFunc != nil {
-					return tt.checkFunc(ctx, id, req, folder)
-				}
-				return types.CheckResponse{Allowed: false}, nil
+// TestAuthorizerDecisionMatrix covers all decision paths for each authorizer.
+func TestAuthorizerDecisionMatrix(t *testing.T) {
+	for _, sc := range authorizerScenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			tests := []struct {
+				name            string
+				subresource     string
+				resourceRequest bool
+				checkFunc       func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error)
+				wantDecision    authorizer.Decision
+				wantReason      string
+				wantErr         bool
+				wantCheckCalled bool
+			}{
+				{
+					name:            sc.specialSubresource + " subresource - allowed",
+					subresource:     sc.specialSubresource,
+					resourceRequest: true,
+					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+						return types.CheckResponse{Allowed: true}, nil
+					},
+					wantDecision:    authorizer.DecisionAllow,
+					wantCheckCalled: true,
+				},
+				{
+					name:            sc.specialSubresource + " subresource - denied",
+					subresource:     sc.specialSubresource,
+					resourceRequest: true,
+					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+						return types.CheckResponse{Allowed: false}, nil
+					},
+					wantDecision:    authorizer.DecisionDeny,
+					wantReason:      sc.deniedReason,
+					wantCheckCalled: true,
+				},
+				{
+					name:            sc.specialSubresource + " subresource - error",
+					subresource:     sc.specialSubresource,
+					resourceRequest: true,
+					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+						return types.CheckResponse{}, errors.New("database error")
+					},
+					wantDecision:    authorizer.DecisionDeny,
+					wantErr:         true,
+					wantCheckCalled: true,
+				},
+				{
+					name:            "no subresource - delegates to ResourceAuthorizer",
+					subresource:     "",
+					resourceRequest: true,
+					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+						return types.CheckResponse{Allowed: true}, nil
+					},
+					wantDecision:    authorizer.DecisionAllow,
+					wantCheckCalled: true,
+				},
+				{
+					name:            "other subresource (" + sc.otherSubresource + ") - delegates to ResourceAuthorizer",
+					subresource:     sc.otherSubresource,
+					resourceRequest: true,
+					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+						return types.CheckResponse{Allowed: true}, nil
+					},
+					wantDecision:    authorizer.DecisionAllow,
+					wantCheckCalled: true,
+				},
+				{
+					name:            "non-resource request - no opinion",
+					resourceRequest: false,
+					wantDecision:    authorizer.DecisionNoOpinion,
+				},
 			}
 
-			fakeClient := &fakeAccessClient{checkFunc: wrappedCheckFunc}
-			userAuth := newUserAuthorizer(fakeClient)
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					checkCalled := false
+					wrappedCheck := func(ctx context.Context, id types.AuthInfo, req types.CheckRequest, folder string) (types.CheckResponse, error) {
+						checkCalled = true
+						if tt.checkFunc != nil {
+							return tt.checkFunc(ctx, id, req, folder)
+						}
+						return types.CheckResponse{Allowed: false}, nil
+					}
 
-			authInfo := authn.NewIDTokenAuthInfo(
-				authn.Claims[authn.AccessTokenClaims]{},
-				&authn.Claims[authn.IDTokenClaims]{},
-			)
-			ctx := types.WithAuthInfo(context.Background(), authInfo)
+					auth := sc.newAuthorizer(&fakeAccessClient{checkFunc: wrappedCheck})
+					ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
 
-			attr := authorizer.AttributesRecord{
-				ResourceRequest: tt.resourceRequest,
-				APIGroup:        iamv0.UserResourceInfo.GroupResource().Group,
-				Resource:        iamv0.UserResourceInfo.GroupResource().Resource,
-				Subresource:     tt.subresource,
-				Name:            "user-xyz",
-				Verb:            "get",
+					attr := authorizer.AttributesRecord{
+						ResourceRequest: tt.resourceRequest,
+						APIGroup:        sc.group,
+						Resource:        sc.resource,
+						Subresource:     tt.subresource,
+						Name:            sc.resourceName,
+						Verb:            "get",
+					}
+
+					decision, reason, err := auth.Authorize(ctx, attr)
+
+					if tt.wantErr {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+					}
+					assert.Equal(t, tt.wantDecision, decision)
+					assert.Equal(t, tt.wantReason, reason)
+					assert.Equal(t, tt.wantCheckCalled, checkCalled, "Check call mismatch")
+				})
 			}
-
-			decision, reason, err := userAuth.Authorize(ctx, attr)
-
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.wantDecision, decision)
-			assert.Equal(t, tt.wantReason, reason)
-			assert.Equal(t, tt.wantCheckCalled, checkCalled, "Check call mismatch")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

### Context

The generic `ResourceAuthorizer` forwards **every** subresource path straight to the RBAC service.
An upcoming change ([#118377](https://github.com/grafana/grafana/pull/118377)) will tighten that service: when a subresource has **no mapper entry** the RBAC service will deny the request outright instead of falling through.

**`serviceaccounts/tokens`** is affected: no RBAC mapper entry exists for this subresource. In the legacy
`/api/serviceaccounts` endpoints, viewing tokens is gated on `serviceaccounts:read` scoped to the
parent service account (`serviceaccounts:id:<id>`), not on a standalone subresource permission
(see `pkg/services/serviceaccounts/api/api.go:66`). The new `newServiceAccountAuthorizer` mirrors
that pattern by issuing a `get` check against the parent service-account resource and stripping the
subresource from the RBAC call entirely.

Keeping resources wired to the generic `ResourceAuthorizer` would silently break once #118377 lands.

### Changes

- Extract a shared `newAuthorizerWithCustomSubCheck` helper that:
  - Routes known subresources to a caller-supplied check function.
  - Delegates **everything else** (including no-subresource requests) to the standard `ResourceAuthorizer`, preserving existing behaviour.
- Add `newServiceAccountAuthorizer`: gates `serviceaccounts/tokens` on a `get` check against the parent service-account resource.
- Wire the new authorizer in `newIAMAuthorizer` (previously both resources used the generic authorizer).
- Refactor tests into a table-driven `authorizerScenarios` matrix so that all three authorizers (team, user, serviceaccount) are covered by the same exhaustive decision-matrix and check-request tests — no separate per-resource test functions needed.
