### PR TITLE
[release-11.6.15] DashboardKind: Add panels from collapsed rows into lookup

### DIFF
--- a/devenv/dev-dashboards/scenarios/all-colapsed-rows-public.json
+++ b/devenv/dev-dashboards/scenarios/all-colapsed-rows-public.json
@@ -1,0 +1,149 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 1,
+          "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-local",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-testdata-datasource"
+              },
+              "refId": "A",
+              "scenarioId": "random_walk",
+              "seriesCount": 1
+            }
+          ],
+          "title": "New panel",
+          "type": "timeseries"
+        }
+      ],
+      "title": "New row",
+      "type": "row"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 42,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+  },
+  "timezone": "browser",
+  "title": "All Colapsed Rows",
+  "version": 5,
+  "uid": "adbfpbv",
+  "id": 2739313037512704
+}

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -10,6 +10,7 @@
     "Repeating-a-row-with-a-repeating-horizon": (import '../dev-dashboards/e2e-repeats/Repeating-a-row-with-a-repeating-horizontal-panel.json'),
     "Repeating-a-row-with-a-repeating-vertica": (import '../dev-dashboards/e2e-repeats/Repeating-a-row-with-a-repeating-vertical-panel.json'),
     "Repeating-an-empty-row": (import '../dev-dashboards/e2e-repeats/Repeating-an-empty-row.json'),
+    "all-colapsed-rows-public": (import '../dev-dashboards/scenarios/all-colapsed-rows-public.json'),
     "all-panels": (import '../dev-dashboards/all-panels.json'),
     "annotation-filtering": (import '../dev-dashboards/annotations/annotation-filtering.json'),
     "auto_decimals": (import '../dev-dashboards/panel-common/auto_decimals.json'),

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -294,6 +294,9 @@ func readDashboardIter(iter *jsoniter.Iterator, lookup DatasourceLookup) (*Dashb
 	for idx, panel := range dash.Panels {
 		if panel.Type == "row" {
 			dash.Panels[idx].Datasource = nil
+			for _, collapsed := range panel.Collapsed {
+				targets.addPanel(collapsed)
+			}
 			continue
 		}
 

--- a/pkg/services/store/kind/dashboard/dashboard_test.go
+++ b/pkg/services/store/kind/dashboard/dashboard_test.go
@@ -72,6 +72,7 @@ func TestReadDashboard(t *testing.T) {
 		"panels-without-datasources",
 		"panel-with-library-panel-field",
 		"k8s-wrapper",
+		"scenarios/all-colapsed-rows-public",
 	}
 
 	devdash := "../../../../../devenv/dev-dashboards/"

--- a/pkg/services/store/kind/dashboard/testdata/devdash-all-colapsed-rows-public-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/devdash-all-colapsed-rows-public-info.json
@@ -1,0 +1,37 @@
+{
+  "id": 2739313037512704,
+  "title": "All Colapsed Rows",
+  "tags": null,
+  "datasource": [
+    {
+      "uid": "default.uid",
+      "type": "default.type"
+    }
+  ],
+  "panels": [
+    {
+      "id": 2,
+      "title": "New row",
+      "type": "row",
+      "collapsed": [
+        {
+          "id": 1,
+          "title": "New panel",
+          "type": "timeseries",
+          "pluginVersion": "13.0.0-local",
+          "datasource": [
+            {
+              "uid": "default.uid",
+              "type": "default.type"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 42,
+  "linkCount": 0,
+  "timeFrom": "now-6h",
+  "timeTo": "now",
+  "timezone": "browser"
+}


### PR DESCRIPTION
Backport bce63f4a1f2874e28644e88ae7c9e08afe7b88cc from #121050

---

**What is this feature?**

Includes panels from collapsed rows to be considered when calling `ReadDashboard`. 

A test case has been added as a devenv dashboard, with the fixture generated showing that it contains the `datasource` array at the root level in the output.

**Why do we need this feature?**

When reading the dashboard with such a lookup:

```go
	lookup := dashboardkind.CreateDatasourceLookup([]*dashboardkind.DatasourceQueryResult{
		// empty values (does not resolve anything)
	})

	dashSummaryInfo, err := dashboardkind.ReadDashboard(bytes.NewReader(payload), lookup)
	if err != nil {
		return nil, fmt.Errorf("failed to parse dashboard: %w", err)
	}
```

If the dashboard has rows that are collapsed, the dashboard model looks different, and `ReadDashboard` won't be able to find the data sources being used by the dashboard.

With this change, we include the panels from collapsed rows into the lookup.

**Who is this feature for?**

Public Dashboards

**Which issue(s) does this PR fix?**:

Addresses https://github.com/grafana/support-escalations/issues/20974

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
