### PR TITLE
Unified: prioritize migration log in status reader (slow)

### DIFF
--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -592,7 +592,10 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	migrationRegistry := provideMigrationRegistry(foldersDashboardsMigrator, playlistMigrator, shortURLMigrator)
 	unifiedMigrator := migrations2.ProvideUnifiedMigrator(resourceClient, migrationRegistry)
 	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry)
-	migrationStatusReader := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry)
+	migrationStatusReader, err := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry, registerer)
+	if err != nil {
+		return nil, err
+	}
 	dualwriteService, err := dualwrite.ProvideService(featureToggles, kvStore, cfg, unifiedStorageMigrationService, migrationStatusReader, registerer)
 	if err != nil {
 		return nil, err
@@ -1284,7 +1287,10 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	migrationRegistry := provideMigrationRegistry(foldersDashboardsMigrator, playlistMigrator, shortURLMigrator)
 	unifiedMigrator := migrations2.ProvideUnifiedMigrator(resourceClient, migrationRegistry)
 	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry)
-	migrationStatusReader := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry)
+	migrationStatusReader, err := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry, registerer)
+	if err != nil {
+		return nil, err
+	}
 	dualwriteService, err := dualwrite.ProvideService(featureToggles, kvStore, cfg, unifiedStorageMigrationService, migrationStatusReader, registerer)
 	if err != nil {
 		return nil, err

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -668,7 +668,7 @@ type Cfg struct {
 	GarbageCollectionMaxAge                    time.Duration
 	DashboardsGarbageCollectionMaxAge          time.Duration
 	// StorageModeCacheTTL is the TTL for caching statusReader results in the dynamic dualwrite service.
-	// Default: 0 (no expiration).
+	// Default: 5 seconds, 0 or negative means no expiration.
 	StorageModeCacheTTL time.Duration
 
 	EventRetentionPeriod time.Duration

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -196,7 +196,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.NotifierSettleDelay = section.Key("notifier_settle_delay").MustDuration(3 * time.Second)
 
 	// TTL for caching statusReader results in the dynamic dualwrite service. 0 = no expiration.
-	cfg.StorageModeCacheTTL = section.Key("storage_mode_cache_ttl").MustDuration(0)
+	cfg.StorageModeCacheTTL = section.Key("storage_mode_cache_ttl").MustDuration(5 * time.Second)
 
 	// use sqlkv (resource/sqlkv) instead of the sql backend (sql/backend) as the StorageServer
 	cfg.EnableSQLKVBackend = section.Key("enable_sqlkv_backend").MustBool(false)

--- a/pkg/storage/legacysql/dualwrite/metrics.go
+++ b/pkg/storage/legacysql/dualwrite/metrics.go
@@ -14,30 +14,48 @@ var (
 		Help: "Total number of failed background operations in unified storage",
 	}, []string{"resource", "method"})
 
+	statusReaderNullMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "dualwriter_status_reader_null_total",
+		Help: "Total number of times the status reader was null when resolving storage mode",
+	}, []string{"resource"})
+
+	statusReaderErrorsMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "dualwriter_status_reader_errors_total",
+		Help: "Total number of errors from the status reader when resolving storage mode",
+	}, []string{"resource"})
+
 	backgroundErrorMethods = []string{"GET", "LIST", "CREATE", "DELETE", "UPDATE", "DELETE_COLLECTION"}
 )
 
 type dualWriterMetrics struct {
-	backgroundErrors *prometheus.CounterVec
+	backgroundErrors   *prometheus.CounterVec
+	statusReaderNull   *prometheus.CounterVec
+	statusReaderErrors *prometheus.CounterVec
 }
 
 func provideDualWriterMetrics(reg prometheus.Registerer) *dualWriterMetrics {
 	registerMetricsOnce.Do(func() {
 		if reg != nil {
-			if err := reg.Register(backgroundErrorsMetric); err != nil {
-				log.New("dualwrite").Warn("failed to register dualwriter metrics", "error", err)
+			for _, m := range []prometheus.Collector{backgroundErrorsMetric, statusReaderNullMetric, statusReaderErrorsMetric} {
+				if err := reg.Register(m); err != nil {
+					log.New("dualwrite").Warn("failed to register dualwriter metrics", "error", err)
+				}
 			}
 		}
 	})
 	return &dualWriterMetrics{
-		backgroundErrors: backgroundErrorsMetric,
+		backgroundErrors:   backgroundErrorsMetric,
+		statusReaderNull:   statusReaderNullMetric,
+		statusReaderErrors: statusReaderErrorsMetric,
 	}
 }
 
-// initResource initializes all method counter combinations to zero for the given resource,
+// initResource initializes all counter combinations to zero for the given resource,
 // so that the metric is distinguishable from "not scraped" (absent) vs "no errors" (zero).
 func (m *dualWriterMetrics) initResource(resource string) {
 	for _, method := range backgroundErrorMethods {
 		m.backgroundErrors.WithLabelValues(resource, method).Add(0)
 	}
+	m.statusReaderNull.WithLabelValues(resource).Add(0)
+	m.statusReaderErrors.WithLabelValues(resource).Add(0)
 }

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	gocache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -37,12 +37,12 @@ type fakeMigrationStatusReader struct {
 
 var _ unifiedmigrations.MigrationStatusReader = (*fakeMigrationStatusReader)(nil)
 
-func (f *fakeMigrationStatusReader) GetStorageMode(ctx context.Context, gr schema.GroupResource) unifiedmigrations.StorageMode {
+func (f *fakeMigrationStatusReader) GetStorageMode(ctx context.Context, gr schema.GroupResource) (unifiedmigrations.StorageMode, error) {
 	mode, ok := f.modes[gr.String()]
 	if !ok {
-		return unifiedmigrations.StorageModeLegacy
+		return unifiedmigrations.StorageModeLegacy, nil
 	}
-	return mode
+	return mode, nil
 }
 
 // NewFakeMigrationStatusReader creates a MigrationStatusReader for tests.
@@ -122,45 +122,33 @@ func ProvideService(
 		}
 	}
 
-	cacheTTL := gocache.NoExpiration
-	cacheCleanup := time.Duration(0)
-	if cfg != nil && cfg.StorageModeCacheTTL > 0 {
-		cacheTTL = cfg.StorageModeCacheTTL
-		cacheCleanup = cacheTTL * 2
-	}
-
 	return &service{
 		db: &keyvalueDB{
 			db:     kv,
 			logger: logging.DefaultLogger.With("logger", "dualwrite.kv"),
 		},
-		enabled:            enabled,
-		statusReader:       statusReader,
-		resourceModesCache: gocache.New(cacheTTL, cacheCleanup),
-		metrics:            metrics,
+		enabled:      enabled,
+		statusReader: statusReader,
+		metrics:      metrics,
 	}, nil
 }
 
 type service struct {
-	db                 *keyvalueDB
-	enabled            bool
-	statusReader       unifiedmigrations.MigrationStatusReader
-	resourceModesCache *gocache.Cache
-	metrics            *dualWriterMetrics
+	db           *keyvalueDB
+	enabled      bool
+	statusReader unifiedmigrations.MigrationStatusReader
+	metrics      *dualWriterMetrics
 }
 
-// getStorageMode returns the cached StorageMode for a non-managed resource.
-// Results are cached with the TTL configured via StorageModeCacheTTL.
+// getStorageMode returns the StorageMode for a non-managed resource.
+// On error, the config-mode is used directly.
 func (m *service) getStorageMode(ctx context.Context, gr schema.GroupResource) unifiedmigrations.StorageMode {
-	key := gr.String()
-	if val, ok := m.resourceModesCache.Get(key); ok {
-		return val.(unifiedmigrations.StorageMode)
+	resource := gr.String()
+	mode, err := m.statusReader.GetStorageMode(ctx, gr)
+	if err != nil {
+		m.metrics.statusReaderErrors.WithLabelValues(resource).Inc()
+		return mode
 	}
-
-	mode := m.statusReader.GetStorageMode(ctx, gr)
-	m.resourceModesCache.SetDefault(key, mode)
-
-	logging.DefaultLogger.With("resource", key, "mode", mode).Info("resolved dynamic storage mode")
 	return mode
 }
 

--- a/pkg/storage/legacysql/dualwrite/service_test.go
+++ b/pkg/storage/legacysql/dualwrite/service_test.go
@@ -2,10 +2,12 @@ package dualwrite
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -231,13 +233,9 @@ func TestService(t *testing.T) {
 		}
 	})
 
