### PR TITLE
IAM: Add authorization checks for user/status and team/groups subresources

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -164,47 +164,43 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 // "teams" is read-only (Connecter/GET), so it checks user get.
 // "status" supports both GET and PUT, so the check verb mirrors the request verb.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	readCheck := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
-			Verb:      utils.VerbGet,
-			Group:     attr.GetAPIGroup(),
-			Resource:  attr.GetResource(),
-			Namespace: attr.GetNamespace(),
-			Name:      attr.GetName(),
-		}, "")
-		if err != nil {
-			return authorizer.DecisionDeny, "", err
-		}
-		if !res.Allowed {
-			return authorizer.DecisionDeny, "requires user get", nil
-		}
-		return authorizer.DecisionAllow, "", nil
-	}
-
-	statusCheck := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		verb := utils.VerbGet
-		if attr.GetVerb() == utils.VerbUpdate || attr.GetVerb() == utils.VerbPatch {
-			verb = utils.VerbUpdate
-		}
-		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
-			Verb:      verb,
-			Group:     attr.GetAPIGroup(),
-			Resource:  attr.GetResource(),
-			Namespace: attr.GetNamespace(),
-			Name:      attr.GetName(),
-		}, "")
-		if err != nil {
-			return authorizer.DecisionDeny, "", err
-		}
-		if !res.Allowed {
-			return authorizer.DecisionDeny, fmt.Sprintf("requires user %s", verb), nil
-		}
-		return authorizer.DecisionAllow, "", nil
-	}
-
 	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
-		"teams":  readCheck,
-		"status": statusCheck,
+		"teams": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+				Verb:      utils.VerbGet,
+				Group:     attr.GetAPIGroup(),
+				Resource:  attr.GetResource(),
+				Namespace: attr.GetNamespace(),
+				Name:      attr.GetName(),
+			}, "")
+			if err != nil {
+				return authorizer.DecisionDeny, "", err
+			}
+			if !res.Allowed {
+				return authorizer.DecisionDeny, "requires user get", nil
+			}
+			return authorizer.DecisionAllow, "", nil
+		},
+		"status": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			verb := utils.VerbGet
+			if attr.GetVerb() == utils.VerbUpdate || attr.GetVerb() == utils.VerbPatch {
+				verb = utils.VerbUpdate
+			}
+			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+				Verb:      verb,
+				Group:     attr.GetAPIGroup(),
+				Resource:  attr.GetResource(),
+				Namespace: attr.GetNamespace(),
+				Name:      attr.GetName(),
+			}, "")
+			if err != nil {
+				return authorizer.DecisionDeny, "", err
+			}
+			if !res.Allowed {
+				return authorizer.DecisionDeny, fmt.Sprintf("requires user %s", verb), nil
+			}
+			return authorizer.DecisionAllow, "", nil
+		},
 	})
 }
 

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -160,10 +160,11 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 	})
 }
 
-// newUserAuthorizer creates an authorizer for users that handles the "teams" and "status" subresources
-// with a get check on the parent user resource.
+// newUserAuthorizer creates an authorizer for users that handles the "teams" and "status" subresources.
+// "teams" is read-only (Connecter/GET), so it checks user get.
+// "status" supports both GET and PUT, so the check verb mirrors the request verb.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	check := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	readCheck := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
 			Verb:      utils.VerbGet,
 			Group:     attr.GetAPIGroup(),
@@ -179,9 +180,31 @@ func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 		}
 		return authorizer.DecisionAllow, "", nil
 	}
+
+	statusCheck := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		verb := utils.VerbGet
+		if attr.GetVerb() == utils.VerbUpdate || attr.GetVerb() == utils.VerbPatch {
+			verb = utils.VerbUpdate
+		}
+		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+			Verb:      verb,
+			Group:     attr.GetAPIGroup(),
+			Resource:  attr.GetResource(),
+			Namespace: attr.GetNamespace(),
+			Name:      attr.GetName(),
+		}, "")
+		if err != nil {
+			return authorizer.DecisionDeny, "", err
+		}
+		if !res.Allowed {
+			return authorizer.DecisionDeny, fmt.Sprintf("requires user %s", verb), nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	}
+
 	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
-		"teams":  check,
-		"status": check,
+		"teams":  readCheck,
+		"status": statusCheck,
 	})
 }
 

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -103,7 +103,9 @@ func (s *iamAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribute
 type subresourceCheck func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error)
 
 // newAuthorizerWithCustomSubCheck creates an authorizer that handles specific subresources
