### PR TITLE
Provisioning: revert folder API from v1 to v1beta1

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"

--- a/pkg/registry/apis/provisioning/resources/cleanup.go
+++ b/pkg/registry/apis/provisioning/resources/cleanup.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )

--- a/pkg/registry/apis/provisioning/resources/client.go
+++ b/pkg/registry/apis/provisioning/resources/client.go
@@ -13,7 +13,7 @@ import (
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	dashboardV2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	dashboardV2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	iam "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"

--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana-app-sdk/logging"
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -330,7 +330,7 @@ func TestCreateFolder(t *testing.T) {
 						return false
 					}
 					capturedUID = res.Name
-					return res.APIVersion == "folder.grafana.app/v1" &&
+					return res.APIVersion == "folder.grafana.app/v1beta1" &&
 						res.Kind == "Folder" &&
 						res.Name != "" &&
 						res.Spec.Title == "newfolder"
@@ -472,7 +472,7 @@ func TestCreateFolder(t *testing.T) {
 					if err := json.Unmarshal(b, &res); err != nil {
 						return false
 					}
-					return res.APIVersion == "folder.grafana.app/v1" &&
+					return res.APIVersion == "folder.grafana.app/v1beta1" &&
 						res.Kind == "Folder" &&
 						res.Name != "" &&
 						res.Spec.Title == "newfolder"

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/stretchr/testify/assert"
@@ -68,7 +68,7 @@ func TestReadFolderMetadata(t *testing.T) {
 	t.Run("missing metadata.name returns invalid folder metadata error", func(t *testing.T) {
 		rw := repository.NewMockReaderWriter(t)
 		rw.On("Read", mock.Anything, "my-folder/_folder.json", "").
-			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1","kind":"Folder","metadata":{"name":""},"spec":{"title":"My Folder"}}`)}, nil)
+			Return(&repository.FileInfo{Data: []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":""},"spec":{"title":"My Folder"}}`)}, nil)
 
 		_, _, err := ReadFolderMetadata(context.Background(), rw, "my-folder/", "")
 
@@ -134,7 +134,7 @@ func TestWriteFolderMetadata(t *testing.T) {
 			if err := json.Unmarshal(b, &f); err != nil {
 				return false
 			}
-			return f.APIVersion == "folder.grafana.app/v1" &&
+			return f.APIVersion == "folder.grafana.app/v1beta1" &&
 				f.Kind == "Folder" &&
 				f.Name == uid &&
 				f.Spec.Title == "myfolder"
@@ -288,7 +288,7 @@ func TestNewFolderManifest(t *testing.T) {
 
 	gvk := f.GetObjectKind().GroupVersionKind()
 	assert.Equal(t, "folder.grafana.app", gvk.Group)
-	assert.Equal(t, "v1", gvk.Version)
+	assert.Equal(t, "v1beta1", gvk.Version)
 	assert.Equal(t, "Folder", gvk.Kind)
 }
 
@@ -630,7 +630,7 @@ func TestParseFolderResource(t *testing.T) {
 
 			// Verify GVK and GVR
 			assert.Equal(t, "folder.grafana.app", result.GVK.Group)
-			assert.Equal(t, "v1", result.GVK.Version)
+			assert.Equal(t, "v1beta1", result.GVK.Version)
 			assert.Equal(t, "Folder", result.GVK.Kind)
 		})
 	}

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
-	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"

--- a/pkg/registry/apis/provisioning/resources/tree.go
+++ b/pkg/registry/apis/provisioning/resources/tree.go
@@ -7,7 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"

--- a/pkg/registry/apis/provisioning/resources/tree_test.go
+++ b/pkg/registry/apis/provisioning/resources/tree_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -37,7 +37,7 @@ import (
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	dashboardsV2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	dashboardsV2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
-	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -1451,7 +1451,7 @@ func (c *FilesClient) RequireValidFolderMetadata(t *testing.T, ctx context.Conte
 	require.NoError(t, err, "%s: _folder.json should be readable via the files endpoint", folderMetadataPath)
 
 	apiVersion, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "apiVersion")
-	require.Equal(t, "folder.grafana.app/v1", apiVersion, "%s: unexpected apiVersion", folderMetadataPath)
+	require.Equal(t, "folder.grafana.app/v1beta1", apiVersion, "%s: unexpected apiVersion", folderMetadataPath)
 	kind, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "kind")
 	require.Equal(t, "Folder", kind, "%s: unexpected kind", folderMetadataPath)
 

--- a/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -20,7 +20,7 @@ func createUnmanagedFolder(t *testing.T, helper *common.ProvisioningTestHelper, 
 	t.Helper()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
+			"apiVersion": "folder.grafana.app/v1beta1",
 			"kind":       "Folder",
 			"metadata": map[string]interface{}{
 				"name":      name,
@@ -39,7 +39,7 @@ func createUnmanagedFolderWithParent(t *testing.T, helper *common.ProvisioningTe
 	t.Helper()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
+			"apiVersion": "folder.grafana.app/v1beta1",
 			"kind":       "Folder",
 			"metadata": map[string]interface{}{
 				"name":      name,

--- a/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -100,7 +100,7 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlag(t *testing.T) {
 		require.NoError(t, err, "_folder.json should be created for a newly exported folder when the flag is enabled")
 
 		// The manifest must carry the actual K8s name as the stable UID.
-		var manifest foldersV1.Folder
+		var manifest foldersV1beta1.Folder
 		require.NoError(t, json.Unmarshal(data, &manifest), "_folder.json should be valid JSON")
 		require.Equal(t, folderUID, manifest.Name, "_folder.json should store the folder's K8s name as stable UID")
 		require.Equal(t, folderTitle, manifest.Spec.Title, "_folder.json should store the folder title")
@@ -139,11 +139,11 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlag(t *testing.T) {
 // TestIntegrationProvisioning_ExportJob_NestedFolders verifies that export correctly
 // handles nested folder hierarchies: paths, _folder.json placement, and UID/title content.
 func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
-	readFolderManifest := func(t *testing.T, path string) foldersV1.Folder {
+	readFolderManifest := func(t *testing.T, path string) foldersV1beta1.Folder {
 		t.Helper()
 		data, err := os.ReadFile(path) //nolint:gosec
 		require.NoError(t, err, "_folder.json should exist at %s", path)
-		var manifest foldersV1.Folder
+		var manifest foldersV1beta1.Folder
 		require.NoError(t, json.Unmarshal(data, &manifest), "_folder.json at %s should be valid JSON", path)
 		return manifest
 	}

--- a/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 )
 
@@ -35,7 +35,7 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataEnabled(t *test
 	// ownership-conflict check that the provisioning files API performs on unmanaged resources.
 	data := helper.GitReadFile(t, ctx, repoName, folderTitle+"/_folder.json")
 
-	var manifest foldersV1.Folder
+	var manifest foldersV1beta1.Folder
 	require.NoError(t, json.Unmarshal(data, &manifest), "_folder.json must be valid JSON")
 	require.Equal(t, folderUID, manifest.Name, "_folder.json must carry the folder's stable UID")
 	require.Equal(t, folderTitle, manifest.Spec.Title, "_folder.json must carry the folder's title")

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_git_test.go
@@ -203,7 +203,7 @@ func requireFolderMetadataOnRef(t *testing.T, h *common.GitTestHelper, ctx conte
 		"%s: failed to decode files API response for branch %q", filePath, ref)
 
 	apiVersion, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "apiVersion")
-	require.Equal(t, "folder.grafana.app/v1", apiVersion,
+	require.Equal(t, "folder.grafana.app/v1beta1", apiVersion,
 		"%s: unexpected apiVersion", filePath)
 	kind, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "kind")
 	require.Equal(t, "Folder", kind,

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -190,7 +190,7 @@ func requireValidFolderMetadata(t *testing.T, ctx context.Context, h *common.Pro
 	require.NoError(t, err, "%s: _folder.json should be readable via the files endpoint", filePath)
 
 	apiVersion, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "apiVersion")
-	require.Equal(t, "folder.grafana.app/v1", apiVersion, "%s: unexpected apiVersion", filePath)
+	require.Equal(t, "folder.grafana.app/v1beta1", apiVersion, "%s: unexpected apiVersion", filePath)
 	kind, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "kind")
 	require.Equal(t, "Folder", kind, "%s: unexpected kind", filePath)
 

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )

--- a/pkg/tests/apis/provisioning/foldermetadata/full/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full/export_folders_test.go
@@ -18,7 +18,7 @@ func createUnmanagedFolder(t *testing.T, helper *common.GitTestHelper, name, tit
 	t.Helper()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
+			"apiVersion": "folder.grafana.app/v1beta1",
 			"kind":       "Folder",
 			"metadata": map[string]interface{}{
 				"name":      name,

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
@@ -85,7 +85,7 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 
 	t.Run("missing spec title field is rejected", func(t *testing.T) {
 		// Raw JSON with spec.title completely absent (not just empty string).
-		body := []byte(`{"apiVersion":"folder.grafana.app/v1","kind":"Folder","metadata":{},"spec":{}}`)
+		body := []byte(`{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{},"spec":{}}`)
 		resp := files.Put(t, "update-test/", body)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "missing title must be rejected: %s", resp.BodyString())
 	})

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"
@@ -124,8 +124,8 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 	t.Run("should set ownerReferences on unmanaged folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "test-folder-",
 				},

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"
@@ -129,8 +129,8 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 	t.Run("should update permissions for unmanaged folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "test-folder-",
 				},

--- a/pkg/tests/apis/provisioning/jobs/export_folders_flag_disabled_test.go
+++ b/pkg/tests/apis/provisioning/jobs/export_folders_flag_disabled_test.go
@@ -18,7 +18,7 @@ func createUnmanagedFolder(t *testing.T, helper *common.ProvisioningTestHelper, 
 	t.Helper()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
+			"apiVersion": "folder.grafana.app/v1beta1",
 			"kind":       "Folder",
 			"metadata": map[string]interface{}{
 				"name":      name,
@@ -37,7 +37,7 @@ func createUnmanagedFolderWithParent(t *testing.T, helper *common.ProvisioningTe
 	t.Helper()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
+			"apiVersion": "folder.grafana.app/v1beta1",
 			"kind":       "Folder",
 			"metadata": map[string]interface{}{
 				"name":      name,

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -59,8 +59,8 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "test-folder-",
 				},

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"
@@ -107,8 +107,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow managed dashboard in unmanaged folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "unmanaged-folder-",
 				},
@@ -148,8 +148,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow unmanaged dashboard in unmanaged folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "plain-folder-",
 				},
@@ -188,8 +188,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("reject moving unmanaged dashboard to managed folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "src-folder-",
 				},
@@ -237,8 +237,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow moving dashboard to unmanaged folder", func(t *testing.T) {
 		folderA := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "folder-a-",
 				},
@@ -252,8 +252,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 
 		folderB := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "folder-b-",
 				},
@@ -303,8 +303,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow removing manager from dashboard in unmanaged folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "mgr-change-folder-",
 				},
@@ -353,8 +353,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow changing manager identity on dashboard in unmanaged folder", func(t *testing.T) {
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "mgr-id-change-folder-",
 				},
@@ -418,8 +418,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("reject unmanaged sub-folder in managed folder", func(t *testing.T) {
 		folder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "unmanaged-subfolder-",
 					"annotations": map[string]interface{}{
@@ -442,8 +442,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("reject sub-folder managed by different manager in managed folder", func(t *testing.T) {
 		folder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "wrong-mgr-subfolder-",
 					"annotations": map[string]interface{}{
@@ -467,8 +467,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow managed sub-folder in unmanaged folder", func(t *testing.T) {
 		parent := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "unmanaged-parent-",
 				},
@@ -482,8 +482,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 
 		child := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "managed-child-",
 					"annotations": map[string]interface{}{
@@ -506,8 +506,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	t.Run("allow unmanaged sub-folder in unmanaged folder", func(t *testing.T) {
 		parent := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "plain-parent-",
 				},
@@ -521,8 +521,8 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 
 		child := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 				"metadata": map[string]interface{}{
 					"generateName": "plain-child-",
 					"annotations": map[string]interface{}{

--- a/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -126,8 +126,8 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 		for i, name := range []string{"export-test-folder-1", "export-test-folder-2"} {
 			folderObj := &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
-					"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+					"apiVersion": foldersV1beta1.FolderResourceInfo.GroupVersion().String(),
+					"kind":       foldersV1beta1.FolderResourceInfo.GroupVersionKind().Kind,
 					"metadata": map[string]interface{}{
 						"name": name,
 					},

--- a/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )


### PR DESCRIPTION
## Summary
- Reverts provisioning code from using `folder.grafana.app/v1` back to `folder.grafana.app/v1beta1`
- PR #119954 moved the folder API to v1 across all consumers, but in Grafana Cloud rollouts are staggered and some servers may not yet serve `folder.grafana.app/v1`, causing provisioning failures
- The v1beta1 types are identical (thin alias layer over v1), so the only behavioral change is the version string in API requests

## Test plan
- [x] `go build ./pkg/registry/apis/provisioning/...` passes
- [x] `go vet ./pkg/registry/apis/provisioning/...` passes
- [x] All 1034 unit tests pass across `resources/`, `controller/`, and `jobs/sync/`
- [ ] CI integration tests pass