### PR TITLE
Feature Toggles: Revert removal of feature_toggles.enable configuration

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2133,7 +2133,7 @@ license_path =
 
 # The `enable` entry is deprecated and will be removed in a future major
 # release. Use individual entries as shown above instead.
-enable = feature1,feature2
+enable =
 
 [feature_toggles.openfeature]
 # This is EXPERIMENTAL. Please, do not use this section

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2133,7 +2133,7 @@ license_path =
 
 # The `enable` entry is deprecated and will be removed in a future major
 # release. Use individual entries as shown above instead.
-# enable = feature1,feature2
+enable = feature1,feature2
 
 [feature_toggles.openfeature]
 # This is EXPERIMENTAL. Please, do not use this section


### PR DESCRIPTION
Partial revert of https://github.com/grafana/grafana/pull/114047

We need to keep the flag in `defaults.ini` until it's fully deprecated