### PR TITLE
FieldOverrides: Delete duplicate code for FieldType.nestedFrames

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -1,4 +1,4 @@
-import { isNumber, set, unset, get, cloneDeep, defaultsDeep } from 'lodash';
+import { isNumber, set, unset, get, cloneDeep } from 'lodash';
 import { createContext, useContext, useMemo, useRef } from 'react';
 import { usePrevious } from 'react-use';
 
@@ -230,57 +230,12 @@ export function applyFieldOverrides(
       );
 
       if (field.type === FieldType.nestedFrames) {
-        const newValues: DataFrame[][] = Array(field.values.length);
-        for (let idx = 0; idx < field.values.length; idx++) {
-          const nestedFrames: DataFrame[] = field.values[idx];
-          for (let nfIndex = 0; nfIndex < nestedFrames.length; nfIndex++) {
-            const nestedFrame = nestedFrames[nfIndex];
-            for (const valueField of nestedFrame.fields) {
-              // Get display processor for nested fields
-              valueField.display = getDisplayProcessor({
-                field: valueField,
-                theme: options.theme,
-                timeZone: options.timeZone,
-              });
-
-              valueField.state = {
-                scopedVars: {
-                  __dataContext: {
-                    value: {
-                      data: nestedFrames,
-                      frame: nestedFrame,
-                      frameIndex: nfIndex,
-                      field: valueField,
-                    },
-                  },
-                },
-              };
-
-              valueField.getLinks = getLinksSupplier(
-                nestedFrame,
-                valueField,
-                valueField.state?.scopedVars ?? {},
-                context.replaceVariables,
-                options.timeZone,
-                options.dataLinkPostProcessor
-              );
-            }
-          }
-          newValues[idx] = applyFieldOverrides(options, nestedFrames, 'nested');
-        }
-        field.values = newValues;
+        field.values = field.values.map((v) => applyFieldOverrides(options, v, 'nested'));
       } else if (field.type === FieldType.frame) {
-        const newValues: DataFrame[] = Array(field.values.length);
-        for (let idx = 0; idx < field.values.length; idx++) {
-          const nestedFrame: DataFrame = field.values[idx] ?? createDataFrame({ fields: [] });
-          for (let fieldIndex = 0; fieldIndex < nestedFrame.fields.length; fieldIndex++) {
-            const valueField = nestedFrame.fields[fieldIndex];
-            valueField.config = defaultsDeep(valueField.config || {}, config);
-          }
-          newValues[idx] = nestedFrame;
-        }
-        // @todo should this be scoped?
-        field.values = applyFieldOverrides(options, newValues);
+        field.values = applyFieldOverrides(
+          options,
+          field.values.map((v) => v ?? createDataFrame({ fields: [] }))
+        );
       }
     }
   }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -1,4 +1,4 @@
-import { isNumber, set, unset, get, cloneDeep } from 'lodash';
+import { isNumber, set, unset, get, cloneDeep, defaultsDeep } from 'lodash';
 import { createContext, useContext, useMemo, useRef } from 'react';
 import { usePrevious } from 'react-use';
 
@@ -232,10 +232,18 @@ export function applyFieldOverrides(
       if (field.type === FieldType.nestedFrames) {
         field.values = field.values.map((v) => applyFieldOverrides(options, v, 'nested'));
       } else if (field.type === FieldType.frame) {
-        field.values = applyFieldOverrides(
-          options,
-          field.values.map((v) => v ?? createDataFrame({ fields: [] }))
-        );
+        const newValues: DataFrame[] = Array(field.values.length);
+        for (let idx = 0; idx < field.values.length; idx++) {
+          // ensure no null frames lead to thrown errors
+          const nestedFrame: DataFrame = field.values[idx] ?? createDataFrame({ fields: [] });
+          // merge default config into the frame field config before applying overrides
+          for (const valueField of nestedFrame.fields) {
+            valueField.config ??= {};
+            valueField.config = defaultsDeep(valueField.config, config);
+          }
+          newValues[idx] = nestedFrame;
+        }
+        field.values = applyFieldOverrides(options, newValues);
       }
     }
   }


### PR DESCRIPTION
I believe everything this PR deletes is now unnecessary because it is handled by the recursive calls to `applyFieldOverrides`; this will need extensive testing and probably should not be part of G13.