### PR TITLE
Gauge: Fixes from bug bash

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.test.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.test.tsx
@@ -86,7 +86,7 @@ describe('RadialArcPathEndpointMarks', () => {
           <RadialArcPathEndpointMarks {...defaultProps} endpointMarker="glow" color="#FF0000" />
         </svg>
       ),
-      '<svg role=\"img\"><path d=\"M 113.89185421335443 21.215379759023364 A 80 80 0 0 1 150 50\" fill=\"none\" stroke-width=\"20\" stroke-linecap=\"butt\"/></svg>'
+      '<svg role=\"img\"><path d=\"M 113.89185421335443 21.215379759023364 A 80 80 0 0 1 150 50\" fill=\"none\" stroke-width=\"20\" stroke-linecap=\"round\"/></svg>'
     );
   });
 
@@ -104,7 +104,7 @@ describe('RadialArcPathEndpointMarks', () => {
           />
         </svg>
       ),
-      '<svg role=\"img\"><path d=\"M 113.89185421335443 21.215379759023364 A 80 80 0 0 1 150 50\" fill=\"none\" stroke-width=\"20\" stroke-linecap=\"butt\"/></svg>'
+      '<svg role=\"img\"><path d=\"M 113.89185421335443 21.215379759023364 A 80 80 0 0 1 150 50\" fill=\"none\" stroke-width=\"20\" stroke-linecap=\"round\"/></svg>'
     );
   });
 

