### PR TITLE
Dashboard: Include filter and topic in mutation API transformation mapping

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -493,6 +493,58 @@ describe('Panel mutation commands', () => {
       expect(result.success).toBe(true);
     });
 
+    it('applies transformations with filter and topic', async () => {
+      const scene = buildPanelScene();
+      const client = new DashboardMutationClient(scene);
+
+      const elementName = await addPanel(client, 'Transform Panel');
+
+      const result = await client.execute({
+        type: 'UPDATE_PANEL',
+        payload: {
+          element: { name: elementName },
+          panel: {
+            kind: 'Panel',
+            spec: {
+              data: {
+                kind: 'QueryGroup',
+                spec: {
+                  transformations: [
+                    {
+                      kind: 'limit',
+                      spec: {
+                        id: 'limit',
+                        disabled: false,
+                        filter: { id: 'byName', options: 'temperature' },
+                        topic: 'series',
+                        options: { limitField: 10 },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as DefaultGridLayoutManager;
+      const dataProvider = body.getVizPanels()[0].state.$data;
+      expect(dataProvider).toBeDefined();
+      if (dataProvider && 'state' in dataProvider) {
+        const transformerState = dataProvider.state as { transformations?: Array<Record<string, unknown>> };
+        expect(transformerState.transformations).toBeDefined();
+        expect(transformerState.transformations![0]).toMatchObject({
+          id: 'limit',
+          disabled: false,
+          filter: { id: 'byName', options: 'temperature' },
+          topic: 'series',
+          options: { limitField: 10 },
+        });
+      }
+    });
+
     it('updates panel description', async () => {
       const scene = buildPanelScene();
       const client = new DashboardMutationClient(scene);

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -165,6 +165,8 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
           const transformations = dataSpec.transformations.map((t: TransformationKind) => ({
             id: t.spec.id,
             disabled: t.spec.disabled,
+            filter: t.spec.filter,
+            topic: t.spec.topic,
             options: t.spec.options,
           }));
           dataPipeline.setState({ transformations });


### PR DESCRIPTION
## Summary

The `UPDATE_PANEL` mutation command was dropping `filter` and `topic` fields when applying transformation updates from the v2beta1 schema to the scene's `SceneDataTransformer`. This could cause transformations with frame matchers or data topic settings to lose those properties when updated via the mutation API.

## Test plan

- [x] Mutation API tests pass (139/139)
- [ ] Manual: edit a panel with a transformation that has a filter, verify filter persists after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)