### PR TITLE
set default permissions when restoring dashboard

### DIFF
--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -303,6 +303,10 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
   restoreDashboard(dashboard: Resource<DashboardDataDTO>) {
     // reset the resource version to create a new resource
     dashboard.metadata.resourceVersion = '';
+    dashboard.metadata.annotations = {
+      ...dashboard.metadata.annotations,
+      [AnnoKeyGrantPermissions]: 'default',
+    };
     return this.client.create(dashboard);
   }
 }

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -250,6 +250,10 @@ export class K8sDashboardV2API
   restoreDashboard(dashboard: Resource<DashboardV2Spec>) {
     // reset the resource version to create a new resource
     dashboard.metadata.resourceVersion = '';
+    dashboard.metadata.annotations = {
+      ...dashboard.metadata.annotations,
+      [AnnoKeyGrantPermissions]: 'default',
+    };
     return this.client.create(dashboard);
   }
 }


### PR DESCRIPTION
when restoring a dashboard to root, it's not picking up default permissions, so only admins can see it.

example, created a dashboard on root with default permissions:

<img width="3804" height="1272" alt="image" src="https://github.com/user-attachments/assets/dcac8dff-182e-40a5-9a86-31b8273cdbf6" />

restore in on root:
<img width="3804" height="1272" alt="image" src="https://github.com/user-attachments/assets/b67e0212-b999-4e8d-aa2b-572e4473245a" />
