### PR TITLE
dashboard versions: remove pagination and display up to 20 versions

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { SceneTimeRange } from '@grafana/scenes';
-import { VERSIONS_FETCH_LIMIT } from 'app/features/dashboard/types/revisionModels';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { activateFullSceneTree } from '../utils/test-utils';
@@ -72,6 +71,23 @@ describe('VersionsEditView', () => {
       expect(versions[2].ageString).toBeDefined();
     });
 
+    it('should sort versions by generation descending regardless of input order', async () => {
+      mockListDashboardHistory.mockResolvedValueOnce({
+        metadata: { continue: '' },
+        items: [
+          createTestResource(1, '2017-02-20T17:43:01-08:00'),
+          createTestResource(5, '2017-02-24T17:43:01-08:00'),
+          createTestResource(3, '2017-02-22T17:43:01-08:00'),
+          createTestResource(2, '2017-02-21T17:43:01-08:00'),
+          createTestResource(4, '2017-02-23T17:43:01-08:00'),
+        ],
+      });
+
+      const { versionsView: view } = await buildTestScene();
+
+      expect(view.versions.map((v) => v.version)).toEqual([5, 4, 3, 2, 1]);
+    });
+
     it('should set the state of a version as checked when onCheck is called', () => {
       versionsView.onCheck(mockEvent, 3);
 
@@ -116,35 +132,6 @@ describe('VersionsEditView', () => {
       versionsView.getDiff();
 
       expect(versionsView.state.isNewLatest).toBe(true);
-    });
-
-    it('should correctly identify last page when partial page is returned without version 1', async () => {
-      mockListDashboardHistory.mockResolvedValueOnce({
-        metadata: { continue: '' },
-        items: [createTestResource(4, '2017-02-22T17:43:01-08:00'), createTestResource(3, '2017-02-22T17:43:01-08:00')],
-      });
-
-      versionsView.reset();
-      versionsView.fetchVersions();
-      await new Promise(process.nextTick);
-
-      expect(versionsView.versions.length).toBeLessThan(VERSIONS_FETCH_LIMIT);
-      expect(versionsView.versions.find((rev) => rev.version === 1)).toBeUndefined();
-    });
-
-    it('should correctly identify last page when continueToken is empty', async () => {
-      mockListDashboardHistory.mockResolvedValueOnce({
-        metadata: { continue: '' },
-        items: [createTestResource(4, '2017-02-22T17:43:01-08:00'), createTestResource(3, '2017-02-22T17:43:01-08:00')],
-      });
-
-      versionsView.reset();
-      versionsView.fetchVersions();
-      await new Promise(process.nextTick);
-
-      expect(versionsView.versions.length).toBeLessThan(VERSIONS_FETCH_LIMIT);
-      expect(versionsView.versions.find((rev) => rev.version === 1)).toBeUndefined();
-      expect(versionsView.continueToken).toBe('');
     });
   });
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -244,12 +244,7 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
           isLoadingUserDisplayNames={isLoadingUserDisplayNames}
         />
       )}
-      {showButtons && (
-        <VersionsHistoryButtons
-          canCompare={canCompare}
-          getDiff={model.getDiff}
-        />
-      )}
+      {showButtons && <VersionsHistoryButtons canCompare={canCompare} getDiff={model.getDiff} />}
     </>
   );
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -73,10 +73,6 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
     return this.state.versions ?? [];
   }
 
