### PR TITLE
APIServer: Allow user to set preferred version

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -136,6 +136,13 @@ keepalive_time =
 keepalive_timeout =
 keepalive_min_time =
 
+#################################### Grafana API server (Kubernetes-style APIs) #########################
+[grafana-apiserver]
+# Comma-separated list of group/version entries. For each entry, discovery uses that version as the
+# preferred version for the group when that version is enabled (via default enablement or runtime_config).
+# Example: dashboard.grafana.app/v1, playlists.grafana.app/v1alpha1
+# preferred_api_version =
+
 #################################### Database ############################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -39,12 +39,12 @@ func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runt
 }
 
 func parseGroupVersionSetting(s string) (schema.GroupVersion, error) {
-	idx := strings.Index(s, "/")
-	if idx <= 0 || idx == len(s)-1 {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
 		return schema.GroupVersion{}, fmt.Errorf(
 			"invalid preferred_api_version entry %q (expected format is group/version, e.g. dashboard.grafana.app/v1)", s)
 	}
-	return schema.GroupVersion{Group: s[:idx], Version: s[idx+1:]}, nil
+	return schema.GroupVersion{Group: parts[0], Version: parts[1]}, nil
 }
 
 func applyPreferredForGroup(logger log.Logger, scheme *runtime.Scheme, apiResourceConfig *serverstorage.ResourceConfig, preferred schema.GroupVersion) error {

--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -1,0 +1,95 @@
+package apiserver
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// applyPreferredAPIVersions reorders scheme version priority when
+// [grafana-apiserver] preferred_api_version lists group/version entries.
+// Only applies when the preferred GroupVersion is present in the scheme and
+// enabled in apiResourceConfig (see ResourceEnabled for the empty resource).
+func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runtime.Scheme, apiResourceConfig *serverstorage.ResourceConfig) error {
+	raw := strings.TrimSpace(cfg.SectionWithEnvOverrides("grafana-apiserver").Key("preferred_api_version").String())
+	if raw == "" {
+		return nil
+	}
+
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		gv, err := parseGroupVersionSetting(part)
+		if err != nil {
+			return err
+		}
+		if err := applyPreferredForGroup(logger, scheme, apiResourceConfig, gv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseGroupVersionSetting(s string) (schema.GroupVersion, error) {
+	idx := strings.Index(s, "/")
+	if idx <= 0 || idx == len(s)-1 {
+		return schema.GroupVersion{}, fmt.Errorf(
+			"invalid preferred_api_version entry %q (expected format is group/version, e.g. dashboard.grafana.app/v1)", s)
+	}
+	return schema.GroupVersion{Group: s[:idx], Version: s[idx+1:]}, nil
+}
+
+func applyPreferredForGroup(logger log.Logger, scheme *runtime.Scheme, apiResourceConfig *serverstorage.ResourceConfig, preferred schema.GroupVersion) error {
+	group := preferred.Group
+	pvs := scheme.PrioritizedVersionsForGroup(group)
+	if len(pvs) == 0 {
+		logger.Info("preferred_api_version: unknown API group, skipping", "group", group)
+		return nil
+	}
+
+	found := false
+	for _, gv := range pvs {
+		if gv == preferred {
+			found = true
+			break
+		}
+	}
+	if !found {
+		logger.Info("preferred_api_version: version not registered for group, skipping",
+			"group", group, "version", preferred.Version)
+		return nil
+	}
+
+	if apiResourceConfig != nil {
+		gvr := preferred.WithResource("")
+		if !apiResourceConfig.ResourceEnabled(gvr) {
+			logger.Info("preferred_api_version: version is not enabled, skipping",
+				"groupVersion", preferred.String())
+			return nil
+		}
+	}
+
+	// preserve relative order of non-preferred versions.
+	reordered := make([]schema.GroupVersion, 0, len(pvs))
+	reordered = append(reordered, preferred)
+	for _, gv := range pvs {
+		if gv == preferred {
+			continue
+		}
+		reordered = append(reordered, gv)
+	}
+
+	if err := scheme.SetVersionPriority(reordered...); err != nil {
+		return fmt.Errorf("preferred_api_version for %s: %w", group, err)
+	}
+	logger.Info("set preferred API version for group", "group", group, "preferredVersion", preferred.Version)
+	return nil
+}

--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -40,7 +40,7 @@ func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runt
 
 func parseGroupVersionSetting(s string) (schema.GroupVersion, error) {
 	parts := strings.Split(s, "/")
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return schema.GroupVersion{}, fmt.Errorf(
 			"invalid preferred_api_version entry %q (expected format is group/version, e.g. dashboard.grafana.app/v1)", s)
 	}

--- a/pkg/services/apiserver/preferred_version_test.go
+++ b/pkg/services/apiserver/preferred_version_test.go
@@ -1,0 +1,65 @@
+package apiserver
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+func TestParseGroupVersionSetting(t *testing.T) {
+	gv, err := parseGroupVersionSetting("dashboard.grafana.app/v1")
+	require.NoError(t, err)
+	require.Equal(t, "dashboard.grafana.app", gv.Group)
+	require.Equal(t, "v1", gv.Version)
+
+	_, err = parseGroupVersionSetting("novslash")
+	require.Error(t, err)
+
+	_, err = parseGroupVersionSetting("/v1")
+	require.Error(t, err)
+}
+
+func TestApplyPreferredForGroup_ReordersVersions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvAlpha := schema.GroupVersion{Group: "test.example", Version: "v1alpha1"}
+	gvStable := schema.GroupVersion{Group: "test.example", Version: "v1"}
+	metav1.AddToGroupVersion(scheme, gvAlpha)
+	metav1.AddToGroupVersion(scheme, gvStable)
+	require.NoError(t, scheme.SetVersionPriority(gvAlpha, gvStable))
+
+	rc := serverstorage.NewResourceConfig()
+	rc.EnableVersions(gvAlpha, gvStable)
+
+	require.NoError(t, applyPreferredForGroup(log.NewNopLogger(), scheme, rc, gvStable))
+
+	pvs := scheme.PrioritizedVersionsForGroup("test.example")
+	require.Len(t, pvs, 2)
+	require.Equal(t, "v1", pvs[0].Version)
+	require.Equal(t, "v1alpha1", pvs[1].Version)
+}
+
+func TestApplyPreferredForGroup_SkipsWhenDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gvAlpha := schema.GroupVersion{Group: "test.example", Version: "v1alpha1"}
+	gvStable := schema.GroupVersion{Group: "test.example", Version: "v1"}
+	metav1.AddToGroupVersion(scheme, gvAlpha)
+	metav1.AddToGroupVersion(scheme, gvStable)
+	require.NoError(t, scheme.SetVersionPriority(gvAlpha, gvStable))
+
+	rc := serverstorage.NewResourceConfig()
+	rc.EnableVersions(gvAlpha)
+	rc.DisableVersions(gvStable)
+
+	require.NoError(t, applyPreferredForGroup(log.NewNopLogger(), scheme, rc, gvStable))
+
+	pvs := scheme.PrioritizedVersionsForGroup("test.example")
+	require.Len(t, pvs, 2)
+	require.Equal(t, "v1alpha1", pvs[0].Version, "unchanged order when preferred is disabled")
+}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -326,6 +326,10 @@ func (s *service) start(ctx context.Context) error {
 		return err
 	}
 
