### PR TITLE
Team Folders: Add owner filter to browse dashboards

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2677,15 +2677,7 @@
       "count": 16
     }
   },
-  "public/app/features/search/types.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "public/app/features/search/utils.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
     "no-restricted-syntax": {
       "count": 3
     }

--- a/packages/grafana-test-utils/src/handlers/api/teams/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/api/teams/handlers.ts
@@ -134,6 +134,34 @@ const searchTeamsHandler = () =>
     });
   });
 
+type SearchTeam = {
+  name: string;
+  email?: string;
+  id?: number;
+  uid: string;
+  orgId?: number;
+  externalUID?: string;
+  isProvisioned?: boolean;
+  avatarUrl?: string;
+  memberCount?: number;
+  permission?: number;
+  accessControl?: Record<string, boolean> | null;
+};
+
+export const getSearchTeamsHandler = (teams: SearchTeam[], totalCount = teams.length) =>
+  http.get('/api/teams/search', async ({ request }) => {
+    const url = new URL(request.url);
+    const page = url.searchParams.get('page') ?? '1';
+    const perPage = url.searchParams.get('perpage') ?? '1000';
+
+    return HttpResponse.json({
+      totalCount,
+      teams,
+      page,
+      perPage,
+    });
+  });
+
 const createTeamHandler = () =>
   http.post<never, { name: string; email: string }>('/api/teams', async ({ request }) => {
     const body = await request.json();

--- a/packages/grafana-test-utils/src/handlers/api/teams/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/api/teams/handlers.ts
@@ -162,6 +162,11 @@ export const getSearchTeamsHandler = (teams: SearchTeam[], totalCount = teams.le
     });
   });
 
