### PR TITLE
Internationalisation: make Trans require either defaults or children

### DIFF
--- a/packages/grafana-i18n/src/types.ts
+++ b/packages/grafana-i18n/src/types.ts
@@ -11,17 +11,15 @@ type UseTranslateHook = () => (id: string, defaultMessage: string, values?: Reco
 type TransChild = React.ReactNode | Record<string, unknown>;
 
 /**
- * Props interface for the Trans component used for internationalization
+ * Shared props for the Trans component used for internationalization.
+ * Either `children` or `defaults` must be provided so that the component
+ * always has fallback text when translations are not loaded.
  */
-interface TransProps {
+interface TransPropsBase {
   /**
    * The translation key to look up
    */
   i18nKey: string;
-  /**
-   * Child elements or values to interpolate
-   */
-  children?: TransChild | readonly TransChild[];
   /**
    * React elements to use for interpolation
    */
@@ -30,10 +28,6 @@ interface TransProps {
    * Count value for pluralization
    */
   count?: number;
-  /**
-   * Default text if translation is not found
-   */
-  defaults?: string;
   /**
    * Namespace for the translation key
    */
@@ -51,6 +45,24 @@ interface TransProps {
    */
   className?: string;
 }
+
+interface TransPropsWithChildren extends TransPropsBase {
+  /**
+   * Child elements or values to interpolate — also serves as fallback text
+   */
+  children: TransChild | readonly TransChild[];
+  defaults?: string;
+}
+
+interface TransPropsWithDefaults extends TransPropsBase {
+  children?: TransChild | readonly TransChild[];
+  /**
+   * Default text if translation is not found
+   */
+  defaults: string;
+}
+
+type TransProps = TransPropsWithChildren | TransPropsWithDefaults;
 
 /**
  * Function declaration for the Trans component

--- a/public/app/features/explore/ExplorePage.tsx
+++ b/public/app/features/explore/ExplorePage.tsx
@@ -70,7 +70,7 @@ function ExplorePageContent(props: GrafanaRouteComponentProps<{}, ExploreQueryPa
       })}
     >
       <h1 className="sr-only">
-        <Trans i18nKey="nav.explore.title" />
+        <Trans i18nKey="nav.explore.title">Explore</Trans>
       </h1>
       <ExploreActions />
       {showCorrelationEditorBar && <CorrelationEditorModeBar panes={panes} />}

--- a/public/app/features/scopes/selector/RecentScopes.tsx
+++ b/public/app/features/scopes/selector/RecentScopes.tsx
@@ -29,7 +29,7 @@ export const RecentScopes = ({ recentScopes, onSelect }: RecentScopesProps) => {
         >
           <Icon name={expanded ? 'angle-down' : 'angle-right'} />
           <Text variant="body">
-            <Trans i18nKey="command-palette.section.recent-scopes" />
+            <Trans i18nKey="command-palette.section.recent-scopes">Recent scopes</Trans>
           </Text>
         </button>
       </legend>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- ensures we always pass either `children` or `defaults` to `Trans`
- fixes the couple of violations
- see slack context: https://raintank-corp.slack.com/archives/C025WTVRBSN/p1774533342299889

**Why do we need this feature?**

- prevent showing internal translation keys in the UI

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
