### PR TITLE
metricTimeSplitting: remove console log

### DIFF
--- a/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
@@ -81,8 +81,6 @@ describe('logs splitTimeRangeAligned', () => {
     const timeRange = makeTimeRange(toUtc('2022-02-01T08:10:03.234Z'), toUtc('2022-02-01T20:10:03.234Z'));
     const result = splitTimeRangeAligned(timeRange, 200);
 
-    console.log(toUtc(result[0][0]).toISOString(), toUtc(result[0][1]).toISOString());
-
     expect(result).toStrictEqual([[Date.parse('2022-02-01T08:10:03.234Z'), Date.parse('2022-02-01T20:10:03.234Z')]]);
   });
 });


### PR DESCRIPTION
Leftover from https://github.com/grafana/grafana/pull/120689