### PR TITLE
`grafana-iam`: Fix crashloop for `nil` teamSearch

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -511,7 +511,9 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamBindingsAPIGroup(opts bui
 
 	authzWrapper := storewrapper.New(teamBindingStore, iamauthorizer.NewTeamBindingAuthorizer(b.accessClient))
 	storage[teamBindingResource.StoragePath()] = authzWrapper
-	b.teamSearch.teamBindingStore = authzWrapper
+	if b.teamSearch != nil {
+		b.teamSearch.teamBindingStore = authzWrapper
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fix a regression introduced with https://github.com/grafana/grafana/pull/121008. The MT App does not have `teamSearch` set.