### PR TITLE
PluginMeta: add mapper for aliasIds

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/hooks.test.tsx
+++ b/packages/grafana-runtime/src/services/pluginMeta/hooks.test.tsx
@@ -464,6 +464,7 @@ describe('useListedPanelPluginIds', () => {
       'candlestick',
       'canvas',
       'dashlist',
+      'debug',
       'flamegraph',
       'gauge',
       'geomap',

--- a/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1AppMapper.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1AppMapper.test.ts
@@ -77,7 +77,7 @@ describe('v0alpha1AppMapper', () => {
   it('should only map specs with type app', () => {
     const result = v0alpha1AppMapper(v0alpha1Response);
 
-    expect(v0alpha1Response.items).toHaveLength(53);
+    expect(v0alpha1Response.items).toHaveLength(54);
     expect(Object.keys(result)).toHaveLength(4);
     expect(Object.keys(result)).toEqual(Object.keys(apps));
   });

--- a/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.test.ts
@@ -15,13 +15,13 @@ describe('v0alpha1PanelMapper', () => {
       expect(result[pluginId].id).toEqual(panels[pluginId].id);
     });
 
-    it('should name id property correctly', () => {
+    it('should map name property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].name).toEqual(panels[pluginId].name);
     });
 
-    it('should name info property correctly', () => {
+    it('should map info property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       const { keywords: resultKeywords, ...resultRest } = result[pluginId].info;
@@ -31,90 +31,96 @@ describe('v0alpha1PanelMapper', () => {
       expect(resultKeywords).toEqual(configKeywords || []); // keywords in config.panels is null when missing keywords
     });
 
-    it('should name hideFromList property correctly', () => {
+    it('should map hideFromList property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].hideFromList).toEqual(panels[pluginId].hideFromList);
     });
 
-    it('should name sort property correctly', () => {
+    it('should map sort property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].sort).toEqual(panels[pluginId].sort);
     });
 
-    it('should name skipDataQuery property correctly', () => {
+    it('should map skipDataQuery property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].skipDataQuery).toEqual(panels[pluginId].skipDataQuery);
     });
 
-    it('should name suggestions property correctly', () => {
+    it('should map suggestions property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].suggestions).toEqual(panels[pluginId].suggestions);
     });
 
-    it('should name state property correctly', () => {
+    it('should map state property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].state).toEqual(panels[pluginId].state);
     });
 
-    it('should name baseUrl property correctly', () => {
+    it('should map baseUrl property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].baseUrl).toEqual(panels[pluginId].baseUrl);
     });
 
-    it('should name signature property correctly', () => {
+    it('should map signature property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].signature).toEqual(panels[pluginId].signature);
     });
 
-    it('should name module property correctly', () => {
+    it('should map module property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].module).toEqual(panels[pluginId].module);
     });
 
-    it('should name angular property correctly', () => {
+    it('should map angular property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].angular).toEqual({});
     });
 
-    it('should name loadingStrategy property correctly', () => {
+    it('should map loadingStrategy property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].loadingStrategy).toEqual(panels[pluginId].loadingStrategy);
     });
 
-    it('should name type property correctly', () => {
+    it('should map type property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].type).toEqual('panel');
     });
 
-    it('should name translations property correctly', () => {
+    it('should map translations property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].translations).toEqual(panels[pluginId].translations);
     });
 
-    it('should name moduleHash property correctly', () => {
+    it('should map moduleHash property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 
       expect(result[pluginId].moduleHash).toEqual(panels[pluginId].moduleHash);
+    });
+
+    it('should map aliasIDs property correctly', () => {
+      const result = v0alpha1PanelMapper(v0alpha1Response);
+
+      expect(result[pluginId].aliasIDs).toEqual(panels[pluginId].aliasIDs);
     });
   });
 
   it('should only map specs with type panel', () => {
     const result = v0alpha1PanelMapper(v0alpha1Response);
 
-    expect(v0alpha1Response.items).toHaveLength(53);
-    expect(Object.keys(result)).toHaveLength(27);
+    expect(v0alpha1Response.items).toHaveLength(54);
+    expect(Object.keys(result)).toHaveLength(28);
     expect(Object.keys(result)).toEqual(Object.keys(panels));
   });
 

--- a/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.ts
@@ -146,6 +146,7 @@ function specMapper(spec: v0alpha1Spec): PanelPluginMeta {
   const angular = angularMapper(spec);
   const translations = spec.translations;
   const moduleHash = spec.module.hash;
+  const aliasIDs = spec.aliasIds;
 
   return {
     id,
@@ -164,6 +165,7 @@ function specMapper(spec: v0alpha1Spec): PanelPluginMeta {
     type,
     translations,
     moduleHash,
+    aliasIDs,
   };
 }
 

--- a/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/config.panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/config.panels.ts
@@ -481,6 +481,43 @@ export const panels: PanelPluginMetas = structuredClone({
     loadingStrategy: PluginLoadingStrategy.script,
     type: PluginType.panel,
   },
+  debug: {
+    id: 'debug',
+    name: 'Debug',
+    aliasIDs: ['debugX'],
+    info: {
+      author: {
+        name: 'Grafana Labs',
+        url: 'https://grafana.com',
+      },
+      description: 'Debug Panel for Grafana',
+      links: [
+        {
+          name: 'Raise issue',
+          url: 'https://github.com/grafana/grafana/issues/new',
+        },
+      ],
+      logos: {
+        small: 'public/plugins/debug/img/icn-debug.svg',
+        large: 'public/plugins/debug/img/icn-debug.svg',
+      },
+      build: {},
+      screenshots: [],
+      version: '',
+      updated: '',
+      keywords: null,
+    },
+    hideFromList: false,
+    sort: 100,
+    skipDataQuery: false,
+    state: PluginState.alpha,
+    baseUrl: 'public/plugins/debug',
+    signature: PluginSignatureStatus.internal,
+    module: 'core:plugin/debug',
+    angular: { detected: false } as AngularMeta,
+    loadingStrategy: PluginLoadingStrategy.script,
+    type: PluginType.panel,
+  },
   flamegraph: {
     id: 'flamegraph',
     name: 'Flame Graph',

--- a/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/v0alpha1Response.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/v0alpha1Response.ts
@@ -1084,6 +1084,57 @@ export const v0alpha1Response: PluginMetasResponse = structuredClone({
       kind: 'Meta',
       apiVersion: 'plugins.grafana.app/v0alpha1',
       metadata: {
+        name: 'debug',
+        namespace: 'default',
+      },
+      spec: {
+        aliasIds: ['debugX'],
+        pluginJson: {
+          id: 'debug',
+          type: 'panel',
+          name: 'Debug',
+          info: {
+            keywords: [],
+            logos: {
+              small: 'public/plugins/debug/img/icn-debug.svg',
+              large: 'public/plugins/debug/img/icn-debug.svg',
+            },
+            updated: '',
+            version: '',
+            author: {
+              name: 'Grafana Labs',
+              url: 'https://grafana.com',
+            },
+            description: 'Debug Panel for Grafana',
+            links: [
+              {
+                name: 'Raise issue',
+                url: 'https://github.com/grafana/grafana/issues/new',
+              },
+            ],
+          },
+          dependencies: {
+            grafanaDependency: '',
+            grafanaVersion: '*',
+          },
+          state: 'alpha',
+        },
+        class: 'core',
+        module: {
+          path: 'core:plugin/debug',
+          loadingStrategy: 'script',
+        },
+        baseURL: 'public/plugins/debug',
+        signature: {
+          status: 'internal',
+        },
+      },
+      status: {},
+    },
+    {
+      kind: 'Meta',
+      apiVersion: 'plugins.grafana.app/v0alpha1',
+      metadata: {
         name: 'elasticsearch',
         namespace: 'default',
       },


### PR DESCRIPTION
**What is this feature?**

This pull request adds mapping for `aliasIds` from the Plugin Meta API and updates test data and test cases.

**Why do we need this feature?**

`aliasIds` was recently added in the [backend](https://github.com/grafana/grafana/pull/121074) so we need to map it in the Frontend 

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #121278

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
