### PR TITLE
Alerting: Route API access control attirbutes

### DIFF
--- a/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/routingtree_ext.go
+++ b/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/routingtree_ext.go
@@ -22,3 +22,10 @@ func (o *RoutingTree) SetProvenanceStatus(status string) {
 	}
 	o.Annotations[ProvenanceStatusAnnotationKey] = status
 }
+
+func (o *RoutingTree) SetAccessControl(action string) {
+	if o.Annotations == nil {
+		o.Annotations = make(map[string]string, 1)
+	}
+	o.Annotations[AccessControlAnnotation(action)] = "true"
+}

--- a/pkg/registry/apps/alerting/notifications/register.go
+++ b/pkg/registry/apps/alerting/notifications/register.go
@@ -131,7 +131,7 @@ func (a AppInstaller) GetLegacyStorage(gvr schema.GroupVersionResource) grafanar
 		}
 		return templategroup.NewStorage(srv, namespacer)
 	case routingtree.ResourceInfo.GroupResource().Resource:
-		return routingtree.NewStorage(api.RouteService, namespacer)
+		return routingtree.NewStorage(api.RouteService, namespacer, api.RouteService)
 	}
 	panic("unknown legacy storage requested: " + gvr.String())
 }

--- a/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
@@ -15,16 +15,23 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, namespacer request.NamespaceMapper) (*model.RoutingTreeList, error) {
+func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, namespacer request.NamespaceMapper, accesses map[string]ngmodels.RoutePermissionSet) (*model.RoutingTreeList, error) {
 	result := &model.RoutingTreeList{
 		Items: make([]model.RoutingTree, 0, len(routes)),
 	}
 	for _, r := range routes {
-		k8sResource, err := ConvertToK8sResource(orgID, r, namespacer)
+		var access *ngmodels.RoutePermissionSet
+		if accesses != nil {
+			if a, ok := accesses[r.GetUID()]; ok {
+				access = &a
+			}
+		}
+		k8sResource, err := ConvertToK8sResource(orgID, r, namespacer, access)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert route %q to k8s resource: %w", r.Name, err)
 		}
@@ -33,7 +40,7 @@ func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, nam
 	return result, nil
 }
 
-func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, namespacer request.NamespaceMapper) (*model.RoutingTree, error) {
+func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, namespacer request.NamespaceMapper, access *ngmodels.RoutePermissionSet) (*model.RoutingTree, error) {
 	spec := model.RoutingTreeSpec{
 		Defaults: model.RoutingTreeRouteDefaults{
 			GroupBy:        r.GroupBy,
@@ -63,9 +70,26 @@ func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, namespace
 		},
 		Spec: spec,
 	}
+	if access != nil {
+		for _, action := range ngmodels.RoutePermissions() {
+			mappedAction, ok := permissionMapper[action]
+			if !ok {
+				return nil, fmt.Errorf("unknown action %v", action)
+			}
+			if can, _ := access.Has(action); can {
+				result.SetAccessControl(mappedAction)
+			}
+		}
+	}
 	result.SetProvenanceStatus(string(r.Provenance))
 	result.UID = gapiutil.CalculateClusterWideUID(result)
 	return result, nil
+}
+
+var permissionMapper = map[ngmodels.RoutePermission]string{
+	ngmodels.RoutePermissionAdmin:  "canAdmin",
+	ngmodels.RoutePermissionWrite:  "canWrite",
+	ngmodels.RoutePermissionDelete: "canDelete",
 }
 
 func convertRouteToK8sSubRoute(r *definitions.Route) model.RoutingTreeRoute {

--- a/pkg/registry/apps/alerting/notifications/routingtree/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/legacy_storage.go
@@ -31,10 +31,15 @@ type RouteService interface {
 	UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree definitions.Route, p alerting_models.Provenance, version string, user identity.Requester) (*legacy_storage.ManagedRoute, error)
 }
 
