### PR TITLE
Zanzana: Fix stores not being deleted for archived/deleted namespaces

### DIFF
--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -98,7 +98,16 @@ func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.Store
 func (s *Server) DeleteStore(ctx context.Context, namespace string) error {
 	info, ok := s.removeStore(namespace)
 	if !ok {
-		return nil
+		// Fallback: look up directly from OpenFGA in case the cache is stale.
+		store, err := s.GetStore(ctx, namespace)
+		if err != nil {
+			if errors.Is(err, zanzana.ErrStoreNotFound) {
+				return nil
+			}
+			return err
+		}
+		info = *store
+		s.removeStore(namespace)
 	}
 
 	_, err := s.openFGAClient.DeleteStore(ctx, &openfgav1.DeleteStoreRequest{StoreId: info.ID})

--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -183,5 +183,19 @@ func (s *Server) ListAllStores(ctx context.Context) ([]zanzana.StoreInfo, error)
 		continuationToken = res.GetContinuationToken()
 	}
 
+	// Populate the cache so DeleteStore can resolve names without a separate lookup.
+	s.populateStoreCache(stores)
+
 	return stores, nil
+}
+
+func (s *Server) populateStoreCache(stores []zanzana.StoreInfo) {
+	s.storesMU.Lock()
+	defer s.storesMU.Unlock()
+
+	for _, info := range stores {
+		if _, ok := s.stores[info.Name]; !ok {
+			s.stores[info.Name] = info
+		}
+	}
 }

--- a/pkg/services/authz/zanzana/server/server_store_test.go
+++ b/pkg/services/authz/zanzana/server/server_store_test.go
@@ -82,3 +82,67 @@ func TestGetOrCreateStore_FullFlow(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, store.ModelID, info2.ModelID)
 }
+
+func TestDeleteStore_ViaListAllStores(t *testing.T) {
+	srv := setupOpenFGAServer(t)
+	ctx := context.Background()
+	testNamespace := "test-delete-via-list"
+
+	store, err := srv.GetOrCreateStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	// Clear cache to simulate the reconciler path where ListAllStores is the
+	// first thing that runs (it queries OpenFGA, not the cache).
+	srv.storesMU.Lock()
+	delete(srv.stores, testNamespace)
+	srv.storesMU.Unlock()
+
+	stores, err := srv.ListAllStores(ctx)
+	require.NoError(t, err)
+	found := false
+	for _, s := range stores {
+		if s.Name == testNamespace {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "ListAllStores should return the created store")
+
+	srv.storesMU.Lock()
+	_, ok := srv.stores[testNamespace]
+	srv.storesMU.Unlock()
+	require.True(t, ok, "ListAllStores should populate the cache")
+
+	err = srv.DeleteStore(ctx, testNamespace)
+	require.NoError(t, err)
+
+	_, err = srv.GetStore(ctx, testNamespace)
+	require.ErrorIs(t, err, zanzana.ErrStoreNotFound)
+}
+
+func TestListAllStores_DoesNotOverwriteCachedModelID(t *testing.T) {
+	srv := setupOpenFGAServer(t)
+	ctx := context.Background()
+	testNamespace := "test-list-preserves-model"
+
+	store, err := srv.GetOrCreateStore(ctx, testNamespace)
+	require.NoError(t, err)
+	require.NotEmpty(t, store.ModelID)
+
+	_, err = srv.ListAllStores(ctx)
+	require.NoError(t, err)
+
+	srv.storesMU.Lock()
+	info := srv.stores[testNamespace]
+	srv.storesMU.Unlock()
+	require.Equal(t, store.ModelID, info.ModelID, "ListAllStores should not overwrite cached ModelID")
+}
+
+func TestDeleteStore_AlreadyDeleted(t *testing.T) {
+	srv := setupOpenFGAServer(t)
+	ctx := context.Background()
+
+	err := srv.DeleteStore(ctx, "non-existent-namespace")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- **Bug**: `ListAllStores()` queries OpenFGA directly but never populated the local store cache. When the reconciler detected a deleted/archived namespace and called `DeleteStore()`, it only checked the local cache, found nothing, and returned `nil` — never actually calling OpenFGA's delete. This caused the same "removing store" warning log every reconciliation tick with no actual deletion.
- **Fix (cache population)**: `ListAllStores()` now populates the local cache after pagination completes, using a conditional write (`populateStoreCache`) to avoid overwriting entries that already have a `ModelID`.
- **Fix (defense-in-depth)**: `DeleteStore()` now falls back to querying OpenFGA directly if the store is not in the local cache.
- **Tests**: Added `TestDeleteStore_ViaListAllStores`, `TestListAllStores_DoesNotOverwriteCachedModelID`, and `TestDeleteStore_AlreadyDeleted`.

## Test plan

- [x] `go test -run "TestDeleteStore|TestListAllStores|TestGetStore" ./pkg/services/authz/zanzana/server/` — all pass
- [ ] Deploy to dev-us-central-0 and verify that stores for archived namespaces are deleted after one reconciliation tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)