### PR TITLE
Filters: Runtime migration to AdHocFilters GroupBy extension when FF is on

### DIFF
--- a/public/app/features/dashboard-scene/serialization/groupByMigration.test.ts
+++ b/public/app/features/dashboard-scene/serialization/groupByMigration.test.ts
@@ -1,9 +1,11 @@
-import type { AdHocVariableModel, GroupByVariableModel, TypedVariableModel } from '@grafana/data';
+import {
+  type AdHocVariableModel,
+  type GroupByVariableModel,
+  LoadingState,
+  type TypedVariableModel,
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
-import type {
-  AdhocVariableKind,
-  GroupByVariableKind,
-} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import type { AdhocVariableKind, GroupByVariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
 import { migrateGroupByVariablesV1, migrateGroupByVariablesV2 } from './groupByMigration';
 
@@ -89,9 +91,7 @@ describe('groupByMigration', () => {
       const result = migrateGroupByVariablesV1([adhoc, groupBy]);
       const migrated = result[0] as AdHocVariableModel;
 
-      expect(migrated.filters).toEqual([
-        { key: 'cpu', operator: 'groupBy', value: '', condition: '' },
-      ]);
+      expect(migrated.filters).toEqual([{ key: 'cpu', operator: 'groupBy', value: '', condition: '' }]);
     });
 
     it('should preserve existing adhoc filters and append groupBy filters', () => {
@@ -221,7 +221,7 @@ function makeAdhocV1(overrides?: Partial<AdHocVariableModel>): AdHocVariableMode
     id: 'adhoc',
     global: false,
     index: 0,
-    state: 0 as any,
+    state: LoadingState.NotStarted,
     error: null,
     name: 'adhoc',
     type: 'adhoc',
@@ -239,7 +239,7 @@ function makeGroupByV1(overrides?: Partial<GroupByVariableModel>): GroupByVariab
     id: 'groupby',
     global: false,
     index: 1,
-    state: 0 as any,
+    state: LoadingState.NotStarted,
     error: null,
     name: 'groupby',
     type: 'groupby',

--- a/public/app/features/dashboard-scene/serialization/groupByMigration.test.ts
+++ b/public/app/features/dashboard-scene/serialization/groupByMigration.test.ts
@@ -1,0 +1,291 @@
+import type { AdHocVariableModel, GroupByVariableModel, TypedVariableModel } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import type {
+  AdhocVariableKind,
+  GroupByVariableKind,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { migrateGroupByVariablesV1, migrateGroupByVariablesV2 } from './groupByMigration';
+
+describe('groupByMigration', () => {
+  beforeEach(() => {
+    config.featureToggles.dashboardUnifiedDrilldownControls = true;
+  });
+
+  afterEach(() => {
+    config.featureToggles.dashboardUnifiedDrilldownControls = false;
+  });
+
+  describe('migrateGroupByVariablesV1', () => {
+    it('should return variables unchanged when FF is off', () => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
+      const vars = [makeAdhocV1(), makeGroupByV1()];
+      expect(migrateGroupByVariablesV1(vars)).toBe(vars);
+    });
+
+    it('should return variables unchanged when there are no groupBy variables', () => {
+      const vars: TypedVariableModel[] = [makeAdhocV1()];
+      expect(migrateGroupByVariablesV1(vars)).toBe(vars);
+    });
+
+    it('should remove groupBy variable and enable groupBy on matching adhoc', () => {
+      const adhoc = makeAdhocV1();
+      const groupBy = makeGroupByV1({ current: {} });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('adhoc');
+      expect((result[0] as AdHocVariableModel).enableGroupBy).toBe(true);
+    });
+
+    it('should migrate current groupBy values as filters without origin', () => {
+      const adhoc = makeAdhocV1();
+      const groupBy = makeGroupByV1({
+        current: { selected: true, text: ['CPU', 'Memory'], value: ['cpu', 'memory'] },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+      const migrated = result[0] as AdHocVariableModel;
+
+      expect(migrated.filters).toEqual([
+        { key: 'cpu', keyLabel: 'CPU', operator: 'groupBy', value: '', condition: '' },
+        { key: 'memory', keyLabel: 'Memory', operator: 'groupBy', value: '', condition: '' },
+      ]);
+    });
+
+    it('should migrate default groupBy values with origin dashboard', () => {
+      const adhoc = makeAdhocV1();
+      const groupBy = makeGroupByV1({
+        current: {},
+        defaultValue: { selected: true, text: ['Disk IO'], value: ['disk_io'] },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+      const migrated = result[0] as AdHocVariableModel;
+
+      expect(migrated.filters).toEqual([
+        { key: 'disk_io', keyLabel: 'Disk IO', operator: 'groupBy', value: '', condition: '', origin: 'dashboard' },
+      ]);
+    });
+
+    it('should migrate both default and current values correctly', () => {
+      const adhoc = makeAdhocV1();
+      const groupBy = makeGroupByV1({
+        current: { selected: true, text: ['CPU', 'Network'], value: ['cpu', 'network'] },
+        defaultValue: { selected: true, text: ['CPU'], value: ['cpu'] },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+      const migrated = result[0] as AdHocVariableModel;
+
+      expect(migrated.filters).toEqual([
+        { key: 'cpu', keyLabel: 'CPU', operator: 'groupBy', value: '', condition: '', origin: 'dashboard' },
+        { key: 'network', keyLabel: 'Network', operator: 'groupBy', value: '', condition: '' },
+      ]);
+    });
+
+    it('should set keyLabel to key when labels are not provided', () => {
+      const adhoc = makeAdhocV1();
+      const groupBy = makeGroupByV1({
+        current: { selected: true, text: 'cpu', value: 'cpu' },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+      const migrated = result[0] as AdHocVariableModel;
+
+      expect(migrated.filters).toEqual([
+        { key: 'cpu', operator: 'groupBy', value: '', condition: '' },
+      ]);
+    });
+
+    it('should preserve existing adhoc filters and append groupBy filters', () => {
+      const adhoc = makeAdhocV1({
+        filters: [{ key: 'existing', operator: '=', value: 'test' }],
+      });
+      const groupBy = makeGroupByV1({
+        current: { selected: true, text: 'cpu', value: 'cpu' },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+      const migrated = result[0] as AdHocVariableModel;
+
+      expect(migrated.filters).toHaveLength(2);
+      expect(migrated.filters[0]).toEqual({ key: 'existing', operator: '=', value: 'test' });
+      expect(migrated.filters[1]).toEqual({
+        key: 'cpu',
+        operator: 'groupBy',
+        value: '',
+        condition: '',
+      });
+    });
+
+    it('should handle single string current values', () => {
+      const adhoc = makeAdhocV1();
+      const groupBy = makeGroupByV1({
+        current: { selected: true, text: 'CPU Usage', value: 'cpu_usage' },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+      const migrated = result[0] as AdHocVariableModel;
+
+      expect(migrated.filters).toEqual([
+        { key: 'cpu_usage', keyLabel: 'CPU Usage', operator: 'groupBy', value: '', condition: '' },
+      ]);
+    });
+
+    it('should not merge groupBy into adhoc with different datasource', () => {
+      const adhoc = makeAdhocV1({ datasource: { uid: 'other-ds', type: 'prometheus' } });
+      const groupBy = makeGroupByV1({
+        current: { selected: true, text: 'cpu', value: 'cpu' },
+      });
+      const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+
+      expect(result).toHaveLength(1);
+      expect((result[0] as AdHocVariableModel).enableGroupBy).toBeUndefined();
+      expect((result[0] as AdHocVariableModel).filters).toEqual([]);
+    });
+  });
+
+  describe('migrateGroupByVariablesV2', () => {
+    it('should return variables unchanged when FF is off', () => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
+      const vars = [makeAdhocV2(), makeGroupByV2()];
+      expect(migrateGroupByVariablesV2(vars)).toBe(vars);
+    });
+
+    it('should remove groupBy variable and enable groupBy on matching adhoc', () => {
+      const adhoc = makeAdhocV2();
+      const groupBy = makeGroupByV2({ current: { text: '', value: '' } });
+      const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kind).toBe('AdhocVariable');
+      expect((result[0] as AdhocVariableKind).spec.enableGroupBy).toBe(true);
+    });
+
+    it('should migrate current groupBy values as filters without origin', () => {
+      const adhoc = makeAdhocV2();
+      const groupBy = makeGroupByV2({
+        current: { text: ['CPU', 'Memory'], value: ['cpu', 'memory'] },
+      });
+      const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+      const migrated = result[0] as AdhocVariableKind;
+
+      expect(migrated.spec.filters).toEqual([
+        { key: 'cpu', keyLabel: 'CPU', operator: 'groupBy', value: '', condition: '' },
+        { key: 'memory', keyLabel: 'Memory', operator: 'groupBy', value: '', condition: '' },
+      ]);
+    });
+
+    it('should migrate default groupBy values with origin dashboard', () => {
+      const adhoc = makeAdhocV2();
+      const groupBy = makeGroupByV2({
+        current: { text: '', value: '' },
+        defaultValue: { text: ['Disk IO'], value: ['disk_io'] },
+      });
+      const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+      const migrated = result[0] as AdhocVariableKind;
+
+      expect(migrated.spec.filters).toEqual([
+        { key: 'disk_io', keyLabel: 'Disk IO', operator: 'groupBy', value: '', condition: '', origin: 'dashboard' },
+      ]);
+    });
+
+    it('should prioritize default values over current when key overlaps', () => {
+      const adhoc = makeAdhocV2();
+      const groupBy = makeGroupByV2({
+        current: { text: ['CPU Label'], value: ['cpu'] },
+        defaultValue: { text: ['CPU Default'], value: ['cpu'] },
+      });
+      const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+      const migrated = result[0] as AdhocVariableKind;
+
+      expect(migrated.spec.filters).toEqual([
+        { key: 'cpu', keyLabel: 'CPU Default', operator: 'groupBy', value: '', condition: '', origin: 'dashboard' },
+      ]);
+    });
+
+    it('should migrate both default and current values correctly', () => {
+      const adhoc = makeAdhocV2();
+      const groupBy = makeGroupByV2({
+        current: { text: ['CPU', 'Network'], value: ['cpu', 'network'] },
+        defaultValue: { text: ['CPU'], value: ['cpu'] },
+      });
+      const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+      const migrated = result[0] as AdhocVariableKind;
+
+      expect(migrated.spec.filters).toEqual([
+        { key: 'cpu', keyLabel: 'CPU', operator: 'groupBy', value: '', condition: '', origin: 'dashboard' },
+        { key: 'network', keyLabel: 'Network', operator: 'groupBy', value: '', condition: '' },
+      ]);
+    });
+  });
+});
+
+function makeAdhocV1(overrides?: Partial<AdHocVariableModel>): AdHocVariableModel {
+  return {
+    id: 'adhoc',
+    global: false,
+    index: 0,
+    state: 0 as any,
+    error: null,
+    name: 'adhoc',
+    type: 'adhoc',
+    datasource: { uid: 'prom-uid', type: 'prometheus' },
+    filters: [],
+    hide: 0,
+    skipUrlSync: false,
+    description: null,
+    ...overrides,
+  } as AdHocVariableModel;
+}
+
+function makeGroupByV1(overrides?: Partial<GroupByVariableModel>): GroupByVariableModel {
+  return {
+    id: 'groupby',
+    global: false,
+    index: 1,
+    state: 0 as any,
+    error: null,
+    name: 'groupby',
+    type: 'groupby',
+    datasource: { uid: 'prom-uid', type: 'prometheus' },
+    multi: true,
+    current: {},
+    options: [],
+    query: '',
+    hide: 0,
+    skipUrlSync: false,
+    description: null,
+    ...overrides,
+  } as GroupByVariableModel;
+}
+
+function makeAdhocV2(overrides?: Partial<AdhocVariableKind>): AdhocVariableKind {
+  return {
+    kind: 'AdhocVariable',
+    group: '',
+    datasource: { name: 'prom' },
+    spec: {
+      name: 'adhoc',
+      baseFilters: [],
+      filters: [],
+      defaultKeys: [],
+      hide: 'dontHide',
+      skipUrlSync: false,
+      allowCustomValue: true,
+    },
+    ...overrides,
+  };
+}
+
+function makeGroupByV2(specOverrides?: Partial<GroupByVariableKind['spec']>): GroupByVariableKind {
+  return {
+    kind: 'GroupByVariable',
+    group: '',
+    datasource: { name: 'prom' },
+    spec: {
+      name: 'groupby',
+      current: { text: '', value: '' },
+      options: [],
+      multi: true,
+      hide: 'dontHide',
+      skipUrlSync: false,
+      ...specOverrides,
+    },
+  };
+}

--- a/public/app/features/dashboard-scene/serialization/groupByMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/groupByMigration.ts
@@ -50,14 +50,14 @@ function buildGroupByFilters(currentEntries: KeyWithLabel[], defaultEntries: Key
   const filters: GroupByFilterEntry[] = [];
   const seen = new Set<string>();
 
-  for (const entry of currentEntries) {
+  for (const entry of defaultEntries) {
     seen.add(entry.key);
-    filters.push(toGroupByFilter(entry.key, entry.label));
+    filters.push(toGroupByFilter(entry.key, entry.label, 'dashboard'));
   }
 
-  for (const entry of defaultEntries) {
+  for (const entry of currentEntries) {
     if (!seen.has(entry.key)) {
-      filters.push(toGroupByFilter(entry.key, entry.label, 'dashboard'));
+      filters.push(toGroupByFilter(entry.key, entry.label));
     }
   }
 

--- a/public/app/features/dashboard-scene/serialization/groupByMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/groupByMigration.ts
@@ -1,0 +1,213 @@
+/**
+ * Runtime migration: GroupByVariable → AdHocFiltersVariable groupBy extension.
+ *
+ * When `dashboardUnifiedDrilldownControls` is enabled, GroupByVariable entries
+ * are merged into the matching AdHocFiltersVariable (same datasource) as
+ * groupBy-operator filters. The GroupByVariable is then dropped from the
+ * variable list so it is never instantiated.
+ *
+ * Since this is a runtime layer the schema will not be persisted until the user saves the dashboard,
+ * so reverting back to the old model by turning the FF off won't work without re-adding a GroupByVariable manually.
+ *
+ * This is a temporary compat layer — remove once GroupByVariable is fully deprecated.
+ */
+import type { GroupByVariableModel, TypedVariableModel } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import type {
+  AdhocVariableKind,
+  GroupByVariableKind,
+  VariableKind,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+const GROUP_BY_OPERATOR = 'groupBy';
+
+interface GroupByFilterEntry {
+  key: string;
+  keyLabel?: string;
+  operator: typeof GROUP_BY_OPERATOR;
+  value: '';
+  condition: '';
+  origin?: 'dashboard';
+}
+
+function toGroupByFilter(key: string, keyLabel?: string, origin?: 'dashboard'): GroupByFilterEntry {
+  return {
+    key,
+    ...(keyLabel && keyLabel !== key ? { keyLabel } : {}),
+    operator: GROUP_BY_OPERATOR,
+    value: '',
+    condition: '',
+    ...(origin ? { origin } : {}),
+  };
+}
+
+interface KeyWithLabel {
+  key: string;
+  label?: string;
+}
+
+function buildGroupByFilters(currentEntries: KeyWithLabel[], defaultEntries: KeyWithLabel[]): GroupByFilterEntry[] {
+  const filters: GroupByFilterEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of currentEntries) {
+    seen.add(entry.key);
+    filters.push(toGroupByFilter(entry.key, entry.label));
+  }
+
+  for (const entry of defaultEntries) {
+    if (!seen.has(entry.key)) {
+      filters.push(toGroupByFilter(entry.key, entry.label, 'dashboard'));
+    }
+  }
+
+  return filters;
+}
+
+// ---------------------------------------------------------------------------
+// V1 (legacy JSON model)
+// ---------------------------------------------------------------------------
+
+/**
+ * Migrates v1 `TypedVariableModel[]`: merges each GroupByVariable into its
+ * datasource-matching AdHocFiltersVariable, then removes it.
+ * Returns a new list (no GroupByVariables). Does not mutate the input.
+ */
+export function migrateGroupByVariablesV1(variables: TypedVariableModel[]): TypedVariableModel[] {
+  if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
+    return variables;
+  }
+
+  const groupByVars = variables.filter(isGroupByModel);
+  if (groupByVars.length === 0) {
+    return variables;
+  }
+
+  const groupByByDsUid = new Map<string | undefined, GroupByVariableModel>();
+  for (const gb of groupByVars) {
+    groupByByDsUid.set(gb.datasource?.uid, gb);
+  }
+
+  const result: TypedVariableModel[] = [];
+
+  for (const v of variables) {
+    if (v.type === 'groupby') {
+      continue;
+    }
+
+    if (v.type !== 'adhoc') {
+      result.push(v);
+      continue;
+    }
+
+    const gb = groupByByDsUid.get(v.datasource?.uid);
+    if (!gb) {
+      result.push(v);
+      continue;
+    }
+
+    const currentEntries = extractV1Entries(gb.current);
+    const defaultEntries = extractV1Entries(gb.defaultValue);
+    const groupByFilters = buildGroupByFilters(currentEntries, defaultEntries);
+
+    result.push({
+      ...v,
+      enableGroupBy: true,
+      filters: [...(v.filters ?? []), ...groupByFilters],
+    });
+  }
+
+  return result;
+}
+
+function isGroupByModel(v: TypedVariableModel): v is GroupByVariableModel {
+  return v.type === 'groupby';
+}
+
+function extractV1Entries(option?: { value?: string | string[]; text?: string | string[] }): KeyWithLabel[] {
+  if (!option?.value) {
+    return [];
+  }
+
+  const values = Array.isArray(option.value) ? option.value.map(String) : [String(option.value)];
+  const labels = Array.isArray(option.text) ? option.text.map(String) : option.text ? [String(option.text)] : [];
+
+  return values.filter(Boolean).map((val, i) => ({
+    key: val,
+    label: labels[i] || undefined,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// V2 (schema v2 kinds)
+// ---------------------------------------------------------------------------
+
+/**
+ * Migrates v2 `VariableKind[]`: merges each GroupByVariableKind into its
+ * datasource-matching AdhocVariableKind, then removes it.
+ * Returns a new list (no GroupByVariableKinds). Does not mutate the input.
+ */
+export function migrateGroupByVariablesV2(variables: VariableKind[]): VariableKind[] {
+  if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
+    return variables;
+  }
+
+  const groupByVars = variables.filter((v): v is GroupByVariableKind => v.kind === 'GroupByVariable');
+  if (groupByVars.length === 0) {
+    return variables;
+  }
+
+  const groupByByDsName = new Map<string | undefined, GroupByVariableKind>();
+  for (const gb of groupByVars) {
+    groupByByDsName.set(gb.datasource?.name, gb);
+  }
+
+  const result: VariableKind[] = [];
+
+  for (const v of variables) {
+    if (v.kind === 'GroupByVariable') {
+      continue;
+    }
+
+    if (v.kind !== 'AdhocVariable') {
+      result.push(v);
+      continue;
+    }
+
+    const gb = groupByByDsName.get(v.datasource?.name);
+    if (!gb) {
+      result.push(v);
+      continue;
+    }
+
+    const currentEntries = extractV2Entries(gb.spec.current);
+    const defaultEntries = extractV2Entries(gb.spec.defaultValue);
+    const groupByFilters = buildGroupByFilters(currentEntries, defaultEntries);
+
+    const migrated: AdhocVariableKind = {
+      ...v,
+      spec: {
+        ...v.spec,
+        enableGroupBy: true,
+        filters: [...(v.spec.filters ?? []), ...groupByFilters],
+      },
+    };
+    result.push(migrated);
+  }
+
+  return result;
+}
+
+function extractV2Entries(option?: { value?: string | string[]; text?: string | string[] }): KeyWithLabel[] {
+  if (!option?.value) {
+    return [];
+  }
+
+  const values = Array.isArray(option.value) ? option.value.map(String) : [String(option.value)];
+  const labels = Array.isArray(option.text) ? option.text.map(String) : option.text ? [String(option.text)] : [];
+
+  return values.filter(Boolean).map((val, i) => ({
+    key: val,
+    label: labels[i] || undefined,
+  }));
+}

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -81,6 +81,7 @@ import { getIntervalsFromQueryString } from '../utils/utils';
 
 import { transformV2ToV1AnnotationQuery } from './annotations';
 import { SnapshotVariable } from './custom-variables/SnapshotVariable';
+import { migrateGroupByVariablesV2 } from './groupByMigration';
 import { layoutDeserializerRegistry } from './layoutSerializers/layoutSerializerRegistry';
 import { getDataSourceForQuery, getRuntimeVariableDataSource } from './layoutSerializers/utils';
 import { registerPanelInteractionsReporter } from './transformSaveModelToScene';
@@ -304,7 +305,8 @@ function getVariables(
 
 function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariables: VariableKind[] = []) {
   const isDefined = (v: SceneVariable | null): v is SceneVariable => Boolean(v);
-  const variableObjects = (dashboard.variables ?? [])
+  const variables = migrateGroupByVariablesV2(dashboard.variables ?? []);
+  const variableObjects = variables
     .map((v) => {
       try {
         return createSceneVariableFromVariableModel(v);

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -18,6 +18,7 @@ import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 
 import { SnapshotVariable } from '../serialization/custom-variables/SnapshotVariable';
+import { migrateGroupByVariablesV1 } from '../serialization/groupByMigration';
 import { createSceneVariableFromVariableModel as createSceneVariableFromVariableModelV2 } from '../serialization/transformSaveModelSchemaV2ToScene';
 
 import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from './utils';
@@ -25,7 +26,8 @@ import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from 
 const DEFAULT_DATASOURCE = 'default';
 
 export function createVariablesForDashboard(oldModel: DashboardModel, defaultVariables: VariableKind[] = []) {
-  const variableObjects = oldModel.templating.list
+  const variables = migrateGroupByVariablesV1(oldModel.templating.list);
+  const variableObjects = variables
     .map((v) => {
       try {
         return createSceneVariableFromVariableModel(v);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a runtime migration layer that would, at runtime, move the groupBy into the adhoc as an extension, when the `dashboardUnifiedDrilldownControls` feature toggle is enabled, migrating applicability and recommendations also.

**Why do we need this feature?**

This is needed to maintain a backward comp way for dashboards that already have groupBy vars set. Since this is a runtime transformation the schema is not actually modified (until the user saves it). So disabling the FF will revert to the old 2 separate variable style, together with the rest of the functionalities.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

For testing:
- With the FF off, create a dashboard with both adhoc and groupBys
- Enable ff, and browser refresh dashboard
- See that the groupBy values have been migrated to the adhoc and the groupBy var was removed. The schema is only persisted on user save
- Everything continues to work properly
- Disabling the FF keeps the old groupByVar (unless the dashboard was saved in the meantime)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
