### PR TITLE
Zanzana: use ListObjects for direct resource phase in BatchCheck

### DIFF
--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -460,8 +460,10 @@ func expandedSubresourcePermissionRelations(relation string) []string {
 	}
 }
 
-// runDirectResourcePhase checks direct access to specific resources.
-// This is the most granular check - access granted directly on the resource itself.
+// runDirectResourcePhase resolves unresolved items via ListObjects instead of
+// per-item Check calls. Most users have direct access to a small number of
+// resources, so listing them all and doing set-membership lookups is cheaper
+// than issuing one Check per batch item (where denials are expensive).
 func (s *Server) runDirectResourcePhase(
 	ctx context.Context,
 	store *zanzana.StoreInfo,
@@ -469,65 +471,29 @@ func (s *Server) runDirectResourcePhase(
 	items map[string]*batchCheckItem,
 	contextuals *openfgav1.ContextualTupleKeys,
 ) (int, error) {
-	var checks []*openfgav1.BatchCheckItem
-	checkIDToCorrelation := make(map[string]string)
-
+	// Collect unresolved items, grouped by type.
+	var genericItems, typedItems []*batchCheckItem
 	for _, item := range items {
 		if item.resolved {
 			continue
 		}
-
 		if item.resource.IsGeneric() {
-			// Generic resource direct access
-			resourceIdent := item.resource.ResourceIdent()
-			if resourceIdent == "" || !item.resource.IsValidRelation(item.relation) {
-				continue
-			}
-
-			checkID := fmt.Sprintf("%s_gd", item.correlationID)
-			checkIDToCorrelation[checkID] = item.correlationID
-			checks = append(checks, &openfgav1.BatchCheckItem{
-				TupleKey: &openfgav1.CheckRequestTupleKey{
-					User:     subject,
-					Relation: item.relation,
-					Object:   resourceIdent,
-				},
-				ContextualTuples: contextuals,
-				Context:          item.resource.Context(),
-				CorrelationId:    checkID,
-			})
+			genericItems = append(genericItems, item)
 		} else {
-			// Typed resource checks (subresource and direct)
-			checks = s.addTypedResourceDirectChecks(checks, subject, item, contextuals, checkIDToCorrelation)
+			typedItems = append(typedItems, item)
 		}
 	}
 
-	if len(checks) == 0 {
+	itemsChecked := len(genericItems) + len(typedItems)
+	if itemsChecked == 0 {
 		return 0, nil
 	}
 
-	results, err := s.doBatchCheck(ctx, store, checks)
-	if err != nil {
-		return len(checks), err
+	if err := s.resolveGenericItems(ctx, store, subject, genericItems, contextuals); err != nil {
+		return itemsChecked, err
 	}
-
-	// Process results - for typed resources, we need to check both subresource and direct
-	for checkID, result := range results {
-		correlationID := checkIDToCorrelation[checkID]
-		item := items[correlationID]
-
-		// Skip if already resolved by another check in this phase
-		if item.resolved {
-			continue
-		}
-
-		if err := result.GetError(); err != nil {
-			item.err = err.GetMessage()
-			item.resolved = true
-		} else if result.GetAllowed() {
-			item.allowed = true
-			item.resolved = true
-		}
+	if err := s.resolveTypedItems(ctx, store, subject, typedItems, contextuals); err != nil {
+		return itemsChecked, err
 	}
 
 	// Mark all remaining unresolved items as resolved (denied)
@@ -537,58 +503,133 @@ func (s *Server) runDirectResourcePhase(
 		}
 	}
 
-	return len(checks), nil
+	return itemsChecked, nil
 }
 
-// addTypedResourceDirectChecks adds OpenFGA checks for typed resources (folder, team, user, etc.)
-func (s *Server) addTypedResourceDirectChecks(
-	checks []*openfgav1.BatchCheckItem,
+// resolveGenericItems enumerates generic resources the user has direct access
+// to, then resolves items by set membership.
+// Folder-based access is already resolved by earlier phases.
+func (s *Server) resolveGenericItems(
+	ctx context.Context,
+	store *zanzana.StoreInfo,
 	subject string,
-	item *batchCheckItem,
+	items []*batchCheckItem,
 	contextuals *openfgav1.ContextualTupleKeys,
-	checkIDToCorrelation map[string]string,
-) []*openfgav1.BatchCheckItem {
-	resourceIdent := item.resource.ResourceIdent()
-	resourceCtx := item.resource.Context()
-
-	// Check subresource access if applicable
-	subresourceRelation := common.SubresourceRelation(item.relation)
-	if item.resource.HasSubresource() && item.resource.IsValidRelation(subresourceRelation) {
-		checkID := fmt.Sprintf("%s_ts", item.correlationID)
-		checkIDToCorrelation[checkID] = item.correlationID
-		checks = append(checks, &openfgav1.BatchCheckItem{
-			TupleKey: &openfgav1.CheckRequestTupleKey{
-				User:     subject,
-				Relation: common.SubresourcePermissionRelation(subresourceRelation),
-				Object:   resourceIdent,
-			},
-			ContextualTuples: contextuals,
-			Context:          resourceCtx,
-			CorrelationId:    checkID,
-		})
+) error {
+	type listKey struct {
+		relation      string
+		groupResource string
+	}
+	groups := make(map[listKey][]*batchCheckItem)
+	for _, item := range items {
+		key := listKey{relation: item.relation, groupResource: item.resource.GroupResource()}
+		groups[key] = append(groups[key], item)
 	}
 
-	// Check direct access to typed resource
-	if resourceIdent != "" && item.resource.IsValidRelation(item.relation) {
-		checkRelation := item.relation
-		if item.resource.Type() == common.TypeFolder {
-			checkRelation = common.FolderPermissionRelation(item.relation)
+	for key, groupItems := range groups {
+		sample := groupItems[0]
+		allowed := make(map[string]bool)
+
+		if sample.resource.IsValidRelation(key.relation) {
+			if err := s.collectAllowedObjects(ctx, allowed, &openfgav1.ListObjectsRequest{
+				StoreId:              store.ID,
+				AuthorizationModelId: store.ModelID,
+				Type:                 common.TypeResource,
+				Relation:             key.relation,
+				User:                 subject,
+				Context:              sample.resource.Context(),
+				ContextualTuples:     contextuals,
+			}); err != nil {
+				return err
+			}
 		}
 
-		checkID := fmt.Sprintf("%s_td", item.correlationID)
-		checkIDToCorrelation[checkID] = item.correlationID
-		checks = append(checks, &openfgav1.BatchCheckItem{
-			TupleKey: &openfgav1.CheckRequestTupleKey{
-				User:     subject,
-				Relation: checkRelation,
-				Object:   resourceIdent,
-			},
-			ContextualTuples: contextuals,
-			CorrelationId:    checkID,
-		})
+		resolveByMembership(groupItems, allowed)
 	}
 
-	return checks
+	return nil
+}
+
+// resolveTypedItems enumerates typed resources (folders, teams, users, etc.)
+// the user has access to, then resolves by set membership.
+func (s *Server) resolveTypedItems(
+	ctx context.Context,
+	store *zanzana.StoreInfo,
+	subject string,
+	items []*batchCheckItem,
+	contextuals *openfgav1.ContextualTupleKeys,
+) error {
+	type listKey struct {
+		relation string
+		typ      string
+	}
+	groups := make(map[listKey][]*batchCheckItem)
+	for _, item := range items {
+		key := listKey{relation: item.relation, typ: item.resource.Type()}
+		groups[key] = append(groups[key], item)
+	}
+
+	for key, groupItems := range groups {
+		sample := groupItems[0]
+		allowed := make(map[string]bool)
+
+		subresourceRelation := common.SubresourceRelation(key.relation)
+		if sample.resource.HasSubresource() && sample.resource.IsValidRelation(subresourceRelation) {
+			if err := s.collectAllowedObjects(ctx, allowed, &openfgav1.ListObjectsRequest{
+				StoreId:              store.ID,
+				AuthorizationModelId: store.ModelID,
+				Type:                 key.typ,
+				Relation:             common.SubresourcePermissionRelation(subresourceRelation),
+				User:                 subject,
+				Context:              sample.resource.Context(),
+				ContextualTuples:     contextuals,
+			}); err != nil {
+				return err
+			}
+		}
+
+		if sample.resource.IsValidRelation(key.relation) {
+			listRelation := key.relation
+			if key.typ == common.TypeFolder {
+				listRelation = common.FolderPermissionRelation(key.relation)
+			}
+			if err := s.collectAllowedObjects(ctx, allowed, &openfgav1.ListObjectsRequest{
+				StoreId:              store.ID,
+				AuthorizationModelId: store.ModelID,
+				Type:                 key.typ,
+				Relation:             listRelation,
+				User:                 subject,
+				ContextualTuples:     contextuals,
+			}); err != nil {
+				return err
+			}
+		}
+
+		resolveByMembership(groupItems, allowed)
+	}
+
+	return nil
+}
+
+// collectAllowedObjects calls ListObjects and adds the results to the allowed set.
+func (s *Server) collectAllowedObjects(ctx context.Context, allowed map[string]bool, req *openfgav1.ListObjectsRequest) error {
+	res, err := s.listObjects(ctx, req)
+	if err != nil {
+		return err
+	}
+	for _, obj := range res.GetObjects() {
+		allowed[obj] = true
+	}
+	return nil
+}
+
+func resolveByMembership(items []*batchCheckItem, allowed map[string]bool) {
+	for _, item := range items {
+		if ident := item.resource.ResourceIdent(); ident != "" && allowed[ident] {
+			item.allowed = true
+			item.resolved = true
+		}
+	}
 }
 
 // doBatchCheck executes a batch check against OpenFGA, splitting into

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -226,6 +226,77 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 		assert.True(t, res.GetResults()["check1"].GetAllowed())
 		assert.True(t, res.GetResults()["check2"].GetAllowed())
 	})
+
+	t.Run("typed resource: team subresource access", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, teamGroup, teamResource, statusSubresource, "", "1"), // user:14 has access
+			newItem("check2", utils.VerbGet, teamGroup, teamResource, statusSubresource, "", "2"), // no access
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:14", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 2)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.False(t, res.GetResults()["check2"].GetAllowed())
+	})
+
+	t.Run("typed resource: user subresource access", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, userGroup, userResource, statusSubresource, "", "1"), // user:15 has access
+			newItem("check2", utils.VerbGet, userGroup, userResource, statusSubresource, "", "2"), // no access
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:15", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 2)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.False(t, res.GetResults()["check2"].GetAllowed())
+	})
+
+	t.Run("typed resource: service account subresource access", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, serviceAccountGroup, serviceAccountResource, statusSubresource, "", "1"), // user:16 has access
+			newItem("check2", utils.VerbGet, serviceAccountGroup, serviceAccountResource, statusSubresource, "", "2"), // no access
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:16", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 2)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.False(t, res.GetResults()["check2"].GetAllowed())
+	})
+
+	t.Run("mixed generic and typed resources in same batch", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("dash", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"),                       // generic: user:1 has access
+			newItem("folder", utils.VerbGet, folderGroup, folderResource, "", "", "1"),                            // typed folder: user:1 does NOT have access
+			newItem("team", utils.VerbGet, teamGroup, teamResource, statusSubresource, "", "1"),                   // typed team: user:1 does NOT have access
+			newItem("dash-no", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "999"),                  // generic: no access
+			newItem("sub", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"),         // generic subresource: no access
+			newItem("sa", utils.VerbGet, serviceAccountGroup, serviceAccountResource, statusSubresource, "", "1"), // typed SA: no access
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:1", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 6)
+		assert.True(t, res.GetResults()["dash"].GetAllowed())
+		assert.False(t, res.GetResults()["folder"].GetAllowed())
+		assert.False(t, res.GetResults()["team"].GetAllowed())
+		assert.False(t, res.GetResults()["dash-no"].GetAllowed())
+		assert.False(t, res.GetResults()["sub"].GetAllowed())
+		assert.False(t, res.GetResults()["sa"].GetAllowed())
+	})
+
+	t.Run("folder subresource access via set_edit", func(t *testing.T) {
+		// user:5 has set_edit on dashboards in folder 1, which grants get/update/create/delete
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "100"),    // allowed via set_edit
+			newItem("check2", utils.VerbUpdate, dashboardGroup, dashboardResource, "", "1", "100"), // allowed via set_edit
+			newItem("check3", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "200"),    // no access
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:5", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 3)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.True(t, res.GetResults()["check2"].GetAllowed())
+		assert.False(t, res.GetResults()["check3"].GetAllowed())
+	})
 }
 
 func TestIntegrationServerBatchCheck_SubBatching(t *testing.T) {

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -207,10 +207,7 @@ func (s *Server) listGeneric(ctx context.Context, subject, relation string, reso
 }
 
 func (s *Server) listObjects(ctx context.Context, req *openfgav1.ListObjectsRequest) (*openfgav1.ListObjectsResponse, error) {
-	fn := s.openFGAClient.ListObjects
-	if s.cfg.UseStreamedListObjects {
-		fn = s.streamedListObjects
-	}
+	fn := s.streamedListObjects
 
 	if s.cfg.CacheSettings.CheckQueryCacheEnabled {
 		return s.listObjectCached(ctx, req, fn)
@@ -253,6 +250,14 @@ func (s *Server) streamedListObjects(ctx context.Context, req *openfgav1.ListObj
 	ctx, span := s.tracer.Start(ctx, "server.streamedListObjects")
 	defer span.End()
 
+	deadline := s.cfg.ListObjectsDeadline
+	if deadline <= 0 {
+		deadline = 3 * time.Second
+	}
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, deadline-time.Second)
+	defer cancel()
+
 	r := &openfgav1.StreamedListObjectsRequest{
 		StoreId:              req.GetStoreId(),
 		AuthorizationModelId: req.GetAuthorizationModelId(),
@@ -278,6 +283,10 @@ func (s *Server) streamedListObjects(ctx context.Context, req *openfgav1.ListObj
 			return nil, err
 		}
 		objects = append(objects, res.GetObject())
+	}
+
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("streamed list objects interrupted: %w", ctx.Err())
 	}
 
 	return &openfgav1.ListObjectsResponse{

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -1,14 +1,22 @@
 package server
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -337,5 +345,76 @@ func TestIntegrationServerListStreaming(t *testing.T) {
 		assert.Contains(t, res.GetFolders(), "4")
 		assert.Contains(t, res.GetFolders(), "5")
 		assert.Contains(t, res.GetFolders(), "6")
+	})
+}
+
+func TestIntegrationServerListCanceledContext(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	server := setupOpenFGAServer(t)
+	setup(t, server)
+
+	newList := func(subject, group, resource string) *authzv1.ListRequest {
+		return &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbList,
+			Subject:   subject,
+			Group:     group,
+			Resource:  resource,
+		}
+	}
+
+	t.Run("canceled context returns an error instead of partial results", func(t *testing.T) {
+		ctx := newContextWithNamespace()
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		_, err := server.List(ctx, newList("user:1", dashboardGroup, dashboardResource))
+		require.Error(t, err)
+	})
+
+	t.Run("expired deadline returns an error instead of partial results", func(t *testing.T) {
+		ctx := newContextWithNamespace()
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+		defer cancel()
+
+		_, err := server.List(ctx, newList("user:1", dashboardGroup, dashboardResource))
+		require.Error(t, err)
+	})
+}
+
+func TestIntegrationServerListStreamDeadline(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	cfg := setting.NewCfg()
+	cfg.ZanzanaServer.ListObjectsDeadline = 1 * time.Nanosecond
+
+	testStore := sqlstore.NewTestStore(t, sqlstore.WithCfg(cfg))
+
+	if testStore.GetDialect().DriverName() == migrator.MySQL {
+		if supported, err := testStore.RecursiveQueriesAreSupported(); !supported || err != nil {
+			t.Skip("skipping integration test")
+		}
+	}
+
+	srv, err := NewEmbeddedZanzanaServer(cfg, testStore, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	setup(t, srv)
+
+	newList := func(subject, group, resource string) *authzv1.ListRequest {
+		return &authzv1.ListRequest{
+			Namespace: namespace,
+			Verb:      utils.VerbList,
+			Subject:   subject,
+			Group:     group,
+			Resource:  resource,
+		}
+	}
+
+	t.Run("stream deadline exceeded returns an error instead of partial results", func(t *testing.T) {
+		_, err := srv.List(newContextWithNamespace(), newList("user:1", dashboardGroup, dashboardResource))
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary
- Replaces per-item `Check` calls in the `direct_resource` phase of `BatchCheck` with `ListObjects` + set-membership lookups. Most users have direct access to a small number of resources, so enumerating them all once and resolving via O(1) set lookups is significantly cheaper than issuing one `Check` per batch item — especially when most items are denied (denials have high dispatch counts).
- Adds test coverage for typed resources (teams, users, service accounts), mixed generic/typed batches, and folder subresource access via `set_edit`.

## Test plan
- [x] All existing `TestIntegrationServerBatchCheck` tests pass
- [x] All existing `TestIntegrationServerBatchCheck_SubBatching` tests pass
- [x] New tests for typed resource subresource access (team, user, service account)
- [x] New test for mixed generic and typed resources in same batch
- [x] New test for folder subresource access via `set_edit`