### PR TITLE
PanelChrome: exclude table column headers from triggering panel selection in edit mode

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -247,7 +247,9 @@ it('does not select the panel when clicking interactive content', async () => {
             <canvas />
             <svg />
             <div className="u-over" />
+            <div className="u-axis" />
             <div role="button" />
+            <div role="columnheader">Column header</div>
             <div>Non-interactive</div>
           </div>
         )}
@@ -274,6 +276,12 @@ it('does not select the panel when clicking interactive content', async () => {
   expect(onSelect).not.toHaveBeenCalled();
 
   await user.pointer({ keys: '[MouseLeft>]', target: document.querySelector('div[role="button"]')! });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: document.querySelector('.u-axis')! });
+  expect(onSelect).not.toHaveBeenCalled();
+
+  await user.pointer({ keys: '[MouseLeft>]', target: screen.getByRole('columnheader', { name: 'Column header' }) });
   expect(onSelect).not.toHaveBeenCalled();
 
   await user.pointer({ keys: '[MouseLeft>]', target: screen.getByText('Non-interactive') });

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -244,9 +244,11 @@ export function PanelChrome({
     (evt: React.PointerEvent) => {
       // Ignore clicks inside buttons, links, canvas and svg elments
       // This does prevent a clicks inside a graphs from selecting panel as there is normal div above the canvas element that intercepts the click
+      // '[role="columnheader"]' targets table column headers (e.g. react-data-grid), preventing sort clicks
+      // and column resize drags from selecting the panel in edit mode.
       if (
         evt.target instanceof Element &&
-        (evt.target.closest('button,a,canvas,svg,[role="button"],#grafana-portal-container') ||
+        (evt.target.closest('button,a,canvas,svg,[role="button"],#grafana-portal-container,[role="columnheader"]') ||
           evt.target.classList.contains('u-over'))
       ) {
         // Stop propagation otherwise row config editor will get selected

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -246,10 +246,12 @@ export function PanelChrome({
       // This does prevent a clicks inside a graphs from selecting panel as there is normal div above the canvas element that intercepts the click
       // '[role="columnheader"]' targets table column headers (e.g. react-data-grid), preventing sort clicks
       // and column resize drags from selecting the panel in edit mode.
+      // '.u-axis' targets uPlot axis elements, preventing axis interactions from selecting the panel.
       if (
         evt.target instanceof Element &&
         (evt.target.closest('button,a,canvas,svg,[role="button"],#grafana-portal-container,[role="columnheader"]') ||
-          evt.target.classList.contains('u-over'))
+          evt.target.classList.contains('u-over') ||
+          evt.target.classList.contains('u-axis'))
       ) {
         // Stop propagation otherwise row config editor will get selected
         evt.stopPropagation();


### PR DESCRIPTION
Clicking on a table column header (to sort) or dragging the resize handle would unintentionally select the panel in the dashboard edit pane. Adding `[role="columnheader"]` to the existing pointer-down exclusion list fixes both cases, consistent with how canvas/svg elements are already excluded for graph panels.

Fixes https://github.com/grafana/grafana/issues/120077