### PR TITLE
Combobox: fix onBlur prop being overridden by downshift's getInputProps

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -683,6 +683,34 @@ describe('Combobox', () => {
     });
   });
 
+  describe('onBlur', () => {
+    it('calls onBlur when the input loses focus', async () => {
+      const onBlurHandler = jest.fn();
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} onBlur={onBlurHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+      await userEvent.tab();
+
+      expect(onBlurHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onBlur when tabbing away with the menu open', async () => {
+      const onBlurHandler = jest.fn();
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} onBlur={onBlurHandler} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      // Menu should be open
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+
+      await userEvent.tab();
+
+      expect(onBlurHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('with RTL selectors', () => {
     it('can be selected by label with HTML <label>', () => {
       render(

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -427,7 +427,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         width={isAutoSize ? undefined : width}
         {...(isAutoSize ? { minWidth, maxWidth } : {})}
         autoFocus={autoFocus}
-        onBlur={onBlur}
         prefix={icon && <Icon name={icon} />}
         disabled={disabled}
         invalid={invalid}
@@ -446,6 +445,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
               event.stopPropagation();
             }
           },
+          onBlur,
         })}
       />
       <Portal>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes the onBlur prop in the `Combobox` component — it was silently ignored and never called.

**Why do we need this feature?**

onBlur is part of the public API of `Combobox` and documented in the prop types. However, it never actually fired. The root cause: onBlur={onBlur} was set as a direct prop on InputComponent, but then
  `{...getInputProps(...)}` was spread after it. Downshift's `getInputProps` always returns its own `onBlur` handler (for internal menu close logic), which completely overwrote the consumer's callback.

  Downshift supports composing external handlers via `callAllEventHandlers` internally — but only when the external onBlur is passed into `getInputProps(...)`, not alongside it.

**Special notes for your reviewer:**

The fix is a one-line change in `Combobox.tsx`. The bug was present since `onBlur` was first introduced to the component. Two tests are added to cover both the basic blur case and the case where the user tabs away
  while the dropdown menu is open.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
