### PR TITLE
fix: pin 69 unpinned action(s)

### DIFF
--- a/.github/workflows/alerting-update-module.yml
+++ b/.github/workflows/alerting-update-module.yml
@@ -107,7 +107,7 @@ jobs:
           go test -v -count=1 -timeout 5m -run TestIntegrationTypeSchemaList ./pkg/tests/apis/alerting/notifications/integrationtypeschema/... || true
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main # zizmor: ignore[unpinned-uses]
         with:
           repo_secrets: |
             GITHUB_APP_ID=alerting-team:app-id
@@ -153,7 +153,7 @@ jobs:
             echo "🔗 [View Pull Request]($PR_URL)"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Send Slack Message
-        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message/v2.0.4
+        uses: grafana/shared-workflows/actions/send-slack-message@2d985e9ff08e467946216a16a3a59fab5bb9e6cf # send-slack-message/v2.0.4
         with:
           method: 'chat.postMessage'
           # send to alerting-reviews channel

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Get vault secrets
         id: secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           export_env: false
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
@@ -78,7 +78,7 @@ jobs:
           git config --local --add --bool push.autoSetupRemote true
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@dev
+        uses: grafana/grafana-github-actions-go/backport@95d01a699db82127c5cdb368d3bb2cf4dddac0fa # dev
         with:
           token: ${{ steps.generate_token.outputs.token }}
           # If triggered by being labelled, only backport that label.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,7 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
           repo_secrets: |

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Get Vault secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GITHUB_APP_ID=grafana_pr_automation_app:app_id
@@ -103,7 +103,7 @@ jobs:
     steps:
       - name: Get Vault secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GITHUB_APP_ID=grafana_pr_automation_app:app_id
@@ -151,7 +151,7 @@ jobs:
     steps:
       - name: Get Vault secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GITHUB_APP_ID=grafana_pr_automation_app:app_id
@@ -285,7 +285,7 @@ jobs:
       - name: Get Vault secrets
         if: github.event.pull_request.head.repo.fork == false
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GITHUB_APP_ID=grafana_pr_automation_app:app_id

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v5
-      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v0.2.1
+      - uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1
         with:
           dry-run: false
           max-date: "1 month ago"

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main # zizmor: ignore[unpinned-uses]
         with:
           # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_commands_github_bot path in Vault
           repo_secrets: |

--- a/.github/workflows/community-release.yml
+++ b/.github/workflows/community-release.yml
@@ -33,14 +33,14 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/repo/grafana/grafana/community_release path in Vault
           repo_secrets: |
             GRAFANABOT_FORUM_KEY=community_release:GRAFANABOT_FORUM_KEY
 
       - name: Run community-release (manually invoked)
-        uses: grafana/grafana-github-actions-go/community-release@main
+        uses: grafana/grafana-github-actions-go/community-release@8f6bbbb778adfec42f3a336bcfd8aa72d3ae4db4 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ inputs.version }}

--- a/.github/workflows/create-next-release-branch.yml
+++ b/.github/workflows/create-next-release-branch.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
           repo_secrets: |
@@ -50,7 +50,7 @@ jobs:
           permissions: "{\"contents\": \"write\", \"pull_requests\": \"write\", \"workflows\":\"write\"}"
       - name: Create release branch
         id: branch
-        uses: grafana/grafana-github-actions-go/bump-release@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/grafana-github-actions-go/bump-release@8f6bbbb778adfec42f3a336bcfd8aa72d3ae4db4 # main # zizmor: ignore[unpinned-uses]
         with:
           ownerRepo: ${{ inputs.ownerRepo }}
           source: ${{ inputs.source }}

--- a/.github/workflows/create-security-branch.yml
+++ b/.github/workflows/create-security-branch.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
           repo_secrets: |