+	if err := applyPreferredAPIVersions(s.log, s.cfg, s.scheme, apiResourceConfig); err != nil {
+		return err
+	}
+
 	serverConfig.Authorization.Authorizer = s.authorizer
 	serverConfig.Authentication.Authenticator = authenticator.NewAuthenticator(serverConfig.Authentication.Authenticator)
 	serverConfig.TracerProvider = s.tracing.GetTracerProvider()
@@ -462,7 +466,7 @@ func (s *service) start(ctx context.Context) error {
 			if !isDataplaneAggregatorEnabled {
 				runningServer, err = s.aggregatorRunner.Run(ctx, transport, s.stoppedCh)
 				if err != nil {
-					s.log.Error("aggregator runner failed to run", "error", err)
+					s.log.Error("aggregator runner failed to run", "err", err)
 					return err
 				}
 			} else {


### PR DESCRIPTION
This PR allows users to set preferred versions for various api groups, e.g.:

<img width="462" height="117" alt="Screenshot 2026-03-26 at 3 01 52 PM" src="https://github.com/user-attachments/assets/8fa1aa0f-1f09-4b0b-a299-bfb4f5026ddf" />

<img width="607" height="624" alt="Screenshot 2026-03-26 at 3 01 25 PM" src="https://github.com/user-attachments/assets/b67d055e-7cab-4ae0-93a6-a3a52ce598db" />
