### PR TITLE
Storage: add broadcaster metrics

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"log/slog"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type Broadcaster[T any] interface {
@@ -12,16 +15,52 @@ type Broadcaster[T any] interface {
 	Unsubscribe(<-chan T)
 }
 
+type BroadcasterMetrics struct {
+	Subscribers          prometheus.Gauge
+	SubscriptionsTotal   *prometheus.CounterVec
+	UnsubscriptionsTotal *prometheus.CounterVec
+	EventsReceivedTotal  prometheus.Counter
+	OverflowEventsTotal  prometheus.Counter
+}
+
+func newBroadcasterMetrics(reg prometheus.Registerer) *BroadcasterMetrics {
+	return &BroadcasterMetrics{
+		Subscribers: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "storage_server_broadcaster_subscribers",
+			Help: "Current number of active broadcaster subscribers.",
+		}),
+		SubscriptionsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "storage_server_broadcaster_subscriptions_total",
+			Help: "Total number of broadcaster subscription attempts by result.",
+		}, []string{"result"}),
+		UnsubscriptionsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "storage_server_broadcaster_unsubscriptions_total",
+			Help: "Total number of broadcaster unsubscriptions by reason.",
+		}, []string{"reason"}),
+		EventsReceivedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "storage_server_broadcaster_events_received_total",
+			Help: "Total number of events received by the broadcaster.",
+		}),
+		OverflowEventsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "storage_server_broadcaster_overflow_events_total",
+			Help: "Total number of events appended to subscriber overflow buffers.",
+		}),
+	}
+}
+
 // NewBroadcaster creates a broadcaster that fans out items received on input to
 // all active subscribers. The caller owns the input channel and is responsible
 // for closing it when no more data will be sent. The broadcaster terminates
 // when either ctx is cancelled or input is closed.
