### PR TITLE
Packaging: Ensure targz build parity between Make and dagger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,8 @@
 /scripts/modowners/ @grafana/grafana-backend-services-squad
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /scripts/ci/backend-tests @grafana/grafana-operator-experience-squad
+/scripts/catalog-plugins-defaults @grafana/grafana-datasources-core-services @kminehart
+/scripts/download-catalog-plugins.sh @grafana/grafana-datasources-core-services @kminehart
 /hack/ @grafana/grafana-app-platform-squad
 /.air.toml @macabu
 
@@ -1269,6 +1271,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/codeql-analysis.yml @DanCech
 /.github/workflows/commands.yml @torkelo
 /.github/workflows/community-release.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/compare-linux-arm64-targz-builds.yml @grafana/grafana-backend-services-squad
 /.github/workflows/detect-breaking-changes-* @grafana/grafana-frontend-platform
 /.github/workflows/detect-plugin-extension-changes.yml @grafana/grafana-frontend-platform
 /.github/workflows/documentation-ci.yml @grafana/docs-tooling

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -11,87 +11,68 @@ inputs:
         * `enterprise:linux/arm64:rpm, enterprise:linux/amd64:docker`
         * `pro:docker:llinux/amd64`
     required: true
-    type: string
   grafana-path:
     description: Path to a clone of the 'grafana' repo
     default: grafana
-    type: string
   grafana-enterprise-path:
     description: Path to a clone of the 'grafana-enterprise' repo
     default: grafana-enterprise
-    type: string
   github-token:
-    type: string
     required: true
   version:
-    type: string
     description: The version to embed in the grafana binary, example `v1.2.3`. If not provided, then the value in Grafana's package.json will be used
     required: true
   build-id:
-    type: string
     description: an identifier number which can be traced back to the workflow run.
     default: ${{github.run_id}}
     required: false
   patches-repo:
-    type: string
     description: Repository to load for patches repo. If empty, patches won't be applied. Must be an HTTPS git URL.
     required: false
     default: ''
   patches-ref:
-    type: string
     description: git ref in the patches repo to check out.
     required: false
     default: main
   patches-path:
-    type: string
     description: Path in the repository where `.patch` files can be found.
     required: false
     default: main
   checksum:
-    type: boolean
     description: If true, then checksums will be produced for each file (with a '.sha256' extension)
     required: false
     default: false
   verify:
-    type: boolean
     description: If true, then the e2e smoke tests will run to verify the produced artifacts (--verify)
     required: false
     default: false
   output:
-    type: string
     description: Filename to redirect stdout to. Contains list of packages that were produced
     default: packages.txt
     required: false
   docker-tag-format:
-    type: string
     default: '{{ .version }}-{{ .arch }}'
     description: Go template of Docker image tag
     required: false
   docker-tag-format-ubuntu:
-    type: string
     default: '{{ .version }}-ubuntu-{{ .arch }}'
     description: Go template of Docker image tag
     required: false
   docker-org:
-    type: string
     description: Docker org of produced images
     default: grafana
     required: false
   docker-registry:
-    type: string
     description: Docker registry of produced images
     default: docker.io
     required: false
   ubuntu-base:
-    type: string
     default: 'ubuntu-base'
     required: false
   alpine-base:
-    type: string
     default: 'alpine-base'
     required: false
   cache-builders:
-    type: boolean
     default: true
     required: false
 outputs:

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -40,7 +40,7 @@ jobs:
     # Run on `main` and on pull_requests where changes were detected
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && needs.detect-changes.outputs.changed == 'true')
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
     strategy:
@@ -91,7 +91,7 @@ jobs:
     needs: detect-changes
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true')
     name: ${{ matrix.name }} (enterprise)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           name: frontend-build
           path: public
+          include-hidden-files: true
           retention-days: 1
 
   build_backend:
@@ -174,32 +175,87 @@ jobs:
         with:
           name: split-build-targz
           path: _split
-      - name: Extract and compare
+      - name: Extract and compare (directory tree + sizes outside public/build)
         run: |
           set -euo pipefail
           mkdir -p _extract/release _extract/split
-          RELEASE_TAR="$(find _release -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
-          SPLIT_TAR="$(find _split -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
+          RELEASE_TAR="$(find _release -maxdepth 1 -type f -name '*.tar.gz' -print | LC_ALL=C sort | head -n 1)"
+          SPLIT_TAR="$(find _split -maxdepth 1 -type f -name '*.tar.gz' -print | LC_ALL=C sort | head -n 1)"
 
           tar -xzf "${RELEASE_TAR}" -C _extract/release
           tar -xzf "${SPLIT_TAR}" -C _extract/split
 
-          RELEASE_TOP="$(find _extract/release -mindepth 1 -maxdepth 1 -type d -print | sort | head -n 1)"
-          SPLIT_TOP="$(find _extract/split -mindepth 1 -maxdepth 1 -type d -print | sort | head -n 1)"
+          RELEASE_TOP="$(find _extract/release -mindepth 1 -maxdepth 1 -type d -print | LC_ALL=C sort | head -n 1)"
+          SPLIT_TOP="$(find _extract/split -mindepth 1 -maxdepth 1 -type d -print | LC_ALL=C sort | head -n 1)"
 
-          set +e
-          DIFF_OUT=$(diff -rq "${RELEASE_TOP}" "${SPLIT_TOP}")
-          set -e
+          rel_from_top() {
+            local top="$1" dir="$2"
+            if [[ "$dir" == "$top" ]]; then
+              printf '%s' "."
+            else
+              printf '%s' "${dir#"${top}"/}"
+            fi
+          }
 
