### PR TITLE
datasources: store and restore old config value in test

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -720,6 +720,7 @@ describe('DataSourceWithBackend', () => {
     });
 
     test("check public dashboard handler is executed when it's public dashboard scope", () => {
+      const oldValue = config.publicDashboardAccessToken;
       config.publicDashboardAccessToken = 'abc123';
       const { ds } = createMockDatasource();
 
@@ -735,6 +736,7 @@ describe('DataSourceWithBackend', () => {
 
       ds.query(request);
 
+      config.publicDashboardAccessToken = oldValue;
       expect(publicDashboardQueryHandler).toHaveBeenCalledWith(request);
     });
   });


### PR DESCRIPTION
store and restore the original value for `config.publicDashboardAccessToken` in a test. otherwise this change will leak into other tests.

(this will help with later pull requests that add additional tests)