### PR TITLE
Command Palette: Show provisioned badge in search results

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -11,6 +11,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { EmptyState, Icon, LoadingBar, useStyles2 } from '@grafana/ui';
+import { ManagerKind } from 'app/features/apiserver/types';
 
 import { KBarResults } from './KBarResults';
 import { KBarSearch } from './KBarSearch';
@@ -165,6 +166,16 @@ const RenderResults = ({ isFetchingSearchResults, searchResults, searchQuery }: 
     [searchResults]
   );
 
+  const managedByMap = useMemo(() => {
+    const map = new Map<string, ManagerKind>();
+    for (const item of searchResults) {
+      if (item.managedBy) {
+        map.set(item.id, item.managedBy);
+      }
+    }
+    return map;
+  }, [searchResults]);
+
   const items = useMemo(() => {
     const results = [...kbarResults];
     if (folderResultItems.length > 0) {
@@ -205,7 +216,12 @@ const RenderResults = ({ isFetchingSearchResults, searchResults, searchQuery }: 
           typeof item === 'string' ? (
             <div className={cx(styles.sectionHeader, isFirst && styles.sectionHeaderFirst)}>{item}</div>
           ) : (
-            <ResultItem action={item} active={active} currentRootActionId={rootActionId!} />
+            <ResultItem
+              action={item}
+              active={active}
+              currentRootActionId={rootActionId!}
+              managedBy={managedByMap.get(item.id)}
+            />
           );
 
         return renderedItem;

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -3,7 +3,9 @@ import { ActionId, ActionImpl } from 'kbar';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { t } from '@grafana/i18n';
+import { Badge, useStyles2 } from '@grafana/ui';
+import { ManagerKind } from 'app/features/apiserver/types';
 
 export const ResultItem = React.forwardRef(
   (
@@ -11,10 +13,12 @@ export const ResultItem = React.forwardRef(
       action,
       active,
       currentRootActionId,
+      managedBy,
     }: {
       action: ActionImpl;
       active: boolean;
       currentRootActionId: ActionId;
+      managedBy?: ManagerKind;
     },
     ref: React.Ref<HTMLDivElement>
   ) => {
@@ -61,6 +65,7 @@ export const ResultItem = React.forwardRef(
             ))}
             <span>{name}</span>
           </div>
+          {managedBy && <ProvisionedBadge managedBy={managedBy} />}
           {action.subtitle && <span className={styles.subtitleText}>{action.subtitle}</span>}
         </div>
       </div>
@@ -69,6 +74,28 @@ export const ResultItem = React.forwardRef(
 );
 
 ResultItem.displayName = 'ResultItem';
+
+function ProvisionedBadge({ managedBy }: { managedBy: ManagerKind }) {
+  let text: string;
+  switch (managedBy) {
+    case ManagerKind.Terraform:
+      text = t('command-palette.provisioned-badge.terraform', 'Terraform');
+      break;
+    case ManagerKind.Kubectl:
+      text = t('command-palette.provisioned-badge.kubectl', 'Kubectl');
+      break;
+    case ManagerKind.Plugin:
+      text = t('command-palette.provisioned-badge.plugin', 'Plugin');
+      break;
+    case ManagerKind.Repo:
+      text = t('command-palette.provisioned-badge.repo', 'Provisioned');
+      break;
+    default:
+      text = t('command-palette.provisioned-badge.default', 'Provisioned');
+  }
+
+  return <Badge text={text} color="purple" icon="exchange-alt" />;
+}
 
 const getResultItemStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/commandPalette/actions/dashboardActions.test.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.test.ts
@@ -166,6 +166,44 @@ describe('dashboardActions', () => {
           },
         ]);
       });
+
+      it('includes managedBy when the search result has a managed-by field', async () => {
+        const managedSearchData: DataFrame = {
+          fields: [
+            { name: 'kind', type: FieldType.string, config: {}, values: ['dashboard'] },
+            { name: 'name', type: FieldType.string, config: {}, values: ['Provisioned dashboard'] },
+            { name: 'uid', type: FieldType.string, config: {}, values: ['prov-dash-1'] },
+            { name: 'url', type: FieldType.string, config: {}, values: ['/prov-dash-1'] },
+            { name: 'tags', type: FieldType.other, config: {}, values: [[]] },
+            { name: 'location', type: FieldType.string, config: {}, values: ['my-folder-1'] },
+            { name: 'managedBy', type: FieldType.string, config: {}, values: ['repo'] },
+          ],
+          meta: {
+            custom: {
+              locationInfo: {
+                'my-folder-1': { name: 'My folder 1', kind: 'folder', url: '/my-folder-1' },
+              },
+            },
+          },
+          length: 1,
+        };
+        const managedResult: QueryResponse = {
+          isItemLoaded: jest.fn(),
+          loadMoreItems: jest.fn(),
+          totalRows: 1,
+          view: new DataFrameView<DashboardQueryResult>(managedSearchData),
+        };
+        grafanaSearcherSpy.mockResolvedValueOnce(managedResult);
+
+        const results = await getSearchResultActions('provisioned');
+        expect(results).toEqual([
+          expect.objectContaining({
+            id: 'go/dashboard/prov-dash-1',
+            name: 'Provisioned dashboard',
+            managedBy: 'repo',
+          }),
+        ]);
+      });
     });
   });
 