-// with custom permission checks, delegating to the standard ResourceAuthorizer for all other subresources.
+// with custom permission checks, delegating to the standard ResourceAuthorizer for direct
+// resource access (no subresource). Unregistered subresources are denied so that authorization
+// for every subresource must be explicitly specified.
 func newAuthorizerWithCustomSubCheck(
 	accessClient authlib.AccessClient,
 	checks map[string]subresourceCheck,
@@ -114,10 +116,14 @@ func newAuthorizerWithCustomSubCheck(
 			return authorizer.DecisionNoOpinion, "", nil
 		}
 
-		check, ok := checks[attr.GetSubresource()]
-		if !ok {
-			// Delegate to the standard ResourceAuthorizer for non-matching subresources
+		sub := attr.GetSubresource()
+		if sub == "" {
 			return delegate.Authorize(ctx, attr)
+		}
+
+		check, ok := checks[sub]
+		if !ok {
+			return authorizer.DecisionDeny, "", fmt.Errorf("no authorizer for subresource %q", sub)
 		}
 
 		ident, ok := authlib.AuthInfoFrom(ctx)
@@ -129,49 +135,53 @@ func newAuthorizerWithCustomSubCheck(
 	})
 }
 
-// newTeamAuthorizer creates an authorizer for teams that handles the "members" subresource
+// newTeamAuthorizer creates an authorizer for teams that handles the "members" and "groups" subresources
 // with a get_permissions check on the parent team resource.
 func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	check := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+			Verb:      utils.VerbGetPermissions,
+			Group:     attr.GetAPIGroup(),
+			Resource:  attr.GetResource(),
+			Namespace: attr.GetNamespace(),
+			Name:      attr.GetName(),
+		}, "")
+		if err != nil {
+			return authorizer.DecisionDeny, "", err
+		}
+		if !res.Allowed {
+			return authorizer.DecisionDeny, "requires team getpermissions", nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	}
 	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
-		"members": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
-				Verb:      utils.VerbGetPermissions,
-				Group:     attr.GetAPIGroup(),
-				Resource:  attr.GetResource(),
-				Namespace: attr.GetNamespace(),
-				Name:      attr.GetName(),
-			}, "")
-			if err != nil {
-				return authorizer.DecisionDeny, "", err
-			}
-			if !res.Allowed {
-				return authorizer.DecisionDeny, "requires team getpermissions", nil
-			}
-			return authorizer.DecisionAllow, "", nil
-		},
+		"members": check,
+		"groups":  check,
 	})
 }
 
-// newUserAuthorizer creates an authorizer for users that handles the "teams" subresource
+// newUserAuthorizer creates an authorizer for users that handles the "teams" and "status" subresources
 // with a get check on the parent user resource.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	check := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+			Verb:      utils.VerbGet,
+			Group:     attr.GetAPIGroup(),
+			Resource:  attr.GetResource(),
+			Namespace: attr.GetNamespace(),
+			Name:      attr.GetName(),
+		}, "")
+		if err != nil {
+			return authorizer.DecisionDeny, "", err
+		}
+		if !res.Allowed {
+			return authorizer.DecisionDeny, "requires user get", nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	}
 	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
