### PR TITLE
Expressions: Add memory limit for math expression binary operations

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2180,6 +2180,12 @@ default_timezone = browser
 # Enable or disable the expressions functionality.
 enabled = true
 
+# Maximum estimated memory (in bytes) that a single math expression binary
+# operation is allowed to allocate. Protects against cartesian explosions when
+# label sets on both sides of a binary operation are incompatible. Set to 0 to
+# disable the limit. Default: 1073741824 (1 GiB).
+math_expression_memory_limit = 1073741824
+
 [geomap]
 # Set the JSON configuration for the default basemap
 default_baselayer_config =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -2081,6 +2081,12 @@ default_datasource_uid =
 # Enable or disable the expressions functionality.
 ;enabled = true
 
+# Maximum estimated memory (in bytes) that a single math expression binary
+# operation is allowed to allocate. Protects against cartesian explosions when
+# label sets on both sides of a binary operation are incompatible. Set to 0 to
+# disable the limit. Default: 1073741824 (1 GiB).
+;math_expression_memory_limit = 1073741824
+
 [geomap]
 # Set the JSON configuration for the default basemap
 ;default_baselayer_config = `{

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/expr/metrics"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // Command is an interface for all expression commands.
@@ -29,11 +30,12 @@ type MathCommand struct {
 	RawExpression string
 	Expression    *mathexp.Expr
 	refID         string
+	memoryLimit   int64 // maximum estimated output bytes for a binary operation; 0 disables
 }
 
 // NewMathCommand creates a new MathCommand. It will return an error
 // if there is an error parsing expr.
-func NewMathCommand(refID, expr string) (*MathCommand, error) {
+func NewMathCommand(refID, expr string, memoryLimit int64) (*MathCommand, error) {
 	parsedExpr, err := mathexp.New(expr)
 	if err != nil {
 		return nil, err
@@ -42,11 +44,12 @@ func NewMathCommand(refID, expr string) (*MathCommand, error) {
 		RawExpression: expr,
 		Expression:    parsedExpr,
 		refID:         refID,
+		memoryLimit:   memoryLimit,
 	}, nil
 }
 
 // UnmarshalMathCommand creates a MathCommand from Grafana's frontend query.
-func UnmarshalMathCommand(rn *rawNode) (*MathCommand, error) {
+func UnmarshalMathCommand(rn *rawNode, cfg *setting.Cfg) (*MathCommand, error) {
 	rawExpr, ok := rn.Query["expression"]
 	if !ok {
 		return nil, errors.New("command is missing an expression")
@@ -56,7 +59,7 @@ func UnmarshalMathCommand(rn *rawNode) (*MathCommand, error) {
 		return nil, fmt.Errorf("math expression is expected to be a string, got %T", rawExpr)
 	}
 
-	gm, err := NewMathCommand(rn.RefID, exprString)
+	gm, err := NewMathCommand(rn.RefID, exprString, cfg.MathExpressionMemoryLimit)
 	if err != nil {
 		return nil, fmt.Errorf("invalid math command: %w", err)
 	}
@@ -75,7 +78,7 @@ func (gm *MathCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Va
 	_, span := tracer.Start(ctx, "SSE.ExecuteMath")
 	span.SetAttributes(attribute.String("expression", gm.RawExpression))
 	defer span.End()
-	return gm.Expression.Execute(gm.refID, vars, tracer)
+	return gm.Expression.Execute(gm.refID, vars, tracer, mathexp.WithMemoryLimit(gm.memoryLimit))
 }
 
 func (gm *MathCommand) Type() string {

--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -30,6 +30,11 @@ type State struct {
 	Drops     map[string]map[string][]data.Labels // binary node text -> LH/RH -> Drop Labels
 	DropCount int64
 
+	// MemoryLimit is the maximum estimated output size (in bytes) for a single
+	// binary operation. If the estimated allocation exceeds this, walkBinary
+	// returns an error instead of proceeding. A value of 0 disables the limit.
+	MemoryLimit int64
+
 	tracer tracing.Tracer
 }
 
@@ -49,14 +54,30 @@ func New(expr string, funcs ...map[string]parse.Func) (*Expr, error) {
 	return e, nil
 }
 
+// ExecuteOption is a functional option for configuring expression execution.
+type ExecuteOption func(*State)
+
+// WithMemoryLimit sets the maximum estimated memory (in bytes) that a single
+// binary operation may allocate for its output. When the estimate exceeds
+// this limit, evaluation returns a descriptive error. A value of 0 disables
+// the limit.
+func WithMemoryLimit(limit int64) ExecuteOption {
+	return func(s *State) {
+		s.MemoryLimit = limit
+	}
+}
+
 // Execute applies a parse expression to the context and executes it
-func (e *Expr) Execute(refID string, vars Vars, tracer tracing.Tracer) (r Results, err error) {
+func (e *Expr) Execute(refID string, vars Vars, tracer tracing.Tracer, opts ...ExecuteOption) (r Results, err error) {
 	s := &State{
 		Expr:  e,
 		Vars:  vars,
 		RefID: refID,
 
 		tracer: tracer,
+	}
+	for _, opt := range opts {
+		opt(s)
 	}
 	return e.executeState(s)
 }
@@ -306,6 +327,150 @@ func (e *State) union(aResults, bResults Results, biNode *parse.BinaryNode) []*U
 	return unions
 }
 
+const (
+	// bytesPerDatapoint is the estimated heap cost per datapoint in the output
+	// series: 24 bytes for time.Time (wall, ext, loc) + 16 bytes for *float64
+	// (pointer + value).
+	bytesPerDatapoint = 40
+
+	// bytesPerBPoint is the estimated heap cost per entry in the bPoints map
+	// used by biSeriesSeries: ~30 bytes for the time string key + 8 bytes for
+	// *float64 + ~50 bytes for map bucket overhead.
+	bytesPerBPoint = 88
+
+	// frameOverhead is the estimated fixed cost per output Value for the
+	// data.Frame, data.Field structs, and metadata.
+	frameOverhead = 500
+)
+
+// labelBytes returns the total byte size of all keys and values in a label set.
+func labelBytes(labels data.Labels) int {
+	n := 0
+	for k, v := range labels {
+		n += len(k) + len(v)
+	}
+	return n
+}
+
+// resultStats holds the pre-computed statistics for one side of a binary operation
+// used for memory estimation.
+type resultStats struct {
+	count         int // total number of Values
+	seriesCount   int // number of Values that are Series
+	maxDatapoints int // longest series length
+	maxLabelBytes int // largest label set in bytes
+}
+
+// computeResultStats computes stats for a Results set in O(n) with zero heap allocation.
+func computeResultStats(r Results) resultStats {
+	var s resultStats
+	s.count = len(r.Values)
+	for _, v := range r.Values {
+		if series, ok := v.(Series); ok {
+			s.seriesCount++
+			if l := series.Len(); l > s.maxDatapoints {
+				s.maxDatapoints = l
+			}
+		}
+		if lb := labelBytes(v.GetLabels()); lb > s.maxLabelBytes {
+			s.maxLabelBytes = lb
+		}
+	}
+	return s
+}
+
+// estimateBinaryOutputBytes computes an upper-bound estimate of the memory that
+// walkBinary would allocate for its output, given the stats from both sides.
+//
+// The estimate is deliberately conservative (over-estimates) in several ways:
+//   - It assumes worst-case label matching: every A pairs with every B. In
+//     practice, union() filters by label compatibility, producing far fewer
+//     pairs when labels match. This means the estimate can be orders of
+//     magnitude higher than actual allocation for well-matched label sets.
+//   - It uses the max datapoints from either side for every union, even though
+//     biSeriesSeries only emits points at matching timestamps (an intersection).
+//   - It charges bPoints map cost for all unions whenever any Series exists on
+//     both sides, even if most unions are Number x Number.
+//
+// These over-estimates are acceptable because the limit is a safety mechanism
+// against cartesian explosions (where labels don't match). Operators who hit
+// false rejections on legitimate high-cardinality expressions can raise the
+// configured limit.
+func estimateBinaryOutputBytes(a, b resultStats) int64 {
+	if a.count == 0 || b.count == 0 {
+		return 0
+	}
+
+	worstCaseUnions := int64(a.count) * int64(b.count)
+
+	// Output cost per union depends on the types involved. We use the worst
+	// case: both sides are Series (the most expensive combination).
+	maxDatapoints := a.maxDatapoints
+	if b.maxDatapoints > maxDatapoints {
+		maxDatapoints = b.maxDatapoints
+	}
+
+	maxLabels := a.maxLabelBytes
+	if b.maxLabelBytes > maxLabels {
+		maxLabels = b.maxLabelBytes
+	}
+
+	// For Series x Series, we also pay for the bPoints map.
+	perUnion := int64(maxDatapoints)*bytesPerDatapoint +
+		int64(maxLabels) +
+		frameOverhead
+	if a.seriesCount > 0 && b.seriesCount > 0 {
+		perUnion += int64(maxDatapoints) * bytesPerBPoint
+	}
+
+	return worstCaseUnions * perUnion
+}
+
+// checkBinaryMemoryLimit estimates the output cost of a binary operation and
+// returns a descriptive error if it exceeds the configured memory limit.
+func (e *State) checkBinaryMemoryLimit(ar, br Results, node *parse.BinaryNode) error {
+	aStats := computeResultStats(ar)
+	bStats := computeResultStats(br)
+	estimated := estimateBinaryOutputBytes(aStats, bStats)
+
+	if estimated <= e.MemoryLimit {
+		return nil
+	}
+
+	aVar := node.Args[0].String()
+	bVar := node.Args[1].String()
+
+	return fmt.Errorf(
+		"expression %q attempted to combine %d series from %s with %d series from %s, "+
+			"producing up to %d series pairs (estimated memory: %s, limit: %s). "+
+			"This usually means the label sets returned by your queries are no longer compatible. "+
+			"When labels match, this expression would produce ~%d pairs. "+
+			"Check that the queries for %s and %s return series with the same label names and values",
+		node.String(),
+		aStats.count, aVar,
+		bStats.count, bVar,
+		int64(aStats.count)*int64(bStats.count),
+		formatBytes(estimated),
+		formatBytes(e.MemoryLimit),
+		max(aStats.count, bStats.count),
+		aVar, bVar,
+	)
+}
+
+// formatBytes returns a human-readable byte size string.
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KiB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
 func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 	res := Results{Values: Values{}}
 	ar, err := e.walk(node.Args[0])
@@ -316,6 +481,13 @@ func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 	if err != nil {
 		return res, err
 	}
+
+	if e.MemoryLimit > 0 {
+		if err := e.checkBinaryMemoryLimit(ar, br, node); err != nil {
+			return res, err
+		}
+	}
+
 	unions := e.union(ar, br, node)
 	for _, uni := range unions {
 		var value Value

--- a/pkg/expr/mathexp/exp_memory_limit_test.go
+++ b/pkg/expr/mathexp/exp_memory_limit_test.go
@@ -1,0 +1,309 @@
+package mathexp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeResultStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  Results
+		expected resultStats
+	}{
+		{
+			name:     "empty results",
+			results:  Results{},
+			expected: resultStats{},
+		},
+		{
+			name: "single number with labels",
+			results: Results{
+				Values: Values{
+					makeNumber("n", data.Labels{"service": "web", "region": "us-east-1"}, float64Pointer(42)),
+				},
+			},
+			expected: resultStats{
+				count:         1,
+				seriesCount:   0,
+				maxDatapoints: 0,
+				maxLabelBytes: len("service") + len("web") + len("region") + len("us-east-1"),
+			},
+		},
+		{
+			name: "two series with different lengths and labels",
+			results: Results{
+				Values: Values{
+					makeSeries("a", data.Labels{"id": "1"},
+						tp{time.Unix(1, 0), float64Pointer(1)},
+						tp{time.Unix(2, 0), float64Pointer(2)},
+					),
+					makeSeries("b", data.Labels{"id": "1", "env": "production"},
+						tp{time.Unix(1, 0), float64Pointer(3)},
+						tp{time.Unix(2, 0), float64Pointer(4)},
+						tp{time.Unix(3, 0), float64Pointer(5)},
+					),
+				},
+			},
+			expected: resultStats{
+				count:         2,
+				seriesCount:   2,
+				maxDatapoints: 3,
+				maxLabelBytes: len("id") + len("1") + len("env") + len("production"),
+			},
+		},
+		{
+			name: "mix of series and numbers",
+			results: Results{
+				Values: Values{
+					makeSeries("s", data.Labels{"x": "y"},
+						tp{time.Unix(1, 0), float64Pointer(1)},
+					),
+					makeNumber("n", data.Labels{"a": "longer-value"}, float64Pointer(10)),
+				},
+			},
+			expected: resultStats{
+				count:         2,
+				seriesCount:   1,
+				maxDatapoints: 1,
+				maxLabelBytes: len("a") + len("longer-value"),
+			},
+		},
+		{
+			name: "NoData values have zero labels and zero datapoints",
+			results: Results{
+				Values: Values{
+					NewNoData(),
+					makeSeries("s", data.Labels{"id": "1"},
+						tp{time.Unix(1, 0), float64Pointer(1)},
+					),
+				},
+			},
+			expected: resultStats{
+				count:         2,
+				seriesCount:   1,
+				maxDatapoints: 1,
+				maxLabelBytes: len("id") + len("1"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeResultStats(tc.results)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestEstimateBinaryOutputBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        resultStats
+		b        resultStats
+		expected int64
+	}{
+		{
+			name:     "empty A returns zero",
+			a:        resultStats{count: 0},
+			b:        resultStats{count: 10, seriesCount: 10, maxDatapoints: 100},
+			expected: 0,
+		},
+		{
+			name:     "empty B returns zero",
+			a:        resultStats{count: 10, seriesCount: 10, maxDatapoints: 100},
+			b:        resultStats{count: 0},
+			expected: 0,
+		},
+		{
+			name: "number x number uses only labels and overhead",
+			a:    resultStats{count: 5, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 100},
+			b:    resultStats{count: 5, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 200},
+			// 25 unions * (0 + 200 + 500) = 17,500
+			expected: 25 * (200 + frameOverhead),
+		},
+		{
+			name: "series x series includes bPoints cost",
+			a:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
+			b:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
+			// 100 unions * (300*bytesPerDatapoint + 200 + frameOverhead + 300*bytesPerBPoint)
+			expected: 100 * (300*bytesPerDatapoint + 200 + frameOverhead + 300*bytesPerBPoint),
+		},
+		{
+			name: "series x number omits bPoints cost",
+			a:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
+			b:    resultStats{count: 1, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 50},
+			// 10 unions * (300*bytesPerDatapoint + 200 + frameOverhead), no bPoints since b has no series
+			expected: 10 * (300*bytesPerDatapoint + 200 + frameOverhead),
+		},
+		{
+			name: "asymmetric series uses max datapoints from either side",
+			a:    resultStats{count: 2, seriesCount: 2, maxDatapoints: 100, maxLabelBytes: 50},
+			b:    resultStats{count: 3, seriesCount: 3, maxDatapoints: 500, maxLabelBytes: 50},
+			// 6 unions * (500*bytesPerDatapoint + 50 + frameOverhead + 500*bytesPerBPoint)
+			expected: 6 * (500*bytesPerDatapoint + 50 + frameOverhead + 500*bytesPerBPoint),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := estimateBinaryOutputBytes(tc.a, tc.b)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestWalkBinary_memory_limit_blocks_cartesian_explosion(t *testing.T) {
+	// Build two sets of 100 series each with non-matching labels.
+	// This creates a worst-case cartesian product of 10,000 unions.
+	aValues := make(Values, 100)
+	bValues := make(Values, 100)
+	for i := 0; i < 100; i++ {
+		aValues[i] = makeSeries("a", data.Labels{"a_id": string(rune('A'+i%26)) + string(rune('0'+i/26))},
+			tp{time.Unix(1, 0), float64Pointer(1)},
+			tp{time.Unix(2, 0), float64Pointer(2)},
+			tp{time.Unix(3, 0), float64Pointer(3)},
+		)
+		bValues[i] = makeSeries("b", data.Labels{"b_id": string(rune('A'+i%26)) + string(rune('0'+i/26))},
+			tp{time.Unix(1, 0), float64Pointer(10)},
+			tp{time.Unix(2, 0), float64Pointer(20)},
+			tp{time.Unix(3, 0), float64Pointer(30)},
+		)
+	}
+
+	vars := Vars{
+		"A": Results{Values: aValues},
+		"B": Results{Values: bValues},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// With a very small limit, the cartesian product should be rejected.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(1024))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "100 series from $A")
+	assert.Contains(t, err.Error(), "100 series from $B")
+	assert.Contains(t, err.Error(), "10000 series pairs")
+}
+
+func TestWalkBinary_memory_limit_allows_matched_labels(t *testing.T) {
+	// Build two sets of 100 series with matching labels.
+	// This produces exactly 100 unions (1:1), which should be well within limits.
+	aValues := make(Values, 100)
+	bValues := make(Values, 100)
+	for i := 0; i < 100; i++ {
+		label := data.Labels{"id": string(rune('A'+i%26)) + string(rune('0'+i/26))}
+		aValues[i] = makeSeries("a", label,
+			tp{time.Unix(1, 0), float64Pointer(float64(i))},
+			tp{time.Unix(2, 0), float64Pointer(float64(i * 2))},
+		)
+		bValues[i] = makeSeries("b", label,
+			tp{time.Unix(1, 0), float64Pointer(1)},
+			tp{time.Unix(2, 0), float64Pointer(2)},
+		)
+	}
+
+	vars := Vars{
+		"A": Results{Values: aValues},
+		"B": Results{Values: bValues},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// The estimate is worst-case (10,000 unions) but the actual matching
+	// produces only 100. Derive the limit from the estimation function
+	// so this test is resilient to constant changes.
+	aStats := computeResultStats(vars["A"])
+	bStats := computeResultStats(vars["B"])
+	estimated := estimateBinaryOutputBytes(aStats, bStats)
+
+	// Set limit exactly at the worst-case estimate: should pass.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(estimated))
+	require.NoError(t, err)
+}
+
+func TestWalkBinary_memory_limit_zero_disables_check(t *testing.T) {
+	// Even a cartesian product should proceed when limit is 0.
+	vars := Vars{
+		"A": Results{Values: Values{
+			makeSeries("a", data.Labels{"a_id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+			makeSeries("a", data.Labels{"a_id": "2"}, tp{time.Unix(1, 0), float64Pointer(2)}),
+		}},
+		"B": Results{Values: Values{
+			makeSeries("b", data.Labels{"b_id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			makeSeries("b", data.Labels{"b_id": "2"}, tp{time.Unix(1, 0), float64Pointer(20)}),
+		}},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// Limit of 0 means no limit.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(0))
+	require.NoError(t, err)
+}
+
+func TestWalkBinary_memory_limit_not_applied_without_option(t *testing.T) {
+	// Without WithMemoryLimit, even small cartesian products should work.
+	vars := Vars{
+		"A": Results{Values: Values{
+			makeSeries("a", data.Labels{"a_id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+		}},
+		"B": Results{Values: Values{
+			makeSeries("b", data.Labels{"b_id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+		}},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// No WithMemoryLimit option: MemoryLimit defaults to 0 (disabled).
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest())
+	require.NoError(t, err)
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int64
+		expected string
+	}{
+		{"bytes", 512, "512 B"},
+		{"kibibytes", 1536, "1.5 KiB"},
+		{"mebibytes", 5 << 20, "5.0 MiB"},
+		{"gibibytes", 1 << 30, "1.0 GiB"},
+		{"fractional gibibytes", 3 * (1 << 30) / 2, "1.5 GiB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatBytes(tc.input))
+		})
+	}
+}
+
+func TestLabelBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   data.Labels
+		expected int
+	}{
+		{"nil labels", nil, 0},
+		{"empty labels", data.Labels{}, 0},
+		{"single pair", data.Labels{"key": "value"}, 8},
+		{"multiple pairs", data.Labels{"service": "web", "region": "us-east-1"}, 7 + 3 + 6 + 9},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, labelBytes(tc.labels))
+		})
+	}
+}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -140,7 +140,7 @@ func buildCMDNode(ctx context.Context, rn *rawNode, toggles featuremgmt.FeatureT
 
 	switch commandType {
 	case TypeMath:
-		node.Command, err = UnmarshalMathCommand(rn)
+		node.Command, err = UnmarshalMathCommand(rn, cfg)
 	case TypeReduce:
 		node.Command, err = UnmarshalReduceCommand(rn)
 	case TypeResample:

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -478,6 +478,12 @@ type Cfg struct {
 	// SQLExpressionTimeoutSeconds is the duration a SQL expression will run before timing out
 	SQLExpressionTimeout time.Duration
 
+	// MathExpressionMemoryLimit is the maximum estimated memory (in bytes) that a
+	// single math expression binary operation is allowed to allocate for its output.
+	// When the estimated cost exceeds this limit, evaluation fails with a descriptive
+	// error. A value of 0 disables the limit. Default: 1 GiB.
+	MathExpressionMemoryLimit int64
+
 	ImageUploadProvider string
 
 	// LiveMaxConnections is a maximum number of WebSocket connections to
@@ -992,6 +998,7 @@ func (cfg *Cfg) readExpressionsSettings() {
 	cfg.SQLExpressionOutputCellLimit = expressions.Key("sql_expression_output_cell_limit").MustInt64(100000)
 	cfg.SQLExpressionTimeout = expressions.Key("sql_expression_timeout").MustDuration(time.Second * 10)
 	cfg.SQLExpressionQueryLengthLimit = expressions.Key("sql_expression_query_length_limit").MustInt64(10000)
+	cfg.MathExpressionMemoryLimit = expressions.Key("math_expression_memory_limit").MustInt64(1 << 30) // 1 GiB
 }
 
 type AnnotationCleanupSettings struct {


### PR DESCRIPTION
**What is this feature?**

A configurable memory limit for math expression binary operations. Before union() or any output allocation runs, walkBinary estimates the worst-case output cost using an O(n) pass over input results (zero heap allocation). If the estimate exceeds the limit, evaluation fails with a human-readable error describing which queries have incompatible labels and what the operator should check.

Default: 1 GiB, configurable via [expressions] math_expression_memory_limit. Set to 0 to disable.

**Why do we need this feature?**

When label sets on both sides of a binary operation become incompatible (e.g. an upstream relabel config changes), union() produces len(A) * len(B) pairs instead of the expected 1:1 matching. For 1,000 series on each side this means 1,000,000 unions instead of 1,000, leading to unbounded memory allocation that can OOM-kill the process.

**Who is this feature for?**

Operators running Grafana with alerting rules that use math expressions combining multi-series query results.