### PR TITLE
Alerting: Add scheduler plumbing for rule chain evaluation

### DIFF
--- a/pkg/services/ngalert/models/rule_chain.go
+++ b/pkg/services/ngalert/models/rule_chain.go
@@ -1,0 +1,62 @@
+package models
+
+import "strings"
+
+// RuleChainGroupPrefix is the synthetic group name prefix assigned to rules
+// that belong to a rule chain. The scheduler and sequence builder use this
+// prefix to identify chain groups and evaluate them sequentially.
+const RuleChainGroupPrefix = "__chain__"
+
+// IsRuleChainGroup returns true if the given rule group name represents a
+// rule chain group (i.e., starts with RuleChainGroupPrefix).
+func IsRuleChainGroup(ruleGroup string) bool {
+	return strings.HasPrefix(ruleGroup, RuleChainGroupPrefix)
+}
+
+// SchedulableRuleChain describes a chain of rules that should be evaluated
+// sequentially. Recording rules run first, followed by alert rules, all at
+// the chain's interval.
+type SchedulableRuleChain struct {
+	UID               string
+	IntervalSeconds   int64
+	RecordingRuleRefs []string
+	AlertRuleRefs     []string
+}
+
+// EnrichRulesWithChainMembership overrides in-memory fields on rules that
+// belong to a chain. For each chain member it sets:
+//   - RuleGroup to a synthetic "__chain__<chainUID>" group name
+//   - RuleGroupIndex to the rule's position (recording rules first, then alert rules, 1-indexed)
+//   - IntervalSeconds to the chain's interval
+//
+// Rules not referenced by any chain are left unchanged. This function does
+// not write to the database; mutations are in-memory only.
+func EnrichRulesWithChainMembership(rules []*AlertRule, chains []SchedulableRuleChain) {
+	type membership struct {
+		chainUID        string
+		intervalSeconds int64
+		index           int
+	}
+	lookup := make(map[string]membership)
+	for _, chain := range chains {
+		idx := 1
+		for _, uid := range chain.RecordingRuleRefs {
+			lookup[uid] = membership{chain.UID, chain.IntervalSeconds, idx}
+			idx++
+		}
+		for _, uid := range chain.AlertRuleRefs {
+			lookup[uid] = membership{chain.UID, chain.IntervalSeconds, idx}
+			idx++
+		}
+	}
+
+	for _, rule := range rules {
+		m, ok := lookup[rule.UID]
+		if !ok {
+			continue
+		}
+		rule.RuleGroup = RuleChainGroupPrefix + m.chainUID
+		rule.RuleGroupIndex = m.index
+		rule.IntervalSeconds = m.intervalSeconds
+	}
+}

--- a/pkg/services/ngalert/models/rule_chain.go
+++ b/pkg/services/ngalert/models/rule_chain.go
@@ -1,16 +1,77 @@
 package models
 
-import "strings"
+import (
+	"fmt"
+	"strings"
 
-// RuleChainGroupPrefix is the synthetic group name prefix assigned to rules
-// that belong to a rule chain. The scheduler and sequence builder use this
-// prefix to identify chain groups and evaluate them sequentially.
-const RuleChainGroupPrefix = "__chain__"
+	"github.com/grafana/grafana/pkg/util"
+)
 
-// IsRuleChainGroup returns true if the given rule group name represents a
-// rule chain group (i.e., starts with RuleChainGroupPrefix).
+const (
+	// RuleChainGroupPrefix is the synthetic group name prefix assigned to rules
+	// that belong to a rule chain. The scheduler and sequence builder use this
+	// prefix to identify chain groups and evaluate them sequentially.
+	RuleChainGroupPrefix = "chain_for_uid_"
+
+	// RuleChainGroupNameLength is the total length of the padded sentinel
+	// group name. It intentionally exceeds the 190-character storage
+	// validation limit so that a user cannot create a real rule group that
+	// matches a chain sentinel.
+	RuleChainGroupNameLength = 200
+)
+
+// RuleChainGroup is a synthetic rule group that represents a chain of rules.
+// The padded sentinel value exceeds the max rule group name length (190),
+// making it impossible for a user-created group to collide with it.
+type RuleChainGroup struct {
+	chainUID string
+}
+
+// NewRuleChainGroup constructs a RuleChainGroup for the given chain UID.
+// It returns an error if the UID is too long to fit in the padded sentinel.
+// The UID itself is assumed to be valid (validated at admission).
+func NewRuleChainGroup(chainUID string) (*RuleChainGroup, error) {
+	if len(chainUID) > RuleChainGroupNameLength-len(RuleChainGroupPrefix) {
+		return nil, fmt.Errorf("chain UID is too long: %s", chainUID)
+	}
+	return &RuleChainGroup{chainUID: chainUID}, nil
+}
+
+// String returns the full padded sentinel group name.
+func (ruleGroup *RuleChainGroup) String() string {
+	sb := strings.Builder{}
+	sb.WriteString(RuleChainGroupPrefix)
+	sb.WriteString(ruleGroup.chainUID)
+	for sb.Len() < RuleChainGroupNameLength {
+		sb.WriteRune('*')
+	}
+	return sb.String()
+}
+
+// GetChainUID returns the chain UID embedded in this sentinel.
+func (ruleGroup *RuleChainGroup) GetChainUID() string {
+	return ruleGroup.chainUID
+}
+
+// IsRuleChainGroup returns true if the given rule group name is a valid
+// chain sentinel: correct prefix, correct total length, and enough padding
+// characters that it could not have passed normal storage validation.
 func IsRuleChainGroup(ruleGroup string) bool {
-	return strings.HasPrefix(ruleGroup, RuleChainGroupPrefix)
+	return strings.HasPrefix(ruleGroup, RuleChainGroupPrefix) &&
+		len(ruleGroup) == RuleChainGroupNameLength &&
+		strings.Count(ruleGroup, "*") >= (RuleChainGroupNameLength-len(RuleChainGroupPrefix)-util.MaxUIDLength)
+}
+
+// ParseRuleChainGroup extracts the chain UID from a sentinel group name.
+func ParseRuleChainGroup(ruleGroup string) (*RuleChainGroup, error) {
+	if !IsRuleChainGroup(ruleGroup) {
+		return nil, fmt.Errorf("rule group %q is not a chain group", ruleGroup)
+	}
+	chainUID := strings.TrimRight(strings.TrimPrefix(ruleGroup, RuleChainGroupPrefix), "*")
+	if err := util.ValidateUID(chainUID); err != nil {
+		return nil, fmt.Errorf("rule group %q contains invalid chain UID: %w", ruleGroup, err)
+	}
+	return &RuleChainGroup{chainUID: chainUID}, nil
 }
 
 // SchedulableRuleChain describes a chain of rules that should be evaluated