--- a/.github/workflows/dashboards-issue-add-label.yml
+++ b/.github/workflows/dashboards-issue-add-label.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main # zizmor: ignore[unpinned-uses]
         with:
           # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_commands_github_bot path in Vault
           repo_secrets: |

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write # Create or update PR comments.
       statuses: write # Update GitHub status check with deploy preview link.
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@57ba2bc9d1a733306e4192012eb82a77a5231a7b # main # zizmor: ignore[unpinned-uses]
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-storybook-preview.yml
+++ b/.github/workflows/deploy-storybook-preview.yml
@@ -65,7 +65,7 @@ jobs:
           echo "deploy-name=pr_${PR_NUMBER}_${SANITIZED_BRANCH:0:30}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Storybook
-        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        uses: grafana/shared-workflows/actions/push-to-gcs@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           environment: prod
           bucket: ${{ env.BUCKET_NAME }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Log in to GCS
         id: login-to-gcs
-        uses: grafana/shared-workflows/actions/login-to-gcs@main
+        uses: grafana/shared-workflows/actions/login-to-gcs@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           environment: prod
           service_account: github-gf-storybook-deploy@grafanalabs-workload-identity.iam.gserviceaccount.com
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload new storybook
         id: upload-new-storybook
-        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        uses: grafana/shared-workflows/actions/push-to-gcs@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           environment: prod
           bucket: ${{ env.BUCKET_NAME }}

--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/vale-action@vale-action/v1 # zizmor: ignore[unpinned-uses]
+      - uses: grafana/writers-toolkit/vale-action@f49dd90f007967990095ac2d18c5bdf37b412a5f # vale-action/v1 # zizmor: ignore[unpinned-uses]
         with:
           filter: '.Name in ["Grafana.GrafanaCom", "Grafana.WordList", "Grafana.Spelling", "Grafana.ProductPossessives"]'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Get vault secrets
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in ci/repo/grafana/grafana/
           repo_secrets: |

--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -31,7 +31,7 @@ jobs:
             FSPERF_PASSWORD=frontend_perf_tests:fsperf_password
 
       - name: Authenticate Docker
-        uses: grafana/shared-workflows/actions/login-to-gar@main
+        uses: grafana/shared-workflows/actions/login-to-gar@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         id: login-to-gar
         with:
           registry: 'us-docker.pkg.dev'

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub release (manually invoked)
-        uses: grafana/grafana-github-actions-go/github-release@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/grafana-github-actions-go/github-release@8f6bbbb778adfec42f3a336bcfd8aa72d3ae4db4 # main # zizmor: ignore[unpinned-uses]
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ inputs.version }}

--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   create-tasks-in-crowdin:
-    uses: grafana/grafana-github-actions/.github/workflows/crowdin-create-tasks.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/crowdin-create-tasks.yml@ea6ae56f0c8cee10e6538c6e395f5dc1072bf3a2 # main
     with:
       crowdin_project_id: 5

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   download-sources-from-crowdin:
     if: github.repository == 'grafana/grafana'
-    uses: grafana/grafana-github-actions/.github/workflows/crowdin-download.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/crowdin-download.yml@ea6ae56f0c8cee10e6538c6e395f5dc1072bf3a2 # main
     with:
       crowdin_project_id: 5
       pr_labels: 'area/frontend, area/internationalization, no-changelog, no-backport'

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -15,6 +15,6 @@ on:
 jobs:
   upload-sources-to-crowdin:
     if: github.repository == 'grafana/grafana'
-    uses: grafana/grafana-github-actions/.github/workflows/crowdin-upload.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/crowdin-upload.yml@ea6ae56f0c8cee10e6538c6e395f5dc1072bf3a2 # main
     with:
       crowdin_project_id: 5

--- a/.github/workflows/i18n-verify.yml
+++ b/.github/workflows/i18n-verify.yml
@@ -14,4 +14,4 @@ jobs:
   verify-i18n:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
-    uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@ea6ae56f0c8cee10e6538c6e395f5dc1072bf3a2 # main

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
         with:
           # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_commands_github_bot path in Vault
           repo_secrets: |