-	t.Run("dynamic getStorageMode caches statusReader results", func(t *testing.T) {
+	t.Run("dynamic getStorageMode delegates to statusReader", func(t *testing.T) {
 		gr := schema.GroupResource{Group: "iam.grafana.app", Resource: "users"}
-		calls := 0
-		reader := &countingStatusReader{
-			delegate: NewFakeMigrationStatusReader(gr.String(), unifiedmigrations.StorageModeUnified),
-			calls:    &calls,
-		}
+		reader := NewFakeMigrationStatusReader(gr.String(), unifiedmigrations.StorageModeUnified)
 
 		svc, err := ProvideService(
 			featuremgmt.WithFeatures(featuremgmt.FlagProvisioning),
@@ -249,33 +247,9 @@ func TestService(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ctx := context.Background()
-		for i := 0; i < 10; i++ {
-			got, err := svc.ReadFromUnified(ctx, gr)
-			require.NoError(t, err)
-			require.True(t, got)
-		}
-		require.Equal(t, 1, calls, "should resolve from reader exactly once (cached)")
-	})
-
-	t.Run("static getStorageMode resolves from reader exactly once", func(t *testing.T) {
-		gr := schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"}
-		calls := 0
-		reader := &countingStatusReader{
-			delegate: NewFakeMigrationStatusReader(gr.String(), unifiedmigrations.StorageModeDualWrite),
-			calls:    &calls,
-		}
-
-		svc := &staticService{
-			cfg:          NewFakeConfig(),
-			statusReader: reader,
-		}
-
-		for i := 0; i < 10; i++ {
-			mode := svc.getStorageMode(context.Background(), gr)
-			require.Equal(t, unifiedmigrations.StorageModeDualWrite, mode)
-		}
-		require.Equal(t, 1, calls, "should resolve from reader exactly once")
+		got, err := svc.ReadFromUnified(context.Background(), gr)
+		require.NoError(t, err)
+		require.True(t, got)
 	})
 
 	t.Run("static", func(t *testing.T) {
@@ -375,13 +349,136 @@ func TestService(t *testing.T) {
 	})
 }
 
-// countingStatusReader wraps a MigrationStatusReader and counts calls to GetStorageMode.
-type countingStatusReader struct {
-	delegate unifiedmigrations.MigrationStatusReader
-	calls    *int
+func TestNewConfigBasedMigrationStatusReader(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := &setting.Cfg{
+		UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+			"globalroles.iam.grafana.app":      {DualWriterMode: rest.Mode5},
+			"dashboards.dashboard.grafana.app": {DualWriterMode: rest.Mode1},
+			"widgets.test.grafana.app":         {DualWriterMode: rest.Mode0},
+		},
+	}
+	reader := NewConfigBasedMigrationStatusReader(cfg)
+
+	// Mode5 → Unified
+	mode, err := reader.GetStorageMode(ctx, schema.GroupResource{Group: "iam.grafana.app", Resource: "globalroles"})
+	require.NoError(t, err)
+	require.Equal(t, unifiedmigrations.StorageModeUnified, mode)
+
+	// Mode1 → DualWrite
+	mode, err = reader.GetStorageMode(ctx, schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"})
+	require.NoError(t, err)
+	require.Equal(t, unifiedmigrations.StorageModeDualWrite, mode)
+
+	// Mode0 → Legacy
+	mode, err = reader.GetStorageMode(ctx, schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"})
+	require.NoError(t, err)
+	require.Equal(t, unifiedmigrations.StorageModeLegacy, mode)
+
+	// Unconfigured resource → Legacy (default)
+	mode, err = reader.GetStorageMode(ctx, schema.GroupResource{Group: "unknown.grafana.app", Resource: "things"})
+	require.NoError(t, err)
+	require.Equal(t, unifiedmigrations.StorageModeLegacy, mode)
+
+	// nil cfg → all Legacy
+	nilReader := NewConfigBasedMigrationStatusReader(nil)
+	mode, err = nilReader.GetStorageMode(ctx, schema.GroupResource{Group: "iam.grafana.app", Resource: "globalroles"})
+	require.NoError(t, err)
+	require.Equal(t, unifiedmigrations.StorageModeLegacy, mode)
 }
 
-func (c *countingStatusReader) GetStorageMode(ctx context.Context, gr schema.GroupResource) unifiedmigrations.StorageMode {
-	*c.calls++
-	return c.delegate.GetStorageMode(ctx, gr)
+func TestServiceMetrics_NullStatusReader(t *testing.T) {
+	gr := schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"}
+
+	cfg := &setting.Cfg{
+		UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+			gr.String(): {DualWriterMode: rest.Mode1},
+		},
+	}
+
+	t.Run("staticService increments statusReaderNull when reader is nil", func(t *testing.T) {
+		metrics := newTestDualWriterMetrics()
+		svc := &staticService{cfg: cfg, metrics: metrics}
+		mode := svc.getStorageMode(context.Background(), gr)
+		require.Equal(t, unifiedmigrations.StorageModeDualWrite, mode)
+		require.Equal(t, float64(1), testutil.ToFloat64(metrics.statusReaderNull.WithLabelValues(gr.String())))
+		require.Equal(t, float64(0), testutil.ToFloat64(metrics.statusReaderErrors.WithLabelValues(gr.String())))
+	})
+}
+
+func TestServiceMetrics_StatusReaderError(t *testing.T) {
+	gr := schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"}
+
+	cfg := &setting.Cfg{
+		UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+			gr.String(): {DualWriterMode: rest.Mode4},
+		},
+	}
+
+	t.Run("service increments statusReaderErrors and uses reader-returned mode", func(t *testing.T) {
+		metrics := newTestDualWriterMetrics()
+		svc := &service{
+			statusReader: &failingStatusReader{mode: unifiedmigrations.StorageModeDualWrite, err: errors.New("db down")},
+			metrics:      metrics,
+		}
+		mode := svc.getStorageMode(context.Background(), gr)
+		require.Equal(t, unifiedmigrations.StorageModeDualWrite, mode, "should use mode returned by reader alongside error")
+		require.Equal(t, float64(0), testutil.ToFloat64(metrics.statusReaderNull.WithLabelValues(gr.String())))
+		require.Equal(t, float64(1), testutil.ToFloat64(metrics.statusReaderErrors.WithLabelValues(gr.String())))
+	})
+
+	t.Run("staticService increments statusReaderErrors and uses reader-returned mode", func(t *testing.T) {
+		metrics := newTestDualWriterMetrics()
+		svc := &staticService{
+			cfg:          cfg,
+			statusReader: &failingStatusReader{mode: unifiedmigrations.StorageModeDualWrite, err: errors.New("db down")},
+			metrics:      metrics,
+		}
+		mode := svc.getStorageMode(context.Background(), gr)
+		require.Equal(t, unifiedmigrations.StorageModeDualWrite, mode, "should use mode returned by reader alongside error")
+		require.Equal(t, float64(0), testutil.ToFloat64(metrics.statusReaderNull.WithLabelValues(gr.String())))
+		require.Equal(t, float64(1), testutil.ToFloat64(metrics.statusReaderErrors.WithLabelValues(gr.String())))
+	})
+}
+
+func TestServiceMetrics_HappyPath(t *testing.T) {
+	gr := schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"}
+	metrics := newTestDualWriterMetrics()
+
+	svc := &service{
+		statusReader: NewFakeMigrationStatusReader(gr.String(), unifiedmigrations.StorageModeUnified),
+		metrics:      metrics,
+	}
+	mode := svc.getStorageMode(context.Background(), gr)
+	require.Equal(t, unifiedmigrations.StorageModeUnified, mode)
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.statusReaderNull.WithLabelValues(gr.String())))
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.statusReaderErrors.WithLabelValues(gr.String())))
+}
+
+// --- test helpers ---
+
+// newTestDualWriterMetrics creates isolated metrics for test assertions.
+func newTestDualWriterMetrics() *dualWriterMetrics {
+	return &dualWriterMetrics{
+		backgroundErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_bg_errors",
+		}, []string{"resource", "method"}),
+		statusReaderNull: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_reader_null",
+		}, []string{"resource"}),
+		statusReaderErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_reader_errors",
+		}, []string{"resource"}),
+	}
+}
+
+// failingStatusReader always returns an error alongside the configured mode.
+type failingStatusReader struct {
+	mode unifiedmigrations.StorageMode
+	err  error
+}
+
+func (f *failingStatusReader) GetStorageMode(_ context.Context, _ schema.GroupResource) (unifiedmigrations.StorageMode, error) {
+	return f.mode, f.err
 }