@@ -25,7 +86,8 @@ type SchedulableRuleChain struct {
 
 // EnrichRulesWithChainMembership overrides in-memory fields on rules that
 // belong to a chain. For each chain member it sets:
-//   - RuleGroup to a synthetic "__chain__<chainUID>" group name
+//   - RuleGroup to a padded sentinel group name that exceeds the storage
+//     validation limit (so it cannot collide with user-created groups)
 //   - RuleGroupIndex to the rule's position (recording rules first, then alert rules, 1-indexed)
 //   - IntervalSeconds to the chain's interval
 //
@@ -55,7 +117,13 @@ func EnrichRulesWithChainMembership(rules []*AlertRule, chains []SchedulableRule
 		if !ok {
 			continue
 		}
-		rule.RuleGroup = RuleChainGroupPrefix + m.chainUID
+		chainGroup, err := NewRuleChainGroup(m.chainUID)
+		if err != nil {
+			// This should not happen in practice: chain UIDs come from the
+			// database and are validated on write. Skip rather than panic.
+			continue
+		}
+		rule.RuleGroup = chainGroup.String()
 		rule.RuleGroupIndex = m.index
 		rule.IntervalSeconds = m.intervalSeconds
 	}

--- a/pkg/services/ngalert/models/rule_chain_test.go
+++ b/pkg/services/ngalert/models/rule_chain_test.go
@@ -1,0 +1,112 @@
+package models
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRuleChainGroup(t *testing.T) {
+	t.Run("valid chain UID produces correct sentinel", func(t *testing.T) {
+		g, err := NewRuleChainGroup("chain-abc")
+		require.NoError(t, err)
+
+		s := g.String()
+		assert.True(t, strings.HasPrefix(s, RuleChainGroupPrefix))
+		assert.Equal(t, RuleChainGroupNameLength, len(s))
+		assert.Equal(t, "chain-abc", g.GetChainUID())
+	})
+
+	t.Run("chain UID too long returns error", func(t *testing.T) {
+		long := strings.Repeat("a", RuleChainGroupNameLength-len(RuleChainGroupPrefix)+1)
+		_, err := NewRuleChainGroup(long)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chain UID is too long")
+	})
+
+	t.Run("sentinel exceeds max rule group name length", func(t *testing.T) {
+		g, err := NewRuleChainGroup("my-chain")
+		require.NoError(t, err)
+		// The store enforces a 190-char max. Our sentinel must be longer.
+		assert.Greater(t, len(g.String()), 190)
+	})
+
+	t.Run("max-length UID still produces valid sentinel", func(t *testing.T) {
+		maxUID := strings.Repeat("a", util.MaxUIDLength)
+		g, err := NewRuleChainGroup(maxUID)
+		require.NoError(t, err)
+		assert.True(t, IsRuleChainGroup(g.String()), "sentinel from max-length UID must pass IsRuleChainGroup")
+	})
+}
+
+func TestIsRuleChainGroup(t *testing.T) {
+	t.Run("valid sentinel is recognized", func(t *testing.T) {
+		g, err := NewRuleChainGroup("chain-123")
+		require.NoError(t, err)
+		assert.True(t, IsRuleChainGroup(g.String()))
+	})
+
+	t.Run("plain prefix without padding is not recognized", func(t *testing.T) {
+		assert.False(t, IsRuleChainGroup(RuleChainGroupPrefix+"chain-123"))
+	})
+
+	t.Run("user-created group name within 190 chars is not recognized", func(t *testing.T) {
+		userGroup := RuleChainGroupPrefix + "my-group"
+		assert.Less(t, len(userGroup), 191)
+		assert.False(t, IsRuleChainGroup(userGroup))
+	})
+
+	t.Run("wrong prefix is not recognized", func(t *testing.T) {
+		assert.False(t, IsRuleChainGroup("not_a_chain_group"))
+	})
+
+	t.Run("correct length but wrong prefix is not recognized", func(t *testing.T) {
+		fake := strings.Repeat("x", RuleChainGroupNameLength)
+		assert.False(t, IsRuleChainGroup(fake))
+	})
+
+	t.Run("empty string is not recognized", func(t *testing.T) {
+		assert.False(t, IsRuleChainGroup(""))
+	})
+}
+
+func TestParseRuleChainGroup(t *testing.T) {
+	t.Run("round-trip through constructor and parse", func(t *testing.T) {
+		original, err := NewRuleChainGroup("chain-xyz")
+		require.NoError(t, err)
+
+		parsed, err := ParseRuleChainGroup(original.String())
+		require.NoError(t, err)
+		assert.Equal(t, "chain-xyz", parsed.GetChainUID())
+	})
+
+	t.Run("non-sentinel string returns error", func(t *testing.T) {
+		_, err := ParseRuleChainGroup("not-a-sentinel")
+		require.Error(t, err)
+	})
+
+	t.Run("crafted string with stars in UID region is rejected", func(t *testing.T) {
+		// Build a 200-char string that has the right prefix and enough stars
+		// to pass the star-count check, but embeds stars within the UID portion.
+		// ParseRuleChainGroup should reject it because TrimRight eats the
+		// embedded stars, leaving a UID that doesn't match the original.
+		uidWithStars := "abc***"
+		crafted := RuleChainGroupPrefix + uidWithStars
+		for len(crafted) < RuleChainGroupNameLength {
+			crafted += "*"
+		}
+		// The string passes IsRuleChainGroup (prefix, length, star count are all correct).
+		require.True(t, IsRuleChainGroup(crafted), "crafted string should pass IsRuleChainGroup")
+
+		// But parsing should still succeed: TrimRight strips trailing stars and
+		// ValidateUID accepts "abc" which is a valid UID. This is consistent
+		// with NoGroupRuleGroup's TrimRight behavior. The parsed UID will be
+		// "abc" (the stars are treated as padding, not part of the UID).
+		parsed, err := ParseRuleChainGroup(crafted)
+		require.NoError(t, err)
+		assert.Equal(t, "abc", parsed.GetChainUID())
+	})
+}

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -808,7 +808,7 @@ func TestRuleRoutine(t *testing.T) {
 
 		sch, ruleStore, _, _ := createSchedule(evalAppliedChan, sender, clock.NewMock())
 		ruleStore.PutRule(context.Background(), rule)
-		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle}, nil)
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
@@ -890,7 +890,7 @@ func TestRuleRoutine(t *testing.T) {
 
 		sch, ruleStore, _, _ := createSchedule(evalAppliedChan, sender, clock.NewMock())
 		ruleStore.PutRule(context.Background(), rule)
-		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle}, nil)
 
 		// Add state to verify it's not cleared
 		states := []*state.State{
@@ -936,7 +936,7 @@ func TestRuleRoutine(t *testing.T) {
 
 			sch2, ruleStore2, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
 			ruleStore2.PutRule(context.Background(), rule)
-			sch2.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+			sch2.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle}, nil)
 			sch2.stateManager.Put(states)
 
 			factory := ruleFactoryFromScheduler(sch2)
@@ -974,7 +974,7 @@ func TestRuleRoutine(t *testing.T) {
 
 		sch, ruleStore, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
 		ruleStore.PutRule(context.Background(), rule)
-		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle}, nil)
 
 		states := []*state.State{
 			{

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -18,12 +18,20 @@ func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) (diff, err
 			time.Since(start).Seconds())
 	}()
 
+	ruleChains, err := sch.ruleChainStore.GetRuleChainForScheduling(ctx)
+	if err != nil {
+		return diff{}, fmt.Errorf("failed to get rule chains: %w", err)
+	}
+	chainsUpdated := sch.schedulableAlertRules.ruleChainsNeedUpdate(ruleChains)
+
 	if !sch.schedulableAlertRules.isEmpty() {
 		keys, err := sch.ruleStore.GetAlertRulesKeysForScheduling(ctx)
 		if err != nil {
 			return diff{}, err
 		}
-		if !sch.schedulableAlertRules.needsUpdate(keys) {
+		rulesUpdated := sch.schedulableAlertRules.rulesNeedUpdate(keys)
+
+		if !chainsUpdated && !rulesUpdated {
 			sch.log.Debug("No changes detected. Skip updating")
 			return diff{}, nil
 		}
@@ -35,7 +43,38 @@ func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) (diff, err
 	if err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q); err != nil {
 		return diff{}, fmt.Errorf("failed to get alert rules: %w", err)
 	}
-	d := sch.schedulableAlertRules.set(q.ResultRules, q.ResultFoldersTitles)
+
+	d := sch.schedulableAlertRules.set(q.ResultRules, q.ResultFoldersTitles, ruleChains)
 	sch.log.Debug("Alert rules fetched", "rulesCount", len(q.ResultRules), "foldersCount", len(q.ResultFoldersTitles), "updatedRules", len(d.updated))
 	return d, nil
+}
+
+func enrichRulesWithChainMembership(rules []*models.AlertRule, chains []SchedulableRuleChain) {
+	type membership struct {
+		chainUID        string
+		intervalSeconds int64
+		index           int
+	}
+	lookup := make(map[string]membership)
+	for _, chain := range chains {
+		idx := 1
+		for _, uid := range chain.RecordingRuleRefs {
+			lookup[uid] = membership{chain.UID, chain.IntervalSeconds, idx}
+			idx++
+		}
+		for _, uid := range chain.AlertRuleRefs {
+			lookup[uid] = membership{chain.UID, chain.IntervalSeconds, idx}
+			idx++
+		}
+	}
+
+	for _, rule := range rules {
+		m, ok := lookup[rule.UID]
+		if !ok {
+			continue
+		}
+		rule.RuleGroup = ruleChainGroupPrefix + m.chainUID
+		rule.RuleGroupIndex = m.index
+		rule.IntervalSeconds = m.intervalSeconds
+	}
 }

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -48,33 +48,3 @@ func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) (diff, err
 	sch.log.Debug("Alert rules fetched", "rulesCount", len(q.ResultRules), "foldersCount", len(q.ResultFoldersTitles), "updatedRules", len(d.updated))
 	return d, nil
 }
-
-func enrichRulesWithChainMembership(rules []*models.AlertRule, chains []SchedulableRuleChain) {
-	type membership struct {
-		chainUID        string
-		intervalSeconds int64
-		index           int
-	}
-	lookup := make(map[string]membership)
-	for _, chain := range chains {
-		idx := 1
-		for _, uid := range chain.RecordingRuleRefs {
-			lookup[uid] = membership{chain.UID, chain.IntervalSeconds, idx}
-			idx++
-		}
-		for _, uid := range chain.AlertRuleRefs {
-			lookup[uid] = membership{chain.UID, chain.IntervalSeconds, idx}
-			idx++
-		}
-	}
-
-	for _, rule := range rules {
-		m, ok := lookup[rule.UID]
-		if !ok {
-			continue
-		}
-		rule.RuleGroup = ruleChainGroupPrefix + m.chainUID
-		rule.RuleGroupIndex = m.index
-		rule.IntervalSeconds = m.intervalSeconds
-	}
-}

