### PR TITLE
unified-storage: sort by RV desc when listing from trash

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"iter"
 	"math/rand/v2"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -1400,14 +1402,12 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 	key := req.Options.Key
 	// Parse continue token if provided
 	lastSeenRV := int64(0)
-	lastSeenName := ""
 	if req.NextPageToken != "" {
 		token, err := GetContinueToken(req.NextPageToken)
 		if err != nil {
 			return 0, fmt.Errorf("invalid continue token: %w", err)
 		}
 		lastSeenRV = token.ResourceVersion
-		lastSeenName = token.Name
 	}
 
 	// Generate a new resource version for the list
@@ -1415,7 +1415,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 
 	// Handle trash differently from regular history
 	if req.Source == resourcepb.ListRequest_TRASH {
-		return k.processTrashEntries(ctx, req, fn, listRV, lastSeenName)
+		return k.processTrashEntries(ctx, req, fn, listRV, lastSeenRV)
 	}
 
 	// Get all history entries by iterating through datastore keys
@@ -1471,44 +1471,21 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 // processTrashEntries handles the special case of listing deleted items (trash).
 // It streams through keys in ascending order, tracking name groups. For each name,
 // if the latest event is a delete, it's a trash candidate.
+//
+// The results are sorted by RV desc: the sorting in this case matters as it's
+// the only convenient place to sort results by RV using the datastore before
+// doing a BatchGet to fetch the resources. Existing user-facing features (such as
+// Restore Dashboards) currently rely on this behaviour.
 func (k *kvStorageBackend) processTrashEntries(
 	ctx context.Context,
 	req *resourcepb.ListRequest,
 	fn func(ListIterator) error,
 	listRV int64,
-	lastSeenName string,
+	lastSeenRV int64,
 ) (int64, error) {
 	reqKey := req.Options.Key
 
 	listKey := ListRequestKey{Group: reqKey.Group, Resource: reqKey.Resource, Namespace: reqKey.Namespace, Name: reqKey.Name}
-	startKey := listKey
-	if lastSeenName != "" {
-		// If we are continuing from a previous name (pagination), the start
-		// key should include the name, but the end key should not.
-		startKey.Name = lastSeenName
-	}
-
-	listOptions := ListOptions{
-		StartKey: startKey.Prefix(),
-		EndKey:   PrefixRangeEnd(listKey.Prefix()),
-		Sort:     SortOrderAsc,
-	}
-	keysIter := func(yield func(DataKey, error) bool) {
-		for rawKey, err := range k.dataStore.kv.Keys(ctx, dataSection, listOptions) {
-			if err != nil {
-				yield(DataKey{}, err)
-				return
-			}
-			dk, err := ParseKey(rawKey)
-			if err != nil {
-				yield(DataKey{}, err)
-				return
-			}
-			if !yield(dk, nil) {
-				return
-			}
-		}
-	}
 
 	// Stream through keys, tracking name groups to find trash candidates
 	candidates := make([]DataKey, 0, min(defaultListBufferSize, req.Limit+1))
@@ -1517,11 +1494,6 @@ func (k *kvStorageBackend) processTrashEntries(
 
 	processNameGroup := func() {
 		if latestKey == nil {
-			return
-		}
-		// When resuming from continue token, skip entries for lastSeenName
-		// (the trash candidate for that name was already yielded)
-		if lastSeenName != "" && latestKey.Name == lastSeenName {
 			return
 		}
 		// Only include if the latest event for this name is a delete (i.e., resource is in trash)
@@ -1535,7 +1507,7 @@ func (k *kvStorageBackend) processTrashEntries(
 		candidates = append(candidates, *latestKey)
 	}
 
-	for dk, err := range keysIter {
+	for dk, err := range k.dataStore.Keys(ctx, listKey, SortOrderAsc) {
 		if err != nil {
 			return 0, err
 		}
@@ -1553,6 +1525,15 @@ func (k *kvStorageBackend) processTrashEntries(
 	}
 	// Process the final name group
 	processNameGroup()
+
+	// Sort candidates by resource version descending so the most recently
+	// deleted items come first.
+	slices.SortFunc(candidates, func(a, b DataKey) int {
+		return cmp.Compare(b.ResourceVersion, a.ResourceVersion)
+	})
+
+	// Apply RV-based pagination: skip candidates already seen on previous pages.
+	candidates = applyPagination(candidates, lastSeenRV)
 
 	// Create pull-style iterator from BatchGet
 	next, stop := iter.Pull2(k.dataStore.BatchGet(ctx, candidates))

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -2973,7 +2973,7 @@ func TestKvStorageBackend_ListHistory_Behaviour(t *testing.T) {
 			}
 
 			// Page through with limit=2
-			var allItems []historyItem
+			var allNames []string
 			nextToken := ""
 			for range numResources {
 				req := &resourcepb.ListRequest{
@@ -3008,30 +3008,21 @@ func TestKvStorageBackend_ListHistory_Behaviour(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				allItems = append(allItems, items...)
+				for _, it := range items {
+					allNames = append(allNames, it.name)
+				}
 
 				if nextToken == "" {
 					break
 				}
 			}
 
-			require.Len(t, allItems, numResources)
+			require.Len(t, allNames, numResources)
 
-			// Verify all expected names are present.
-			allNames := make([]string, 0, len(allItems))
-			for _, it := range allItems {
-				allNames = append(allNames, it.name)
-			}
-			slices.Sort(allNames)
-			slices.Sort(expectedNames)
+			// The names collected should be the reverse of `expectedNames`
+			// (i.e., in RV desc order)
+			slices.Reverse(expectedNames)
 			require.Equal(t, expectedNames, allNames)
-
-			// Verify results are in RV descending order across all pages.
-			for i := 1; i < len(allItems); i++ {
-				require.Greater(t, allItems[i-1].rv, allItems[i].rv,
-					"expected RV descending order, but item %d (rv=%d) <= item %d (rv=%d)",
-					i-1, allItems[i-1].rv, i, allItems[i].rv)
-			}
 		})
 	}
 }

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1600,101 +1600,96 @@ func TestKvStorageBackend_ListTrash_Success(t *testing.T) {
 	backend := setupTestStorageBackend(t)
 	ctx := context.Background()
 
-	// Create a resource
-	testObj, err := createTestObjectWithName("test-resource", appsNamespace, "test-data")
-	require.NoError(t, err)
+	// Helper to create, then delete a resource and return the delete RV.
+	createAndDelete := func(name string) int64 {
+		obj, err := createTestObjectWithName(name, appsNamespace, "data-"+name)
+		require.NoError(t, err)
+		meta, err := utils.MetaAccessor(obj)
+		require.NoError(t, err)
 
-	metaAccessor, err := utils.MetaAccessor(testObj)
-	require.NoError(t, err)
+		addRV, err := backend.WriteEvent(ctx, WriteEvent{
+			Type: resourcepb.WatchEvent_ADDED,
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default", Group: "apps", Resource: "resources", Name: name,
+			},
+			Value:  objectToJSONBytes(t, obj),
+			Object: meta,
+		})
+		require.NoError(t, err)
 
-	writeEvent := WriteEvent{
-		Type: resourcepb.WatchEvent_ADDED,
-		Key: &resourcepb.ResourceKey{
-			Namespace: "default",
-			Group:     "apps",
-			Resource:  "resources",
-			Name:      "test-resource",
-		},
-		Value:      objectToJSONBytes(t, testObj),
-		Object:     metaAccessor,
-		PreviousRV: 0,
+		delRV, err := backend.WriteEvent(ctx, WriteEvent{
+			Type: resourcepb.WatchEvent_DELETED,
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default", Group: "apps", Resource: "resources", Name: name,
+			},
+			Value:      objectToJSONBytes(t, obj),
+			Object:     meta,
+			ObjectOld:  meta,
+			PreviousRV: addRV,
+		})
+		require.NoError(t, err)
+		return delRV
 	}
 
-	rv1, err := backend.WriteEvent(ctx, writeEvent)
-	require.NoError(t, err)
+	// Create and delete three resources. Names are alphabetical, but delete
+	// order (and therefore RV order) is: resource-a, resource-b, resource-c.
+	rvA := createAndDelete("resource-a")
+	rvB := createAndDelete("resource-b")
+	rvC := createAndDelete("resource-c")
 
-	// Delete the resource
-	writeEvent.Type = resourcepb.WatchEvent_DELETED
-	writeEvent.PreviousRV = rv1
-	writeEvent.Object = metaAccessor
-	writeEvent.ObjectOld = metaAccessor
-
-	rv2, err := backend.WriteEvent(ctx, writeEvent)
+	// Also create a provisioned object — it should be filtered out.
+	provObj, err := createTestObjectWithName("provisioned-obj", appsNamespace, "test-data")
 	require.NoError(t, err)
-
-	// Do the same for a provisioned object
-	provisionedObj, err := createTestObjectWithName("provisioned-obj", appsNamespace, "test-data")
+	provMeta, err := utils.MetaAccessor(provObj)
 	require.NoError(t, err)
-	metaAccessorProvisioned, err := utils.MetaAccessor(provisionedObj)
-	require.NoError(t, err)
-	metaAccessorProvisioned.SetAnnotation(utils.AnnoKeyManagerKind, "repo")
+	provMeta.SetAnnotation(utils.AnnoKeyManagerKind, "repo")
 
-	writeEventProvisioned := WriteEvent{
+	provAddRV, err := backend.WriteEvent(ctx, WriteEvent{
 		Type: resourcepb.WatchEvent_ADDED,
 		Key: &resourcepb.ResourceKey{
-			Namespace: "default",
-			Group:     "apps",
-			Resource:  "resources",
-			Name:      "provisioned-obj",
+			Namespace: "default", Group: "apps", Resource: "resources", Name: "provisioned-obj",
 		},
-		Value:      objectToJSONBytes(t, provisionedObj),
-		Object:     metaAccessorProvisioned,
-		PreviousRV: 0,
-	}
-
-	rv3, err := backend.WriteEvent(ctx, writeEventProvisioned)
+		Value:  objectToJSONBytes(t, provObj),
+		Object: provMeta,
+	})
+	require.NoError(t, err)
+	_, err = backend.WriteEvent(ctx, WriteEvent{
+		Type: resourcepb.WatchEvent_DELETED,
+		Key: &resourcepb.ResourceKey{
+			Namespace: "default", Group: "apps", Resource: "resources", Name: "provisioned-obj",
+		},
+		Value:      objectToJSONBytes(t, provObj),
+		Object:     provMeta,
+		ObjectOld:  provMeta,
+		PreviousRV: provAddRV,
+	})
 	require.NoError(t, err)
 
-	writeEventProvisioned.Type = resourcepb.WatchEvent_DELETED
-	writeEventProvisioned.PreviousRV = rv3
-	writeEventProvisioned.Object = metaAccessorProvisioned
-	writeEventProvisioned.ObjectOld = metaAccessorProvisioned
-	_, err = backend.WriteEvent(ctx, writeEventProvisioned)
-	require.NoError(t, err)
-
-	// List the trash (deleted items)
+	// List all trash items — should be sorted by RV DESC.
 	listReq := &resourcepb.ListRequest{
 		Options: &resourcepb.ListOptions{
 			Key: &resourcepb.ResourceKey{
-				Namespace: "default",
-				Group:     "apps",
-				Resource:  "resources",
-				Name:      "test-resource",
+				Namespace: "default", Group: "apps", Resource: "resources",
 			},
 		},
 		Source: resourcepb.ListRequest_TRASH,
 		Limit:  10,
 	}
 
-	var trashItems []struct {
+	type trashItem struct {
 		name            string
 		resourceVersion int64
-		value           []byte
 	}
+	var items []trashItem
 
 	rv, err := backend.ListHistory(ctx, listReq, func(iter ListIterator) error {
 		for iter.Next() {
 			if err := iter.Error(); err != nil {
 				return err
 			}
-			trashItems = append(trashItems, struct {
-				name            string
-				resourceVersion int64
-				value           []byte
-			}{
+			items = append(items, trashItem{
 				name:            iter.Name(),
 				resourceVersion: iter.ResourceVersion(),
-				value:           iter.Value(),
 			})
 		}
 		return iter.Error()
@@ -1702,12 +1697,16 @@ func TestKvStorageBackend_ListTrash_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Greater(t, rv, int64(0))
-	require.Len(t, trashItems, 1) // Should have the non-provisioned deleted item
+	// Provisioned item is filtered out, leaving 3 non-provisioned items.
+	require.Len(t, items, 3)
 
-	// Verify the trash item
-	require.Equal(t, "test-resource", trashItems[0].name)
-	require.Equal(t, rv2, trashItems[0].resourceVersion)
-	require.Equal(t, objectToJSONBytes(t, testObj), trashItems[0].value)
+	// Verify RV descending order: resource-c (highest RV) first.
+	require.Equal(t, "resource-c", items[0].name)
+	require.Equal(t, rvC, items[0].resourceVersion)
+	require.Equal(t, "resource-b", items[1].name)
+	require.Equal(t, rvB, items[1].resourceVersion)
+	require.Equal(t, "resource-a", items[2].name)
+	require.Equal(t, rvA, items[2].resourceVersion)
 }
 
 func TestKvStorageBackend_GetResourceStats_Success(t *testing.T) {
@@ -2974,7 +2973,7 @@ func TestKvStorageBackend_ListHistory_Behaviour(t *testing.T) {
 			}
 
 			// Page through with limit=2
-			var allNames []string
+			var allItems []historyItem
 			nextToken := ""
 			for range numResources {
 				req := &resourcepb.ListRequest{
@@ -3009,19 +3008,30 @@ func TestKvStorageBackend_ListHistory_Behaviour(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				for _, it := range items {
-					allNames = append(allNames, it.name)
-				}
+				allItems = append(allItems, items...)
 
 				if nextToken == "" {
 					break
 				}
 			}
 
-			require.Len(t, allNames, numResources)
+			require.Len(t, allItems, numResources)
+
+			// Verify all expected names are present.
+			allNames := make([]string, 0, len(allItems))
+			for _, it := range allItems {
+				allNames = append(allNames, it.name)
+			}
 			slices.Sort(allNames)
 			slices.Sort(expectedNames)
 			require.Equal(t, expectedNames, allNames)
+
+			// Verify results are in RV descending order across all pages.
+			for i := 1; i < len(allItems); i++ {
+				require.Greater(t, allItems[i-1].rv, allItems[i].rv,
+					"expected RV descending order, but item %d (rv=%d) <= item %d (rv=%d)",
+					i-1, allItems[i-1].rv, i, allItems[i].rv)
+			}
 		})
 	}
 }


### PR DESCRIPTION
We were initially planning to sort these by name (the natural sorting in the KV datastore) and let the client (frontend) apply any sorting on their end. Unfortunately, that doesn't quite work because of the page size limits we have in the resource server:

https://github.com/grafana/grafana/blob/361e52858550d69d77c6a4871213fd1bc6816d99/pkg/storage/unified/resource/server.go#L1377

As a result, the client will only see a small subset of deleted dashboards in larger instances, and sorting by RV in the client wouldn't be useful.