-func NewBroadcaster[T any](ctx context.Context, input <-chan T) Broadcaster[T] {
-	return newBroadcasterWithSizes[T](ctx, input, watchChanSize, defaultOverflowCap)
+func NewBroadcaster[T any](ctx context.Context, input <-chan T, metrics *BroadcasterMetrics) Broadcaster[T] {
+	return newBroadcasterWithSizes[T](ctx, input, watchChanSize, defaultOverflowCap, metrics)
 }
 
 // newBroadcasterWithSizes creates a broadcaster with configurable buffer sizes for testing.
-func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufSize, ovfCap int) *broadcaster[T] {
+func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufSize, ovfCap int, metrics *BroadcasterMetrics) *broadcaster[T] {
+	if metrics == nil {
+		metrics = newBroadcasterMetrics(nil)
+	}
 	b := &broadcaster[T]{
 		shouldTerminate: ctx.Done(),
 		cache:           newRingBuffer[T](defaultCacheSize),
@@ -29,6 +68,7 @@ func newBroadcasterWithSizes[T any](ctx context.Context, input <-chan T, subBufS
 		unsubscribe:     make(chan (<-chan T), internalChanSize),
 		subs:            make(map[<-chan T]*subscription[T]),
 		terminated:      make(chan struct{}),
+		metrics:         metrics,
 		watchBufSize:    subBufSize,
 		overflowCap:     ovfCap,
 	}
@@ -56,6 +96,7 @@ type broadcaster[T any] struct {
 	subscribe   chan *subscription[T]
 	unsubscribe chan (<-chan T)
 	subs        map[<-chan T]*subscription[T]
+	metrics     *BroadcasterMetrics
 
 	// configuration
 
@@ -64,6 +105,17 @@ type broadcaster[T any] struct {
 	lastOverflowLog time.Time
 	overflowCount   int64 // overflow events since last log
 }
+
+const (
+	subscriptionResultOK           = "ok"
+	subscriptionResultCtxCanceled  = "ctx_canceled"
+	subscriptionResultTerminated   = "terminated"
+	subscriptionResultReplayFailed = "replay_failed"
+
+	unsubscriptionReasonClient      = "client"
+	unsubscriptionReasonOverflowCap = "overflow_cap"
+	unsubscriptionReasonShutdown    = "shutdown"
+)
 
 const (
 	// internalChanSize is the buffer for internal subscribe/unsubscribe coordination channels.
@@ -94,8 +146,10 @@ func (b *broadcaster[T]) Subscribe(ctx context.Context, name string) (<-chan T, 
 
 	select {
 	case <-ctx.Done(): // client canceled
+		b.metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultCtxCanceled).Inc()
 		return nil, ctx.Err()
 	case <-b.terminated: // no more data
+		b.metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultTerminated).Inc()
 		return nil, io.EOF
 	case b.subscribe <- sub: // success submitting subscription
 		return sub.ch, nil
@@ -148,28 +202,21 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 		// prevent new subscriptions and make sure to discard unsubscriptions
 		close(b.terminated)
 		// terminate all subscriptions
-		for recv, sub := range b.subs {
-			sub.overflow = nil
-			close(sub.ch)
-			delete(b.subs, recv)
+		for recv := range b.subs {
+			b.removeSubscriber(recv, unsubscriptionReasonShutdown)
 		}
 	}()
-
-	unsubscribe := func(recv <-chan T) {
-		if sub, ok := b.subs[recv]; ok {
-			sub.overflow = nil
-			close(sub.ch)
-			delete(b.subs, recv)
-		}
-	}
 
 	addSubscriber := func(sub *subscription[T]) {
 		// send initial batch of cached items
 		if !b.cache.readInto(sub.ch) {
+			b.metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultReplayFailed).Inc()
 			close(sub.ch)
 			return
 		}
 		b.subs[sub.ch] = sub
+		b.metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK).Inc()
+		b.metrics.Subscribers.Inc()
 	}
 
 	for {
@@ -191,13 +238,14 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 					drained = true
 				}
 			}
-			unsubscribe(recv)
+			b.removeSubscriber(recv, unsubscriptionReasonClient)
 
 		case item, ok := <-input: // data arrived, send to subscribers
 			// input closed, drain subscribers and exit
 			if !ok {
 				return
 			}
+			b.metrics.EventsReceivedTotal.Inc()
 			b.cache.add(item)
 
 			var slow []<-chan T
@@ -207,6 +255,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 				if len(sub.overflow) > 0 {
 					// Still overflowing — append to overflow
 					sub.overflow = append(sub.overflow, item)
+					b.metrics.OverflowEventsTotal.Inc()
 					b.overflowCount++
 					if len(sub.overflow) > b.overflowCap {
 						slog.Warn("disconnecting subscriber: overflow cap exceeded",
@@ -220,6 +269,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 					case sub.ch <- item:
 					default:
 						sub.overflow = append(sub.overflow, item)
+						b.metrics.OverflowEventsTotal.Inc()
 						b.overflowCount++
 						now := time.Now()
 						if now.Sub(b.lastOverflowLog) > overflowLogInterval {
@@ -237,7 +287,7 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 			// Sending to b.unsubscribe could lead to deadlock, if there are too many elements in the
 			// channel buffer already.
 			for _, recv := range slow {
-				unsubscribe(recv)
+				b.removeSubscriber(recv, unsubscriptionReasonOverflowCap)
 			}
 
 		case <-drainTicker.C: // periodically drain overflow for idle periods
@@ -246,6 +296,18 @@ func (b *broadcaster[T]) stream(input <-chan T) {
 			}
 		}
 	}
+}
+
+func (b *broadcaster[T]) removeSubscriber(recv <-chan T, reason string) {
+	sub, ok := b.subs[recv]
+	if !ok {
+		return
+	}
+	sub.overflow = nil
+	close(sub.ch)
+	delete(b.subs, recv)
+	b.metrics.Subscribers.Dec()
+	b.metrics.UnsubscriptionsTotal.WithLabelValues(reason).Inc()
 }
 
 // ringBuffer is a fixed-size circular buffer. It is not safe for concurrent

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -2,9 +2,12 @@ package resource
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,6 +18,18 @@ func drainChan[T any](ch chan T) []T {
 		out = append(out, v)
 	}
 	return out
+}
+
+func requireMetricValue(t *testing.T, collector prometheus.Collector, expected float64) {
+	t.Helper()
+	require.Equal(t, expected, testutil.ToFloat64(collector))
+}
+
+func requireMetricEventually(t *testing.T, collector prometheus.Collector, expected float64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(collector) == expected
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestRingBuffer(t *testing.T) {
@@ -62,6 +77,8 @@ func TestRingBuffer(t *testing.T) {
 func TestBroadcaster(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan int)
+	reg := prometheus.NewPedanticRegistry()
+	metrics := newBroadcasterMetrics(reg)
 	input := []int{1, 2, 3}
 	go func() {
 		for _, v := range input {
@@ -72,7 +89,7 @@ func TestBroadcaster(t *testing.T) {
 		close(ch)
 	})
 
-	b := NewBroadcaster(ctx, ch)
+	b := NewBroadcaster(ctx, ch, metrics)
 
 	sub, err := b.Subscribe(ctx, "test")
 	require.NoError(t, err)
@@ -82,11 +99,16 @@ func TestBroadcaster(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, expected, v)
 	}
+	requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK), 1)
+	requireMetricValue(t, metrics.EventsReceivedTotal, float64(len(input)))
+	requireMetricEventually(t, metrics.Subscribers, 1)
 
 	// cancel the context should close the stream
 	cancel()
 	_, ok := <-sub
 	require.False(t, ok)
+	requireMetricEventually(t, metrics.Subscribers, 0)
+	requireMetricValue(t, metrics.UnsubscriptionsTotal.WithLabelValues(unsubscriptionReasonShutdown), 1)
 }
 
 func TestBroadcasterUnsubscribe(t *testing.T) {
@@ -95,8 +117,10 @@ func TestBroadcasterUnsubscribe(t *testing.T) {
 
 	ch := make(chan int)
 	t.Cleanup(func() { close(ch) })
+	reg := prometheus.NewPedanticRegistry()
+	metrics := newBroadcasterMetrics(reg)
 
-	b := NewBroadcaster(ctx, ch)
+	b := NewBroadcaster(ctx, ch, metrics)
 
 	// subscribe three, then unsubscribe all
 	sub1, err := b.Subscribe(ctx, "sub1")
@@ -126,6 +150,10 @@ func TestBroadcasterUnsubscribe(t *testing.T) {
 	v, ok := <-sub4
 	require.True(t, ok)
 	require.Equal(t, 42, v)
+	requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK), 4)
+	requireMetricValue(t, metrics.UnsubscriptionsTotal.WithLabelValues(unsubscriptionReasonClient), 3)
+	requireMetricValue(t, metrics.EventsReceivedTotal, 1)
+	requireMetricEventually(t, metrics.Subscribers, 1)
 }
 
 func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
@@ -137,7 +165,7 @@ func TestBroadcasterSlowConsumerDeadlock(t *testing.T) {
 	// Use small overflow cap so slow consumers get disconnected quickly.
 	const subBuf = 10
 	const ovfCap = 20
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil)
 
 	// Create 101 subscribers that never read — enough to exceed the
 	// internal unsubscribe channel buffer and exercise bulk disconnect.
@@ -175,7 +203,7 @@ func TestBroadcasterOverflowSpoolsInsteadOfDisconnecting(t *testing.T) {
 
 	const subBuf = 10
 	const ovfCap = 100
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil)
 
 	sub, err := b.Subscribe(ctx, "test")
 	require.NoError(t, err)
@@ -207,10 +235,12 @@ func TestBroadcasterDisconnectsOnOverflowCapExceeded(t *testing.T) {
 
 	ch := make(chan int)
 	t.Cleanup(func() { close(ch) })
+	reg := prometheus.NewPedanticRegistry()
+	metrics := newBroadcasterMetrics(reg)
 
 	const subBuf = 10
 	const ovfCap = 20
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, metrics)
 
 	sub, err := b.Subscribe(ctx, "test")
 	require.NoError(t, err)
@@ -238,6 +268,11 @@ func TestBroadcasterDisconnectsOnOverflowCapExceeded(t *testing.T) {
 		select {
 		case _, ok := <-sub:
 			if !ok {
+				requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK), 1)
+				requireMetricValue(t, metrics.EventsReceivedTotal, float64(subBuf+ovfCap+10))
+				requireMetricValue(t, metrics.OverflowEventsTotal, float64(ovfCap+1))
+				requireMetricValue(t, metrics.UnsubscriptionsTotal.WithLabelValues(unsubscriptionReasonOverflowCap), 1)
+				requireMetricValue(t, metrics.Subscribers, 0)
 				return
 			}
 		case <-time.After(5 * time.Second):
@@ -257,7 +292,7 @@ func TestBroadcasterReadIntoDoesNotFillChannel(t *testing.T) {
 	// so readInto should leave headroom.
 	const subBuf = defaultCacheSize + 100
 	const ovfCap = 1000
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, nil)
 
 	// Fill the cache to capacity by sending items through the input channel
 	// (no subscribers yet, so items only go to cache).
@@ -301,10 +336,12 @@ func TestBroadcasterOverflowMemoryReleasedWhenCaughtUp(t *testing.T) {
 
 	ch := make(chan int)
 	t.Cleanup(func() { close(ch) })
+	reg := prometheus.NewPedanticRegistry()
+	metrics := newBroadcasterMetrics(reg)
 
 	const subBuf = 10
 	const ovfCap = 100
-	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap)
+	b := newBroadcasterWithSizes(ctx, ch, subBuf, ovfCap, metrics)
 
 	sub, err := b.Subscribe(ctx, "test")
 	require.NoError(t, err)
@@ -343,4 +380,46 @@ func TestBroadcasterOverflowMemoryReleasedWhenCaughtUp(t *testing.T) {
 	s := b.subs[sub]
 	require.NotNil(t, s, "subscriber should still exist")
 	require.Nil(t, s.overflow, "overflow should be nil after subscriber caught up")
+	requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK), 1)
+	requireMetricValue(t, metrics.EventsReceivedTotal, float64(totalItems+1))
+	requireMetricValue(t, metrics.UnsubscriptionsTotal.WithLabelValues(unsubscriptionReasonOverflowCap), 0)
+	requireMetricEventually(t, metrics.Subscribers, 1)
+}
+
+func TestBroadcasterMetricsSubscribeFailures(t *testing.T) {
+	t.Run("context canceled", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		metrics := newBroadcasterMetrics(reg)
+
+		ctx := context.Background()
+		subCtx, subCancel := context.WithCancel(ctx)
+		subCancel()
+
+		b := &broadcaster[int]{
+			subscribe:    make(chan *subscription[int]),
+			terminated:   make(chan struct{}),
+			metrics:      metrics,
+			watchBufSize: watchChanSize,
+		}
+
+		_, err := b.Subscribe(subCtx, "sub1")
+		require.Error(t, err)
+		requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultCtxCanceled), 1)
+	})
+
+	t.Run("terminated", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		metrics := newBroadcasterMetrics(reg)
+
+		ctx := context.Background()
+		input := make(chan int)
+		b := newBroadcasterWithSizes(ctx, input, watchChanSize, defaultOverflowCap, metrics)
+		close(input)
+
+		require.Eventually(t, func() bool {
+			_, err := b.Subscribe(ctx, "sub1")
+			return err == io.EOF
+		}, time.Second, 10*time.Millisecond)
+		requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultTerminated), 1)
+	})
 }

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -269,11 +269,11 @@ func TestBroadcasterDisconnectsOnOverflowCapExceeded(t *testing.T) {
 		select {
 		case _, ok := <-sub:
 			if !ok {
-				requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK), 1)
-				requireMetricValue(t, metrics.EventsReceivedTotal, float64(subBuf+ovfCap+10))
-				requireMetricValue(t, metrics.OverflowEventsTotal, float64(ovfCap+1))
-				requireMetricValue(t, metrics.UnsubscriptionsTotal.WithLabelValues(unsubscriptionReasonOverflowCap), 1)
-				requireMetricValue(t, metrics.Subscribers, 0)
+				requireMetricEventually(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultOK), 1)
+				requireMetricEventually(t, metrics.EventsReceivedTotal, float64(subBuf+ovfCap+10))
+				requireMetricEventually(t, metrics.OverflowEventsTotal, float64(ovfCap+1))
+				requireMetricEventually(t, metrics.UnsubscriptionsTotal.WithLabelValues(unsubscriptionReasonOverflowCap), 1)
+				requireMetricEventually(t, metrics.Subscribers, 0)
 				return
 			}
 		case <-time.After(5 * time.Second):

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -418,7 +419,7 @@ func TestBroadcasterMetricsSubscribeFailures(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			_, err := b.Subscribe(ctx, "sub1")
-			return err == io.EOF
+			return errors.Is(err, io.EOF)
 		}, time.Second, 10*time.Millisecond)
 		requireMetricValue(t, metrics.SubscriptionsTotal.WithLabelValues(subscriptionResultTerminated), 1)
 	})