@@ -71,7 +71,7 @@ jobs:
 
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
         with:
           # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_triager path in Vault
           repo_secrets: |
@@ -105,7 +105,7 @@ jobs:
       - name: Send issue to the auto triager action
         id: auto_triage
         if: steps.check-if-grafana-org-member.outputs.is_grafana_org_member != 'true' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'OWNER'
-        uses: grafana/auto-triager@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/auto-triager@5f4f74eeaabba468b95da80d05fd9af14a77958e # main # zizmor: ignore[unpinned-uses]
         with:
           token: ${{ steps.generate_token.outputs.token }}
           issue_number: ${{ github.event.issue.number }}
@@ -139,7 +139,7 @@ jobs:
     steps:
         - name: "Get vault secrets"
           id: vault-secrets
-          uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
+          uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0 # zizmor: ignore[unpinned-uses]
           with:
             # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_triager path in Vault
             repo_secrets: |

--- a/.github/workflows/migrate-prs.yml
+++ b/.github/workflows/migrate-prs.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
           repo_secrets: |
@@ -52,7 +52,7 @@ jobs:
           app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
           private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Migrate PRs
-        uses: grafana/grafana-github-actions-go/migrate-open-prs@main
+        uses: grafana/grafana-github-actions-go/migrate-open-prs@8f6bbbb778adfec42f3a336bcfd8aa72d3ae4db4 # main
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ownerRepo: ${{ inputs.ownerRepo }}

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -39,9 +39,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+      - uses: grafana/shared-workflows/actions/dockerhub-login@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         if: github.event.pull_request.head.repo.fork == false
       - uses: actions/checkout@v5
         with:
@@ -90,7 +90,7 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@eb02241ed0a92aff205feab8ac3afcdf51c757c8 # create-github-app-token-v0.2.0
         with:
           github_app: "delivery-bot-app"
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         id: login-to-gar
         with:
           registry: 'us-docker.pkg.dev'

--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Retrieve GitHub App secrets
       id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1 # zizmor: ignore[unpinned-uses]
+      uses: grafana/shared-workflows/actions/get-vault-secrets@97c6f45f01d4bca8a3b1acfe397113ce88858a81 # get-vault-secrets-v1.0.1 # zizmor: ignore[unpinned-uses]
       with:
         repo_secrets: |
           APP_ID=grafana-go-workspace-bot:app-id

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -130,9 +130,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@main
+      - uses: grafana/shared-workflows/actions/dockerhub-login@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         if: github.event.pull_request.head.repo.fork == false
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         if: github.event.pull_request.head.repo.fork == false
 
       - name: Checkout code
@@ -322,7 +322,7 @@ jobs:
 
       - name: Check test suites
         id: check-jobs
-        uses: grafana/grafana/.github/actions/check-jobs@main
+        uses: grafana/grafana/.github/actions/check-jobs@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
         continue-on-error: true # Failure will be reported on Check test results step
         with:
           needs: ${{ toJson(needs) }}
@@ -403,7 +403,7 @@ jobs:
     runs-on: ubuntu-x64-small
     steps:
       - id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GRAFANA_MISC_STATS_API_KEY=grafana-misc-stats:api_key

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -18,7 +18,7 @@ permissions:
 # target branch onto the source branch, to verify compatibility before merging.
 jobs:
   dispatch-job:
-    uses: grafana/grafana/.github/workflows/pr-patch-check.yml@main
+    uses: grafana/grafana/.github/workflows/pr-patch-check.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       head_ref: ${{ github.head_ref }}
       base_ref: ${{ github.base_ref }}

--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
           repo_secrets: |

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -52,7 +52,7 @@ jobs:
           path: ./artifact
       - name: Log in to GCS
         id: login-to-gcs
-        uses: grafana/shared-workflows/actions/login-to-gcs@main
+        uses: grafana/shared-workflows/actions/login-to-gcs@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           environment: ${{ inputs.environment }}
           service_account: ${{ inputs.service-account }}
