### PR TITLE
Alerting docs: Documentation for `alertingSaveStateCompressed` upgrad…

### DIFF
--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -60,9 +60,11 @@ For more information, refer to [this GitHub issue](https://github.com/grafana/gr
 
 If you have a high number of alert rules or alert instances, the load on the database can get very high.
 
-By default, Grafana performs one SQL update per alert rule after each evaluation, which updates all alert instances belonging to the rule.
+By default, Grafana performs one SQL update per alert rule after each evaluation, which updates all alert instances belonging to the rule. This is controlled by the `alertingSaveStateCompressed` feature flag, which is enabled by default since Grafana v12.0.
 
-You can change this behavior by disabling the `alertingSaveStateCompressed` feature flag. In this case, Grafana performs a separate SQL update for each state change of an alert instance. This configuration is rarely recommended, as it can add significant database overhead for alert rules with many instances.
+You can change this behavior by disabling the `alertingSaveStateCompressed` feature flag. If compression is disabled and periodic saves aren't enabled (refer to [Save state periodically](#save-state-periodically)), Grafana performs a separate SQL update for each state change of an alert instance, which can add significant database overhead for alert rules with many instances.
+
+However, disabling compression while enabling batch-based periodic saves is a valid configuration. This is particularly relevant for environments that tuned batch settings prior to v12.0, as it restores the pre-v12.0 save behavior. Refer to [Batch-based periodic saves](#batch-based-periodic-saves) for details.
 
 ### Save state periodically
 
@@ -72,11 +74,15 @@ There are two approaches for periodic state saving:
 
 #### Compressed periodic saves
 
+{{< admonition type="note" >}}
+Combining compressed state storage with periodic saves requires **Grafana v12.4 or later**. In Grafana v12.0 through v12.3, these features are mutually exclusive — compression takes precedence and periodic save settings (such as `state_periodic_save_interval` and `state_periodic_save_batch_size`) are ignored. If you need periodic batch saves on v12.0–v12.3, disable `alertingSaveStateCompressed` and use [batch-based periodic saves](#batch-based-periodic-saves) instead.
+{{< /admonition >}}
+
 You can combine compressed alert state storage with periodic saves by enabling both `alertingSaveStateCompressed` and `alertingSaveStatePeriodic` feature toggles together.
 
 This approach groups all alert instances by rule UID and compresses them together for efficient storage.
 
-When both feature toggles are enabled, Grafana will save compressed alert states at the interval specified by `state_periodic_save_interval`. Note that in compressed mode, the `state_periodic_save_batch_size` setting is ignored as the system groups instances by rule UID rather than by batch size.
+When both feature toggles are enabled, Grafana saves compressed alert states at the interval specified by `state_periodic_save_interval`. Note that in compressed mode, the `state_periodic_save_batch_size` setting is ignored as the system groups instances by rule UID rather than by batch size.
 
 #### Batch-based periodic saves
 

--- a/docs/sources/upgrade-guide/upgrade-v12.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v12.0/index.md
@@ -81,6 +81,31 @@ Since Grafana 10.2, the endpoint to check compatible versions when installing a 
 
 We _do not_ recommend installing plugins declared as incompatible. However, if you need to force install a plugin despite it being declared as incompatible, refer to the [Installing a plugin from a ZIP](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-plugin-from-a-zip-file) guidance.
 
+### Alert state compression enabled by default
+
+**Review your alerting state save configuration if you use batch-based periodic saves**
+
+Starting in Grafana v12.0, the `alertingSaveStateCompressed` feature flag is enabled by default. Compressed state storage performs one SQL update per alert rule after each evaluation, grouping all alert instances belonging to the rule together.
+
+In Grafana v12.0 through v12.3, compressed state storage and batch-based periodic saves (`alertingSaveStatePeriodic`) are mutually exclusive — compression takes precedence. If you previously configured batch-based periodic saves with settings such as `state_periodic_save_interval` and `state_periodic_save_batch_size`, those settings become a no-op after upgrading to v12.0.
+
+#### How do I know if I'm affected?
+
+You're affected if both of the following are true:
+
+- You enabled `alertingSaveStatePeriodic` and configured batch save settings (such as `state_periodic_save_interval` or `state_periodic_save_batch_size`) prior to upgrading.
+- You haven't explicitly set `alertingSaveStateCompressed` in your feature toggles (meaning it defaults to `true`).
+
+In this case, your batch settings are silently ignored after the upgrade and alert state is saved after every evaluation instead of periodically. This can lead to increased database connections and load, especially in environments with a high number of alert rules.
+
+#### What should I do?
+
+You have two options:
+
+1. **Disable compression and keep batching (v12.0–v12.3):** Explicitly disable the `alertingSaveStateCompressed` feature flag while keeping `alertingSaveStatePeriodic` enabled. This restores the pre-v12.0 batch save behavior. For more information, refer to [Batch-based periodic saves]({{< relref "../../alerting/set-up/performance-limitations#batch-based-periodic-saves" >}}).
+
+1. **Upgrade to v12.4 to combine both:** Grafana v12.4 supports combining compressed state storage with periodic batch saves and jitter. If you can upgrade, this is the recommended path. For more information, refer to [Compressed periodic saves]({{< relref "../../alerting/set-up/performance-limitations#compressed-periodic-saves" >}}).
+
 ### Annotation table migration
 
 **Plan for increased disk usage when upgrading from Grafana v11.x**


### PR DESCRIPTION
RE: [Support request 21416](https://github.com/grafana/support-escalations/issues/21416)

This pull request updates the documentation to clarify how alert state compression and periodic batch saves interact in Grafana v12.x. It explains the default behavior change in v12.0, the mutual exclusivity of compression and batching in v12.0–v12.3, and the new ability to combine both features in v12.4 and later. These changes help users understand how their alerting configurations may be affected when upgrading and how to adjust settings for optimal performance.

**Alert state compression and periodic save behavior:**

* Updated the performance limitations documentation to clarify that the `alertingSaveStateCompressed` feature flag is enabled by default since Grafana v12.0, and describes how disabling compression restores pre-v12.0 batch save behavior for users who previously tuned batch settings.
* Added a note that combining compressed state storage with periodic saves requires Grafana v12.4 or later; in v12.0–v12.3, compression takes precedence and periodic save settings are ignored, with guidance for users who need batch saves on earlier versions.

**Upgrade guidance:**

* Added a new section to the v12.0 upgrade guide warning users that alert state compression is now enabled by default, and that batch-based periodic save settings are ignored unless compression is disabled in v12.0–v12.3. Provides instructions for affected users and recommends upgrading to v12.4 to combine both features.