-  public get limit(): number {
-    return this._limit;
-  }
-
   public getUrlKey(): string {
     return 'versions';
   }

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -35,7 +35,6 @@ import { VersionHistoryTable } from './version-history/VersionHistoryTable';
 export interface VersionsEditViewState extends DashboardEditViewState {
   versions?: DecoratedRevisionModel[];
   isLoading?: boolean;
-  isAppending?: boolean;
   viewMode?: 'list' | 'compare';
   diffData?: { lhs: object; rhs: object };
   newInfo?: DecoratedRevisionModel;
@@ -46,14 +45,12 @@ export interface VersionsEditViewState extends DashboardEditViewState {
 export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> implements DashboardEditView {
   public static Component = VersionsEditorSettingsListView;
   private _limit: number = VERSIONS_FETCH_LIMIT;
-  private _continueToken = '';
 
   constructor(state: VersionsEditViewState) {
     super({
       ...state,
       versions: [],
       isLoading: true,
-      isAppending: true,
       viewMode: 'list',
       isNewLatest: false,
       diffData: { lhs: {}, rhs: {} },
@@ -80,10 +77,6 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
     return this._limit;
   }
 
-  public get continueToken(): string {
-    return this._continueToken;
-  }
-
   public getUrlKey(): string {
     return 'versions';
   }
@@ -96,30 +89,24 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
     return sceneGraph.getTimeRange(this._dashboard);
   }
 
-  public fetchVersions = (append = false): void => {
+  public fetchVersions = (): void => {
     const uid = this._dashboard.state.uid;
 
     if (!uid) {
       return;
     }
 
-    this.setState({ isAppending: append });
-
-    const options = append ? { limit: this._limit, continueToken: this._continueToken } : { limit: this._limit };
-
     getDashboardAPI()
       .then(async (api) => {
-        const result = await api.listDashboardHistory(uid, options);
+        const result = await api.listDashboardHistory(uid, { limit: this._limit });
         const versions = this.transformToRevisionModels(result.items);
+        versions.sort((a, b) => b.version - a.version);
         this.setState({
           isLoading: false,
-          versions: [...(append ? (this.state.versions ?? []) : []), ...this.decorateVersions(versions)],
+          versions: this.decorateVersions(versions),
         });
-        // Update the continueToken for the next request, if available
-        this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
-      .finally(() => this.setState({ isAppending: false }));
+      .catch((err) => console.log(err));
   };
 
   private transformToRevisionModels(items: Array<Resource<unknown>>): RevisionModel[] {
@@ -158,7 +145,6 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
   };
 
   public reset = () => {
-    this._continueToken = '';
     this.setState({
       baseInfo: undefined,
       diffData: { lhs: {}, rhs: {} },
@@ -193,7 +179,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
 
 function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsEditView>) {
   const dashboard = model.getDashboard();
-  const { isLoading, isAppending, viewMode, baseInfo, newInfo, isNewLatest } = model.useState();
+  const { isLoading, viewMode, baseInfo, newInfo, isNewLatest } = model.useState();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
 
   const userKeys = useMemo(
@@ -222,12 +208,6 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
 
   const canCompare = model.versions.filter((version) => version.checked).length === 2;
   const showButtons = model.versions.length > 1;
-  const hasMore = model.versions.length >= model.limit;
-  // older versions may have been cleaned up in the db, so also check if the last page is less than the limit, if so, we are at the end
-  let isLastPage =
-    model.versions.find((rev) => rev.version === 1) ||
-    model.versions.length % model.limit !== 0 ||
-    model.continueToken === '';
 
   const viewModeCompare = (
     <>
@@ -264,14 +244,10 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
           isLoadingUserDisplayNames={isLoadingUserDisplayNames}
         />
       )}
-      {isAppending && <VersionsHistorySpinner msg="Fetching more entries&hellip;" />}
       {showButtons && (
         <VersionsHistoryButtons
-          hasMore={hasMore}
           canCompare={canCompare}
-          getVersions={model.fetchVersions}
           getDiff={model.getDiff}
-          isLastPage={!!isLastPage}
         />
       )}
     </>

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryButtons.test.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryButtons.test.tsx
@@ -20,10 +20,4 @@ describe('VersionHistoryButtons', () => {
     const compareButton = screen.getByRole('button', { name: /compare versions/i });
     expect(compareButton).toBeDisabled();
   });
-
-  it('does not render a show more versions button', () => {
-    render(<VersionsHistoryButtons canCompare={false} getDiff={jest.fn()} />);
-
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
-  });
 });

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryButtons.test.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryButtons.test.tsx
@@ -1,30 +1,29 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import { DashboardInteractions } from '../../utils/interactions';
-
 import { VersionsHistoryButtons } from './VersionHistoryButtons';
 
-jest.mock('../../utils/interactions', () => ({
-  DashboardInteractions: {
-    showMoreVersionsClicked: jest.fn(),
-  },
-}));
-
 describe('VersionHistoryButtons', () => {
-  it('triggers a user event when the show more versions is clicked', async () => {
-    render(
-      <VersionsHistoryButtons
-        getVersions={jest.fn()}
-        canCompare={true}
-        hasMore={true}
-        getDiff={jest.fn()}
-        isLastPage={false}
-      />
-    );
+  it('renders compare button enabled when canCompare is true', () => {
+    const getDiff = jest.fn();
+    render(<VersionsHistoryButtons canCompare={true} getDiff={getDiff} />);
 
-    const showMoreButton = screen.getByText('Show more versions');
-    fireEvent.click(showMoreButton);
+    const compareButton = screen.getByRole('button', { name: /compare versions/i });
+    expect(compareButton).toBeEnabled();
 
-    expect(DashboardInteractions.showMoreVersionsClicked).toHaveBeenCalledWith();
+    fireEvent.click(compareButton);
+    expect(getDiff).toHaveBeenCalled();
+  });
+
+  it('renders compare button disabled when canCompare is false', () => {
+    render(<VersionsHistoryButtons canCompare={false} getDiff={jest.fn()} />);
+
+    const compareButton = screen.getByRole('button', { name: /compare versions/i });
+    expect(compareButton).toBeDisabled();
+  });
+
+  it('does not render a show more versions button', () => {
+    render(<VersionsHistoryButtons canCompare={false} getDiff={jest.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryButtons.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryButtons.tsx
@@ -1,36 +1,13 @@
 import { Trans, t } from '@grafana/i18n';
 import { Tooltip, Button, Stack } from '@grafana/ui';
-import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
 type VersionsButtonsType = {
-  hasMore: boolean;
   canCompare: boolean;
-  getVersions: (append: boolean) => void;
   getDiff: () => void;
-  isLastPage: boolean;
 };
-export const VersionsHistoryButtons = ({
-  hasMore,
-  canCompare,
-  getVersions,
-  getDiff,
-  isLastPage,
-}: VersionsButtonsType) => {
+export const VersionsHistoryButtons = ({ canCompare, getDiff }: VersionsButtonsType) => {
   return (
     <Stack>
-      {hasMore && (
-        <Button
-          type="button"
-          onClick={() => {
-            getVersions(true);
-            DashboardInteractions.showMoreVersionsClicked();
-          }}
-          variant="secondary"
-          disabled={isLastPage}
-        >
-          <Trans i18nKey="dashboard-scene.versions-history-buttons.show-more-versions">Show more versions</Trans>
-        </Button>
-      )}
       <Tooltip
         content={t(
           'dashboard-scene.versions-history-buttons.content-select-two-versions-to-start-comparing',

--- a/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.test.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/VersionHistoryTable.test.tsx
@@ -9,7 +9,6 @@ import { VersionHistoryTable } from './VersionHistoryTable';
 jest.mock('../../utils/interactions', () => ({
   DashboardInteractions: {
     versionRestoreClicked: jest.fn(),
-    showMoreVersionsClicked: jest.fn(),
   },
 }));
 

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
@@ -190,8 +190,8 @@ describe('UnifiedDashboardAPI', () => {
 
       const result = await api.listDashboardHistory('dash-1');
 
-      expect(v1Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: undefined });
-      expect(v2Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: undefined });
+      expect(v1Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 20, continueToken: undefined });
+      expect(v2Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 20, continueToken: undefined });
       expect(result.items).toHaveLength(2);
       expect(result.items).toEqual(mockV2Response.items);
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -166,7 +166,7 @@ describe('VersionSettings', () => {
     const compareButton = screen.getByRole('button', { name: /compare versions/i });
     const tableBody = screen.getAllByRole('rowgroup')[1];
     await user.click(within(tableBody).getAllByRole('checkbox')[0]);
-    await user.click(within(tableBody).getAllByRole('checkbox')[versionsResourceList.items.length - 1]);
+    await user.click(within(tableBody).getAllByRole('checkbox')[versionsResourceList.items.length - 2]);
 
     expect(compareButton).toBeEnabled();
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -95,9 +95,39 @@ describe('VersionSettings', () => {
     mockListDashboardHistory.mockResolvedValue({
       metadata: { continue: '' },
       items: [
-        { apiVersion: 'v1', kind: 'Dashboard', metadata: { name: 'uid', generation: 1, creationTimestamp: '2021-01-01T00:00:00Z', annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' } }, spec: {} },
-        { apiVersion: 'v1', kind: 'Dashboard', metadata: { name: 'uid', generation: 5, creationTimestamp: '2021-01-05T00:00:00Z', annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' } }, spec: {} },
-        { apiVersion: 'v1', kind: 'Dashboard', metadata: { name: 'uid', generation: 3, creationTimestamp: '2021-01-03T00:00:00Z', annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' } }, spec: {} },
+        {
+          apiVersion: 'v1',
+          kind: 'Dashboard',
+          metadata: {
+            name: 'uid',
+            generation: 1,
+            creationTimestamp: '2021-01-01T00:00:00Z',
+            annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' },
+          },
+          spec: {},
+        },
+        {
+          apiVersion: 'v1',
+          kind: 'Dashboard',
+          metadata: {
+            name: 'uid',
+            generation: 5,
+            creationTimestamp: '2021-01-05T00:00:00Z',
+            annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' },
+          },
+          spec: {},
+        },
+        {
+          apiVersion: 'v1',
+          kind: 'Dashboard',
+          metadata: {
+            name: 'uid',
+            generation: 3,
+            creationTimestamp: '2021-01-03T00:00:00Z',
+            annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' },
+          },
+          spec: {},
+        },
       ],
     });
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -2,8 +2,6 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
-import { VERSIONS_FETCH_LIMIT } from 'app/features/dashboard/types/revisionModels';
-
 import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { VersionsSettings } from './VersionsSettings';
@@ -86,129 +84,48 @@ describe('VersionSettings', () => {
 
     setup();
 
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /compare versions/i })).not.toBeInTheDocument();
 
     await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
 
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /compare versions/i })).not.toBeInTheDocument();
   });
 
-  test('does not render show more button if versions < VERSIONS_FETCH_LIMIT', async () => {
+  test('sorts versions by generation descending regardless of backend order', async () => {
     mockListDashboardHistory.mockResolvedValue({
       metadata: { continue: '' },
-      items: versionsResourceList.items.slice(0, VERSIONS_FETCH_LIMIT - 5),
+      items: [
+        { apiVersion: 'v1', kind: 'Dashboard', metadata: { name: 'uid', generation: 1, creationTimestamp: '2021-01-01T00:00:00Z', annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' } }, spec: {} },
+        { apiVersion: 'v1', kind: 'Dashboard', metadata: { name: 'uid', generation: 5, creationTimestamp: '2021-01-05T00:00:00Z', annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' } }, spec: {} },
+        { apiVersion: 'v1', kind: 'Dashboard', metadata: { name: 'uid', generation: 3, creationTimestamp: '2021-01-03T00:00:00Z', annotations: { 'grafana.app/updatedBy': 'admin', 'grafana.app/message': '' } }, spec: {} },
+      ],
     });
 
     setup();
 
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /compare versions/i })).not.toBeInTheDocument();
-
     await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
 
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /compare versions/i })).toBeInTheDocument();
+    const tableBodyRows = within(screen.getAllByRole('rowgroup')[1]).getAllByRole('row');
+    // First row (highest generation) should have "Latest" tag
+    expect(within(tableBodyRows[0]).getByText(/latest/i)).toBeInTheDocument();
+    // Verify descending order by checking version numbers in the rows
+    expect(tableBodyRows[0]).toHaveTextContent('5');
+    expect(tableBodyRows[1]).toHaveTextContent('3');
+    expect(tableBodyRows[2]).toHaveTextContent('1');
   });
 
-  test('renders buttons if versions >= VERSIONS_FETCH_LIMIT', async () => {
-    mockListDashboardHistory.mockResolvedValue({
-      metadata: { continue: 'next-page-token' },
-      items: versionsResourceList.items.slice(0, VERSIONS_FETCH_LIMIT),
-    });
-
-    setup();
-
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /compare versions/i })).not.toBeInTheDocument();
-
-    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
-    const compareButton = screen.getByRole('button', { name: /compare versions/i });
-    const showMoreButton = screen.getByRole('button', { name: /show more versions/i });
-
-    expect(showMoreButton).toBeInTheDocument();
-    expect(showMoreButton).toBeEnabled();
-
-    expect(compareButton).toBeInTheDocument();
-    expect(compareButton).toBeDisabled();
-  });
-
-  test('clicking show more appends results to the table', async () => {
-    mockListDashboardHistory
-      .mockImplementationOnce(() =>
-        Promise.resolve({
-          metadata: { continue: 'next-page-token' },
-          items: versionsResourceList.items.slice(0, VERSIONS_FETCH_LIMIT),
-        })
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve({
-          metadata: { continue: '' },
-          items: versionsResourceList.items.slice(VERSIONS_FETCH_LIMIT),
-        })
-      );
-
-    setup();
-
-    await waitFor(() => expect(mockListDashboardHistory).toHaveBeenCalledTimes(1));
-
-    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
-
-    expect(within(screen.getAllByRole('rowgroup')[1]).getAllByRole('row').length).toBe(VERSIONS_FETCH_LIMIT);
-
-    const showMoreButton = screen.getByRole('button', { name: /show more versions/i });
-    await user.click(showMoreButton);
-
-    expect(mockListDashboardHistory).toHaveBeenCalledTimes(2);
-    expect(screen.getByText(/Fetching more entries/i)).toBeInTheDocument();
-    jest.advanceTimersByTime(1000);
-
-    await waitFor(() => {
-      expect(screen.queryByText(/Fetching more entries/i)).not.toBeInTheDocument();
-      expect(within(screen.getAllByRole('rowgroup')[1]).getAllByRole('row').length).toBe(
-        versionsResourceList.items.length
-      );
-    });
-  });
-
-  test('does not show more button when receiving partial page without version 1', async () => {
-    // Mock a partial page response (less than VERSIONS_FETCH_LIMIT)
-    mockListDashboardHistory.mockResolvedValueOnce({
-      metadata: { continue: '' },
-      items: versionsResourceList.items.slice(0, VERSIONS_FETCH_LIMIT - 5),
-    });
-
-    setup();
-
-    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
-
-    // Verify that show more button is not present since we got a partial page
-    expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
-    // Verify that compare button is still present
-    expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
-  });
-
-  test('does not show more button when continueToken is empty', async () => {
-    mockListDashboardHistory.mockResolvedValueOnce({
-      metadata: { continue: '' },
-      items: versionsResourceList.items.slice(0, VERSIONS_FETCH_LIMIT - 1),
-    });
-
+  test('does not render show more versions button', async () => {
+    mockListDashboardHistory.mockResolvedValue(versionsResourceList);
     setup();
 
     await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
 
     expect(screen.queryByRole('button', { name: /show more versions/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /compare versions/i })).toBeInTheDocument();
   });
 
   test('selecting two versions and clicking compare button should render compare view', async () => {
     // getDiff now uses already-loaded data from versionsResourceList, no separate API call needed
-    mockListDashboardHistory.mockResolvedValue({
-      metadata: { continue: '' },
-      items: versionsResourceList.items.slice(0, VERSIONS_FETCH_LIMIT),
-    });
+    mockListDashboardHistory.mockResolvedValue(versionsResourceList);
 
     setup();
 
@@ -219,7 +136,7 @@ describe('VersionSettings', () => {
     const compareButton = screen.getByRole('button', { name: /compare versions/i });
     const tableBody = screen.getAllByRole('rowgroup')[1];
     await user.click(within(tableBody).getAllByRole('checkbox')[0]);
-    await user.click(within(tableBody).getAllByRole('checkbox')[VERSIONS_FETCH_LIMIT - 1]);
+    await user.click(within(tableBody).getAllByRole('checkbox')[versionsResourceList.items.length - 1]);
 
     expect(compareButton).toBeEnabled();
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -155,12 +155,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
         ) : (
           <VersionHistoryTable versions={versions} onCheck={this.onCheck} canCompare={canCompare} />
         )}
-        {showButtons && (
-          <VersionsHistoryButtons
-            canCompare={canCompare}
-            getDiff={this.getDiff}
-          />
-        )}
+        {showButtons && <VersionsHistoryButtons canCompare={canCompare} getDiff={this.getDiff} />}
       </Page>
     );
   }

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -22,7 +22,6 @@ interface Props extends SettingsPageProps {}
 
 type State = {
   isLoading: boolean;
-  isAppending: boolean;
   versions: DecoratedRevisionModel[];
   viewMode: 'list' | 'compare';
   diffData: { lhs: object; rhs: object };
@@ -32,13 +31,9 @@ type State = {
 };
 
 export class VersionsSettings extends PureComponent<Props, State> {
-  continueToken: string;
-
   constructor(props: Props) {
     super(props);
-    this.continueToken = '';
     this.state = {
-      isAppending: true,
       isLoading: true,
       versions: [],
       viewMode: 'list',
@@ -51,26 +46,18 @@ export class VersionsSettings extends PureComponent<Props, State> {
     this.getVersions();
   }
 
-  getVersions = (append = false) => {
-    this.setState({ isAppending: append });
-
-    const options = append
-      ? { limit: VERSIONS_FETCH_LIMIT, continueToken: this.continueToken }
-      : { limit: VERSIONS_FETCH_LIMIT };
-
+  getVersions = () => {
     getDashboardAPI()
       .then(async (api) => {
-        const result = await api.listDashboardHistory(this.props.dashboard.uid, options);
+        const result = await api.listDashboardHistory(this.props.dashboard.uid, { limit: VERSIONS_FETCH_LIMIT });
         const versions = this.transformToRevisionModels(result.items);
+        versions.sort((a, b) => b.version - a.version);
         this.setState({
           isLoading: false,
-          versions: [...(this.state.versions ?? []), ...this.decorateVersions(versions)],
+          versions: this.decorateVersions(versions),
         });
-        // Update the continueToken for the next request, if available
-        this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
-      .finally(() => this.setState({ isAppending: false }));
+      .catch((err) => console.log(err));
   };
 
   transformToRevisionModels(items: Array<Resource<unknown>>): RevisionModel[] {
@@ -113,14 +100,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
       checked: false,
     }));
 
-  isLastPage() {
-    return (
-      this.state.versions.find((rev) => rev.version === 1) ||
-      this.state.versions.length % VERSIONS_FETCH_LIMIT !== 0 ||
-      this.continueToken === ''
-    );
-  }
-
   onCheck = (ev: React.FormEvent<HTMLInputElement>, versionId: number) => {
     this.setState({
       versions: this.state.versions.map((version) =>
@@ -130,7 +109,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
   };
 
   reset = () => {
-    this.continueToken = '';
     this.setState({
       baseInfo: undefined,
       diffData: { lhs: {}, rhs: {} },
@@ -145,7 +123,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
     const { versions, viewMode, baseInfo, newInfo, isNewLatest, isLoading, diffData } = this.state;
     const canCompare = versions.filter((version) => version.checked).length === 2;
     const showButtons = versions.length > 1;
-    const hasMore = versions.length >= VERSIONS_FETCH_LIMIT;
     const pageNav = this.props.sectionNav.node.parentItem;
 
     if (viewMode === 'compare') {
@@ -178,14 +155,10 @@ export class VersionsSettings extends PureComponent<Props, State> {
         ) : (
           <VersionHistoryTable versions={versions} onCheck={this.onCheck} canCompare={canCompare} />
         )}
-        {this.state.isAppending && <VersionsHistorySpinner msg="Fetching more entries&hellip;" />}
         {showButtons && (
           <VersionsHistoryButtons
-            hasMore={hasMore}
             canCompare={canCompare}
-            getVersions={this.getVersions}
             getDiff={this.getDiff}
-            isLastPage={!!this.isLastPage()}
           />
         )}
       </Page>

--- a/public/app/features/dashboard/types/revisionModels.ts
+++ b/public/app/features/dashboard/types/revisionModels.ts
@@ -1,4 +1,4 @@
-export const VERSIONS_FETCH_LIMIT = 10;
+export const VERSIONS_FETCH_LIMIT = 20;
 
 export interface RevisionModel {
   id: number;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7691,8 +7691,7 @@
     },
     "versions-history-buttons": {
       "compare-versions": "Compare versions",
-      "content-select-two-versions-to-start-comparing": "Select two versions to start comparing",
-      "show-more-versions": "Show more versions"
+      "content-select-two-versions-to-start-comparing": "Select two versions to start comparing"
     },
     "visualization-button": {
       "aria-label-change-visualization": "Change visualization",


### PR DESCRIPTION
This removes the coupling the client (frontend) had on the particular ordering implemented by the `List` call on the backend (which is not part of the Kubernetes [list semantics](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list)).

This commit removes the pagination button and logic and instead fetches up to 20 revisions, which is the maximum number of revisions we keep for resources. Crucially, it sorts by generation in the client instead of assuming the results come in any particular order.