### PR TITLE
Unified: Fix SQLITE_BUSY flake in ClusterScopedResources test

### DIFF
--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -2288,7 +2288,11 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	})
 
 	t.Run("sqlkv", func(t *testing.T) {
-		backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)), withChannelNotifier)
+		opts := []func(*KVBackendOptions){withKV(setupSqlKV(t))}
+		if db.IsTestDbSQLite() {
+			opts = append(opts, withChannelNotifier)
+		}
+		backend := setupTestStorageBackend(t, opts...)
 		testClusterScopedResources(t, backend)
 	})
 }

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -2288,7 +2288,7 @@ func TestKvStorageBackend_ClusterScopedResources(t *testing.T) {
 	})
 
 	t.Run("sqlkv", func(t *testing.T) {
-		backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+		backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)), withChannelNotifier)
 		testClusterScopedResources(t, backend)
 	})
 }


### PR DESCRIPTION
## Summary
- Fix flaky `TestKvStorageBackend_ClusterScopedResources/sqlkv` test that intermittently fails with `SQLITE_BUSY` errors
- Use `channelNotifier` instead of `pollingNotifier` for the sqlkv subtest, avoiding concurrent DB reads (from polling) conflicting with test writes on SQLite
- This matches the existing pattern in `NewTestSqlKvBackend` (`storage_backend_sql_compatibility.go:44-46`)

## Test plan
- [x] Ran the test 100 times (300 subtests) with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)