### PR TITLE
Expressions: Add disable toggle for queries

### DIFF
--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -149,6 +149,11 @@ export interface ExpressionQuery extends DataQuery {
   upsampler?: string;
   conditions?: ClassicCondition[];
   settings?: ExpressionQuerySettings;
+  /**
+   * If disabled is true, the expression query is excluded from the request entirely.
+   * Unlike hide (which only hides the response), disable prevents execution.
+   */
+  disabled?: boolean;
 }
 
 export interface SqlExpressionQuery extends ExpressionQuery {

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -34,7 +34,7 @@ import {
 } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 
 import { useQueryLibraryContext } from '../../explore/QueryLibrary/QueryLibraryContext';
-import { ExpressionDatasourceUID } from '../../expressions/types';
+import { ExpressionDatasourceUID, ExpressionQuery } from '../../expressions/types';
 
 import { QueryActionAssistantButton } from './QueryActionAssistantButton';
 import { QueryActionComponent, RowActionComponents } from './QueryActionComponent';
@@ -287,6 +287,18 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     });
   };
 
+  onDisableQuery = () => {
+    const { query, onChange, onRunQuery } = this.props;
+    const expressionQuery = query as unknown as ExpressionQuery;
+    const newDisabled = !expressionQuery.disabled;
+    onChange({ ...query, disabled: newDisabled } as TQuery);
+    onRunQuery();
+
+    reportInteraction('query_editor_row_disable_query_clicked', {
+      disabled: newDisabled,
+    });
+  };
+
   onToggleHelp = () => {
     this.setState((state) => ({
       showingHelp: !state.showingHelp,
@@ -403,11 +415,13 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     const { query, hideHideQueryButton: hideHideQueryButton = false, queryLibraryRef, app } = this.props;
     const { datasource, showingHelp } = this.state;
     const isHidden = !!query.hide;
+    const isDisabled = !!(query as unknown as ExpressionQuery).disabled;
 
     const hasEditorHelp = datasource?.components?.QueryEditorHelp;
     const isEditingQueryLibrary = queryLibraryRef !== undefined;
     const isUnifiedAlerting = app === CoreApp.UnifiedAlerting;
     const isExpressionQuery = query.datasource?.uid === ExpressionDatasourceUID;
+    const hasExpressionQuery = this.props.queries.some((q) => q.datasource?.uid === ExpressionDatasourceUID);
 
     return (
       <>
@@ -442,6 +456,18 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
           />
         )}
 
+        {(isExpressionQuery || hasExpressionQuery) && (
+          <QueryOperationToggleAction
+            title={
+              isDisabled
+                ? t('query-operation.header.enable-expression', 'Enable expression')
+                : t('query-operation.header.disable-expression', 'Disable expression')
+            }
+            icon="ban"
+            active={isDisabled}
+            onClick={this.onDisableQuery}
+          />
+        )}
         {!hideHideQueryButton ? (
           <QueryOperationToggleAction
             dataTestId={selectors.components.QueryEditorRow.actionButton('Hide response')}
@@ -452,6 +478,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
             }
             icon={isHidden ? 'eye-slash' : 'eye'}
             active={isHidden}
+            disabled={isDisabled}
             onClick={this.onHideQuery}
           />
         ) : null}
@@ -477,6 +504,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         onChangeDataSource={onChangeDataSource}
         dataSource={dataSource}
         hidden={query.hide}
+        disabled={!!(query as unknown as ExpressionQuery).disabled}
         onChange={onChange}
         collapsedText={!props.isOpen ? this.renderCollapsedText() : null}
         renderExtras={() => (

--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -12,6 +12,7 @@ export interface Props<TQuery extends DataQuery = DataQuery> {
   query: TQuery;
   queries: TQuery[];
   hidden?: boolean;
+  disabled?: boolean;
   dataSource: DataSourceInstanceSettings;
   renderExtras?: () => ReactNode;
   onChangeDataSource?: (settings: DataSourceInstanceSettings) => void;
@@ -22,7 +23,7 @@ export interface Props<TQuery extends DataQuery = DataQuery> {
 }
 
 export const QueryEditorRowHeader = <TQuery extends DataQuery>(props: Props<TQuery>) => {
-  const { query, queries, onChange, collapsedText, renderExtras, hidden, hideRefId = false } = props;
+  const { query, queries, onChange, collapsedText, renderExtras, hidden, disabled, hideRefId = false } = props;
 
   const styles = useStyles2(getStyles);
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -119,7 +120,12 @@ export const QueryEditorRowHeader = <TQuery extends DataQuery>(props: Props<TQue
         )}
         {renderDataSource(props, styles)}
         {renderExtras && <div className={styles.itemWrapper}>{renderExtras()}</div>}
-        {hidden && (
+        {disabled && (
+          <em className={styles.contextInfo}>
+            <Trans i18nKey="query.query-editor-row-header.disabled">Disabled</Trans>
+          </em>
+        )}
+        {hidden && !disabled && (
           <em className={styles.contextInfo}>
             <Trans i18nKey="query.query-editor-row-header.hidden">Hidden</Trans>
           </em>

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -216,6 +216,9 @@ export function callQueryMethod(
     return from(datasource.query(request));
   }
 
+  // Filter out disabled queries before execution
+  request.targets = request.targets.filter((t) => !(t as ExpressionQuery).disabled);
+
   for (const target of request.targets) {
     if (isExpressionReference(target.datasource)) {
       return expressionDatasource.query(request as DataQueryRequest<ExpressionQuery>);


### PR DESCRIPTION
## Summary
- Adds a disable button (ban icon) next to the hide (eye) button on query rows when expressions (SSE) are present
- Disabled queries are excluded from the backend request entirely, unlike hide which only filters the response
- When disabled, the hide button is greyed out and the header shows "Disabled"
- Appears on both data source queries and expression queries when at least one expression exists

## Context
FE PoC — in the future the BE will respect the disabled flag natively, and dependent expressions can also be disabled.

## Test plan
- [ ] Add a data source query and an expression query in panel edit
- [ ] Verify the ban (disable) icon appears on both queries
- [ ] Click disable on the expression — verify it shows "Disabled", hide is greyed out, and the expression is not executed
- [ ] Click disable on the DS query — verify it is excluded from the request
- [ ] Re-enable and verify normal behavior resumes
- [ ] Verify disable button does not appear when there are no expression queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)