### PR TITLE
InlineSecureValues: Replace the last-applied-configuration annotation

### DIFF
--- a/pkg/storage/unified/apistore/secure.go
+++ b/pkg/storage/unified/apistore/secure.go
@@ -2,8 +2,11 @@ package apistore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -100,6 +103,25 @@ func prepareSecureValues(ctx context.Context, store secret.InlineSecureValueSupp
 		}
 
 		delete(previous, k)
+	}
+
+	// Replace the secure values with resolved names
+	// This avoids exposing the raw value in the last-applied-configuration annotation from kubectl
+	lastAppliedConfig := obj.GetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig)
+	if len(lastAppliedConfig) > 0 {
+		raw := []byte(lastAppliedConfig)
+		cfg := &unstructured.Unstructured{}
+		err = json.Unmarshal(raw, cfg)
+		if err == nil {
+			cfg.Object["secure"] = secure
+			raw, err = cfg.MarshalJSON()
+		}
+		if err == nil {
+			lastAppliedConfig = string(raw)
+		} else {
+			lastAppliedConfig = ""
+		}
+		obj.SetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig, lastAppliedConfig)
 	}
 
 	// Keep all previous values that were not referenced in the update

--- a/pkg/storage/unified/apistore/secure.go
+++ b/pkg/storage/unified/apistore/secure.go
@@ -2,11 +2,8 @@ package apistore
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -86,6 +83,9 @@ func prepareSecureValues(ctx context.Context, store secret.InlineSecureValueSupp
 				v.createdSecureValues = append(v.createdSecureValues, n)
 				v.hasChanged = true
 				secure[k] = common.InlineSecureValue{Name: n}
+
+				// Avoid exposing a raw secret in the kubectl metadata
+				obj.SetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig, "")
 				continue
 			}
 			return fmt.Errorf("invalid secure value state: %s", k)
@@ -103,25 +103,6 @@ func prepareSecureValues(ctx context.Context, store secret.InlineSecureValueSupp
 		}
 
 		delete(previous, k)
-	}
-
-	// Replace the secure values with resolved names
-	// This avoids exposing the raw value in the last-applied-configuration annotation from kubectl
-	lastAppliedConfig := obj.GetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig)
-	if len(lastAppliedConfig) > 0 {
-		raw := []byte(lastAppliedConfig)
-		cfg := &unstructured.Unstructured{}
-		err = json.Unmarshal(raw, cfg)
-		if err == nil {
-			cfg.Object["secure"] = secure
-			raw, err = cfg.MarshalJSON()
-		}
-		if err == nil {
-			lastAppliedConfig = string(raw)
-		} else {
-			lastAppliedConfig = ""
-		}
-		obj.SetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig, lastAppliedConfig)
 	}
 
 	// Keep all previous values that were not referenced in the update

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -65,10 +65,8 @@ func TestSecureLifecycle(t *testing.T) {
 			"b": {"name": "NameForB"}
 		}`, asJSON(secure, true))
 
-		rt, _ := obj.GetRuntimeObject()
-		out, err := json.Marshal(rt)
-		require.NoError(t, err)
-		require.NotContains(t, string(out), "[REDACTED]")
+		v := obj.GetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig)
+		require.Empty(t, v, "should exclude the last config with raw secrets")
 
 		secureStore.AssertExpectations(t)
 	})
@@ -172,6 +170,9 @@ func TestSecureLifecycle(t *testing.T) {
 			"a": {"name": "NameForA"},
 			"c": {"name": "NameForC"}
 		}`, asJSON(secure, true))
+
+		v := obj.GetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig)
+		require.NotEmpty(t, v, "should keep the annotations when a raw secret is not exposed")
 
 		// When there is not an error, the finish command will do a real delete
 		owner := utils.ToObjectReference(obj)

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSecureLifecycle(t *testing.T) {
 	resourceWithSecureValues := func(sv common.InlineSecureValues) utils.GrafanaMetaAccessor {
-		obj, err := utils.MetaAccessor(&unstructured.Unstructured{
+		tmp := &unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": "something.grafana.app/v1beta1",
 				"kind":       "CustomKind",
@@ -28,7 +28,14 @@ func TestSecureLifecycle(t *testing.T) {
 				},
 				"secure": sv,
 			},
+		}
+		raw, err := tmp.MarshalJSON() // NOTE, any secret gets replaced with: [REDACTED]
+		require.NoError(t, err)
+		tmp.SetAnnotations(map[string]string{
+			utils.AnnoKeyKubectlLastAppliedConfig: string(raw),
 		})
+
+		obj, err := utils.MetaAccessor(tmp)
 		require.NoError(t, err)
 		return obj
 	}
@@ -57,6 +64,12 @@ func TestSecureLifecycle(t *testing.T) {
 			"a": {"name": "NameForA"},
 			"b": {"name": "NameForB"}
 		}`, asJSON(secure, true))
+
+		rt, _ := obj.GetRuntimeObject()
+		out, err := json.Marshal(rt)
+		require.NoError(t, err)
+		require.NotContains(t, string(out), "[REDACTED]")
+
 		secureStore.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
Removes the `last-applied-configuration` annotation when a raw secure value is included in the inline section