+type MetadataService interface {
+	AccessControlMetadata(ctx context.Context, user identity.Requester, receivers ...*legacy_storage.ManagedRoute) (map[string]alerting_models.RoutePermissionSet, error)
+}
+
 type legacyStorage struct {
 	service        RouteService
 	namespacer     request.NamespaceMapper
 	tableConverter rest.TableConvertor
+	metadata       MetadataService
 }
 
 func (s *legacyStorage) New() runtime.Object {
@@ -74,7 +79,12 @@ func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions
 	if err != nil {
 		return nil, err
 	}
-	return ConvertToK8sResources(orgId, managedRoutes, s.namespacer)
+
+	set, err := s.metadata.AccessControlMetadata(ctx, user, managedRoutes...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access control metadata: %w", err)
+	}
+	return ConvertToK8sResources(orgId, managedRoutes, s.namespacer, set)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -91,7 +101,16 @@ func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptio
 	if err != nil {
 		return nil, err
 	}
-	return ConvertToK8sResource(info.OrgID, &managedRoute, s.namespacer)
+
+	accesses, err := s.metadata.AccessControlMetadata(ctx, user, &managedRoute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access control metadata: %w", err)
+	}
+	var access *alerting_models.RoutePermissionSet
+	if a, ok := accesses[managedRoute.GetUID()]; ok {
+		access = &a
+	}
+	return ConvertToK8sResource(info.OrgID, &managedRoute, s.namespacer, access)
 }
 
 func (s *legacyStorage) Create(ctx context.Context,
@@ -126,7 +145,15 @@ func (s *legacyStorage) Create(ctx context.Context,
 		return nil, err
 	}
 
-	return ConvertToK8sResource(info.OrgID, created, s.namespacer)
+	accesses, err := s.metadata.AccessControlMetadata(ctx, user, created)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access control metadata: %w", err)
+	}
+	var access *alerting_models.RoutePermissionSet
+	if a, ok := accesses[created.GetUID()]; ok {
+		access = &a
+	}
+	return ConvertToK8sResource(info.OrgID, created, s.namespacer, access)
 }
 
 func (s *legacyStorage) Update(
@@ -175,7 +202,15 @@ func (s *legacyStorage) Update(
 		return nil, false, err
 	}
 
-	obj, err = ConvertToK8sResource(info.OrgID, updated, s.namespacer)
+	accesses, err := s.metadata.AccessControlMetadata(ctx, user, updated)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get access control metadata: %w", err)
+	}
+	var access *alerting_models.RoutePermissionSet
+	if a, ok := accesses[updated.GetUID()]; ok {
+		access = &a
+	}
+	obj, err = ConvertToK8sResource(info.OrgID, updated, s.namespacer, access)
 	return obj, false, err
 }
 

--- a/pkg/registry/apps/alerting/notifications/routingtree/storage.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/storage.go
@@ -7,10 +7,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 )
 
-func NewStorage(legacySvc RouteService, namespacer request.NamespaceMapper) grafanarest.Storage {
+func NewStorage(legacySvc RouteService, namespacer request.NamespaceMapper, metadata MetadataService) grafanarest.Storage {
 	return &legacyStorage{
 		service:        legacySvc,
 		namespacer:     namespacer,
 		tableConverter: rest.NewDefaultTableConvertor(ResourceInfo.GroupResource()),
+		metadata:       metadata,
 	}
 }

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -499,6 +499,8 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext) *navtree.Na
 		ac.EvalPermission(ac.ActionAlertingRoutesWrite),
 		ac.EvalPermission(ac.ActionAlertingNotificationsTimeIntervalsRead),
 		ac.EvalPermission(ac.ActionAlertingNotificationsTimeIntervalsWrite),
