### PR TITLE
Table: Fixes from nested table bug bash

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1763,5 +1763,85 @@ describe('TableNG', () => {
 
       expect(screen.queryByTestId(selectors.components.DataLinksActionsTooltip.tooltipWrapper)).not.toBeInTheDocument();
     });
+
+    it('uses the correct row nested frame fields for data links', async () => {
+      // Each outer row has a different nested frame with a different State value and different link titles.
+      // The bug caused all nested sub-tables to use the first outer row's field (and its getLinks), so
+      // clicking any nested cell always showed links from row 0 regardless of which row was expanded.
+      const nestedFrameRow0 = withFieldOverrides(
+        toDataFrame({
+          name: 'NestedRow0',
+          fields: [
+            {
+              name: 'State',
+              type: FieldType.string,
+              values: ['Down'],
+              config: {
+                custom: {},
+                links: [
+                  { url: 'http://example.com/?state=Down&link=1', title: 'Down Link 1' },
+                  { url: 'http://example.com/?state=Down&link=2', title: 'Down Link 2' },
+                ],
+              },
+            },
+          ],
+        })
+      );
+
+      const nestedFrameRow1 = withFieldOverrides(
+        toDataFrame({
+          name: 'NestedRow1',
+          fields: [
+            {
+              name: 'State',
+              type: FieldType.string,
+              values: ['Up'],
+              config: {
+                custom: {},
+                links: [
+                  { url: 'http://example.com/?state=Up&link=1', title: 'Up Link 1' },
+                  { url: 'http://example.com/?state=Up&link=2', title: 'Up Link 2' },
+                ],
+              },
+            },
+          ],
+        })
+      );
+
+      const outerFrame = withFieldOverrides(
+        toDataFrame({
+          name: 'TestData',
+          fields: [
+            { name: 'Name', type: FieldType.string, values: ['A', 'B'], config: { custom: {} } },
+            {
+              name: '__nestedFrames',
+              type: FieldType.nestedFrames,
+              values: [[nestedFrameRow0], [nestedFrameRow1]],
+              config: { custom: {} },
+            },
+          ],
+        })
+      );
+
+      const { container } = render(<TableNG enableVirtualization={false} data={outerFrame} width={800} height={600} />);
+
+      // Expand the second outer row (index 1), which has State='Up'
+      const expandButtons = container.querySelectorAll('[aria-label="Expand row"]');
+      expect(expandButtons).toHaveLength(2);
+      await user.click(expandButtons[1]);
+
+      // Click the 'Up' state cell in the expanded nested sub-table
+      const upCell = screen.getByText('Up');
+      await user.click(upCell);
+
+      // Should show links from row 1's nested frame ('Up Link *')
+      // Before the fix this showed row 0's links ('Down Link *') because nestedColumnsMatrix
+      // used nestedVisibleFields (from the first row) for all rows' columns.
+      const tooltip = screen.getByTestId(selectors.components.DataLinksActionsTooltip.tooltipWrapper);
+      expect(tooltip).toBeInTheDocument();
+      expect(screen.getByText('Up Link 1')).toBeInTheDocument();
+      expect(screen.getByText('Up Link 2')).toBeInTheDocument();
+      expect(screen.queryByText('Down Link 1')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -876,11 +876,12 @@ export function TableNG(props: TableNGProps) {
     }
     for (const row of rows) {
       if (row.__depth > 0) {
+        const rowNestedFrame = nestedData![row.__index]!;
         result.push(
           fromFields(
-            nestedVisibleFields,
+            getVisibleFields(rowNestedFrame.fields),
             nestedFieldWidths,
-            nestedData![row.__index]!,
+            rowNestedFrame,
             nestedRows[row.__index].raw,
             nestedRows[row.__index].final
           )
@@ -888,7 +889,7 @@ export function TableNG(props: TableNGProps) {
       }
     }
     return result;
-  }, [rows, hasNestedFrames, nestedData, nestedRows, nestedVisibleFields, nestedFieldWidths, fromFields]);
+  }, [rows, hasNestedFrames, nestedData, nestedRows, nestedFieldWidths, fromFields]);
 
   const { columns, cellRootRenderers } = useMemo(() => {
     const result = fromFields(visibleFields, widths, data, rows, sortedRows);

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -701,13 +701,13 @@ describe('TableNG hooks', () => {
         ).toBe(defaultHeight * 4 + TABLE.CELL_PADDING * 2 + 16); // 3 rows + header + padding + scrollbar
       });
 
-      it('calculates the height to return using default height', () => {
+      it('uses defaultNestedHeight (not defaultHeight) for the nested sub-table header', () => {
         const { fields } = setupData();
         const frame = createDataFrame({ fields });
         const frameToRecords = compileFrameToRecords(frame, 'nested');
         const nestedRows = frameToRecords(frame);
         const defaultNonNestedHeight = 60;
-        const defaultHeight = 40;
+        const defaultNestedHeight = 40;
 
         expect(
           renderHook(() => {
@@ -718,7 +718,7 @@ describe('TableNG hooks', () => {
               ],
               columnWidths: [100],
               defaultHeight: defaultNonNestedHeight,
-              defaultNestedHeight: defaultHeight,
+              defaultNestedHeight,
               typographyCtx: typographyCtx,
               hasNestedFrames: true,
               nestedRows: [{ raw: nestedRows, final: nestedRows }],
@@ -735,7 +735,8 @@ describe('TableNG hooks', () => {
               data: frame,
             });
           }).result.current
-        ).toBe(defaultHeight * 3 + defaultNonNestedHeight + TABLE.CELL_PADDING * 2 + 16); // 3 nested rows + 1 non-nested row + header + padding + scrollbar
+          // 3 nested rows + nested header (uses defaultNestedHeight, not parent defaultHeight) + padding + scrollbar
+        ).toBe(defaultNestedHeight * 4 + TABLE.CELL_PADDING * 2 + 16);
       });
 
       it('uses a string-based default height for the nested rows', () => {
@@ -955,6 +956,68 @@ describe('TableNG hooks', () => {
           'Annie Lennox',
           100 - TABLE.CELL_PADDING * 2 - TABLE.BORDER_RIGHT,
           fieldsWithWrappedText[0],
+          0,
+          22
+        );
+      });
+
+      it('handles wrapped Time fields in nested frames (uses display-formatted value)', () => {
+        const FORMATTED_TIME = '2024-03-26 14:30:00';
+        const EPOCH_MS = 1711462200000;
+
+        const nestedFieldsWithTime: Field[] = [
+          {
+            name: 'Time',
+            type: FieldType.time,
+            values: [EPOCH_MS, EPOCH_MS, EPOCH_MS],
+            config: { custom: { wrapText: true } },
+            display: jest.fn(() => ({ text: FORMATTED_TIME, numeric: EPOCH_MS, color: undefined, title: undefined })),
+          },
+        ];
+
+        const topFrame = createDataFrame({
+          fields: [
+            { name: 'foo', type: FieldType.string, values: ['1'] },
+            {
+              name: 'nested',
+              type: FieldType.nestedFrames,
+              values: [[createDataFrame({ fields: nestedFieldsWithTime })]],
+            },
+          ],
+        });
+        const nestedFrame = createDataFrame({ fields: nestedFieldsWithTime });
+        const nestedFrameToRecords = compileFrameToRecords(nestedFrame, 'nested');
+        const nestedRows = nestedFrameToRecords(nestedFrame, 0);
+
+        const measureHeightFn = jest.fn(() => 40);
+        const estimateHeightFn = jest.fn(() => 40);
+        const { result } = renderHook(() => {
+          const rowHeight = useRowHeight({
+            nestedData: [nestedFrame],
+            fields: topFrame.fields,
+            columnWidths: [330],
+            defaultHeight: 40,
+            defaultNestedHeight: 40,
+            typographyCtx: { ...typographyCtx, measureHeight: measureHeightFn, estimateHeight: estimateHeightFn },
+            hasNestedFrames: true,
+            visibleNestedRowCounts: [3],
+            nestedRows: [{ raw: nestedRows, final: nestedRows }],
+            nestedFields: nestedFieldsWithTime,
+            nestedColWidths: [200],
+          });
+          if (typeof rowHeight !== 'function') {
+            throw new Error('Expected rowHeight to be a function');
+          }
+          return rowHeight;
+        });
+
+        result.current(nestedRows[0]);
+
+        // The measurer must receive the display-formatted string, not the raw epoch timestamp
+        expect(measureHeightFn).toHaveBeenCalledWith(
+          FORMATTED_TIME,
+          200 - TABLE.CELL_PADDING * 2 - TABLE.BORDER_RIGHT,
+          nestedFieldsWithTime[0],
           0,
           22
         );

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -498,7 +498,7 @@ export function useRowHeight({
           return TABLE.NESTED_NO_DATA_HEIGHT + TABLE.CELL_PADDING * 2;
         }
 
-        const nestedHeaderHeight = nestedData?.[row.__index]?.meta?.custom?.noHeader ? 0 : defaultHeight;
+        const nestedHeaderHeight = nestedData?.[row.__index]?.meta?.custom?.noHeader ? 0 : defaultNestedHeight;
         const nestedRowsHeight = nestedRows[row.__index].final.reduce(
           (acc, row) => acc + getNestedRowHeightWithCache(row),
           0

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1189,14 +1189,53 @@ describe('TableNG utils', () => {
       expect(measurers![0].fieldIdxs).toEqual([0]);
     });
 
-    it('does not enable text counting for non-string fields', () => {
+    it('enables text counting for Time fields rendered by AutoCellRenderer', () => {
       const fields: Field[] = [
         { name: 'Name', type: FieldType.string, values: [], config: { custom: {} } },
-        { name: 'Age', type: FieldType.number, values: [], config: { custom: { wrapText: true } } },
+        {
+          name: 'Time',
+          type: FieldType.time,
+          values: [],
+          config: { custom: { wrapText: true } },
+          display: (v) => ({ text: '2024-03-26 14:30:00', numeric: v as number, color: undefined, title: undefined }),
+        },
       ];
 
       const measurers = buildCellHeightMeasurers(fields, ctx);
-      // empty array - we had one column that indicated it wraps, but it was numeric, so we just ignore it
+      // Time fields use AutoCellRenderer (same as string fields) and can produce long formatted strings
+      expect(measurers).toBeDefined();
+      expect(measurers![0].fieldIdxs).toEqual([1]);
+    });
+
+    it('enables text counting for Number fields rendered by AutoCellRenderer', () => {
+      const fields: Field[] = [
+        {
+          name: 'Value',
+          type: FieldType.number,
+          values: [],
+          config: { custom: { wrapText: true } },
+          display: (v) => ({ text: String(v), numeric: v as number, color: undefined, title: undefined }),
+        },
+      ];
+
+      const measurers = buildCellHeightMeasurers(fields, ctx);
+      expect(measurers).toBeDefined();
+      expect(measurers![0].fieldIdxs).toEqual([0]);
+    });
+
+    it('does not enable text counting for non-AutoCellRenderer fields like Gauge', () => {
+      const fields: Field[] = [
+        { name: 'Name', type: FieldType.string, values: [], config: { custom: {} } },
+        {
+          name: 'Score',
+          type: FieldType.number,
+          values: [],
+          config: { custom: { wrapText: true, cellOptions: { type: TableCellDisplayMode.Gauge } } },
+        },
+      ];
+
+      const measurers = buildCellHeightMeasurers(fields, ctx);
+      // Gauge cells don't use AutoCellRenderer, so no measurer is set up
       expect(measurers).toBeUndefined();
     });
 
@@ -1354,6 +1393,93 @@ describe('TableNG utils', () => {
         jest.mocked(measurers[1].estimate!).mockReturnValue(SINGLE_LINE_ESTIMATE_THRESHOLD + thresholdOffset);
 
         expect(getRowHeight(fields, rows[3], [30, 30], 36, measurers, 20, 10)).toBe(50);
+      });
+    });
+
+    describe('non-string fields with display processor', () => {
+      it('measures the display-formatted string for Time fields, not the raw epoch number', () => {
+        const FORMATTED_TIME = '2024-03-26 14:30:00';
+        const EPOCH_MS = 1711462200000;
+
+        const timeFields: Field[] = [
+          {
+            name: 'Time',
+            type: FieldType.time,
+            values: [EPOCH_MS],
+            config: { custom: { wrapText: true } },
+            display: jest.fn(() => ({ text: FORMATTED_TIME, numeric: EPOCH_MS, color: undefined, title: undefined })),
+          },
+        ];
+        const frame = createDataFrame({ fields: timeFields });
+        const frameToRecords = compileFrameToRecords(frame);
+        const timeRows = frameToRecords(frame);
+
+        const timeMeasurer = {
+          measure: jest.fn((_value, _width, _field, _rowIdx, lineHeight) => lineHeight),
+          fieldIdxs: [0],
+        };
+
+        getRowHeight(timeFields, timeRows[0], [100], 36, [timeMeasurer], 20, 10);
+
+        // Must be called with the formatted string, not the raw epoch number
+        expect(timeMeasurer.measure).toHaveBeenCalledWith(FORMATTED_TIME, 100, timeFields[0], 0, 20);
+        expect(timeMeasurer.measure).not.toHaveBeenCalledWith(EPOCH_MS, 100, timeFields[0], 0, 20);
+      });
+
+      it('still passes the raw value for string fields (no display transformation)', () => {
+        const stringFields: Field[] = [
+          {
+            name: 'Name',
+            type: FieldType.string,
+            values: ['hello world'],
+            config: { custom: { wrapText: true } },
+            display: jest.fn(() => ({ text: 'SHOULD NOT BE USED', numeric: NaN, color: undefined, title: undefined })),
+          },
+        ];
+        const frame = createDataFrame({ fields: stringFields });
+        const frameToRecords = compileFrameToRecords(frame);
+        const stringRows = frameToRecords(frame);
+
+        const stringMeasurer = {
+          measure: jest.fn((_value, _width, _field, _rowIdx, lineHeight) => lineHeight),
+          fieldIdxs: [0],
+        };
+
+        getRowHeight(stringFields, stringRows[0], [100], 36, [stringMeasurer], 20, 10);
+
+        // String fields pass through the raw value, not the display-formatted value
+        expect(stringMeasurer.measure).toHaveBeenCalledWith('hello world', 100, stringFields[0], 0, 20);
+      });
+
+      it('uses the display name for header rows (rowIdx === -1) regardless of field type', () => {
+        const EPOCH_MS = 1711462200000;
+
+        const timeFields: Field[] = [
+          {
+            name: 'Time',
+            type: FieldType.time,
+            values: [EPOCH_MS],
+            config: { custom: { wrapText: true } },
+            display: jest.fn(() => ({
+              text: '2024-03-26 14:30:00',
+              numeric: EPOCH_MS,
+              color: undefined,
+              title: undefined,
+            })),
+          },
+        ];
+
+        const timeMeasurer = {
+          measure: jest.fn((_value, _width, _field, _rowIdx, lineHeight) => lineHeight),
+          fieldIdxs: [0],
+        };
+
+        // rowIdx -1 = header row; value should be the field display name
+        getRowHeight(timeFields, { __index: -1, __depth: 0 }, [100], 36, [timeMeasurer], 20, 10);
+
+        expect(timeMeasurer.measure).toHaveBeenCalledWith('Time', 100, timeFields[0], -1, 20);
+        // display() should not have been called for header rows
+        expect(timeFields[0].display).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -315,10 +315,9 @@ export function buildCellHeightMeasurers(
         setupMeasurerForIdx(TableCellDisplayMode.DataLinks, fieldIdx);
       } else if (cellType === TableCellDisplayMode.Pill) {
         setupMeasurerForIdx(TableCellDisplayMode.Pill, fieldIdx);
-      } else if (
-        field.type === FieldType.string &&
-        getCellRenderer(field, getCellOptions(field)) === AutoCellRenderer
-      ) {
+      } else if (getCellRenderer(field, getCellOptions(field)) === AutoCellRenderer) {
+        // Any field rendered by AutoCellRenderer (string, time, number, boolean, etc.) can
+        // produce a multi-line formatted string, so we include it in height measurement.
         setupMeasurerForIdx(TableCellDisplayMode.Auto, fieldIdx);
       } else {
         // no measurer was configured for this cell type
@@ -376,11 +375,18 @@ export function getRowHeight(
       // special case: for the header, provide `-1` as the row index.
       const cellValueRaw = row.__index === -1 ? displayName : row[displayName];
       if (cellValueRaw != null) {
+        // For non-string fields (e.g. Time, Number), the raw value is a number/epoch that
+        // AutoCell formats via field.display() before rendering. Measure the rendered string
+        // so the height matches what is actually displayed in the cell.
+        const cellValueForMeasuring =
+          field.type !== FieldType.string && row.__index !== -1 && field.display != null
+            ? formattedValueToString(field.display(cellValueRaw))
+            : cellValueRaw;
         const colWidth = columnWidths[fieldIdx];
-        const estimatedHeight = measurer(cellValueRaw, colWidth, field, row.__index, lineHeight);
+        const estimatedHeight = measurer(cellValueForMeasuring, colWidth, field, row.__index, lineHeight);
         if (estimatedHeight > maxHeight) {
           maxHeight = estimatedHeight;
-          maxValue = cellValueRaw;
+          maxValue = cellValueForMeasuring;
           maxWidth = colWidth;
           maxField = field;
           preciseMeasurer = isEstimating ? measure : undefined;


### PR DESCRIPTION
### Summary

- fixes an issue where non-`FieldType.string` fields with `field.display` methods that returned strings would not be appropriately handled for text wrapping. (this caused text wrapping to fail for time fields with string formats, for example.)
- fixes an issue where the first nested frame was passed thru to rendering in a way that caused certain things, like field.getLinks, to be wrong

Dashboard JSON demonstrating both issues: [debug-dashboard.json](https://github.com/user-attachments/files/26310350/debug-dashboard.json)

#### Before

<img width="1728" height="787" alt="Screenshot 2026-03-27 at 12 46 33 PM" src="https://github.com/user-attachments/assets/9dfad2b0-9677-4f5c-aba2-5d047bb298e3" />

#### After

<img width="1728" height="881" alt="Screenshot 2026-03-27 at 12 47 40 PM" src="https://github.com/user-attachments/assets/ef996c17-2074-4bdb-b93b-6c48e2edc0d7" />