@@ -62,7 +62,7 @@ jobs:
           find ./artifact -mindepth 2 -maxdepth 2 -exec cp -r {} out/ \;
           ls -al out
       - name: Upload artifacts
-        uses: grafana/shared-workflows/actions/push-to-gcs@main
+        uses: grafana/shared-workflows/actions/push-to-gcs@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           bucket: ${{ inputs.bucket }}
           environment: ${{ inputs.environment }}

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1 # zizmor: ignore[unpinned-uses]
+      - uses: grafana/writers-toolkit/publish-technical-documentation@9aed4f7c5b3caa1b58d72ee39232333407d4acbf # publish-technical-documentation/v1 # zizmor: ignore[unpinned-uses]
         with:
           website_directory: content/docs/grafana/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@8cc658b604c6e05c275af30163a1c7728dfe19b2 # publish-technical-documentation-release/v2 # zizmor: ignore[unpinned-uses]
         with:
           release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           release_branch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -84,7 +84,7 @@ jobs:
     name: Dispatch grafana-enterprise build
     steps:
       - id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
@@ -177,8 +177,8 @@ jobs:
             artifacts: targz:grafana:darwin/arm64:nocgo
             verify: true
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
+      - uses: grafana/shared-workflows/actions/login-to-gar@f02682926bde2aa45a1a8b74409c94508d8952ec # main
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -211,7 +211,7 @@ jobs:
 
   publish-artifacts:
     name: Upload artifacts
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     permissions:
       id-token: write
     needs:
@@ -235,7 +235,7 @@ jobs:
       - setup
       - build
     steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
+      - uses: grafana/shared-workflows/actions/dockerhub-login@c6d954f7cd9c0022018982e01268de6cb75b913c # dockerhub-login/v1.0.2
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
           name: artifacts-list-linux-amd64
@@ -319,7 +319,7 @@ jobs:
       - setup
     steps:
       - id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -66,21 +66,21 @@ jobs:
   create_next_release_branch_grafana:
     name: Create next release branch (Grafana)
     needs: setup
-    uses: grafana/grafana/.github/workflows/create-next-release-branch.yml@main
+    uses: grafana/grafana/.github/workflows/create-next-release-branch.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       ownerRepo: 'grafana/grafana'
       source: ${{ needs.setup.outputs.release_branch }}
   create_next_release_branch_enterprise:
     name: Create next release branch (Grafana Enterprise)
     needs: setup
-    uses: grafana/grafana/.github/workflows/create-next-release-branch.yml@main
+    uses: grafana/grafana/.github/workflows/create-next-release-branch.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       ownerRepo: 'grafana/grafana-enterprise'
       source: ${{ needs.setup.outputs.release_branch }}
   create_security_branch_grafana:
     name: Create security branch (Grafana Security Mirror)
     needs: setup
-    uses: grafana/grafana/.github/workflows/create-security-branch.yml@main
+    uses: grafana/grafana/.github/workflows/create-security-branch.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       release_branch: ${{ needs.setup.outputs.release_branch }}
       security_branch_number: "01"
@@ -88,7 +88,7 @@ jobs:
   create_security_branch_enterprise:
     name: Create security branch (Enterprise)
     needs: setup
-    uses: grafana/grafana/.github/workflows/create-security-branch.yml@main
+    uses: grafana/grafana/.github/workflows/create-security-branch.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       release_branch: ${{ needs.setup.outputs.release_branch }}
       security_branch_number: "01"
@@ -97,7 +97,7 @@ jobs:
     needs:
       - setup
       - create_next_release_branch_grafana
-    uses: grafana/grafana/.github/workflows/migrate-prs.yml@main
+    uses: grafana/grafana/.github/workflows/migrate-prs.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       ownerRepo: 'grafana/grafana'
       from: ${{ needs.setup.outputs.release_branch }}
@@ -106,7 +106,7 @@ jobs:
     needs:
       - setup
       - create_next_release_branch_enterprise
