### PR TITLE
ci: fail if cue module version is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,8 @@ install-cue:
 
 .PHONY: fix-cue
 fix-cue: install-cue ## Format and fix CUE files. Use app=<name> to fix a specific app.
-	@root_dir="."; \
+	@set -e; \
+	root_dir="."; \
 	if [ -n "$(app)" ]; then \
 		root_dir="./apps/$(app)"; \
 		if [ ! -d "$$root_dir" ]; then \
@@ -282,12 +283,12 @@ fix-cue: install-cue ## Format and fix CUE files. Use app=<name> to fix a specif
 			exit 1; \
 		fi; \
 	fi; \
-	find "$$root_dir" -type d -name 'cue.mod' | while read -r mod_dir; do \
+	for mod_dir in $$(find "$$root_dir" -type d -name 'cue.mod'); do \
 		project_dir="$$(dirname $$mod_dir)"; \
 		echo "Fixing: $$project_dir"; \
 		(cd "$$project_dir" && $(CUE) fmt ./...); \
 		(cd "$$project_dir" && $(CUE) fix ./...); \
-	done \
+	done
 
 .PHONY: gen-jsonnet
 gen-jsonnet:


### PR DESCRIPTION
Just a quick fix to make the fix-cue make target more comprehensive. It will fail if a cue module does not have a version set.
```
❯ make fix-cue
go install cuelang.org/go/cmd/cue@v0.16.0
Fixing: .
Fixing: ./apps/alerting/historian/kinds
Fixing: ./apps/alerting/rules/kinds
Fixing: ./apps/alerting/notifications/kinds
Fixing: ./apps/advisor/kinds
Fixing: ./apps/preferences/kinds
Fixing: ./apps/playlist/kinds
Fixing: ./apps/plugins/kinds
Fixing: ./apps/example/kinds
Fixing: ./apps/quotas/kinds
Fixing: ./apps/folder/kinds
Fixing: ./apps/logsdrilldown/kinds
Fixing: ./apps/provisioning/kinds
Fixing: ./apps/annotation/kinds
Fixing: ./apps/dashvalidator/kinds
Fixing: ./apps/dashboard/kinds
Fixing: ./apps/iam/kinds
Fixing: ./apps/live/kinds
Fixing: ./apps/shorturl/kinds
Fixing: ./apps/secret/kinds
Fixing: ./apps/collections/kinds
Fixing: ./apps/correlations/kinds
Fixing: ./pkg/extensions/apis/usageinsights/kinds
no language version declared in module.cue
make: *** [fix-cue] Error 1
```