--- a/pkg/storage/legacysql/dualwrite/static.go
+++ b/pkg/storage/legacysql/dualwrite/static.go
@@ -3,12 +3,10 @@ package dualwrite
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/setting"
 	unifiedmigrations "github.com/grafana/grafana/pkg/storage/unified/migrations/contract"
@@ -30,9 +28,6 @@ type staticService struct {
 	cfg          *setting.Cfg
 	statusReader unifiedmigrations.MigrationStatusReader
 	metrics      *dualWriterMetrics
-
-	// resourceModesCache holds the resolved StorageMode per resource
-	resourceModesCache sync.Map // map[string]unifiedmigrations.StorageMode
 }
 
 // Used in tests
@@ -49,26 +44,18 @@ func (m *staticService) SetMode(gr schema.GroupResource, mode rest.DualWriterMod
 }
 
 // getStorageMode returns the StorageMode for a resource.
-//
-// When a MigrationStatusReader is available the result is cached.
-// Without a statusReader (tests via NewStaticStorage) the config-mode.
+// Without a statusReader or on error, the config-mode is used directly.
 func (m *staticService) getStorageMode(ctx context.Context, gr schema.GroupResource) unifiedmigrations.StorageMode {
+	resource := gr.String()
 	if m.statusReader == nil {
-		config := m.cfg.UnifiedStorage[gr.String()]
-		return storageModeFromConfigMode(config.DualWriterMode)
+		m.metrics.statusReaderNull.WithLabelValues(resource).Inc()
+		return storageModeFromConfigMode(m.cfg.UnifiedStorage[resource].DualWriterMode)
 	}
-
-	key := gr.String()
-
-	if val, ok := m.resourceModesCache.Load(key); ok {
-		return val.(unifiedmigrations.StorageMode)
+	mode, err := m.statusReader.GetStorageMode(ctx, gr)
+	if err != nil {
+		m.metrics.statusReaderErrors.WithLabelValues(resource).Inc()
+		return mode
 	}
-
-	// Resolve once from the MigrationStatusReader.
-	mode := m.statusReader.GetStorageMode(ctx, gr)
-	m.resourceModesCache.Store(key, mode)
-
-	logging.DefaultLogger.With("resource", key, "mode", mode).Info("resolved static storage mode")
 	return mode
 }
 

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -78,9 +78,3 @@ type SearchAdapter struct {
 func NewSearchAdapter(s Service) *SearchAdapter {
 	return &SearchAdapter{Service: s}
 }
-
-func (d *SearchAdapter) IsEnabled(gr schema.GroupResource) bool {
-	//nolint:errcheck
-	status, _ := d.Status(context.Background(), gr)
-	return status.Runtime && d.ShouldManage(gr)
-}

--- a/pkg/storage/unified/migrations/contract/migrations.go
+++ b/pkg/storage/unified/migrations/contract/migrations.go
@@ -53,10 +53,10 @@ func (m StorageMode) String() string {
 // legacy storage, dual-write mode, or unified storage.
 //
 // Resolution priority:
-//  1. Config Mode1 (or Mode2/Mode3 for backward compat) → DualWrite
-//  2. Migration log entry exists → Unified
+//  1. Migration log entry exists → Unified
+//  2. Config Mode1 (or Mode2/Mode3 for backward compat) → DualWrite
 //  3. Config Mode4/Mode5 → Unified (temporary fallback for cloud backfill transition)
 //  4. Otherwise → Legacy
 type MigrationStatusReader interface {
-	GetStorageMode(ctx context.Context, gr schema.GroupResource) StorageMode
+	GetStorageMode(ctx context.Context, gr schema.GroupResource) (StorageMode, error)
 }

--- a/pkg/storage/unified/migrations/resources.go
+++ b/pkg/storage/unified/migrations/resources.go
@@ -72,11 +72,13 @@ func isMigrationEnabled(def MigrationDefinition, cfg *setting.Cfg) (bool, error)
 
 const migrationLogTableName = "unifiedstorage_migration_log"
 
-func migrationExists(ctx context.Context, sqlStore db.DB, migrationID string) (bool, error) {
+func successfulMigrationExists(ctx context.Context, sqlStore db.DB, migrationID string) (bool, error) {
 	var count int64
 	err := sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
 		var err error
-		count, err = sess.Table(migrationLogTableName).Where("migration_id = ?", migrationID).Count()
+		count, err = sess.Table(migrationLogTableName).
+			Where("migration_id = ? AND success = ?", migrationID, true).
+			Count()
 		return err
 	})
 	if err != nil {

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -73,6 +73,14 @@ func (p *UnifiedStorageMigrationServiceImpl) Run(ctx context.Context) error {
 
 // EnsureMigrationLogTable creates the unifiedstorage_migration_log table if it doesn't exist.
 func EnsureMigrationLogTable(ctx context.Context, sqlStore db.DB, cfg *setting.Cfg) error {
+	exists, err := sqlStore.GetEngine().IsTableExist(migrationLogTableName)
+	if err != nil {
+		return fmt.Errorf("failed to check migration log table existence: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
 	mg := sqlstoremigrator.NewScopedMigrator(sqlStore.GetEngine(), cfg, "unifiedstorage")
 	mg.AddCreateMigration()
 	sec := cfg.Raw.Section("database")

--- a/pkg/storage/unified/migrations/status_reader.go
+++ b/pkg/storage/unified/migrations/status_reader.go
@@ -2,18 +2,59 @@ package migrations
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/migrations/contract"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var (
+	registerStatusReaderMetricsOnce sync.Once
+
+	migrationLogBootstrapFailuresMetric = metricutil.NewCounterStartingAtZero(prometheus.CounterOpts{
+		Name: "migration_status_reader_bootstrap_failures_total",
+		Help: "Total number of failures when ensuring the migration log table exists at startup",
+	})
+)
+
+type statusReaderMetrics struct {
+	bootstrapFailures prometheus.Counter
+}
+
+func provideStatusReaderMetrics(reg prometheus.Registerer) *statusReaderMetrics {
+	registerStatusReaderMetricsOnce.Do(func() {
+		if reg != nil {
+			if err := reg.Register(migrationLogBootstrapFailuresMetric); err != nil {
+				logger.Warn("Failed to register status reader metrics", "error", err)
+			}
+		} else {
+			logger.Warn("No Prometheus registerer provided, status reader metrics will not be registered")
+		}
+	})
+	return &statusReaderMetrics{
+		bootstrapFailures: migrationLogBootstrapFailuresMetric,
+	}
+}
+
 type migrationStatusReader struct {
 	sqlStore db.DB
 	cfg      *setting.Cfg
 	registry *MigrationRegistry
+	cache    *gocache.Cache
+	metrics  *statusReaderMetrics
+	onlyCfg  bool
 }
 
 var _ contract.MigrationStatusReader = (*migrationStatusReader)(nil)
@@ -23,63 +64,108 @@ func ProvideMigrationStatusReader(
 	sqlStore db.DB,
 	cfg *setting.Cfg,
 	registry *MigrationRegistry,
-) contract.MigrationStatusReader {
+	reg prometheus.Registerer,
+) (contract.MigrationStatusReader, error) {
+	cacheTTL := gocache.NoExpiration
+	cacheCleanup := time.Duration(0)
+	if cfg.StorageModeCacheTTL > 0 {
+		cacheTTL = cfg.StorageModeCacheTTL
+		cacheCleanup = cacheTTL * 2
+	}
+
+	metrics := provideStatusReaderMetrics(reg)
 	reader := &migrationStatusReader{
 		sqlStore: sqlStore,
 		cfg:      cfg,
 		registry: registry,
+		cache:    gocache.New(cacheTTL, cacheCleanup),
+		metrics:  metrics,
 	}
 
 	if err := EnsureMigrationLogTable(context.Background(), sqlStore, cfg); err != nil {
-		logger.Warn("Failed to ensure migration log table exists", "error", err)
-		return reader
+		metrics.bootstrapFailures.Inc()
+		// Fail startup on lock errors
+		if errors.Is(err, migrator.ErrMigratorIsLocked) || errors.Is(err, migrator.ErrLockDB) {
+			return nil, fmt.Errorf("failed to ensure migration log table: %w", err)
+		}
+		// Can't create migration log table, fall back to config-only mode.
+		reader.onlyCfg = true
+		logger.Warn("Migration log table missing and bootstrap failed, falling back to config-driven resolution", "error", err)
 	}
-
-	return reader
+	return reader, nil
 }
 
 // GetStorageMode determines the storage mode for a resource.
 //
 // Resolution priority:
-//  1. Config Mode1 (or Mode2/Mode3 for backward compat) → DualWrite
-//     This is an explicit operational knob, primarily used in cloud to hold a resource
-//     in dual-write mode for validation before promoting to unified.
-//  2. Migration log entry exists → Unified (data has been synced)
+//  1. Migration log entry exists → Unified (data has been synced)
+//  2. Config Mode1 (or Mode2/Mode3 for backward compat) → DualWrite
 //  3. Config Mode4/Mode5 → Unified (temporary fallback for cloud backfill transition)
 //  4. Otherwise → Legacy
-func (r *migrationStatusReader) GetStorageMode(ctx context.Context, gr schema.GroupResource) contract.StorageMode {
-	// Check config for explicit DualWrite modes (Mode1, Mode2, Mode3).
-	// This takes priority because it's an explicit operational decision — cloud may want
-	// to hold a resource in dual-write even after data has been synced.
+func (r *migrationStatusReader) GetStorageMode(ctx context.Context, gr schema.GroupResource) (contract.StorageMode, error) {
+	key := gr.String()
+	if val, ok := r.cache.Get(key); ok {
+		return val.(contract.StorageMode), nil
+	}
+	return r.resolveStorageMode(ctx, gr)
+}
+
+func (r *migrationStatusReader) resolveStorageMode(ctx context.Context, gr schema.GroupResource) (contract.StorageMode, error) {
 	configKey := gr.Resource + "." + gr.Group
+	// Config is used if table does not exist or in case of errors
+	// DualWrite modes (Mode1, Mode2, Mode3) and Unified modes (Mode4, Mode5).
+	mode := contract.StorageModeLegacy
 	if config, found := r.cfg.UnifiedStorage[configKey]; found {
 		if config.DualWriterMode >= rest.Mode1 && config.DualWriterMode <= rest.Mode3 {
-			return contract.StorageModeDualWrite
+			mode = contract.StorageModeDualWrite
+		}
+		if config.DualWriterMode >= rest.Mode4 {
+			mode = contract.StorageModeUnified
 		}
 	}
 
-	// Check the migration log (primary source of truth for "data has been synced").
+	if r.onlyCfg {
+		if !r.migrationLogTableAvailable() {
+			logger.Debug("Migration log table not available, using config for storage mode resolution", "resource", gr.String(), "config_mode", configKey, "resolved_mode", mode)
+			return mode, nil
+		}
+		logger.Info("Migration log table now available, using log-based resolution")
+		r.onlyCfg = false
+	}
+
+	// The migration log is the source of truth for "data has been synced".
+	// Cache the result of this check to avoid database queries on every request.
 	def, ok := r.findDefinition(gr)
 	if ok {
-		exists, err := migrationExists(ctx, r.sqlStore, def.MigrationID)
+		exists, err := successfulMigrationExists(ctx, r.sqlStore, def.MigrationID)
 		if err != nil {
-			// If the migration log query fails (e.g., table not created yet),
-			// log and fall through to the config fallback rather than failing hard.
 			logger.Warn("Failed to check migration log, falling back to config", "resource", gr.String(), "error", err)
-		} else if exists {
-			return contract.StorageModeUnified
+			return mode, fmt.Errorf("failed to resolve storage mode: resource=%s err=%w", gr.String(), err)
 		}
+		if exists {
+			logger.Info("Resolved storage mode from migration log", "resource", gr.String(), "mode", contract.StorageModeUnified)
+			r.cache.Set(gr.String(), contract.StorageModeUnified, gocache.NoExpiration)
+			return contract.StorageModeUnified, nil
+		}
+		r.cache.SetDefault(gr.String(), mode)
+	}
+	return mode, nil
+}
+
+const tableExistsCacheKey = "__migration_log_table_exists"
+
+// migrationLogTableAvailable checks whether the migration log table exists with cache TTL
+func (r *migrationStatusReader) migrationLogTableAvailable() bool {
+	if _, ok := r.cache.Get(tableExistsCacheKey); ok {
+		return false
 	}
 
-	// Fallback: check config for Mode4+ (for environments where migrations are external).
-	// This is temporary and will be removed once all environments backfill the migration log.
-	if config, found := r.cfg.UnifiedStorage[configKey]; found {
-		if config.DualWriterMode >= rest.Mode4 {
-			return contract.StorageModeUnified
-		}
+	exists, err := r.sqlStore.GetEngine().IsTableExist(migrationLogTableName)
+	if err != nil || !exists {
+		r.cache.SetDefault(tableExistsCacheKey, false)
+		return false
 	}
-
-	return contract.StorageModeLegacy
+	return true
 }
 
 // findDefinition locates the MigrationDefinition that contains the given GroupResource.

--- a/pkg/storage/unified/migrations/status_reader_test.go
+++ b/pkg/storage/unified/migrations/status_reader_test.go
@@ -2,9 +2,16 @@ package migrations
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
+	infraDB "github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/migrations/contract"
 	"github.com/stretchr/testify/require"
@@ -34,189 +41,327 @@ func TestMigrationStatusReader_FindDefinition(t *testing.T) {
 		},
 	})
 
-	reader := &migrationStatusReader{registry: registry}
+	reader := newTestStatusReader(t, &setting.Cfg{}, registry)
 
-	t.Run("finds definition for folder resource", func(t *testing.T) {
-		def, ok := reader.findDefinition(folderGR)
-		require.True(t, ok)
-		require.Equal(t, "folders-dashboards", def.ID)
-	})
+	tests := []struct {
+		name      string
+		gr        schema.GroupResource
+		wantID    string
+		wantFound bool
+	}{
+		{name: "resource in multi-resource definition", gr: folderGR, wantID: "folders-dashboards", wantFound: true},
+		{name: "second resource in same definition", gr: dashboardGR, wantID: "folders-dashboards", wantFound: true},
+		{name: "resource in single-resource definition", gr: playlistGR, wantID: "playlists", wantFound: true},
+		{name: "unregistered resource", gr: unknownGR, wantFound: false},
+	}
 
-	t.Run("finds definition for dashboard resource", func(t *testing.T) {
-		def, ok := reader.findDefinition(dashboardGR)
-		require.True(t, ok)
-		require.Equal(t, "folders-dashboards", def.ID)
-	})
-
-	t.Run("finds definition for playlist resource", func(t *testing.T) {
-		def, ok := reader.findDefinition(playlistGR)
-		require.True(t, ok)
-		require.Equal(t, "playlists", def.ID)
-	})
-
-	t.Run("returns false for unknown resource", func(t *testing.T) {
-		_, ok := reader.findDefinition(unknownGR)
-		require.False(t, ok)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def, ok := reader.findDefinition(tt.gr)
+			require.Equal(t, tt.wantFound, ok)
+			if tt.wantFound {
+				require.Equal(t, tt.wantID, def.ID)
+			}
+		})
+	}
 }
 
-func TestMigrationStatusReader_GetStorageMode_ConfigOnly(t *testing.T) {
-	// These tests exercise config-based resolution (no DB).
-	// The migration log path requires a real database and is covered by integration tests.
-
+func TestMigrationStatusReader_GetStorageMode_ConfigResolution(t *testing.T) {
 	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
 	unknownGR := schema.GroupResource{Resource: "unknown", Group: "unknown.grafana.app"}
+	configKey := "playlists.playlist.grafana.app"
 
-	t.Run("Mode5 returns Unified", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode5},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(), // empty registry = no migration log path
-		}
+	tests := []struct {
+		name     string
+		gr       schema.GroupResource
+		cfg      *setting.Cfg
+		wantMode contract.StorageMode
+	}{
+		{
+			name:     "Mode0 returns Legacy",
+			gr:       playlistGR,
+			cfg:      cfgWithMode(configKey, rest.Mode0),
+			wantMode: contract.StorageModeLegacy,
+		},
+		{
+			name:     "Mode1 returns DualWrite",
+			gr:       playlistGR,
+			cfg:      cfgWithMode(configKey, rest.Mode1),
+			wantMode: contract.StorageModeDualWrite,
+		},
+		{
+			name:     "Mode2 returns DualWrite (backward compat)",
+			gr:       playlistGR,
+			cfg:      cfgWithMode(configKey, rest.Mode2),
+			wantMode: contract.StorageModeDualWrite,
+		},
+		{
+			name:     "Mode3 returns DualWrite (backward compat)",
+			gr:       playlistGR,
+			cfg:      cfgWithMode(configKey, rest.Mode3),
+			wantMode: contract.StorageModeDualWrite,
+		},
+		{
+			name:     "Mode4 returns Unified",
+			gr:       playlistGR,
+			cfg:      cfgWithMode(configKey, rest.Mode4),
+			wantMode: contract.StorageModeUnified,
+		},
+		{
+			name:     "Mode5 returns Unified",
+			gr:       playlistGR,
+			cfg:      cfgWithMode(configKey, rest.Mode5),
+			wantMode: contract.StorageModeUnified,
+		},
+		{
+			name:     "resource not in config returns Legacy",
+			gr:       unknownGR,
+			cfg:      &setting.Cfg{UnifiedStorage: map[string]setting.UnifiedStorageConfig{}},
+			wantMode: contract.StorageModeLegacy,
+		},
+		{
+			name:     "nil UnifiedStorage returns Legacy",
+			gr:       playlistGR,
+			cfg:      &setting.Cfg{},
+			wantMode: contract.StorageModeLegacy,
+		},
+	}
 
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeUnified, mode)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := newTestStatusReader(t, tt.cfg, NewMigrationRegistry())
 
-	t.Run("Mode4 returns Unified", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode4},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeUnified, mode)
-	})
-
-	t.Run("Mode1 returns DualWrite", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeDualWrite, mode)
-	})
-
-	t.Run("Mode2 returns DualWrite (backward compat)", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode2},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeDualWrite, mode)
-	})
-
-	t.Run("Mode3 returns DualWrite (backward compat)", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode3},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeDualWrite, mode)
-	})
-
-	t.Run("Mode0 returns Legacy", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode0},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeLegacy, mode)
-	})
-
-	t.Run("resource not in config returns Legacy", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), unknownGR)
-		require.Equal(t, contract.StorageModeLegacy, mode)
-	})
-
-	t.Run("nil UnifiedStorage returns Legacy", func(t *testing.T) {
-		cfg := &setting.Cfg{}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: NewMigrationRegistry(),
-		}
-
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeLegacy, mode)
-	})
+			mode, err := reader.GetStorageMode(context.Background(), tt.gr)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMode, mode)
+		})
+	}
 }
 
