### PR TITLE
Alerting: add annotation index for cleanup query performance

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -202,6 +202,10 @@ func addAnnotationMig(mg *Migrator) {
 	}))
 
 	mg.AddMigration("Add missing dashboard_uid to annotation table", &SetDashboardUIDMigration{})
+
+	mg.AddMigration("Add index for created_alert_id on annotation table", NewAddIndexMigration(table, &Index{
+		Cols: []string{"created", "alert_id"}, Type: IndexType,
+	}))
 }
 
 type AddMakeRegionSingleRowMigration struct {


### PR DESCRIPTION
**What is this feature?**

Adds a SQL migration that creates a composite index on the annotation table: (created, alert_id).

**Why do we need this feature?**

Issue #112501 reports high PostgreSQL IOPS during annotation retention cleanup. This index improves selectivity for alert-related cleanup queries and reduces expensive scans.

**Who is this feature for?**

Grafana operators who use annotation retention cleanup

**Which issue(s) does this PR fix?**:

Fixes #112501

Validation performed:
- go test ./pkg/services/sqlstore/migrations -run Test -count=1