### PR TITLE
 Dashboards: Add enableGroupBy field to v1 ad-hoc variable schema and conversions

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
@@ -209,6 +209,8 @@ lineage: schemas: [{
 			multi?: bool | *false
 			// Allow custom values to be entered in the variable
 			allowCustomValue?: bool | *true
+			// Whether the group-by operator is enabled in the ad hoc filter combobox.
+			enableGroupBy?: bool | *false
 			// Options that can be selected for a variable.
 			options?: [...#VariableOption]
 			// Options to config when to refresh a variable

--- a/apps/dashboard/pkg/apis/dashboard/v1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v1/dashboard_kind.cue
@@ -209,6 +209,8 @@ lineage: schemas: [{
 			multi?: bool | *false
 			// Allow custom values to be entered in the variable
 			allowCustomValue?: bool | *true
+			// Whether the group-by operator is enabled in the ad hoc filter combobox.
+			enableGroupBy?: bool | *false
 			// Options that can be selected for a variable.
 			options?: [...#VariableOption]
 			// Options to config when to refresh a variable

--- a/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
@@ -1688,9 +1688,10 @@ func buildAdhocVariable(ctx context.Context, varMap map[string]interface{}, comm
 		},
 	}
 
-	if _, exists := varMap["enableGroupBy"]; exists {
-		enableGroupBy := getBoolField(varMap, "enableGroupBy", false)
-		adhocVar.Spec.EnableGroupBy = &enableGroupBy
+	if val, exists := varMap["enableGroupBy"]; exists {
+		if b, ok := val.(bool); ok {
+			adhocVar.Spec.EnableGroupBy = &b
+		}
 	}
 
 	// Transform baseFilters if they exist, otherwise default to empty array

--- a/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
@@ -1688,6 +1688,11 @@ func buildAdhocVariable(ctx context.Context, varMap map[string]interface{}, comm
 		},
 	}
 
+	if _, exists := varMap["enableGroupBy"]; exists {
+		enableGroupBy := getBoolField(varMap, "enableGroupBy", false)
+		adhocVar.Spec.EnableGroupBy = &enableGroupBy
+	}
+
 	// Transform baseFilters if they exist, otherwise default to empty array
 	if baseFilters, exists := varMap["baseFilters"]; exists {
 		if baseFiltersArray, ok := baseFilters.([]interface{}); ok {

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1.go
@@ -1668,6 +1668,9 @@ func convertAdhocVariableToV1(variable *dashv2alpha1.DashboardAdhocVariableKind)
 	}
 	// Always include allowCustomValue for adhoc variables, including false values
 	varMap["allowCustomValue"] = spec.AllowCustomValue
+	if spec.EnableGroupBy != nil {
+		varMap["enableGroupBy"] = *spec.EnableGroupBy
+	}
 
 	// Resolve datasource - Adhoc variables don't have a query kind, so use empty string (will fall back to default)
 	datasource := getDataSourceForQuery(spec.Datasource, "")

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v2beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v2beta1.go
@@ -785,6 +785,7 @@ func convertVariable_V2alpha1_to_V2beta1(in *dashv2alpha1.DashboardVariableKind,
 				SkipUrlSync:      in.AdhocVariableKind.Spec.SkipUrlSync,
 				Description:      in.AdhocVariableKind.Spec.Description,
 				AllowCustomValue: in.AdhocVariableKind.Spec.AllowCustomValue,
+				EnableGroupBy:    in.AdhocVariableKind.Spec.EnableGroupBy,
 			},
 		}
 	}

--- a/apps/dashboard/pkg/migration/conversion/v2beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2beta1_to_v2alpha1.go
@@ -819,6 +819,7 @@ func convertVariable_V2beta1_to_V2alpha1(in *dashv2beta1.DashboardVariableKind, 
 				SkipUrlSync:      in.AdhocVariableKind.Spec.SkipUrlSync,
 				Description:      in.AdhocVariableKind.Spec.Description,
 				AllowCustomValue: in.AdhocVariableKind.Spec.AllowCustomValue,
+				EnableGroupBy:    in.AdhocVariableKind.Spec.EnableGroupBy,
 				Datasource:       datasource,
 			},
 		}

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -205,6 +205,8 @@ lineage: schemas: [{
 			multi?: bool | *false
 			// Allow custom values to be entered in the variable
 			allowCustomValue?: bool | *true
+			// Whether the group-by operator is enabled in the ad hoc filter combobox.
+			enableGroupBy?: bool | *false
 			// Options that can be selected for a variable.
 			options?: [...#VariableOption]
 			// Options to config when to refresh a variable

--- a/packages/grafana-schema/src/raw/dashboard/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/types.gen.ts
@@ -151,6 +151,10 @@ export interface VariableModel {
    */
   description?: string;
   /**
+   * Whether the group-by operator is enabled in the ad hoc filter combobox.
+   */
+  enableGroupBy?: boolean;
+  /**
    * Visibility configuration for the variable
    */
   hide?: VariableHide;
@@ -219,6 +223,7 @@ export interface VariableModel {
 
 export const defaultVariableModel: Partial<VariableModel> = {
   allowCustomValue: true,
+  enableGroupBy: false,
   includeAll: false,
   multi: false,
   options: [],

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -857,6 +857,8 @@ type VariableModel struct {
 	Multi *bool `json:"multi,omitempty"`
 	// Allow custom values to be entered in the variable
 	AllowCustomValue *bool `json:"allowCustomValue,omitempty"`
+	// Whether the group-by operator is enabled in the ad hoc filter combobox.
+	EnableGroupBy *bool `json:"enableGroupBy,omitempty"`
 	// Options that can be selected for a variable.
 	Options []VariableOption `json:"options,omitempty"`
 	// Options to config when to refresh a variable
@@ -886,6 +888,7 @@ func NewVariableModel() *VariableModel {
 		SkipUrlSync:      (func(input bool) *bool { return &input })(false),
 		Multi:            (func(input bool) *bool { return &input })(false),
 		AllowCustomValue: (func(input bool) *bool { return &input })(true),
+		EnableGroupBy:    (func(input bool) *bool { return &input })(false),
 		IncludeAll:       (func(input bool) *bool { return &input })(false),
 		ValuesFormat:     (func(input VariableModelValuesFormat) *VariableModelValuesFormat { return &input })(VariableModelValuesFormatCsv),
 	}

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -232,9 +232,6 @@ export function sceneVariablesSetToVariables(set: SceneVariables, keepQueryOptio
         filters: [...validateFiltersOrigin(variable.state.originFilters), ...variable.state.filters],
         defaultKeys: variable.state.defaultKeys,
         ...(variable.state.allowCustomValue !== undefined && { allowCustomValue: variable.state.allowCustomValue }),
-        enableGroupBy: config.featureToggles.dashboardUnifiedDrilldownControls
-          ? (variable.state.enableGroupBy ?? false)
-          : false,
       };
       variables.push(adhocVariable);
     } else if (sceneUtils.isSwitchVariable(variable)) {

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -232,6 +232,9 @@ export function sceneVariablesSetToVariables(set: SceneVariables, keepQueryOptio
         filters: [...validateFiltersOrigin(variable.state.originFilters), ...variable.state.filters],
         defaultKeys: variable.state.defaultKeys,
         ...(variable.state.allowCustomValue !== undefined && { allowCustomValue: variable.state.allowCustomValue }),
+        enableGroupBy: config.featureToggles.dashboardUnifiedDrilldownControls
+          ? (variable.state.enableGroupBy ?? false)
+          : false,
       };
       variables.push(adhocVariable);
     } else if (sceneUtils.isSwitchVariable(variable)) {


### PR DESCRIPTION
**What is this feature?**

Adds the `enableGroupBy` field to the v1 dashboard `#VariableModel` schema 
