### PR TITLE
Modal: Remove deprecated props

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.story.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.story.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof ConfirmModal> = {
     },
   },
   argTypes: {
-    icon: { control: { type: 'select', options: ['exclamation-triangle', 'power', 'cog', 'lock', 'trash-alt'] } },
     body: { control: { type: 'text' } },
     description: { control: { type: 'text' } },
   },
@@ -43,7 +42,6 @@ export const Basic: StoryFn<typeof ConfirmModal> = ({
   confirmText,
   confirmButtonVariant,
   dismissText,
-  icon,
   isOpen,
 }) => {
   const { onConfirm, onDismiss } = defaultActions;
@@ -56,7 +54,6 @@ export const Basic: StoryFn<typeof ConfirmModal> = ({
       confirmText={confirmText}
       confirmButtonVariant={confirmButtonVariant}
       dismissText={dismissText}
-      icon={icon}
       onConfirm={onConfirm}
       onDismiss={onDismiss}
     />
@@ -76,7 +73,6 @@ Basic.args = {
   confirmText: 'Delete',
   confirmButtonVariant: 'destructive',
   dismissText: 'Cancel',
-  icon: 'exclamation-triangle',
   isOpen: true,
 };
 
@@ -86,7 +82,6 @@ export const AlternativeAction: StoryFn<typeof ConfirmModal> = ({
   description,
   confirmText,
   dismissText,
-  icon,
   alternativeText,
   isOpen,
 }) => {
@@ -100,7 +95,6 @@ export const AlternativeAction: StoryFn<typeof ConfirmModal> = ({
       confirmText={confirmText}
       dismissText={dismissText}
       alternativeText={alternativeText}
-      icon={icon}
       onConfirm={onConfirm}
       onDismiss={onDismiss}
       onAlternative={onAlternative}
@@ -120,7 +114,6 @@ AlternativeAction.args = {
   alternativeText: 'Delete row only',
   confirmText: 'Yes',
   dismissText: 'Cancel',
-  icon: 'trash-alt',
   isOpen: true,
 };
 
@@ -131,7 +124,6 @@ export const WithConfirmation: StoryFn<typeof ConfirmModal> = ({
   confirmationText,
   confirmText,
   dismissText,
-  icon,
   isOpen,
 }) => {
   const { onConfirm, onDismiss } = defaultActions;
@@ -144,7 +136,6 @@ export const WithConfirmation: StoryFn<typeof ConfirmModal> = ({
       description={description}
       confirmText={confirmText}
       dismissText={dismissText}
-      icon={icon}
       onConfirm={onConfirm}
       onDismiss={onDismiss}
     />
@@ -164,7 +155,6 @@ WithConfirmation.args = {
   confirmationText: 'Delete',
   confirmText: 'Delete',
   dismissText: 'Cancel',
-  icon: 'trash-alt',
   isOpen: true,
 };
 

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -2,8 +2,6 @@ import { css, cx } from '@emotion/css';
 import * as React from 'react';
 import type { JSX } from 'react';
 
-import { IconName } from '@grafana/data';
-
 import { useStyles2 } from '../../themes/ThemeContext';
 import { ButtonVariant } from '../Button/Button';
 import { Modal } from '../Modal/Modal';
@@ -27,8 +25,6 @@ export interface ConfirmModalProps {
   dismissText?: string;
   /** Variant for dismiss button */
   dismissVariant?: ButtonVariant;
-  /** Icon for the modal header */
-  icon?: IconName;
   /** Additional styling for modal container */
   modalClass?: string;
   /** Text user needs to fill in before confirming */
@@ -66,7 +62,6 @@ export const ConfirmModal = ({
   dismissVariant = 'secondary',
   alternativeText,
   modalClass,
-  icon = 'exclamation-triangle',
   onConfirm,
   onDismiss,
   onAlternative,
@@ -76,7 +71,7 @@ export const ConfirmModal = ({
   const styles = useStyles2(getStyles);
 
   return (
-    <Modal className={cx(styles.modal, modalClass)} title={title} icon={icon} isOpen={isOpen} onDismiss={onDismiss}>
+    <Modal className={cx(styles.modal, modalClass)} title={title} isOpen={isOpen} onDismiss={onDismiss}>
       <ConfirmContent
         body={body}
         description={description}

--- a/packages/grafana-ui/src/components/Modal/Modal.story.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.story.tsx
@@ -3,7 +3,6 @@ import { StoryFn, Meta } from '@storybook/react';
 import { oneLineTrim } from 'common-tags';
 import { useState } from 'react';
 
-import { getAvailableIcons } from '../../types/icon';
 import { Button } from '../Button/Button';
 import { TabContent } from '../Tabs/TabContent';
 
@@ -34,12 +33,6 @@ const meta: Meta = {
     amet.`),
   },
   argTypes: {
-    icon: {
-      control: {
-        type: 'select',
-        options: getAvailableIcons(),
-      },
-    },
     title: {
       control: {
         type: 'text',
@@ -63,10 +56,8 @@ export const Basic: StoryFn = ({ body, title, ...args }) => {
 };
 Basic.args = {
   title: 'My Modal',
-  icon: 'exclamation-triangle',
   isOpen: true,
   closeOnEscape: false,
-  iconTooltip: 'icon tooltip',
 };
 
 const tabs = [
@@ -80,7 +71,6 @@ export const WithTabs: StoryFn = (args) => {
   const modalHeader = (
     <ModalTabsHeader
       title={args.title}
-      icon={args.icon}
       tabs={tabs}
       activeTab={activeTab}
       onChangeTab={(t) => {
@@ -120,10 +110,8 @@ export const UsingContentClassName: StoryFn = ({ title, body, ...args }) => {
 };
 UsingContentClassName.args = {
   title: 'Using contentClassName to override background',
-  icon: 'exclamation-triangle',
   isOpen: true,
   closeOnEscape: false,
-  iconTooltip: 'icon tooltip',
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -6,7 +6,6 @@ import { PropsWithChildren, ReactNode, useId, type JSX } from 'react';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
-import { IconName } from '../../types/icon';
 import { IconButton } from '../IconButton/IconButton';
 import { Stack } from '../Layout/Stack/Stack';
 import { getPortalContainer } from '../Portal/Portal';
@@ -15,10 +14,6 @@ import { ModalHeader } from './ModalHeader';
 import { getModalStyles } from './getModalStyles';
 
 interface BaseProps {
-  /** @deprecated no longer used */
-  icon?: IconName;
-  /** @deprecated no longer used */
-  iconTooltip?: string;
   className?: string;
   contentClassName?: string;
   closeOnEscape?: boolean;
@@ -77,7 +72,7 @@ export function Modal(props: PropsWithChildren<Props>) {
   });
 
   const dismiss = useDismiss(context, {
-    enabled: closeOnEscape,
+    escapeKey: closeOnEscape,
   });
 
   const role = useRole(context, {
@@ -108,7 +103,7 @@ export function Modal(props: PropsWithChildren<Props>) {
           {...getFloatingProps()}
         >
           <div className={headerClass}>
-            {typeof title === 'string' && <DefaultModalHeader {...props} title={title} id={titleId} />}
+            {typeof title === 'string' && <ModalHeader title={title} id={titleId} />}
             {
               // FIXME: custom title components won't get an accessible title.
               // Do we really want to support them or shall we just limit this ModalTabsHeader?
@@ -158,14 +153,3 @@ function ModalButtonRow({ leftItems, children }: { leftItems?: ReactNode; childr
 }
 
 Modal.ButtonRow = ModalButtonRow;
-
-interface DefaultModalHeaderProps {
-  id?: string;
-  title: string;
-  icon?: IconName;
-  iconTooltip?: string;
-}
-
-function DefaultModalHeader({ icon, iconTooltip, title, id }: DefaultModalHeaderProps): JSX.Element {
-  return <ModalHeader icon={icon} iconTooltip={iconTooltip} title={title} id={id} />;
-}

--- a/packages/grafana-ui/src/components/Modal/ModalHeader.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalHeader.tsx
@@ -1,21 +1,16 @@
-import * as React from 'react';
+import { PropsWithChildren } from 'react';
 
 import { useStyles2 } from '../../themes/ThemeContext';
-import { IconName } from '../../types/icon';
 
 import { getModalStyles } from './getModalStyles';
 
 interface Props {
   title: string;
   id?: string;
-  /** @deprecated */
-  icon?: IconName;
-  /** @deprecated */
-  iconTooltip?: string;
 }
 
 /** @internal */
-export const ModalHeader = ({ icon, iconTooltip, title, children, id }: React.PropsWithChildren<Props>) => {
+export const ModalHeader = ({ title, children, id }: PropsWithChildren<Props>) => {
   const styles = useStyles2(getModalStyles);
 
   return (

--- a/packages/grafana-ui/src/components/Modal/ModalTabsHeader.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalTabsHeader.tsx
@@ -14,16 +14,15 @@ interface ModalTab {
 }
 
 interface Props {
-  icon: IconName;
   title: string;
   tabs: ModalTab[];
   activeTab: string;
   onChangeTab(tab: ModalTab): void;
 }
 
-export const ModalTabsHeader = ({ icon, title, tabs, activeTab, onChangeTab }: Props) => {
+export const ModalTabsHeader = ({ title, tabs, activeTab, onChangeTab }: Props) => {
   return (
-    <ModalHeader icon={icon} title={title}>
+    <ModalHeader title={title}>
       <TabsBar hideBorder={true}>
         {tabs.map((t, index) => {
           return (

--- a/public/app/core/components/FormPrompt/FormPrompt.tsx
+++ b/public/app/core/components/FormPrompt/FormPrompt.tsx
@@ -101,7 +101,6 @@ const UnsavedChangesModal = ({ onDiscard, onBackToForm, isOpen }: UnsavedChanges
       isOpen={isOpen}
       title={t('form-prompt.title', 'Leave page?')}
       onDismiss={onBackToForm}
-      icon="exclamation-triangle"
       className={css({ width: '500px' })}
     >
       <h5>

--- a/public/app/core/context/ModalsContextProvider.tsx
+++ b/public/app/core/context/ModalsContextProvider.tsx
@@ -87,7 +87,6 @@ function showConfirmModal({ payload }: ShowConfirmModalEvent, setState: (state: 
     text,
     text2htmlBind,
     yesText = 'Yes',
-    icon,
     title = 'Confirm',
     yesButtonVariant,
   } = payload;
@@ -98,7 +97,6 @@ function showConfirmModal({ payload }: ShowConfirmModalEvent, setState: (state: 
     confirmText: yesText,
     confirmButtonVariant: yesButtonVariant,
     confirmationText: confirmText,
-    icon,
     title,
     body: text,
     description: text2 && text2htmlBind ? textUtil.sanitize(text2) : text2,

--- a/public/app/features/admin/AdminOrgsTable.tsx
+++ b/public/app/features/admin/AdminOrgsTable.tsx
@@ -63,7 +63,6 @@ function AdminOrgsTableComponent({ orgs, onDelete }: Props) {
       {deleteOrg && (
         <ConfirmModal
           isOpen
-          icon="trash-alt"
           title={t('admin.admin-orgs-table.title-delete', 'Delete')}
           body={
             <div>

--- a/public/app/features/alerting/unified/components/import-to-gma/Wizard/useCancelWizardModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/Wizard/useCancelWizardModal.tsx
@@ -55,7 +55,6 @@ export function useCancelWizardModal({
         )}
         confirmText={t('alerting.import-to-gma.wizard.cancel-confirm-yes', 'Discard changes')}
         dismissText={t('alerting.import-to-gma.wizard.cancel-confirm-no', 'Dismiss')}
-        icon="exclamation-triangle"
         onConfirm={handleConfirm}
         onDismiss={dismissModal}
       />

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -673,7 +673,6 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
           </div>
         }
         confirmText={t('alerting.query-and-expressions-step.confirmText-deactivate', 'Deactivate')}
-        icon="exclamation-triangle"
         onConfirm={() => {
           setValue('editorSettings.simplifiedQueryEditor', true);
           setShowResetModal(false);

--- a/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
@@ -83,7 +83,6 @@ export const useDeleteModal = (redirectToListView = false): DeleteModalHook => {
               )
         }
         confirmText={t('alerting.use-delete-modal.modal.confirmText-yes-delete', 'Yes, delete')}
-        icon="exclamation-triangle"
         onConfirm={deleteRule}
         onDismiss={dismissModal}
       />

--- a/public/app/features/auth-config/ProviderConfigForm.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.tsx
@@ -246,7 +246,6 @@ export const ProviderConfigForm = ({ config, provider, isLoading }: ProviderConf
       {resetConfig && (
         <ConfirmModal
           isOpen
-          icon="trash-alt"
           title={t('auth-config.provider-config-form.title-reset', 'Reset')}
           body={
             <Stack direction={'column'} gap={3}>

--- a/public/app/features/dashboard-scene/saving/DashboardPrompt.tsx
+++ b/public/app/features/dashboard-scene/saving/DashboardPrompt.tsx
@@ -138,7 +138,6 @@ export const UnsavedChangesModal = ({ onDiscard, onDismiss, onSaveDashboardClick
       isOpen={true}
       title={t('dashboard-scene.unsaved-changes-modal.title-unsaved-changes', 'Unsaved changes')}
       onDismiss={onDismiss}
-      icon="exclamation-triangle"
       className={styles.modal}
     >
       <h5>

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -358,7 +358,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
             'dashboard-scene.dashboard-scene.modal.text.save-changes-question',
             'Do you want to save your changes?'
           ),
-          icon: 'trash-alt',
           altActionText: t('dashboard-scene.dashboard-scene.modal.save', 'Save'),
           noText: t('dashboard-scene.dashboard-scene.modal.cancel', 'Cancel'),
           yesText: t('dashboard-scene.dashboard-scene.modal.discard', 'Discard'),
@@ -382,7 +381,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
             'dashboard-scene.dashboard-scene.title.discard-changes-to-dashboard',
             'Discard changes to dashboard?'
           ),
-          icon: 'trash-alt',
           text: t(
             'dashboard-scene.dashboard-scene.title.unsaved-changes-question',
             'You have unsaved changes to this dashboard. Are you sure you want to discard them?'

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -530,7 +530,6 @@ export function onRemovePanel(dashboard: DashboardScene, panel: VizPanel) {
     new ShowConfirmModalEvent({
       title: t('dashboard-scene.on-remove-panel.title.remove-panel', 'Remove panel'),
       text: t('dashboard-scene.on-remove-panel.text.remove-panel', 'Are you sure you want to remove this panel?'),
-      icon: 'trash-alt',
       yesText: 'Remove',
       onConfirm: () => dashboard.removePanel(panel),
     })

--- a/public/app/features/dashboard-scene/scene/UnlinkModal.tsx
+++ b/public/app/features/dashboard-scene/scene/UnlinkModal.tsx
@@ -11,7 +11,6 @@ export const UnlinkModal = ({ isOpen, onConfirm, onDismiss }: Props) => {
   return (
     <ConfirmModal
       title={t('dashboard-scene.unlink-modal.title-really-unlink-panel', 'Do you really want to unlink this panel?')}
-      icon="question-circle"
       body={t(
         'dashboard-scene.unlink-modal.body-unlink-panel',
         'If you unlink this panel, you will be able to edit it without affecting any other dashboards. However, once you make a change you will not be able to revert to its original reusable panel.'

--- a/public/app/features/dashboard-scene/scene/layout-default/row-actions/RowActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/row-actions/RowActions.tsx
@@ -64,7 +64,6 @@ export class RowActions extends SceneObjectBase<RowActionsState> {
           'Are you sure you want to remove this row and all its panels?'
         ),
         altActionText: t('dashboard.default-layout.row-actions.modal.alt-action', 'Delete row only'),
-        icon: 'trash-alt',
         onConfirm: () => this.removeRow(true),
         onAltAction: () => this.removeRow(),
       })

--- a/public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx
@@ -93,7 +93,6 @@ export function DeleteDashboardModal({ dashboardTitle, onConfirm, onClose }: Del
       onConfirm={onConfirm}
       onDismiss={onClose}
       title={t('dashboard-settings.delete-modal.title', 'Delete')}
-      icon="trash-alt"
       confirmText={t('dashboard-settings.delete-modal.delete-button', 'Delete')}
       confirmationText={t('dashboard-settings.delete-modal.confirmation-text', 'Delete')}
     />
@@ -108,7 +107,6 @@ function ProvisionedDeleteModal({ dashboardId, onClose }: ProvisionedDeleteModal
         'dashboard-scene.provisioned-delete-modal.title-cannot-delete-provisioned-dashboard',
         'Cannot delete provisioned dashboard'
       )}
-      icon="trash-alt"
       onDismiss={onClose}
     >
       <p>

--- a/public/app/features/dashboard-scene/settings/version-history/RevertDashboardModal.tsx
+++ b/public/app/features/dashboard-scene/settings/version-history/RevertDashboardModal.tsx
@@ -30,7 +30,6 @@ export const RevertDashboardModal = ({ hideModal, onRestore, version }: RevertDa
     <ConfirmModal
       isOpen={true}
       title={t('dashboard-scene.revert-dashboard-modal.title-restore-version', 'Restore version')}
-      icon="history"
       onDismiss={hideModal}
       onConfirm={onRestoreDashboard}
       body={

--- a/public/app/features/dashboard-scene/sharing/SaveBeforeShareModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/SaveBeforeShareModal.tsx
@@ -55,13 +55,7 @@ export function SaveBeforeShareModal({ dashboard, onContinue, onDismiss, title, 
   }
 
   return (
-    <Modal
-      isOpen={true}
-      title={title ?? defaultTitle}
-      onDismiss={onDismiss}
-      icon="exclamation-triangle"
-      className={css({ width: '500px' })}
-    >
+    <Modal isOpen={true} title={title ?? defaultTitle} onDismiss={onDismiss} className={css({ width: '500px' })}>
       <h5>{message ?? defaultMessage}</h5>
       <Modal.ButtonRow>
         <Button variant="secondary" onClick={onCancel} fill="outline">

--- a/public/app/features/dashboard-scene/sharing/public-dashboards/ConfirmModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/public-dashboards/ConfirmModal.tsx
@@ -13,7 +13,6 @@ export class ConfirmModal extends SceneObjectBase<ConfirmModalState> implements 
       confirmVariant: 'destructive',
       dismissText: 'Cancel',
       dismissVariant: 'secondary',
-      icon: 'exclamation-triangle',
       confirmButtonVariant: 'destructive',
       ...state,
     });

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -88,7 +88,6 @@ export class UnthemedDashboardRow extends Component<DashboardRowProps> {
         title: t('dashboard.unthemed-dashboard-row.title.delete-row', 'Delete row'),
         text: 'Are you sure you want to remove this row and all its panels?',
         altActionText: 'Delete row only',
-        icon: 'trash-alt',
         onConfirm: () => {
           this.props.dashboard.removeRow(this.props.panel, true);
         },

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -54,7 +54,6 @@ const ProvisionedDeleteModal = ({ hideModal, provisionedId }: { hideModal(): voi
     <Modal
       isOpen={true}
       title={t('dashboard-settings.provisioned-delete-modal.title', 'Cannot delete provisioned dashboard')}
-      icon="trash-alt"
       onDismiss={hideModal}
       className={css({
         width: '500px',

--- a/public/app/features/dashboard/components/RowOptions/RowOptionsModal.tsx
+++ b/public/app/features/dashboard/components/RowOptions/RowOptionsModal.tsx
@@ -21,7 +21,6 @@ export const RowOptionsModal = ({ repeat, title, onDismiss, onUpdate, warning }:
     <Modal
       isOpen={true}
       title={t('dashboard.row-options-modal.title-row-options', 'Row options')}
-      icon="copy"
       onDismiss={onDismiss}
       className={styles.modal}
     >

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardErrorProxy.tsx
@@ -125,7 +125,6 @@ const ConfirmPluginDashboardSaveModal = ({ onDismiss, dashboard }: SaveDashboard
     <Modal
       className={styles.modal}
       title={t('dashboard.confirm-plugin-dashboard-save-modal.title-plugin-dashboard', 'Plugin dashboard')}
-      icon="copy"
       isOpen={true}
       onDismiss={onDismiss}
     >

--- a/public/app/features/dashboard/components/SaveDashboard/UnsavedChangesModal.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/UnsavedChangesModal.tsx
@@ -20,7 +20,6 @@ export const UnsavedChangesModal = ({ dashboard, onSaveSuccess, onDiscard, onDis
       isOpen={true}
       title={t('dashboard.unsaved-changes-modal.title-unsaved-changes', 'Unsaved changes')}
       onDismiss={onDismiss}
-      icon="exclamation-triangle"
       className={css({
         width: '500px',
       })}

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -119,9 +119,7 @@ export function ShareModal({ dashboard, panel, activeTab: initialActiveTab, onDi
   const ActiveTab = activeTabModel.component;
   const modalTitle = panel ? t('share-modal.panel.title', 'Share Panel') : t('share-modal.dashboard.title', 'Share');
 
-  const title = (
-    <ModalTabsHeader title={modalTitle} icon="share-alt" tabs={tabs} activeTab={activeTab} onChangeTab={onSelectTab} />
-  );
+  const title = <ModalTabsHeader title={modalTitle} tabs={tabs} activeTab={activeTab} onChangeTab={onSelectTab} />;
 
   return (
     <Modal ariaLabel={modalTitle} isOpen={true} title={title} onDismiss={onDismiss}>

--- a/public/app/features/dashboard/components/VersionHistory/RevertDashboardModal.tsx
+++ b/public/app/features/dashboard/components/VersionHistory/RevertDashboardModal.tsx
@@ -24,7 +24,6 @@ export const RevertDashboardModal = ({ hideModal, id, version }: RevertDashboard
     <ConfirmModal
       isOpen={true}
       title={t('dashboard.revert-dashboard-modal.title-restore-version', 'Restore version')}
-      icon="history"
       onDismiss={hideModal}
       onConfirm={() => void onRestoreDashboard()}
       body={

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -33,7 +33,6 @@ export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: b
       new ShowConfirmModalEvent({
         title: t('dashboard.remove-panel.title.remove-panel', 'Remove panel'),
         text: t('dashboard.remove-panel.text.remove-panel', 'Are you sure you want to remove this panel?'),
-        icon: 'trash-alt',
         confirmText: confirmText,
         yesText: 'Remove',
         onConfirm: () => removePanel(dashboard, panel, false),

--- a/public/app/features/datasources/state/hooks.ts
+++ b/public/app/features/datasources/state/hooks.ts
@@ -100,7 +100,6 @@ export const useDeleteLoadedDataSource = () => {
         title: t('datasources.use-delete-loaded-data-source.title.delete', 'Delete'),
         text: `Are you sure you want to delete the "${name}" data source?`,
         yesText: 'Delete',
-        icon: 'trash-alt',
         onConfirm: () => dispatch(deleteLoadedDataSource()),
       })
     );

--- a/public/app/features/explore/CorrelationUnsavedChangesModal.tsx
+++ b/public/app/features/explore/CorrelationUnsavedChangesModal.tsx
@@ -19,7 +19,6 @@ export const CorrelationUnsavedChangesModal = ({ onSave, onDiscard, onCancel, me
         'Unsaved changes to correlation'
       )}
       onDismiss={onCancel}
-      icon="exclamation-triangle"
       className={css({ width: '600px' })}
     >
       <h5>{message}</h5>

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -198,7 +198,6 @@ export function RichHistoryCard(props: Props) {
             'Are you sure you want to permanently delete your starred query?'
           ),
           yesText: t('explore.rich-history-card.confirm-delete', 'Delete'),
-          icon: 'trash-alt',
           onConfirm: () => performDelete(queryHistoryItem.id),
         })
       );

--- a/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx
@@ -71,7 +71,6 @@ export function RichHistorySettingsTab(props: RichHistorySettingsProps) {
           'Are you sure you want to permanently delete your query history?'
         ),
         yesText: t('explore.rich-history-settings-tab.delete-confirm', 'Delete'),
-        icon: 'trash-alt',
         onConfirm: () => {
           deleteRichHistory();
           dispatch(

--- a/public/app/features/library-panels/components/DeleteLibraryPanelModal/DeleteLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/DeleteLibraryPanelModal/DeleteLibraryPanelModal.tsx
@@ -35,7 +35,6 @@ export const DeleteLibraryPanelModal: FC<Props> = ({ libraryPanel, onDismiss, on
     <Modal
       className={styles.modal}
       title={t('library-panels.delete-library-panel-modal.title-delete-library-panel', 'Delete library panel')}
-      icon="trash-alt"
       onDismiss={onDismiss}
       isOpen={true}
     >

--- a/public/app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal.tsx
@@ -60,7 +60,7 @@ export const SaveLibraryPanelModal = ({
   const title = isUnsavedPrompt ? 'Unsaved library panel changes' : 'Save library panel';
 
   return (
-    <Modal title={title} icon="save" onDismiss={onDismiss} isOpen={true}>
+    <Modal title={title} onDismiss={onDismiss} isOpen={true}>
       <div>
         <p className={styles.textInfo}>
           <Trans

--- a/public/app/features/live/dashboard/DashboardChangedModal.tsx
+++ b/public/app/features/live/dashboard/DashboardChangedModal.tsx
@@ -30,7 +30,6 @@ export function DashboardChangedModal({ onDismiss, event }: Props) {
     <Modal
       isOpen={true}
       title={t('live.dashboard-changed-modal.title-dashboard-changed', 'Dashboard changed')}
-      icon="copy"
       onDismiss={onDismiss}
       onClickBackdrop={() => {}}
       className={styles.modal}

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -281,7 +281,6 @@ export const LogRows = memo(
               </>
             }
             confirmText={t('logs.log-rows.disable-popover.confirm', 'Confirm')}
-            icon="exclamation-triangle"
             onConfirm={onDisableConfirm}
             onDismiss={onDisableCancel}
           />

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -522,7 +522,6 @@ const LogListComponent = ({
               </>
             }
             confirmText={t('logs.log-rows.disable-popover.confirm', 'Confirm')}
-            icon="exclamation-triangle"
             onConfirm={onDisableConfirm}
             onDismiss={onDisableCancel}
           />

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable/DeletePublicDashboardModal.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable/DeletePublicDashboardModal.tsx
@@ -32,7 +32,6 @@ export const DeletePublicDashboardModal = ({
       onConfirm={onConfirm}
       onDismiss={onDismiss}
       title={translatedRevocationModalText}
-      icon="trash-alt"
       confirmText={translatedRevocationModalText}
     />
   );

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -102,7 +102,6 @@ export const SnapshotListTable = () => {
 
       <ConfirmModal
         isOpen={!!removeSnapshot}
-        icon="trash-alt"
         title={t('manage-dashboards.snapshot-list-table.title-delete', 'Delete')}
         body={t(
           'manage-dashboards.snapshot-list-table.body-delete',

--- a/public/app/features/playlist/StartModal.tsx
+++ b/public/app/features/playlist/StartModal.tsx
@@ -61,12 +61,7 @@ export const StartModal = ({ playlist, onDismiss }: Props) => {
   };
 
   return (
-    <Modal
-      isOpen={true}
-      icon="play"
-      title={t('playlist.start-modal.title-start-playlist', 'Start playlist')}
-      onDismiss={onDismiss}
-    >
+    <Modal isOpen={true} title={t('playlist.start-modal.title-start-playlist', 'Start playlist')} onDismiss={onDismiss}>
       <FieldSet>
         <Stack direction="column" alignItems="start" justifyContent="left" gap={2}>
           <Field noMargin label={t('playlist.start-modal.label-mode', 'Mode')}>

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -144,7 +144,6 @@ export function InstallControlsButton({
           'Are you sure you want to uninstall this plugin?'
         )}
         confirmText={t('plugins.install-controls-button.uninstall-controls.confirmText-confirm', 'Confirm')}
-        icon="exclamation-triangle"
         onConfirm={onUninstall}
         onDismiss={hideConfirmModal}
       />

--- a/public/app/features/search/page/components/ExplainScorePopup.tsx
+++ b/public/app/features/search/page/components/ExplainScorePopup.tsx
@@ -24,7 +24,6 @@ export function ExplainScorePopup({ name, explain, frame, row }: Props) {
   const modalHeader = (
     <ModalTabsHeader
       title={name}
-      icon={'info'}
       tabs={tabs}
       activeTab={activeTab}
       onChangeTab={(t) => {

--- a/public/app/features/variables/inspect/NetworkGraphModal.tsx
+++ b/public/app/features/variables/inspect/NetworkGraphModal.tsx
@@ -30,14 +30,7 @@ export function NetworkGraphModal({ edges, nodes, show: propsShow, title, childr
 
   return (
     <>
-      <Modal
-        isOpen={show}
-        title={title}
-        icon="info-circle"
-        iconTooltip="The graph can be moved, zoomed in, and zoomed out."
-        onClickBackdrop={onClose}
-        onDismiss={onClose}
-      >
+      <Modal isOpen={show} title={title} onClickBackdrop={onClose} onDismiss={onClose}>
         <NetworkGraph nodes={nodes} edges={edges} />
       </Modal>
       {children({ showModal })}

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -99,7 +99,6 @@ export const MetricsQueryEditor = (props: Props) => {
           body="You will lose changes made to the query if you change to Metric Insights Builder mode."
           confirmText="Yes, I am sure."
           dismissText="No, continue editing the query."
-          icon="exclamation-triangle"
           onConfirm={() => {
             setShowConfirm(false);
             setCodeEditorIsDirty(false);

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/SelectedLogGroups.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/SelectedLogGroups.tsx
@@ -78,7 +78,6 @@ export const SelectedLogGroups = ({
         body="Are you sure you want to clear all log groups?"
         confirmText="Yes"
         dismissText="No"
-        icon="exclamation-triangle"
         onConfirm={() => {
           setShowConfirm(false);
           onChange([]);

--- a/public/app/plugins/datasource/grafana/utils.ts
+++ b/public/app/plugins/datasource/grafana/utils.ts
@@ -24,7 +24,6 @@ export function onUpdatePanelSnapshotData(panel: PanelModel, frames: DataFrame[]
         title: 'Change to panel embedded data',
         text: 'If you want to change the data shown in this panel Grafana will need to remove the panels current query and replace it with a snapshot of the current data. This enables you to edit the data.',
         yesText: 'Continue',
-        icon: 'pen',
         onConfirm: () => {
           updateSnapshotData(frames, panel);
           resolve(true);

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -1,5 +1,5 @@
 import { AnnotationQuery, BusEventBase, BusEventWithPayload, eventFactory } from '@grafana/data';
-import { IconName, ButtonVariant } from '@grafana/ui';
+import { ButtonVariant } from '@grafana/ui';
 
 /**
  * Event Payloads
@@ -48,7 +48,6 @@ export interface ShowConfirmModalPayload {
   altActionText?: string;
   yesText?: string;
   noText?: string;
-  icon?: IconName;
   yesButtonVariant?: ButtonVariant;
 
   onDismiss?: () => void;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

spotted these whilst reviewing https://github.com/grafana/grafana/issues/120110:
- removes the deprecated `icon` and `iconTooltip` props
  - these have been deprecated for ~4 years and didn't do anything, it's time to remove them
  - removes any lingering uses of the prop in the rest of the codebase
- fixes a small bug with the `closeOnEscape` property
  - before setting this to `false` would disable the whole dismiss behaviour
  - instead we use `escapeKey` so that it only controls the escape key behaviour
- sibling enterprise PR: https://github.com/grafana/grafana-enterprise/pull/11466

**Why do we need this feature?**

- 🧹 

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

# Release notice breaking change

The deprecated `icon` and `iconTooltip` props have been removed from `Modal` and `ConfirmModal`. Whilst you were still able to pass these, the Modal code would just ignore them. It is safe to remove them completely.