### PR TITLE
Alerting: Fix apiVersion for list items on k8s API's

### DIFF
--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -141,9 +141,17 @@ func (a AppInstaller) AddToScheme(scheme *runtime.Scheme) error {
 	if err := a.AppInstaller.AddToScheme(scheme); err != nil {
 		return err
 	}
-	// All list types have identical memory layouts between v0alpha1 and v1beta1
-	// (same fields: TypeMeta, ListMeta, Items), so we can reinterpret the pointer
-	// directly — the same approach used by conversion-gen for layout-identical types.
+	return registerListConversions(scheme)
+}
+
+// registerListConversions adds bidirectional v0alpha1 ↔ v1beta1 list conversion functions to
+// the scheme for all five notification resource types.
+func registerListConversions(scheme *runtime.Scheme) error {
+	// Individual item types have identical memory layouts between v0alpha1 and v1beta1,
+	// so we reinterpret each item pointer directly — the same approach used by conversion-gen
+	// for layout-identical types. We must allocate a fresh Items slice to avoid aliasing the
+	// backing array across both list objects, and set each item's TypeMeta to the target version.
+	// The list-level TypeMeta is set by the scheme's setTargetKind after this function returns.
 	type convPair struct {
 		src, dst  interface{}
 		convertFn conversion.ConversionFunc
@@ -152,70 +160,150 @@ func (a AppInstaller) AddToScheme(scheme *runtime.Scheme) error {
 		{
 			(*v0alpha1.ReceiverList)(nil), (*v1beta1.ReceiverList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v1beta1.ReceiverList) = *(*v1beta1.ReceiverList)(unsafe.Pointer(in.(*v0alpha1.ReceiverList))) // #nosec G103
+				inList := in.(*v0alpha1.ReceiverList)
+				outList := out.(*v1beta1.ReceiverList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v1beta1.Receiver, len(inList.Items))
+				itemGVK := v1beta1.ReceiverKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v1beta1.Receiver)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v1beta1.ReceiverList)(nil), (*v0alpha1.ReceiverList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v0alpha1.ReceiverList) = *(*v0alpha1.ReceiverList)(unsafe.Pointer(in.(*v1beta1.ReceiverList))) // #nosec G103
+				inList := in.(*v1beta1.ReceiverList)
+				outList := out.(*v0alpha1.ReceiverList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v0alpha1.Receiver, len(inList.Items))
+				itemGVK := v0alpha1.ReceiverKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v0alpha1.Receiver)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v0alpha1.InhibitionRuleList)(nil), (*v1beta1.InhibitionRuleList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v1beta1.InhibitionRuleList) = *(*v1beta1.InhibitionRuleList)(unsafe.Pointer(in.(*v0alpha1.InhibitionRuleList))) // #nosec G103
+				inList := in.(*v0alpha1.InhibitionRuleList)
+				outList := out.(*v1beta1.InhibitionRuleList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v1beta1.InhibitionRule, len(inList.Items))
+				itemGVK := v1beta1.InhibitionRuleKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v1beta1.InhibitionRule)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v1beta1.InhibitionRuleList)(nil), (*v0alpha1.InhibitionRuleList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v0alpha1.InhibitionRuleList) = *(*v0alpha1.InhibitionRuleList)(unsafe.Pointer(in.(*v1beta1.InhibitionRuleList))) // #nosec G103
+				inList := in.(*v1beta1.InhibitionRuleList)
+				outList := out.(*v0alpha1.InhibitionRuleList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v0alpha1.InhibitionRule, len(inList.Items))
+				itemGVK := v0alpha1.InhibitionRuleKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v0alpha1.InhibitionRule)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v0alpha1.RoutingTreeList)(nil), (*v1beta1.RoutingTreeList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v1beta1.RoutingTreeList) = *(*v1beta1.RoutingTreeList)(unsafe.Pointer(in.(*v0alpha1.RoutingTreeList))) // #nosec G103
+				inList := in.(*v0alpha1.RoutingTreeList)
+				outList := out.(*v1beta1.RoutingTreeList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v1beta1.RoutingTree, len(inList.Items))
+				itemGVK := v1beta1.RoutingTreeKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v1beta1.RoutingTree)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v1beta1.RoutingTreeList)(nil), (*v0alpha1.RoutingTreeList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v0alpha1.RoutingTreeList) = *(*v0alpha1.RoutingTreeList)(unsafe.Pointer(in.(*v1beta1.RoutingTreeList))) // #nosec G103
+				inList := in.(*v1beta1.RoutingTreeList)
+				outList := out.(*v0alpha1.RoutingTreeList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v0alpha1.RoutingTree, len(inList.Items))
+				itemGVK := v0alpha1.RoutingTreeKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v0alpha1.RoutingTree)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v0alpha1.TemplateGroupList)(nil), (*v1beta1.TemplateGroupList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v1beta1.TemplateGroupList) = *(*v1beta1.TemplateGroupList)(unsafe.Pointer(in.(*v0alpha1.TemplateGroupList))) // #nosec G103
+				inList := in.(*v0alpha1.TemplateGroupList)
+				outList := out.(*v1beta1.TemplateGroupList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v1beta1.TemplateGroup, len(inList.Items))
+				itemGVK := v1beta1.TemplateGroupKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v1beta1.TemplateGroup)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v1beta1.TemplateGroupList)(nil), (*v0alpha1.TemplateGroupList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v0alpha1.TemplateGroupList) = *(*v0alpha1.TemplateGroupList)(unsafe.Pointer(in.(*v1beta1.TemplateGroupList))) // #nosec G103
+				inList := in.(*v1beta1.TemplateGroupList)
+				outList := out.(*v0alpha1.TemplateGroupList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v0alpha1.TemplateGroup, len(inList.Items))
+				itemGVK := v0alpha1.TemplateGroupKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v0alpha1.TemplateGroup)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v0alpha1.TimeIntervalList)(nil), (*v1beta1.TimeIntervalList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v1beta1.TimeIntervalList) = *(*v1beta1.TimeIntervalList)(unsafe.Pointer(in.(*v0alpha1.TimeIntervalList))) // #nosec G103
+				inList := in.(*v0alpha1.TimeIntervalList)
+				outList := out.(*v1beta1.TimeIntervalList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v1beta1.TimeInterval, len(inList.Items))
+				itemGVK := v1beta1.TimeIntervalKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v1beta1.TimeInterval)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},
 		{
 			(*v1beta1.TimeIntervalList)(nil), (*v0alpha1.TimeIntervalList)(nil),
 			func(in, out interface{}, _ conversion.Scope) error {
-				*out.(*v0alpha1.TimeIntervalList) = *(*v0alpha1.TimeIntervalList)(unsafe.Pointer(in.(*v1beta1.TimeIntervalList))) // #nosec G103
+				inList := in.(*v1beta1.TimeIntervalList)
+				outList := out.(*v0alpha1.TimeIntervalList)
+				inList.ListMeta.DeepCopyInto(&outList.ListMeta)
+				outList.Items = make([]v0alpha1.TimeInterval, len(inList.Items))
+				itemGVK := v0alpha1.TimeIntervalKind().GroupVersionKind()
+				for i := range inList.Items {
+					outList.Items[i] = *(*v0alpha1.TimeInterval)(unsafe.Pointer(&inList.Items[i])) // #nosec G103
+					outList.Items[i].SetGroupVersionKind(itemGVK)
+				}
 				return nil
 			},
 		},

