### PR TITLE
Security: Add configurable gravatar URL

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -406,6 +406,10 @@ available_encryption_providers =
 # disable gravatar profile images
 disable_gravatar = false
 
+# set to a gravatar-compatible URL to use a different avatar service
+# e.g. https://seccdn.libravatar.org/avatar/
+gravatar_url = https://secure.gravatar.com/avatar/
+
 # data source proxy whitelist (ip_or_domain:port separated by spaces)
 data_source_proxy_whitelist =
 

--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -134,7 +134,7 @@ func (a *AvatarCacheServer) GetAvatarForHashContext(ctx context.Context, cfg *se
 		alog.Warn("'GetGravatarForHash' called despite gravatars being disabled; returning default profile image")
 		return a.notFound
 	}
-	return a.getAvatarForHashContext(ctx, hash, gravatarSource)
+	return a.getAvatarForHashContext(ctx, hash, cfg.GravatarUrl)
 }
 
 func (a *AvatarCacheServer) getAvatarForHash(hash string, baseUrl string) *Avatar {

--- a/pkg/api/avatar/avatar_test.go
+++ b/pkg/api/avatar/avatar_test.go
@@ -98,6 +98,33 @@ func TestAvatar_ExpirationHandler(t *testing.T) {
 	require.Equal(t, callCounter, 4)
 }
 
+func TestAvatar_CustomGravatarUrl(t *testing.T) {
+	cfg := setting.NewCfg()
+	callCounter := 0
+	mockServer := setupMockGravatarServer(&callCounter, false)
+
+	t.Cleanup(func() {
+		mockServer.Close()
+	})
+
+	// Configure a custom gravatar URL pointing to the mock server.
+	cfg.GravatarUrl = mockServer.URL + "/avatar/"
+	avc := newCacheServer(cfg)
+
+	av := avc.GetAvatarForHashContext(t.Context(), cfg, DEFAULT_NONSENSE_HASH)
+	require.Equal(t, 2, callCounter)
+	require.Equal(t, NONSENSE_BODY, av.data)
+}
+
+func TestAvatar_DisabledGravatar(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.DisableGravatar = true
+	avc := newCacheServer(cfg)
+
+	av := avc.GetAvatarForHashContext(t.Context(), cfg, DEFAULT_NONSENSE_HASH)
+	require.True(t, av.notFound)
+}
+
 func setupMockGravatarServer(counter *int, simulateError bool) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		(*counter)++

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -206,6 +206,7 @@ type Cfg struct {
 	CSPReportOnlyTemplate           string
 	EnableFrontendSandboxForPlugins []string
 	DisableGravatar                 bool
+	GravatarUrl                     string
 	DataProxyWhiteList              map[string]bool
 	ActionsAllowPostURL             string
 
@@ -1804,6 +1805,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	security := iniFile.Section("security")
 	cfg.SecretKey = valueAsString(security, "secret_key", "")
 	cfg.DisableGravatar = security.Key("disable_gravatar").MustBool(true)
+	cfg.GravatarUrl = valueAsString(security, "gravatar_url", "https://secure.gravatar.com/avatar/")
 
 	cfg.DisableBruteForceLoginProtection = security.Key("disable_brute_force_login_protection").MustBool(false)
 	cfg.BruteForceLoginProtectionMaxAttempts = security.Key("brute_force_login_protection_max_attempts").MustInt64(5)


### PR DESCRIPTION
## Summary

Adds a `gravatar_url` configuration option under `[security]` that allows administrators to specify an alternative gravatar-compatible avatar service URL (e.g. libravatar). Enterprise deployments behind firewalls can now use internal avatar services instead of the public gravatar.com.

**Changes:**
- `conf/defaults.ini` — new `gravatar_url` option with default `https://secure.gravatar.com/avatar/`
- `pkg/setting/setting.go` — `GravatarUrl` field on `Cfg` struct, read from config
- `pkg/api/avatar/avatar.go` — use `cfg.GravatarUrl` instead of hardcoded constant
- `pkg/api/avatar/avatar_test.go` — tests for custom URL and disabled gravatar

**Usage:**
```ini
[security]
gravatar_url = https://seccdn.libravatar.org/avatar/
```

Default behavior is unchanged — existing deployments continue using gravatar.com.

Fixes #83005