### PR TITLE
Zipkin: Fix incorrect JSON field casing in TraceLog struct

### DIFF
--- a/pkg/tsdb/zipkin/handler_querydata.go
+++ b/pkg/tsdb/zipkin/handler_querydata.go
@@ -86,8 +86,8 @@ type TraceKeyValuePair struct {
 }
 
 type TraceLog struct {
-	Timestamp int64
-	Fields    []TraceKeyValuePair
+	Timestamp int64               `json:"timestamp"`
+	Fields    []TraceKeyValuePair `json:"fields"`
 }
 
 func transformResponse(zipkinSpans []model.SpanModel, refId string) *data.Frame {

--- a/pkg/tsdb/zipkin/handler_querydata_test.go
+++ b/pkg/tsdb/zipkin/handler_querydata_test.go
@@ -1,7 +1,9 @@
 package zipkin
 
 import (
+	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +11,54 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 )
+
+func TestTraceLogJSONCasing(t *testing.T) {
+	// Verify that TraceLog fields serialize to lowercase JSON keys,
+	// matching the frontend TraceLog type from @grafana/data which expects
+	// "timestamp" and "fields" (not "Timestamp" and "Fields").
+	span := model.SpanModel{
+		SpanContext: model.SpanContext{
+			TraceID: model.TraceID{High: 1, Low: 2},
+			ID:      1,
+		},
+		Name:      "test-span",
+		Timestamp: time.Unix(0, 1*int64(time.Microsecond)),
+		Duration:  10 * time.Microsecond,
+		LocalEndpoint: &model.Endpoint{
+			ServiceName: "test-service",
+		},
+		Annotations: []model.Annotation{
+			{Timestamp: time.Unix(0, 100*int64(time.Microsecond)), Value: "test annotation"},
+		},
+	}
+
+	frame := transformResponse([]model.SpanModel{span}, "test")
+
+	// The "logs" field is at index 8
+	logsRaw := frame.Fields[8].At(0)
+	logsJSON, ok := logsRaw.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected json.RawMessage, got %T", logsRaw)
+	}
+
+	logsStr := string(logsJSON)
+
+	// Should use lowercase keys (matching @grafana/data TraceLog type)
+	if !strings.Contains(logsStr, `"timestamp"`) {
+		t.Errorf("expected lowercase \"timestamp\" in logs JSON, got: %s", logsStr)
+	}
+	if !strings.Contains(logsStr, `"fields"`) {
+		t.Errorf("expected lowercase \"fields\" in logs JSON, got: %s", logsStr)
+	}
+
+	// Should NOT use uppercase keys
+	if strings.Contains(logsStr, `"Timestamp"`) {
+		t.Errorf("found uppercase \"Timestamp\" in logs JSON — frontend expects lowercase: %s", logsStr)
+	}
+	if strings.Contains(logsStr, `"Fields"`) {
+		t.Errorf("found uppercase \"Fields\" in logs JSON — frontend expects lowercase: %s", logsStr)
+	}
+}
 
 func TestTransformResponse(t *testing.T) {
 	t.Run("simple_trace", func(t *testing.T) {

--- a/pkg/tsdb/zipkin/testdata/simple_trace.golden.jsonc
+++ b/pkg/tsdb/zipkin/testdata/simple_trace.golden.jsonc
@@ -17,7 +17,7 @@
 //  | Labels:                          | Labels:          | Labels:            | Labels:             | Labels:           | Labels:                                                                                             | Labels:         | Labels:         | Labels:                                                                                                                                                 | Labels:                                                           |
 //  | Type: []string                   | Type: []string   | Type: []*string    | Type: []string      | Type: []string    | Type: []json.RawMessage                                                                             | Type: []float64 | Type: []float64 | Type: []json.RawMessage                                                                                                                                 | Type: []json.RawMessage                                           |
 //  +----------------------------------+------------------+--------------------+---------------------+-------------------+-----------------------------------------------------------------------------------------------------+-----------------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------+
-//  | 000000000000007b00000000000001c8 | 0000000000000001 | null               | span 1              | service 1         | [{"key":"ipv4","value":"1.0.0.1"},{"key":"port","value":42},{"key":"endpointType","value":"local"}] | 0.001           | 0.01            | [{"Timestamp":2,"Fields":[{"key":"annotation","value":"annotation text"}]},{"Timestamp":6,"Fields":[{"key":"annotation","value":"annotation text 3"}]}] | [{"key":"kind","value":"CLIENT"},{"key":"tag1","value":"val1"}]   |
+//  | 000000000000007b00000000000001c8 | 0000000000000001 | null               | span 1              | service 1         | [{"key":"ipv4","value":"1.0.0.1"},{"key":"port","value":42},{"key":"endpointType","value":"local"}] | 0.001           | 0.01            | [{"timestamp":2,"fields":[{"key":"annotation","value":"annotation text"}]},{"timestamp":6,"fields":[{"key":"annotation","value":"annotation text 3"}]}] | [{"key":"kind","value":"CLIENT"},{"key":"tag1","value":"val1"}]   |
 //  | 000000000000007b00000000000001c8 | 0000000000000002 | 0000000000000001   | span 2              | service 2         | [{"key":"ipv4","value":"1.0.0.1"},{"key":"endpointType","value":"local"}]                           | 0.004           | 0.005           | []                                                                                                                                                      | [{"key":"error","value":true},{"key":"errorValue","value":"404"}] |
 //  | 000000000000007b00000000000001c8 | 0000000000000003 | 0000000000000001   | span 3              | spanstore-jdbc    | [{"key":"ipv6","value":"::1"},{"key":"endpointType","value":"remote"}]                              | 0.006           | 0.007           | []                                                                                                                                                      | []                                                                |
 //  +----------------------------------+------------------+--------------------+---------------------+-------------------+-----------------------------------------------------------------------------------------------------+-----------------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------+
@@ -190,8 +190,8 @@
           [
             [
               {
-                "Timestamp": 2,
-                "Fields": [
+                "timestamp": 2,
+                "fields": [
                   {
                     "key": "annotation",
                     "value": "annotation text"
@@ -199,8 +199,8 @@
                 ]
               },
               {
-                "Timestamp": 6,
-                "Fields": [
+                "timestamp": 6,
+                "fields": [
                   {
                     "key": "annotation",
                     "value": "annotation text 3"


### PR DESCRIPTION
**What is this feature?**

Add missing `json` struct tags to the `TraceLog` type in the Zipkin datasource backend, so that
`Timestamp` and `Fields` serialize as lowercase `timestamp` and `fields`.

**Why do we need this feature?**

The `TraceLog` struct in `pkg/tsdb/zipkin/handler_querydata.go` had no JSON tags, causing
`json.Marshal` to produce uppercase keys (`"Timestamp"`, `"Fields"`). The frontend `TraceLog`
type from `@grafana/data` expects lowercase (`"timestamp"`, `"fields"`). This mismatch caused
span events/logs to render as NaN/NaH in the trace view and broke tag filtering.

Note: the upload query path (frontend-only) worked correctly because it used a separate
`transformAnnotation` function that already produced lowercase keys. Only the backend query
path via gRPC was affected.

**Who is this feature for?**

Users querying traces from a Zipkin datasource that contain annotations (span events/logs).

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana-zipkin-datasource#54

**Special notes for your reviewer:**

- The same `TraceLog` struct in Tempo and Jaeger datasources already had correct `json` tags — this PR
  brings Zipkin in line with them.
- Added a dedicated `TestTraceLogJSONCasing` test that validates lowercase JSON keys.
- Updated the golden test file to reflect the corrected output.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.