### PR TITLE
fix: break 38 circular dependencies via import type conversions

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -15,7 +15,7 @@ import { convertToGMAApi } from '../../api/convertToGMAApi';
 import { createListFilterLink } from '../../utils/navigation';
 import { getRuleName, isPluginProvidedRule } from '../../utils/rules';
 
-import { ImportFormValues } from './ImportToGMARules';
+import type { ImportFormValues } from './ImportToGMARules';
 import { useGetRulesThatMightBeOverwritten, useGetRulesToBeImported } from './hooks';
 import { parseYamlFileToRulerRulesConfigDTO } from './yamlToRulerConverter';
 

--- a/public/app/features/alerting/unified/components/import-to-gma/NamespaceAndGroupFilter.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/NamespaceAndGroupFilter.tsx
@@ -6,7 +6,7 @@ import { Combobox, ComboboxOption, Field, Stack } from '@grafana/ui';
 
 import { useGetNameSpacesByDatasourceName } from '../rule-editor/useAlertRuleSuggestions';
 
-import { ImportFormValues } from './ImportToGMARules';
+import type { ImportFormValues } from './ImportToGMARules';
 
 interface Props {
   rulesSourceName?: string;

--- a/public/app/features/alerting/unified/components/silences/SilenceDetails.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceDetails.tsx
@@ -6,7 +6,7 @@ import { Stack, useStyles2 } from '@grafana/ui';
 
 import { SilenceMetadataGrid } from './SilenceMetadataGrid';
 import SilencedAlertsTable from './SilencedAlertsTable';
-import { SilenceTableItem } from './SilencesTable';
+import type { SilenceTableItem } from './SilencesTable';
 
 interface Props {
   silence: SilenceTableItem;

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -15,7 +15,7 @@ import { shouldUseSavedSearches } from '../../featureToggles';
 import { useRulesFilter } from '../../hooks/useFilteredRules';
 import { getSearchFilterFromQuery } from '../../search/rulesSearchParser';
 
-import { RulesFilterProps } from './RulesFilter';
+import type { RulesFilterProps } from './RulesFilter';
 import { trackSavedSearchApplied, useSavedSearches } from './useSavedSearches';
 
 type SearchQueryForm = {

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.tsx
@@ -11,7 +11,7 @@ import { dashboardEditActions } from '../../edit-pane/shared';
 import { getLowerTranslatedObjectType } from '../object';
 
 import { ConditionalRenderingConditionWrapper } from './ConditionalRenderingConditionWrapper';
-import { ConditionalRenderingConditionsSerializerRegistryItem } from './serializers';
+import type { ConditionalRenderingConditionsSerializerRegistryItem } from './serializers';
 import { checkGroup, getObjectType } from './utils';
 
 interface ConditionalRenderingTimeRangeSizeState extends SceneObjectState {

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
@@ -22,7 +22,7 @@ import { getDashboardSceneFor } from '../../utils/utils';
 import { getLowerTranslatedObjectType } from '../object';
 
 import { ConditionalRenderingConditionWrapper } from './ConditionalRenderingConditionWrapper';
-import { ConditionalRenderingConditionsSerializerRegistryItem } from './serializers';
+import type { ConditionalRenderingConditionsSerializerRegistryItem } from './serializers';
 import { checkGroup, getObject, getObjectType } from './utils';
 
 type VariableConditionValueOperator = '=' | '!=' | '=~' | '!~';

--- a/public/app/features/dashboard-scene/edit-pane/MultiSelectedVizPanelsEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/MultiSelectedVizPanelsEditableElement.tsx
@@ -7,7 +7,7 @@ import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../scene/types/EditableDashboardElement';
 
-import { VizPanelEditableElement } from './VizPanelEditableElement';
+import type { VizPanelEditableElement } from './VizPanelEditableElement';
 
 export class MultiSelectedVizPanelsEditableElement implements EditableDashboardElement {
   public readonly isEditableDashboardElement = true;

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -13,7 +13,7 @@ import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { UnlinkModal } from '../scene/UnlinkModal';
 import { getDashboardSceneFor, getLibraryPanelBehavior } from '../utils/utils';
 
-import { PanelEditor } from './PanelEditor';
+import type { PanelEditor } from './PanelEditor';
 import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
 import { useSnappingSplitter } from './splitter/useSnappingSplitter';
 import { scrollReflowMediaCondition, useScrollReflowLimit } from './useScrollReflowLimit';

--- a/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
@@ -7,7 +7,7 @@ import { SaveDashboardOptions } from 'app/features/dashboard/components/SaveDash
 
 import { DashboardScene } from '../scene/DashboardScene';
 
-import { SaveDashboardDrawer } from './SaveDashboardDrawer';
+import type { SaveDashboardDrawer } from './SaveDashboardDrawer';
 import {
   DashboardChangeInfo,
   NameAlreadyExistsError,

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -8,7 +8,7 @@ import { Button, ClipboardButton, Stack, CodeEditor, Box, TextLink } from '@graf
 
 import { DashboardScene } from '../scene/DashboardScene';
 
-import { SaveDashboardDrawer } from './SaveDashboardDrawer';
+import type { SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { SaveDashboardFormCommonOptions } from './SaveDashboardForm';
 import { DashboardChangeInfo } from './shared';
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -10,7 +10,7 @@ import { useSelector } from 'app/types/store';
 
 import { DashboardEditPaneSplitter } from '../edit-pane/DashboardEditPaneSplitter';
 
-import { DashboardScene } from './DashboardScene';
+import type { DashboardScene } from './DashboardScene';
 import { PanelSearchLayout } from './PanelSearchLayout';
 import { SoloPanelContextProvider, useDefineSoloPanelContext } from './SoloPanelContext';
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -6,7 +6,7 @@ import { createDashboardEditViewFor } from '../settings/utils';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { findEditPanel, getLibraryPanelBehavior } from '../utils/utils';
 
-import { DashboardScene, DashboardSceneState } from './DashboardScene';
+import type { DashboardScene, DashboardSceneState } from './DashboardScene';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemEditor.tsx
@@ -6,7 +6,7 @@ import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSel
 import { useConditionalRenderingEditor } from '../../conditional-rendering/hooks/useConditionalRenderingEditor';
 import { dashboardEditActions } from '../../edit-pane/shared';
 
-import { AutoGridItem } from './AutoGridItem';
+import type { AutoGridItem } from './AutoGridItem';
 
 export function getOptions(model: AutoGridItem): OptionsPaneCategoryDescriptor[] {
   const repeatCategory = new OptionsPaneCategoryDescriptor({

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
@@ -13,7 +13,7 @@ import { useSoloPanelContext, renderMatchingSoloPanels } from '../SoloPanelConte
 import { getIsLazy } from '../layouts-shared/utils';
 import { AUTO_GRID_ITEM_DROP_TARGET_ATTR } from '../types/DashboardDropTarget';
 
-import { AutoGridItem } from './AutoGridItem';
+import type { AutoGridItem } from './AutoGridItem';
 import { AutoGridLayoutManager } from './AutoGridLayoutManager';
 import { DRAGGED_ITEM_HEIGHT, DRAGGED_ITEM_LEFT, DRAGGED_ITEM_TOP, DRAGGED_ITEM_WIDTH } from './const';
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManagerEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManagerEditor.tsx
@@ -8,7 +8,7 @@ import { t } from '@grafana/i18n';
 import { Button, Combobox, ComboboxOption, Field, InlineSwitch, Input, Stack, useStyles2 } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
-import { AutoGridColumnWidth, AutoGridRowHeight, AutoGridLayoutManager } from './AutoGridLayoutManager';
+import type { AutoGridColumnWidth, AutoGridRowHeight, AutoGridLayoutManager } from './AutoGridLayoutManager';
 
 export function getEditOptions(layoutManager: AutoGridLayoutManager): OptionsPaneItemDescriptor[] {
   const options: OptionsPaneItemDescriptor[] = [];

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
@@ -13,7 +13,7 @@ import { CanvasGridAddActions } from '../layouts-shared/CanvasGridAddActions';
 import { dashboardCanvasAddButtonHoverStyles } from '../layouts-shared/styles';
 import { DASHBOARD_DROP_TARGET_KEY_ATTR } from '../types/DashboardDropTarget';
 
-import { AutoGridLayout, AutoGridLayoutState } from './AutoGridLayout';
+import type { AutoGridLayout, AutoGridLayoutState } from './AutoGridLayout';
 import { AutoGridLayoutManager } from './AutoGridLayoutManager';
 
 export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLayout>) {

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -12,7 +12,7 @@ import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSel
 import { useConditionalRenderingEditor } from '../../conditional-rendering/hooks/useConditionalRenderingEditor';
 import { dashboardEditActions } from '../../edit-pane/shared';
 
-import { DashboardGridItem } from './DashboardGridItem';
+import type { DashboardGridItem } from './DashboardGridItem';
 
 export function getDashboardGridItemOptions(gridItem: DashboardGridItem): OptionsPaneCategoryDescriptor[] {
   const categoryId = 'repeat-options';

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemRenderer.tsx
@@ -11,7 +11,7 @@ import { SoloPanelContextValueWithSearchStringFilter } from '../PanelSearchLayou
 import { renderMatchingSoloPanels, useSoloPanelContext } from '../SoloPanelContext';
 import { getIsLazy } from '../layouts-shared/utils';
 
-import { DashboardGridItem, RepeatDirection } from './DashboardGridItem';
+import type { DashboardGridItem, RepeatDirection } from './DashboardGridItem';
 
 interface PanelWrapperProps {
   panel: VizPanel;

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemVariableDependencyHandler.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemVariableDependencyHandler.ts
@@ -1,6 +1,6 @@
 import { SceneVariable, SceneVariableDependencyConfigLike } from '@grafana/scenes';
 
-import { DashboardGridItem } from './DashboardGridItem';
+import type { DashboardGridItem } from './DashboardGridItem';
 
 export class DashboardGridItemVariableDependencyHandler implements SceneVariableDependencyConfigLike {
   constructor(private _gridItem: DashboardGridItem) {}

--- a/public/app/features/dashboard-scene/scene/layout-default/row-actions/RowActionsRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/row-actions/RowActionsRenderer.tsx
@@ -12,7 +12,7 @@ import { getQueryRunnerFor, useDashboardState } from '../../../utils/utils';
 import { DashboardGridItem } from '../DashboardGridItem';
 import { RowRepeaterBehavior } from '../RowRepeaterBehavior';
 
-import { RowActions } from './RowActions';
+import type { RowActions } from './RowActions';
 import { RowOptionsButton } from './RowOptionsButton';
 
 export function RowActionsRenderer({ model }: SceneComponentProps<RowActions>) {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
@@ -15,7 +15,7 @@ import { getQueryRunnerFor } from '../../utils/utils';
 import { useLayoutCategory } from '../layouts-shared/DashboardLayoutSelector';
 import { generateUniqueTitle, useEditPaneInputAutoFocus } from '../layouts-shared/utils';
 
-import { RowItem } from './RowItem';
+import type { RowItem } from './RowItem';
 
 export function useEditOptions(this: RowItem, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
   const model = this;

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -16,7 +16,7 @@ import { useSoloPanelContext } from '../SoloPanelContext';
 import { DASHBOARD_DROP_TARGET_KEY_ATTR } from '../types/DashboardDropTarget';
 import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 
-import { RowItem } from './RowItem';
+import type { RowItem } from './RowItem';
 
 export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
   const {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItems.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItems.tsx
@@ -3,7 +3,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 
 import { EditableDashboardElementInfo, EditableDashboardElement } from '../types/EditableDashboardElement';
 
-import { RowItem } from './RowItem';
+import type { RowItem } from './RowItem';
 import { getEditOptions } from './RowItemsEditor';
 
 export class RowItems implements EditableDashboardElement {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemsEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemsEditor.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
-import { RowItems } from './RowItems';
+import type { RowItems } from './RowItems';
 
 export function getEditOptions(model: RowItems): OptionsPaneCategoryDescriptor[] {
   const categoryId = 'rows-options';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManagerRenderer.tsx
@@ -17,7 +17,7 @@ import { DASHBOARD_DROP_TARGET_KEY_ATTR } from '../types/DashboardDropTarget';
 
 import { RowItem } from './RowItem';
 import { RowItemRepeater } from './RowItemRepeater';
-import { RowsLayoutManager } from './RowsLayoutManager';
+import type { RowsLayoutManager } from './RowsLayoutManager';
 
 export function RowLayoutManagerRenderer({ model }: SceneComponentProps<RowsLayoutManager>) {
   const { rows, key } = model.useState();

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
@@ -15,7 +15,7 @@ import { getQueryRunnerFor } from '../../utils/utils';
 import { useLayoutCategory } from '../layouts-shared/DashboardLayoutSelector';
 import { generateUniqueTitle, useEditPaneInputAutoFocus } from '../layouts-shared/utils';
 
-import { TabItem } from './TabItem';
+import type { TabItem } from './TabItem';
 
 export function useEditOptions(this: TabItem, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
   const model = this;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItems.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItems.tsx
@@ -3,7 +3,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../types/EditableDashboardElement';
 
-import { TabItem } from './TabItem';
+import type { TabItem } from './TabItem';
 
 export class TabItems implements EditableDashboardElement {
   public readonly isEditableDashboardElement = true;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -18,7 +18,7 @@ import { DASHBOARD_DROP_TARGET_KEY_ATTR } from '../types/DashboardDropTarget';
 import { TabItem } from './TabItem';
 import { TabItemLayoutRenderer } from './TabItemRenderer';
 import { TabItemRepeater } from './TabItemRepeater';
-import { TabsLayoutManager } from './TabsLayoutManager';
+import type { TabsLayoutManager } from './TabsLayoutManager';
 
 export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLayoutManager>) {
   const styles = useStyles2(getStyles);

--- a/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
+++ b/public/app/features/dashboard-scene/scene/types/LayoutRegistryItem.ts
@@ -1,6 +1,6 @@
 import { IconName, RegistryItem } from '@grafana/data';
 
-import { DashboardLayoutManager } from './DashboardLayoutManager';
+import type { DashboardLayoutManager } from './DashboardLayoutManager';
 
 /**
  * The layout descriptor used when selecting / switching layouts

--- a/public/app/features/dashboard-scene/settings/EditListViewSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/settings/EditListViewSceneUrlSync.ts
@@ -1,8 +1,8 @@
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '@grafana/scenes';
 
-import { AnnotationsEditView, AnnotationsEditViewState } from './AnnotationsEditView';
-import { DashboardLinksEditView, DashboardLinksEditViewState } from './DashboardLinksEditView';
-import { VariablesEditView, VariablesEditViewState } from './VariablesEditView';
+import type { AnnotationsEditView, AnnotationsEditViewState } from './AnnotationsEditView';
+import type { DashboardLinksEditView, DashboardLinksEditViewState } from './DashboardLinksEditView';
+import type { VariablesEditView, VariablesEditViewState } from './VariablesEditView';
 
 type EditListViewUrlSync = DashboardLinksEditView | VariablesEditView | AnnotationsEditView;
 type EditListViewState = DashboardLinksEditViewState | VariablesEditViewState | AnnotationsEditViewState;

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationBasicOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationBasicOptions.tsx
@@ -11,7 +11,7 @@ import { useEditPaneInputAutoFocus } from '../../scene/layouts-shared/utils';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../../utils/utils';
 
-import { AnnotationLayer } from './AnnotationEditableElement';
+import type { AnnotationLayer } from './AnnotationEditableElement';
 import { annotationEditActions } from './actions';
 
 export function AnnotationNameInput({ layer, autoFocus }: { layer: AnnotationLayer; autoFocus: boolean }) {

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -13,7 +13,7 @@ import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryL
 
 import { dashboardEditActions } from '../../edit-pane/shared';
 
-import { AnnotationLayer } from './AnnotationEditableElement';
+import type { AnnotationLayer } from './AnnotationEditableElement';
 
 export function AnnotationQueryEditorButton({ layer }: { layer: AnnotationLayer }) {
   const { queryLibraryEnabled } = useQueryLibraryContext();

--- a/public/app/features/dashboard-scene/settings/links/LinkBasicOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkBasicOptions.tsx
@@ -8,7 +8,7 @@ import { Field, Input, Select, Switch, TagsInput } from '@grafana/ui';
 import { DashboardScene } from '../../scene/DashboardScene';
 import { useEditPaneInputAutoFocus } from '../../scene/layouts-shared/utils';
 
-import { LinkEdit } from './LinkAddEditableElement';
+import type { LinkEdit } from './LinkAddEditableElement';
 import { linkEditActions } from './actions';
 import { LINK_ICON_MAP } from './utils';
 

--- a/public/app/features/explore/ContentOutline/ContentOutlineContext.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutlineContext.tsx
@@ -2,7 +2,7 @@ import { uniqueId } from 'lodash';
 import { useState, useContext, createContext, ReactNode, useCallback, useRef, useEffect } from 'react';
 import { SetOptional } from 'type-fest';
 
-import { ContentOutlineItemBaseProps, ITEM_TYPES } from './ContentOutlineItem';
+import type { ContentOutlineItemBaseProps, ITEM_TYPES } from './ContentOutlineItem';
 
 export interface ContentOutlineItemContextProps extends ContentOutlineItemBaseProps {
   id: string;

--- a/public/app/features/explore/TraceView/components/model/ddg/PathElem.tsx
+++ b/public/app/features/explore/TraceView/components/model/ddg/PathElem.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TDdgOperation, TDdgPath } from './types';
+import type { TDdgOperation, TDdgPath } from './types';
 
 export default class PathElem {
   memberIdx: number;

--- a/public/app/features/explore/TraceView/components/utils/DraggableManager/DraggableManager.tsx
+++ b/public/app/features/explore/TraceView/components/utils/DraggableManager/DraggableManager.tsx
@@ -17,7 +17,7 @@ import { get as _get } from 'lodash';
 import TNil from '../../types/TNil';
 
 import EUpdateTypes from './EUpdateTypes';
-import { DraggableBounds, DraggingUpdate } from './types';
+import type { DraggableBounds, DraggingUpdate } from './types';
 
 const LEFT_MOUSE_BUTTON = 0;
 


### PR DESCRIPTION
## Summary
- Converts 38 type-only `import` statements to `import type` across dashboard-scene, alerting, explore, and TraceView modules
- Reduces circular dependency count from 1062 to 1024 (38 cycles broken)
- Zero runtime behavior changes — only import syntax modifications

## Areas touched
- `dashboard-scene/` — conditional rendering, edit pane, panel edit, saving, scene renderers, layouts (auto-grid, default, rows, tabs), settings, serialization
- `alerting/unified/` — import-to-gma, silences, rule-list filter
- `explore/` — ContentOutline, TraceView (ddg, DraggableManager)

## Verification
- [x] `yarn typecheck` passes
- [x] `yarn madge --circular` confirms cycles reduced (1062 → 1024)
- [x] ESLint passes

Part of the circular dependency cleanup tracked in the TODO list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)