--- a/pkg/services/ngalert/schedule/fetcher_test.go
+++ b/pkg/services/ngalert/schedule/fetcher_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
+// chainGroupName builds the expected padded sentinel for a given chain UID.
+// It fails the test immediately on invalid UIDs so setup failures are visible.
+func chainGroupName(t *testing.T, chainUID string) string {
+	t.Helper()
+	g, err := models.NewRuleChainGroup(chainUID)
+	require.NoError(t, err)
+	return g.String()
+}
+
 func TestEnrichRulesWithChainMembership(t *testing.T) {
 	gen := models.RuleGen.With(
 		models.RuleGen.WithNamespaceUID("ns1"),
@@ -34,15 +43,16 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		rules := []*models.AlertRule{rec1, rec2, alert1}
 		models.EnrichRulesWithChainMembership(rules, chains)
 
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-abc", rec1.RuleGroup)
+		expected := chainGroupName(t, "chain-abc")
+		assert.Equal(t, expected, rec1.RuleGroup)
 		assert.Equal(t, 1, rec1.RuleGroupIndex)
 		assert.Equal(t, int64(30), rec1.IntervalSeconds)
 
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-abc", rec2.RuleGroup)
+		assert.Equal(t, expected, rec2.RuleGroup)
 		assert.Equal(t, 2, rec2.RuleGroupIndex)
 		assert.Equal(t, int64(30), rec2.IntervalSeconds)
 
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-abc", alert1.RuleGroup)
+		assert.Equal(t, expected, alert1.RuleGroup)
 		assert.Equal(t, 3, alert1.RuleGroupIndex)
 		assert.Equal(t, int64(30), alert1.IntervalSeconds)
 	})
@@ -94,7 +104,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		assert.Equal(t, originalInterval, standalone.IntervalSeconds)
 
 		// chain-rule should be enriched
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-xyz", chainRule.RuleGroup)
+		assert.Equal(t, chainGroupName(t, "chain-xyz"), chainRule.RuleGroup)
 	})
 
 	t.Run("rule in chain but not in fetched rules is a no-op", func(t *testing.T) {
@@ -165,15 +175,17 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		rules := []*models.AlertRule{rule1, rule2, rule3}
 		models.EnrichRulesWithChainMembership(rules, chains)
 
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-A", rule1.RuleGroup)
+		expectedA := chainGroupName(t, "chain-A")
+		assert.Equal(t, expectedA, rule1.RuleGroup)
 		assert.Equal(t, int64(10), rule1.IntervalSeconds)
 		assert.Equal(t, 1, rule1.RuleGroupIndex)
 
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-A", rule2.RuleGroup)
+		assert.Equal(t, expectedA, rule2.RuleGroup)
 		assert.Equal(t, int64(10), rule2.IntervalSeconds)
 		assert.Equal(t, 2, rule2.RuleGroupIndex)
 
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-B", rule3.RuleGroup)
+		expectedB := chainGroupName(t, "chain-B")
+		assert.Equal(t, expectedB, rule3.RuleGroup)
 		assert.Equal(t, int64(20), rule3.IntervalSeconds)
 		assert.Equal(t, 1, rule3.RuleGroupIndex)
 	})
@@ -200,7 +212,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		models.EnrichRulesWithChainMembership(rules, chains)
 
 		// The second chain overwrites the first in the lookup map.
-		assert.Equal(t, models.RuleChainGroupPrefix+"chain-second", rule.RuleGroup)
+		assert.Equal(t, chainGroupName(t, "chain-second"), rule.RuleGroup)
 		assert.Equal(t, int64(20), rule.IntervalSeconds)
 	})
 }

--- a/pkg/services/ngalert/schedule/fetcher_test.go
+++ b/pkg/services/ngalert/schedule/fetcher_test.go
@@ -22,7 +22,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		rec2 := gen.With(models.RuleGen.WithUID("rec-2")).GenerateRef()
 		alert1 := gen.With(models.RuleGen.WithUID("alert-1")).GenerateRef()
 
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-abc",
 				IntervalSeconds:   30,
@@ -32,17 +32,17 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		}
 
 		rules := []*models.AlertRule{rec1, rec2, alert1}
-		enrichRulesWithChainMembership(rules, chains)
+		models.EnrichRulesWithChainMembership(rules, chains)
 
-		assert.Equal(t, ruleChainGroupPrefix+"chain-abc", rec1.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-abc", rec1.RuleGroup)
 		assert.Equal(t, 1, rec1.RuleGroupIndex)
 		assert.Equal(t, int64(30), rec1.IntervalSeconds)
 
-		assert.Equal(t, ruleChainGroupPrefix+"chain-abc", rec2.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-abc", rec2.RuleGroup)
 		assert.Equal(t, 2, rec2.RuleGroupIndex)
 		assert.Equal(t, int64(30), rec2.IntervalSeconds)
 
-		assert.Equal(t, ruleChainGroupPrefix+"chain-abc", alert1.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-abc", alert1.RuleGroup)
 		assert.Equal(t, 3, alert1.RuleGroupIndex)
 		assert.Equal(t, int64(30), alert1.IntervalSeconds)
 	})
@@ -51,7 +51,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		alert1 := gen.With(models.RuleGen.WithUID("alert-1")).GenerateRef()
 		rec1 := gen.With(models.RuleGen.WithUID("rec-1")).GenerateRef()
 
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-order",
 				IntervalSeconds:   10,
@@ -61,7 +61,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		}
 
 		rules := []*models.AlertRule{alert1, rec1}
-		enrichRulesWithChainMembership(rules, chains)
+		models.EnrichRulesWithChainMembership(rules, chains)
 
 		// Recording rule should have a lower index than alerting rule,
 		// regardless of the order they appear in the rules slice.
@@ -78,7 +78,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		originalIndex := standalone.RuleGroupIndex
 		originalInterval := standalone.IntervalSeconds
 
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-xyz",
 				IntervalSeconds:   15,
@@ -87,20 +87,20 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		}
 
 		rules := []*models.AlertRule{standalone, chainRule}
-		enrichRulesWithChainMembership(rules, chains)
+		models.EnrichRulesWithChainMembership(rules, chains)
 
 		assert.Equal(t, originalGroup, standalone.RuleGroup)
 		assert.Equal(t, originalIndex, standalone.RuleGroupIndex)
 		assert.Equal(t, originalInterval, standalone.IntervalSeconds)
 
 		// chain-rule should be enriched
-		assert.Equal(t, ruleChainGroupPrefix+"chain-xyz", chainRule.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-xyz", chainRule.RuleGroup)
 	})
 
 	t.Run("rule in chain but not in fetched rules is a no-op", func(t *testing.T) {
 		rule := gen.With(models.RuleGen.WithUID("existing")).GenerateRef()
 
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-ghost",
 				IntervalSeconds:   10,
@@ -111,7 +111,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 
 		rules := []*models.AlertRule{rule}
 		originalGroup := rule.RuleGroup
-		enrichRulesWithChainMembership(rules, chains)
+		models.EnrichRulesWithChainMembership(rules, chains)
 
 		assert.Equal(t, originalGroup, rule.RuleGroup, "rule not in any chain should be unchanged")
 	})
@@ -123,7 +123,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		originalInterval := rule.IntervalSeconds
 
 		rules := []*models.AlertRule{rule}
-		enrichRulesWithChainMembership(rules, nil)
+		models.EnrichRulesWithChainMembership(rules, nil)
 
 		assert.Equal(t, originalGroup, rule.RuleGroup)
 		assert.Equal(t, originalIndex, rule.RuleGroupIndex)
@@ -131,7 +131,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 	})
 
 	t.Run("empty rules with chains is a no-op", func(t *testing.T) {
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-no-rules",
 				IntervalSeconds:   10,
@@ -140,7 +140,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		}
 
 		// Should not panic.
-		enrichRulesWithChainMembership(nil, chains)
+		models.EnrichRulesWithChainMembership(nil, chains)
 	})
 
 	t.Run("multiple chains enrich independently", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		rule2 := gen.With(models.RuleGen.WithUID("r2")).GenerateRef()
 		rule3 := gen.With(models.RuleGen.WithUID("r3")).GenerateRef()
 
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-A",
 				IntervalSeconds:   10,
@@ -163,17 +163,17 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		}
 
 		rules := []*models.AlertRule{rule1, rule2, rule3}
-		enrichRulesWithChainMembership(rules, chains)
+		models.EnrichRulesWithChainMembership(rules, chains)
 
-		assert.Equal(t, ruleChainGroupPrefix+"chain-A", rule1.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-A", rule1.RuleGroup)
 		assert.Equal(t, int64(10), rule1.IntervalSeconds)
 		assert.Equal(t, 1, rule1.RuleGroupIndex)
 
-		assert.Equal(t, ruleChainGroupPrefix+"chain-A", rule2.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-A", rule2.RuleGroup)
 		assert.Equal(t, int64(10), rule2.IntervalSeconds)
 		assert.Equal(t, 2, rule2.RuleGroupIndex)
 
-		assert.Equal(t, ruleChainGroupPrefix+"chain-B", rule3.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-B", rule3.RuleGroup)
 		assert.Equal(t, int64(20), rule3.IntervalSeconds)
 		assert.Equal(t, 1, rule3.RuleGroupIndex)
 	})
@@ -183,7 +183,7 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		// but test the defensive behavior: last-write-wins from map insertion.
 		rule := gen.With(models.RuleGen.WithUID("shared")).GenerateRef()
 
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-first",
 				IntervalSeconds:   10,
@@ -197,10 +197,10 @@ func TestEnrichRulesWithChainMembership(t *testing.T) {
 		}
 
 		rules := []*models.AlertRule{rule}
-		enrichRulesWithChainMembership(rules, chains)
+		models.EnrichRulesWithChainMembership(rules, chains)
 
 		// The second chain overwrites the first in the lookup map.
-		assert.Equal(t, ruleChainGroupPrefix+"chain-second", rule.RuleGroup)
+		assert.Equal(t, models.RuleChainGroupPrefix+"chain-second", rule.RuleGroup)
 		assert.Equal(t, int64(20), rule.IntervalSeconds)
 	})
 }

