### PR TITLE
Query: Write directly to HTTP handler

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -15,7 +15,6 @@ import (
 	errorsK8s "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/authlib/authn"
@@ -33,6 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dsquerierclient"
 	service "github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -128,15 +128,13 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 
 		ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
 		defer span.End()
-		ctx = request.WithNamespace(ctx, request.NamespaceValue(connectCtx))
-		traceId := span.SpanContext().TraceID()
 		connectLogger := b.log.New(
-			"traceId", traceId.String(),
+			"traceId", span.SpanContext().TraceID().String(),
 			"rule_uid", httpreq.Header.Get("X-Rule-Uid"),
 			"caller", getCaller(ctx),
 		)
 		connectLogger.Debug("received query-service request")
-		responder := newResponderWrapper(incomingResponder,
+		responder := newResponderWrapper(ctx, w,
 			func(statusCode *int, obj runtime.Object) {
 				if *statusCode/100 == 4 {
 					span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
@@ -394,25 +392,32 @@ func handleQuery(
 }
 
 type responderWrapper struct {
-	wrapped    rest.Responder
+	w          http.ResponseWriter
+	ctx        context.Context
 	onObjectFn func(statusCode *int, obj runtime.Object)
 	onErrorFn  func(err error)
 }
 
-func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
+func newResponderWrapper(ctx context.Context, w http.ResponseWriter, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
 	return &responderWrapper{
-		wrapped:    responder,
+		ctx:        ctx,
+		w:          w,
 		onObjectFn: onObjectFn,
 		onErrorFn:  onErrorFn,
 	}
 }
 
-func (r responderWrapper) Object(statusCode int, obj runtime.Object) {
+func (r responderWrapper) Object(statusCode int, obj *query.QueryDataResponse) {
 	if r.onObjectFn != nil {
 		r.onObjectFn(&statusCode, obj)
 	}
 
-	r.wrapped.Object(statusCode, obj)
+	// Write the value as JSON
+	r.w.Header().Set("Content-Type", "application/json")
+	r.w.WriteHeader(statusCode)
+	if err := json.NewEncoder(r.w).Encode(obj); err != nil {
+		http.Error(r.w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func (r responderWrapper) Error(err error) {
@@ -420,7 +425,7 @@ func (r responderWrapper) Error(err error) {
 		r.onErrorFn(err)
 	}
 
-	r.wrapped.Error(err)
+	errhttp.Write(r.ctx, err, r.w)
 }
 
 func logEmptyRefids(queries []v0alpha1.DataQuery, logger log.Logger) {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -193,23 +192,23 @@ func TestQueryAPI(t *testing.T) {
 				req.Header.Set(key, value)
 			}
 
-			ctx := context.Background()
-			mr := &mockResponder{}
+			rr := httptest.NewRecorder()
 			qr := newQueryREST(builder)
 
-			handler, err := qr.Connect(ctx, "name", nil, mr)
-			require.NoError(t, err)
-			rr := httptest.NewRecorder()
+			handler, _ := qr.Connect(context.Background(), "name", nil, nil)
 			handler.ServeHTTP(rr, req)
 
-			require.NoError(t, mr.err, "Should not have error in responder")
-			require.Equal(t, tc.expectedStatus, mr.statusCode, "Should return expected status code")
-			require.NotNil(t, mr.response, "Should have a response object")
+			result := rr.Result()
+			defer func() {
+				_ = result.Body.Close()
+			}()
+
+			require.Equal(t, tc.expectedStatus, result.StatusCode, "Should return expected status code")
 
 			// Verify the response is the expected type
-			qdr, ok := mr.response.(*queryapi.QueryDataResponse)
-			require.True(t, ok, "Response should be QueryDataResponse type")
-			require.NotNil(t, qdr.Responses, "Should have responses")
+			qdr := &queryapi.QueryDataResponse{}
+			err := json.NewDecoder(result.Body).Decode(qdr)
+			require.NoError(t, err, "Failed to decode response body")
 
 			// Load expected frames from testdata if provided
 			if tc.testdataFile != "" {
@@ -245,23 +244,6 @@ func TestQueryAPI(t *testing.T) {
 			t.Logf("Test case '%s' completed successfully", tc.name)
 		})
 	}
-}
-
-type mockResponder struct {
-	statusCode int
-	response   runtime.Object
-	err        error
-}
-
-// Object writes the provided object to the response. Invoking this method multiple times is undefined.
-func (m *mockResponder) Object(statusCode int, obj runtime.Object) {
-	m.statusCode = statusCode
-	m.response = obj
-}
-
-// Error writes the provided error to the response. This method may only be invoked once.
-func (m *mockResponder) Error(err error) {
-	m.err = err
 }
 
 type mockClient struct {


### PR DESCRIPTION
Rather than use the `rest.Responder` this writes results (and errors) to the raw http stream.

This is extracted from https://github.com/grafana/grafana/pull/118803 to make review easier.

NOTE: the `responderWrapper` structure is still pretty weird -- however this small refactor will make a larger one a bit more obvious