+		ac.EvalPermission(ac.ActionAlertingManagedRoutesRead),
+		ac.EvalPermission(ac.ActionAlertingManagedRoutesWrite),
 	}
 
 	hasContactPointsAccess := hasAccess(ac.EvalAny(contactPointsPerms...))

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -45,6 +45,7 @@ type routeAccessControl interface {
 	AuthorizeDeleteByUID(ctx context.Context, user identity.Requester, uid string) error
 	SetDefaultPermissions(ctx context.Context, user identity.Requester, route *legacy_storage.ManagedRoute) error
 	DeleteAllPermissions(ctx context.Context, orgID int64, route *legacy_storage.ManagedRoute) error
+	Access(ctx context.Context, user identity.Requester, routes ...*legacy_storage.ManagedRoute) (map[string]models.RoutePermissionSet, error)
 }
 
 type Service struct {
@@ -57,6 +58,24 @@ type Service struct {
 	FeatureToggles  featuremgmt.FeatureToggles
 	tracer          tracing.Tracer
 	routeAccess     routeAccessControl
+}
+
+func (nps *Service) AccessControlMetadata(ctx context.Context, user identity.Requester, routes ...*legacy_storage.ManagedRoute) (map[string]models.RoutePermissionSet, error) {
+	permissions, err := nps.routeAccess.Access(ctx, user, routes...)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range routes {
+		if m.Origin == models.ResourceOriginGrafana {
+			continue
+		}
+		perms := permissions[m.GetUID()]
+		perms.Set(models.RoutePermissionAdmin, false)
+		perms.Set(models.RoutePermissionWrite, false)
+		perms.Set(models.RoutePermissionDelete, false)
+		permissions[m.GetUID()] = perms
+	}
+	return permissions, nil
 }
 
 func NewService(

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -378,8 +378,10 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		if err := nps.routeAccess.DeleteAllPermissions(ctx, orgID, existing); err != nil {
-			return err
+		if action == "Deleted" { // do not delete permissions on reset of default route
+			if err := nps.routeAccess.DeleteAllPermissions(ctx, orgID, existing); err != nil {
+				return err
+			}
 		}
 		return nps.provenanceStore.DeleteProvenance(ctx, existing, orgID)
 	})

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -378,7 +378,7 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		if action == "Deleted" { // do not delete permissions on reset of default route
+		if name != legacy_storage.UserDefinedRoutingTreeName { // do not delete permissions on reset of default route
 			if err := nps.routeAccess.DeleteAllPermissions(ctx, orgID, existing); err != nil {
 				return err
 			}

--- a/pkg/services/ngalert/notifier/routes/service_test.go
+++ b/pkg/services/ngalert/notifier/routes/service_test.go
@@ -57,7 +57,9 @@ func createServiceSut(
 		provenanceStore: provStore,
 		xact:            &nopTransactionManager{},
 		log:             log.NewNopLogger(),
-		settings:        setting.UnifiedAlertingSettings{},
+		settings: setting.UnifiedAlertingSettings{
+			DefaultConfiguration: setting.GetAlertmanagerDefaultConfiguration(),
+		},
 		validator: func(from, to models.Provenance) error {
 			return nil
 		},
@@ -101,6 +103,7 @@ func configRevisionWithManagedRoutes() *legacy_storage.ConfigRevision {
 				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{Receiver: definitions.Receiver{Name: "grafana-default"}},
+					{Receiver: definitions.Receiver{Name: "empty"}},
 				},
 			},
 			ManagedRoutes: definitions.ManagedRoutes{
@@ -443,5 +446,22 @@ func TestDeleteManagedRoute(t *testing.T) {
 		err := sut.DeleteManagedRoute(context.Background(), orgID, "route-a", models.ProvenanceNone, "", user)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"AuthorizeDeleteByUID", "DeleteAllPermissions"}, authz.Calls.Methods())
+	})
+
+	t.Run("does not delete permissions when reset the default route", func(t *testing.T) {
+		rev := configRevisionWithManagedRoutes()
+		configStore := &legacy_storage.AlertmanagerConfigStoreFake{
+			GetFn: func(_ context.Context, _ int64) (*legacy_storage.ConfigRevision, error) {
+				return rev, nil
+			},
+		}
+		provStore := fakes.NewFakeProvisioningStore()
+		features := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies)
+		authz := &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{}
+		sut := createServiceSut(configStore, provStore, features, authz)
+
+		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, models.ProvenanceNone, "", user)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"AuthorizeDeleteByUID"}, authz.Calls.Methods())
 	})
 }

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -317,6 +317,41 @@ func (a apiClient) AssignReceiverPermission(t *testing.T, receiverUID string, cm
 	return resp.StatusCode, string(b)
 }
 
