### PR TITLE
CI: Fix innacurate test coverage comparisons

### DIFF
--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -214,6 +214,15 @@ jobs:
         with:
           ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Merge main into PR branch
+        if: steps.check-affected.outputs.affected == 'true' && matrix.branch == 'pr'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit
 
       - name: Setup Node.js
         if: steps.check-affected.outputs.affected == 'true'

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -212,7 +212,7 @@ jobs:
         if: steps.check-affected.outputs.affected == 'true'
         uses: actions/checkout@v5
         with:
-          ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
+          ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.ref || github.event.pull_request.head.sha }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -221,8 +221,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit
+          git fetch origin "${BASE_REF}"
+          git merge "origin/${BASE_REF}" --no-edit
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
 
       - name: Setup Node.js
         if: steps.check-affected.outputs.affected == 'true'

--- a/jest.config.codeowner.js
+++ b/jest.config.codeowner.js
@@ -80,7 +80,7 @@ module.exports = {
   coverageReporters: ['none'],
   coverageDirectory: '/tmp/jest-coverage-ignore',
 
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
   reporters: [
     'default',
     [
@@ -88,7 +88,7 @@ module.exports = {
       {
         name: `Coverage Report - ${codeownerName} owned files`,
         outputDir: outputDir,
-        reports: ['console-summary', 'v8', 'json', 'lcov'],
+        reports: ['console-summary', 'json', 'lcov', ['html-spa', { subdir: 'html' }]],
         sourceFilter: (coveredFile) => sourceFiles.includes(coveredFile),
         all: {
           dir: ['./packages', './public'],


### PR DESCRIPTION
**What is this feature?**

This change fixes inaccuracies in the opt-in automated test coverage comparison CI workflows for codeowners.

Test coverage has been improved by:
1. Merging _latest_ `main` into the feature branch before generating coverage
2. Pulling _latest_ `main` before generating coverage to compare the PR against, and
3. Most importantly replacing `v8` as the test coverage collection format with `istanbul`/`nyc` format

> [!NOTE]
> Please note that these scripts aren't on `main` yet, so the coverage comparison on this PR will be askew, but subsequent PRs _after_ this is merged will become accurate.

### ❌ Before ... _(Variance of up to ~0.94% between 10x runs)_

<img width="568" height="364" alt="Screenshot 2026-03-30 at 11 25 56" src="https://github.com/user-attachments/assets/c8d8f8b2-7a57-418d-88a7-f40d42545a6b" />


### ✅ After !!! _(No variance 0% between 10x runs)_

<img width="512" height="411" alt="Screenshot 2026-03-30 at 11 15 21" src="https://github.com/user-attachments/assets/efca998d-0c22-4685-82d8-202f1f51e3ef" />


🤷 I'm still not quite sure _why_ the `v8` coverage collection was so flaky in this setup, but no matter.


**Why do we need this feature?**

To avoid noisy CI checks.

**Who is this feature for?**

Contributors to Grafana.

**Which issue(s) does this PR fix?**:

🎟️ Fixes: https://github.com/grafana/grafana/issues/121317

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