-func TestMigrationStatusReader_GetStorageMode_DualWritePriority(t *testing.T) {
-	// Verify that Mode1 config takes priority even when a resource is registered
-	// in the migration registry (but no DB to check migration log).
-	// This simulates cloud holding a resource in DualWrite.
+func TestMigrationStatusReader_GetStorageMode_MigrationLogOverridesConfig(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
+	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+	registry := newPlaylistRegistry()
 
+	require.NoError(t, EnsureMigrationLogTable(context.Background(), sqlStore, cfg))
+
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
+	}
+
+	reader, err := ProvideMigrationStatusReader(sqlStore, cfg, registry, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	require.NoError(t, insertMigrationLogRow(sqlStore, "playlists migration", true, ""))
+
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.NoError(t, err)
+	require.Equal(t, contract.StorageModeUnified, mode)
+}
+
+func TestMigrationStatusReader_GetStorageMode_IgnoresFailedMigrationLogRows(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
+	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+	registry := newPlaylistRegistry()
+
+	require.NoError(t, EnsureMigrationLogTable(context.Background(), sqlStore, cfg))
+
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
+	}
+
+	reader, err := ProvideMigrationStatusReader(sqlStore, cfg, registry, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	require.NoError(t, insertMigrationLogRow(sqlStore, "playlists migration", false, "boom"))
+
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.NoError(t, err)
+	require.Equal(t, contract.StorageModeDualWrite, mode)
+}
+
+func TestMigrationStatusReader_GetStorageMode_ConfigFallbackWhenLogMissing(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
 	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
 
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode5},
+	}
+
+	reader, err := ProvideMigrationStatusReader(sqlStore, cfg, newPlaylistRegistry(), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.NoError(t, err)
+	require.Equal(t, contract.StorageModeUnified, mode)
+}
+
+func TestMigrationStatusReader_OnlyCfgRecoveryWhenTableAppears(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
+	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
+	}
+
+	reader, err := ProvideMigrationStatusReader(sqlStore, cfg, newPlaylistRegistry(), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	typed := reader.(*migrationStatusReader)
+
+	// Simulate bootstrap failure.
+	typed.onlyCfg = true
+
+	// Insert a successful migration log row. Since the table exists, the retry in
+	// resolveStorageMode should detect it, clear onlyCfg, and read the log.
+	require.NoError(t, insertMigrationLogRow(sqlStore, "playlists migration", true, ""))
+
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.NoError(t, err)
+	require.Equal(t, contract.StorageModeUnified, mode, "should recover and use migration log")
+	require.False(t, typed.onlyCfg, "onlyCfg should be cleared after table is found")
+}
+
+func TestMigrationStatusReader_OnlyCfgPersistsWhenTableMissing(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
+	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
+	}
+
+	reader, err := ProvideMigrationStatusReader(sqlStore, cfg, newPlaylistRegistry(), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	typed := reader.(*migrationStatusReader)
+
+	// Drop the table and set onlyCfg to simulate a real bootstrap failure.
+	require.NoError(t, sqlStore.WithDbSession(context.Background(), func(sess *infraDB.Session) error {
+		_, err := sess.Exec("DROP TABLE IF EXISTS " + migrationLogTableName)
+		return err
+	}))
+	typed.onlyCfg = true
+
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.NoError(t, err)
+	require.Equal(t, contract.StorageModeDualWrite, mode, "should use config when table is missing")
+	require.True(t, typed.onlyCfg, "onlyCfg should remain set when table is still missing")
+}
+
+func TestMigrationStatusReader_GetStorageMode_DBErrorFallsBackToConfig(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
+	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+	registry := newPlaylistRegistry()
+
+	require.NoError(t, EnsureMigrationLogTable(context.Background(), sqlStore, cfg))
+
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
+	}
+
+	failingDB := &failingMigrationStatusDB{DB: sqlStore}
+	bootstrapCounter := newTestCounter("test_bootstrap_failures_db_error")
+
+	reader, err := ProvideMigrationStatusReader(failingDB, cfg, registry, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	typed := reader.(*migrationStatusReader)
+	require.False(t, typed.onlyCfg, "onlyCfg should not be set when bootstrap succeeds")
+	typed.metrics = &statusReaderMetrics{bootstrapFailures: bootstrapCounter}
+
+	failingDB.fail = true
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.Error(t, err)
+	require.Equal(t, contract.StorageModeDualWrite, mode)
+
+	// Bootstrap counter should not increment on runtime DB errors.
+	require.Equal(t, float64(0), testutil.ToFloat64(bootstrapCounter))
+}
+
+func TestMigrationStatusReader_GetStorageMode_NoErrorWhenBootstrapSucceeds(t *testing.T) {
+	sqlStore, cfg := infraDB.InitTestDBWithCfg(t)
+	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+
+	require.NoError(t, EnsureMigrationLogTable(context.Background(), sqlStore, cfg))
+
+	cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+		"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
+	}
+
+	bootstrapCounter := newTestCounter("test_bootstrap_no_error")
+	reader, err := ProvideMigrationStatusReader(sqlStore, cfg, newPlaylistRegistry(), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	typed := reader.(*migrationStatusReader)
+	require.False(t, typed.onlyCfg)
+	typed.metrics = &statusReaderMetrics{bootstrapFailures: bootstrapCounter}
+
+	mode, err := reader.GetStorageMode(context.Background(), playlistGR)
+	require.NoError(t, err)
+	require.Equal(t, contract.StorageModeDualWrite, mode)
+	require.Equal(t, float64(0), testutil.ToFloat64(bootstrapCounter))
+}
+
+func newTestCounter(name string) prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{Name: name})
+}
+
+func cfgWithMode(key string, mode rest.DualWriterMode) *setting.Cfg {
+	return &setting.Cfg{
+		UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+			key: {DualWriterMode: mode},
+		},
+	}
+}
+
+func newPlaylistRegistry() *MigrationRegistry {
 	registry := NewMigrationRegistry()
 	registry.Register(MigrationDefinition{
 		ID:          "playlists",
 		MigrationID: "playlists migration",
-		Resources:   []ResourceInfo{{GroupResource: playlistGR}},
+		Resources: []ResourceInfo{
+			{GroupResource: schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}},
+		},
 	})
