### PR TITLE
ToolbarButton: fix text overflow causing overlap with adjacent elements

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -252,6 +252,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     contentWithIcon: css({
       display: 'none',
       paddingLeft: theme.spacing(1),
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      minWidth: 0,
 
       [`@media ${mediaUp(theme.v1.breakpoints.md)}`]: {
         display: 'block',


### PR DESCRIPTION
Fixes #119789

## What this PR does

Fixes the ToolbarButton text overflowing and overlapping with adjacent elements when the button has a fixed width and the translation text is longer than the English original.

The root cause is that `@grafana/scenes` `SceneRefreshPicker` sets a hardcoded `width: 96px` on the Refresh button, which is sufficient for English ("Refresh"/"Cancel") but not for longer translations like German ("Aktualisieren"). While the ideal fix is in `@grafana/scenes` (as noted by @ashharrison90 and @ivanortegaalba), this PR adds defensive overflow handling in `ToolbarButton` so that **any** toolbar button with a constrained width gracefully truncates text instead of overflowing.

### Changes

Added to the `contentWithIcon` style in `ToolbarButton.tsx`:
- `overflow: hidden` - prevents text from overflowing the button content area
- `textOverflow: ellipsis` - displays an ellipsis ("...") when text is truncated
- `minWidth: 0` - required for flex items to shrink below their minimum content size

These are standard, safe CSS properties that only take effect when the text actually overflows its container.

## How to test

1. Switch Grafana locale to German (`de-DE`)
2. Open any dashboard
3. Verify the "Aktualisieren" Refresh button does not overlap with the refresh interval dropdown
4. Verify the button shows an ellipsis if the text is too long for the fixed width
5. Check other locales with long translations to confirm they also work correctly