### PR TITLE
Dashboard: Temporarily disable v2 API version negotiation

### DIFF
--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -39,10 +39,11 @@ describe('DashboardAPIVersionResolver', () => {
 
   describe('resolve', () => {
     it.each([
-      { versions: ['v2', 'v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2' }, desc: 'both stable' },
+      // v2 negotiation is temporarily disabled (#119474) — always resolves to v2beta1
+      { versions: ['v2', 'v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2beta1' }, desc: 'both stable' },
       { versions: ['v2beta1', 'v1beta1'], expected: BETA_FALLBACK, desc: 'beta only' },
       { versions: ['v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2beta1' }, desc: 'v1 stable only' },
-      { versions: ['v2', 'v2beta1', 'v1beta1'], expected: { v1: 'v1beta1', v2: 'v2' }, desc: 'v2 stable only' },
+      { versions: ['v2', 'v2beta1', 'v1beta1'], expected: { v1: 'v1beta1', v2: 'v2beta1' }, desc: 'v2 stable only' },
     ])('should resolve correctly when $desc are available', async ({ versions, expected }) => {
       mockDiscoveryResponse(versions);
 
@@ -69,7 +70,8 @@ describe('DashboardAPIVersionResolver', () => {
       expect(await dashboardAPIVersionResolver.resolve()).toEqual(BETA_FALLBACK);
 
       mockDiscoveryResponse(['v2', 'v1']);
-      expect(await dashboardAPIVersionResolver.resolve()).toEqual({ v1: 'v1', v2: 'v2' });
+      // v2 negotiation temporarily disabled (#119474)
+      expect(await dashboardAPIVersionResolver.resolve()).toEqual({ v1: 'v1', v2: 'v2beta1' });
     });
 
     it('should cache and deduplicate concurrent resolve calls', async () => {
@@ -81,7 +83,7 @@ describe('DashboardAPIVersionResolver', () => {
         dashboardAPIVersionResolver.resolve(),
       ]);
 
-      const expected = { v1: 'v1', v2: 'v2' };
+      const expected = { v1: 'v1', v2: 'v2beta1' };
       expect(r1).toEqual(expected);
       expect(r2).toEqual(expected);
       expect(r3).toEqual(expected);
@@ -143,7 +145,8 @@ describe('DashboardAPIVersionResolver', () => {
       mockDiscoveryResponse(['v2', 'v1']);
       await dashboardAPIVersionResolver.resolve();
       expect(dashboardAPIVersionResolver.getV1()).toBe('v1');
-      expect(dashboardAPIVersionResolver.getV2()).toBe('v2');
+      // v2 negotiation temporarily disabled (#119474)
+      expect(dashboardAPIVersionResolver.getV2()).toBe('v2beta1');
     });
   });
 });

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
@@ -75,7 +75,10 @@ class DashboardAPIVersionResolver {
     const availableVersions = new Set(group.versions.map((v) => v.version));
 
     const v1: DashboardV1Version = availableVersions.has('v1') ? 'v1' : BETA_V1;
-    const v2: DashboardV2Version = availableVersions.has('v2') ? 'v2' : BETA_V2;
+    // TODO: Enable v2 negotiation once the frontend compat layer lands (#119474).
+    // The v2 API has a breaking change in TransformationKind shape that the frontend
+    // cannot handle yet. Until then, always use v2beta1.
+    const v2: DashboardV2Version = BETA_V2;
 
     debugLog(`Version negotiation: v1=${v1}, v2=${v2} (available: ${Array.from(availableVersions).join(', ')})`);
 


### PR DESCRIPTION
## Summary

**Hotfix** — The v2 stable dashboard API was merged (#118646) but the frontend compat layer (#119474) hasn't landed yet. The `DashboardAPIVersionResolver` discovers v2 as available and routes requests through `/v2`, but the frontend deserialization code still expects v2beta1 `TransformationKind` shape. This breaks any dashboard with transformations:

```
Registry.ts:80 Uncaught Error: "undefined" not found in: reduce,filterFieldsByName,...
transformSceneToSaveModelSchemaV2.ts:514 Uncaught Error: Unsupported transformation type
```

This PR temporarily hardcodes v2 resolution to `v2beta1` until #119474 lands with the `normalizeTransformation()` compat layer.

## Test plan

- [x] Unit tests updated and passing (13/13)
- [ ] Verify dashboards with transformations load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
