### PR TITLE
Prometheus: Fetch metric metadata on code editor mount

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -14,7 +14,7 @@ const dataProviderSettings = {
     queryLabelKeys: jest.fn(),
     queryLabelValues: jest.fn(),
     retrieveLabelKeys: jest.fn(),
-    retrieveMetricsMetadata: jest.fn(),
+    retrieveMetricsMetadata: jest.fn().mockReturnValue({}),
   },
   historyProvider: history.map((expr, idx) => ({ query: { expr, refId: 'some-ref' }, ts: idx })),
 } as unknown as DataProviderParams;

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -13,6 +13,7 @@ const dataProviderSettings = {
   languageProvider: {
     queryLabelKeys: jest.fn(),
     queryLabelValues: jest.fn(),
+    queryMetricsMetadata: jest.fn().mockResolvedValue({}),
     retrieveLabelKeys: jest.fn(),
     retrieveMetricsMetadata: jest.fn().mockReturnValue({}),
   },

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
@@ -12,7 +12,7 @@ const createLanguageProviderMock = (existingMetadata: Record<string, unknown> = 
 
 const createDataProvider = (languageProvider: Partial<PrometheusLanguageProvider>) => {
   return new DataProvider({ languageProvider } as DataProviderParams);
-}
+};
 
 describe('DataProvider', () => {
   describe('metadata fetching', () => {
@@ -23,7 +23,9 @@ describe('DataProvider', () => {
     });
 
     it('does not call queryMetricsMetadata when metadata is already cached', () => {
-      const languageProvider = createLanguageProviderMock({ http_requests_total: { type: 'counter', help: 'Total HTTP requests' } });
+      const languageProvider = createLanguageProviderMock({
+        http_requests_total: { type: 'counter', help: 'Total HTTP requests' },
+      });
       createDataProvider(languageProvider);
       expect(languageProvider.queryMetricsMetadata).not.toHaveBeenCalled();
     });

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
@@ -1,0 +1,31 @@
+import { PrometheusLanguageProvider } from '../../../language_provider';
+
+import { DataProvider, type DataProviderParams } from './data_provider';
+
+const createLanguageProviderMock = (existingMetadata: Record<string, unknown> = {}) => ({
+  queryLabelKeys: jest.fn(),
+  queryLabelValues: jest.fn(),
+  queryMetricsMetadata: jest.fn().mockResolvedValue({}),
+  retrieveMetrics: jest.fn().mockReturnValue([]),
+  retrieveMetricsMetadata: jest.fn().mockReturnValue(existingMetadata),
+});
+
+const createDataProvider = (languageProvider: Partial<PrometheusLanguageProvider>) => {
+  return new DataProvider({ languageProvider } as DataProviderParams);
+}
+
+describe('DataProvider', () => {
+  describe('metadata fetching', () => {
+    it('calls queryMetricsMetadata when no metadata is cached', () => {
+      const languageProvider = createLanguageProviderMock({});
+      createDataProvider(languageProvider);
+      expect(languageProvider.queryMetricsMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call queryMetricsMetadata when metadata is already cached', () => {
+      const languageProvider = createLanguageProviderMock({ http_requests_total: { type: 'counter', help: 'Total HTTP requests' } });
+      createDataProvider(languageProvider);
+      expect(languageProvider.queryMetricsMetadata).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.test.ts
@@ -1,4 +1,4 @@
-import { PrometheusLanguageProvider } from '../../../language_provider';
+import type { PrometheusLanguageProvider } from '../../../language_provider';
 
 import { DataProvider, type DataProviderParams } from './data_provider';
 

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -57,6 +57,13 @@ export class DataProvider {
 
     this.queryLabelKeys = this.languageProvider.queryLabelKeys.bind(this.languageProvider);
     this.queryLabelValues = this.languageProvider.queryLabelValues.bind(this.languageProvider);
+
+    // Ensure metadata is loaded for completions. The builder mode triggers this via its own
+    // components, but the code editor does not, so we need to fetch it here if not already cached.
+    const existingMetadata = this.languageProvider.retrieveMetricsMetadata();
+    if (Object.keys(existingMetadata).length === 0) {
+      this.languageProvider.queryMetricsMetadata();
+    }
   }
 
   /**


### PR DESCRIPTION
When opening the Prometheus query editor directly in code mode, metric metadata was missing from Monaco autocomplete suggestions. This happened because metadata is only fetched from the builder mode but the code editor had no equivalent. This change fetches the metadata when we render the code editor.

**Before (top) / After (bottom):**
> see in the before video, the metadata is only fetched, **after** you open the builder mode.

https://github.com/user-attachments/assets/ada41957-2536-426e-bca1-81c2b876cd26

https://github.com/user-attachments/assets/10cf1e5d-a382-45d4-886a-016a9e078201

Fixes: https://github.com/grafana/grafana/issues/116175