### PR TITLE
Prometheus: Fix label refresh on series limit input blur

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -15,9 +15,24 @@ export function MetricSelector() {
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
 
+  // Local state for the limit input display value.
+  // We only propagate to seriesLimit (which triggers a re-fetch) on blur,
+  // not on every keystroke. See: https://github.com/grafana/grafana/issues/120727
+  const [limitInputValue, setLimitInputValue] = useState(String(seriesLimit));
+
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
   }, [metrics, selectedMetric, metricSearchTerm]);
+
+  const handleLimitBlur = () => {
+    const parsed = parseInt(limitInputValue.trim(), 10);
+    if (!isNaN(parsed)) {
+      setSeriesLimit(parsed);
+    } else {
+      // Reset display to the current committed value if input is invalid
+      setLimitInputValue(String(seriesLimit));
+    }
+  };
 
   return (
     <div>
@@ -28,7 +43,7 @@ export function MetricSelector() {
             'Once a metric is selected only possible labels are shown. Labels are limited by the series limit below.'
           )}
         >
-          <Trans i18nKey="grafana-prometheus.components.metric-selector.select-a-metric">1. Select a metric</Trans>
+          <Trans i18nKey='grafana-prometheus.components.metric-selector.select-a-metric'>1. Select a metric</Trans>
         </Label>
         <div>
           <Input
@@ -47,21 +62,22 @@ export function MetricSelector() {
             'The limit applies to all metrics, labels, and values. Leave the field empty to use the default limit. Set to 0 to disable the limit and fetch everything — this may cause performance issues.'
           )}
         >
-          <Trans i18nKey="grafana-prometheus.components.metric-selector.series-limit">Series limit</Trans>
+          <Trans i18nKey='grafana-prometheus.components.metric-selector.series-limit'>Series limit</Trans>
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setLimitInputValue(e.currentTarget.value)}
+            onBlur={handleLimitBlur}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={limitInputValue}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>
         <div
-          role="list"
+          role='list'
           className={styles.valueListWrapper}
           data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.metricList}
         >

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -25,13 +25,17 @@ export function MetricSelector() {
   }, [metrics, selectedMetric, metricSearchTerm]);
 
   const handleLimitBlur = () => {
-    const parsed = parseInt(limitInputValue.trim(), 10);
-    if (!isNaN(parsed)) {
-      setSeriesLimit(parsed);
-    } else {
-      // Reset display to the current committed value if input is invalid
+    const trimmed = limitInputValue.trim();
+    // Only accept strings that are purely numeric (no partial like "12abc")
+    if (trimmed === '' || !/^\d+$/.test(trimmed)) {
+      // Reset display to the current committed value if input is empty or invalid
       setLimitInputValue(String(seriesLimit));
+      return;
     }
+    const parsed = parseInt(trimmed, 10);
+    setSeriesLimit(parsed);
+    // Sync display with the normalized value (strips leading zeros, whitespace)
+    setLimitInputValue(String(parsed));
   };
 
   return (
@@ -43,7 +47,7 @@ export function MetricSelector() {
             'Once a metric is selected only possible labels are shown. Labels are limited by the series limit below.'
           )}
         >
-          <Trans i18nKey='grafana-prometheus.components.metric-selector.select-a-metric'>1. Select a metric</Trans>
+          <Trans i18nKey="grafana-prometheus.components.metric-selector.select-a-metric">1. Select a metric</Trans>
         </Label>
         <div>
           <Input
@@ -62,7 +66,7 @@ export function MetricSelector() {
             'The limit applies to all metrics, labels, and values. Leave the field empty to use the default limit. Set to 0 to disable the limit and fetch everything — this may cause performance issues.'
           )}
         >
-          <Trans i18nKey='grafana-prometheus.components.metric-selector.series-limit'>Series limit</Trans>
+          <Trans i18nKey="grafana-prometheus.components.metric-selector.series-limit">Series limit</Trans>
         </Label>
         <div>
           <Input
@@ -77,7 +81,7 @@ export function MetricSelector() {
           />
         </div>
         <div
-          role='list'
+          role="list"
           className={styles.valueListWrapper}
           data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.metricList}
         >


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the metrics browser series limit input triggering a backend label re-fetch on every keystroke.

**Before:** The series limit `<Input>` used `onChange` to call `setSeriesLimit` directly. This caused `useDebounce` in `useMetricsLabelsValues` to fire `initialize()` — which fetches metrics, label keys, and label values from the backend — after each 300ms debounce interval while the user was still typing. Typing `5000` would trigger up to 4 separate fetches.

**After:** The limit input now maintains local display state via `limitInputValue`. `onChange` updates only local state (no backend call). `setSeriesLimit` (which triggers the re-fetch) is called only in the `onBlur` handler — once, when the cursor leaves the field.

## Which issue(s) this PR fixes

Fixes #120727

## Special notes for your reviewer

- Change isolated to `MetricSelector.tsx` only — no hook changes needed
- `useDebounce` in `useMetricsLabelsValues` preserved unchanged; fires once after blur
- Invalid non-numeric input on blur resets display to the previously committed value
- Existing test suite unaffected; `seriesLimit` state API is unchanged