-		"teams": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
-				Verb:      utils.VerbGet,
-				Group:     attr.GetAPIGroup(),
-				Resource:  attr.GetResource(),
-				Namespace: attr.GetNamespace(),
-				Name:      attr.GetName(),
-			}, "")
-			if err != nil {
-				return authorizer.DecisionDeny, "", err
-			}
-			if !res.Allowed {
-				return authorizer.DecisionDeny, "requires user get", nil
-			}
-			return authorizer.DecisionAllow, "", nil
-		},
+		"teams":  check,
+		"status": check,
 	})
 }
 

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -36,50 +36,46 @@ func (f *fakeAccessClient) BatchCheck(ctx context.Context, id types.AuthInfo, re
 
 // authorizerScenario captures the per-resource configuration used to drive the shared test logic.
 type authorizerScenario struct {
-	name               string
-	newAuthorizer      func(types.AccessClient) authorizer.Authorizer
-	group              string
-	resource           string
-	resourceName       string
-	specialSubresource string // subresource that triggers the custom check
-	otherSubresource   string // unrelated subresource that should delegate to ResourceAuthorizer
-	deniedReason       string // reason string returned when the custom check denies
-	checkRequestVerb   string // verb expected in the CheckRequest built for the custom check
+	name             string
+	newAuthorizer    func(types.AccessClient) authorizer.Authorizer
+	group            string
+	resource         string
+	resourceName     string
+	subResources     []string // subresources that trigger the custom check
+	deniedReason     string   // reason string returned when the custom check denies
+	checkRequestVerb string   // verb expected in the CheckRequest built for the custom check
 }
 
 var authorizerScenarios = []authorizerScenario{
 	{
-		name:               "team",
-		newAuthorizer:      newTeamAuthorizer,
-		group:              iamv0.TeamResourceInfo.GroupResource().Group,
-		resource:           iamv0.TeamResourceInfo.GroupResource().Resource,
-		resourceName:       "team-abc",
-		specialSubresource: "members",
-		otherSubresource:   "groups",
-		deniedReason:       "requires team getpermissions",
-		checkRequestVerb:   "get_permissions",
+		name:             "team",
+		newAuthorizer:    newTeamAuthorizer,
+		group:            iamv0.TeamResourceInfo.GroupResource().Group,
+		resource:         iamv0.TeamResourceInfo.GroupResource().Resource,
+		resourceName:     "team-abc",
+		subResources:     []string{"members", "groups"},
+		deniedReason:     "requires team getpermissions",
+		checkRequestVerb: "get_permissions",
 	},
 	{
-		name:               "user",
-		newAuthorizer:      newUserAuthorizer,
-		group:              iamv0.UserResourceInfo.GroupResource().Group,
-		resource:           iamv0.UserResourceInfo.GroupResource().Resource,
-		resourceName:       "user-xyz",
-		specialSubresource: "teams",
-		otherSubresource:   "status",
-		deniedReason:       "requires user get",
-		checkRequestVerb:   "get",
+		name:             "user",
+		newAuthorizer:    newUserAuthorizer,
+		group:            iamv0.UserResourceInfo.GroupResource().Group,
+		resource:         iamv0.UserResourceInfo.GroupResource().Resource,
+		resourceName:     "user-xyz",
+		subResources:     []string{"teams", "status"},
+		deniedReason:     "requires user get",
+		checkRequestVerb: "get",
 	},
 	{
-		name:               "serviceaccount",
-		newAuthorizer:      newServiceAccountAuthorizer,
-		group:              iamv0.ServiceAccountResourceInfo.GroupResource().Group,
-		resource:           iamv0.ServiceAccountResourceInfo.GroupResource().Resource,
-		resourceName:       "sa-abc",
-		specialSubresource: "tokens",
-		otherSubresource:   "status",
-		deniedReason:       "requires serviceaccount get",
-		checkRequestVerb:   "get",
+		name:             "serviceaccount",
+		newAuthorizer:    newServiceAccountAuthorizer,
+		group:            iamv0.ServiceAccountResourceInfo.GroupResource().Group,
+		resource:         iamv0.ServiceAccountResourceInfo.GroupResource().Resource,
+		resourceName:     "sa-abc",
+		subResources:     []string{"tokens"},
+		deniedReason:     "requires serviceaccount get",
+		checkRequestVerb: "get",
 	},
 }
 
@@ -92,40 +88,44 @@ func newTestAuthInfo() types.AuthInfo {
 }
 
 // TestAuthorizerCheckRequest verifies that each authorizer builds the correct
-// CheckRequest when its custom subresource is accessed.
+// CheckRequest when its custom subresources are accessed.
 func TestAuthorizerCheckRequest(t *testing.T) {
 	for _, sc := range authorizerScenarios {
 		t.Run(sc.name, func(t *testing.T) {
-			var capturedReq *types.CheckRequest
-			fakeClient := &fakeAccessClient{
-				checkFunc: func(_ context.Context, _ types.AuthInfo, req types.CheckRequest, _ string) (types.CheckResponse, error) {
-					capturedReq = &req
-					return types.CheckResponse{Allowed: true}, nil
-				},
+			for _, sub := range sc.subResources {
+				t.Run(sub, func(t *testing.T) {
+					var capturedReq *types.CheckRequest
+					fakeClient := &fakeAccessClient{
+						checkFunc: func(_ context.Context, _ types.AuthInfo, req types.CheckRequest, _ string) (types.CheckResponse, error) {
+							capturedReq = &req
+							return types.CheckResponse{Allowed: true}, nil
+						},
+					}
+
+					auth := sc.newAuthorizer(fakeClient)
+					ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+					attr := authorizer.AttributesRecord{
+						ResourceRequest: true,
+						APIGroup:        sc.group,
+						Resource:        sc.resource,
+						Subresource:     sub,
+						Name:            sc.resourceName,
+						Verb:            "get",
+						Namespace:       "org-1",
+					}
+
+					_, _, err := auth.Authorize(ctx, attr)
+					require.NoError(t, err)
+					require.NotNil(t, capturedReq)
+
+					assert.Equal(t, sc.checkRequestVerb, capturedReq.Verb)
+					assert.Equal(t, sc.group, capturedReq.Group)
+					assert.Equal(t, sc.resource, capturedReq.Resource)
+					assert.Equal(t, sc.resourceName, capturedReq.Name)
+					assert.Equal(t, "org-1", capturedReq.Namespace)
+				})
 			}
-
-			auth := sc.newAuthorizer(fakeClient)
-			ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
-
-			attr := authorizer.AttributesRecord{
-				ResourceRequest: true,
-				APIGroup:        sc.group,
-				Resource:        sc.resource,
-				Subresource:     sc.specialSubresource,
-				Name:            sc.resourceName,
-				Verb:            "get",
-				Namespace:       "org-1",
-			}
-
-			_, _, err := auth.Authorize(ctx, attr)
-			require.NoError(t, err)
-			require.NotNil(t, capturedReq)
-
-			assert.Equal(t, sc.checkRequestVerb, capturedReq.Verb)
-			assert.Equal(t, sc.group, capturedReq.Group)
-			assert.Equal(t, sc.resource, capturedReq.Resource)
-			assert.Equal(t, sc.resourceName, capturedReq.Name)
-			assert.Equal(t, "org-1", capturedReq.Namespace)
 		})
 	}
 }
@@ -134,7 +134,7 @@ func TestAuthorizerCheckRequest(t *testing.T) {
 func TestAuthorizerDecisionMatrix(t *testing.T) {
 	for _, sc := range authorizerScenarios {
 		t.Run(sc.name, func(t *testing.T) {
-			tests := []struct {
+			type testCase struct {
 				name            string
 				subresource     string
 				resourceRequest bool
@@ -143,20 +143,23 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 				wantReason      string
 				wantErr         bool
 				wantCheckCalled bool
-			}{
-				{
-					name:            sc.specialSubresource + " subresource - allowed",
-					subresource:     sc.specialSubresource,
+			}
+
+			var tests []testCase
+
+			for _, sub := range sc.subResources {
+				tests = append(tests, testCase{
+					name:            sub + " subresource - allowed",
+					subresource:     sub,
 					resourceRequest: true,
 					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
 						return types.CheckResponse{Allowed: true}, nil
 					},
 					wantDecision:    authorizer.DecisionAllow,
 					wantCheckCalled: true,
-				},
-				{
-					name:            sc.specialSubresource + " subresource - denied",
-					subresource:     sc.specialSubresource,
+				}, testCase{
+					name:            sub + " subresource - denied",
+					subresource:     sub,
 					resourceRequest: true,
 					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
 						return types.CheckResponse{Allowed: false}, nil
@@ -164,10 +167,9 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 					wantDecision:    authorizer.DecisionDeny,
 					wantReason:      sc.deniedReason,
 					wantCheckCalled: true,
-				},
-				{
-					name:            sc.specialSubresource + " subresource - error",
-					subresource:     sc.specialSubresource,
+				}, testCase{
+					name:            sub + " subresource - error",
+					subresource:     sub,
 					resourceRequest: true,
 					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
 						return types.CheckResponse{}, errors.New("database error")
@@ -175,33 +177,29 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 					wantDecision:    authorizer.DecisionDeny,
 					wantErr:         true,
 					wantCheckCalled: true,
-				},
-				{
-					name:            "no subresource - delegates to ResourceAuthorizer",
-					subresource:     "",
-					resourceRequest: true,
-					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
-						return types.CheckResponse{Allowed: true}, nil
-					},
-					wantDecision:    authorizer.DecisionAllow,
-					wantCheckCalled: true,
-				},
-				{
-					name:            "other subresource (" + sc.otherSubresource + ") - delegates to ResourceAuthorizer",
-					subresource:     sc.otherSubresource,
-					resourceRequest: true,
-					checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
-						return types.CheckResponse{Allowed: true}, nil
-					},
-					wantDecision:    authorizer.DecisionAllow,
-					wantCheckCalled: true,
-				},
-				{
-					name:            "non-resource request - no opinion",
-					resourceRequest: false,
-					wantDecision:    authorizer.DecisionNoOpinion,
-				},
+				})
 			}
+
+			tests = append(tests, testCase{
+				name:            "no subresource - delegates to ResourceAuthorizer",
+				subresource:     "",
+				resourceRequest: true,
+				checkFunc: func(_ context.Context, _ types.AuthInfo, _ types.CheckRequest, _ string) (types.CheckResponse, error) {
+					return types.CheckResponse{Allowed: true}, nil
+				},
+				wantDecision:    authorizer.DecisionAllow,
+				wantCheckCalled: true,
+			}, testCase{
+				name:            "not specified subresource ( unknown ) - denied",
+				subresource:     "unknown",
+				resourceRequest: true,
+				wantDecision:    authorizer.DecisionDeny,
+				wantErr:         true,
+			}, testCase{
+				name:            "non-resource request - no opinion",
+				resourceRequest: false,
+				wantDecision:    authorizer.DecisionNoOpinion,
+			})
 
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -65,7 +65,7 @@ var authorizerScenarios = []authorizerScenario{
 		resourceName:     "user-xyz",
 		subResources:     []string{"teams", "status"},
 		deniedReason:     "requires user get",
-		checkRequestVerb: "get",
+		checkRequestVerb: "get", // shared tests use verb "get"; update verb tested separately
 	},
 	{
 		name:             "serviceaccount",
@@ -236,6 +236,53 @@ func TestAuthorizerDecisionMatrix(t *testing.T) {
 					assert.Equal(t, tt.wantCheckCalled, checkCalled, "Check call mismatch")
 				})
 			}
+		})
+	}
+}
+
+// TestUserAuthorizerStatusVerbMapping verifies that the user/status subresource
+// maps request verbs to the correct RBAC check verbs (GET→get, UPDATE→update, PATCH→update).
+func TestUserAuthorizerStatusVerbMapping(t *testing.T) {
+	tests := []struct {
+		name             string
+		requestVerb      string
+		wantCheckVerb    string
+		wantDeniedReason string
+	}{
+		{name: "get maps to get", requestVerb: "get", wantCheckVerb: "get", wantDeniedReason: "requires user get"},
+		{name: "update maps to update", requestVerb: "update", wantCheckVerb: "update", wantDeniedReason: "requires user update"},
+		{name: "patch maps to update", requestVerb: "patch", wantCheckVerb: "update", wantDeniedReason: "requires user update"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedReq *types.CheckRequest
+			fakeClient := &fakeAccessClient{
+				checkFunc: func(_ context.Context, _ types.AuthInfo, req types.CheckRequest, _ string) (types.CheckResponse, error) {
+					capturedReq = &req
+					return types.CheckResponse{Allowed: false}, nil
+				},
+			}
+
+			auth := newUserAuthorizer(fakeClient)
+			ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+			attr := authorizer.AttributesRecord{
+				ResourceRequest: true,
+				APIGroup:        iamv0.UserResourceInfo.GroupResource().Group,
+				Resource:        iamv0.UserResourceInfo.GroupResource().Resource,
+				Subresource:     "status",
+				Name:            "user-xyz",
+				Verb:            tt.requestVerb,
+				Namespace:       "org-1",
+			}
+
+			decision, reason, _ := auth.Authorize(ctx, attr)
+
+			require.NotNil(t, capturedReq)
+			assert.Equal(t, tt.wantCheckVerb, capturedReq.Verb)
+			assert.Equal(t, authorizer.DecisionDeny, decision)
+			assert.Equal(t, tt.wantDeniedReason, reason)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add authorization check for `user/status` subresource (requires user get/update permission)
- Add authorization check for `team/groups` subresource (requires team getpermissions permission)
- Explicitly deny access to unknown subresources instead of delegating to ResourceAuthorizer

## Why
The generic ResourceAuthorizer forwards every subresource path straight to the RBAC service. An upcoming change (#118377) will tighten that service: when a subresource has no mapper entry the RBAC service will deny the request outright instead of falling through.

`user/status` and `team/groups` are affected — these were missed in previous PRs.

The new authorization check through the team and user authorizers mirrors what's done today for these subresources.

This change also introduces explicit denial of access to unknown subresources so that authorization intent is forced.

Made with [Cursor](https://cursor.com)