--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -12,6 +12,7 @@ type StorageMetrics struct {
 	WatchEventLatency      *prometheus.HistogramVec
 	PollerLatency          prometheus.Histogram
 	ListWithFieldSelectors *prometheus.CounterVec
+	Broadcaster            *BroadcasterMetrics
 }
 
 func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
@@ -38,5 +39,6 @@ func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 			Name: "storage_server_field_selector_search_count",
 			Help: "number of times List was served by field selector search",
 		}, []string{"resource", "served_by"}),
+		Broadcaster: newBroadcasterMetrics(reg),
 	}
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1469,7 +1469,11 @@ func (s *server) initWatcher() error {
 		}
 	}()
 
-	s.broadcaster = NewBroadcaster(s.ctx, out)
+	var broadcasterMetrics *BroadcasterMetrics
+	if s.storageMetrics != nil {
+		broadcasterMetrics = s.storageMetrics.Broadcaster
+	}
+	s.broadcaster = NewBroadcaster(s.ctx, out, broadcasterMetrics)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add broadcaster-specific metrics for subscriptions, unsubscriptions, received events, and overflow events
- wire broadcaster metrics through StorageMetrics while keeping metric ownership in broadcaster.go
- cover the new metrics in existing broadcaster tests plus dedicated subscribe failure cases

## Testing
- go test ./pkg/storage/unified/resource