--- a/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialArcPathEndpointMarks.tsx
@@ -89,7 +89,7 @@ export const RadialArcPathEndpointMarks = memo(
             fill="none"
             strokeWidth={barWidth}
             stroke={endpointMarkerGlowFilter}
-            strokeLinecap={roundedBars ? 'round' : 'butt'}
+            strokeLinecap="round"
             filter={glowFilter}
           />
         );

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -205,7 +205,9 @@ export function RadialGauge(props: RadialGaugeProps) {
       }
 
       if (glowCenter) {
-        graphics.push(<MiddleCircleGlow key="center-glow" gaugeId={gaugeId} color={color} dimensions={dimensions} />);
+        graphics.push(
+          <MiddleCircleGlow key="center-glow" gaugeId={gaugeId} color={color} dimensions={dimensions} shape={shape} />
+        );
       }
 
       graphics.push(

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -13,7 +13,7 @@ import { RadialScaleLabels } from './RadialScaleLabels';
 import { RadialSparkline } from './RadialSparkline';
 import { RadialText } from './RadialText';
 import { ThresholdsBar } from './ThresholdsBar';
-import { buildGradientColors } from './colors';
+import { buildGradientColors, colorAtGradientPercent } from './colors';
 import { ARC_END, ARC_START, DEFAULT_DECIMALS } from './constants';
 import { GlowGradient, MiddleCircleGlow, SpotlightGradient } from './effects';
 import { RadialShape, RadialTextMode } from './types';
@@ -149,6 +149,9 @@ export function RadialGauge(props: RadialGaugeProps) {
     const glowFilterRef = glowBar ? `url(#${glowFilterId})` : undefined;
 
     if (endpointMarker === 'glow') {
+      const endpointColor = gradientStops
+        ? colorAtGradientPercent(gradientStops, fieldDisplay.display.percent ?? 1).toHexString()
+        : color;
       defs.push(
         <SpotlightGradient
           key={spotlightGradientId}
@@ -157,6 +160,7 @@ export function RadialGauge(props: RadialGaugeProps) {
           dimensions={dimensions}
           roundedBars={roundedBars}
           theme={theme}
+          color={endpointColor}
         />
       );
     }

--- a/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialScaleLabels.tsx
@@ -87,7 +87,7 @@ export const RadialScaleLabels = memo(
       if (isFullCircle) {
         // For full circle: nudge labels near the top at the end of the circle
         // counter-clockwise along the path to create extra space at 12 o'clock
-        const paddingFactor = 0.375; // 3/8 of the label width - a bit of trial-and-error showed this was a good value to use.
+        const paddingFactor = 0.65; // needs to be >= 0.5 so that center-to-center gap (2x factor x width) >= label width
         const padding = measure.width * paddingFactor;
         if (isFirst) {
           offset += padding;

--- a/packages/grafana-ui/src/components/RadialGauge/effects.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/effects.tsx
@@ -5,9 +5,6 @@ import { RadialGaugeDimensions, RadialShape } from './types';
 
 // some utility transparent white colors for gradients
 const TRANSPARENT_WHITE = '#ffffff00';
-const MOSTLY_TRANSPARENT_WHITE = '#ffffff88';
-const MOSTLY_OPAQUE_WHITE = '#ffffffbb';
-const OPAQUE_WHITE = '#ffffff';
 
 const MIN_GLOW_SIZE = 0.75;
 const GLOW_FACTOR = 0.08;
@@ -46,10 +43,7 @@ export function MiddleCircleGlow({ dimensions, gaugeId, color, shape }: CenterGl
   const clipId = `circle-glow-clip-${gaugeId}`;
   const transparentColor = color ? colorManipulator.alpha(color, CENTER_GLOW_OPACITY) : color;
 
-  // For the 'gauge' shape the arc ends at ARC_END degrees (110°) on the right side.
-  // Using toRad convention (0° = up, clockwise), the arc endpoint Y offset from center is:
-  //   radius * sin((ARC_END - 90) * π/180)  =  radius * sin(20°)  ≈  radius * 0.342
-  // The clip rect bottom sits at that Y so the glow matches the flat-bottom opening of the arc.
+  // Clip the glow to the gauge arc's flat-bottom opening (arc endpoints sit at centerY + radius * sin(20°)).
   const isGaugeShape = shape === 'gauge';
   const arcEndOffsetY = Math.sin(((ARC_END - 90) * Math.PI) / 180);
 
@@ -62,7 +56,6 @@ export function MiddleCircleGlow({ dimensions, gaugeId, color, shape }: CenterGl
         </radialGradient>
         {isGaugeShape && (
           <clipPath id={clipId}>
-            {/* Clip bottom at the Y where the arc endpoints sit: centerY + radius * sin(20°) */}
             <rect
               x={dimensions.centerX - dimensions.radius}
               y={dimensions.centerY - dimensions.radius}
@@ -91,25 +84,27 @@ interface SpotlightGradientProps {
   angle: number;
   roundedBars: boolean;
   theme: GrafanaTheme2;
+  color: string;
 }
 
-export function SpotlightGradient({ id, dimensions, roundedBars, angle, theme }: SpotlightGradientProps) {
+export function SpotlightGradient({ id, dimensions, roundedBars, angle, theme, color }: SpotlightGradientProps) {
   if (theme.isLight) {
     return null;
   }
 
-  const angleRadian = ((angle - 90) * Math.PI) / 180;
+  // Shift the centre forward by the endcap's angular half-width so the bloom sits over the visual tip.
+  const endcapOffsetRad = roundedBars ? dimensions.barWidth / (2 * dimensions.radius) : 0;
+  const angleRadian = ((angle - 90) * Math.PI) / 180 + endcapOffsetRad;
 
-  let x1 = dimensions.centerX + dimensions.radius * Math.cos(angleRadian - 0.2);
-  let y1 = dimensions.centerY + dimensions.radius * Math.sin(angleRadian - 0.2);
-  let x2 = dimensions.centerX + dimensions.radius * Math.cos(angleRadian);
-  let y2 = dimensions.centerY + dimensions.radius * Math.sin(angleRadian);
+  const cx = dimensions.centerX + dimensions.radius * Math.cos(angleRadian);
+  const cy = dimensions.centerY + dimensions.radius * Math.sin(angleRadian);
+  const glowRadius = dimensions.barWidth * 1.5;
+  const tintTip = colorManipulator.alpha(colorManipulator.lighten(color, 0.8), 0.85);
 
   return (
-    <linearGradient x1={x1} y1={y1} x2={x2} y2={y2} id={id} gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stopColor={TRANSPARENT_WHITE} />
-      <stop offset="95%" stopColor={MOSTLY_TRANSPARENT_WHITE} />
-      {roundedBars && <stop offset="100%" stopColor={roundedBars ? MOSTLY_OPAQUE_WHITE : OPAQUE_WHITE} />}
-    </linearGradient>
+    <radialGradient id={id} cx={cx} cy={cy} r={glowRadius} fx={cx} fy={cy} gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stopColor={tintTip} />
+      <stop offset="100%" stopColor={TRANSPARENT_WHITE} />
+    </radialGradient>
   );
 }

--- a/packages/grafana-ui/src/components/RadialGauge/effects.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/effects.tsx
@@ -1,6 +1,7 @@
 import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
 
-import { RadialGaugeDimensions } from './types';
+import { ARC_END } from './constants';
+import { RadialGaugeDimensions, RadialShape } from './types';
 
 // some utility transparent white colors for gradients
 const TRANSPARENT_WHITE = '#ffffff00';
@@ -37,11 +38,20 @@ export interface CenterGlowProps {
   dimensions: RadialGaugeDimensions;
   gaugeId: string;
   color?: string;
+  shape?: RadialShape;
 }
 
-export function MiddleCircleGlow({ dimensions, gaugeId, color }: CenterGlowProps) {
+export function MiddleCircleGlow({ dimensions, gaugeId, color, shape }: CenterGlowProps) {
   const gradientId = `circle-glow-${gaugeId}`;
+  const clipId = `circle-glow-clip-${gaugeId}`;
   const transparentColor = color ? colorManipulator.alpha(color, CENTER_GLOW_OPACITY) : color;
+
+  // For the 'gauge' shape the arc ends at ARC_END degrees (110°) on the right side.
+  // Using toRad convention (0° = up, clockwise), the arc endpoint Y offset from center is:
+  //   radius * sin((ARC_END - 90) * π/180)  =  radius * sin(20°)  ≈  radius * 0.342
+  // The clip rect bottom sits at that Y so the glow matches the flat-bottom opening of the arc.
+  const isGaugeShape = shape === 'gauge';
+  const arcEndOffsetY = Math.sin(((ARC_END - 90) * Math.PI) / 180);
 
   return (
     <>
@@ -50,9 +60,26 @@ export function MiddleCircleGlow({ dimensions, gaugeId, color }: CenterGlowProps
           <stop offset="0%" stopColor={transparentColor} />
           <stop offset="90%" stopColor={TRANSPARENT_WHITE} />
         </radialGradient>
+        {isGaugeShape && (
+          <clipPath id={clipId}>
+            {/* Clip bottom at the Y where the arc endpoints sit: centerY + radius * sin(20°) */}
+            <rect
+              x={dimensions.centerX - dimensions.radius}
+              y={dimensions.centerY - dimensions.radius}
+              width={dimensions.radius * 2}
+              height={dimensions.radius * (1 + arcEndOffsetY)}
+            />
+          </clipPath>
+        )}
       </defs>
       <g>
-        <circle cx={dimensions.centerX} cy={dimensions.centerY} r={dimensions.radius} fill={`url(#${gradientId})`} />
+        <circle
+          cx={dimensions.centerX}
+          cy={dimensions.centerY}
+          r={dimensions.radius}
+          fill={`url(#${gradientId})`}
+          clipPath={isGaugeShape ? `url(#${clipId})` : undefined}
+        />
       </g>
     </>
   );


### PR DESCRIPTION
### Summary

grab-bag of visual bug fixes:

- fixes a collision of the labels at the top of the panel for percentage and non-percentage threshold min/maxes
- changes the center glow of the gauge when in "arc" shape to have a flat bottom which aligns with the edge of the visualization, rather than a circle that can extend beyond in some layouts
- cleans up the "glow" endpoint mode for rounded bars, replacing the gradient with one that more gradually follows the end of the bar to avoid a hard line in the gradient.

<details>
    <summary>JSON for dashboard with test cases</summary>

```json
{
  "apiVersion": "dashboard.grafana.app/v2beta1",
  "kind": "Dashboard",
  "metadata": {
    "name": "adhqdsb",
    "namespace": "default",
    "uid": "b4ed4439-89f5-4c63-a00c-db11fea5a5ba",
    "resourceVersion": "1774550574253991",
    "generation": 10,
    "creationTimestamp": "2026-03-26T17:47:57Z",
    "labels": {
      "grafana.app/deprecatedInternalID": "1598021136629760"
    },
    "annotations": {
      "grafana.app/createdBy": "user:eel75p7l7tiwwb",
      "grafana.app/folder": "",
      "grafana.app/saved-from-ui": "Grafana v13.0.0-local (f7a7b4e36a)",
      "grafana.app/updatedBy": "user:eel75p7l7tiwwb",
      "grafana.app/updatedTimestamp": "2026-03-26T18:42:54Z"
    }
  },
  "spec": {
    "annotations": [
      {
        "kind": "AnnotationQuery",
        "spec": {
          "query": {
            "kind": "DataQuery",
            "group": "grafana",
            "version": "v0",
            "datasource": {
              "name": "-- Grafana --"
            },
            "spec": {}
          },
          "enable": true,
          "hide": true,
          "iconColor": "rgba(0, 211, 255, 1)",
          "name": "Annotations & Alerts",
          "builtIn": true
        }
      }
    ],
    "cursorSync": "Off",
    "editable": true,
    "elements": {
      "panel-1": {
        "kind": "Panel",
        "spec": {
          "id": 1,
          "title": "Label collision - percentage",
          "description": "",
          "links": [],
          "data": {
            "kind": "QueryGroup",
            "spec": {
              "queries": [
                {
                  "kind": "PanelQuery",
                  "spec": {
                    "query": {
                      "kind": "DataQuery",
                      "group": "",
                      "version": "v0",
                      "spec": {}
                    },
                    "refId": "A",
                    "hidden": false
                  }
                }
              ],
              "transformations": [],
              "queryOptions": {}
            }
          },
          "vizConfig": {
            "kind": "VizConfig",
            "group": "gauge",
            "version": "13.0.0-local",
            "spec": {
              "options": {
                "barShape": "flat",
                "barWidthFactor": 0.3,
                "effects": {
                  "barGlow": false,
                  "centerGlow": false,
                  "gradient": true
                },
                "endpointMarker": "point",
                "minVizHeight": 75,
                "minVizWidth": 75,
                "orientation": "auto",
                "reduceOptions": {
                  "calcs": [
                    "lastNotNull"
                  ],
                  "fields": "",
                  "values": false
                },
                "segmentCount": 1,
                "segmentSpacing": 0.3,
                "shape": "circle",
                "showThresholdLabels": true,
                "showThresholdMarkers": false,
                "sizing": "auto",
                "sparkline": true,
                "textMode": "auto"
              },
              "fieldConfig": {
                "defaults": {
                  "min": 0,
                  "max": 100,
                  "thresholds": {
                    "mode": "percentage",
                    "steps": [
                      {
                        "value": 0,
                        "color": "green"
                      },
                      {
                        "value": 80,
                        "color": "red"
                      }
                    ]
                  },
                  "color": {
                    "mode": "palette-classic"
                  }
                },
                "overrides": []
              }
            }
          }
        }
      },
      "panel-2": {
        "kind": "Panel",
        "spec": {
          "id": 2,
          "title": "Label collision - value",
          "description": "",
          "links": [],
          "data": {
            "kind": "QueryGroup",
            "spec": {
              "queries": [
                {
                  "kind": "PanelQuery",
                  "spec": {
                    "query": {
                      "kind": "DataQuery",
                      "group": "",
                      "version": "v0",
                      "spec": {}
                    },
                    "refId": "A",
                    "hidden": false
                  }
                }
              ],
              "transformations": [],
              "queryOptions": {}
            }
          },
          "vizConfig": {
            "kind": "VizConfig",
            "group": "gauge",
            "version": "13.0.0-local",
            "spec": {
              "options": {
                "barShape": "flat",
                "barWidthFactor": 0.3,
                "effects": {
                  "barGlow": false,
                  "centerGlow": false,
                  "gradient": true
                },
                "endpointMarker": "point",
                "minVizHeight": 75,
                "minVizWidth": 75,
                "orientation": "auto",
                "reduceOptions": {
                  "calcs": [
                    "lastNotNull"
                  ],
                  "fields": "",
                  "values": false
                },
                "segmentCount": 1,
                "segmentSpacing": 0.3,
                "shape": "circle",
                "showThresholdLabels": true,
                "showThresholdMarkers": false,
                "sizing": "auto",
                "sparkline": true,
                "textMode": "auto"
              },
              "fieldConfig": {
                "defaults": {
                  "min": 0,
                  "max": 100,
                  "thresholds": {
                    "mode": "absolute",
                    "steps": [
                      {
                        "value": 0,
                        "color": "green"
                      },
                      {
                        "value": 80,
                        "color": "red"
                      }
                    ]
                  },
                  "color": {
                    "mode": "palette-classic"
                  }
                },
                "overrides": []
              }
            }
          }
        }
      },
      "panel-3": {
        "kind": "Panel",
        "spec": {
          "id": 3,
          "title": "Arc gauges w/ glow (check cut of glow)",
          "description": "",
          "links": [],
          "data": {
            "kind": "QueryGroup",
            "spec": {
              "queries": [
                {
                  "kind": "PanelQuery",
                  "spec": {
                    "query": {
                      "kind": "DataQuery",
                      "group": "grafana-testdata-datasource",
                      "version": "v0",
                      "datasource": {
                        "name": "PD8C576611E62080A"
                      },
                      "spec": {
                        "scenarioId": "random_walk",
                        "seriesCount": 8
                      }
                    },
                    "refId": "A",
                    "hidden": false
                  }
                }
              ],
              "transformations": [],
              "queryOptions": {}
            }
          },
          "vizConfig": {
            "kind": "VizConfig",
            "group": "gauge",
            "version": "13.0.0-local",
            "spec": {
              "options": {
                "barShape": "flat",
                "barWidthFactor": 0.3,
                "effects": {
                  "barGlow": false,
                  "centerGlow": true,
                  "gradient": true
                },
                "endpointMarker": "point",
                "minVizHeight": 75,
                "minVizWidth": 75,
                "orientation": "auto",
                "reduceOptions": {
                  "calcs": [
                    "lastNotNull"
                  ],
                  "fields": "",
                  "values": false
                },
                "segmentCount": 1,
                "segmentSpacing": 0.3,
                "shape": "gauge",
                "showThresholdLabels": false,
                "showThresholdMarkers": false,
                "sizing": "auto",
                "sparkline": false,
                "textMode": "auto"
              },
              "fieldConfig": {
                "defaults": {
                  "thresholds": {
                    "mode": "absolute",
                    "steps": [
                      {
                        "value": 0,
                        "color": "green"
                      },
                      {
                        "value": 80,
                        "color": "red"
                      }
                    ]
                  },
                  "color": {
                    "mode": "palette-classic"
                  }
                },
                "overrides": []
              }
            }
          }
        }
      },
      "panel-4": {
        "kind": "Panel",
        "spec": {
          "id": 4,
          "title": "Glow endpoint (use dark mode)",
          "description": "",
          "links": [],
          "data": {
            "kind": "QueryGroup",
            "spec": {
              "queries": [
                {
                  "kind": "PanelQuery",
                  "spec": {
                    "query": {
                      "kind": "DataQuery",
                      "group": "",
                      "version": "v0",
                      "spec": {}
                    },
                    "refId": "A",
                    "hidden": false
                  }
                }
              ],
              "transformations": [],
              "queryOptions": {}
            }
          },
          "vizConfig": {
            "kind": "VizConfig",
            "group": "gauge",
            "version": "13.0.0-local",
            "spec": {
              "options": {
                "barShape": "rounded",
                "barWidthFactor": 0.59,
                "effects": {
                  "barGlow": false,
                  "centerGlow": false,
                  "gradient": true
                },
                "endpointMarker": "glow",
                "minVizHeight": 75,
                "minVizWidth": 75,
                "orientation": "auto",
                "reduceOptions": {
                  "calcs": [
                    "lastNotNull"
                  ],
                  "fields": "",
                  "values": false
                },
                "segmentCount": 1,
                "segmentSpacing": 0.3,
                "shape": "gauge",
                "showThresholdLabels": false,
                "showThresholdMarkers": false,
                "sizing": "auto",
                "sparkline": true,
                "textMode": "auto"
              },
              "fieldConfig": {
                "defaults": {
                  "thresholds": {
                    "mode": "absolute",
                    "steps": [
                      {
                        "value": 0,
                        "color": "green"
                      },
                      {
                        "value": 80,
                        "color": "red"
                      }
                    ]
                  },
                  "color": {
                    "mode": "continuous-magma"
                  }
                },
                "overrides": []
              }
            }
          }
        }
      }
    },
    "layout": {
      "kind": "GridLayout",
      "spec": {
        "items": [
          {
            "kind": "GridLayoutItem",
            "spec": {
              "x": 0,
              "y": 0,
              "width": 12,
              "height": 8,
              "element": {
                "kind": "ElementReference",
                "name": "panel-1"
              }
            }
          },
          {
            "kind": "GridLayoutItem",
            "spec": {
              "x": 12,
              "y": 0,
              "width": 12,
              "height": 8,
              "element": {
                "kind": "ElementReference",
                "name": "panel-2"
              }
            }
          },
          {
            "kind": "GridLayoutItem",
            "spec": {
              "x": 0,
              "y": 8,
              "width": 12,
              "height": 12,
              "element": {
                "kind": "ElementReference",
                "name": "panel-3"
              }
            }
          },
          {
            "kind": "GridLayoutItem",
            "spec": {
              "x": 12,
              "y": 8,
              "width": 12,
              "height": 8,
              "element": {
                "kind": "ElementReference",
                "name": "panel-4"
              }
            }
          }
        ]
      }
    },
    "links": [],
    "liveNow": false,
    "preload": false,
    "tags": [],
    "timeSettings": {
      "timezone": "browser",
      "from": "now-6h",
      "to": "now",
      "autoRefresh": "",
      "autoRefreshIntervals": [
        "5s",
        "10s",
        "30s",
        "1m",
        "5m",
        "15m",
        "30m",
        "1h",
        "2h",
        "1d"
      ],
      "hideTimepicker": false,
      "fiscalYearStartMonth": 0
    },
    "title": "testing gauge bug bash fixes",
    "variables": []
  }
}
```
</details>

#### Before

<img width="1638" height="774" alt="Screenshot 2026-03-26 at 2 43 00 PM" src="https://github.com/user-attachments/assets/e1589fb1-66c9-4835-8c38-c709f3acd08e" />

#### After

##### Chrome

<img width="1642" height="775" alt="Screenshot 2026-03-26 at 2 46 46 PM" src="https://github.com/user-attachments/assets/726be76f-f621-46fa-8082-192aab5d9f7d" />

##### Safari 26.3

<img width="1271" height="782" alt="Screenshot 2026-03-26 at 2 51 04 PM" src="https://github.com/user-attachments/assets/3045fc96-d688-4575-b40b-037ac0ebaee2" />

