### PR TITLE
Docs: document risks of editing dashboard JSON model directly

### DIFF
--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -211,6 +211,31 @@ You can input confidential data like login credentials and secrets into Grafana 
 
 You can apply this technique to any configuration options in `conf/grafana.ini` by setting `GF_<SectionName>_<KeyName>__FILE` to the file path that contains the secret information. For more information about Docker secret command usage, refer to [docker secret](https://docs.docker.com/engine/reference/commandline/secret/).
 
+{{< admonition type="note" >}}
+The `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD` environment variables (and their `__FILE` variants) are only used during the very first startup of Grafana, when no users exist in the database yet. If you use a persistent volume for `/var/lib/grafana`, changing these variables after the initial setup and restarting the container has no effect.
+
+To reset the admin password in a running container, use the Grafana CLI:
+
+```bash
+grafana cli admin reset-admin-password <new-password>
+```
+
+To automatically reset the admin password on every container startup, override the entrypoint:
+
+```yaml
+services:
+  grafana:
+    image: grafana/grafana-enterprise
+    entrypoint:
+      - "sh"
+      - "-c"
+      - "grafana cli admin reset-admin-password $${GF_SECURITY_ADMIN_PASSWORD} && /run.sh"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=mysecretpassword
+```
+
+{{< /admonition >}}
+
 The following example demonstrates how to set the admin password:
 
 - Admin password secret: `/run/secrets/admin_password`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -696,9 +696,23 @@ Disable creation of a Grafana Admin user on first start of Grafana. Default is `
 The name of the default Grafana Admin user, who has full permissions.
 Default is `admin`.
 
+This setting is only used during the initial startup when no users exist in the database. Changing it after the admin user has been created has no effect. To change the admin username after initial setup, use the Grafana UI or the [Admin API](/docs/grafana/latest/developers/http_api/admin/).
+
 #### `admin_password`
 
 The password of the default Grafana Admin. Set once on first-run. Default is `admin`.
+
+This setting is only used during the initial startup when no users exist in the database. Changing it after the admin user has been created has no effect, including when set through the `GF_SECURITY_ADMIN_PASSWORD` environment variable or Docker Secrets (`GF_SECURITY_ADMIN_PASSWORD__FILE`). To reset the admin password after initial setup, run:
+
+```bash
+grafana cli admin reset-admin-password <new-password>
+```
+
+In Docker or Kubernetes environments, you can override the container entrypoint to reset the password on every startup:
+
+```bash
+grafana cli admin reset-admin-password "$GF_SECURITY_ADMIN_PASSWORD" && /run.sh
+```
 
 #### `admin_email`
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -55,6 +55,16 @@ There are currently three dashboard JSON schema models:
 [Observability as Code](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/) works with all versions of the JSON model, and it's fully compatible with version 2.
 {{< /admonition >}}
 
+## Risks of editing the JSON model directly
+
+Editing the JSON model directly is a powerful option, but it comes with risks that you should be aware of before making changes:
+
+- **Data source UIDs are instance-specific.** If you copy a dashboard JSON from one Grafana instance to another, the `datasource` UIDs in the panels won't match. You need to update them to the correct UIDs on the target instance, or use [provisioning variables](https://grafana.com/docs/grafana/latest/administration/provisioning/#using-a-provisioned-dashboard) to make them portable.
+- **Dashboard and panel IDs can collide.** The numeric `id` field is assigned by the database and is unique per instance. When you import a JSON model, set `id` to `null` so Grafana assigns a new one. The `uid` field should also be unique; duplicates overwrite existing dashboards.
+- **Schema version mismatches.** The `schemaVersion` field tracks the JSON schema version. Importing a dashboard with a newer schema version into an older Grafana instance can cause rendering errors or data loss.
+- **Permissions are not included.** Dashboard JSON doesn't contain permission settings. After importing, the dashboard inherits the permissions of the target folder. You need to reconfigure any custom permissions manually.
+- **Invalid JSON breaks the dashboard.** Malformed JSON or invalid field values can make the dashboard unloadable. Use the **JSON Model** tab in the dashboard settings to validate changes before saving, and keep a backup of the working JSON.
+
 ## Access and update the JSON model {#view-json}
 
 To access the JSON representation of a dashboard:


### PR DESCRIPTION
## Summary

- Add a "Risks of editing the JSON model directly" section to the dashboard JSON model page
- Document common pitfalls: instance-specific data source UIDs, ID collisions, schema version mismatches, permissions not being included, and invalid JSON breaking dashboards

Users who export/import dashboard JSON or edit it directly often encounter these issues without warning. The existing documentation describes the JSON schema fields but doesn't mention what can go wrong.

## Test plan

- [ ] Verify the new section renders correctly in the docs preview
- [ ] Confirm the provisioning variables link is valid

Fixes #75472