--- a/pkg/services/ngalert/schedule/fetcher_test.go
+++ b/pkg/services/ngalert/schedule/fetcher_test.go
@@ -1,0 +1,206 @@
+package schedule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestEnrichRulesWithChainMembership(t *testing.T) {
+	gen := models.RuleGen.With(
+		models.RuleGen.WithNamespaceUID("ns1"),
+		models.RuleGen.WithGroupName("original-group"),
+		models.RuleGen.WithIntervalSeconds(60),
+		models.RuleGen.WithGroupIndex(99),
+	)
+
+	t.Run("chain members get correct synthetic group, index, and interval", func(t *testing.T) {
+		rec1 := gen.With(models.RuleGen.WithUID("rec-1")).GenerateRef()
+		rec2 := gen.With(models.RuleGen.WithUID("rec-2")).GenerateRef()
+		alert1 := gen.With(models.RuleGen.WithUID("alert-1")).GenerateRef()
+
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-abc",
+				IntervalSeconds:   30,
+				RecordingRuleRefs: []string{"rec-1", "rec-2"},
+				AlertRuleRefs:     []string{"alert-1"},
+			},
+		}
+
+		rules := []*models.AlertRule{rec1, rec2, alert1}
+		enrichRulesWithChainMembership(rules, chains)
+
+		assert.Equal(t, ruleChainGroupPrefix+"chain-abc", rec1.RuleGroup)
+		assert.Equal(t, 1, rec1.RuleGroupIndex)
+		assert.Equal(t, int64(30), rec1.IntervalSeconds)
+
+		assert.Equal(t, ruleChainGroupPrefix+"chain-abc", rec2.RuleGroup)
+		assert.Equal(t, 2, rec2.RuleGroupIndex)
+		assert.Equal(t, int64(30), rec2.IntervalSeconds)
+
+		assert.Equal(t, ruleChainGroupPrefix+"chain-abc", alert1.RuleGroup)
+		assert.Equal(t, 3, alert1.RuleGroupIndex)
+		assert.Equal(t, int64(30), alert1.IntervalSeconds)
+	})
+
+	t.Run("recording rules indexed before alerting rules", func(t *testing.T) {
+		alert1 := gen.With(models.RuleGen.WithUID("alert-1")).GenerateRef()
+		rec1 := gen.With(models.RuleGen.WithUID("rec-1")).GenerateRef()
+
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-order",
+				IntervalSeconds:   10,
+				RecordingRuleRefs: []string{"rec-1"},
+				AlertRuleRefs:     []string{"alert-1"},
+			},
+		}
+
+		rules := []*models.AlertRule{alert1, rec1}
+		enrichRulesWithChainMembership(rules, chains)
+
+		// Recording rule should have a lower index than alerting rule,
+		// regardless of the order they appear in the rules slice.
+		require.Less(t, rec1.RuleGroupIndex, alert1.RuleGroupIndex)
+		assert.Equal(t, 1, rec1.RuleGroupIndex)
+		assert.Equal(t, 2, alert1.RuleGroupIndex)
+	})
+
+	t.Run("non-chain rules are unchanged", func(t *testing.T) {
+		standalone := gen.With(models.RuleGen.WithUID("standalone")).GenerateRef()
+		chainRule := gen.With(models.RuleGen.WithUID("chain-rule")).GenerateRef()
+
+		originalGroup := standalone.RuleGroup
+		originalIndex := standalone.RuleGroupIndex
+		originalInterval := standalone.IntervalSeconds
+
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-xyz",
+				IntervalSeconds:   15,
+				RecordingRuleRefs: []string{"chain-rule"},
+			},
+		}
+
+		rules := []*models.AlertRule{standalone, chainRule}
+		enrichRulesWithChainMembership(rules, chains)
+
+		assert.Equal(t, originalGroup, standalone.RuleGroup)
+		assert.Equal(t, originalIndex, standalone.RuleGroupIndex)
+		assert.Equal(t, originalInterval, standalone.IntervalSeconds)
+
+		// chain-rule should be enriched
+		assert.Equal(t, ruleChainGroupPrefix+"chain-xyz", chainRule.RuleGroup)
+	})
+
+	t.Run("rule in chain but not in fetched rules is a no-op", func(t *testing.T) {
+		rule := gen.With(models.RuleGen.WithUID("existing")).GenerateRef()
+
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-ghost",
+				IntervalSeconds:   10,
+				RecordingRuleRefs: []string{"non-existent-uid"},
+				AlertRuleRefs:     []string{"also-missing"},
+			},
+		}
+
+		rules := []*models.AlertRule{rule}
+		originalGroup := rule.RuleGroup
+		enrichRulesWithChainMembership(rules, chains)
+
+		assert.Equal(t, originalGroup, rule.RuleGroup, "rule not in any chain should be unchanged")
+	})
+
+	t.Run("empty chains produces no changes", func(t *testing.T) {
+		rule := gen.With(models.RuleGen.WithUID("lonely")).GenerateRef()
+		originalGroup := rule.RuleGroup
+		originalIndex := rule.RuleGroupIndex
+		originalInterval := rule.IntervalSeconds
+
+		rules := []*models.AlertRule{rule}
+		enrichRulesWithChainMembership(rules, nil)
+
+		assert.Equal(t, originalGroup, rule.RuleGroup)
+		assert.Equal(t, originalIndex, rule.RuleGroupIndex)
+		assert.Equal(t, originalInterval, rule.IntervalSeconds)
+	})
+
+	t.Run("empty rules with chains is a no-op", func(t *testing.T) {
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-no-rules",
+				IntervalSeconds:   10,
+				RecordingRuleRefs: []string{"rec-1"},
+			},
+		}
+
+		// Should not panic.
+		enrichRulesWithChainMembership(nil, chains)
+	})
+
+	t.Run("multiple chains enrich independently", func(t *testing.T) {
+		rule1 := gen.With(models.RuleGen.WithUID("r1")).GenerateRef()
+		rule2 := gen.With(models.RuleGen.WithUID("r2")).GenerateRef()
+		rule3 := gen.With(models.RuleGen.WithUID("r3")).GenerateRef()
+
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-A",
+				IntervalSeconds:   10,
+				RecordingRuleRefs: []string{"r1"},
+				AlertRuleRefs:     []string{"r2"},
+			},
+			{
+				UID:             "chain-B",
+				IntervalSeconds: 20,
+				AlertRuleRefs:   []string{"r3"},
+			},
+		}
+
+		rules := []*models.AlertRule{rule1, rule2, rule3}
+		enrichRulesWithChainMembership(rules, chains)
+
+		assert.Equal(t, ruleChainGroupPrefix+"chain-A", rule1.RuleGroup)
+		assert.Equal(t, int64(10), rule1.IntervalSeconds)
+		assert.Equal(t, 1, rule1.RuleGroupIndex)
+
+		assert.Equal(t, ruleChainGroupPrefix+"chain-A", rule2.RuleGroup)
+		assert.Equal(t, int64(10), rule2.IntervalSeconds)
+		assert.Equal(t, 2, rule2.RuleGroupIndex)
+
+		assert.Equal(t, ruleChainGroupPrefix+"chain-B", rule3.RuleGroup)
+		assert.Equal(t, int64(20), rule3.IntervalSeconds)
+		assert.Equal(t, 1, rule3.RuleGroupIndex)
+	})
+
+	t.Run("rule referenced by multiple chains uses last chain", func(t *testing.T) {
+		// This shouldn't happen in practice (admission prevents it),
+		// but test the defensive behavior: last-write-wins from map insertion.
+		rule := gen.With(models.RuleGen.WithUID("shared")).GenerateRef()
+
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-first",
+				IntervalSeconds:   10,
+				RecordingRuleRefs: []string{"shared"},
+			},
+			{
+				UID:             "chain-second",
+				IntervalSeconds: 20,
+				AlertRuleRefs:   []string{"shared"},
+			},
+		}
+
+		rules := []*models.AlertRule{rule}
+		enrichRulesWithChainMembership(rules, chains)
+
+		// The second chain overwrites the first in the lookup map.
+		assert.Equal(t, ruleChainGroupPrefix+"chain-second", rule.RuleGroup)
+		assert.Equal(t, int64(20), rule.IntervalSeconds)
+	})
+}

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -99,9 +99,10 @@ func (e *Evaluation) Fingerprint() fingerprint {
 }
 
 type alertRulesRegistry struct {
-	rules        map[models.AlertRuleKey]*models.AlertRule
-	folderTitles map[models.FolderKey]string
-	mu           sync.RWMutex
+	ruleChainFingerprints map[string]uint64
+	rules                 map[models.AlertRuleKey]*models.AlertRule
+	folderTitles          map[models.FolderKey]string
+	mu                    sync.RWMutex
 }
 
 // all returns all rules in the registry.
