### PR TITLE
unified-storage: follow `versions_to_keep` setting when pruning history

### DIFF
--- a/pkg/storage/unified/resource/pruner_history_limits.go
+++ b/pkg/storage/unified/resource/pruner_history_limits.go
@@ -1,13 +1,22 @@
 package resource
 
+// defaultPrunerHistoryLimit is the default number of history entries to keep per resource.
+const defaultPrunerHistoryLimit = 20
+
 // customPrunerHistoryLimits defines resource-specific history limits.
 // The key format is "group/resource".
 var customPrunerHistoryLimits = map[string]int{
 	"plugins.grafana.app/plugins": 3,
 }
 
-// LookupCustomPrunerHistoryLimit returns a resource-specific history limit when one is configured.
-func LookupCustomPrunerHistoryLimit(group, resource string) (int, bool) {
-	limit, ok := customPrunerHistoryLimits[group+"/"+resource]
-	return limit, ok
+// LookupPrunerHistoryLimit returns the history limit for the given group/resource,
+// honouring the dashboardVersionsToKeep configuration setting.
+func LookupPrunerHistoryLimit(group, resource string, dashboardVersionsToKeep int) int {
+	if group == "dashboard.grafana.app" && resource == "dashboards" {
+		return max(dashboardVersionsToKeep, 1)
+	}
+	if limit, ok := customPrunerHistoryLimits[group+"/"+resource]; ok {
+		return limit
+	}
+	return defaultPrunerHistoryLimit
 }

--- a/pkg/storage/unified/resource/pruner_history_limits_test.go
+++ b/pkg/storage/unified/resource/pruner_history_limits_test.go
@@ -6,34 +6,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLookupCustomPrunerHistoryLimit(t *testing.T) {
+func TestLookupPrunerHistoryLimit(t *testing.T) {
 	tests := []struct {
-		name     string
-		group    string
-		resource string
-		expected int
-		ok       bool
+		name                    string
+		group                   string
+		resource                string
+		dashboardVersionsToKeep int
+		expected                int
 	}{
 		{
-			name:     "returns custom limit for plugins",
-			group:    "plugins.grafana.app",
-			resource: "plugins",
-			expected: 3,
-			ok:       true,
+			name:                    "returns custom limit for plugins",
+			group:                   "plugins.grafana.app",
+			resource:                "plugins",
+			dashboardVersionsToKeep: 20,
+			expected:                3,
 		},
 		{
-			name:     "returns not found for other resources",
-			group:    "dashboard.grafana.app",
-			resource: "dashboards",
-			expected: 0,
-			ok:       false,
+			name:                    "returns configured limit for dashboards",
+			group:                   "dashboard.grafana.app",
+			resource:                "dashboards",
+			dashboardVersionsToKeep: 25,
+			expected:                25,
+		},
+		{
+			name:                    "clamps dashboard versions to minimum of 1",
+			group:                   "dashboard.grafana.app",
+			resource:                "dashboards",
+			dashboardVersionsToKeep: 0,
+			expected:                1,
+		},
+		{
+			name:                    "clamps negative dashboard versions to minimum of 1",
+			group:                   "dashboard.grafana.app",
+			resource:                "dashboards",
+			dashboardVersionsToKeep: -5,
+			expected:                1,
+		},
+		{
+			name:                    "returns default limit for other resources",
+			group:                   "some.app",
+			resource:                "resources",
+			dashboardVersionsToKeep: 100,
+			expected:                20,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			limit, ok := LookupCustomPrunerHistoryLimit(tc.group, tc.resource)
-			require.Equal(t, tc.ok, ok)
+			limit := LookupPrunerHistoryLimit(tc.group, tc.resource, tc.dashboardVersionsToKeep)
 			require.Equal(t, tc.expected, limit)
 		})
 	}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -37,8 +37,7 @@ import (
 const (
 	defaultListBufferSize             = 100
 	defaultEventRetentionPeriod       = 1 * time.Hour
-	defaultEventPruningLimit          = 20
-	defaultEventPruningInterval       = 5 * time.Minute
+defaultEventPruningInterval       = 5 * time.Minute
 	defaultSearchLookback             = 1 * time.Second
 	defaultGarbageCollectionBatchWait = 1 * time.Second
 )
@@ -62,8 +61,9 @@ type kvStorageBackend struct {
 	eventStore           *eventStore
 	notifier             notifier
 	log                  log.Logger
-	disablePruner        bool
-	eventRetentionPeriod time.Duration
+	disablePruner           bool
+	dashboardVersionsToKeep int
+	eventRetentionPeriod    time.Duration
 	eventPruningInterval time.Duration
 	historyPruner        Pruner
 	garbageCollection    GarbageCollectionConfig
@@ -133,6 +133,8 @@ type KVBackendOptions struct {
 	// SearchLookback is the duration subtracted from sinceRv in calls to ListModifiedSince.
 	// This guards against concurrent writes that commit slightly out-of-order. 0 means no lookback.
 	SearchLookback time.Duration
+
+	DashboardVersionsToKeep int
 }
 
 var (
@@ -200,7 +202,8 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		lastImportTimeMaxAge: opts.LastImportTimeMaxAge,
 		garbageCollection:    garbageCollection,
 		searchLookback:       opts.SearchLookback,
-		disablePruner:        opts.DisablePruner,
+		disablePruner:           opts.DisablePruner,
+		dashboardVersionsToKeep: opts.DashboardVersionsToKeep,
 	}
 	err = backend.initPruner(ctx)
 	if err != nil {
@@ -315,7 +318,7 @@ func (k *kvStorageBackend) pruneEvents(ctx context.Context, key PruningKey) erro
 		return fmt.Errorf("invalid pruning key: group, resource, and name must be set: %+v", key)
 	}
 
-	prunerMaxLimit := k.prunerHistoryLimit(key.Group, key.Resource)
+	prunerMaxLimit := LookupPrunerHistoryLimit(key.Group, key.Resource, k.dashboardVersionsToKeep)
 	counter := 0
 	deleted := 0
 	// iterate over all keys for the resource and delete versions beyond the configured limit
@@ -652,13 +655,6 @@ func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName 
 		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
 	}
 	return cutoffTimestamp
-}
-
-func (b *kvStorageBackend) prunerHistoryLimit(group, resource string) int {
-	if limit, ok := LookupCustomPrunerHistoryLimit(group, resource); ok {
-		return limit
-	}
-	return defaultEventPruningLimit
 }
 
 // WriteEvent writes a resource event (create/update/delete) to the storage backend.

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -37,7 +37,7 @@ import (
 const (
 	defaultListBufferSize             = 100
 	defaultEventRetentionPeriod       = 1 * time.Hour
-defaultEventPruningInterval       = 5 * time.Minute
+	defaultEventPruningInterval       = 5 * time.Minute
 	defaultSearchLookback             = 1 * time.Second
 	defaultGarbageCollectionBatchWait = 1 * time.Second
 )
@@ -54,21 +54,21 @@ type GarbageCollectionConfig struct {
 
 // kvStorageBackend Unified storage backend based on KV storage.
 type kvStorageBackend struct {
-	snowflake            *snowflake.Node
-	kv                   KV
-	bulkLock             *BulkLock
-	dataStore            *dataStore
-	eventStore           *eventStore
-	notifier             notifier
-	log                  log.Logger
+	snowflake               *snowflake.Node
+	kv                      KV
+	bulkLock                *BulkLock
+	dataStore               *dataStore
+	eventStore              *eventStore
+	notifier                notifier
+	log                     log.Logger
 	disablePruner           bool
 	dashboardVersionsToKeep int
 	eventRetentionPeriod    time.Duration
-	eventPruningInterval time.Duration
-	historyPruner        Pruner
-	garbageCollection    GarbageCollectionConfig
-	lastImportStore      *lastImportStore
-	lastImportTimeMaxAge time.Duration
+	eventPruningInterval    time.Duration
+	historyPruner           Pruner
+	garbageCollection       GarbageCollectionConfig
+	lastImportStore         *lastImportStore
+	lastImportTimeMaxAge    time.Duration
 	//tracer        trace.Tracer
 	//reg           prometheus.Registerer
 
@@ -186,22 +186,22 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 	}
 
 	backend := &kvStorageBackend{
-		kv:                   kv,
-		bulkLock:             NewBulkLock(),
-		dataStore:            newDataStore(kv),
-		eventStore:           eventStore,
-		notifier:             newNotifier(eventStore, notifierOptions{log: logger, useChannelNotifier: opts.UseChannelNotifier}),
-		watchOpts:            opts.WatchOptions.normalize(),
-		snowflake:            s,
-		log:                  logger,
-		eventRetentionPeriod: eventRetentionPeriod,
-		eventPruningInterval: eventPruningInterval,
-		rvManager:            opts.RvManager,
-		dbKeepAlive:          opts.DBKeepAlive,
-		lastImportStore:      newLastImportStore(kv),
-		lastImportTimeMaxAge: opts.LastImportTimeMaxAge,
-		garbageCollection:    garbageCollection,
-		searchLookback:       opts.SearchLookback,
+		kv:                      kv,
+		bulkLock:                NewBulkLock(),
+		dataStore:               newDataStore(kv),
+		eventStore:              eventStore,
+		notifier:                newNotifier(eventStore, notifierOptions{log: logger, useChannelNotifier: opts.UseChannelNotifier}),
+		watchOpts:               opts.WatchOptions.normalize(),
+		snowflake:               s,
+		log:                     logger,
+		eventRetentionPeriod:    eventRetentionPeriod,
+		eventPruningInterval:    eventPruningInterval,
+		rvManager:               opts.RvManager,
+		dbKeepAlive:             opts.DBKeepAlive,
+		lastImportStore:         newLastImportStore(kv),
+		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
+		garbageCollection:       garbageCollection,
+		searchLookback:          opts.SearchLookback,
 		disablePruner:           opts.DisablePruner,
 		dashboardVersionsToKeep: opts.DashboardVersionsToKeep,
 	}

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -2184,6 +2184,87 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		}
 		require.Equal(t, defaultPrunerHistoryLimit, counter)
 	})
+
+	t.Run("honours DashboardVersionsToKeep for dashboard resources", func(t *testing.T) {
+		dashboardVersionsToKeep := 5
+		backend := setupTestStorageBackend(t, func(opts *KVBackendOptions) {
+			opts.DashboardVersionsToKeep = dashboardVersionsToKeep
+		})
+		ctx := t.Context()
+
+		ns := NamespacedResource{
+			Namespace: "default",
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+		}
+		testObj, err := createTestObjectWithName("my-dashboard", ns, "test-data")
+		require.NoError(t, err)
+		metaAccessor, err := utils.MetaAccessor(testObj)
+		require.NoError(t, err)
+		writeEvent := WriteEvent{
+			Type: resourcepb.WatchEvent_ADDED,
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+				Name:      "my-dashboard",
+			},
+			Value:      objectToJSONBytes(t, testObj),
+			Object:     metaAccessor,
+			PreviousRV: 0,
+		}
+		rv1, err := backend.WriteEvent(ctx, writeEvent)
+		require.NoError(t, err)
+
+		// Update the dashboard dashboardVersionsToKeep times to exceed the configured limit.
+		// Total events: 1 (create) + dashboardVersionsToKeep (updates) = limit + 1.
+		previousRV := rv1
+		for i := 0; i < dashboardVersionsToKeep; i++ {
+			testObj.Object["spec"].(map[string]any)["value"] = fmt.Sprintf("update-%d", i)
+			writeEvent.Type = resourcepb.WatchEvent_MODIFIED
+			writeEvent.Value = objectToJSONBytes(t, testObj)
+			writeEvent.PreviousRV = previousRV
+			newRv, err := backend.WriteEvent(ctx, writeEvent)
+			require.NoError(t, err)
+			previousRV = newRv
+		}
+
+		pruningKey := PruningKey{
+			Namespace: "default",
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Name:      "my-dashboard",
+		}
+
+		err = backend.pruneEvents(ctx, pruningKey)
+		require.NoError(t, err)
+
+		// The first event (rv1) should have been pruned
+		eventKey1 := DataKey{
+			Namespace:       "default",
+			Group:           "dashboard.grafana.app",
+			Resource:        "dashboards",
+			Name:            "my-dashboard",
+			Action:          DataActionCreated,
+			ResourceVersion: rv1,
+		}
+		_, err = backend.dataStore.Get(ctx, eventKey1)
+		require.ErrorIs(t, err, ErrNotFound, "oldest event should be pruned")
+
+		// Exactly dashboardVersionsToKeep events should remain
+		counter := 0
+		for datakey, err := range backend.dataStore.Keys(ctx, ListRequestKey{
+			Namespace: "default",
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Name:      "my-dashboard",
+		}, SortOrderDesc) {
+			require.NoError(t, err)
+			require.Greater(t, datakey.ResourceVersion, rv1)
+			counter++
+		}
+		require.Equal(t, dashboardVersionsToKeep, counter)
+	})
 }
 
 // createTestObject creates a test unstructured object with standard values

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1836,9 +1836,9 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		rv1, err := backend.WriteEvent(ctx, writeEvent)
 		require.NoError(t, err)
 
