### PR TITLE
PieChartPanel: Add gradient color scheme with WCAG-aware slice labels

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -72,6 +72,13 @@ export const fieldColorModeRegistry = new Registry<FieldColorMode>(() => {
       getCalculator: getShadedColor,
     },
     {
+      id: FieldColorModeId.Gradient,
+      name: 'Gradient',
+      description:
+        'Interpolate between two colors based on value order. The highest value gets the start color; the lowest gets the end color.',
+      getCalculator: getFixedColor,
+    },
+    {
       id: FieldColorModeId.Thresholds,
       name: 'From thresholds',
       isByValue: true,

--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -171,6 +171,12 @@ export interface FieldColorConfigSettings {
    * This will enable the Color by series UI option that sets the `color.seriesBy` option.
    */
   bySeriesSupport?: boolean;
+  /**
+   * Set to true if the visualization supports the Gradient color scheme.
+   * When false (default), the Gradient option is hidden from the color picker.
+   * Currently only the pie chart panel supports this mode.
+   */
+  gradientSupport?: boolean;
 }
 
 export interface StatsPickerConfigSettings {

--- a/packages/grafana-data/src/types/fieldColor.ts
+++ b/packages/grafana-data/src/types/fieldColor.ts
@@ -28,6 +28,7 @@ export enum FieldColorModeId {
   ContinuousCividis = 'continuous-cividis',
   Fixed = 'fixed',
   Shades = 'shades',
+  Gradient = 'gradient',
 }
 
 /**
@@ -36,8 +37,10 @@ export enum FieldColorModeId {
 export interface FieldColor {
   /** The main color scheme mode */
   mode: FieldColorModeId | string;
-  /** Stores the fixed color value if mode is fixed */
+  /** Stores the fixed color value if mode is fixed, shades, or gradient (start color) */
   fixedColor?: string;
+  /** End color for gradient mode (smallest value). Only used when mode is "gradient". */
+  gradientColorTo?: string;
   /** Some visualizations need to know how to assign a series color from by value color schemes */
   seriesBy?: FieldColorSeriesByMode;
 }

--- a/public/app/core/components/OptionsUI/fieldColor.tsx
+++ b/public/app/core/components/OptionsUI/fieldColor.tsx
@@ -15,9 +15,12 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { useStyles2, useTheme2, Field, RadioButtonGroup, Select } from '@grafana/ui';
+import { useStyles2, useTheme2, Field, RadioButtonGroup, Select, Stack } from '@grafana/ui';
 
 import { ColorValueEditor } from './color';
+
+const GRADIENT_DEFAULT_FROM = '#73BF69';
+const GRADIENT_DEFAULT_TO = '#F2495C';
 
 type Props = StandardEditorProps<FieldColor | undefined, FieldColorConfigSettings>;
 
@@ -33,7 +36,9 @@ export const FieldColorEditor = ({ value, onChange, item, id }: Props) => {
   const filteredOptions = availableOptions.filter(
     (option) =>
       !option.excludeFromPicker &&
-      (option.id !== FieldColorModeId.PaletteColorblind || config.featureToggles.enableColorblindSafePanelOptions)
+      (option.id !== FieldColorModeId.PaletteColorblind || config.featureToggles.enableColorblindSafePanelOptions) &&
+      (option.id !== FieldColorModeId.Gradient ||
+        (item.settings?.gradientSupport && config.featureToggles.pieChartGradientColorScheme))
   );
 
   const options: Array<SelectableValue<string>> = [];
@@ -69,10 +74,13 @@ export const FieldColorEditor = ({ value, onChange, item, id }: Props) => {
   }
 
   const onModeChange = (newMode: SelectableValue<string>) => {
-    onChange({
-      ...value,
-      mode: newMode.value!,
-    });
+    const update: FieldColor = { ...value, mode: newMode.value! };
+    // Seed gradient defaults so the pickers are never empty when first selected.
+    if (newMode.value === FieldColorModeId.Gradient) {
+      update.fixedColor = value?.fixedColor ?? GRADIENT_DEFAULT_FROM;
+      update.gradientColorTo = value?.gradientColorTo ?? GRADIENT_DEFAULT_TO;
+    }
+    onChange(update);
   };
 
   const onColorChange = (color?: string) => {
@@ -80,6 +88,14 @@ export const FieldColorEditor = ({ value, onChange, item, id }: Props) => {
       ...value,
       mode,
       fixedColor: color,
+    });
+  };
+
+  const onGradientColorToChange = (color?: string) => {
+    onChange({
+      ...value,
+      mode,
+      gradientColorTo: color,
     });
   };
 
@@ -105,6 +121,25 @@ export const FieldColorEditor = ({ value, onChange, item, id }: Props) => {
           inputId={id}
         />
         <ColorValueEditor value={value?.fixedColor} onChange={onColorChange} />
+      </div>
+    );
+  }
+
+  if (mode === FieldColorModeId.Gradient) {
+    return (
+      <div className={styles.group}>
+        <Select
+          minMenuHeight={200}
+          options={options}
+          value={mode}
+          onChange={onModeChange}
+          className={styles.select}
+          inputId={id}
+        />
+        <Stack gap={0.5}>
+          <ColorValueEditor value={value?.fixedColor ?? GRADIENT_DEFAULT_FROM} onChange={onColorChange} />
+          <ColorValueEditor value={value?.gradientColorTo ?? GRADIENT_DEFAULT_TO} onChange={onGradientColorToChange} />
+        </Stack>
       </div>
     );
   }

--- a/public/app/core/components/OptionsUI/fieldColorGradient.test.tsx
+++ b/public/app/core/components/OptionsUI/fieldColorGradient.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FieldColorModeId } from '@grafana/data';
+
+import { FieldColorEditor } from './fieldColor';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+// Enable the feature flag so the Gradient option is not filtered out by the flag guard.
+jest.mock('@grafana/runtime', () => ({
+  config: { featureToggles: { pieChartGradientColorScheme: true } },
+}));
+
+// Replace ColorValueEditor with a lightweight stub so we can assert on the
+// number of color pickers rendered and the value each one receives.
+jest.mock('./color', () => ({
+  ColorValueEditor: ({ value, onChange }: { value?: string; onChange: (v: string) => void }) => (
+    <button data-testid="color-value-editor" data-value={value ?? ''} onClick={() => onChange(value ?? '')}>
+      {value ?? 'no-color'}
+    </button>
+  ),
+}));
+
+// Use a real-ish registry that includes Fixed, Shades, and Gradient so mode
+// switching works without depending on the full registry initialisation.
+jest.mock('@grafana/data', () => {
+  const actualData = jest.requireActual('@grafana/data');
+  return {
+    ...actualData,
+    fieldColorModeRegistry: new actualData.Registry(() => [
+      {
+        id: actualData.FieldColorModeId.Fixed,
+        name: 'Single color',
+        getCalculator: () => () => 'red',
+      },
+      {
+        id: actualData.FieldColorModeId.Shades,
+        name: 'Shades of a color',
+        getCalculator: () => () => 'red',
+      },
+      {
+        id: actualData.FieldColorModeId.Gradient,
+        name: 'Gradient',
+        getCalculator: () => () => 'red',
+      },
+    ]),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setup(jsx: JSX.Element) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  };
+}
+
+// gradientSupport must be true so the Gradient option is not filtered out of the picker.
+// Tests in this file specifically cover gradient mode behaviour so this flag is always needed.
+const noopItem = { settings: { gradientSupport: true } } as Parameters<typeof FieldColorEditor>[0]['item'];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FieldColorEditor — gradient mode', () => {
+  describe('rendering', () => {
+    it('renders two color pickers when mode is gradient', () => {
+      render(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Gradient, fixedColor: '#73BF69', gradientColorTo: '#F2495C' }}
+          onChange={() => {}}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      const pickers = screen.getAllByTestId('color-value-editor');
+      expect(pickers).toHaveLength(2);
+    });
+
+    it('shows the start color (fixedColor) in the first picker', () => {
+      render(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Gradient, fixedColor: '#aabbcc', gradientColorTo: '#F2495C' }}
+          onChange={() => {}}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      const pickers = screen.getAllByTestId('color-value-editor');
+      expect(pickers[0]).toHaveAttribute('data-value', '#aabbcc');
+    });
+
+    it('shows the end color (gradientColorTo) in the second picker', () => {
+      render(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Gradient, fixedColor: '#73BF69', gradientColorTo: '#ddeeff' }}
+          onChange={() => {}}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      const pickers = screen.getAllByTestId('color-value-editor');
+      expect(pickers[1]).toHaveAttribute('data-value', '#ddeeff');
+    });
+
+    it('shows default start color when fixedColor is not set', () => {
+      render(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Gradient }}
+          onChange={() => {}}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      const pickers = screen.getAllByTestId('color-value-editor');
+      expect(pickers[0]).toHaveAttribute('data-value', '#73BF69');
+    });
+
+    it('shows default end color when gradientColorTo is not set', () => {
+      render(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Gradient }}
+          onChange={() => {}}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      const pickers = screen.getAllByTestId('color-value-editor');
+      expect(pickers[1]).toHaveAttribute('data-value', '#F2495C');
+    });
+
+    it('renders only one color picker for Fixed mode (no regression)', () => {
+      render(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Fixed, fixedColor: '#ff0000' }}
+          onChange={() => {}}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      expect(screen.getAllByTestId('color-value-editor')).toHaveLength(1);
+    });
+  });
+
+  describe('onChange behaviour when switching to gradient', () => {
+    it('seeds fixedColor and gradientColorTo defaults when switching to gradient', async () => {
+      const onChange = jest.fn();
+      const { user } = setup(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Fixed }}
+          onChange={onChange}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Gradient'));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: FieldColorModeId.Gradient,
+          fixedColor: '#73BF69',
+          gradientColorTo: '#F2495C',
+        })
+      );
+    });
+
+    it('preserves existing fixedColor when switching to gradient', async () => {
+      const onChange = jest.fn();
+      const { user } = setup(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Fixed, fixedColor: '#custom1' }}
+          onChange={onChange}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Gradient'));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: FieldColorModeId.Gradient,
+          fixedColor: '#custom1', // preserved — not overwritten
+        })
+      );
+    });
+
+    it('preserves existing gradientColorTo when switching back to gradient', async () => {
+      const onChange = jest.fn();
+      const { user } = setup(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Fixed, gradientColorTo: '#custom2' }}
+          onChange={onChange}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Gradient'));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gradientColorTo: '#custom2', // preserved — not overwritten
+        })
+      );
+    });
+
+    it('only gradient mode triggers default seeding — switching to Fixed does not add extra fields', async () => {
+      const onChange = jest.fn();
+      const { user } = setup(
+        <FieldColorEditor
+          value={{ mode: FieldColorModeId.Gradient, fixedColor: '#73BF69', gradientColorTo: '#F2495C' }}
+          onChange={onChange}
+          id="test"
+          context={{ data: [] }}
+          item={noopItem}
+        />
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Single color'));
+
+      // mode is updated; no extra gradient-specific seeding happens for Fixed
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ mode: FieldColorModeId.Fixed }));
+      const call = onChange.mock.calls[0][0];
+      // Verify the seeding block was NOT entered (no new defaults injected beyond spread)
+      expect(call.fixedColor).toBe('#73BF69'); // preserved from previous value via spread
+      expect(call.gradientColorTo).toBe('#F2495C'); // preserved from previous value via spread
+    });
+  });
+});

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -45,6 +45,13 @@ interface PieChartProps {
   displayLabels?: PieChartLabels[];
   useGradients?: boolean; // not used?
   tooltipOptions: VizTooltipOptions;
+  /**
+   * Pre-computed gradient fills keyed by FieldDisplay object reference.
+   * Using the object reference (instead of display.title) ensures uniqueness
+   * even when multiple series share the same display name.
+   * Computed once in PieChartPanel and shared with both the chart and legend.
+   */
+  gradientFills?: Map<FieldDisplay, string>;
 }
 
 export const PieChart = ({
@@ -56,6 +63,7 @@ export const PieChart = ({
   highlightedTitle,
   displayLabels = [],
   tooltipOptions,
+  gradientFills,
 }: PieChartProps) => {
   const theme = useTheme2();
   const componentInstanceId = useComponentInstanceId('PieChart');
@@ -83,6 +91,9 @@ export const PieChart = ({
       filteredFieldDisplayValues.map((fieldDisplayValue) => fieldDisplayValue.display.color ?? FALLBACK_COLOR)
     ),
   ];
+
+  // gradientFills is pre-computed in PieChartPanel and shared with the legend
+  // to guarantee consistent colors between slices and legend items.
 
   return (
     <div className={styles.container}>
@@ -118,6 +129,13 @@ export const PieChart = ({
                 {pie.arcs.map((arc) => {
                   const color = arc.data.display.color ?? FALLBACK_COLOR;
                   const highlightState = getHighlightState(highlightedTitle, arc);
+                  // In gradient mode use the pre-computed interpolated fill; otherwise
+                  // fall back to the per-series radial gradient (existing behaviour).
+                  // Items with a field-level color override are not in gradientFills —
+                  // fall back to display.color (the override value) rather than FALLBACK_COLOR.
+                  const fill = gradientFills
+                    ? (gradientFills.get(arc.data) ?? arc.data.display.color ?? FALLBACK_COLOR)
+                    : getGradientColor(color);
 
                   if (arc.data.hasLinks && arc.data.getLinks) {
                     return (
@@ -128,9 +146,10 @@ export const PieChart = ({
                             highlightState={highlightState}
                             arc={arc}
                             pie={pie}
-                            fill={getGradientColor(color)}
+                            fill={fill}
                             openMenu={api.openMenu}
                             tooltipOptions={tooltipOptions}
+                            gradientFills={gradientFills}
                           />
                         )}
                       </DataLinksContextMenu>
@@ -143,8 +162,9 @@ export const PieChart = ({
                         tooltip={tooltip}
                         arc={arc}
                         pie={pie}
-                        fill={getGradientColor(color)}
+                        fill={fill}
                         tooltipOptions={tooltipOptions}
+                        gradientFills={gradientFills}
                       />
                     );
                   }
@@ -152,6 +172,16 @@ export const PieChart = ({
                 {showLabel &&
                   pie.arcs.map((arc) => {
                     const highlightState = getHighlightState(highlightedTitle, arc);
+                    // In gradient mode pick black or white based on WCAG contrast ratio
+                    // so labels stay readable across the full color range of the gradient.
+                    const fillForLabel = gradientFills?.get(arc.data);
+                    const labelColor = fillForLabel
+                      ? tinycolor
+                          .mostReadable(fillForLabel, ['#ffffff', '#000000'], {
+                            includeFallbackColors: true,
+                          })
+                          .toHexString()
+                      : theme.colors.text.primary;
                     return (
                       <PieLabel
                         arc={arc}
@@ -161,7 +191,7 @@ export const PieChart = ({
                         innerRadius={layout.innerRadius}
                         displayLabels={displayLabels}
                         total={total}
-                        color={theme.colors.text.primary}
+                        color={labelColor}
                       />
                     );
                   })}
@@ -193,10 +223,11 @@ interface SliceProps {
   fill: string;
   tooltip: UseTooltipParams<SeriesTableRowProps[]>;
   tooltipOptions: VizTooltipOptions;
+  gradientFills?: Map<FieldDisplay, string>;
   openMenu?: (event: React.MouseEvent<SVGElement>) => void;
 }
 
-function PieSlice({ arc, pie, highlightState, openMenu, fill, tooltip, tooltipOptions }: SliceProps) {
+function PieSlice({ arc, pie, highlightState, openMenu, fill, tooltip, tooltipOptions, gradientFills }: SliceProps) {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const { eventBus } = usePanelContext();
@@ -236,11 +267,11 @@ function PieSlice({ arc, pie, highlightState, openMenu, fill, tooltip, tooltipOp
         tooltip.showTooltip({
           tooltipLeft: coords!.x,
           tooltipTop: coords!.y,
-          tooltipData: getTooltipData(pie, arc, tooltipOptions),
+          tooltipData: getTooltipData(pie, arc, tooltipOptions, gradientFills),
         });
       }
     },
-    [eventBus, arc, tooltip, pie, tooltipOptions]
+    [eventBus, arc, tooltip, pie, tooltipOptions, gradientFills]
   );
 
   const pieStyle = getSvgStyle(highlightState, styles);
@@ -318,7 +349,8 @@ function PieLabel({ arc, outerRadius, innerRadius, displayLabels, total, color, 
 function getTooltipData(
   pie: ProvidedProps<FieldDisplay>,
   arc: PieArcDatum<FieldDisplay>,
-  tooltipOptions: VizTooltipOptions
+  tooltipOptions: VizTooltipOptions,
+  gradientFills?: Map<FieldDisplay, string>
 ) {
   if (tooltipOptions.mode === 'multi') {
     return pie.arcs
@@ -332,7 +364,7 @@ function getTooltipData(
       })
       .map((pieArc) => {
         return {
-          color: pieArc.data.display.color ?? FALLBACK_COLOR,
+          color: gradientFills?.get(pieArc.data) ?? pieArc.data.display.color ?? FALLBACK_COLOR,
           label: pieArc.data.display.title,
           value: formattedValueToString(pieArc.data.display),
           isActive: pieArc.index === arc.index,
@@ -341,7 +373,7 @@ function getTooltipData(
   }
   return [
     {
-      color: arc.data.display.color ?? FALLBACK_COLOR,
+      color: gradientFills?.get(arc.data) ?? arc.data.display.color ?? FALLBACK_COLOR,
       label: arc.data.display.title,
       value: formattedValueToString(arc.data.display),
     },
@@ -352,6 +384,47 @@ function getLabelPos(arc: PieArcDatum<FieldDisplay>, outerRadius: number, innerR
   const r = (outerRadius + innerRadius) / 2;
   const a = (+arc.startAngle + +arc.endAngle) / 2 - Math.PI / 2;
   return [Math.cos(a) * r, Math.sin(a) * r];
+}
+
+/**
+ * Compute a flat hex fill color for each slice when the "gradient" color scheme is active.
+ *
+ * Slices are ranked by their numeric value from largest (rank 0) to smallest
+ * (rank N-1). The interpolation parameter t = rank / (N-1) linearly maps that
+ * rank onto the [colorFrom, colorTo] range in RGB space:
+ *   - largest slice  → colorFrom (t = 0)
+ *   - smallest slice → colorTo   (t = 1)
+ *   - intermediate   → RGB lerp between the two
+ *
+ * When there is only one slice it receives colorFrom exactly.
+ * Duplicate values retain their relative order (stable sort).
+ *
+ * @returns A Map keyed by the `FieldDisplay` object reference → hex color string.
+ *   Using the object reference as the key (instead of display.title) guarantees
+ *   uniqueness even when multiple series share the same display name.
+ */
+export function computeGradientFills(
+  items: FieldDisplay[],
+  colorFrom: string,
+  colorTo: string
+): Map<FieldDisplay, string> {
+  // Sort a copy by value descending to determine rank; original order is unchanged.
+  const sorted = [...items].sort((a, b) => b.display.numeric - a.display.numeric);
+  const n = sorted.length;
+  const from = tinycolor(colorFrom).toRgb();
+  const to = tinycolor(colorTo).toRgb();
+  const fills = new Map<FieldDisplay, string>();
+
+  for (let rank = 0; rank < n; rank++) {
+    const item = sorted[rank];
+    const t = n > 1 ? rank / (n - 1) : 0;
+    const r = Math.round(from.r * (1 - t) + to.r * t);
+    const g = Math.round(from.g * (1 - t) + to.g * t);
+    const b = Math.round(from.b * (1 - t) + to.b * t);
+    fills.set(item, tinycolor({ r, g, b }).toHexString());
+  }
+
+  return fills;
 }
 
 function getGradientColorFrom(color: string, theme: GrafanaTheme2) {

--- a/public/app/plugins/panel/piechart/PieChartGradient.test.ts
+++ b/public/app/plugins/panel/piechart/PieChartGradient.test.ts
@@ -1,0 +1,314 @@
+import { FieldColorModeId, type FieldDisplay } from '@grafana/data';
+
+import { computeGradientFills } from './PieChart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal FieldDisplay stub with just the properties we need. */
+function makeItem(title: string, value: number): FieldDisplay {
+  return {
+    display: { title, numeric: value, text: String(value) },
+    field: { config: {} },
+    hasLinks: false,
+    view: undefined,
+  } as unknown as FieldDisplay;
+}
+
+/**
+ * Build a FieldDisplay stub whose color config matches the panel-level gradient
+ * defaults (mode: gradient + matching fixedColor + gradientColorTo). These items
+ * pass the PieChartPanel filter and are included in gradient computation.
+ */
+function makeGradientItem(title: string, value: number, fixedColor: string, gradientColorTo: string): FieldDisplay {
+  return {
+    display: { title, numeric: value, text: String(value), color: fixedColor },
+    field: { color: { mode: FieldColorModeId.Gradient, fixedColor, gradientColorTo } },
+    hasLinks: false,
+    view: undefined,
+  } as unknown as FieldDisplay;
+}
+
+/**
+ * Build a FieldDisplay stub that simulates a series with a fixed-color override
+ * (e.g. the user pinned it to a specific color via the Overrides editor).
+ * PieChartPanel detects these via field.color.mode !== 'gradient' and excludes
+ * them from gradient computation so the override color is preserved.
+ */
+function makeItemWithFixedOverride(title: string, value: number, overrideColor: string): FieldDisplay {
+  return {
+    display: { title, numeric: value, text: String(value), color: overrideColor },
+    // FieldDisplay.field is FieldConfig — the merged config for this series.
+    // An overridden series has field.color.mode set to the override value (e.g. 'fixed').
+    field: { color: { mode: FieldColorModeId.Fixed, fixedColor: overrideColor } },
+    hasLinks: false,
+    view: undefined,
+  } as unknown as FieldDisplay;
+}
+
+/**
+ * Build a FieldDisplay stub that simulates a series with a gradient-mode override
+ * but with different from/to colors than the panel defaults.
+ * PieChartPanel detects these via color config mismatch and excludes them so
+ * the override's own colors take effect (start color visible, full gradient-
+ * within-gradient rendering deferred to a follow-up).
+ */
+function makeItemWithGradientOverride(
+  title: string,
+  value: number,
+  fixedColor: string,
+  gradientColorTo: string,
+  resolvedColor: string
+): FieldDisplay {
+  return {
+    display: { title, numeric: value, text: String(value), color: resolvedColor },
+    field: { color: { mode: FieldColorModeId.Gradient, fixedColor, gradientColorTo } },
+    hasLinks: false,
+    view: undefined,
+  } as unknown as FieldDisplay;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const clean = hex.replace('#', '');
+  return {
+    r: parseInt(clean.slice(0, 2), 16),
+    g: parseInt(clean.slice(2, 4), 16),
+    b: parseInt(clean.slice(4, 6), 16),
+  };
+}
+
+const COLOR_GREEN = '#00ff00'; // rgb(0, 255, 0)
+const COLOR_RED = '#ff0000'; // rgb(255, 0, 0)
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('computeGradientFills', () => {
+  describe('N = 1 (single slice)', () => {
+    it('returns colorFrom for the only slice', () => {
+      const a = makeItem('A', 100);
+      const fills = computeGradientFills([a], COLOR_GREEN, COLOR_RED);
+
+      expect(fills.size).toBe(1);
+      // t = 0 → should be exactly colorFrom
+      const { r, g, b } = hexToRgb(fills.get(a)!);
+      expect(r).toBe(0);
+      expect(g).toBe(255);
+      expect(b).toBe(0);
+    });
+  });
+
+  describe('N = 2 (two slices)', () => {
+    it('assigns colorFrom to the largest and colorTo to the smallest', () => {
+      const small = makeItem('small', 10);
+      const large = makeItem('large', 90);
+      const fills = computeGradientFills([small, large], COLOR_GREEN, COLOR_RED);
+
+      expect(fills.size).toBe(2);
+
+      // largest → t=0 → colorFrom (green)
+      const largeRgb = hexToRgb(fills.get(large)!);
+      expect(largeRgb.r).toBe(0);
+      expect(largeRgb.g).toBe(255);
+      expect(largeRgb.b).toBe(0);
+
+      // smallest → t=1 → colorTo (red)
+      const smallRgb = hexToRgb(fills.get(small)!);
+      expect(smallRgb.r).toBe(255);
+      expect(smallRgb.g).toBe(0);
+      expect(smallRgb.b).toBe(0);
+    });
+  });
+
+  describe('N = 5 (multiple slices)', () => {
+    const rank4 = makeItem('rank4', 10);
+    const rank2 = makeItem('rank2', 60);
+    const rank0 = makeItem('rank0', 100);
+    const rank3 = makeItem('rank3', 30);
+    const rank1 = makeItem('rank1', 80);
+    const items = [rank4, rank2, rank0, rank3, rank1];
+
+    // GREEN (#00ff00) → RED (#ff0000)
+    // Sorted descending: rank0(100), rank1(80), rank2(60), rank3(30), rank4(10)
+    // t values:         0,         0.25,       0.5,       0.75,      1.0
+
+    it('produces 5 distinct fills', () => {
+      const fills = computeGradientFills(items, COLOR_GREEN, COLOR_RED);
+      expect(fills.size).toBe(5);
+    });
+
+    it('rank0 (largest) gets colorFrom', () => {
+      const fills = computeGradientFills(items, COLOR_GREEN, COLOR_RED);
+      const { r, g, b } = hexToRgb(fills.get(rank0)!);
+      expect(r).toBe(0);
+      expect(g).toBe(255);
+      expect(b).toBe(0);
+    });
+
+    it('rank4 (smallest) gets colorTo', () => {
+      const fills = computeGradientFills(items, COLOR_GREEN, COLOR_RED);
+      const { r, g, b } = hexToRgb(fills.get(rank4)!);
+      expect(r).toBe(255);
+      expect(g).toBe(0);
+      expect(b).toBe(0);
+    });
+
+    it('rank2 (middle, t=0.5) gets the midpoint color', () => {
+      const fills = computeGradientFills(items, COLOR_GREEN, COLOR_RED);
+      // t=0.5 → r=round(0*(0.5)+255*0.5)=128, g=round(255*0.5+0*0.5)=128, b=0
+      const { r, g, b } = hexToRgb(fills.get(rank2)!);
+      expect(r).toBe(128);
+      expect(g).toBe(128);
+      expect(b).toBe(0);
+    });
+
+    it('colors become progressively more red as rank increases', () => {
+      const fills = computeGradientFills(items, COLOR_GREEN, COLOR_RED);
+      const refs = [rank0, rank1, rank2, rank3, rank4];
+      const reds = refs.map((item) => hexToRgb(fills.get(item)!).r);
+      // Red channel should be monotonically non-decreasing
+      for (let i = 0; i < reds.length - 1; i++) {
+        expect(reds[i]).toBeLessThanOrEqual(reds[i + 1]);
+      }
+    });
+  });
+
+  describe('duplicate display names (non-unique titles)', () => {
+    it('assigns distinct colors to items with the same display name', () => {
+      // Two series both named 'CPU' — title-based keying would map both to the same entry.
+      const cpu1 = makeItem('CPU', 90);
+      const cpu2 = makeItem('CPU', 10);
+      const fills = computeGradientFills([cpu1, cpu2], COLOR_GREEN, COLOR_RED);
+
+      expect(fills.size).toBe(2);
+      // cpu1 is larger → gets colorFrom (green)
+      const { r: r1, g: g1 } = hexToRgb(fills.get(cpu1)!);
+      expect(r1).toBe(0);
+      expect(g1).toBe(255);
+      // cpu2 is smaller → gets colorTo (red)
+      const { r: r2, g: g2 } = hexToRgb(fills.get(cpu2)!);
+      expect(r2).toBe(255);
+      expect(g2).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles all slices with the same value (stable order, no NaN)', () => {
+      const a = makeItem('A', 50);
+      const b = makeItem('B', 50);
+      const c = makeItem('C', 50);
+      const fills = computeGradientFills([a, b, c], COLOR_GREEN, COLOR_RED);
+
+      expect(fills.size).toBe(3);
+      // No NaN or undefined values
+      for (const color of fills.values()) {
+        expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+      }
+    });
+
+    it('returns an empty Map for an empty input array', () => {
+      const fills = computeGradientFills([], COLOR_GREEN, COLOR_RED);
+      expect(fills.size).toBe(0);
+    });
+
+    it('does not mutate the input array order', () => {
+      const first = makeItem('first', 10);
+      const second = makeItem('second', 90);
+      const items = [first, second];
+      const originalOrder = [...items];
+      computeGradientFills(items, COLOR_GREEN, COLOR_RED);
+      expect(items).toEqual(originalOrder);
+    });
+
+    it('accepts shorthand hex colors (tinycolor normalises them)', () => {
+      const a = makeItem('A', 100);
+      const b = makeItem('B', 50);
+      // #f00 = red, #0f0 = green — tinycolor expands these
+      expect(() => computeGradientFills([a, b], '#0f0', '#f00')).not.toThrow();
+      const fills = computeGradientFills([a, b], '#0f0', '#f00');
+      expect(fills.size).toBe(2);
+    });
+  });
+
+  describe('field-level color overrides', () => {
+    // Panel-level defaults used by the filter to detect per-field overrides.
+    const PANEL_FROM = COLOR_GREEN; // '#00ff00'
+    const PANEL_TO = COLOR_RED; // '#ff0000'
+
+    /**
+     * Mirrors the filter logic in PieChartPanel.tsx:
+     * include a field in gradient computation only when its color config
+     * matches the panel defaults exactly (mode + fixedColor + gradientColorTo).
+     */
+    function panelFilter(item: FieldDisplay): boolean {
+      return (
+        item.field.color?.mode === FieldColorModeId.Gradient &&
+        item.field.color.fixedColor === PANEL_FROM &&
+        item.field.color.gradientColorTo === PANEL_TO
+      );
+    }
+
+    it('fixed-color override is excluded from gradient fills', () => {
+      const normal = makeGradientItem('normal', 80, PANEL_FROM, PANEL_TO);
+      const overridden = makeItemWithFixedOverride('overridden', 100, '#0000ff');
+
+      const fills = computeGradientFills([normal, overridden].filter(panelFilter), PANEL_FROM, PANEL_TO);
+
+      expect(fills.has(overridden)).toBe(false);
+      expect(fills.has(normal)).toBe(true);
+      // normal is the only gradient item → t=0 → colorFrom (green)
+      const { r, g, b } = hexToRgb(fills.get(normal)!);
+      expect(r).toBe(0);
+      expect(g).toBe(255);
+      expect(b).toBe(0);
+    });
+
+    it('gradient override with same colors as panel defaults is included', () => {
+      const normal = makeGradientItem('normal', 80, PANEL_FROM, PANEL_TO);
+      // Override sets gradient mode with the exact same colors → treated as default gradient
+      const sameGradient = makeGradientItem('same', 100, PANEL_FROM, PANEL_TO);
+
+      const fills = computeGradientFills([normal, sameGradient].filter(panelFilter), PANEL_FROM, PANEL_TO);
+
+      expect(fills.has(sameGradient)).toBe(true);
+      expect(fills.has(normal)).toBe(true);
+      expect(fills.size).toBe(2);
+    });
+
+    it('gradient override with different fixedColor is excluded', () => {
+      const normal = makeGradientItem('normal', 50, PANEL_FROM, PANEL_TO);
+      // Override sets gradient mode but with a different start color (blue→red)
+      const diffFrom = makeItemWithGradientOverride('diffFrom', 100, '#0000ff', PANEL_TO, '#0000ff');
+
+      const fills = computeGradientFills([normal, diffFrom].filter(panelFilter), PANEL_FROM, PANEL_TO);
+
+      expect(fills.has(diffFrom)).toBe(false);
+      expect(fills.has(normal)).toBe(true);
+    });
+
+    it('gradient override with different gradientColorTo is excluded', () => {
+      const normal = makeGradientItem('normal', 50, PANEL_FROM, PANEL_TO);
+      // Override sets gradient mode but with a different end color (green→blue)
+      const diffTo = makeItemWithGradientOverride('diffTo', 100, PANEL_FROM, '#0000ff', PANEL_FROM);
+
+      const fills = computeGradientFills([normal, diffTo].filter(panelFilter), PANEL_FROM, PANEL_TO);
+
+      expect(fills.has(diffTo)).toBe(false);
+      expect(fills.has(normal)).toBe(true);
+    });
+
+    it('excluded gradient-override item falls back to display.color (override start color)', () => {
+      // Arc renderer uses display.color when item is absent from gradientFills map.
+      const diffFrom = makeItemWithGradientOverride('override', 100, '#0000ff', COLOR_RED, '#0000ff');
+      const normal = makeGradientItem('normal', 50, PANEL_FROM, PANEL_TO);
+
+      const fills = computeGradientFills([normal, diffFrom].filter(panelFilter), PANEL_FROM, PANEL_TO);
+
+      // Not in fills → arc falls back to display.color = '#0000ff' (blue, the override start)
+      expect(fills.has(diffFrom)).toBe(false);
+      expect(diffFrom.display.color).toBe('#0000ff');
+    });
+  });
+});

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -5,6 +5,7 @@ import {
   DataHoverClearEvent,
   DataHoverEvent,
   FALLBACK_COLOR,
+  FieldColorModeId,
   type FieldDisplay,
   formattedValueToString,
   getFieldDisplayValues,
@@ -21,7 +22,7 @@ import {
   type VizLegendItem,
 } from '@grafana/ui';
 
-import { PieChart } from './PieChart';
+import { PieChart, computeGradientFills } from './PieChart';
 import { type PieChartLegendOptions, PieChartLegendValues, type Options } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
@@ -56,8 +57,51 @@ export function PieChartPanel(props: Props) {
     return <PanelDataErrorView panelId={id} fieldConfig={fieldConfig} data={data} />;
   }
 
+  // Compute gradient fills once here so both the chart and the legend share
+  // the exact same color map (same rank order, same interpolated hex values).
+  //
+  // Items are grouped by their (fixedColor, gradientColorTo) gradient config.
+  // This handles three cases uniformly:
+  //   1. Panel default = Gradient → all non-overridden items share one group.
+  //   2. Per-field gradient override (e.g. byType, byRegexp) → items sharing
+  //      the same override colors form their own group and are ranked together.
+  //   3. Non-gradient items (fixed color, palette, etc.) → skipped entirely,
+  //      fall back to display.color in the arc renderer.
+  const allGradientFills = new Map<FieldDisplay, string>();
+  const gradientGroups = new Map<string, { items: FieldDisplay[]; from: string; to: string }>();
+
+  for (const item of fieldDisplayValues) {
+    if (!filterDisplayItems(item)) {
+      continue;
+    }
+    if (item.field.color?.mode !== FieldColorModeId.Gradient) {
+      continue;
+    }
+    const fixedColor = item.field.color.fixedColor ?? '#73BF69';
+    const gradientColorTo = item.field.color.gradientColorTo ?? '#F2495C';
+    const key = `${fixedColor}|${gradientColorTo}`;
+    let group = gradientGroups.get(key);
+    if (!group) {
+      group = {
+        items: [],
+        from: theme.visualization.getColorByName(fixedColor),
+        to: theme.visualization.getColorByName(gradientColorTo),
+      };
+      gradientGroups.set(key, group);
+    }
+    group.items.push(item);
+  }
+
+  for (const { items, from, to } of gradientGroups.values()) {
+    for (const [item, color] of computeGradientFills(items, from, to)) {
+      allGradientFills.set(item, color);
+    }
+  }
+
+  const gradientFills = allGradientFills.size > 0 ? allGradientFills : undefined;
+
   return (
-    <VizLayout width={width} height={height} legend={getLegend(props, fieldDisplayValues)}>
+    <VizLayout width={width} height={height} legend={getLegend(props, fieldDisplayValues, gradientFills)}>
       {(vizWidth: number, vizHeight: number) => {
         return (
           <PieChart
@@ -69,6 +113,7 @@ export function PieChartPanel(props: Props) {
             pieType={options.pieType}
             sort={options.sort}
             displayLabels={options.displayLabels}
+            gradientFills={gradientFills}
           />
         );
       }}
@@ -76,7 +121,7 @@ export function PieChartPanel(props: Props) {
   );
 }
 
-function getLegend(props: Props, displayValues: FieldDisplay[]) {
+function getLegend(props: Props, displayValues: FieldDisplay[], gradientFills?: Map<FieldDisplay, string>) {
   const legendOptions = props.options.legend ?? defaultLegendOptions;
 
   if (legendOptions.showLegend === false) {
@@ -100,7 +145,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
       const display = value.display;
       return {
         label: display.title ?? '',
-        color: display.color ?? FALLBACK_COLOR,
+        color: gradientFills?.get(value) ?? display.color ?? FALLBACK_COLOR,
         yAxis: 1,
         disabled: hideFromViz,
         getItemKey: () => (display.title ?? '') + idx,

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -21,9 +21,13 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
           byValueSupport: false,
           bySeriesSupport: true,
           preferThresholdsMode: false,
+          gradientSupport: true,
         },
         defaultValue: {
           mode: FieldColorModeId.PaletteClassic,
+          // Seed fixedColor so switching to Single color, Shades, or Gradient
+          // on a fresh panel shows a meaningful color instead of an empty picker.
+          fixedColor: '#73BF69',
         },
       },
     },


### PR DESCRIPTION
## What is this feature?

A new (experimental: requires `pieChartGradientColorScheme` feature toggle) **Gradient** option in the standard **Color scheme** picker (positioned after "Shades of a color"). When selected, two inline color pickers appear — identical layout to "Single color" — where the start color is assigned to the largest slice and the end color to the smallest. All intermediate slices receive linearly interpolated RGB fills ordered by value.

On-slice labels (name, value, percent) automatically switch between black and white using the WCAG contrast ratio algorithm (`tinycolor.mostReadable`) so they stay readable across the full gradient range. Legend item colors are kept in sync — gradient fills are computed once in `PieChartPanel` and shared with both the chart and the legend via the same `Map`.

**Before (Shades of color):**

<img width="622" height="453" alt="image" src="https://github.com/user-attachments/assets/5d896cbe-fd9f-4982-a85b-3b844f53405b" />

**After (Gradient):**

<img width="625" height="447" alt="image" src="https://github.com/user-attachments/assets/acfee06a-f9ad-45b9-9800-596d61d14eed" />

## Why do we need this feature?

The pie chart is used for **proportional comparison** (CPU usage by workload, budget splits, traffic by service, etc.). With `palette-classic` every slice has an unrelated hue — colors carry no information about relative magnitude. A gradient adds a second visual encoding channel: color intensity reinforces slice size, making the dominant slice immediately distinct from the smallest without requiring labels or hover.

## Who is this feature for?

Dashboard authors doing proportional comparisons — particularly in executive or summary dashboards where color should reinforce magnitude at a glance.

## Which issue(s) does this PR fix?

Fixes #121301

## Current changes

| File | Change |
|---|---|
| `packages/grafana-data/src/types/fieldColor.ts` | Add `FieldColorModeId.Gradient`; add optional `FieldColor.gradientColorTo` |
| `packages/grafana-data/src/field/fieldColor.ts` | Register Gradient mode after Shades in the registry initializer |
| `public/app/core/components/OptionsUI/fieldColor.tsx` | Render two inline `ColorValueEditor` pickers for Gradient; seed defaults on mode switch |
| `public/app/core/components/OptionsUI/fieldColorGradient.test.tsx` | 10 RTL tests for the gradient UI branch (new file) |
| `public/app/plugins/panel/piechart/PieChart.tsx` | Accept pre-computed `gradientFills` map; WCAG-contrasting label color per slice |
| `public/app/plugins/panel/piechart/PieChartGradient.test.ts` | 11 unit tests for `computeGradientFills` (new file) |
| `public/app/plugins/panel/piechart/PieChartPanel.tsx` | Compute gradient fills once, share with chart and legend |
| `public/app/plugins/panel/piechart/module.tsx` | Seed `fixedColor` default; no panel-level color scheme option |
| `public/app/plugins/panel/piechart/panelcfg.cue` / `.gen.ts` | No gradient fields in panel options — colors live in `FieldColor` |
