### PR TITLE
Docs: Remove manual provisioning feature toggle instructions

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -44,7 +44,7 @@ For further details on how Git Sync operates refer to [key concepts](https://gra
 
 ## Enable required feature toggles
 
-The `provisioning` feature toggle is enabled by default in Grafana Cloud and starting in Grafana v13 for OSS and Enterprise. No manual configuration is required.
+The `provisioning` feature toggle is enabled by default in Grafana Cloud and, starting in Grafana v13, for OSS and Enterprise as well. No manual configuration is required.
 
 For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -44,21 +44,11 @@ For further details on how Git Sync operates refer to [key concepts](https://gra
 
 ## Enable required feature toggles
 
+The `provisioning` feature toggle is enabled by default starting in Grafana v13. No manual configuration is required.
+
 In Grafana Cloud, Git Sync is being rolled out gradually. For more details refer to [Rolling release channels for Grafana Cloud](https://grafana.com/docs/rolling-release/).
 
-To activate Git Sync in Grafana OSS/Enterprise, set the `provisioning` feature toggle to `true`:
-
-1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
-1. Enable the provisioning toggle:
-
-   ```ini
-   [feature_toggles]
-   provisioning = true
-   ```
-
-1. Save the changes to the file and restart Grafana.
-
-For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
+For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
 
 ### Enable Git providers
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -44,9 +44,7 @@ For further details on how Git Sync operates refer to [key concepts](https://gra
 
 ## Enable required feature toggles
 
-The `provisioning` feature toggle is enabled by default starting in Grafana v13. No manual configuration is required.
-
-In Grafana Cloud, Git Sync is being rolled out gradually. For more details refer to [Rolling release channels for Grafana Cloud](https://grafana.com/docs/rolling-release/).
+The `provisioning` feature toggle is enabled by default in Grafana Cloud and starting in Grafana v13 for OSS and Enterprise. No manual configuration is required.
 
 For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
 

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -59,7 +59,7 @@ Git Sync is available for any Git provider through a Pure Git repository type, a
 | GitLab       | Cloud, Enterprise      | Personal Access Token               |
 | Bitbucket    | Cloud, Enterprise      | API token with scopes               |
 
-Note that Pure Git, GitLab and Bitbucket are supported in Grafana v12.4.x only. Refer to [Enable required feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before#enable-required-feature-toggles) to set them up.
+Note that Pure Git, GitLab and Bitbucket are supported in Grafana v12.4.x only. Refer to [Enable Git providers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before#enable-git-providers) to set them up.
 
 ### The Pure Git repository type
 

--- a/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
@@ -34,7 +34,7 @@ Using the local path lets you also use it with a tool like `fuse`, allowing you 
 
 To set up file sync with local with local files, you need to:
 
-1. Enable feature toggles and paths in Grafana configuration file (first time set up).
+1. Configure permitted paths in Grafana configuration file (first time set up).
 1. Set the local path.
 1. Choose what content to sync with Grafana.
 
@@ -53,22 +53,16 @@ For production systems, use the `folderFromFilesStructure` capability instead of
 
 ## Before you begin
 
-{{< admonition type="note" >}}
-Enable the `provisioning` feature toggle in Grafana to use this feature.
-{{< /admonition >}}
-
 To set up file provisioning, you need:
 
 - Administration rights in your Grafana organization.
 - A local directory where your dashboards will be stored.
   - If you want to use a GitHub repository, refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
 - To update the `permitted_provisioning_paths` section of `custom.ini`.
-- To enable the required feature toggles in your Grafana instance.
 
-## Enable required feature toggles and configure permitted paths
+## Configure permitted paths
 
-To activate local file provisioning in Grafana, you need to enable the `provisioning` feature toggle.
-For additional information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles).
+The `provisioning` feature toggle is enabled by default starting in Grafana v13. No manual configuration of the feature toggle is required.
 
 The local setting must be a relative path and its relative path must be configured in the `permitted_provisioned_paths` configuration option.
 The configuration option is relative to your working directory, i.e. where you are running Grafana from; this is usually `/usr/share/grafana` or similar.
@@ -81,14 +75,7 @@ Any subdirectories are automatically included.
 
 The values that you enter for the `permitted_provisioning_paths` become the base paths for those entered when you enter a local path in the **Connect to local storage** wizard.
 
-1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`. For file location based on operating system, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
-1. Locate or add a `[feature_toggles]` section. Add this value:
-
-   ```ini
-   [feature_toggles]
-   provisioning = true
-   ```
-
+1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`. For file location based on operating system, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
 1. Locate or add a `[paths]` section. To add more than one location, use the pipe character (`|`) to separate the paths. The list should not include empty paths or trailing pipes. Add these values:
 
    ```ini
@@ -112,7 +99,7 @@ To start setting up file-based provisioning:
 ### Connect to local storage
 
 The local path can point to any directory that is permitted by the configuration.
-Refer to [Enabled required feature toggles and paths](#enable-required-feature-toggles-and-configure-permitted-paths) for information.
+Refer to [Configure permitted paths](#configure-permitted-paths) for information.
 
 The starting path is always your working `grafana` directory.
 The prefix that must be entered is determined by the locations configured in `permitted_provisioning_paths`.

--- a/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
@@ -62,7 +62,7 @@ To set up file provisioning, you need:
 
 ## Configure permitted paths
 
-The `provisioning` feature toggle is enabled by default starting in Grafana v13. No manual configuration of the feature toggle is required.
+The `provisioning` feature toggle is enabled by default in Grafana Cloud and starting in Grafana v13 for OSS and Enterprise. No manual configuration of the feature toggle is required.
 
 The local setting must be a relative path and its relative path must be configured in the `permitted_provisioned_paths` configuration option.
 The configuration option is relative to your working directory, i.e. where you are running Grafana from; this is usually `/usr/share/grafana` or similar.

--- a/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
@@ -62,7 +62,7 @@ To set up file provisioning, you need:
 
 ## Configure permitted paths
 
-The `provisioning` feature toggle is enabled by default in Grafana Cloud and starting in Grafana v13 for OSS and Enterprise. No manual configuration of the feature toggle is required.
+The `provisioning` feature toggle is enabled by default in Grafana Cloud and, starting in Grafana v13, for OSS and Enterprise as well. No manual configuration of the feature toggle is required.
 
 The local setting must be a relative path and its relative path must be configured in the `permitted_provisioned_paths` configuration option.
 The configuration option is relative to your working directory, i.e. where you are running Grafana from; this is usually `/usr/share/grafana` or similar.


### PR DESCRIPTION
## What

Remove instructions for manually enabling the `provisioning` feature toggle from Git Sync and file provisioning setup docs.

## Why

The `provisioning` feature toggle is now enabled by default in Grafana Cloud and starting in Grafana v13 for OSS/Enterprise (see #120014). Users no longer need to manually enable it, so the setup docs should reflect this.

## Changes

- **`set-up-before.md`** — Removed the "Enable required feature toggles" section; replaced with a note that provisioning is enabled by default.
- **`file-path-setup.md`** — Removed the admonition and config example for enabling the toggle; renamed heading to "Configure permitted paths".
- **`usage-limits.md`** — Updated cross-reference link to point to "Enable Git providers" instead of the removed section.

Made with [Cursor](https://cursor.com)