+export const getSearchTeamsErrorHandler = (message = 'Failed to load teams', status = 500) =>
+  http.get('/api/teams/search', async () => {
+    return HttpResponse.json({ message }, { status });
+  });
+
 const createTeamHandler = () =>
   http.post<never, { name: string; email: string }>('/api/teams', async ({ request }) => {
     const body = await request.json();

--- a/packages/grafana-test-utils/src/handlers/apis/dashboard.grafana.app/v0alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/dashboard.grafana.app/v0alpha1/handlers.ts
@@ -37,6 +37,7 @@ export function getCustomSearchHandler(hits: DashboardHit[]) {
     const typeFilter = url.searchParams.getAll('type');
     const nameFilter = url.searchParams.getAll('name');
     const tagFilter = url.searchParams.getAll('tag');
+    const ownerReferenceFilter = url.searchParams.getAll('ownerReference');
     const offset = parseInt(url.searchParams.get('offset') || '', 10) || 0;
 
     const filters: HitFilterArray = [];
@@ -52,6 +53,12 @@ export function getCustomSearchHandler(hits: DashboardHit[]) {
 
     if (tagFilter.length > 0) {
       filters.push((hit) => Boolean(hit.tags?.some((tag) => tagFilter.includes(tag))));
+    }
+
+    if (ownerReferenceFilter.length > 0) {
+      filters.push((hit) =>
+        Boolean(hit.ownerReferences?.some((ownerReference) => ownerReferenceFilter.includes(ownerReference)))
+      );
     }
 
     if (folderFilter === 'general') {

--- a/packages/grafana-test-utils/src/handlers/index.ts
+++ b/packages/grafana-test-utils/src/handlers/index.ts
@@ -1,3 +1,4 @@
 export { BASE as PROVISIONING_API_BASE } from './apis/provisioning.grafana.app/v0alpha1/handlers';
 export { USAGE_URL as QUOTAS_USAGE_URL } from './apis/quotas.grafana.app/v0alpha1/handlers';
 export { getCustomSearchHandler } from './apis/dashboard.grafana.app/v0alpha1/handlers';
+export { getSearchTeamsHandler } from './api/teams/handlers';

--- a/packages/grafana-test-utils/src/handlers/index.ts
+++ b/packages/grafana-test-utils/src/handlers/index.ts
@@ -1,4 +1,4 @@
 export { BASE as PROVISIONING_API_BASE } from './apis/provisioning.grafana.app/v0alpha1/handlers';
 export { USAGE_URL as QUOTAS_USAGE_URL } from './apis/quotas.grafana.app/v0alpha1/handlers';
 export { getCustomSearchHandler } from './apis/dashboard.grafana.app/v0alpha1/handlers';
-export { getSearchTeamsHandler } from './api/teams/handlers';
+export { getSearchTeamsErrorHandler, getSearchTeamsHandler } from './api/teams/handlers';

--- a/public/app/features/browse-dashboards/components/BrowseFilters.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseFilters.test.tsx
@@ -1,0 +1,123 @@
+import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
+import { render, screen, testWithFeatureToggles } from 'test/test-utils';
+
+import { SearchLayout, type SearchState } from 'app/features/search/types';
+
+import { BrowseFilters } from './BrowseFilters';
+
+const mockUseSearchStateManager = jest.fn();
+const mockSearchTeamsQuery = jest.fn();
+const mockGetSortOptions = jest.fn().mockResolvedValue([]);
+
+jest.mock('app/features/search/state/SearchStateManager', () => ({
+  useSearchStateManager: () => mockUseSearchStateManager(),
+}));
+
+jest.mock('app/features/search/service/searcher', () => ({
+  getGrafanaSearcher: () => ({
+    getSortOptions: mockGetSortOptions,
+    sortPlaceholder: 'Sort',
+  }),
+}));
+
+jest.mock('app/api/clients/legacy', () => ({
+  legacyAPI: {
+    reducerPath: 'legacyAPI',
+    reducer: (state = {}) => state,
+    middleware: () => (next: (action: unknown) => unknown) => (action: unknown) => next(action),
+  },
+  useSearchTeamsQuery: (...args: unknown[]) => mockSearchTeamsQuery(...args),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    hasPermission: jest.fn(() => true),
+    user: { uid: 1, orgId: 1 },
+  },
+}));
+
+comboboxTestSetup();
+
+const createSearchState = (partial?: Partial<SearchState>): SearchState => ({
+  query: '',
+  tag: [],
+  ownerReference: [],
+  starred: false,
+  layout: SearchLayout.Folders,
+  eventTrackingNamespace: 'dashboard_search',
+  deleted: false,
+  ...partial,
+});
+
+const createStateManager = () => ({
+  getTagOptions: jest.fn().mockResolvedValue([]),
+  onLayoutChange: jest.fn(),
+  onStarredFilterChange: jest.fn(),
+  onSortChange: jest.fn(),
+  onTagFilterChange: jest.fn(),
+  onDatasourceChange: jest.fn(),
+  onPanelTypeChange: jest.fn(),
+  onSetIncludePanels: jest.fn(),
+  onCreatedByChange: jest.fn(),
+  onOwnerReferenceChange: jest.fn(),
+});
+
+describe('BrowseFilters', () => {
+  testWithFeatureToggles({ enable: ['teamFolders', 'unifiedStorageSearchUI'] });
+
+  beforeEach(() => {
+    mockSearchTeamsQuery.mockReturnValue({
+      data: {
+        teams: [
+          { uid: 'team-a', name: 'Team A', avatarUrl: '' },
+          { uid: 'test-team', name: 'Test Team', avatarUrl: '' },
+        ],
+      },
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the owner filter with the all teams option and user teams', async () => {
+    const stateManager = createStateManager();
+    mockUseSearchStateManager.mockReturnValue([createSearchState(), stateManager]);
+
+    const { user } = render(<BrowseFilters />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+
+    expect(await screen.findByText('All teams')).toBeInTheDocument();
+    expect(await screen.findByText('Team A')).toBeInTheDocument();
+    expect(await screen.findByText('Test Team')).toBeInTheDocument();
+  });
+
+  it('normalizes a team selection into ownerReference values', async () => {
+    const stateManager = createStateManager();
+    mockUseSearchStateManager.mockReturnValue([createSearchState(), stateManager]);
+
+    const { user } = render(<BrowseFilters />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+    await user.click(await screen.findByText('Team A'));
+
+    expect(stateManager.onOwnerReferenceChange).toHaveBeenCalledWith(['iam.grafana.app/Team/team-a']);
+  });
+
+  it('normalizes the all teams option into all ownerReference values', async () => {
+    const stateManager = createStateManager();
+    mockUseSearchStateManager.mockReturnValue([createSearchState(), stateManager]);
+
+    const { user } = render(<BrowseFilters />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+    await user.click(await screen.findByText('All teams'));
+
+    expect(stateManager.onOwnerReferenceChange).toHaveBeenCalledWith([
+      'iam.grafana.app/Team/team-a',
+      'iam.grafana.app/Team/test-team',
+    ]);
+  });
+});

--- a/public/app/features/browse-dashboards/components/BrowseFilters.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseFilters.tsx
@@ -21,6 +21,7 @@ export function BrowseFilters() {
       onPanelTypeChange={stateManager.onPanelTypeChange}
       onSetIncludePanels={stateManager.onSetIncludePanels}
       onCreatedByChange={stateManager.onCreatedByChange}
+      onOwnerReferenceChange={stateManager.onOwnerReferenceChange}
     />
   );
 }

--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -11,6 +11,9 @@ import { TagFilter, type TermCount } from 'app/core/components/TagFilter/TagFilt
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { SearchLayout, type SearchState } from '../../types';
+import { needsListLayout } from '../../utils';
+
+import { OwnersFilter } from './OwnersFilter';
 
 function getLayoutOptions() {
   return [
@@ -39,16 +42,15 @@ interface ActionRowProps {
   onPanelTypeChange: (pt?: string) => void;
   onSetIncludePanels: (v: boolean) => void;
   onCreatedByChange?: (createdBy?: string) => void;
+  onOwnerReferenceChange?: (ownerReference: string[]) => void;
 }
 
-export function getValidQueryLayout(q: SearchState): SearchLayout {
+function getValidQueryLayout(q: SearchState): SearchLayout {
   const layout = q.layout ?? SearchLayout.Folders;
 
   // Folders is not valid when a query exists
-  if (layout === SearchLayout.Folders) {
-    if (q.query || q.sort || q.starred || q.tag.length > 0 || q.createdBy) {
-      return SearchLayout.List;
-    }
+  if (layout === SearchLayout.Folders && needsListLayout(q)) {
+    return SearchLayout.List;
   }
 
   return layout;
@@ -69,6 +71,7 @@ export const ActionRow = ({
   onPanelTypeChange,
   onSetIncludePanels,
   onCreatedByChange,
+  onOwnerReferenceChange,
 }: ActionRowProps) => {
   const styles = useStyles2(getStyles);
 
@@ -78,10 +81,7 @@ export const ActionRow = ({
   const showCreatedByMeSearchFilter = isCreatedByMeSearchFilterEnabled && config.featureToggles.unifiedStorageSearchUI;
 
   // Disabled folder layout option when query is present
-  const disabledOptions =
-    state.tag.length || state.starred || state.query || state.datasource || state.panel_type || state.createdBy
-      ? [SearchLayout.Folders]
-      : [];
+  const disabledOptions = needsListLayout(state) ? [SearchLayout.Folders] : [];
 
   const createdByMe = `user:${contextSrv.user.uid}`;
   const isFilteredByMe = state.createdBy === createdByMe;
@@ -90,6 +90,9 @@ export const ActionRow = ({
     <Stack justifyContent="space-between" alignItems="center" wrap={true}>
       <Stack alignItems="center">
         <TagFilter isClearable={false} tags={state.tag} tagOptions={getTagOptions} onChange={onTagFilterChange} />
+        {config.featureToggles.teamFolders && onOwnerReferenceChange && (
+          <OwnersFilter values={state.ownerReference ?? []} onChange={onOwnerReferenceChange} />
+        )}
         {config.featureToggles.panelTitleSearch && (
           <Checkbox
             data-testid="include-panels"

--- a/public/app/features/search/page/components/OwnersFilter.test.tsx
+++ b/public/app/features/search/page/components/OwnersFilter.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
 import { render, screen } from 'test/test-utils';
 
@@ -67,9 +68,11 @@ describe('OwnersFilter', () => {
 
     await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
 
-    expect(screen.queryByText('All teams')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('All teams')).not.toBeInTheDocument();
+    });
     expect(await screen.findByText('Team A')).toBeInTheDocument();
-    expect(await screen.findByText('Test Team')).toBeInTheDocument();
+    expect(screen.getByText('Test Team')).toBeInTheDocument();
 
     await user.hover(await screen.findByLabelText('Owner filter limit warning'));
 

--- a/public/app/features/search/page/components/OwnersFilter.test.tsx
+++ b/public/app/features/search/page/components/OwnersFilter.test.tsx
@@ -2,7 +2,7 @@ import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
 import { render, screen } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
-import { getSearchTeamsHandler } from '@grafana/test-utils/handlers';
+import { getSearchTeamsErrorHandler, getSearchTeamsHandler } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
 
@@ -50,5 +50,39 @@ describe('OwnersFilter', () => {
     await user.click(await screen.findByText('All teams'));
 
     expect(onChange).toHaveBeenCalledWith(['iam.grafana.app/Team/team-a', 'iam.grafana.app/Team/test-team']);
+  });
+
+  it('does not show the all teams option when totalCount is more than 200 and shows a warning', async () => {
+    server.use(
+      getSearchTeamsHandler(
+        [
+          { id: 1, uid: 'team-a', name: 'Team A', avatarUrl: '' },
+          { id: 2, uid: 'test-team', name: 'Test Team', avatarUrl: '' },
+        ],
+        201
+      )
+    );
+
+    const { user } = render(<OwnersFilter values={[]} onChange={jest.fn()} />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+
+    expect(screen.queryByText('All teams')).not.toBeInTheDocument();
+    expect(await screen.findByText('Team A')).toBeInTheDocument();
+    expect(await screen.findByText('Test Team')).toBeInTheDocument();
+
+    await user.hover(await screen.findByLabelText('Owner filter limit warning'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Listing only first 200 teams out of 201.');
+  });
+
+  it('shows an error tooltip when loading teams fails', async () => {
+    server.use(getSearchTeamsErrorHandler('Team API unavailable'));
+
+    const { user } = render(<OwnersFilter values={[]} onChange={jest.fn()} />);
+
+    await user.hover(await screen.findByLabelText('Owner filter load error'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Team API unavailable');
   });
 });

--- a/public/app/features/search/page/components/OwnersFilter.test.tsx
+++ b/public/app/features/search/page/components/OwnersFilter.test.tsx
@@ -1,0 +1,54 @@
+import { comboboxTestSetup } from 'test/helpers/comboboxTestSetup';
+import { render, screen } from 'test/test-utils';
+
+import { setBackendSrv } from '@grafana/runtime';
+import { getSearchTeamsHandler } from '@grafana/test-utils/handlers';
+import server, { setupMockServer } from '@grafana/test-utils/server';
+import { backendSrv } from 'app/core/services/backend_srv';
+
+import { OwnersFilter } from './OwnersFilter';
+
+setBackendSrv(backendSrv);
+setupMockServer();
+comboboxTestSetup();
+
+describe('OwnersFilter', () => {
+  beforeEach(() => {
+    server.use(
+      getSearchTeamsHandler([
+        { id: 1, uid: 'team-a', name: 'Team A', avatarUrl: '' },
+        { id: 2, uid: 'test-team', name: 'Test Team', avatarUrl: '' },
+      ])
+    );
+  });
+
+  it('shows the all teams option and fetched teams', async () => {
+    const { user } = render(<OwnersFilter values={[]} onChange={jest.fn()} />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+
+    expect(await screen.findByText('All teams')).toBeInTheDocument();
+    expect(await screen.findByText('Team A')).toBeInTheDocument();
+    expect(await screen.findByText('Test Team')).toBeInTheDocument();
+  });
+
+  it('normalizes a team selection into ownerReference values', async () => {
+    const onChange = jest.fn();
+    const { user } = render(<OwnersFilter values={[]} onChange={onChange} />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+    await user.click(await screen.findByText('Team A'));
+
+    expect(onChange).toHaveBeenCalledWith(['iam.grafana.app/Team/team-a']);
+  });
+
+  it('normalizes the all teams option into all ownerReference values', async () => {
+    const onChange = jest.fn();
+    const { user } = render(<OwnersFilter values={[]} onChange={onChange} />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'Owner filter' }));
+    await user.click(await screen.findByText('All teams'));
+
+    expect(onChange).toHaveBeenCalledWith(['iam.grafana.app/Team/team-a', 'iam.grafana.app/Team/test-team']);
+  });
+});

--- a/public/app/features/search/page/components/OwnersFilter.tsx
+++ b/public/app/features/search/page/components/OwnersFilter.tsx
@@ -1,0 +1,97 @@
+import { css } from '@emotion/css';
+import { useMemo } from 'react';
+
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Icon, MultiSelect, useStyles2 } from '@grafana/ui';
+import { useSearchTeamsQuery } from 'app/api/clients/legacy';
+import { teamOwnerRef } from 'app/features/browse-dashboards/utils/dashboards';
+
+const ALL_TEAMS_VALUE = '__all-teams__';
+
+interface OwnersFilterProps {
+  values: string[];
+  onChange: (ownerReference: string[]) => void;
+}
+
+/**
+ * A filter component that allows selecting multiple existing teams.
+ */
+export function OwnersFilter({ values, onChange }: OwnersFilterProps) {
+  const styles = useStyles2(getStyles);
+  // At this point we have hard limit for number of items we show. The issue is we are using MultiSelect because of
+  // some UX bug (it opens only when clicking on internal input, not the full element) in Combobox but Multiselect
+  // then does not allow for async options loading.
+  const { data, isLoading } = useSearchTeamsQuery({ perpage: 200, sort: 'name-asc' });
+
+  const teamOptions = useMemo<Array<SelectableValue<string>>>(() => {
+    if (!data?.teams) {
+      return [];
+    }
+    return data.teams.map((team) => ({
+      label: team.name,
+      value: teamOwnerRef(team),
+      imgUrl: team.avatarUrl,
+    }));
+  }, [data?.teams]);
+
+  const allTeamsValue = useMemo(() => {
+    return {
+      label: t('browse-dashboards.filters.all-teams', 'All teams'),
+      value: ALL_TEAMS_VALUE,
+    };
+  }, []);
+
+  // We go through some hoops here to create a virtual "all teams" item to allow quickly selecting all the teams
+  // in the select.
+  const allTeamReferences = useMemo(() => {
+    // option.value is UID of the team. This needs to exist always so we should be able to use ! here.
+    return teamOptions.map((option) => option.value!);
+  }, [teamOptions]);
+
+  // Check if the value prop matches list of all the teams we get from the API
+  const hasAllTeamsSelected =
+    values.length > 0 &&
+    allTeamReferences.length > 0 &&
+    values.length === allTeamReferences.length &&
+    allTeamReferences.every((reference) => values.includes(reference));
+
+  const value = hasAllTeamsSelected
+    ? [allTeamsValue]
+    : teamOptions.filter((option) => option.value && values.includes(option.value));
+
+  // Add "all teams" option if there are some actual teams
+  const options = useMemo<Array<SelectableValue<string>>>(() => {
+    if (teamOptions.length === 0) {
+      return [];
+    }
+    return [allTeamsValue, ...teamOptions];
+  }, [teamOptions, allTeamsValue]);
+
+  return (
+    <div className={styles.ownerFilter}>
+      <MultiSelect<string>
+        aria-label={t('browse-dashboards.filters.owner-aria-label', 'Owner filter')}
+        options={options}
+        value={value}
+        onChange={(selectedOptions) => {
+          const values = selectedOptions.map((option) => option.value!);
+          // We don't send ALL_TEAMS_VALUE upstream, so we map it to actual list of all the teams.
+          onChange(values.includes(ALL_TEAMS_VALUE) ? allTeamReferences : values);
+        }}
+        noOptionsMessage={t('browse-dashboards.filters.owner-no-options', 'No teams found')}
+        loadingMessage={t('browse-dashboards.filters.owner-loading', 'Loading teams...')}
+        placeholder={t('browse-dashboards.filters.owner-placeholder', 'Filter by owner')}
+        isLoading={isLoading}
+        prefix={<Icon name="filter" />}
+      />
+    </div>
+  );
+}
+
+const getStyles = (_theme: GrafanaTheme2) => ({
+  ownerFilter: css({
+    minWidth: '180px',
+    flexGrow: 1,
+  }),
+});

--- a/public/app/features/search/page/components/OwnersFilter.tsx
+++ b/public/app/features/search/page/components/OwnersFilter.tsx
@@ -93,7 +93,7 @@ export function OwnersFilter({ values, onChange }: OwnersFilterProps) {
         options={options}
         value={value}
         onChange={(selectedOptions) => {
-          const values = selectedOptions.map((option) => option.value!);
+          const values = selectedOptions.map((option) => option.value).filter((value) => value !== undefined);
           // We don't send ALL_TEAMS_VALUE upstream, so we map it to actual list of all the teams.
           onChange(!hasMoreTeamsThanLimit && values.includes(ALL_TEAMS_VALUE) ? allTeamReferences : values);
         }}

--- a/public/app/features/search/page/components/OwnersFilter.tsx
+++ b/public/app/features/search/page/components/OwnersFilter.tsx
@@ -3,11 +3,14 @@ import { useMemo } from 'react';
 
 import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Icon, MultiSelect, useStyles2 } from '@grafana/ui';
+import { Icon, MultiSelect, Tooltip, useStyles2 } from '@grafana/ui';
 import { useSearchTeamsQuery } from 'app/api/clients/legacy';
+import { extractErrorMessage } from 'app/api/utils';
 import { teamOwnerRef } from 'app/features/browse-dashboards/utils/dashboards';
 
 const ALL_TEAMS_VALUE = '__all-teams__';
+// The number here is currently arbitrary, feel free to change if it makes sense.
+const TEAM_OPTIONS_LIMIT = 200;
 
 interface OwnersFilterProps {
   values: string[];
@@ -20,10 +23,13 @@ interface OwnersFilterProps {
 export function OwnersFilter({ values, onChange }: OwnersFilterProps) {
   const styles = useStyles2(getStyles);
   // At this point we have hard limit for number of items we show. The issue is we are using MultiSelect because of
-  // some UX bug (it opens only when clicking on internal input, not the full element) in Combobox but Multiselect
+  // UX bug https://github.com/grafana/grafana/issues/121586 in Combobox but Multiselect
   // then does not allow for async options loading.
-  const { data, isLoading } = useSearchTeamsQuery({ perpage: 200, sort: 'name-asc' });
+  const { data, error, isLoading } = useSearchTeamsQuery({ perpage: TEAM_OPTIONS_LIMIT, sort: 'name-asc' });
 
+  // In this case we show a warning tooltip and don't show the allTeamsValue as we cannot really select *all* the teams
+  // if we cannot load them.
+  const hasMoreTeamsThanLimit = (data?.totalCount ?? 0) > TEAM_OPTIONS_LIMIT;
   const teamOptions = useMemo<Array<SelectableValue<string>>>(() => {
     if (!data?.teams) {
       return [];
@@ -45,28 +51,40 @@ export function OwnersFilter({ values, onChange }: OwnersFilterProps) {
   // We go through some hoops here to create a virtual "all teams" item to allow quickly selecting all the teams
   // in the select.
   const allTeamReferences = useMemo(() => {
-    // option.value is UID of the team. This needs to exist always so we should be able to use ! here.
-    return teamOptions.map((option) => option.value!);
+    return (
+      teamOptions
+        .map((option) => option.value)
+        // option.value is UID of the team so should always exist but this helps with typing.
+        .filter((value) => value !== undefined)
+    );
   }, [teamOptions]);
 
   // Check if the value prop matches list of all the teams we get from the API
   const hasAllTeamsSelected =
+    !hasMoreTeamsThanLimit &&
     values.length > 0 &&
     allTeamReferences.length > 0 &&
     values.length === allTeamReferences.length &&
     allTeamReferences.every((reference) => values.includes(reference));
 
-  const value = hasAllTeamsSelected
-    ? [allTeamsValue]
-    : teamOptions.filter((option) => option.value && values.includes(option.value));
+  const value = useMemo(() => {
+    return hasAllTeamsSelected
+      ? [allTeamsValue]
+      : teamOptions.filter((option) => option.value && values.includes(option.value));
+  }, [hasAllTeamsSelected, allTeamsValue, teamOptions, values]);
 
   // Add "all teams" option if there are some actual teams
   const options = useMemo<Array<SelectableValue<string>>>(() => {
     if (teamOptions.length === 0) {
       return [];
     }
+
+    if (hasMoreTeamsThanLimit) {
+      return teamOptions;
+    }
+
     return [allTeamsValue, ...teamOptions];
-  }, [teamOptions, allTeamsValue]);
+  }, [allTeamsValue, hasMoreTeamsThanLimit, teamOptions]);
 
   return (
     <div className={styles.ownerFilter}>
@@ -77,21 +95,85 @@ export function OwnersFilter({ values, onChange }: OwnersFilterProps) {
         onChange={(selectedOptions) => {
           const values = selectedOptions.map((option) => option.value!);
           // We don't send ALL_TEAMS_VALUE upstream, so we map it to actual list of all the teams.
-          onChange(values.includes(ALL_TEAMS_VALUE) ? allTeamReferences : values);
+          onChange(!hasMoreTeamsThanLimit && values.includes(ALL_TEAMS_VALUE) ? allTeamReferences : values);
         }}
         noOptionsMessage={t('browse-dashboards.filters.owner-no-options', 'No teams found')}
         loadingMessage={t('browse-dashboards.filters.owner-loading', 'Loading teams...')}
         placeholder={t('browse-dashboards.filters.owner-placeholder', 'Filter by owner')}
         isLoading={isLoading}
-        prefix={<Icon name="filter" />}
+        prefix={
+          error ? (
+            <LoadErrorTooltip error={error} />
+          ) : hasMoreTeamsThanLimit ? (
+            <TruncatedListTooltip totalCount={data?.totalCount} />
+          ) : (
+            <Icon name="filter" />
+          )
+        }
       />
     </div>
   );
 }
 
-const getStyles = (_theme: GrafanaTheme2) => ({
+function TruncatedListTooltip({ totalCount }: { totalCount: number | undefined }) {
+  const styles = useStyles2(getStyles);
+  return (
+    <Tooltip
+      content={t(
+        'browse-dashboards.filters.owner-limit-warning',
+        'Listing only first {{limit}} teams out of {{totalCount}}.',
+        { limit: TEAM_OPTIONS_LIMIT, totalCount: totalCount ?? 0 }
+      )}
+      placement="top"
+    >
+      <span
+        aria-label={t('browse-dashboards.filters.owner-limit-warning-icon', 'Owner filter limit warning')}
+        className={styles.warningIcon}
+      >
+        <Icon name="exclamation-triangle" size="sm" />
+      </span>
+    </Tooltip>
+  );
+}
+
+function LoadErrorTooltip({ error }: { error: unknown }) {
+  const styles = useStyles2(getStyles);
+
+  const errorMessage =
+    t('browse-dashboards.filters.owner-load-error-prefix', 'Failed to load teams because of error:') +
+    ' ' +
+    extractErrorMessage(error);
+
+  return (
+    <Tooltip content={errorMessage} placement="top">
+      <span
+        aria-label={t('browse-dashboards.filters.owner-load-error-icon', 'Owner filter load error')}
+        className={styles.errorIcon}
+      >
+        <Icon name="exclamation-circle" size="sm" />
+      </span>
+    </Tooltip>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
   ownerFilter: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
     minWidth: '180px',
     flexGrow: 1,
+  }),
+  warningIcon: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.warning.text,
+    cursor: 'help',
+  }),
+  errorIcon: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.error.text,
+    cursor: 'help',
   }),
 });

--- a/public/app/features/search/page/reporting.ts
+++ b/public/app/features/search/page/reporting.ts
@@ -9,6 +9,7 @@ interface QueryProps {
   sortValue?: string;
   query: string;
   tagCount: number;
+  ownerReference?: boolean;
   includePanels?: boolean;
   deleted: boolean;
   createdBy?: boolean;
@@ -47,6 +48,7 @@ const getQuerySearchContext = (query: QueryProps) => {
     starredFilter: query.starred ?? false,
     sort: query.sortValue ?? '',
     tagCount: query.tagCount ?? 0,
+    ownerReference: query.ownerReference ?? false,
     queryLength: query.query?.length ?? 0,
     includePanels: query.includePanels ?? false,
     deleted: query.deleted ?? false,

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -35,7 +35,7 @@ export interface SearchQuery {
   panel_type?: string;
   createdBy?: string;
 
-  // Both name and UID translate to reasource.name in k8s world
+  // Both name and UID translate to resource.name in k8s world
   name?: string[];
   uid?: string[];
 

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -27,11 +27,18 @@ export interface SearchQuery {
   ds_uid?: string;
   ds_type?: string;
   tags?: string[];
+  // Owner of the folder only supported with unified search. Currently, there can be only teams, so the format of each
+  // ref is "iam.grafana.app/Team/{teamUID}"
+  ownerReference?: string[];
+  // Equates to resource type.
   kind?: string[];
   panel_type?: string;
   createdBy?: string;
+
+  // Both name and UID translate to reasource.name in k8s world
   name?: string[];
   uid?: string[];
+
   facet?: FacetField[];
   explain?: boolean;
   panelTitleSearch?: boolean;

--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -101,6 +101,41 @@ describe('Unified Storage Searcher', () => {
     // expect(response.view.get(0).description).toBe(null);
     // expect(response.view.get(1).description).toBe('foobar');
   });
+
+  it('should filter search results by ownerReference', async () => {
+    server.use(
+      getCustomSearchHandler([
+        {
+          name: 'team-owned-dashboard',
+          title: 'Team owned dashboard',
+          resource: 'dashboard',
+          ownerReferences: ['iam.grafana.app/Team/team-a'],
+        },
+        {
+          name: 'other-team-dashboard',
+          title: 'Other team dashboard',
+          resource: 'dashboard',
+          ownerReferences: ['iam.grafana.app/Team/team-b'],
+        },
+        {
+          name: 'unowned-dashboard',
+          title: 'Unowned dashboard',
+          resource: 'dashboard',
+        },
+      ])
+    );
+
+    const searcher = new UnifiedSearcher(mockFallbackSearcher);
+
+    const response = await searcher.search({
+      query: '*',
+      ownerReference: ['iam.grafana.app/Team/team-a', 'iam.grafana.app/Team/test-team'],
+    });
+
+    expect(response.view.length).toBe(1);
+    expect(response.view.get(0).name).toBe('Team owned dashboard');
+    expect(response.view.get(0).uid).toBe('team-owned-dashboard');
+  });
 });
 
 describe('toDashboardResults', () => {

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -332,6 +332,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
       uri += '&createdBy=' + encodeURIComponent(query.createdBy);
     }
 
+    if (query.ownerReference?.length) {
+      uri += '&' + query.ownerReference.map((ref) => `ownerReference=${encodeURIComponent(ref)}`).join('&');
+    }
+
     if (query.panelTitleSearch) {
       uri += '&panelTitleSearch=true';
     }

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -16,11 +16,12 @@ import {
 import { getGrafanaSearcher } from '../service/searcher';
 import { type SearchQuery } from '../service/types';
 import { SearchLayout, type SearchQueryParams, type SearchState } from '../types';
-import { parseRouteParams } from '../utils';
+import { needsListLayout, parseRouteParams } from '../utils';
 
 export const initialState: SearchState = {
   query: '',
   tag: [],
+  ownerReference: [],
   starred: false,
   layout: SearchLayout.Folders,
   sort: undefined,
@@ -35,6 +36,7 @@ export const defaultQueryParams: SearchQueryParams = {
   starred: null,
   query: null,
   tag: null,
+  ownerReference: null,
   layout: null,
   createdBy: null,
 };
@@ -47,6 +49,20 @@ const getLocalStorageLayout = () => {
     return SearchLayout.Folders;
   }
 };
+
+type SearchReportInfo = Parameters<typeof reportSearchQueryInteraction>[1];
+const getSearchReportInfo = (state: SearchState): SearchReportInfo => ({
+  layout: state.layout,
+  starred: state.starred,
+  sortValue: state.sort,
+  query: state.query,
+  tagCount: state.tag?.length,
+  ownerReference: Boolean(state.ownerReference?.length),
+  includePanels: state.includePanels,
+  deleted: state.deleted,
+  createdBy: !!state.createdBy,
+});
+
 export class SearchStateManager extends StateManagerBase<SearchState> {
   updateLocation = debounce((query) => locationService.partial(query, true), 300);
   doSearchWithDebounce = debounce(() => this.doSearch(), 300);
@@ -58,7 +74,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
     const stateFromUrl = parseRouteParams(locationService.getSearchObject());
 
     // Force list view when conditions are specified from the URL
-    if (stateFromUrl.query || stateFromUrl.datasource || stateFromUrl.panel_type || stateFromUrl.createdBy) {
+    if (needsListLayout(stateFromUrl)) {
       stateFromUrl.layout = SearchLayout.List;
     }
 
@@ -95,6 +111,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
     this.updateLocation({
       query: this.state.query.length === 0 ? null : this.state.query,
       tag: this.state.tag,
+      ownerReference: this.state.ownerReference?.length ? this.state.ownerReference : null,
       datasource: this.state.datasource,
       panel_type: this.state.panel_type,
       createdBy: this.state.createdBy ?? null,
@@ -122,6 +139,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       query: '',
       datasource: undefined,
       tag: [],
+      ownerReference: [],
       panel_type: undefined,
       createdBy: undefined,
       starred: undefined,
@@ -139,6 +157,10 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
 
   onTagFilterChange = (tags: string[]) => {
     this.setStateAndDoSearch({ tag: tags });
+  };
+
+  onOwnerReferenceChange = (ownerReference: string[]) => {
+    this.setStateAndDoSearch({ ownerReference });
   };
 
   onAddTag = (newTag: string) => {
@@ -211,6 +233,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
     return Boolean(
       this.state.query ||
         this.state.tag.length ||
+        this.state.ownerReference?.length ||
         this.state.starred ||
         this.state.panel_type ||
         this.state.createdBy ||
@@ -224,6 +247,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
     const q: SearchQuery = {
       query: this.state.query,
       tags: this.state.tag,
+      ownerReference: this.state.ownerReference,
       ds_uid: this.state.datasource,
       panel_type: this.state.panel_type,
       createdBy: this.state.createdBy,
@@ -259,16 +283,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   }
 
   doSearch() {
-    const trackingInfo = {
-      layout: this.state.layout,
-      starred: this.state.starred,
-      sortValue: this.state.sort,
-      query: this.state.query,
-      tagCount: this.state.tag?.length,
-      includePanels: this.state.includePanels,
-      deleted: this.state.deleted,
-      createdBy: !!this.state.createdBy,
-    };
+    const trackingInfo = getSearchReportInfo(this.state);
 
     reportSearchQueryInteraction(this.state.eventTrackingNamespace, trackingInfo);
 
@@ -312,32 +327,14 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
    * When item is selected clear some filters and report interaction
    */
   onSearchItemClicked = (e: React.MouseEvent<HTMLElement>) => {
-    reportSearchResultInteraction(this.state.eventTrackingNamespace, {
-      layout: this.state.layout,
-      starred: this.state.starred,
-      sortValue: this.state.sort,
-      query: this.state.query,
-      tagCount: this.state.tag?.length,
-      includePanels: this.state.includePanels,
-      deleted: this.state.deleted,
-      createdBy: !!this.state.createdBy,
-    });
+    reportSearchResultInteraction(this.state.eventTrackingNamespace, getSearchReportInfo(this.state));
   };
 
   /**
    * Caller should handle debounce
    */
   onReportSearchUsage = () => {
-    reportDashboardListViewed(this.state.eventTrackingNamespace, {
-      layout: this.state.layout,
-      starred: this.state.starred,
-      sortValue: this.state.sort,
-      query: this.state.query,
-      tagCount: this.state.tag?.length,
-      includePanels: this.state.includePanels,
-      deleted: this.state.deleted,
-      createdBy: !!this.state.createdBy,
-    });
+    reportDashboardListViewed(this.state.eventTrackingNamespace, getSearchReportInfo(this.state));
   };
 }
 

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -1,5 +1,3 @@
-import { type Action } from 'redux';
-
 import { type WithAccessControlMetadata } from '@grafana/data';
 
 import { type ManagerKind } from '../apiserver/types';
@@ -92,15 +90,14 @@ export interface DashboardViewItem {
   };
 }
 
-export interface SearchAction extends Action {
-  payload?: any;
-}
-
 export type EventTrackingNamespace = 'manage_dashboards' | 'dashboard_search';
 
 export interface SearchState {
   query: string;
   tag: string[];
+  // Owner of the folder. Currently, there can be only teams, so the format of each ref
+  // is "iam.grafana.app/Team/{teamUID}"
+  ownerReference?: string[];
   starred: boolean;
   explain?: boolean; // adds debug info
   datasource?: string;
@@ -117,8 +114,6 @@ export interface SearchState {
   deleted: boolean;
 }
 
-export type OnToggleChecked = (item: DashboardViewItem) => void;
-
 export enum SearchLayout {
   List = 'list',
   Folders = 'folders',
@@ -129,10 +124,8 @@ export interface SearchQueryParams {
   sort?: string | null;
   starred?: boolean | null;
   tag?: string[] | null;
+  ownerReference?: string[] | null;
   layout?: SearchLayout | null;
   folder?: string | null;
   createdBy?: string | null;
 }
-
-// new Search Types
-export type OnMoveOrDeleleSelectedItems = () => void;

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -1,3 +1,5 @@
+import { type Action } from 'redux';
+
 import { type WithAccessControlMetadata } from '@grafana/data';
 
 import { type ManagerKind } from '../apiserver/types';

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -1,5 +1,3 @@
-import { type Action } from 'redux';
-
 import { type WithAccessControlMetadata } from '@grafana/data';
 
 import { type ManagerKind } from '../apiserver/types';

--- a/public/app/features/search/utils.test.ts
+++ b/public/app/features/search/utils.test.ts
@@ -25,6 +25,23 @@ describe('Search utils', () => {
       });
     });
 
+    it('should return ownerReference as array, if present', () => {
+      const params = { ownerReference: 'iam.grafana.app/v0alpha1/Team/test-team', query: 'test' };
+      expect(parseRouteParams(params)).toEqual({
+        query: 'test',
+        ownerReference: ['iam.grafana.app/v0alpha1/Team/test-team'],
+      });
+
+      const params2: Partial<SearchQueryParams> = {
+        ownerReference: ['iam.grafana.app/v0alpha1/Team/test-team'],
+        query: 'test',
+      };
+      expect(parseRouteParams(params2)).toEqual({
+        query: 'test',
+        ownerReference: ['iam.grafana.app/v0alpha1/Team/test-team'],
+      });
+    });
+
     it('should prepend folder:{folder} to the query if folder is present', () => {
       expect(parseRouteParams({ folder: 'current' })).toEqual({
         folder: 'current',

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -11,7 +11,7 @@ export const hasFilters = (query: SearchState) => {
   if (!query) {
     return false;
   }
-  return Boolean(query.query || query.tag?.length > 0 || query.starred || query.sort);
+  return Boolean(query.query || query.tag?.length > 0 || query.ownerReference?.length || query.starred || query.sort);
 };
 
 /** Cleans up old local storage values that remembered many open folders */
@@ -27,7 +27,7 @@ export const cleanupOldExpandedFolders = () => {
 };
 
 /**
- * Get storage key for a dashboard folder by its title
+ * Get a storage key for a dashboard folder by its title
  * @param title
  */
 export const getSectionStorageKey = (title = 'General') => {
@@ -37,14 +37,15 @@ export const getSectionStorageKey = (title = 'General') => {
 /**
  * Remove undefined keys from url params object and format non-primitive values
  * @param params
- * @param folder
  */
 export const parseRouteParams = (params: UrlQueryMap) => {
   const cleanedParams = Object.entries(params).reduce<Partial<SearchState>>((obj, [key, val]) => {
     if (!val) {
       return obj;
     } else if (key === 'tag' && !Array.isArray(val)) {
-      return { ...obj, tag: [val] as string[] };
+      return { ...obj, tag: [val.toString()] };
+    } else if (key === 'ownerReference' && !Array.isArray(val)) {
+      return { ...obj, ownerReference: [val.toString()] };
     }
 
     return { ...obj, [key]: val };
@@ -60,3 +61,19 @@ export const parseRouteParams = (params: UrlQueryMap) => {
 
   return { ...cleanedParams };
 };
+
+/**
+ * If we have filter, we can only show the results in the list layout as the tree layout does not work well
+ */
+export function needsListLayout(q: Partial<SearchState>) {
+  return (
+    q.query ||
+    q.sort ||
+    q.starred ||
+    q.tag?.length ||
+    q.createdBy ||
+    q.ownerReference?.length ||
+    q.panel_type ||
+    q.datasource
+  );
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4364,6 +4364,13 @@
       "title": "You haven't created any dashboards yet",
       "title-folder": "This folder doesn't have any dashboards yet"
     },
+    "filters": {
+      "all-teams": "All teams",
+      "owner-aria-label": "Owner filter",
+      "owner-loading": "Loading teams...",
+      "owner-no-options": "No teams found",
+      "owner-placeholder": "Filter by owner"
+    },
     "folder-actions-button": {
       "delete": "Delete this folder",
       "delete-folder-error": "Error deleting folder. Please try again later.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4367,6 +4367,10 @@
     "filters": {
       "all-teams": "All teams",
       "owner-aria-label": "Owner filter",
+      "owner-limit-warning": "Listing only first {{limit}} teams out of {{totalCount}}.",
+      "owner-limit-warning-icon": "Owner filter limit warning",
+      "owner-load-error-icon": "Owner filter load error",
+      "owner-load-error-prefix": "Failed to load teams because of error:",
       "owner-loading": "Loading teams...",
       "owner-no-options": "No teams found",
       "owner-placeholder": "Filter by owner"


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/116755

Adds a filter to browse dashboards that allows to filter by team owning the folder.

Due to permission restriction, you can see folders of others team right now but you don't have access to list those teams so the dropdown may not show all the teams in the system.


https://github.com/user-attachments/assets/c43f9084-fc67-4024-90c2-6d18a27beccb


Due to a weird UX issue with combobox (todo add issue) I am using Multiselect which then have an issue with async loading options. This means right now hardcoded limit of 200 items is shown in the select.

Limit reached state:
<img width="377" height="91" alt="Screenshot 2026-03-31 at 17 39 04" src="https://github.com/user-attachments/assets/1f6ccd9b-f9cf-4fd5-8e96-f323a8d4e515" />

Error state:
<img width="416" height="98" alt="Screenshot 2026-03-31 at 17 37 55" src="https://github.com/user-attachments/assets/a19ba01d-184b-4656-9c95-138dc4a11ee6" />

