### PR TITLE
Dynamic Dashboards: Do not resolve to v2 yet

### DIFF
--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -39,10 +39,10 @@ describe('DashboardAPIVersionResolver', () => {
 
   describe('resolve', () => {
     it.each([
-      { versions: ['v2', 'v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2' }, desc: 'both stable' },
+      { versions: ['v2', 'v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2beta1' }, desc: 'both stable' },
       { versions: ['v2beta1', 'v1beta1'], expected: BETA_FALLBACK, desc: 'beta only' },
       { versions: ['v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2beta1' }, desc: 'v1 stable only' },
-      { versions: ['v2', 'v2beta1', 'v1beta1'], expected: { v1: 'v1beta1', v2: 'v2' }, desc: 'v2 stable only' },
+      { versions: ['v2', 'v2beta1', 'v1beta1'], expected: { v1: 'v1beta1', v2: 'v2beta1' }, desc: 'v2 stable only' },
     ])('should resolve correctly when $desc are available', async ({ versions, expected }) => {
       mockDiscoveryResponse(versions);
 
@@ -69,7 +69,7 @@ describe('DashboardAPIVersionResolver', () => {
       expect(await dashboardAPIVersionResolver.resolve()).toEqual(BETA_FALLBACK);
 
       mockDiscoveryResponse(['v2', 'v1']);
-      expect(await dashboardAPIVersionResolver.resolve()).toEqual({ v1: 'v1', v2: 'v2' });
+      expect(await dashboardAPIVersionResolver.resolve()).toEqual({ v1: 'v1', v2: 'v2beta1' });
     });
 
     it('should cache and deduplicate concurrent resolve calls', async () => {
@@ -81,7 +81,7 @@ describe('DashboardAPIVersionResolver', () => {
         dashboardAPIVersionResolver.resolve(),
       ]);
 
-      const expected = { v1: 'v1', v2: 'v2' };
+      const expected = { v1: 'v1', v2: 'v2beta1' };
       expect(r1).toEqual(expected);
       expect(r2).toEqual(expected);
       expect(r3).toEqual(expected);
@@ -143,7 +143,7 @@ describe('DashboardAPIVersionResolver', () => {
       mockDiscoveryResponse(['v2', 'v1']);
       await dashboardAPIVersionResolver.resolve();
       expect(dashboardAPIVersionResolver.getV1()).toBe('v1');
-      expect(dashboardAPIVersionResolver.getV2()).toBe('v2');
+      expect(dashboardAPIVersionResolver.getV2()).toBe('v2beta1');
     });
   });
 });

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
@@ -75,7 +75,7 @@ class DashboardAPIVersionResolver {
     const availableVersions = new Set(group.versions.map((v) => v.version));
 
     const v1: DashboardV1Version = availableVersions.has('v1') ? 'v1' : BETA_V1;
-    const v2: DashboardV2Version = availableVersions.has('v2') ? 'v2' : BETA_V2;
+    const v2: DashboardV2Version = BETA_V2;
 
     debugLog(`Version negotiation: v1=${v1}, v2=${v2} (available: ${Array.from(availableVersions).join(', ')})`);
 

--- a/public/app/features/dashboard/api/dashboard_api.test.ts
+++ b/public/app/features/dashboard/api/dashboard_api.test.ts
@@ -150,7 +150,7 @@ describe('DashboardApi', () => {
       // Second call: discovery succeeds → clients rebuilt with stable versions
       mockDiscoveryResponse(['v2', 'v1']);
       await getDashboardAPI('v2');
-      expect(getK8sV2DashboardApiConfig().version).toBe('v2');
+      expect(getK8sV2DashboardApiConfig().version).toBe('v2beta1');
       expect(getK8sV1DashboardApiConfig().version).toBe('v1');
     });
   });


### PR DESCRIPTION
[Backend changes were merged](https://github.com/grafana/grafana/pull/118646) causing API discovery to use v2 already. It should be hold off until frontend changes are merged in https://github.com/grafana/grafana/pull/119474

Currently panels with transformations created in v2beta1 throw:

```
Registry.ts:80 Uncaught Error: "undefined" not found in: reduce,filterFieldsByName,renameByRegex,filterByRefId,filterByValue,organize,joinByField,seriesToRows,concatenate,calculateField,labelsToFields,groupBy,sortBy,merge,histogram,rowsToFields,configFromData,prepareTimeSeries,convertFieldType,spatial,fieldLookup,extractFields,heatmap,groupingToMatrix,limit,joinByLabels,regression,partitionByValues,formatString,groupToNestedTable,formatTime,timeSeriesTable,transpose
    at Registry.get (Registry.ts:80:13)
   

transformSceneToSaveModelSchemaV2.ts:514 
Uncaught Error: Unsupported transformation type
    at getVizPanelTransformations (transformSceneToSaveModelSchemaV2.ts:514:15)
    at vizPanelToSchemaV2 (transformSceneToSaveModelSchemaV2.ts:293:28)
```

This should be reverted in https://github.com/grafana/grafana/pull/119474