### PR TITLE
Alerting: Sort recently deleted alert rules by deletion time

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -278,9 +278,13 @@ func (srv RulerSrv) RouteGetRulesConfig(c *contextmodel.ReqContext) response.Res
 		result := apimodels.NamespaceConfigResponse{}
 		userUIDmapping := srv.getUserUIDmapping(c.Req.Context(), rules)
 		if len(rules) > 0 {
-			result[""] = []apimodels.GettableRuleGroupConfig{
-				toGettableRuleGroupConfig("", rules, map[string]ngmodels.Provenance{}, userUIDmapping),
-			}
+			group := toGettableRuleGroupConfig("", rules, map[string]ngmodels.Provenance{}, userUIDmapping)
+			// toGettableRuleGroupConfig sorts by group index, which is not meaningful for deleted rules.
+			// Re-sort by deletion time (Updated) descending so the most recently deleted rules appear first.
+			slices.SortStableFunc(group.Rules, func(a, b apimodels.GettableExtendedRuleNode) int {
+				return b.GrafanaManagedAlert.Updated.Compare(a.GrafanaManagedAlert.Updated)
+			})
+			result[""] = []apimodels.GettableRuleGroupConfig{group}
 		}
 		return response.JSON(http.StatusOK, result)
 	}

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -779,6 +780,72 @@ func TestRouteGetRulesConfig(t *testing.T) {
 				require.Fail(t, fmt.Sprintf("rules are not sorted by group index. Expected: %v. Actual: %v", expectedUIDs, actualUIDs))
 			}
 		}
+	})
+
+	t.Run("deleted=true should return deleted rules sorted by deletion time descending", func(t *testing.T) {
+		orgID := rand.Int63()
+		ruleStore := fakes.NewRuleStore(t)
+
+		now := time.Now()
+		// Create three deleted rules with distinct deletion times.
+		// The fake store returns them in the order they are appended (oldest first),
+		// which is the wrong order the fix must correct.
+		rule1 := models.RuleGen.With(models.RuleGen.WithOrgID(orgID)).Generate()
+		rule1.Updated = now.Add(-2 * time.Minute) // deleted earliest
+
+		rule2 := models.RuleGen.With(models.RuleGen.WithOrgID(orgID)).Generate()
+		rule2.Updated = now.Add(-1 * time.Minute) // deleted in the middle
+
+		rule3 := models.RuleGen.With(models.RuleGen.WithOrgID(orgID)).Generate()
+		rule3.Updated = now // deleted most recently
+
+		// Intentionally append in oldest-first order so that any accidental
+		// reliance on insertion order would produce the wrong answer.
+		ruleStore.Deleted = map[int64][]*models.AlertRule{
+			orgID: {&rule1, &rule2, &rule3},
+		}
+
+		uri, _ := url.Parse("http://localhost?deleted=true")
+		ctx := web.Context{
+			Req: &http.Request{
+				URL:    uri,
+				Header: make(http.Header),
+				// Form must not be pre-initialised so that web.Context.Query
+				// calls ParseForm and picks up the URL query parameters.
+			},
+			Resp: web.NewResponseWriter("GET", httptest.NewRecorder()),
+		}
+		req := &contextmodel.ReqContext{
+			IsSignedIn: true,
+			SignedInUser: &user.SignedInUser{
+				OrgID:   orgID,
+				OrgRole: identity.RoleAdmin,
+				Permissions: map[int64]map[string][]string{
+					orgID: {datasources.ActionQuery: {datasources.ScopeAll}},
+				},
+			},
+			Context: &ctx,
+		}
+
+		svc := createService(ruleStore, nil)
+		svc.featureManager = featuremgmt.WithFeatures(featuremgmt.FlagAlertRuleRestore)
+
+		response := svc.RouteGetRulesConfig(req)
+		require.Equal(t, http.StatusOK, response.Status())
+
+		result := &apimodels.NamespaceConfigResponse{}
+		require.NoError(t, json.Unmarshal(response.Body(), result))
+
+		groups, ok := (*result)[""]
+		require.True(t, ok)
+		require.Len(t, groups, 1)
+		rules := groups[0].Rules
+		require.Len(t, rules, 3)
+
+		// Most recently deleted rule (rule3) should be first.
+		assert.Equal(t, rule3.GUID, rules[0].GrafanaManagedAlert.GUID, "first rule should be the most recently deleted")
+		assert.Equal(t, rule2.GUID, rules[1].GrafanaManagedAlert.GUID, "second rule should be the second most recently deleted")
+		assert.Equal(t, rule1.GUID, rules[2].GrafanaManagedAlert.GUID, "third rule should be the oldest deleted")
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Fixes the sort order of recently deleted alert rules returned by `GET /api/ruler/grafana/api/v1/rules?deleted=true`. Rules are now returned most-recently-deleted first.

**Why do we need this feature?**

`RouteGetRulesConfig` delegates rule-to-API-model conversion to `toGettableRuleGroupConfig`, which internally calls `rules.SortByGroupIndex()`. For live rules this produces the correct in-group order. For deleted rules it is meaningless — all deleted rules have `RuleGroupIndex = 0`, so the sort degrades to `ID ASC` (oldest-deleted-first by the version table's autoincrement PK), discarding the `ORDER BY created DESC` the DB query already applied.

The fix re-sorts the returned group's `Rules` slice by `GrafanaManagedAlert.Updated` descending after `toGettableRuleGroupConfig` returns. For deleted rules `Updated` holds the deletion timestamp (mapped from `alert_rule_version.created` at deletion time), producing most-recently-deleted-first ordering.

**Who is this feature for?**

Grafana admins using the alert rule restore feature (`alertRuleRestore` feature toggle).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.