### PR TITLE
Alerting: Prototype improved alert rule details view layout

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
@@ -89,6 +89,8 @@ export const Details = ({ rule }: DetailsProps) => {
       ? String(rule.rulerRule.grafana_alert.missing_series_evals_to_resolve)
       : undefined;
 
+  const interval = rule.group.interval;
+
   const pausedIcon = (
     <Stack>
       <Text color="warning">
@@ -101,49 +103,15 @@ export const Details = ({ rule }: DetailsProps) => {
   );
   return (
     <div className={styles.metadata}>
-      <DetailGroup>
-        <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={determinedRuleType} />
-        {rulerRuleType.grafana.rule(rule.rulerRule) && (
-          <>
-            <DetailText
-              id="rule-type"
-              label={t('alerting.alert.rule-identifier', 'Rule identifier')}
-              value={rule.rulerRule.grafana_alert.uid}
-              monospace
-              showCopyButton
-              copyValue={rule.rulerRule.grafana_alert.uid}
-            />
-            <DetailText
-              id="last-updated-by"
-              label={t('alerting.alert.last-updated-by', 'Last updated by')}
-              value={<UpdatedByUser user={rule.rulerRule.grafana_alert.updated_by} />}
-            />
-            {updated && (
-              <DetailText
-                id="date-of-last-update"
-                label={t('alerting.alert.last-updated-at', 'Last updated at')}
-                value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
-              />
-            )}
-          </>
-        )}
-        {showTargetDatasource && (
+      {/* 1. Evaluation — operationally most important */}
+      <DetailGroup title={t('alerting.alert.evaluation', 'Evaluation')}>
+        {interval && (
           <DetailText
-            id="target-datasource-uid"
-            label={t('alerting.alert.target-datasource-uid', 'Target data source')}
-            value={
-              <Link href={`/connections/datasources/edit/${datasource?.uid}`}>
-                <Stack direction="row" gap={1}>
-                  <img style={{ width: '16px' }} src={datasource?.meta.info.logos.small} alt="datasource logo" />
-                  {datasource?.name}
-                </Stack>
-              </Link>
-            }
+            id="evaluation-interval"
+            label={t('alerting.alert.evaluation-interval', 'Evaluation interval')}
+            value={interval}
           />
         )}
-      </DetailGroup>
-
-      <DetailGroup title={t('alerting.alert.evaluation', 'Evaluation')}>
         {isPaused ? (
           pausedIcon
         ) : (
@@ -198,13 +166,13 @@ export const Details = ({ rule }: DetailsProps) => {
         )}
       </DetailGroup>
 
-      {/* show simplified routing information for Grafana managed alert rules */}
+      {/* 2. Notification configuration */}
       {rulerRuleType.grafana.alertingRule(rule.rulerRule) &&
         (!isEmpty(rule.rulerRule.grafana_alert.notification_settings) ||
           config.featureToggles.alertingPolicyRoutingSettings) && <NotificationSettings rulerRule={rule.rulerRule} />}
 
+      {/* 3. Alert state */}
       {rulerRuleType.grafana.rule(rule.rulerRule) &&
-        // grafana recording rules don't have these fields
         rule.rulerRule.grafana_alert.no_data_state &&
         rule.rulerRule.grafana_alert.exec_err_state && (
           <DetailGroup title={t('alerting.alert.alert-state', 'Alert state')}>
@@ -225,6 +193,7 @@ export const Details = ({ rule }: DetailsProps) => {
           </DetailGroup>
         )}
 
+      {/* 4. Annotations */}
       {annotations && (
         <DetailGroup title={t('alerting.alert.annotations', 'Annotations')}>
           {Object.keys(annotations).length === 0 ? (
@@ -241,6 +210,49 @@ export const Details = ({ rule }: DetailsProps) => {
           )}
         </DetailGroup>
       )}
+
+      {/* 5. Rule metadata — demoted to last */}
+      <DetailGroup title={t('alerting.alert.rule-metadata', 'Rule metadata')}>
+        <DetailText id="rule-type" label={t('alerting.alert.rule-type', 'Rule type')} value={determinedRuleType} />
+        {rulerRuleType.grafana.rule(rule.rulerRule) && (
+          <>
+            <DetailText
+              id="rule-type"
+              label={t('alerting.alert.rule-identifier', 'Rule identifier')}
+              value={rule.rulerRule.grafana_alert.uid}
+              monospace
+              showCopyButton
+              copyValue={rule.rulerRule.grafana_alert.uid}
+            />
+            <DetailText
+              id="last-updated-by"
+              label={t('alerting.alert.last-updated-by', 'Last updated by')}
+              value={<UpdatedByUser user={rule.rulerRule.grafana_alert.updated_by} />}
+            />
+            {updated && (
+              <DetailText
+                id="date-of-last-update"
+                label={t('alerting.alert.last-updated-at', 'Last updated at')}
+                value={dateTimeFormat(updated) + ` (${dateTimeFormatTimeAgo(updated)})`}
+              />
+            )}
+          </>
+        )}
+        {showTargetDatasource && (
+          <DetailText
+            id="target-datasource-uid"
+            label={t('alerting.alert.target-datasource-uid', 'Target data source')}
+            value={
+              <Link href={`/connections/datasources/edit/${datasource?.uid}`}>
+                <Stack direction="row" gap={1}>
+                  <img style={{ width: '16px' }} src={datasource?.meta.info.logos.small} alt="datasource logo" />
+                  {datasource?.name}
+                </Stack>
+              </Link>
+            }
+          />
+        )}
+      </DetailGroup>
     </div>
   );
 };

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -190,6 +190,7 @@ describe('RuleViewer', () => {
       const labels = mockRule.labels;
 
       expect(ELEMENTS.metadata.summary(ruleSummary).get()).toBeInTheDocument();
+      expect(ELEMENTS.metadata.dashboardAndPanel.get()).toBeInTheDocument();
       // Evaluation interval appears in the details sidebar
       expect(screen.getByText(groupInterval!)).toBeInTheDocument();
 

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -191,9 +191,8 @@ describe('RuleViewer', () => {
       const labels = mockRule.labels;
 
       expect(ELEMENTS.metadata.summary(ruleSummary).get()).toBeInTheDocument();
-      expect(ELEMENTS.metadata.dashboardAndPanel.get()).toBeInTheDocument();
-      expect(ELEMENTS.metadata.runbook(runBookURL).get()).toBeInTheDocument();
-      expect(ELEMENTS.metadata.evaluationInterval(groupInterval!).get()).toBeInTheDocument();
+      // Evaluation interval appears in the details sidebar
+      expect(screen.getByText(groupInterval!)).toBeInTheDocument();
 
       for (const label in labels) {
         expect(ELEMENTS.metadata.label([label, labels[label]]).get()).toBeInTheDocument();
@@ -401,11 +400,9 @@ describe('RuleViewer', () => {
       expect(screen.getByText('cloud test alert')).toBeInTheDocument();
       expect(screen.getByText('Firing')).toBeInTheDocument();
 
-      // summary appears in both the page header and the always-visible sidebar
       expect(screen.getAllByText(mockRule.annotations[Annotation.summary])[0]).toBeInTheDocument();
-      // runbook URL appears in both the page header and the always-visible sidebar
       expect(screen.getAllByRole('link', { name: mockRule.annotations[Annotation.runbookURL] })[0]).toBeInTheDocument();
-      expect(screen.getByText(`Every ${mockRule.group.interval}`)).toBeInTheDocument();
+      expect(screen.getByText(mockRule.group.interval!)).toBeInTheDocument();
     });
 
     it('should render custom plugin actions for a plugin-provided rule', async () => {
@@ -478,7 +475,7 @@ describe('RuleViewer', () => {
       expect(screen.getByText('prom test alert')).toBeInTheDocument();
 
       // Both summary and runbook are rendered by the Title component, and the DetailsTab component
-      expect(ELEMENTS.metadata.summary(mockRule.annotations[Annotation.runbookURL]).getAll()).toHaveLength(2);
+      expect(ELEMENTS.metadata.summary(mockRule.annotations[Annotation.runbookURL]).getAll()).toHaveLength(1);
       expect(ELEMENTS.metadata.summary(mockRule.annotations[Annotation.summary]).getAll()).toHaveLength(2);
 
       expect(ELEMENTS.details.pendingPeriod.get()).toHaveTextContent(/15m/i);

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -186,7 +186,6 @@ describe('RuleViewer', () => {
 
       // alert rule metadata
       const ruleSummary = mockRule.annotations[Annotation.summary];
-      const runBookURL = mockRule.annotations[Annotation.runbookURL];
       const groupInterval = mockRule.group.interval;
       const labels = mockRule.labels;
 

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { chain, truncate } from 'lodash';
+import { chain } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useMeasure } from 'react-use';
 

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { chain } from 'lodash';
+import { chain, truncate } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useMeasure } from 'react-use';
 
@@ -16,6 +16,7 @@ import {
   TabContent,
   TabsBar,
   Text,
+  TextLink,
   useStyles2,
   withErrorBoundary,
 } from '@grafana/ui';
@@ -48,7 +49,7 @@ import { normalizeHealth, normalizeState } from '../../rule-list/components/util
 import { Annotation } from '../../utils/constants';
 import { getRulesSourceUid, ruleIdentifierToRuleSourceIdentifier } from '../../utils/datasource';
 import { labelsSize } from '../../utils/labels';
-import { stringifyErrorLike } from '../../utils/misc';
+import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
 import { createListFilterLink, groups } from '../../utils/navigation';
 import {
   type RulePluginOrigin,
@@ -61,6 +62,7 @@ import {
 } from '../../utils/rules';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { ProvisioningBadge } from '../Provisioning';
+import { WithReturnButton } from '../WithReturnButton';
 import { decodeGrafanaNamespace } from '../expressions/util';
 import { RedirectToCloneRule } from '../rules/CloneRule';
 
@@ -215,10 +217,44 @@ const RuleViewer = () => {
 };
 
 const createMetadata = (rule: CombinedRule): PageInfoItem[] => {
-  const { labels } = rule;
+  const { labels, annotations } = rule;
   const metadata: PageInfoItem[] = [];
 
+  const dashboardUID = annotations[Annotation.dashboardUID];
+  const panelID = annotations[Annotation.panelID];
+  const hasDashboardAndPanel = dashboardUID && panelID;
+  const hasDashboard = dashboardUID;
   const hasLabels = labelsSize(labels) > 0;
+
+  if (hasDashboardAndPanel) {
+    metadata.push({
+      label: t('alerting.create-metadata.label.dashboard-and-panel', 'Dashboard and panel'),
+      value: (
+        <WithReturnButton
+          title={rule.name}
+          component={
+            <TextLink variant="bodySmall" href={makePanelLink(dashboardUID, panelID)}>
+              <Trans i18nKey="alerting.create-metadata.view-panel">View panel</Trans>
+            </TextLink>
+          }
+        />
+      ),
+    });
+  } else if (hasDashboard) {
+    metadata.push({
+      label: t('alerting.create-metadata.label.dashboard', 'Dashboard'),
+      value: (
+        <WithReturnButton
+          title={rule.name}
+          component={
+            <TextLink title={rule.name} variant="bodySmall" href={makeDashboardLink(dashboardUID)}>
+              <Trans i18nKey="alerting.create-metadata.view-dashboard">View dashboard</Trans>
+            </TextLink>
+          }
+        />
+      ),
+    });
+  }
 
   if (hasLabels) {
     metadata.push({

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { chain, truncate } from 'lodash';
+import { chain } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useMeasure } from 'react-use';
 
@@ -12,9 +12,10 @@ import {
   LinkButton,
   LoadingBar,
   Stack,
+  Tab,
   TabContent,
+  TabsBar,
   Text,
-  TextLink,
   useStyles2,
   withErrorBoundary,
 } from '@grafana/ui';
@@ -47,7 +48,7 @@ import { normalizeHealth, normalizeState } from '../../rule-list/components/util
 import { Annotation } from '../../utils/constants';
 import { getRulesSourceUid, ruleIdentifierToRuleSourceIdentifier } from '../../utils/datasource';
 import { labelsSize } from '../../utils/labels';
-import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
+import { stringifyErrorLike } from '../../utils/misc';
 import { createListFilterLink, groups } from '../../utils/navigation';
 import {
   type RulePluginOrigin,
@@ -60,11 +61,9 @@ import {
 } from '../../utils/rules';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { ProvisioningBadge } from '../Provisioning';
-import { WithReturnButton } from '../WithReturnButton';
 import { decodeGrafanaNamespace } from '../expressions/util';
 import { RedirectToCloneRule } from '../rules/CloneRule';
 
-import { ContactPointLink } from './ContactPointLink';
 import { Details } from './Details';
 import { FederatedRuleWarning } from './FederatedRuleWarning';
 import { useAlertRule } from './RuleContext';
@@ -91,7 +90,7 @@ const alertingListViewV2 = shouldUseAlertingListViewV2();
 
 const RuleViewer = () => {
   const { rule, identifier } = useAlertRule();
-  const { pageNav, activeTab } = usePageNav(rule);
+  const { pageNav, tabs, activeTab } = usePageNav(rule);
   const styles = useStyles2(getStyles);
 
   // GMA /api/v1/rules endpoint is strongly consistent, so we don't need to check for consistency
@@ -136,7 +135,7 @@ const RuleViewer = () => {
         />
       )}
       actions={<RuleActionsButtons rule={rule} rulesSource={rule.namespace.rulesSource} />}
-      info={createMetadata(rule, styles)}
+      info={createMetadata(rule)}
       subTitle={
         <Stack direction="column">
           {summary}
@@ -163,8 +162,24 @@ const RuleViewer = () => {
     >
       {shouldUseConsistencyCheck && <PrometheusConsistencyCheck ruleIdentifier={identifier} />}
       <div className={styles.layout}>
-        <Stack direction="column" gap={2}>
-          {/* tabs and tab content */}
+        <Stack direction="column" gap={0}>
+          {/* local tab bar — rendered inside the grid so sidebar sits alongside it */}
+          <div className={styles.tabsWrapper}>
+            <TabsBar>
+              {tabs.map((tab, index) =>
+                !tab.hideFromTabs ? (
+                  <Tab
+                    key={`${tab.text}-${index}`}
+                    label={tab.text}
+                    active={tab.active}
+                    counter={tab.tabCounter}
+                    suffix={tab.tabSuffix}
+                    onChangeTab={tab.onClick}
+                  />
+                ) : null
+              )}
+            </TabsBar>
+          </div>
           <TabContent>
             {activeTab === ActiveTab.Query && <QueryResults rule={rule} />}
             {activeTab === ActiveTab.Instances && <InstancesList rule={rule} />}
@@ -199,100 +214,15 @@ const RuleViewer = () => {
   );
 };
 
-const createMetadata = (rule: CombinedRule, styles: ReturnType<typeof getStyles>): PageInfoItem[] => {
-  const { labels, annotations, group, rulerRule } = rule;
+const createMetadata = (rule: CombinedRule): PageInfoItem[] => {
+  const { labels } = rule;
   const metadata: PageInfoItem[] = [];
 
-  const runbookUrl = annotations[Annotation.runbookURL];
-  const dashboardUID = annotations[Annotation.dashboardUID];
-  const panelID = annotations[Annotation.panelID];
-
-  const hasDashboardAndPanel = dashboardUID && panelID;
-  const hasDashboard = dashboardUID;
   const hasLabels = labelsSize(labels) > 0;
-
-  const interval = group.interval;
-
-  // if the alert rule uses simplified routing, we'll show a link to the contact point
-  if (rulerRuleType.grafana.alertingRule(rulerRule)) {
-    const contactPointName = rulerRule.grafana_alert.notification_settings?.receiver;
-
-    if (contactPointName) {
-      metadata.push({
-        label: t('alerting.create-metadata.label.contact-point', 'Notifications are delivered to'),
-        value: <ContactPointLink name={contactPointName} variant="bodySmall" />,
-      });
-    }
-  }
-
-  if (runbookUrl) {
-    /* TODO instead of truncating the string, we should use flex and text overflow properly to allow it to take up all of the horizontal space available */
-    const truncatedUrl = truncate(runbookUrl, { length: 42 });
-    const valueToAdd = isValidRunbookURL(runbookUrl) ? (
-      <TextLink variant="bodySmall" className={styles.url} href={runbookUrl} external>
-        {truncatedUrl}
-      </TextLink>
-    ) : (
-      <Text variant="bodySmall">{truncatedUrl}</Text>
-    );
-    metadata.push({
-      label: t('alerting.create-metadata.label.runbook-url', 'Runbook URL'),
-      value: valueToAdd,
-    });
-  }
-
-  if (hasDashboardAndPanel) {
-    metadata.push({
-      label: t('alerting.create-metadata.label.dashboard-and-panel', 'Dashboard and panel'),
-      value: (
-        <WithReturnButton
-          title={rule.name}
-          component={
-            <TextLink variant="bodySmall" href={makePanelLink(dashboardUID, panelID)}>
-              <Trans i18nKey="alerting.create-metadata.view-panel">View panel</Trans>
-            </TextLink>
-          }
-        />
-      ),
-    });
-  } else if (hasDashboard) {
-    metadata.push({
-      label: t('alerting.create-metadata.label.dashboard', 'Dashboard'),
-      value: (
-        <WithReturnButton
-          title={rule.name}
-          component={
-            <TextLink title={rule.name} variant="bodySmall" href={makeDashboardLink(dashboardUID)}>
-              <Trans i18nKey="alerting.create-metadata.view-dashboard">View dashboard</Trans>
-            </TextLink>
-          }
-        />
-      ),
-    });
-  }
-  if (rulerRuleType.grafana.recordingRule(rule.rulerRule)) {
-    const metric = rule.rulerRule?.grafana_alert.record?.metric ?? '';
-    metadata.push({
-      label: t('alerting.create-metadata.label.metric-name', 'Metric name'),
-      value: <Text color="primary">{metric}</Text>,
-    });
-  }
-
-  if (interval) {
-    metadata.push({
-      label: t('alerting.create-metadata.label.evaluation-interval', 'Evaluation interval'),
-      value: (
-        <Text color="primary">
-          <Trans i18nKey="alerting.rule-viewer.evaluation-interval">Every {{ interval }}</Trans>
-        </Text>
-      ),
-    });
-  }
 
   if (hasLabels) {
     metadata.push({
       label: t('alerting.create-metadata.label.labels', 'Labels'),
-      /* TODO truncate number of labels, maybe build in to component? */
       value: <AlertLabels labels={labels} size="sm" />,
     });
   }
@@ -467,56 +397,57 @@ function usePageNav(rule: CombinedRule) {
     }
   };
 
+  const tabs: NavModelItem[] = [
+    {
+      text: t('alerting.use-page-nav.page-nav.text.query-and-conditions', 'Query and conditions'),
+      active: activeTab === ActiveTab.Query,
+      onClick: () => {
+        setActiveTab(ActiveTab.Query);
+      },
+    },
+    {
+      text: t('alerting.use-page-nav.page-nav.text.instances', 'Instances'),
+      active: activeTab === ActiveTab.Instances,
+      onClick: () => {
+        setActiveTab(ActiveTab.Instances);
+      },
+      tabCounter: numberOfInstance,
+      hideFromTabs: isRecordingRuleType,
+    },
+    {
+      text: t('alerting.use-page-nav.page-nav.text.history', 'History'),
+      active: activeTab === ActiveTab.History,
+      onClick: () => {
+        setActiveTab(ActiveTab.History);
+      },
+      // alert state history is only available for Grafana managed alert rules
+      hideFromTabs: !isGrafanaAlertRule,
+    },
+    {
+      text: t('alerting.use-page-nav.page-nav.text.notifications', 'Notifications'),
+      active: activeTab === ActiveTab.Notifications,
+      onClick: () => {
+        setActiveTab(ActiveTab.Notifications);
+      },
+      // notification history is only available for Grafana managed alert rules and requires feature toggles
+      hideFromTabs: !isGrafanaAlertRule || !config.featureToggles.alertingNotificationHistoryRuleViewer,
+    },
+    // Enterprise extensions (e.g. Alert enrichment) should appear after routing
+    ...useRuleViewExtensionsNav(activeTab, setActiveTabFromString),
+    {
+      text: t('alerting.use-page-nav.page-nav.text.versions', 'Versions'),
+      active: activeTab === ActiveTab.VersionHistory,
+      onClick: () => {
+        setActiveTab(ActiveTab.VersionHistory);
+      },
+      hideFromTabs: !isGrafanaAlertRule && !isGrafanaRecordingRule,
+    },
+  ];
+
   const pageNav: NavModelItem = {
     ...defaultPageNav,
     text: rule.name,
     subTitle: summary,
-    children: [
-      {
-        text: t('alerting.use-page-nav.page-nav.text.query-and-conditions', 'Query and conditions'),
-        active: activeTab === ActiveTab.Query,
-        onClick: () => {
-          setActiveTab(ActiveTab.Query);
-        },
-      },
-      {
-        text: t('alerting.use-page-nav.page-nav.text.instances', 'Instances'),
-        active: activeTab === ActiveTab.Instances,
-        onClick: () => {
-          setActiveTab(ActiveTab.Instances);
-        },
-        tabCounter: numberOfInstance,
-        hideFromTabs: isRecordingRuleType,
-      },
-      {
-        text: t('alerting.use-page-nav.page-nav.text.history', 'History'),
-        active: activeTab === ActiveTab.History,
-        onClick: () => {
-          setActiveTab(ActiveTab.History);
-        },
-        // alert state history is only available for Grafana managed alert rules
-        hideFromTabs: !isGrafanaAlertRule,
-      },
-      {
-        text: t('alerting.use-page-nav.page-nav.text.notifications', 'Notifications'),
-        active: activeTab === ActiveTab.Notifications,
-        onClick: () => {
-          setActiveTab(ActiveTab.Notifications);
-        },
-        // notification history is only available for Grafana managed alert rules and requires feature toggles
-        hideFromTabs: !isGrafanaAlertRule || !config.featureToggles.alertingNotificationHistoryRuleViewer,
-      },
-      // Enterprise extensions (e.g. Alert enrichment) should appear after routing
-      ...useRuleViewExtensionsNav(activeTab, setActiveTabFromString),
-      {
-        text: t('alerting.use-page-nav.page-nav.text.versions', 'Versions'),
-        active: activeTab === ActiveTab.VersionHistory,
-        onClick: () => {
-          setActiveTab(ActiveTab.VersionHistory);
-        },
-        hideFromTabs: !isGrafanaAlertRule && !isGrafanaRecordingRule,
-      },
-    ],
     parentItem: {
       text: groupName,
       url: groupDetailsUrl,
@@ -530,6 +461,7 @@ function usePageNav(rule: CombinedRule) {
 
   return {
     pageNav,
+    tabs,
     activeTab,
   };
 }
@@ -550,8 +482,8 @@ export const calculateTotalInstances = (stats: AlertInstanceTotals) => {
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  url: css({
-    wordBreak: 'break-all',
+  tabsWrapper: css({
+    paddingBottom: theme.spacing(3),
   }),
   layout: css({
     display: 'grid',
@@ -575,20 +507,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
 });
-
-function isValidRunbookURL(url: string) {
-  const isRelative = url.startsWith('/');
-  let isAbsolute = false;
-
-  try {
-    new URL(url);
-    isAbsolute = true;
-  } catch (_) {
-    return false;
-  }
-
-  return isRelative || isAbsolute;
-}
 
 function getNamespaceString(rule: CombinedRule): string {
   // try rule.namespace.uid

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -370,6 +370,7 @@
       "annotations": "Annotations",
       "description-missing-series-evaluations": "The number of consecutive evaluation intervals a dimension must be missing before the alert instance becomes stale, and is then automatically resolved and evicted. Defaults to 2 if empty.",
       "evaluation": "Evaluation",
+      "evaluation-interval": "Evaluation interval",
       "evaluation-paused": "Alert evaluation currently paused",
       "evaluation-paused-description": "Notifications for this rule will not fire and no alert instances will be created until the rule is un-paused.",
       "keep-firing-for": "Keep firing for",
@@ -390,6 +391,7 @@
       },
       "pending-period": "Pending period",
       "rule-identifier": "Rule identifier",
+      "rule-metadata": "Rule metadata",
       "rule-type": "Rule type",
       "state-error-timeout": "Alert state if execution error or timeout",
       "state-no-data": "Alert state if no data or all values are null",
@@ -1007,16 +1009,8 @@
     },
     "create-metadata": {
       "label": {
-        "contact-point": "Notifications are delivered to",
-        "dashboard": "Dashboard",
-        "dashboard-and-panel": "Dashboard and panel",
-        "evaluation-interval": "Evaluation interval",
-        "labels": "Labels",
-        "metric-name": "Metric name",
-        "runbook-url": "Runbook URL"
-      },
-      "view-dashboard": "View dashboard",
-      "view-panel": "View panel"
+        "labels": "Labels"
+      }
     },
     "create-new-folder": {
       "folder": {
@@ -3064,7 +3058,6 @@
     "rule-viewer": {
       "aria-label-return-to": "Return to previous view",
       "error-loading": "Something went wrong loading the rule",
-      "evaluation-interval": "Every {{interval}}",
       "prometheus-consistency-check": {
         "alert-message": "Alert rule has been added or updated. Changes may take up to a minute to appear on the Alert rules list view.",
         "alert-title": "Update in progress"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1009,8 +1009,12 @@
     },
     "create-metadata": {
       "label": {
+        "dashboard": "Dashboard",
+        "dashboard-and-panel": "Dashboard and panel",
         "labels": "Labels"
-      }
+      },
+      "view-dashboard": "View dashboard",
+      "view-panel": "View panel"
     },
     "create-new-folder": {
       "folder": {


### PR DESCRIPTION
## Summary
- **Reorder details sidebar sections** for operational priority: Evaluation → Notifications → Alert state → Annotations → Rule metadata (demoted from top)
- **Move evaluation interval** into the Evaluation detail group (previously in page header metadata)
- **Simplify page header metadata** to only show labels, removing redundant info (runbook URL, dashboard link, contact point, metric name) that already appears in the sidebar
- **Render tabs locally** inside the layout grid so the sidebar sits alongside tab content instead of floating separately

<img width="1493" height="738" alt="image" src="https://github.com/user-attachments/assets/6eca0d85-6a2b-47a8-9595-76412d1f3130" />

## Context
This is a **prototype/exploration branch** for UX improvements to the alert rule details view. The goal is to surface operationally important information (evaluation config, notification routing) more prominently while demoting administrative metadata.

## Test plan
- [ ] Verify Grafana-managed alert rules render all detail sections in the new order
- [ ] Verify cloud/Prometheus rules still render correctly
- [ ] Verify tab navigation works as before (Query, Instances, History, Notifications, Versions)
- [ ] Verify sidebar details panel renders alongside tab content
- [ ] Check that removed page header items (runbook, dashboard link, contact point) still appear in appropriate sidebar sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)