### PR TITLE
Admin: Skip reencryption test in sqlite for now

### DIFF
--- a/pkg/tests/api/admin/encryption/reencrypt_enterprise_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_enterprise_test.go
@@ -21,6 +21,11 @@ import (
 func TestIntegration_AdminApiReencrypt_Enterprise(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
+	// TODO: this test is failing due to DB locks in SQLite.
+	if db.IsTestDbSQLite() {
+		t.Skip("skip flaky in sqlite while we figure out the problem with this test")
+	}
+
 	getSecretsFunctions := map[string]func(*testing.T, *server.TestEnv) map[int]secret{}
 	getSecretsFunctions["settings"] = func(t *testing.T, env *server.TestEnv) map[int]secret {
 		return getSettingSecrets(t, env.SQLStore)

--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -33,6 +33,11 @@ func TestMain(m *testing.M) {
 func TestIntegration_AdminApiReencrypt(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
+	// TODO: this test is failing due to DB locks in SQLite.
+	if db.IsTestDbSQLite() {
+		t.Skip("skip flaky in sqlite while we figure out the problem with this test")
+	}
+
 	const (
 		dataSourceTable              = "data_source"
 		secretsTable                 = "secrets"


### PR DESCRIPTION
Let's skip it in SQLite for now since it is quite flaky there because of DB locks, we need to understand better why and how to avoid it..