-		// Update the resource defaultEventPruningLimit times. This will create one more event than the pruner limit.
+		// Update the resource defaultPrunerHistoryLimit times. This will create one more event than the pruner limit.
 		previousRV := rv1
-		for i := 0; i < defaultEventPruningLimit; i++ {
+		for i := 0; i < defaultPrunerHistoryLimit; i++ {
 			testObj.Object["spec"].(map[string]any)["value"] = fmt.Sprintf("update-%d", i)
 			writeEvent.Type = resourcepb.WatchEvent_MODIFIED
 			writeEvent.Value = objectToJSONBytes(t, testObj)
@@ -1870,7 +1870,7 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		_, err = backend.dataStore.Get(ctx, eventKey1)
 		require.Error(t, err) // Should return error as event is pruned
 
-		// assert defaultEventPruningLimit most recent events exist
+		// assert defaultPrunerHistoryLimit most recent events exist
 		counter := 0
 		for datakey, err := range backend.dataStore.Keys(ctx, ListRequestKey{
 			Namespace: "default",
@@ -1882,7 +1882,7 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			require.NotEqual(t, rv1, datakey.ResourceVersion)
 			counter++
 		}
-		require.Equal(t, defaultEventPruningLimit, counter)
+		require.Equal(t, defaultPrunerHistoryLimit, counter)
 	})
 
 	t.Run("will not prune events when less than limit", func(t *testing.T) {
@@ -1914,9 +1914,9 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		rv1, err := backend.WriteEvent(ctx, writeEvent)
 		require.NoError(t, err)
 
-		// Update the resource defaultEventPruningLimit-1 times. This will create same number of events as the pruner limit.
+		// Update the resource defaultPrunerHistoryLimit-1 times. This will create same number of events as the pruner limit.
 		previousRV := rv1
-		for i := 0; i < defaultEventPruningLimit-1; i++ {
+		for i := 0; i < defaultPrunerHistoryLimit-1; i++ {
 			testObj.Object["spec"].(map[string]any)["value"] = fmt.Sprintf("update-%d", i)
 			writeEvent.Type = resourcepb.WatchEvent_MODIFIED
 			writeEvent.Value = objectToJSONBytes(t, testObj)
@@ -1947,7 +1947,7 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			require.NoError(t, err)
 			counter++
 		}
-		require.Equal(t, defaultEventPruningLimit, counter)
+		require.Equal(t, defaultPrunerHistoryLimit, counter)
 	})
 
 	t.Run("will not prune deleted events", func(t *testing.T) {
@@ -1979,12 +1979,12 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		rv1, err := backend.WriteEvent(ctx, writeEvent)
 		require.NoError(t, err)
 
-		// Create defaultEventPruningLimit deleted events by repeatedly deleting and recreating the resource
-		// This will create: 1 initial ADDED + defaultEventPruningLimit cycles of (DELETE + ADDED)
+		// Create defaultPrunerHistoryLimit deleted events by repeatedly deleting and recreating the resource
+		// This will create: 1 initial ADDED + defaultPrunerHistoryLimit cycles of (DELETE + ADDED)
 		// = 1 + 20 + 20 = 41 total events (21 ADDED + 20 DELETED)
 		// Multiple deleted events for a resource shouldn't happen - this is just to ensure the pruner won't remove deleted events
 		previousRV := rv1
-		for i := 0; i < defaultEventPruningLimit; i++ {
+		for i := 0; i < defaultPrunerHistoryLimit; i++ {
 			testObj.Object["spec"].(map[string]any)["value"] = fmt.Sprintf("delete-%d", i)
 			metaAccessor, err := utils.MetaAccessor(testObj)
 			require.NoError(t, err)
@@ -2036,8 +2036,8 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			}
 			counter++
 		}
-		require.Equal(t, defaultEventPruningLimit, deletedCount, "All deleted events should be kept")
-		require.Equal(t, defaultEventPruningLimit*2, counter, "Should have 20 deleted + 20 non-deleted events")
+		require.Equal(t, defaultPrunerHistoryLimit, deletedCount, "All deleted events should be kept")
+		require.Equal(t, defaultPrunerHistoryLimit*2, counter, "Should have 20 deleted + 20 non-deleted events")
 	})
 
 	t.Run("will prune oldest events for cluster-scoped resources", func(t *testing.T) {
@@ -2069,9 +2069,9 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		rv1, err := backend.WriteEvent(ctx, writeEvent)
 		require.NoError(t, err)
 
-		// Update the resource defaultEventPruningLimit times to exceed the pruner limit
+		// Update the resource defaultPrunerHistoryLimit times to exceed the pruner limit
 		previousRV := rv1
-		for i := 0; i < defaultEventPruningLimit; i++ {
+		for i := 0; i < defaultPrunerHistoryLimit; i++ {
 			testObj.Object["spec"].(map[string]any)["value"] = fmt.Sprintf("update-%d", i)
 			writeEvent.Type = resourcepb.WatchEvent_MODIFIED
 			writeEvent.Value = objectToJSONBytes(t, testObj)
@@ -2105,7 +2105,7 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		require.Error(t, err) // Should return error as event is pruned
 		require.ErrorIs(t, err, ErrNotFound)
 
-		// assert defaultEventPruningLimit most recent events exist
+		// assert defaultPrunerHistoryLimit most recent events exist
 		counter := 0
 		for datakey, err := range backend.dataStore.Keys(ctx, ListRequestKey{
 			Namespace: "",
@@ -2117,7 +2117,7 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			require.NotEqual(t, rv1, datakey.ResourceVersion)
 			counter++
 		}
-		require.Equal(t, defaultEventPruningLimit, counter)
+		require.Equal(t, defaultPrunerHistoryLimit, counter)
 	})
 
 	t.Run("will not prune events for cluster-scoped resources when less than limit", func(t *testing.T) {
@@ -2149,9 +2149,9 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 		rv1, err := backend.WriteEvent(ctx, writeEvent)
 		require.NoError(t, err)
 
-		// Update defaultEventPruningLimit-1 times (total events = limit, nothing to prune)
+		// Update defaultPrunerHistoryLimit-1 times (total events = limit, nothing to prune)
 		previousRV := rv1
-		for i := 0; i < defaultEventPruningLimit-1; i++ {
+		for i := 0; i < defaultPrunerHistoryLimit-1; i++ {
 			testObj.Object["spec"].(map[string]any)["value"] = fmt.Sprintf("update-%d", i)
 			writeEvent.Type = resourcepb.WatchEvent_MODIFIED
 			writeEvent.Value = objectToJSONBytes(t, testObj)
@@ -2182,7 +2182,7 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			require.NoError(t, err)
 			counter++
 		}
-		require.Equal(t, defaultEventPruningLimit, counter)
+		require.Equal(t, defaultPrunerHistoryLimit, counter)
 	})
 }
 
@@ -2533,42 +2533,6 @@ func testClusterScopedResources(t *testing.T, backend *kvStorageBackend) {
 		case <-ctx.Done():
 			t.Fatalf("Timeout waiting for event %d", i)
 		}
-	}
-}
-
-func TestKvStorageBackend_prunerHistoryLimit(t *testing.T) {
-	tests := []struct {
-		name     string
-		group    string
-		resource string
-		expected int
-	}{
-		{
-			name:     "plugin resource returns custom limit",
-			group:    "plugins.grafana.app",
-			resource: "plugins",
-			expected: 3,
-		},
-		{
-			name:     "dashboard resource returns default limit",
-			group:    "dashboard.grafana.app",
-			resource: "dashboards",
-			expected: defaultEventPruningLimit,
-		},
-		{
-			name:     "other resource returns default limit",
-			group:    "some.app",
-			resource: "resources",
-			expected: defaultEventPruningLimit,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			backend := setupTestStorageBackend(t)
-			limit := backend.prunerHistoryLimit(tc.group, tc.resource)
-			require.Equal(t, tc.expected, limit)
-		})
 	}
 }
 

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -48,7 +48,6 @@ var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/sql")
 
 const defaultPollingInterval = 100 * time.Millisecond
 const defaultWatchBufferSize = 100 // number of events to buffer in the watch stream
-const defaultPrunerHistoryLimit = 20
 const defaultGarbageCollectionBatchWait = 1 * time.Second
 
 type GarbageCollectionConfig struct {
@@ -122,6 +121,7 @@ func NewStorageBackend(
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
+			DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 		})
 	}
 
@@ -162,7 +162,8 @@ func NewStorageBackend(
 		EventRetentionPeriod: cfg.EventRetentionPeriod,
 		EventPruningInterval: cfg.EventPruningInterval,
 		SearchLookback:       cfg.SearchLookback,
-		WatchOptions:         resource.WatchOptions{SettleDelay: cfg.NotifierSettleDelay},
+		WatchOptions:            resource.WatchOptions{SettleDelay: cfg.NotifierSettleDelay},
+		DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 	}
 
 	if cfg.EnableSQLKVCompatibilityMode {
@@ -192,8 +193,9 @@ func NewFileBackend(cfg *setting.Cfg) (resource.StorageBackend, error) {
 
 	kvStore := resource.NewBadgerKV(db)
 	return resource.NewKVStorageBackend(resource.KVBackendOptions{
-		KvStore: kvStore,
-		Log:     log.New("storage-backend"),
+		KvStore:                 kvStore,
+		Log:                     log.New("storage-backend"),
+		DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 	})
 }
 
@@ -208,6 +210,8 @@ type BackendOptions struct {
 
 	DisableStorageServices bool
 	DisablePruner          bool
+
+	DashboardVersionsToKeep int
 
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	MigrationParquetBuffer bool
@@ -239,6 +243,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		isHA:                    opts.IsHA,
 		disableStorageServices:  opts.DisableStorageServices,
 		disablePruner:           opts.DisablePruner,
+		dashboardVersionsToKeep: opts.DashboardVersionsToKeep,
 		done:                    ctx.Done(),
 		cancel:                  cancel,
 		log:                     logging.DefaultLogger.With("logger", "sql-resource-server"),
@@ -301,8 +306,9 @@ type backend struct {
 	// testing
 	simulatedNetworkLatency time.Duration
 
-	disablePruner bool
-	historyPruner resource.Pruner
+	disablePruner           bool
+	dashboardVersionsToKeep int
+	historyPruner           resource.Pruner
 
 	garbageCollection GarbageCollectionConfig
 
@@ -401,7 +407,7 @@ func (b *backend) initPruner(ctx context.Context) error {
 			return b.db.WithTx(ctx, ReadCommitted, func(ctx context.Context, tx db.Tx) error {
 				res, err := dbutil.Exec(ctx, tx, sqlResourceHistoryPrune, &sqlPruneHistoryRequest{
 					SQLTemplate:  sqltemplate.New(b.dialect),
-					HistoryLimit: b.prunerHistoryLimit(key.Group, key.Resource),
+					HistoryLimit: int64(resource.LookupPrunerHistoryLimit(key.Group, key.Resource, b.dashboardVersionsToKeep)),
 					Key: &resourcepb.ResourceKey{
 						Namespace: key.Namespace,
 						Group:     key.Group,
@@ -534,13 +540,6 @@ func (b *backend) garbageCollectionCutoffTimestamp(group, resourceName string, d
 		return time.Now().Add(-b.garbageCollection.DashboardsMaxAge).UnixMicro()
 	}
 	return defaultCutoff
-}
-
-func (b *backend) prunerHistoryLimit(group, resourceName string) int64 {
-	if limit, ok := resource.LookupCustomPrunerHistoryLimit(group, resourceName); ok {
-		return int64(limit)
-	}
-	return defaultPrunerHistoryLimit
 }
 
 func (b *backend) garbageCollectBatch(ctx context.Context, group, resourceName string, cutoffTimestamp int64, batchSize int) (int64, error) {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -159,9 +159,9 @@ func NewStorageBackend(
 			MaxAge:           cfg.GarbageCollectionMaxAge,
 			DashboardsMaxAge: cfg.DashboardsGarbageCollectionMaxAge,
 		},
-		EventRetentionPeriod: cfg.EventRetentionPeriod,
-		EventPruningInterval: cfg.EventPruningInterval,
-		SearchLookback:       cfg.SearchLookback,
+		EventRetentionPeriod:    cfg.EventRetentionPeriod,
+		EventPruningInterval:    cfg.EventPruningInterval,
+		SearchLookback:          cfg.SearchLookback,
 		WatchOptions:            resource.WatchOptions{SettleDelay: cfg.NotifierSettleDelay},
 		DashboardVersionsToKeep: cfg.DashboardVersionsToKeep,
 	}

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -1044,4 +1044,3 @@ func TestSqlPruneHistoryRequest_Validate(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -1045,38 +1045,3 @@ func TestSqlPruneHistoryRequest_Validate(t *testing.T) {
 	}
 }
 
-func TestBackend_prunerHistoryLimit(t *testing.T) {
-	tests := []struct {
-		name     string
-		group    string
-		resource string
-		expected int64
-	}{
-		{
-			name:     "plugin resource returns custom limit",
-			group:    "plugins.grafana.app",
-			resource: "plugins",
-			expected: 3,
-		},
-		{
-			name:     "dashboard resource returns default limit",
-			group:    "dashboard.grafana.app",
-			resource: "dashboards",
-			expected: defaultPrunerHistoryLimit,
-		},
-		{
-			name:     "other resource returns default limit",
-			group:    "some.app",
-			resource: "resources",
-			expected: defaultPrunerHistoryLimit,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			b, _ := setupBackendTest(t)
-			limit := b.prunerHistoryLimit(tc.group, tc.resource)
-			require.Equal(t, tc.expected, limit)
-		})
-	}
-}


### PR DESCRIPTION
Both backends will now honour the value configured in the `versions_to_keep` setting.

Ticket: https://github.com/grafana/search-and-storage-team/issues/727