### PR TITLE
Dashboards: Extract PanelDataPane factory to break circular dependency

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -19,11 +19,6 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { getRulesPermissions } from 'app/features/alerting/unified/utils/access-control';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 
-import { PanelDataPaneNext } from '../PanelEditNext/PanelDataPaneNext';
-
-import { PanelDataAlertingTab } from './PanelDataAlertingTab';
-import { PanelDataQueriesTab } from './PanelDataQueriesTab';
-import { PanelDataTransformationsTab } from './PanelDataTransformationsTab';
 import { PanelDataPaneTab, PanelEditorInterface, TabId } from './types';
 
 function isPanelEditor(obj: object): obj is PanelEditorInterface {
@@ -45,36 +40,6 @@ export interface PanelDataPaneState extends SceneObjectState {
 export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
   static Component = PanelDataPaneRendered;
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['tab'] });
-
-  /**
-   * Create a data pane for the given panel.
-   * @param panel The VizPanel to create the data pane for
-   * @param useQueryEditorNext Signals whether to use the query editor v2 experience or the original (v1) experience.
-   */
-  public static createFor(panel: VizPanel, useQueryEditorNext: boolean | undefined) {
-    const panelRef = panel.getRef();
-
-    // Query experience v2
-    if (useQueryEditorNext) {
-      return new PanelDataPaneNext({ panelRef });
-    }
-
-    // Original experience
-    const tabs: PanelDataPaneTab[] = [
-      new PanelDataQueriesTab({ panelRef }),
-      new PanelDataTransformationsTab({ panelRef }),
-    ];
-
-    if (shouldShowAlertingTab(panel.state.pluginId)) {
-      tabs.push(new PanelDataAlertingTab({ panelRef }));
-    }
-
-    return new PanelDataPane({
-      panelRef,
-      tabs,
-      tab: TabId.Queries,
-    });
-  }
 
   public onChangeTab = (tab: PanelDataPaneTab) => {
     this.setState({ tab: tab.tabId });

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPaneFactory.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPaneFactory.ts
@@ -1,0 +1,39 @@
+import { VizPanel } from '@grafana/scenes';
+
+import { PanelDataPaneNext } from '../PanelEditNext/PanelDataPaneNext';
+
+import { PanelDataAlertingTab } from './PanelDataAlertingTab';
+import { PanelDataPane, shouldShowAlertingTab } from './PanelDataPane';
+import { PanelDataQueriesTab } from './PanelDataQueriesTab';
+import { PanelDataTransformationsTab } from './PanelDataTransformationsTab';
+import { PanelDataPaneTab, TabId } from './types';
+
+/**
+ * Create a data pane for the given panel.
+ * @param panel The VizPanel to create the data pane for
+ * @param useQueryEditorNext Signals whether to use the query editor v2 experience or the original (v1) experience.
+ */
+export function createPanelDataPane(panel: VizPanel, useQueryEditorNext: boolean | undefined) {
+  const panelRef = panel.getRef();
+
+  // Query experience v2
+  if (useQueryEditorNext) {
+    return new PanelDataPaneNext({ panelRef });
+  }
+
+  // Original experience
+  const tabs: PanelDataPaneTab[] = [
+    new PanelDataQueriesTab({ panelRef }),
+    new PanelDataTransformationsTab({ panelRef }),
+  ];
+
+  if (shouldShowAlertingTab(panel.state.pluginId)) {
+    tabs.push(new PanelDataAlertingTab({ panelRef }));
+  }
+
+  return new PanelDataPane({
+    panelRef,
+    tabs,
+    tab: TabId.Queries,
+  });
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -40,6 +40,7 @@ import {
 
 import { DataProviderSharer } from './PanelDataPane/DataProviderSharer';
 import { PanelDataPane } from './PanelDataPane/PanelDataPane';
+import { createPanelDataPane } from './PanelDataPane/PanelDataPaneFactory';
 import { PanelDataPaneNext } from './PanelEditNext/PanelDataPaneNext';
 import { PanelEditorRendererNext } from './PanelEditNext/PanelEditorRendererNext';
 import { QUERY_EDITOR_V2_PREFERENCE_KEY } from './PanelEditNext/constants';
@@ -274,7 +275,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
 
     if (!skipDataQuery) {
       if (!this.state.dataPane) {
-        const dataPane = PanelDataPane.createFor(this.getPanel(), this.state.useQueryExperienceNext);
+        const dataPane = createPanelDataPane(this.getPanel(), this.state.useQueryExperienceNext);
         this.setState({ dataPane });
         this.publishEvent(new NewSceneObjectAddedEvent(dataPane), true);
       }
@@ -405,7 +406,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   public onToggleQueryEditorVersion = () => {
     const newUseQueryExperienceNext = !this.state.useQueryExperienceNext;
     trackEditorVersionToggle(newUseQueryExperienceNext ? 'upgrade' : 'downgrade');
-    const dataPane = PanelDataPane.createFor(this.getPanel(), newUseQueryExperienceNext);
+    const dataPane = createPanelDataPane(this.getPanel(), newUseQueryExperienceNext);
 
     setLocalStorageWithTTL(QUERY_EDITOR_V2_PREFERENCE_KEY, newUseQueryExperienceNext);
 


### PR DESCRIPTION
**What is this feature?**

Extracts the `createFor` static method from `PanelDataPane` into a standalone `createPanelDataPane` factory function in a new `PanelDataPaneFactory.ts` file.

**Why do we need this feature?**

`PanelDataPane.tsx` and `PanelDataTransformationsTab.tsx` have a circular dependency. `PanelDataPane` imports `PanelDataTransformationsTab` (to construct it in `createFor`), while `PanelDataTransformationsTab` imports `PanelDataPane` (for `instanceof` check in `onGoToQueries`). By moving the factory to its own file, `PanelDataPane` no longer imports any tab implementations, breaking the cycle.

**Who is this feature for?**

Developers working on the dashboard panel editor.

**Which issue(s) does this PR fix?**:

N/A — internal refactor to fix circular dependency.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.