+func (a apiClient) AssignRoutePermission(t *testing.T, routeUID string, cmd accesscontrol.SetResourcePermissionCommand) (int, string) {
+	t.Helper()
+
+	var assignment string
+	var assignTo string
+	if cmd.UserID != 0 {
+		assignment = "users"
+		assignTo = fmt.Sprintf("%d", cmd.UserID)
+	} else if cmd.TeamID != 0 {
+		assignment = "teams"
+		assignTo = fmt.Sprintf("%d", cmd.TeamID)
+	} else {
+		assignment = "builtInRoles"
+		assignTo = cmd.BuiltinRole
+	}
+
+	body := strings.NewReader(fmt.Sprintf(`{"permission": "%s"}`, cmd.Permission))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/access-control/%s/%s/%s/%s", a.url, accesscontrol.AlertingRoutesResource, routeUID, assignment, assignTo), body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return resp.StatusCode, string(b)
+}
+
 // CreateFolder creates a folder for storing our alerts, and then refreshes the permission cache to make sure that following requests will be accepted
 func (a apiClient) CreateFolder(t *testing.T, uID string, title string, parentUID ...string) {
 	t.Helper()

--- a/pkg/tests/apis/alerting/notifications/common/testing.go
+++ b/pkg/tests/apis/alerting/notifications/common/testing.go
@@ -71,7 +71,7 @@ func UpdateDefaultRoute(t *testing.T, user apis.User, r *definitions.Route) {
 	require.NoError(t, err)
 	route := legacy_storage.NewManagedRoute(v1beta1.UserDefinedRoutingTreeName, r)
 	route.Version = "" // Avoid version conflict.
-	v1route, err := routingtree.ConvertToK8sResource(user.Identity.GetOrgID(), route, func(int64) string { return apis.DefaultNamespace })
+	v1route, err := routingtree.ConvertToK8sResource(user.Identity.GetOrgID(), route, func(int64) string { return apis.DefaultNamespace }, nil)
 	require.NoError(t, err)
 	_, err = routeClient.Update(context.Background(), v1route, resource.UpdateOptions{})
 	require.NoError(t, err)

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -907,7 +907,7 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 
 		assert.Equal(t, expectedRoute.Spec, gotRoute.Spec)
 		assert.Equal(t, expectedRoute.TypeMeta, gotRoute.TypeMeta)
-		assert.Equal(t, expectedRoute.ObjectMeta.Name, gotRoute.ObjectMeta.Name)
+		assert.Equal(t, expectedRoute.Name, gotRoute.Name)
 	}
 
 	t.Run("Create", func(t *testing.T) {

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -529,7 +529,7 @@ func TestIntegrationDataConsistency(t *testing.T) {
 		require.NoError(t, err)
 		managedRoute := legacy_storage.NewManagedRoute(v1beta1.UserDefinedRoutingTreeName, &route)
 		managedRoute.Version = "" // Avoid version conflict.
-		v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.Admin.Identity.GetOrgID(), managedRoute, func(int64) string { return "default" })
+		v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.Admin.Identity.GetOrgID(), managedRoute, func(int64) string { return "default" }, nil)
 		require.NoError(t, err)
 		_, err = routeClient.Update(ctx, v1Route, resource.UpdateOptions{})
 		require.NoError(t, err)
@@ -904,7 +904,10 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 		t.Helper()
 		gotRoute, err := adminClient.Get(ctx, nameToIdentifier(name))
 		require.NoError(t, err)
-		assert.Equal(t, expectedRoute, gotRoute)
+
+		assert.Equal(t, expectedRoute.Spec, gotRoute.Spec)
+		assert.Equal(t, expectedRoute.TypeMeta, gotRoute.TypeMeta)
+		assert.Equal(t, expectedRoute.ObjectMeta.Name, gotRoute.ObjectMeta.Name)
 	}
 
 	t.Run("Create", func(t *testing.T) {
@@ -1117,6 +1120,285 @@ func TestIntegrationMultipleRoutesCRUD(t *testing.T) {
 	})
 }
 
+// TestIntegrationResourcePermissions focuses on testing resource permissions for the alerting route resource. It
+// verifies that access is correctly set when creating resources and assigning permissions to users, teams, and roles.
+func TestIntegrationResourcePermissions(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := getTestHelper(t)
+
+	org1 := helper.Org1
+	noneUser := org1.None
+
+	creator := helper.CreateUser("routeCreator", apis.Org1, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions: []string{accesscontrol.ActionAlertingManagedRoutesCreate},
+		},
+	})
+
+	admin := org1.Admin
+	viewer := org1.Viewer
+	editor := org1.Editor
+	adminClient, err := v1beta1.NewRoutingTreeClientFromGenerator(admin.GetClientRegistry())
+	require.NoError(t, err)
+
+	writeACMetadata := []string{"canWrite", "canDelete"}
+	allACMetadata := []string{"canWrite", "canDelete", "canAdmin"}
+
+	mustID := func(user apis.User) int64 {
+		id, err := user.Identity.GetInternalID()
+		require.NoError(t, err)
+		return id
+	}
+
+	for _, tc := range []struct {
+		name          string
+		creatingUser  apis.User
+		testUser      apis.User
+		assignments   []accesscontrol.SetResourcePermissionCommand
+		expACMetadata []string
+		expRead       bool
+		expUpdate     bool
+		expDelete     bool
+	}{
+		// Basic access.
+		{
+			name:          "Admin creates and has all access",
+			creatingUser:  admin,
+			testUser:      admin,
+			expACMetadata: allACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		{
+			name:          "Creator creates and has all access",
+			creatingUser:  creator,
+			testUser:      creator,
+			expACMetadata: allACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		{
+			name:          "Admin creates, noneUser has no access",
+			creatingUser:  admin,
+			testUser:      noneUser,
+			expACMetadata: nil,
+		},
+		{
+			name:          "Admin creates, viewer has read access",
+			creatingUser:  admin,
+			testUser:      viewer,
+			expACMetadata: nil,
+			expRead:       true,
+		},
+		{
+			name:          "Admin creates, editor has read and write access",
+			creatingUser:  admin,
+			testUser:      editor,
+			expACMetadata: writeACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		// User-based assignments.
+		{
+			name:          "Admin creates, assigns view, noneUser has read access",
+			creatingUser:  admin,
+			testUser:      noneUser,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{UserID: mustID(noneUser), Permission: string(models.PermissionView)}},
+			expACMetadata: nil,
+			expRead:       true,
+		},
+		{
+			name:          "Admin creates, assigns edit, noneUser has read+write+delete access",
+			creatingUser:  admin,
+			testUser:      noneUser,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{UserID: mustID(noneUser), Permission: string(models.PermissionEdit)}},
+			expACMetadata: writeACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		{
+			name:          "Admin creates, assigns admin, noneUser has all access",
+			creatingUser:  admin,
+			testUser:      noneUser,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{UserID: mustID(noneUser), Permission: string(models.PermissionAdmin)}},
+			expACMetadata: allACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		// Role-based access.
+		{
+			name:          "Admin creates, assigns edit, viewer has read+write+delete access",
+			creatingUser:  admin,
+			testUser:      viewer,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{UserID: mustID(viewer), Permission: string(models.PermissionEdit)}},
+			expACMetadata: writeACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		{
+			name:          "Admin creates, assigns admin, viewer has all access",
+			creatingUser:  admin,
+			testUser:      viewer,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{UserID: mustID(viewer), Permission: string(models.PermissionAdmin)}},
+			expACMetadata: allACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+		// Team-based access. Staff team has editor+admin but not viewer in it.
+		{
+			name:          "Admin creates, assigns admin to staff, viewer has read access only",
+			creatingUser:  admin,
+			testUser:      viewer,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{TeamID: org1.Staff.ID, Permission: string(models.PermissionAdmin)}},
+			expACMetadata: nil,
+			expRead:       true,
+		},
+		{
+			name:          "Admin creates, assigns admin to staff, editor has all access",
+			creatingUser:  admin,
+			testUser:      editor,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{TeamID: org1.Staff.ID, Permission: string(models.PermissionAdmin)}},
+			expACMetadata: allACMetadata,
+			expRead:       true,
+			expUpdate:     true,
+			expDelete:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			createClient, err := v1beta1.NewRoutingTreeClientFromGenerator(tc.creatingUser.GetClientRegistry())
+			require.NoError(t, err)
+			client, err := v1beta1.NewRoutingTreeClientFromGenerator(tc.testUser.GetClientRegistry())
+			require.NoError(t, err)
+
+			routeName := fmt.Sprintf("perm-test-%s", util.GenerateShortUID())
+			created, err := createClient.Create(ctx, k8sRoute(t, routeName, &defaultPolicy), resource.CreateOptions{})
+			require.NoError(t, err)
+
+			defer func() {
+				_ = adminClient.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+			}()
+
+			// Assign resource permissions.
+			cliCfg := helper.Org1.Admin.NewRestConfig()
+			alertingApi := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
+			for _, permission := range tc.assignments {
+				status, body := alertingApi.AssignRoutePermission(t, routeName, permission)
+				require.Equalf(t, http.StatusOK, status, "Expected status 200 but got %d: %s", status, body)
+			}
+
+			assertACMetadata := func(t *testing.T, annotations map[string]string) {
+				t.Helper()
+				for _, k := range allACMetadata {
+					key := v1beta1.AccessControlAnnotation(k)
+					var expected bool
+					for _, exp := range tc.expACMetadata {
+						if exp == k {
+							expected = true
+							break
+						}
+					}
+					if expected {
+						assert.Equalf(t, "true", annotations[key], "expected annotation %s to be set", key)
+					} else {
+						_, exists := annotations[key]
+						assert.Falsef(t, exists, "expected annotation %s to not be set", key)
+					}
+				}
+			}
+
+			if tc.expRead {
+				t.Run("should be able to read route", func(t *testing.T) {
+					got, err := client.Get(ctx, created.GetStaticMetadata().Identifier())
+					require.NoError(t, err)
+					assertACMetadata(t, got.Annotations)
+				})
+
+				t.Run("should see route in list with correct metadata", func(t *testing.T) {
+					list, err := client.List(ctx, apis.DefaultNamespace, resource.ListOptions{})
+					require.NoError(t, err)
+					var found bool
+					for _, item := range list.Items {
+						if item.Name == routeName {
+							found = true
+							assertACMetadata(t, item.Annotations)
+							break
+						}
+					}
+					assert.Truef(t, found, "expected route %s to be in list", routeName)
+				})
+			} else {
+				t.Run("should be forbidden to read route", func(t *testing.T) {
+					_, err := client.Get(ctx, created.GetStaticMetadata().Identifier())
+					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
+				})
+			}
+
+			if tc.expUpdate {
+				t.Run("should be able to update route", func(t *testing.T) {
+					current, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
+					require.NoError(t, err)
+					updated := current.Copy().(*v1beta1.RoutingTree)
+					updated.Spec.Routes = []v1beta1.RoutingTreeRoute{
+						{
+							Matchers: []v1beta1.RoutingTreeMatcher{
+								{
+									Label: "test",
+									Type:  v1beta1.RoutingTreeMatcherTypeEqual,
+									Value: "test",
+								},
+							},
+						},
+					}
+					_, err = client.Update(ctx, updated, resource.UpdateOptions{})
+					require.NoError(t, err)
+				})
+			} else {
+				t.Run("should be forbidden to update route", func(t *testing.T) {
+					current, err := adminClient.Get(ctx, created.GetStaticMetadata().Identifier())
+					require.NoError(t, err)
+					updated := current.Copy().(*v1beta1.RoutingTree)
+					updated.Spec.Routes = []v1beta1.RoutingTreeRoute{
+						{
+							Matchers: []v1beta1.RoutingTreeMatcher{
+								{
+									Label: "test",
+									Type:  v1beta1.RoutingTreeMatcherTypeEqual,
+									Value: "test",
+								},
+							},
+						},
+					}
+					_, err = client.Update(ctx, updated, resource.UpdateOptions{})
+					require.Error(t, err)
+					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
+				})
+			}
+
+			if tc.expDelete {
+				t.Run("should be able to delete route", func(t *testing.T) {
+					err := client.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+					require.NoError(t, err)
+				})
+			} else {
+				t.Run("should be forbidden to delete route", func(t *testing.T) {
+					err := client.Delete(ctx, created.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+					require.Error(t, err)
+					require.Truef(t, errors.IsForbidden(err), "should get Forbidden error but got %s", err)
+				})
+			}
+		})
+	}
+}
+
 func TestIntegrationMultipleRoutesReferentialIntegrity(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
@@ -1225,7 +1507,11 @@ func k8sRoute(t *testing.T, name string, r *definitions.Route) *v1beta1.RoutingT
 	err := r.Validate()
 	require.NoError(t, err)
 	managedRoute := legacy_storage.NewManagedRoute(name, r)
-	v1Route, err := routingtree.ConvertToK8sResource(-1, managedRoute, func(int64) string { return apis.DefaultNamespace })
+	allPermissions := models.NewRoutePermissionSet()
+	allPermissions.Set(models.RoutePermissionWrite, true)
+	allPermissions.Set(models.RoutePermissionDelete, true)
+	allPermissions.Set(models.RoutePermissionAdmin, true)
+	v1Route, err := routingtree.ConvertToK8sResource(-1, managedRoute, func(int64) string { return apis.DefaultNamespace }, &allPermissions)
 	require.NoError(t, err)
 	v1Route.TypeMeta = v1.TypeMeta{
 		Kind:       v1beta1.RoutingTreeKind().Kind(),


### PR DESCRIPTION
**What is this feature?**

- This is a follow up to https://github.com/grafana/grafana/pull/121034 
- adds annotations to `routingtree` resource that encode whether user has write\delete\admin access to a particular resource
- changes behavior for "delete" of the default route, which has in fact a "reset" semantic. The permissions are not deleted for the default route.
- adds integration tests for annotations and permissions assignments.

**Why do we need this feature?**
This PR concludes back-end changes for RBAC of managed routes. 