### PR TITLE
Devenv: Re-include fs build directory in docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,5 +25,6 @@ node_modules
 !.yarn/versions
 !.yarn/cache
 devenv
+!devenv/frontend-service/build/grafana
 .nx
 scripts/grafana-server/tmp

--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -168,6 +168,7 @@ runs:
             - '${{ inputs.self }}'
           devenv:
             - 'devenv/**'
+            - '.dockerignore'
             - '${{ inputs.self }}'
     - name: Print all change groups
       shell: bash


### PR DESCRIPTION
Fixes issue introduced in https://github.com/grafana/grafana/issues/121151 that causes `make frontend-service` to not work because the build directory is not available to docker anymore.