### PR TITLE
Fix: Set correct border-radius on Alert background

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -160,6 +160,7 @@ const getStyles = (
         bottom: 0,
         right: 0,
         background: theme.colors.background.primary,
+        borderRadius: theme.shape.radius.default,
         zIndex: -1,
       },
     }),


### PR DESCRIPTION
**What is this feature?**

The `Box` inside the `Alert` uses the default border radius, but the pseudo-element background applied around the `Box` did not have a border radius set, resulting in the background leaking.

| Before | After |
|-|-|
| <img width="2712" height="1392" alt="image" src="https://github.com/user-attachments/assets/ef63e780-190b-4dea-8b5c-5c4725e6b581" /> | <img width="2712" height="1392" alt="image" src="https://github.com/user-attachments/assets/f339fc95-28f2-45fd-b219-6b633e345608" /> |

**Why do we need this feature?**

UI cleanliness.

**Who is this feature for?**

All users.