--- a/pkg/registry/apps/alerting/notifications/register_test.go
+++ b/pkg/registry/apps/alerting/notifications/register_test.go
@@ -1,0 +1,122 @@
+package notifications
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v0alpha1 "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v0alpha1"
+	v1beta1 "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+
+	gv0 := v0alpha1.RoutingTreeKind().GroupVersionKind().GroupVersion()
+	gv1 := v1beta1.RoutingTreeKind().GroupVersionKind().GroupVersion()
+
+	scheme.AddKnownTypes(gv0,
+		&v0alpha1.ReceiverList{},
+		&v0alpha1.InhibitionRuleList{},
+		&v0alpha1.RoutingTreeList{},
+		&v0alpha1.TemplateGroupList{},
+		&v0alpha1.TimeIntervalList{},
+	)
+	scheme.AddKnownTypes(gv1,
+		&v1beta1.ReceiverList{},
+		&v1beta1.InhibitionRuleList{},
+		&v1beta1.RoutingTreeList{},
+		&v1beta1.TemplateGroupList{},
+		&v1beta1.TimeIntervalList{},
+	)
+	metav1.AddToGroupVersion(scheme, gv0)
+	metav1.AddToGroupVersion(scheme, gv1)
+
+	require.NoError(t, registerListConversions(scheme))
+	return scheme
+}
+
+func TestRegisterListConversions_ItemTypeMetaIsUpdated(t *testing.T) {
+	scheme := newTestScheme(t)
+
+	v1beta1GV := v1beta1.RoutingTreeKind().GroupVersionKind().GroupVersion()
+	v0alpha1GV := v0alpha1.RoutingTreeKind().GroupVersionKind().GroupVersion()
+
+	t.Run("v1beta1 RoutingTreeList to v0alpha1 sets item TypeMeta", func(t *testing.T) {
+		inList := &v1beta1.RoutingTreeList{
+			Items: []v1beta1.RoutingTree{
+				{TypeMeta: metav1.TypeMeta{APIVersion: v1beta1GV.String(), Kind: "RoutingTree"}},
+				{TypeMeta: metav1.TypeMeta{APIVersion: v1beta1GV.String(), Kind: "RoutingTree"}},
+			},
+		}
+
+		out, err := scheme.ConvertToVersion(inList, v0alpha1GV)
+		require.NoError(t, err)
+
+		outList, ok := out.(*v0alpha1.RoutingTreeList)
+		require.True(t, ok)
+		require.Len(t, outList.Items, 2)
+		for _, item := range outList.Items {
+			assert.Equal(t, v0alpha1GV.String(), item.APIVersion)
+			assert.Equal(t, "RoutingTree", item.Kind)
+		}
+	})
+
+	t.Run("v0alpha1 RoutingTreeList to v1beta1 sets item TypeMeta", func(t *testing.T) {
+		inList := &v0alpha1.RoutingTreeList{
+			Items: []v0alpha1.RoutingTree{
+				{TypeMeta: metav1.TypeMeta{APIVersion: v0alpha1GV.String(), Kind: "RoutingTree"}},
+			},
+		}
+
+		out, err := scheme.ConvertToVersion(inList, v1beta1GV)
+		require.NoError(t, err)
+
+		outList, ok := out.(*v1beta1.RoutingTreeList)
+		require.True(t, ok)
+		require.Len(t, outList.Items, 1)
+		assert.Equal(t, v1beta1GV.String(), outList.Items[0].APIVersion)
+		assert.Equal(t, "RoutingTree", outList.Items[0].Kind)
+	})
+
+	t.Run("converted items do not alias input slice", func(t *testing.T) {
+		inList := &v1beta1.RoutingTreeList{
+			Items: []v1beta1.RoutingTree{
+				{TypeMeta: metav1.TypeMeta{APIVersion: v1beta1GV.String(), Kind: "RoutingTree"}},
+			},
+		}
+
+		out, err := scheme.ConvertToVersion(inList, v0alpha1GV)
+		require.NoError(t, err)
+
+		outList := out.(*v0alpha1.RoutingTreeList)
+		// Mutating the output should not affect the input.
+		outList.Items[0].Name = "mutated"
+		assert.Empty(t, inList.Items[0].Name)
+	})
+}
+
+func TestRegisterListConversions_ListMetaIsPreserved(t *testing.T) {
+	scheme := newTestScheme(t)
+
+	v0alpha1GV := v0alpha1.RoutingTreeKind().GroupVersionKind().GroupVersion()
+
+	inList := &v1beta1.RoutingTreeList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "42",
+			Continue:        "tok",
+		},
+	}
+
+	out, err := scheme.ConvertToVersion(inList, v0alpha1GV)
+	require.NoError(t, err)
+
+	outList := out.(*v0alpha1.RoutingTreeList)
+	assert.Equal(t, "42", outList.ResourceVersion)
+	assert.Equal(t, "tok", outList.Continue)
+}


### PR DESCRIPTION
## Context

We've recently promoted the alerting.notifications API's to v1beta1, adding conversion functions for bi-directional conversion of v0alpha1 <-> v1beta1. We did that using unsafe pointers as the memory layout of the schemas are the same.

For list endpoints, however, there's a subtle bug. The list envelope is correctly set to the apiVersion that gets called, but the list items will always be set to v1beta1 (since that's what legacy storage returns).

This fixes it by instead instantiating a new slice for list types, converting each item independently and setting their version explicitly.

Related to https://github.com/grafana/grafana/pull/120738