-          # Print only paths present on one side (no file bodies). Suppress "Files a and b differ" lines.
-          echo "${DIFF_OUT}" | grep '^Only in' || true
+          # Sorted list of relative directory paths (layout must match).
+          tree_manifest() {
+            local top="$1" out="$2"
+            find "$top" -type d -print0 | LC_ALL=C sort -z | while IFS= read -r -d '' dir; do
+              rel_from_top "$top" "$dir"
+              printf '\n'
+            done | LC_ALL=C sort >"$out"
+          }
 
-          FAILED=0
-          if echo "${DIFF_OUT}" | grep -q '^Only in'; then
-            FAILED=1
+          skip_du_for_rel() {
+            local rel="$1"
+            # Root and public/ aggregate hashed webpack output; public/build/** differs by platform (arm64 Dagger vs amd64 CI).
+            [[ "$rel" == "." ]] && return 0
+            [[ "$rel" == "public" ]] && return 0
+            [[ "$rel" == "public/build" ]] && return 0
+            [[ "$rel" == public/build/* ]] && return 0
+            return 1
+          }
+
+          # Per-dir recursive byte size (GNU du -sb); omit paths where totals are not expected to match across builds.
+          size_manifest() {
+            local top="$1" out="$2"
+            find "$top" -type d -print0 | LC_ALL=C sort -z | while IFS= read -r -d '' dir; do
+              rel="$(rel_from_top "$top" "$dir")"
+              if skip_du_for_rel "$rel"; then
+                continue
+              fi
+              bytes="$(du -sb "$dir" | cut -f1)"
+              printf '%s\t%s\n' "$rel" "$bytes"
+            done | LC_ALL=C sort -t $'\t' -k1,1 >"$out"
+          }
+
+          tree_manifest "$RELEASE_TOP" /tmp/release-tree.txt
+          tree_manifest "$SPLIT_TOP" /tmp/split-tree.txt
+          size_manifest "$RELEASE_TOP" /tmp/release-sizes.txt
+          size_manifest "$SPLIT_TOP" /tmp/split-sizes.txt
+
+          echo "Compared package roots:"
+          echo "  release: ${RELEASE_TOP}"
+          echo "  split:   ${SPLIT_TOP}"
+          echo ""
+          echo "1) Directory tree (must be identical)."
+          echo "   Directory count — release: $(wc -l </tmp/release-tree.txt)  split: $(wc -l </tmp/split-tree.txt)"
+          echo ""
+          echo "2) Recursive sizes per directory (GNU du -sb), excluding: .  public/  public/build/**"
+          echo "   (Webpack [contenthash] output is not byte-identical between Dagger linux/arm64 Node and native amd64.)"
+          echo "   Sized paths — release: $(wc -l </tmp/release-sizes.txt)  split: $(wc -l </tmp/split-sizes.txt)"
+          echo ""
+
+          ok=1
+          if ! diff -u /tmp/release-tree.txt /tmp/split-tree.txt; then
+            echo >&2 "Compare failed: directory layouts differ."
+            ok=0
           fi
-          if echo "${DIFF_OUT}" | grep -q ' differ$'; then
-            echo >&2 "Compare failed: at least one path exists in both trees with different content (skipping diff body)."
-            FAILED=1
+          if ! diff -u /tmp/release-sizes.txt /tmp/split-sizes.txt; then
+            echo >&2 "Compare failed: directory sizes differ (outside public/build)."
+            ok=0
           fi
-          exit "${FAILED}"
+          if [[ "$ok" -ne 1 ]]; then
+            exit 1
+          fi
+          echo "OK: same directory tree; matching sizes for all directories outside public/build."

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -1,10 +1,20 @@
 name: Compare Linux ARM64 tar.gz builds
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   setup:
@@ -47,8 +57,10 @@ jobs:
           checksum: false
           verify: false
       - name: Locate tar.gz output
+        env:
+          ARTIFACTS_LIST: ${{ steps.build.outputs.file }}
         run: |
-          TARGZ="$(grep -E '\.tar\.gz$' "${{ steps.build.outputs.file }}" | head -n 1)"
+          TARGZ="$(grep -E '\.tar\.gz$' "${ARTIFACTS_LIST}" | head -n 1)"
           mkdir -p _out
           cp "${TARGZ}" _out/release-action.tar.gz
       - uses: actions/upload-artifact@v7
@@ -80,6 +92,8 @@ jobs:
     name: Build backend binary
     runs-on: ubuntu-latest
     needs: setup
+    env:
+      BUILD_NUMBER: ${{ needs.setup.outputs.build_number }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -87,7 +101,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Build backend
-        run: make build-go OS=linux ARCH=arm64 BUILD_NUMBER=${{ needs.setup.outputs.build_number }}
+        run: make build-go OS=linux ARCH=arm64 BUILD_NUMBER="${BUILD_NUMBER}"
       - uses: actions/upload-artifact@v7
         with:
           name: backend-linux-arm64
@@ -98,6 +112,9 @@ jobs:
     name: Build tar.gz from split artifacts
     runs-on: ubuntu-latest
     needs: [setup, build_frontend, build_backend]
+    env:
+      BUILD_VERSION: ${{ needs.setup.outputs.version }}
+      BUILD_NUMBER: ${{ needs.setup.outputs.build_number }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -124,11 +141,11 @@ jobs:
           make build-targz \
             OS=linux \
             ARCH=arm64 \
-            BUILD_VERSION="${{ needs.setup.outputs.version }}" \
-            BUILD_NUMBER="${{ needs.setup.outputs.build_number }}"
+            BUILD_VERSION="${BUILD_VERSION}" \
+            BUILD_NUMBER="${BUILD_NUMBER}"
       - name: Locate split tar.gz output
         run: |
-          TARGZ="$(ls dist/*.tar.gz | head -n 1)"
+          TARGZ="$(find dist -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
           mkdir -p _out
           cp "${TARGZ}" _out/split-build.tar.gz
       - uses: actions/upload-artifact@v7
@@ -153,13 +170,13 @@ jobs:
       - name: Extract and compare
         run: |
           mkdir -p _extract/release _extract/split
-          RELEASE_TAR="$(ls _release/*.tar.gz | head -n 1)"
-          SPLIT_TAR="$(ls _split/*.tar.gz | head -n 1)"
+          RELEASE_TAR="$(find _release -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
+          SPLIT_TAR="$(find _split -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
 
           tar -xzf "${RELEASE_TAR}" -C _extract/release
           tar -xzf "${SPLIT_TAR}" -C _extract/split
 
-          RELEASE_ROOT="$(ls -1 _extract/release | head -n 1)"
-          SPLIT_ROOT="$(ls -1 _extract/split | head -n 1)"
+          RELEASE_TOP="$(find _extract/release -mindepth 1 -maxdepth 1 -type d -print | sort | head -n 1)"
+          SPLIT_TOP="$(find _extract/split -mindepth 1 -maxdepth 1 -type d -print | sort | head -n 1)"
 
-          diff -r "_extract/release/${RELEASE_ROOT}" "_extract/split/${SPLIT_ROOT}"
+          diff -r "${RELEASE_TOP}" "${SPLIT_TOP}"

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -175,6 +175,7 @@ jobs:
           path: _split
       - name: Extract and compare
         run: |
+          set -euo pipefail
           mkdir -p _extract/release _extract/split
           RELEASE_TAR="$(find _release -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
           SPLIT_TAR="$(find _split -maxdepth 1 -type f -name '*.tar.gz' -print | sort | head -n 1)"
@@ -185,4 +186,19 @@ jobs:
           RELEASE_TOP="$(find _extract/release -mindepth 1 -maxdepth 1 -type d -print | sort | head -n 1)"
           SPLIT_TOP="$(find _extract/split -mindepth 1 -maxdepth 1 -type d -print | sort | head -n 1)"
 
-          diff -r "${RELEASE_TOP}" "${SPLIT_TOP}"
+          set +e
+          DIFF_OUT=$(diff -rq "${RELEASE_TOP}" "${SPLIT_TOP}")
+          set -e
+
+          # Print only paths present on one side (no file bodies). Suppress "Files a and b differ" lines.
+          echo "${DIFF_OUT}" | grep '^Only in' || true
+
+          FAILED=0
+          if echo "${DIFF_OUT}" | grep -q '^Only in'; then
+            FAILED=1
+          fi
+          if echo "${DIFF_OUT}" | grep -q ' differ$'; then
+            echo >&2 "Compare failed: at least one path exists in both trees with different content (skipping diff body)."
+            FAILED=1
+          fi
+          exit "${FAILED}"

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     outputs:
       version: ${{ steps.version.outputs.version }}
       build_number: ${{ steps.version.outputs.build_number }}
@@ -35,7 +35,7 @@ jobs:
 
   build_with_release_action:
     name: Build via build-package action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     needs: setup
     permissions:
       contents: read
@@ -71,7 +71,7 @@ jobs:
 
   build_frontend:
     name: Build frontend assets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     needs: setup
     steps:
       - uses: actions/checkout@v6
@@ -98,7 +98,7 @@ jobs:
 
   build_backend:
     name: Build backend binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     needs: setup
     env:
       BUILD_NUMBER: ${{ needs.setup.outputs.build_number }}
@@ -118,7 +118,7 @@ jobs:
 
   build_split_targz:
     name: Build tar.gz from split artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     needs: [setup, build_frontend, build_backend]
     env:
       BUILD_VERSION: ${{ needs.setup.outputs.version }}
@@ -162,7 +162,7 @@ jobs:
 
   compare_targz_contents:
     name: Compare tar.gz contents
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large-io
     needs: [build_with_release_action, build_split_targz]
     steps:
       - uses: actions/download-artifact@v5

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -1,0 +1,165 @@
+name: Compare Linux ARM64 tar.gz builds
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      build_number: ${{ steps.version.outputs.build_number }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - id: version
+        name: Compute build metadata
+        run: |
+          VERSION="$(jq -r .version package.json | sed -s "s/pre/${GITHUB_RUN_ID}/g")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+  build_with_release_action:
+    name: Build via build-package action
+    runs-on: ubuntu-latest
+    needs: setup
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-package
+        name: Build Linux ARM64 tar.gz
+        id: build
+        with:
+          artifacts: targz:grafana:linux/arm64
+          grafana-path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ needs.setup.outputs.version }}
+          build-id: ${{ needs.setup.outputs.build_number }}
+          output: release-action-artifacts.txt
+          checksum: false
+          verify: false
+      - name: Locate tar.gz output
+        run: |
+          TARGZ="$(grep -E '\.tar\.gz$' "${{ steps.build.outputs.file }}" | head -n 1)"
+          mkdir -p _out
+          cp "${TARGZ}" _out/release-action.tar.gz
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-action-targz
+          path: _out/release-action.tar.gz
+          retention-days: 1
+
+  build_frontend:
+    name: Build frontend assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build frontend
+        run: make build-js
+      - uses: actions/upload-artifact@v7
+        with:
+          name: frontend-build
+          path: public/build
+          retention-days: 1
+
+  build_backend:
+    name: Build backend binary
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Build backend
+        run: make build-go OS=linux ARCH=arm64 BUILD_NUMBER=${{ needs.setup.outputs.build_number }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: backend-linux-arm64
+          path: bin/linux/arm64/grafana
+          retention-days: 1
+
+  build_split_targz:
+    name: Build tar.gz from split artifacts
+    runs-on: ubuntu-latest
+    needs: [setup, build_frontend, build_backend]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - uses: actions/download-artifact@v5
+        with:
+          name: frontend-build
+          path: _frontend
+      - uses: actions/download-artifact@v5
+        with:
+          name: backend-linux-arm64
+          path: _backend
+      - name: Assemble workspace from split artifacts
+        run: |
+          rm -rf public/build
+          mkdir -p public/build
+          cp -R _frontend/. public/build/
+          mkdir -p bin/linux/arm64
+          cp _backend/grafana bin/linux/arm64/grafana
+      - name: Build Linux ARM64 tar.gz
+        run: |
+          make build-targz \
+            OS=linux \
+            ARCH=arm64 \
+            BUILD_VERSION="${{ needs.setup.outputs.version }}" \
+            BUILD_NUMBER="${{ needs.setup.outputs.build_number }}"
+      - name: Locate split tar.gz output
+        run: |
+          TARGZ="$(ls dist/*.tar.gz | head -n 1)"
+          mkdir -p _out
+          cp "${TARGZ}" _out/split-build.tar.gz
+      - uses: actions/upload-artifact@v7
+        with:
+          name: split-build-targz
+          path: _out/split-build.tar.gz
+          retention-days: 1
+
+  compare_targz_contents:
+    name: Compare tar.gz contents
+    runs-on: ubuntu-latest
+    needs: [build_with_release_action, build_split_targz]
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: release-action-targz
+          path: _release
+      - uses: actions/download-artifact@v5
+        with:
+          name: split-build-targz
+          path: _split
+      - name: Extract and compare
+        run: |
+          mkdir -p _extract/release _extract/split
+          RELEASE_TAR="$(ls _release/*.tar.gz | head -n 1)"
+          SPLIT_TAR="$(ls _split/*.tar.gz | head -n 1)"
+
+          tar -xzf "${RELEASE_TAR}" -C _extract/release
+          tar -xzf "${SPLIT_TAR}" -C _extract/split
+
+          RELEASE_ROOT="$(ls -1 _extract/release | head -n 1)"
+          SPLIT_ROOT="$(ls -1 _extract/split | head -n 1)"
+
+          diff -r "_extract/release/${RELEASE_ROOT}" "_extract/split/${SPLIT_ROOT}"

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -137,6 +137,7 @@ jobs:
           path: _backend
       - name: Assemble workspace from split artifacts
         run: |
+          set -euo pipefail
           rm -rf public
           mkdir -p public
           cp -R _frontend/. public/

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -72,6 +72,7 @@ jobs:
   build_frontend:
     name: Build frontend assets
     runs-on: ubuntu-latest
+    needs: setup
     steps:
       - uses: actions/checkout@v6
         with:
@@ -80,12 +81,19 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: yarn install --immutable
+      # Match pkg/build/daggerbuild/frontend.Build: lerna version, yarn build, prune public node_modules
+      - name: Lerna version (align workspaces with release version)
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: yarn lerna version "${VERSION}" --exact --no-git-tag-version --no-push --force-publish -y
       - name: Build frontend
-        run: make build-js
+        run: yarn run build
+      - name: Prune node_modules under public
+        run: find public -type d -name node_modules -print0 | xargs -0 rm -rf
       - uses: actions/upload-artifact@v7
         with:
           name: frontend-build
-          path: public/build
+          path: public
           retention-days: 1
 
   build_backend:
@@ -119,8 +127,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
       - uses: actions/download-artifact@v5
         with:
           name: frontend-build
@@ -131,9 +137,9 @@ jobs:
           path: _backend
       - name: Assemble workspace from split artifacts
         run: |
-          rm -rf public/build
-          mkdir -p public/build
-          cp -R _frontend/. public/build/
+          rm -rf public
+          mkdir -p public
+          cp -R _frontend/. public/
           mkdir -p bin/linux/arm64
           cp _backend/grafana bin/linux/arm64/grafana
       - name: Build Linux ARM64 tar.gz

--- a/.github/workflows/compare-linux-arm64-targz-builds.yml
+++ b/.github/workflows/compare-linux-arm64-targz-builds.yml
@@ -208,11 +208,16 @@ jobs:
 
           skip_du_for_rel() {
             local rel="$1"
-            # Root and public/ aggregate hashed webpack output; public/build/** differs by platform (arm64 Dagger vs amd64 CI).
+            # Sizes omitted where release (Dagger arm64) vs split (native amd64) or different Go link are expected to diverge.
             [[ "$rel" == "." ]] && return 0
+            [[ "$rel" == "bin" ]] && return 0
+            [[ "$rel" == bin/* ]] && return 0
             [[ "$rel" == "public" ]] && return 0
             [[ "$rel" == "public/build" ]] && return 0
             [[ "$rel" == public/build/* ]] && return 0
+            # Built-in plugins emit public/app/plugins/*/dist with [contenthash]; same cross-arch variance as public/build.
+            [[ "$rel" == "public/app" ]] && return 0
+            [[ "$rel" == public/app/* ]] && return 0
             return 1
           }
 
@@ -241,8 +246,8 @@ jobs:
           echo "1) Directory tree (must be identical)."
           echo "   Directory count — release: $(wc -l </tmp/release-tree.txt)  split: $(wc -l </tmp/split-tree.txt)"
           echo ""
-          echo "2) Recursive sizes per directory (GNU du -sb), excluding: .  public/  public/build/**"
-          echo "   (Webpack [contenthash] output is not byte-identical between Dagger linux/arm64 Node and native amd64.)"
+          echo "2) Recursive sizes (GNU du -sb), excluding: .  bin/**  public/  public/build/**  public/app/**"
+          echo "   (Go binary link + webpack/plugin dist hashes differ arm64 Dagger vs amd64 CI.)"
           echo "   Sized paths — release: $(wc -l </tmp/release-sizes.txt)  split: $(wc -l </tmp/split-sizes.txt)"
           echo ""
 
@@ -252,10 +257,10 @@ jobs:
             ok=0
           fi
           if ! diff -u /tmp/release-sizes.txt /tmp/split-sizes.txt; then
-            echo >&2 "Compare failed: directory sizes differ (outside public/build)."
+            echo >&2 "Compare failed: directory sizes differ (outside excluded paths)."
             ok=0
           fi
           if [[ "$ok" -ne 1 ]]; then
             exit 1
           fi
-          echo "OK: same directory tree; matching sizes for all directories outside public/build."
+          echo "OK: same directory tree; matching sizes for all non-excluded directories."

--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ build: build-go build-js ## Build backend and frontend.
 TARGZ_PACKAGE_NAME ?= grafana
 
 .PHONY: build-targz
-build-targz: | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (same layout as daggerbuild).
+build-targz: | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (bin, public, conf, data)
 	TARGZ_PACKAGE_NAME="$(TARGZ_PACKAGE_NAME)" \
 	BUILD_VERSION="$(BUILD_VERSION)" \
 	BUILD_NUMBER="$(BUILD_NUMBER)" \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 GO_RACE  := $(shell [ -n "$(GO_RACE)" -o -e ".go-race-enabled-locally" ] && echo 1 )
 GO_RACE_FLAG := $(if $(GO_RACE),-race)
-# Backend build version and ldflags (aligned with pkg/build/daggerbuild/backend).
+# Backend build version and ldflags (release / packaging conventions).
 BUILD_NUMBER ?= local
 BUILD_VERSION := $(shell sed -n 's/.*"version": *"\(.*\)".*/\1/p' package.json | sed 's/-pre/-$(BUILD_NUMBER)/')
 BUILD_COMMIT := $(if $(COMMIT_SHA),$(COMMIT_SHA),$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown"))
@@ -375,11 +375,33 @@ build-plugin-go: ## Build decoupled plugins
 .PHONY: build
 build: build-go build-js ## Build backend and frontend.
 
-# Tar.gz packaging variables (aligned with pkg/build/daggerbuild/packages)
+# Tar.gz packaging variables (artifact / file naming).
 TARGZ_PACKAGE_NAME ?= grafana
 
+# Default catalog plugins under data/plugins-bundled. Stamp encodes OS/ARCH so cross-builds refresh.
+DATA_PLUGINS_BUNDLED_STAMP := data/plugins-bundled/.platform-$(OS)-$(ARCH).stamp
+
+$(DATA_PLUGINS_BUNDLED_STAMP): package.json \
+		$(wildcard pkg/build/catalogbundle/*.go) \
+		pkg/build/cmd/download-catalog-plugins/main.go \
+		pkg/build/daggerbuild/arguments/catalog_plugins.go
+	@rm -rf data/plugins-bundled
+	@mkdir -p data/plugins-bundled
+	@$(GO) run ./pkg/build/cmd/download-catalog-plugins \
+		-out data/plugins-bundled \
+		-grafana-version "$(BUILD_VERSION)" \
+		-os "$(OS)" \
+		-arch "$(ARCH)"
+	@touch $(DATA_PLUGINS_BUNDLED_STAMP)
+
+data/plugins-bundled: $(DATA_PLUGINS_BUNDLED_STAMP)
+	@:
+
+.PHONY: build-catalog-plugins-data
+build-catalog-plugins-data: data/plugins-bundled ## Download default catalog plugins into data/plugins-bundled (network; alias).
+
 .PHONY: build-targz
-build-targz: | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (bin, public, conf, data)
+build-targz: data/plugins-bundled | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (bin, public, conf, data/plugins-bundled from catalog)
 	TARGZ_PACKAGE_NAME="$(TARGZ_PACKAGE_NAME)" \
 	BUILD_VERSION="$(BUILD_VERSION)" \
 	BUILD_NUMBER="$(BUILD_NUMBER)" \

--- a/Makefile
+++ b/Makefile
@@ -382,16 +382,15 @@ TARGZ_PACKAGE_NAME ?= grafana
 DATA_PLUGINS_BUNDLED_STAMP := data/plugins-bundled/.platform-$(OS)-$(ARCH).stamp
 
 $(DATA_PLUGINS_BUNDLED_STAMP): package.json \
-		$(wildcard pkg/build/catalogbundle/*.go) \
-		pkg/build/cmd/download-catalog-plugins/main.go \
-		pkg/build/daggerbuild/arguments/catalog_plugins.go
+		scripts/download-catalog-plugins.sh \
+		scripts/catalog-plugins-defaults
 	@rm -rf data/plugins-bundled
 	@mkdir -p data/plugins-bundled
-	@$(GO) run ./pkg/build/cmd/download-catalog-plugins \
-		-out data/plugins-bundled \
-		-grafana-version "$(BUILD_VERSION)" \
-		-os "$(OS)" \
-		-arch "$(ARCH)"
+	@bash scripts/download-catalog-plugins.sh \
+		--out data/plugins-bundled \
+		--grafana-version "$(BUILD_VERSION)" \
+		--os "$(OS)" \
+		--arch "$(ARCH)"
 	@touch $(DATA_PLUGINS_BUNDLED_STAMP)
 
 data/plugins-bundled: $(DATA_PLUGINS_BUNDLED_STAMP)

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ data/plugins-bundled: $(DATA_PLUGINS_BUNDLED_STAMP)
 build-catalog-plugins-data: data/plugins-bundled ## Download default catalog plugins into data/plugins-bundled (network; alias).
 
 .PHONY: build-targz
-build-targz: data/plugins-bundled | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (bin, public, conf, data/plugins-bundled from catalog)
+build-targz: data/plugins-bundled | bin/$(OS)/$(ARCH)/grafana public/build ## Build a tar.gz package (bin, public, conf, plugins-bundled/, data/plugins-bundled from catalog)
 	TARGZ_PACKAGE_NAME="$(TARGZ_PACKAGE_NAME)" \
 	BUILD_VERSION="$(BUILD_VERSION)" \
 	BUILD_NUMBER="$(BUILD_NUMBER)" \

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -24,6 +24,11 @@ DIR="${STAGING}/${ROOT}"
 
 echo "build tar.gz: ${FILENAME}"
 
+if [[ ! -d "${REPO_ROOT}/conf" ]]; then
+  echo "error: ${REPO_ROOT}/conf is missing; cannot package" >&2
+  exit 1
+fi
+
 rm -rf "${STAGING}"
 mkdir -p "${DIR}/tools" "${DIR}/docs" "${DIR}/packaging"
 
@@ -32,6 +37,8 @@ cp LICENSE NOTICE.md README.md Dockerfile "${DIR}/"
 cp "$("${GO}" env GOROOT)/lib/time/zoneinfo.zip" "${DIR}/tools/"
 
 cp -r conf "${DIR}/conf"
+mkdir -p "${DIR}/data/plugins-bundled"
+
 cp -r docs/sources "${DIR}/docs/sources"
 cp -r packaging/deb "${DIR}/packaging/deb"
 cp -r packaging/rpm "${DIR}/packaging/rpm"
@@ -42,13 +49,6 @@ mkdir -p "${DIR}/bin"
 cp "bin/${OS}/${ARCH}/"* "${DIR}/bin/"
 cp -r public "${DIR}/public"
 find "${DIR}/public" -type d -name node_modules -print0 | xargs -0 rm -rf 2>/dev/null || true
-
-if [ -d plugins-bundled ]; then
-  cp -r plugins-bundled "${DIR}/plugins-bundled"
-  find "${DIR}/plugins-bundled" -type d -name node_modules -print0 | xargs -0 rm -rf 2>/dev/null || true
-else
-  mkdir -p "${DIR}/plugins-bundled"
-fi
 
 mkdir -p dist
 (cd "${STAGING}" && tar -czf "${REPO_ROOT}/dist/${FILENAME}" "${ROOT}")

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -54,6 +54,11 @@ cp -r packaging/wrappers "${DIR}/packaging/wrappers"
 
 mkdir -p "${DIR}/bin"
 cp "bin/${OS}/${ARCH}/"* "${DIR}/bin/"
+
+# This directory is unused, but it is preserved for backwards compatibility.
+# Bundled plugins are in 'data/plugins-bundled' now.
+mkdir -p "${DIR}/plugins-bundled"
+
 cp -r public "${DIR}/public"
 find "${DIR}/public" -type d -name node_modules -print0 | xargs -0 rm -rf 2>/dev/null || true
 

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -37,7 +37,14 @@ cp LICENSE NOTICE.md README.md Dockerfile "${DIR}/"
 cp "$("${GO}" env GOROOT)/lib/time/zoneinfo.zip" "${DIR}/tools/"
 
 cp -r conf "${DIR}/conf"
-mkdir -p "${DIR}/data/plugins-bundled"
+
+mkdir -p "${DIR}/data"
+if [[ -d "${REPO_ROOT}/data/plugins-bundled" ]]; then
+  cp -a "${REPO_ROOT}/data/plugins-bundled" "${DIR}/data/"
+  find "${DIR}/data/plugins-bundled" -type d -name node_modules -print0 2>/dev/null | xargs -0 rm -rf || true
+else
+  mkdir -p "${DIR}/data/plugins-bundled"
+fi
 
 cp -r docs/sources "${DIR}/docs/sources"
 cp -r packaging/deb "${DIR}/packaging/deb"

--- a/scripts/catalog-plugins-defaults
+++ b/scripts/catalog-plugins-defaults
@@ -1,0 +1,4 @@
+# Catalog plugin IDs to bundle under data/plugins-bundled (one per line).
+# Optional pin: id:version. Keep in sync with DefaultCatalogPlugins in
+# pkg/build/daggerbuild/arguments/catalog_plugins.go.
+elasticsearch

--- a/scripts/download-catalog-plugins.sh
+++ b/scripts/download-catalog-plugins.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# Download plugins from grafana.com into a directory (for data/plugins-bundled).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GRAFANA_CATALOG_API="${GRAFANA_CATALOG_API:-https://grafana.com/api/plugins}"
+DEFAULTS_FILE="${SCRIPT_DIR}/catalog-plugins-defaults"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: download-catalog-plugins.sh --os GOOS --arch GOARCH
+  [--out DIR] [--grafana-version VER] [--no-default-catalog-plugins]
+  [--plugins id,id:version,...]
+EOF
+  exit 2
+}
+
+require_cmds() {
+  local c
+  for c in curl jq unzip openssl; do
+    if ! command -v "$c" >/dev/null 2>&1; then
+      echo "download-catalog-plugins: required command not found: $c" >&2
+      exit 1
+    fi
+  done
+}
+
+extract_plugin_zip() {
+  local zipfile="$1"
+  local dest="$2"
+  local tmp
+  tmp="$(mktemp -d)"
+  if ! unzip -q -o "$zipfile" -d "$tmp"; then
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$dest"
+  mkdir -p "$dest"
+
+  local dir_count file_count root_dir
+  dir_count="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+  file_count="$(find "$tmp" -mindepth 1 -maxdepth 1 ! -type d 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$dir_count" -eq 1 && "$file_count" -eq 0 ]]; then
+    root_dir="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+    cp -a "${root_dir}/." "${dest}/"
+  else
+    cp -a "${tmp}/." "${dest}/"
+  fi
+  rm -rf "$tmp"
+}
+
+merge_specs_lines() {
+  # stdin: lines "id|version" (checksum optional as id|ver|sha — ver/sha may be empty). stdout: stable "id|version|checksum".
+  # Deduplication matches pkg/build/daggerbuild/arguments.MergeCatalogPluginSpecs (first-seen order preserved).
+  awk -F'|' '
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    NF < 1 { next }
+    {
+      id = trim($1)
+      v = (NF >= 2 ? trim($2) : "")
+      csum = (NF >= 3 ? trim($3) : "")
+      if (id == "") next
+      if (!(id in seen)) {
+        n++
+        order[n] = id
+        ver[id] = v
+        chk[id] = csum
+        seen[id] = 1
+        next
+      }
+      if (ver[id] == v) {
+        if (chk[id] == csum || csum == "") next
+        if (chk[id] == "") { chk[id] = csum; next }
+        print "download-catalog-plugins: conflicting checksums for plugin " id > "/dev/stderr"
+        exit 1
+      }
+      if (ver[id] == "") {
+        ver[id] = v
+        if (chk[id] == "" && csum != "") chk[id] = csum
+        next
+      }
+      if (v == "") {
+        if (csum != "" && chk[id] == "") chk[id] = csum
+        next
+      }
+      print "download-catalog-plugins: conflicting versions for plugin " id ": " ver[id] " vs " v > "/dev/stderr"
+      exit 1
+    }
+    END {
+      for (i = 1; i <= n; i++) {
+        id = order[i]
+        print id "|" ver[id] "|" chk[id]
+      }
+    }'
+}
+
+fetch_resolved_meta() {
+  # GET /api/plugins/{id}/versions — headers match pkg/plugins/repo.Client.createReq (resolver runs in Go before Dagger download).
+  local plugin_id="$1"
+  local grafana_ver="$2"
+  local os="$3"
+  local arch="$4"
+  local os_arch_key
+  os_arch_key="$(echo "${os}" | tr '[:upper:]' '[:lower:]')-${arch}"
+
+  local url="${GRAFANA_CATALOG_API}/${plugin_id}/versions"
+  local hdrs=(-fSL)
+  if [[ -n "${grafana_ver}" ]]; then
+    hdrs+=(-H "grafana-version: ${grafana_ver}" -H "User-Agent: grafana ${grafana_ver}")
+  fi
+  hdrs+=(-H "grafana-os: ${os}" -H "grafana-arch: ${arch}")
+
+  local json
+  if ! json="$(curl "${hdrs[@]}" -- "${url}")"; then
+    echo "download-catalog-plugins: failed to fetch versions for ${plugin_id}" >&2
+    return 1
+  fi
+
+  # Selection matches pkg/plugins/repo.latestSupportedVersion + SelectSystemCompatibleVersion (version ""):
+  # supportsCurrentArch true when .packages is null (Go Arch nil).
+  jq -r --arg k "${os_arch_key}" '
+    (.items // [])
+    | map(select(.isCompatible == null or .isCompatible == true))
+    | map(select(.packages == null or (.packages[$k] != null) or (.packages["any"] != null)))
+    | if length == 0 then error("no compatible version on \($k)")
+      else .[0] | {
+          version: .version,
+          sha256: (
+            if .packages == null then ""
+            else ((.packages[$k] // .packages["any"] // {}).sha256 // "")
+            end
+          )
+        } end
+  ' <<<"${json}"
+}
+
+download_plugin_archive() {
+  local plugin_id="$1"
+  local resolved_version="$2"
+  local want_checksum="$3"
+  local grafana_ver="$4"
+  local os="$5"
+  local arch="$6"
+  local out_zip="$7"
+
+  local dl_url="${GRAFANA_CATALOG_API}/${plugin_id}/versions/${resolved_version}/download"
+  # pkg/build/daggerbuild/plugins.DownloadPlugins curl (zip fetch), not repo.Client User-Agent.
+  local hdrs=(-fSL -H "User-Agent: grafana-build")
+  if [[ -n "${grafana_ver}" ]]; then
+    hdrs+=(-H "grafana-version: ${grafana_ver}")
+  fi
+  hdrs+=(-H "grafana-os: ${os}" -H "grafana-arch: ${arch}")
+
+  if ! curl "${hdrs[@]}" -o "${out_zip}" -- "${dl_url}"; then
+    echo "download-catalog-plugins: download failed for ${plugin_id} ${resolved_version}" >&2
+    return 1
+  fi
+
+  if [[ -n "${want_checksum}" ]]; then
+    want_checksum="${want_checksum#sha256:}"
+    local got
+    got="$(openssl dgst -sha256 "${out_zip}" | awk '{print $2}')"
+    if [[ "${got}" != "${want_checksum}" ]]; then
+      echo "download-catalog-plugins: checksum mismatch for ${plugin_id} (expected ${want_checksum}, got ${got})" >&2
+      return 1
+    fi
+  fi
+}
+
+main() {
+  local out="data/plugins-bundled"
+  local grafana_version=""
+  local os_str=""
+  local arch_str=""
+  local no_default=0
+  local plugins_csv=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --out)
+        out="$2"
+        shift 2
+        ;;
+      --grafana-version)
+        grafana_version="$2"
+        shift 2
+        ;;
+      --os)
+        os_str="$2"
+        shift 2
+        ;;
+      --arch)
+        arch_str="$2"
+        shift 2
+        ;;
+      --no-default-catalog-plugins)
+        no_default=1
+        shift
+        ;;
+      --plugins)
+        plugins_csv="$2"
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        ;;
+      *)
+        echo "download-catalog-plugins: unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  if [[ -z "${os_str}" || -z "${arch_str}" ]]; then
+    echo "download-catalog-plugins: --os and --arch are required" >&2
+    exit 2
+  fi
+
+  require_cmds
+
+  local specs_tmp
+  specs_tmp="$(mktemp)"
+  cleanup_specs() { rm -f "$specs_tmp"; }
+  trap 'cleanup_specs' EXIT
+
+  if [[ "${no_default}" -eq 0 ]]; then
+    if [[ ! -f "${DEFAULTS_FILE}" ]]; then
+      echo "download-catalog-plugins: missing ${DEFAULTS_FILE}" >&2
+      exit 1
+    fi
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+      [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+      line="$(echo "${line}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [[ -z "${line}" ]] && continue
+      if [[ "${line}" == *:*:* ]]; then
+        _pps_id="${line%%:*}"
+        _pps_sha="${line#*:*:}"
+        _pps_ver="${line#*:}"
+        _pps_ver="${_pps_ver%%:*}"
+        printf '%s\n' "${_pps_id}|${_pps_ver}|${_pps_sha}" >>"${specs_tmp}"
+      elif [[ "${line}" == *:* ]]; then
+        printf '%s\n' "${line%%:*}|${line#*:}|" >>"${specs_tmp}"
+      else
+        printf '%s\n' "${line}||" >>"${specs_tmp}"
+      fi
+    done <"${DEFAULTS_FILE}"
+  fi
+  if [[ -n "${plugins_csv}" ]]; then
+    local part
+    IFS=',' read -r -a parts <<<"${plugins_csv}"
+    for part in "${parts[@]}"; do
+      part="$(echo "${part}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [[ -z "${part}" ]] && continue
+      # id, id:version, or id:version:sha256 (sha256 optional; matches catalog plugin spec)
+      if [[ "${part}" == *:*:* ]]; then
+        _pps_id="${part%%:*}"
+        _pps_sha="${part#*:*:}"
+        _pps_ver="${part#*:}"
+        _pps_ver="${_pps_ver%%:*}"
+        printf '%s\n' "${_pps_id}|${_pps_ver}|${_pps_sha}" >>"${specs_tmp}"
+      elif [[ "${part}" == *:* ]]; then
+        printf '%s\n' "${part%%:*}|${part#*:}|" >>"${specs_tmp}"
+      else
+        printf '%s\n' "${part}||" >>"${specs_tmp}"
+      fi
+    done
+  fi
+
+  rm -rf "${out}"
+  mkdir -p "${out}"
+
+  local line plugin_id plan_ver spec_checksum meta resolved_ver sha tmp_zip
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    IFS='|' read -r plugin_id plan_ver spec_checksum <<<"${line}"
+
+    if [[ -n "${plan_ver}" ]]; then
+      # pkg/build/daggerbuild/plugins.ResolvePluginVersions (pinned): no versions API call;
+      # URL from BuildPluginDownloadURL; checksum only from spec (optional).
+      resolved_ver="${plan_ver}"
+      sha="${spec_checksum}"
+      if [[ -n "${sha}" ]]; then
+        sha="${sha#sha256:}"
+      fi
+    else
+      meta="$(fetch_resolved_meta "${plugin_id}" "${grafana_version}" "${os_str}" "${arch_str}")"
+      resolved_ver="$(jq -r '.version' <<<"${meta}")"
+      sha="$(jq -r '.sha256 // empty' <<<"${meta}")"
+      if [[ -n "${spec_checksum}" ]]; then
+        spec_checksum="${spec_checksum#sha256:}"
+        if [[ -n "${spec_checksum}" ]]; then
+          sha="${spec_checksum}"
+        fi
+      fi
+    fi
+
+    tmp_zip="$(mktemp)"
+
+    download_plugin_archive "${plugin_id}" "${resolved_ver}" "${sha}" "${grafana_version}" "${os_str}" "${arch_str}" "${tmp_zip}"
+    extract_plugin_zip "${tmp_zip}" "${out}/${plugin_id}"
+    rm -f "${tmp_zip}"
+  done < <(merge_specs_lines <"${specs_tmp}")
+}
+
+main "$@"

--- a/scripts/download-catalog-plugins.sh
+++ b/scripts/download-catalog-plugins.sh
@@ -218,7 +218,7 @@ main() {
 
   require_cmds
 
-  local specs_tmp
+  # Not local: EXIT runs after main returns, so locals would be unbound (set -u) when cleanup runs.
   specs_tmp="$(mktemp)"
   cleanup_specs() { rm -f "$specs_tmp"; }
   trap 'cleanup_specs' EXIT


### PR DESCRIPTION
- Add CI check to ensure parity between daggerbuild tar.gz and Makefile targz
- Add script which downloads the bundled plugins, same as daggerbuild
- Update the build-targz makefile target to run the script when creating a targz (if they weren't downloaded already)