### PR TITLE
bugfix: fix calling dashboard star returning 500 with postgres

### DIFF
--- a/pkg/services/star/starimpl/star.go
+++ b/pkg/services/star/starimpl/star.go
@@ -11,6 +11,7 @@ import (
 
 type Service struct {
 	store  store
+	db     db.DB
 	logger log.Logger
 }
 
@@ -27,6 +28,7 @@ func ProvideService(db db.DB) star.Service {
 		store: &sqlStore{
 			db: db,
 		},
+		db:     db,
 		logger: starLogger,
 	}
 }
@@ -35,7 +37,11 @@ func (s *Service) Add(ctx context.Context, cmd *star.StarDashboardCommand) error
 	if err := cmd.Validate(); err != nil {
 		return err
 	}
-	return s.store.Insert(ctx, cmd)
+	err := s.store.Insert(ctx, cmd)
+	if s.db.GetDialect().IsUniqueConstraintViolation(err) {
+		return nil
+	}
+	return err
 }
 
 func (s *Service) Delete(ctx context.Context, cmd *star.UnstarDashboardCommand) error {

--- a/pkg/services/star/starimpl/xorm_store.go
+++ b/pkg/services/star/starimpl/xorm_store.go
@@ -46,10 +46,6 @@ func (s *sqlStore) Insert(ctx context.Context, cmd *star.StarDashboardCommand) e
 		}
 
 		_, err := sess.Insert(&entity)
-		if s.db.GetDialect().IsUniqueConstraintViolation(err) {
-			return nil
-		}
-
 		return err
 	})
 }


### PR DESCRIPTION
related https://github.com/grafana/support-escalations/issues/21361

The star endpoint is supposed to be idempotent, and behaves as you'd expect with SQLite and MySQL. With Postgres it returns a 500 error and we can see in the logs `pq: Could not complete operation in a failed transaction`. This is because Postgres aborts the transaction when it encounters an error. So when we later try to commit it, we surface this error.

This PR moves the constraint validation check one level up, so we don't commit the transaction as there's really nothing to do anyway.