+	return registry
+}
 
-	t.Run("Mode1 takes priority over migration log lookup", func(t *testing.T) {
-		cfg := &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"playlists.playlist.grafana.app": {DualWriterMode: rest.Mode1},
-			},
-		}
-		reader := &migrationStatusReader{
-			cfg:      cfg,
-			registry: registry,
-			// sqlStore is nil — if we reach the migration log check, it will panic.
-			// The test verifies Mode1 short-circuits before that.
-		}
+func newTestStatusReader(t *testing.T, cfg *setting.Cfg, registry *MigrationRegistry) *migrationStatusReader {
+	t.Helper()
 
-		mode := reader.GetStorageMode(context.Background(), playlistGR)
-		require.Equal(t, contract.StorageModeDualWrite, mode)
+	sqlStore, testCfg := infraDB.InitTestDBWithCfg(t)
+	testCfg.UnifiedStorage = cfg.UnifiedStorage
+	testCfg.StorageModeCacheTTL = cfg.StorageModeCacheTTL
+	reader, err := ProvideMigrationStatusReader(sqlStore, testCfg, registry, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	typed, ok := reader.(*migrationStatusReader)
+	require.True(t, ok)
+	return typed
+}
+
+func insertMigrationLogRow(sqlStore infraDB.DB, migrationID string, success bool, migrationError string) error {
+	return sqlStore.WithDbSession(context.Background(), func(sess *infraDB.Session) error {
+		_, err := sess.Exec(
+			"INSERT INTO "+migrationLogTableName+" (migration_id, sql, success, error, timestamp) VALUES (?, ?, ?, ?, ?)",
+			migrationID,
+			"test",
+			success,
+			migrationError,
+			time.Now(),
+		)
+		return err
 	})
 }
 
-func TestStorageMode_String(t *testing.T) {
-	require.Equal(t, "legacy", contract.StorageModeLegacy.String())
-	require.Equal(t, "dual-write", contract.StorageModeDualWrite.String())
-	require.Equal(t, "unified", contract.StorageModeUnified.String())
-	require.Equal(t, "unknown", contract.StorageMode(99).String())
+type failingMigrationStatusDB struct {
+	infraDB.DB
+	fail bool
+}
+
+func (f *failingMigrationStatusDB) WithDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error {
+	if f.fail {
+		return errors.New("boom")
+	}
+	return f.DB.WithDbSession(ctx, callback)
 }

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -37,7 +37,6 @@ var (
 )
 
 type DualWriter interface {
-	IsEnabled(schema.GroupResource) bool
 	ReadFromUnified(context.Context, schema.GroupResource) (bool, error)
 	Status(ctx context.Context, gr schema.GroupResource) (dualwrite.StorageStatus, error)
 }

--- a/pkg/storage/unified/resource/search_client_test.go
+++ b/pkg/storage/unified/resource/search_client_test.go
@@ -23,11 +23,6 @@ type MockDualWriter struct {
 	mock.Mock
 }
 
-func (m *MockDualWriter) IsEnabled(gr schema.GroupResource) bool {
-	args := m.Called(gr)
-	return args.Bool(0)
-}
-
 func (m *MockDualWriter) ReadFromUnified(ctx context.Context, gr schema.GroupResource) (bool, error) {
 	args := m.Called(ctx, gr)
 	return args.Bool(0), args.Error(1)


### PR DESCRIPTION
**What is this feature?**

Backport of https://github.com/grafana/grafana/pull/120185

**Why do we need this feature?**

For enabling migrations to unified storage in slow channel