--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -6,6 +6,7 @@ import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getRecentlyViewedDashboards } from 'app/features/browse-dashboards/api/recentlyViewed';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+import { extractManagerKind } from 'app/features/search/service/utils';
 
 import { CommandPaletteAction } from '../types';
 import { RECENT_DASHBOARDS_PRIORITY, SEARCH_RESULTS_PRIORITY } from '../values';
@@ -49,7 +50,7 @@ export async function getSearchResultActions(searchQuery: string): Promise<Comma
   });
 
   const goToSearchResultActions: CommandPaletteAction[] = data.view.map((item) => {
-    const { url, name, kind, location } = item; // items are backed by DataFrameView, so must hold the url in a closure
+    const { url, name, kind, location, managedBy } = item;
     return {
       id: `go/${kind}${url}`,
       name: `${name}`,
@@ -60,6 +61,7 @@ export async function getSearchResultActions(searchQuery: string): Promise<Comma
       priority: SEARCH_RESULTS_PRIORITY,
       url,
       subtitle: data.view.dataFrame.meta?.custom?.locationInfo[location]?.name,
+      managedBy: extractManagerKind(managedBy),
     };
   });
 

--- a/public/app/features/commandPalette/types.ts
+++ b/public/app/features/commandPalette/types.ts
@@ -1,5 +1,7 @@
 import { Action } from 'kbar';
 
+import { ManagerKind } from 'app/features/apiserver/types';
+
 type NotNullable<T> = Exclude<T, null | undefined>;
 
 // Create our own action type to make priority mandatory.
@@ -8,16 +10,18 @@ export type CommandPaletteAction = RootCommandPaletteAction | ChildCommandPalett
 
 export type URLCallback = (searchQuery: string) => string;
 
+type SharedActionFields = {
+  target?: React.HTMLAttributeAnchorTarget;
+  url?: string | URLCallback;
+  managedBy?: ManagerKind;
+};
+
 type RootCommandPaletteAction = Omit<Action, 'parent'> & {
   section: NotNullable<Action['section']>;
   priority: NotNullable<Action['priority']>;
-  target?: React.HTMLAttributeAnchorTarget;
-  url?: string | URLCallback;
-};
+} & SharedActionFields;
 
 type ChildCommandPaletteAction = Action & {
   parent: NotNullable<Action['parent']>;
   priority: NotNullable<Action['priority']>;
-  target?: React.HTMLAttributeAnchorTarget;
-  url?: string | URLCallback;
-};
+} & SharedActionFields;


### PR DESCRIPTION
## Summary
- Surfaces the `managedBy` field from unified search results in the command palette (Cmd+K), so users can see which dashboards and folders are provisioned directly from search.
- Adds a purple `Badge` with the `exchange-alt` icon next to provisioned results, following the same visual pattern used by `ManagedDashboardNavBarBadge`.
- Differentiates manager types: shows "Provisioned" for repo-managed, "Terraform"/"Kubectl"/"Plugin" for other manager kinds.

## Implementation
- **`types.ts`** — Added `managedBy?: ManagerKind` to `CommandPaletteAction` via shared field type.
- **`dashboardActions.ts`** — Extracts `managedBy` from search results using the existing `extractManagerKind` utility.
- **`CommandPalette.tsx`** — Builds a `managedByMap` from search results and passes it to `ResultItem`.
- **`ResultItem.tsx`** — Accepts optional `managedBy` prop; renders a `ProvisionedBadge` component when set.
- **`dashboardActions.test.ts`** — Added test verifying `managedBy` flows through when present in search results.

## Caveats
- The legacy SQL search path does **not** include `managedBy` in its DataFrame — only the unified search path does. The badge gracefully does not appear in that case.
- i18n extraction (`make i18n-extract`) needs to be run to generate translation entries for the new badge strings.

## Test plan
- [ ] Open the command palette and search for a known provisioned dashboard — verify the purple "Provisioned" badge appears
- [ ] Search for a non-provisioned dashboard — verify no badge appears
- [ ] Verify the badge text matches the manager type (Terraform, Kubectl, Plugin, Provisioned)
- [ ] Run `yarn jest public/app/features/commandPalette/actions/dashboardActions.test.ts` — all tests pass
- [ ] Verify the badge doesn't break layout with long dashboard names


Made with [Cursor](https://cursor.com)