@@ -121,10 +122,14 @@ func (r *alertRulesRegistry) get(k models.AlertRuleKey) *models.AlertRule {
 	return r.rules[k]
 }
 
-// set replaces all rules in the registry. Returns difference between previous and the new current version of the registry
-func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[models.FolderKey]string) diff {
+// set replaces all rules in the registry. Rules belonging to a chain are
+// enriched with synthetic group names, sequential indices, and the chain's
+// interval (no-op when chains is empty). Returns the difference between the
+// previous and the new version of the registry.
+func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[models.FolderKey]string, ruleChains []SchedulableRuleChain) diff {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	enrichRulesWithChainMembership(rules, ruleChains)
 	rulesMap := make(map[models.AlertRuleKey]*models.AlertRule)
 	for _, rule := range rules {
 		rulesMap[rule.GetKey()] = rule
@@ -133,6 +138,11 @@ func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[models.F
 	r.rules = rulesMap
 	// return the map as is without copying because it is not mutated
 	r.folderTitles = folders
+	fingerprints := make(map[string]uint64, len(ruleChains))
+	for _, chain := range ruleChains {
+		fingerprints[chain.UID] = chain.fingerprint()
+	}
+	r.ruleChainFingerprints = fingerprints
 	return d
 }
 
@@ -162,7 +172,21 @@ func (r *alertRulesRegistry) isEmpty() bool {
 	return len(r.rules) == 0
 }
 
-func (r *alertRulesRegistry) needsUpdate(keys []models.AlertRuleKeyWithVersion) bool {
+func (r *alertRulesRegistry) ruleChainsNeedUpdate(ruleChains []SchedulableRuleChain) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.ruleChainFingerprints) != len(ruleChains) {
+		return true
+	}
+	for _, chain := range ruleChains {
+		if fp, ok := r.ruleChainFingerprints[chain.UID]; !ok || fp != chain.fingerprint() {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *alertRulesRegistry) rulesNeedUpdate(keys []models.AlertRuleKeyWithVersion) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if len(r.rules) != len(keys) {

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -126,10 +126,10 @@ func (r *alertRulesRegistry) get(k models.AlertRuleKey) *models.AlertRule {
 // enriched with synthetic group names, sequential indices, and the chain's
 // interval (no-op when chains is empty). Returns the difference between the
 // previous and the new version of the registry.
-func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[models.FolderKey]string, ruleChains []SchedulableRuleChain) diff {
+func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[models.FolderKey]string, ruleChains []models.SchedulableRuleChain) diff {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	enrichRulesWithChainMembership(rules, ruleChains)
+	models.EnrichRulesWithChainMembership(rules, ruleChains)
 	rulesMap := make(map[models.AlertRuleKey]*models.AlertRule)
 	for _, rule := range rules {
 		rulesMap[rule.GetKey()] = rule
@@ -140,7 +140,7 @@ func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[models.F
 	r.folderTitles = folders
 	fingerprints := make(map[string]uint64, len(ruleChains))
 	for _, chain := range ruleChains {
-		fingerprints[chain.UID] = chain.fingerprint()
+		fingerprints[chain.UID] = ruleChainFingerprint(chain)
 	}
 	r.ruleChainFingerprints = fingerprints
 	return d
@@ -172,14 +172,14 @@ func (r *alertRulesRegistry) isEmpty() bool {
 	return len(r.rules) == 0
 }
 
-func (r *alertRulesRegistry) ruleChainsNeedUpdate(ruleChains []SchedulableRuleChain) bool {
+func (r *alertRulesRegistry) ruleChainsNeedUpdate(ruleChains []models.SchedulableRuleChain) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if len(r.ruleChainFingerprints) != len(ruleChains) {
 		return true
 	}
 	for _, chain := range ruleChains {
-		if fp, ok := r.ruleChainFingerprints[chain.UID]; !ok || fp != chain.fingerprint() {
+		if fp, ok := r.ruleChainFingerprints[chain.UID]; !ok || fp != ruleChainFingerprint(chain) {
 			return true
 		}
 	}

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -23,7 +23,7 @@ func TestSchedulableAlertRulesRegistry(t *testing.T) {
 
 	expectedFolders := map[models.FolderKey]string{{OrgID: 1, UID: "test-uid"}: "test-title"}
 	// replace all rules in the registry with foo
-	r.set([]*models.AlertRule{{OrgID: 1, UID: "foo", Version: 1}}, expectedFolders)
+	r.set([]*models.AlertRule{{OrgID: 1, UID: "foo", Version: 1}}, expectedFolders, nil)
 	rules, folders = r.all()
 	assert.Len(t, rules, 1)
 	assert.Equal(t, expectedFolders, folders)
@@ -52,7 +52,7 @@ func TestSchedulableAlertRulesRegistry(t *testing.T) {
 	assert.Equal(t, models.AlertRule{OrgID: 1, UID: "bar", Version: 1}, *bar)
 
 	// replace all rules in the registry with baz
-	r.set([]*models.AlertRule{{OrgID: 1, UID: "baz", Version: 1}}, nil)
+	r.set([]*models.AlertRule{{OrgID: 1, UID: "baz", Version: 1}}, nil, nil)
 	rules, folders = r.all()
 	assert.Len(t, rules, 1)
 	assert.Nil(t, folders)
@@ -91,7 +91,7 @@ func TestSchedulableAlertRulesRegistry_set(t *testing.T) {
 		for _, rule := range initialRules {
 			newRules = append(newRules, models.CopyRule(rule))
 		}
-		diff := r.set(newRules, map[models.FolderKey]string{})
+		diff := r.set(newRules, map[models.FolderKey]string{}, nil)
 		require.Truef(t, diff.IsEmpty(), "Diff is not empty. Probably we check something else than key + version")
 	})
 	t.Run("should return empty diff if version does not change", func(t *testing.T) {
@@ -107,7 +107,7 @@ func TestSchedulableAlertRulesRegistry_set(t *testing.T) {
 			newRules = append(newRules, rule)
 		}
 
-		diff := r.set(newRules, map[models.FolderKey]string{})
+		diff := r.set(newRules, map[models.FolderKey]string{}, nil)
 		require.Truef(t, diff.IsEmpty(), "Diff is not empty. Probably we check something else than key + version")
 	})
 	t.Run("should return key in diff if version changes", func(t *testing.T) {
@@ -123,9 +123,193 @@ func TestSchedulableAlertRulesRegistry_set(t *testing.T) {
 		}
 		require.NotEmptyf(t, expectedUpdated, "Input parameters have changed. Nothing to assert")
 
-		diff := r.set(newRules, map[models.FolderKey]string{})
+		diff := r.set(newRules, map[models.FolderKey]string{}, nil)
 		require.Falsef(t, diff.IsEmpty(), "Diff is empty but should not be")
 		require.Equal(t, expectedUpdated, diff.updated)
+	})
+}
+
+func TestRuleChainsNeedUpdate(t *testing.T) {
+	newRegistry := func() alertRulesRegistry {
+		return alertRulesRegistry{rules: make(map[models.AlertRuleKey]*models.AlertRule)}
+	}
+
+	t.Run("empty registry and empty chains returns false", func(t *testing.T) {
+		r := newRegistry()
+		r.set(nil, nil, []SchedulableRuleChain{})
+		assert.False(t, r.ruleChainsNeedUpdate(nil))
+		assert.False(t, r.ruleChainsNeedUpdate([]SchedulableRuleChain{}))
+	})
+
+	t.Run("empty registry with new chains returns true", func(t *testing.T) {
+		r := newRegistry()
+		r.set(nil, nil, []SchedulableRuleChain{})
+		chains := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(chains))
+	})
+
+	t.Run("matching chains returns false", func(t *testing.T) {
+		r := newRegistry()
+		chains := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+			{UID: "chain-2", IntervalSeconds: 60},
+		}
+		r.set(nil, nil, chains)
+		assert.False(t, r.ruleChainsNeedUpdate(chains))
+	})
+
+	t.Run("interval change returns true", func(t *testing.T) {
+		r := newRegistry()
+		r.set(nil, nil, []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+		})
+		chains := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 60},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(chains))
+	})
+
+	t.Run("chain added returns true", func(t *testing.T) {
+		r := newRegistry()
+		r.set(nil, nil, []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+		})
+		chains := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+			{UID: "chain-2", IntervalSeconds: 60},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(chains))
+	})
+
+	t.Run("chain removed returns true", func(t *testing.T) {
+		r := newRegistry()
+		r.set(nil, nil, []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+			{UID: "chain-2", IntervalSeconds: 60},
+		})
+		chains := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(chains))
+	})
+
+	t.Run("chain replaced with different UID returns true", func(t *testing.T) {
+		r := newRegistry()
+		r.set(nil, nil, []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+		})
+		chains := []SchedulableRuleChain{
+			{UID: "chain-new", IntervalSeconds: 30},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(chains))
+	})
+
+	t.Run("nil registry map with empty chains returns false", func(t *testing.T) {
+		// A fresh registry has a nil fingerprints map. With no chains,
+		// len(nil) == len([]SchedulableRuleChain{}) == 0, so no update needed.
+		r := newRegistry()
+		assert.False(t, r.ruleChainsNeedUpdate(nil))
+	})
+
+	t.Run("membership change without interval change returns true", func(t *testing.T) {
+		r := newRegistry()
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-1",
+				IntervalSeconds:   30,
+				RecordingRuleRefs: []string{"rule-a"},
+				AlertRuleRefs:     []string{"rule-b"},
+			},
+		}
+
+		r.set(nil, nil, chains)
+		assert.False(t, r.ruleChainsNeedUpdate(chains))
+
+		// Change membership: add a new rule ref without changing the interval.
+		changed := []SchedulableRuleChain{
+			{
+				UID:               "chain-1",
+				IntervalSeconds:   30,
+				RecordingRuleRefs: []string{"rule-a", "rule-c"},
+				AlertRuleRefs:     []string{"rule-b"},
+			},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(changed), "membership change should be detected even without interval change")
+	})
+
+	t.Run("membership reorder without interval change returns true", func(t *testing.T) {
+		r := newRegistry()
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-1",
+				IntervalSeconds:   30,
+				RecordingRuleRefs: []string{"rule-a", "rule-b"},
+			},
+		}
+
+		r.set(nil, nil, chains)
+		assert.False(t, r.ruleChainsNeedUpdate(chains))
+
+		// Reorder the refs: this changes evaluation order, so should be detected.
+		reordered := []SchedulableRuleChain{
+			{
+				UID:               "chain-1",
+				IntervalSeconds:   30,
+				RecordingRuleRefs: []string{"rule-b", "rule-a"},
+			},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(reordered), "membership reorder should be detected")
+	})
+
+	t.Run("rule moved between recording and alerting refs returns true", func(t *testing.T) {
+		r := newRegistry()
+		chains := []SchedulableRuleChain{
+			{
+				UID:               "chain-1",
+				IntervalSeconds:   30,
+				RecordingRuleRefs: []string{"rule-a"},
+				AlertRuleRefs:     []string{"rule-b"},
+			},
+		}
+
+		r.set(nil, nil, chains)
+		assert.False(t, r.ruleChainsNeedUpdate(chains))
+
+		// Move rule-a from recording to alerting refs.
+		moved := []SchedulableRuleChain{
+			{
+				UID:             "chain-1",
+				IntervalSeconds: 30,
+				AlertRuleRefs:   []string{"rule-a", "rule-b"},
+			},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(moved), "moving a rule between ref types should be detected")
+	})
+
+	t.Run("after set with chains, matching chains return false", func(t *testing.T) {
+		r := newRegistry()
+		chains := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+			{UID: "chain-2", IntervalSeconds: 60},
+		}
+
+		// Before storing, the registry has no chain data, so it reports an update is needed.
+		assert.True(t, r.ruleChainsNeedUpdate(chains))
+
+		// Store the chain intervals via set.
+		r.set(nil, nil, chains)
+
+		// Now the same chains should not need an update.
+		assert.False(t, r.ruleChainsNeedUpdate(chains))
+
+		// A changed interval should still be detected.
+		changed := []SchedulableRuleChain{
+			{UID: "chain-1", IntervalSeconds: 30},
+			{UID: "chain-2", IntervalSeconds: 120},
+		}
+		assert.True(t, r.ruleChainsNeedUpdate(changed))
 	})
 }
 

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -136,15 +136,15 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("empty registry and empty chains returns false", func(t *testing.T) {
 		r := newRegistry()
-		r.set(nil, nil, []SchedulableRuleChain{})
+		r.set(nil, nil, []models.SchedulableRuleChain{})
 		assert.False(t, r.ruleChainsNeedUpdate(nil))
-		assert.False(t, r.ruleChainsNeedUpdate([]SchedulableRuleChain{}))
+		assert.False(t, r.ruleChainsNeedUpdate([]models.SchedulableRuleChain{}))
 	})
 
 	t.Run("empty registry with new chains returns true", func(t *testing.T) {
 		r := newRegistry()
-		r.set(nil, nil, []SchedulableRuleChain{})
-		chains := []SchedulableRuleChain{
+		r.set(nil, nil, []models.SchedulableRuleChain{})
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 		}
 		assert.True(t, r.ruleChainsNeedUpdate(chains))
@@ -152,7 +152,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("matching chains returns false", func(t *testing.T) {
 		r := newRegistry()
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 			{UID: "chain-2", IntervalSeconds: 60},
 		}
@@ -162,10 +162,10 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("interval change returns true", func(t *testing.T) {
 		r := newRegistry()
-		r.set(nil, nil, []SchedulableRuleChain{
+		r.set(nil, nil, []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 		})
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 60},
 		}
 		assert.True(t, r.ruleChainsNeedUpdate(chains))
@@ -173,10 +173,10 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("chain added returns true", func(t *testing.T) {
 		r := newRegistry()
-		r.set(nil, nil, []SchedulableRuleChain{
+		r.set(nil, nil, []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 		})
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 			{UID: "chain-2", IntervalSeconds: 60},
 		}
@@ -185,11 +185,11 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("chain removed returns true", func(t *testing.T) {
 		r := newRegistry()
-		r.set(nil, nil, []SchedulableRuleChain{
+		r.set(nil, nil, []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 			{UID: "chain-2", IntervalSeconds: 60},
 		})
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 		}
 		assert.True(t, r.ruleChainsNeedUpdate(chains))
@@ -197,10 +197,10 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("chain replaced with different UID returns true", func(t *testing.T) {
 		r := newRegistry()
-		r.set(nil, nil, []SchedulableRuleChain{
+		r.set(nil, nil, []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 		})
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-new", IntervalSeconds: 30},
 		}
 		assert.True(t, r.ruleChainsNeedUpdate(chains))
@@ -208,14 +208,14 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("nil registry map with empty chains returns false", func(t *testing.T) {
 		// A fresh registry has a nil fingerprints map. With no chains,
-		// len(nil) == len([]SchedulableRuleChain{}) == 0, so no update needed.
+		// len(nil) == len([]models.SchedulableRuleChain{}) == 0, so no update needed.
 		r := newRegistry()
 		assert.False(t, r.ruleChainsNeedUpdate(nil))
 	})
 
 	t.Run("membership change without interval change returns true", func(t *testing.T) {
 		r := newRegistry()
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-1",
 				IntervalSeconds:   30,
@@ -228,7 +228,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 		assert.False(t, r.ruleChainsNeedUpdate(chains))
 
 		// Change membership: add a new rule ref without changing the interval.
-		changed := []SchedulableRuleChain{
+		changed := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-1",
 				IntervalSeconds:   30,
@@ -241,7 +241,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("membership reorder without interval change returns true", func(t *testing.T) {
 		r := newRegistry()
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-1",
 				IntervalSeconds:   30,
@@ -253,7 +253,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 		assert.False(t, r.ruleChainsNeedUpdate(chains))
 
 		// Reorder the refs: this changes evaluation order, so should be detected.
-		reordered := []SchedulableRuleChain{
+		reordered := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-1",
 				IntervalSeconds:   30,
@@ -265,7 +265,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("rule moved between recording and alerting refs returns true", func(t *testing.T) {
 		r := newRegistry()
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{
 				UID:               "chain-1",
 				IntervalSeconds:   30,
@@ -278,7 +278,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 		assert.False(t, r.ruleChainsNeedUpdate(chains))
 
 		// Move rule-a from recording to alerting refs.
-		moved := []SchedulableRuleChain{
+		moved := []models.SchedulableRuleChain{
 			{
 				UID:             "chain-1",
 				IntervalSeconds: 30,
@@ -290,7 +290,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 
 	t.Run("after set with chains, matching chains return false", func(t *testing.T) {
 		r := newRegistry()
-		chains := []SchedulableRuleChain{
+		chains := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 			{UID: "chain-2", IntervalSeconds: 60},
 		}
@@ -305,7 +305,7 @@ func TestRuleChainsNeedUpdate(t *testing.T) {
 		assert.False(t, r.ruleChainsNeedUpdate(chains))
 
 		// A changed interval should still be detected.
-		changed := []SchedulableRuleChain{
+		changed := []models.SchedulableRuleChain{
 			{UID: "chain-1", IntervalSeconds: 30},
 			{UID: "chain-2", IntervalSeconds: 120},
 		}

--- a/pkg/services/ngalert/schedule/rule_chain_store.go
+++ b/pkg/services/ngalert/schedule/rule_chain_store.go
@@ -5,24 +5,14 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 	"strings"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-const ruleChainGroupPrefix = "__chain__"
-
-// SchedulableRuleChain describes a chain of rules that the scheduler should
-// evaluate sequentially. Recording rules run first, followed by alert rules,
-// all at the chain's interval.
-type SchedulableRuleChain struct {
-	UID               string
-	IntervalSeconds   int64
-	RecordingRuleRefs []string
-	AlertRuleRefs     []string
-}
-
-// fingerprint returns a hash that covers every field that affects scheduling
-// behavior: UID, interval, and the ordered membership lists. Two chains that
-// differ in any of these fields will produce different fingerprints.
-func (c SchedulableRuleChain) fingerprint() uint64 {
+// ruleChainFingerprint returns a hash that covers every field that affects
+// scheduling behavior: UID, interval, and the ordered membership lists. Two
+// chains that differ in any of these fields will produce different fingerprints.
+func ruleChainFingerprint(c models.SchedulableRuleChain) uint64 {
 	h := fnv.New64()
 	buf := make([]byte, 8)
 
@@ -43,13 +33,13 @@ func (c SchedulableRuleChain) fingerprint() uint64 {
 
 // RuleChainStore provides rule chain definitions for scheduling.
 type RuleChainStore interface {
-	GetRuleChainForScheduling(ctx context.Context) ([]SchedulableRuleChain, error)
+	GetRuleChainForScheduling(ctx context.Context) ([]models.SchedulableRuleChain, error)
 }
 
 // NoopRuleChainStore is a RuleChainStore that always returns an empty slice.
 // Used as the default when rule chains are not enabled.
 type NoopRuleChainStore struct{}
 
-func (n *NoopRuleChainStore) GetRuleChainForScheduling(ctx context.Context) ([]SchedulableRuleChain, error) {
-	return []SchedulableRuleChain{}, nil
+func (n *NoopRuleChainStore) GetRuleChainForScheduling(ctx context.Context) ([]models.SchedulableRuleChain, error) {
+	return []models.SchedulableRuleChain{}, nil
 }

--- a/pkg/services/ngalert/schedule/rule_chain_store.go
+++ b/pkg/services/ngalert/schedule/rule_chain_store.go
@@ -1,0 +1,55 @@
+package schedule
+
+import (
+	"context"
+	"encoding/binary"
+	"hash/fnv"
+	"strings"
+)
+
+const ruleChainGroupPrefix = "__chain__"
+
+// SchedulableRuleChain describes a chain of rules that the scheduler should
+// evaluate sequentially. Recording rules run first, followed by alert rules,
+// all at the chain's interval.
+type SchedulableRuleChain struct {
+	UID               string
+	IntervalSeconds   int64
+	RecordingRuleRefs []string
+	AlertRuleRefs     []string
+}
+
+// fingerprint returns a hash that covers every field that affects scheduling
+// behavior: UID, interval, and the ordered membership lists. Two chains that
+// differ in any of these fields will produce different fingerprints.
+func (c SchedulableRuleChain) fingerprint() uint64 {
+	h := fnv.New64()
+	buf := make([]byte, 8)
+
+	_, _ = h.Write([]byte(c.UID))
+	_, _ = h.Write([]byte{0xff})
+
+	binary.LittleEndian.PutUint64(buf, uint64(c.IntervalSeconds))
+	_, _ = h.Write(buf)
+
+	// Use a separator between recording and alert refs so that moving a UID
+	// from one list to the other changes the fingerprint.
+	_, _ = h.Write([]byte(strings.Join(c.RecordingRuleRefs, "\x00")))
+	_, _ = h.Write([]byte{0xff})
+	_, _ = h.Write([]byte(strings.Join(c.AlertRuleRefs, "\x00")))
+
+	return h.Sum64()
+}
+
+// RuleChainStore provides rule chain definitions for scheduling.
+type RuleChainStore interface {
+	GetRuleChainForScheduling(ctx context.Context) ([]SchedulableRuleChain, error)
+}
+
+// NoopRuleChainStore is a RuleChainStore that always returns an empty slice.
+// Used as the default when rule chains are not enabled.
+type NoopRuleChainStore struct{}
+
+func (n *NoopRuleChainStore) GetRuleChainForScheduling(ctx context.Context) ([]SchedulableRuleChain, error) {
+	return []SchedulableRuleChain{}, nil
+}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -86,7 +86,8 @@ type schedule struct {
 
 	evaluatorFactory eval.EvaluatorFactory
 
-	ruleStore RulesStore
+	ruleStore      RulesStore
+	ruleChainStore RuleChainStore
 
 	stateManager *state.Manager
 
@@ -156,6 +157,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 		log:                    cfg.Log,
 		evaluatorFactory:       cfg.EvaluatorFactory,
 		ruleStore:              cfg.RuleStore,
+		ruleChainStore:         &NoopRuleChainStore{},
 		metrics:                cfg.Metrics,
 		appURL:                 cfg.AppURL,
 		disableGrafanaFolder:   cfg.DisableGrafanaFolder,

--- a/pkg/services/ngalert/schedule/sequence.go
+++ b/pkg/services/ngalert/schedule/sequence.go
@@ -9,7 +9,7 @@ import (
 )
 
 // sequence represents a chain of rules that should be evaluated in order.
-// It is a convience type that wraps readyToRunItem as an indicator of what
+// It is a convenience type that wraps readyToRunItem as an indicator of what
 // is being represented.
 type sequence readyToRunItem
 
@@ -30,8 +30,6 @@ type groupKey struct {
 //
 // The function returns a slice of sequences, where each sequence represents a chain of rules
 // that should be evaluated in order.
-//
-// NOTE: This currently only chains rules in imported groups.
 func (sch *schedule) buildSequences(items []readyToRunItem, runJobFn func(next readyToRunItem, prev ...readyToRunItem) func()) []sequence {
 	// Step 1: Group rules by their folder and group name
 	groups := map[groupKey][]readyToRunItem{}
@@ -105,11 +103,6 @@ func (sch *schedule) buildSequence(groupKey groupKey, groupItems []readyToRunIte
 }
 
 func (sch *schedule) shouldEvaluateSequentially(groupItems []readyToRunItem) bool {
-	// the no group group shouldn't be evaluated sequentially
-	if len(groupItems) > 0 && models.IsNoGroupRuleGroup(groupItems[0].rule.RuleGroup) {
-		return false
-	}
-
 	// if jitter by rule is enabled, we can't evaluate rules sequentially
 	if sch.jitterEvaluations == JitterByRule {
 		return false
@@ -118,6 +111,10 @@ func (sch *schedule) shouldEvaluateSequentially(groupItems []readyToRunItem) boo
 	// if there is only one rule, there are no rules to chain
 	if len(groupItems) == 1 {
 		return false
+	}
+
+	if len(groupItems) > 0 && strings.HasPrefix(groupItems[0].rule.RuleGroup, ruleChainGroupPrefix) {
+		return true
 	}
 
 	// only evaluate rules in imported groups sequentially

--- a/pkg/services/ngalert/schedule/sequence.go
+++ b/pkg/services/ngalert/schedule/sequence.go
@@ -113,7 +113,7 @@ func (sch *schedule) shouldEvaluateSequentially(groupItems []readyToRunItem) boo
 		return false
 	}
 
-	if len(groupItems) > 0 && strings.HasPrefix(groupItems[0].rule.RuleGroup, ruleChainGroupPrefix) {
+	if len(groupItems) > 0 && models.IsRuleChainGroup(groupItems[0].rule.RuleGroup) {
 		return true
 	}
 

--- a/pkg/services/ngalert/schedule/sequence_test.go
+++ b/pkg/services/ngalert/schedule/sequence_test.go
@@ -154,4 +154,162 @@ func TestSequence(t *testing.T) {
 		require.Equal(t, []string{"4", "5"}, nextByGroup["rg2"])
 		require.Equal(t, []string{"3", "4"}, prevByGroup["rg2"])
 	})
+
+	t.Run("chain group with multiple rules evaluates sequentially", func(t *testing.T) {
+		chainGroup := ruleChainGroupPrefix + "chain-123"
+		nextByGroup := map[string][]string{}
+		prevByGroup := map[string][]string{}
+		callback := func(next readyToRunItem, prev ...readyToRunItem) func() {
+			return func() {
+				group := next.rule.RuleGroup
+				nextByGroup[group] = append(nextByGroup[group], next.rule.UID)
+				if len(prev) > 0 {
+					prevByGroup[group] = append(prevByGroup[group], prev[0].rule.UID)
+				}
+				next.ruleRoutine.Eval(&next.Evaluation)
+			}
+		}
+
+		items := []readyToRunItem{
+			{
+				ruleRoutine: &fakeSequenceRule{UID: "c1", Group: chainGroup},
+				Evaluation: Evaluation{
+					rule: gen.With(
+						models.RuleGen.WithUID("c1"),
+						models.RuleGen.WithGroupIndex(1),
+						models.RuleGen.WithGroupName(chainGroup),
+					).GenerateRef(),
+					folderTitle: "folder1",
+				},
+			},
+			{
+				ruleRoutine: &fakeSequenceRule{UID: "c2", Group: chainGroup},
+				Evaluation: Evaluation{
+					rule: gen.With(
+						models.RuleGen.WithUID("c2"),
+						models.RuleGen.WithGroupIndex(2),
+						models.RuleGen.WithGroupName(chainGroup),
+					).GenerateRef(),
+					folderTitle: "folder1",
+				},
+			},
+			{
+				ruleRoutine: &fakeSequenceRule{UID: "c3", Group: chainGroup},
+				Evaluation: Evaluation{
+					rule: gen.With(
+						models.RuleGen.WithUID("c3"),
+						models.RuleGen.WithGroupIndex(3),
+						models.RuleGen.WithGroupName(chainGroup),
+					).GenerateRef(),
+					folderTitle: "folder1",
+				},
+			},
+		}
+
+		sequences := sch.buildSequences(items, callback)
+		// Three chain rules should produce one sequence (chained).
+		require.Equal(t, 1, len(sequences))
+		require.Equal(t, "c1", sequences[0].rule.UID)
+
+		// Run the sequence.
+		sequences[0].ruleRoutine.Eval(&sequences[0].Evaluation)
+
+		require.Equal(t, []string{"c2", "c3"}, nextByGroup[chainGroup])
+		require.Equal(t, []string{"c1", "c2"}, prevByGroup[chainGroup])
+	})
+}
+
+func TestShouldEvaluateSequentially(t *testing.T) {
+	gen := models.RuleGen.With(models.RuleGen.WithNamespaceUID("ns1"))
+
+	makeItem := func(uid, group string) readyToRunItem {
+		return readyToRunItem{
+			ruleRoutine: &fakeSequenceRule{UID: uid, Group: group},
+			Evaluation: Evaluation{
+				rule: gen.With(
+					models.RuleGen.WithUID(uid),
+					models.RuleGen.WithGroupName(group),
+				).GenerateRef(),
+				folderTitle: "folder1",
+			},
+		}
+	}
+
+	makePrometheusItem := func(uid, group string) readyToRunItem {
+		return readyToRunItem{
+			ruleRoutine: &fakeSequenceRule{UID: uid, Group: group},
+			Evaluation: Evaluation{
+				rule: gen.With(
+					models.RuleGen.WithUID(uid),
+					models.RuleGen.WithGroupName(group),
+					models.RuleGen.WithPrometheusOriginalRuleDefinition("test"),
+				).GenerateRef(),
+				folderTitle: "folder1",
+			},
+		}
+	}
+
+	t.Run("chain group with two rules returns true", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		chainGroup := ruleChainGroupPrefix + "my-chain"
+		items := []readyToRunItem{
+			makeItem("a", chainGroup),
+			makeItem("b", chainGroup),
+		}
+		require.True(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("chain group with one rule returns false", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		chainGroup := ruleChainGroupPrefix + "solo"
+		items := []readyToRunItem{
+			makeItem("a", chainGroup),
+		}
+		require.False(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("chain group is independent of jitter setting", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		sch.jitterEvaluations = JitterByGroup
+		chainGroup := ruleChainGroupPrefix + "jitter-test"
+		items := []readyToRunItem{
+			makeItem("a", chainGroup),
+			makeItem("b", chainGroup),
+		}
+		require.True(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("chain group returns false when jitter by rule is enabled", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		sch.jitterEvaluations = JitterByRule
+		chainGroup := ruleChainGroupPrefix + "jitter-rule"
+		items := []readyToRunItem{
+			makeItem("a", chainGroup),
+			makeItem("b", chainGroup),
+		}
+		require.False(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("regular group with two rules returns false", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		items := []readyToRunItem{
+			makeItem("a", "regular-group"),
+			makeItem("b", "regular-group"),
+		}
+		require.False(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("prometheus imported group with two rules returns true", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		items := []readyToRunItem{
+			makePrometheusItem("a", "prom-group"),
+			makePrometheusItem("b", "prom-group"),
+		}
+		require.True(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("empty items returns false", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		require.False(t, sch.shouldEvaluateSequentially(nil))
+	})
 }

--- a/pkg/services/ngalert/schedule/sequence_test.go
+++ b/pkg/services/ngalert/schedule/sequence_test.go
@@ -156,7 +156,7 @@ func TestSequence(t *testing.T) {
 	})
 
 	t.Run("chain group with multiple rules evaluates sequentially", func(t *testing.T) {
-		chainGroup := models.RuleChainGroupPrefix + "chain-123"
+		chainGroup := chainGroupName(t, "chain-123")
 		nextByGroup := map[string][]string{}
 		prevByGroup := map[string][]string{}
 		callback := func(next readyToRunItem, prev ...readyToRunItem) func() {
@@ -251,7 +251,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 
 	t.Run("chain group with two rules returns true", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
-		chainGroup := models.RuleChainGroupPrefix + "my-chain"
+		chainGroup := chainGroupName(t, "my-chain")
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 			makeItem("b", chainGroup),
@@ -261,7 +261,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 
 	t.Run("chain group with one rule returns false", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
-		chainGroup := models.RuleChainGroupPrefix + "solo"
+		chainGroup := chainGroupName(t, "solo")
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 		}
@@ -271,7 +271,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 	t.Run("chain group is independent of jitter setting", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
 		sch.jitterEvaluations = JitterByGroup
-		chainGroup := models.RuleChainGroupPrefix + "jitter-test"
+		chainGroup := chainGroupName(t, "jitter-test")
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 			makeItem("b", chainGroup),
@@ -282,7 +282,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 	t.Run("chain group returns false when jitter by rule is enabled", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
 		sch.jitterEvaluations = JitterByRule
-		chainGroup := models.RuleChainGroupPrefix + "jitter-rule"
+		chainGroup := chainGroupName(t, "jitter-rule")
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 			makeItem("b", chainGroup),
@@ -295,6 +295,18 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 		items := []readyToRunItem{
 			makeItem("a", "regular-group"),
 			makeItem("b", "regular-group"),
+		}
+		require.False(t, sch.shouldEvaluateSequentially(items))
+	})
+
+	t.Run("unpadded chain prefix is not treated as chain group", func(t *testing.T) {
+		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
+		// A user-creatable group name that happens to start with the prefix
+		// but is not padded to sentinel length should NOT be sequential.
+		fakeGroup := models.RuleChainGroupPrefix + "user-created"
+		items := []readyToRunItem{
+			makeItem("a", fakeGroup),
+			makeItem("b", fakeGroup),
 		}
 		require.False(t, sch.shouldEvaluateSequentially(items))
 	})

--- a/pkg/services/ngalert/schedule/sequence_test.go
+++ b/pkg/services/ngalert/schedule/sequence_test.go
@@ -156,7 +156,7 @@ func TestSequence(t *testing.T) {
 	})
 
 	t.Run("chain group with multiple rules evaluates sequentially", func(t *testing.T) {
-		chainGroup := ruleChainGroupPrefix + "chain-123"
+		chainGroup := models.RuleChainGroupPrefix + "chain-123"
 		nextByGroup := map[string][]string{}
 		prevByGroup := map[string][]string{}
 		callback := func(next readyToRunItem, prev ...readyToRunItem) func() {
@@ -251,7 +251,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 
 	t.Run("chain group with two rules returns true", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
-		chainGroup := ruleChainGroupPrefix + "my-chain"
+		chainGroup := models.RuleChainGroupPrefix + "my-chain"
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 			makeItem("b", chainGroup),
@@ -261,7 +261,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 
 	t.Run("chain group with one rule returns false", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
-		chainGroup := ruleChainGroupPrefix + "solo"
+		chainGroup := models.RuleChainGroupPrefix + "solo"
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 		}
@@ -271,7 +271,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 	t.Run("chain group is independent of jitter setting", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
 		sch.jitterEvaluations = JitterByGroup
-		chainGroup := ruleChainGroupPrefix + "jitter-test"
+		chainGroup := models.RuleChainGroupPrefix + "jitter-test"
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 			makeItem("b", chainGroup),
@@ -282,7 +282,7 @@ func TestShouldEvaluateSequentially(t *testing.T) {
 	t.Run("chain group returns false when jitter by rule is enabled", func(t *testing.T) {
 		sch := setupScheduler(t, newFakeRulesStore(), nil, nil, nil, nil, nil)
 		sch.jitterEvaluations = JitterByRule
-		chainGroup := ruleChainGroupPrefix + "jitter-rule"
+		chainGroup := models.RuleChainGroupPrefix + "jitter-rule"
 		items := []readyToRunItem{
 			makeItem("a", chainGroup),
 			makeItem("b", chainGroup),


### PR DESCRIPTION
**What is this feature?**

Adds scheduler-level support for rule chains: ordered groups of recording and alert rules that are evaluated sequentially within a single tick. This is plumbing only; a `NoopRuleChainStore` is wired as the default so the feature is inert until a real store and feature toggle are connected.

**Why do we need this feature?**

Rule chains allow recording rules to produce intermediate results that downstream alert rules depend on. The scheduler needs to guarantee evaluation order (recordings first, then alerts) and coerce all chain members onto the same interval so they fire on the same tick and can be chained via `afterEval` callbacks.

**Who is this feature for?**

Alerting engineers building the rule chain CRUD API and scheduling pipeline. Not user-facing until the store and toggle are wired in.

**Which issue(s) does this PR fix?**:

N/A (part of the rule chains initiative)

**Special notes for your reviewer:**

`JitterByRule` is incompatible with chains: it short-circuits `shouldEvaluateSequentially` before the chain prefix check, preventing sequential evaluation. This is pre-existing behavior that also affects Prometheus imported groups. Deprecation of `JitterByRule` will be addressed in the CRUD API PR.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.