### PR TITLE
Admin: Retry reencryption in flaky tests

### DIFF
--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -105,17 +105,25 @@ func RunAdminApiReencryptTest(
 	require.NoError(t, err)
 
 	// Reencrypt with new data key.
-	ok, err := env.Server.HTTPServer.SecretsMigrator.ReEncryptSecrets(context.Background())
-	require.NoError(t, err)
-	assert.True(t, ok, "Failed to reencrypt all secrets")
+	require.Eventually(t, func() bool {
+		ok, err := env.Server.HTTPServer.SecretsMigrator.ReEncryptSecrets(context.Background())
+		if err != nil {
+			return false
+		}
+		return ok
+	}, 5*time.Second, time.Second)
 
 	afterReencrypt := getSecrets(t, secretsFns, env)
 	verifyAllSecrets(t, env, beforeReencrypt, afterReencrypt)
 
 	// Rollback from envelope to legacy encryption.
-	ok, err = env.Server.HTTPServer.SecretsMigrator.RollBackSecrets(context.Background())
-	require.NoError(t, err)
-	assert.True(t, ok, "Failed to rollback all secrets")
+	require.Eventually(t, func() bool {
+		ok, err := env.Server.HTTPServer.SecretsMigrator.RollBackSecrets(context.Background())
+		if err != nil {
+			return false
+		}
+		return ok
+	}, 5*time.Second, time.Second)
 
 	afterRollback := getSecrets(t, secretsFns, env)
 	verifyAllSecrets(t, env, afterReencrypt, afterRollback)


### PR DESCRIPTION
This seems to be flaky because of SQLite locking the DB, so we can retry every second in case of failure up to 5 times...