-    uses: grafana/grafana/.github/workflows/migrate-prs.yml@main
+    uses: grafana/grafana/.github/workflows/migrate-prs.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       ownerRepo: 'grafana/grafana-enterprise'
       from: ${{ needs.setup.outputs.release_branch }}
@@ -123,7 +123,7 @@ jobs:
     # The github-release action retrieves the changelog using the /repos/grafana/grafana/contents/CHANGELOG.md API
     # endpoint.
     needs: setup
-    uses: grafana/grafana/.github/workflows/github-release.yml@main
+    uses: grafana/grafana/.github/workflows/github-release.yml@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Get Vault secrets
         if: steps.check-e2e-changes.outputs.changes > 0
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           repo_secrets: |
             GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY

--- a/.github/workflows/skye-add-to-project.yml
+++ b/.github/workflows/skye-add-to-project.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main # zizmor: ignore[unpinned-uses]
         with:
           # Vault secret paths:
           # - ci/repo/grafana/grafana/grafana_pr_automation_app

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -79,7 +79,7 @@ jobs:
         run: echo "No frontend changes detected, skipping storybook a11y tests"
       - name: Check test suites
         if: needs.detect-changes.outputs.changed == 'true'
-        uses: grafana/grafana/.github/actions/check-jobs@main
+        uses: grafana/grafana/.github/actions/check-jobs@d293db7a1e30541085fe18808ce3cf05825a3d0d # main
         with:
           needs: ${{ toJson(needs) }}
           failure-message: "One or more storybook a11y test suites have failed"

--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: "Get vault secrets"
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@f02682926bde2aa45a1a8b74409c94508d8952ec # main
         with:
           # Secrets placed in the ci/data/repo/grafana/grafana/delivery-bot-app path in Vault
           repo_secrets: |

--- a/.github/workflows/update-schema-types.yml
+++ b/.github/workflows/update-schema-types.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       
-      - uses: grafana/plugin-actions/bundle-schema-types@main
+      - uses: grafana/plugin-actions/bundle-schema-types@4698961fa64137fcac207108397ebe8a738a33d1 # main


### PR DESCRIPTION
> This is a re-submission of #121246, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/alerting-update-module.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/backport-workflow.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/bump-version.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/changelog.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/check-frontend-test-coverage.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/cleanup-branches.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/commands.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/community-release.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/create-next-release-branch.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/create-security-branch.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/dashboards-issue-add-label.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-pr-preview.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-storybook-preview.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/deploy-storybook.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/documentation-ci.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/ephemeral-instances-pr-comment.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/frontend-perf-tests.yaml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/github-release.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/i18n-crowdin-create-tasks.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/i18n-crowdin-download.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/i18n-crowdin-upload.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/i18n-verify.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/issue-opened.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/migrate-prs.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/pr-build-grafana.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/pr-dependabot-update-go-workspace.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/pr-e2e-tests.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/pr-patch-check-event.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/pr-patch-check.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/publish-artifact.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/publish-technical-documentation-next.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/publish-technical-documentation-release.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release-build.yml` | Pinned 6 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release-comms.yml` | Pinned 7 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release-npm.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release-pr.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/skye-add-to-project.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/storybook-a11y.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/sync-mirror-event.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/update-schema-types.yml` | Pinned 1 third-party action(s) to commit SHA |


### Additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-018 | high | `.github/workflows/actionlint.yml` | Suspicious Payload Execution Pattern |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/backport-workflow.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-018 | high | `.github/workflows/pr-frontend-unit-tests.yml` | Suspicious Payload Execution Pattern |
| RGS-003 | high | `.github/workflows/pr-go-workspace-check.yml` | Filename Injection via Git Diff or File Listing |
| RGS-005 | medium | `.github/workflows/commands.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/ephemeral-instances-pr-comment.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/pr-commands.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/pr-external-labelling.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: Pins third-party actions to immutable commit SHAs (original version tag preserved as comment)


---

If this PR is not welcome, just close it and I won't send another.