### PR TITLE
CloudWatch: Add pagination support for log groups selection

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -265,15 +265,17 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 		err := ds.CallResource(contextWithFeaturesEnabled(features.FlagCloudWatchCrossAccountQuerying), req, sender)
 		assert.NoError(t, err)
 
-		assert.JSONEq(t, `[
-		   {
-			  "accountId":"111",
-			  "value":{
-				 "arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
-				 "name":"group_a"
+		assert.JSONEq(t, `{
+		   "results":[
+			  {
+				 "accountId":"111",
+				 "value":{
+					"arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
+					"name":"group_a"
+				 }
 			  }
-		   }
-		]`, string(sender.Response.Body))
+		   ]
+		}`, string(sender.Response.Body))
 
 		logsApi.AssertCalled(t, "DescribeLogGroups",
 			&cloudwatchlogs.DescribeLogGroupsInput{

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -29,13 +29,15 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns 1 log group with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
-			Value: resources.LogGroup{
-				Arn:  "some arn",
-				Name: "some name",
-			},
-			AccountId: utils.Pointer("111"),
-		}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
+			Results: []resources.ResourceResponse[resources.LogGroup]{{
+				Value: resources.LogGroup{
+					Arn:  "some arn",
+					Name: "some name",
+				},
+				AccountId: utils.Pointer("111"),
+			}},
+		}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -44,25 +46,27 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
 	})
 
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return(
-			[]resources.ResourceResponse[resources.LogGroup]{
-				{
-					Value: resources.LogGroup{
-						Arn:  "arn 1",
-						Name: "name 1",
+			resources.LogGroupsResponse{
+				Results: []resources.ResourceResponse[resources.LogGroup]{
+					{
+						Value: resources.LogGroup{
+							Arn:  "arn 1",
+							Name: "name 1",
+						},
+						AccountId: utils.Pointer("111"),
+					}, {
+						Value: resources.LogGroup{
+							Arn:  "arn 2",
+							Name: "name 2",
+						},
+						AccountId: utils.Pointer("222"),
 					},
-					AccountId: utils.Pointer("111"),
-				}, {
-					Value: resources.LogGroup{
-						Arn:  "arn 2",
-						Name: "name 2",
-					},
-					AccountId: utils.Pointer("222"),
 				},
 			}, nil)
 
@@ -73,7 +77,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `[
+		assert.JSONEq(t, `{"results":[
 		   {
 			  "value":{
 				 "name":"name 1",
@@ -88,12 +92,12 @@ func TestLogGroupsRoute(t *testing.T) {
 			  },
 			  "accountId":"222"
 		   }
-		]`, rr.Body.String())
+		]}`, rr.Body.String())
 	})
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix&logGroupPattern=some-pattern", nil)
@@ -107,7 +111,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -125,7 +129,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -141,7 +145,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?limit=2", nil)
@@ -156,7 +160,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix", nil)
@@ -172,7 +176,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupPattern=some-pattern", nil)
@@ -188,7 +192,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?accountId=some-account-id", nil)
@@ -205,7 +209,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("returns error if service returns error", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).
-			Return([]resources.ResourceResponse[resources.LogGroup]{}, fmt.Errorf("some error"))
+			Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, fmt.Errorf("some error"))
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -215,5 +219,28 @@ func TestLogGroupsRoute(t *testing.T) {
 
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		assert.JSONEq(t, `{"Error":"some error","Message":"GetLogGroups error: some error","StatusCode":500}`, rr.Body.String())
+	})
+
+	t.Run("successfully returns log groups with nextToken", func(t *testing.T) {
+		mockLogsService = mocks.LogsService{}
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
+			Results: []resources.ResourceResponse[resources.LogGroup]{{
+				Value: resources.LogGroup{
+					Arn:  "some arn",
+					Name: "some name",
+				},
+				AccountId: utils.Pointer("111"),
+			}},
+			NextToken: utils.Pointer("next_page_token"),
+		}, nil)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/log-groups", nil)
+		ds := newTestDatasource()
+		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}],"nextToken":"next_page_token"}`, rr.Body.String())
 	})
 }

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -29,10 +29,10 @@ type LogsService struct {
 	mock.Mock
 }
 
-func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
 	args := l.Called(request)
 
-	return args.Get(0).([]resources.ResourceResponse[resources.LogGroup]), args.Error(1)
+	return args.Get(0).(resources.LogGroupsResponse), args.Error(1)
 }
 
 func (l *LogsService) GetLogGroupFields(_ context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -34,7 +34,7 @@ type ListMetricsProvider interface {
 }
 
 type LogGroupsProvider interface {
-	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error)
+	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error)
 	GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error)
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
@@ -13,6 +13,7 @@ type LogGroupsRequest struct {
 	Limit                                   int32
 	LogGroupNamePrefix, LogGroupNamePattern *string
 	ListAllLogGroups                        bool
+	NextToken                               *string
 }
 
 func (r LogGroupsRequest) IsTargetingAllAccounts() bool {
@@ -35,6 +36,7 @@ func ParseLogGroupsRequest(parameters url.Values) (LogGroupsRequest, error) {
 		LogGroupNamePrefix:  logGroupNamePrefix,
 		LogGroupNamePattern: logGroupPattern,
 		ListAllLogGroups:    parameters.Get("listAllLogGroups") == "true",
+		NextToken:           setIfNotEmptyString(parameters.Get("nextToken")),
 	}, nil
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -44,3 +44,8 @@ type LogGroupField struct {
 	Percent int64  `json:"percent"`
 	Name    string `json:"name"`
 }
+
+type LogGroupsResponse struct {
+	Results   []ResourceResponse[LogGroup] `json:"results"`
+	NextToken *string                      `json:"nextToken,omitempty"`
+}

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -20,7 +20,7 @@ var NewLogGroupsService = func(logsClient models.CloudWatchLogsAPIProvider, isCr
 	return &LogGroupsService{logGroupsAPI: logsClient, isCrossAccountEnabled: isCrossAccountEnabled}
 }
 
-func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int32(req.Limit),
 		LogGroupNamePrefix: req.LogGroupNamePrefix,
@@ -36,12 +36,17 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 			input.AccountIdentifiers = []string{*req.AccountId}
 		}
 	}
+
+	if req.NextToken != nil {
+		input.NextToken = req.NextToken
+	}
+
 	result := []resources.ResourceResponse[resources.LogGroup]{}
 
 	for {
 		response, err := s.logGroupsAPI.DescribeLogGroups(ctx, input)
 		if err != nil || response == nil {
-			return nil, err
+			return resources.LogGroupsResponse{}, err
 		}
 
 		for _, logGroup := range response.LogGroups {
@@ -55,12 +60,13 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 
 		if !req.ListAllLogGroups || response.NextToken == nil {
-			break
+			return resources.LogGroupsResponse{
+				Results:   result,
+				NextToken: response.NextToken,
+			}, nil
 		}
 		input.NextToken = response.NextToken
 	}
-
-	return result, nil
 }
 
 func (s *LogGroupsService) GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -46,7 +46,7 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("333"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group_c", Name: "group_c"},
 			},
-		}, resp)
+		}, resp.Results)
 	})
 
 	t.Run("Should return an empty error if api doesn't return any data", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGetLogGroups(t *testing.T) {
 		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp.Results)
 	})
 
 	t.Run("Should only use LogGroupNamePrefix even if LogGroupNamePattern passed in resource call", func(t *testing.T) {
@@ -131,7 +131,41 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp)
+		}, resp.Results)
+		assert.Equal(t, aws.String("next_token"), resp.NextToken)
+	})
+
+	t.Run("Should pass NextToken to the API when provided in the request", func(t *testing.T) {
+		mockLogsAPI := &mocks.LogsAPI{}
+		req := resources.LogGroupsRequest{
+			Limit:              2,
+			LogGroupNamePrefix: utils.Pointer("test"),
+			NextToken:          utils.Pointer("some_token"),
+		}
+
+		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit:              aws.Int32(req.Limit),
+			LogGroupNamePrefix: req.LogGroupNamePrefix,
+			NextToken:          utils.Pointer("some_token"),
+		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
+			},
+			NextToken: aws.String("another_token"),
+		}, nil)
+
+		service := NewLogGroupsService(mockLogsAPI, false)
+		resp, err := service.GetLogGroups(context.Background(), req)
+
+		assert.NoError(t, err)
+		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
+			{
+				AccountId: utils.Pointer("111"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
+			},
+		}, resp.Results)
+		assert.Equal(t, aws.String("another_token"), resp.NextToken)
 	})
 
 	t.Run("Should keep on calling the api until NextToken is empty in case ListAllLogGroups is set to true", func(t *testing.T) {
@@ -176,7 +210,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("222"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
 			},
-		}, resp)
+		}, resp.Results)
+		assert.Nil(t, resp.NextToken)
 	})
 }
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -40,7 +40,7 @@ describe('LogGroupSelection', () => {
     config.featureToggles.cloudWatchCrossAccountQuerying = true;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     defaultProps.datasource.resources.templateSrv = setupMockedTemplateService();
     render(<LogGroupsField {...defaultProps} legacyLogGroupNames={['loggroupname']} />);
 
@@ -57,7 +57,7 @@ describe('LogGroupSelection', () => {
     defaultProps.datasource = setupMockedDataSource({ variables: [logGroupNamesVariable] }).datasource;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     const varName = '$' + logGroupNamesVariable.name;
     render(<LogGroupsField {...defaultProps} legacyLogGroupNames={['loggroupname', varName]} />);
 
@@ -77,7 +77,7 @@ describe('LogGroupSelection', () => {
     config.featureToggles.cloudWatchCrossAccountQuerying = true;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     defaultProps.datasource.resources.templateSrv = setupMockedTemplateService();
     render(<LogGroupsField {...defaultProps} logGroups={[{ arn: 'arn', name: 'loggroupname' }]} />);
     await waitFor(() => expect(screen.getByText('Select log groups')).toBeInTheDocument());

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -82,7 +82,7 @@ export const LogGroupsField = ({
       )
         .then((results) => {
           const logGroups = results.flatMap((r) =>
-            r.map((lg) => ({
+            r.results.map((lg) => ({
               arn: lg.value.arn,
               name: lg.value.name,
               accountId: lg.accountId,
@@ -101,7 +101,7 @@ export const LogGroupsField = ({
     <Stack direction="column" gap={1}>
       <LogGroupsSelector
         fetchLogGroups={async (params: Partial<DescribeLogGroupsRequest>) =>
-          datasource?.resources.getLogGroups({ region: region, ...params }) ?? []
+          datasource?.resources.getLogGroups({ region: region, ...params }) ?? { results: [] }
         }
         onChange={onChange}
         accountOptions={accountState.value}

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -4,9 +4,28 @@ import userEvent from '@testing-library/user-event';
 import lodash from 'lodash';
 import selectEvent from 'react-select-event';
 
-import { type ResourceResponse, type LogGroupResponse } from '../../../resources/types';
+import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
+
+const defaultLogGroupsResponse: LogGroupsResponse = {
+  results: [
+    {
+      accountId: '123',
+      value: {
+        name: 'logGroup1',
+        arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+      },
+    },
+    {
+      accountId: '456',
+      value: {
+        name: 'logGroup2',
+        arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
+      },
+    },
+  ],
+};
 
 const defaultProps = {
   variables: [],
@@ -23,23 +42,7 @@ const defaultProps = {
       label: 'Account Name 456',
     },
   ],
-  fetchLogGroups: () =>
-    Promise.resolve([
-      {
-        accountId: '123',
-        value: {
-          name: 'logGroup1',
-          arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
-        },
-      },
-      {
-        accountId: '456',
-        value: {
-          name: 'logGroup2',
-          arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
-        },
-      },
-    ] as Array<ResourceResponse<LogGroupResponse>>),
+  fetchLogGroups: () => Promise.resolve(defaultLogGroupsResponse),
   onChange: jest.fn(),
 };
 
@@ -77,7 +80,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return defaultProps.fetchLogGroups();
+      return defaultLogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -92,7 +95,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return [];
+      return { results: [] } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -105,7 +108,7 @@ describe('LogGroupsSelector', () => {
   });
 
   it('calls fetchLogGroups with a search phrase when it is typed in the Search Field', async () => {
-    const fetchLogGroups = jest.fn(() => defaultProps.fetchLogGroups());
+    const fetchLogGroups = jest.fn(() => Promise.resolve(defaultLogGroupsResponse));
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
@@ -121,11 +124,11 @@ describe('LogGroupsSelector', () => {
     const fetchLogGroups = jest.fn(async () => {
       if (once) {
         await Promise.all([secondCall.promise]);
-        return defaultProps.fetchLogGroups();
+        return defaultLogGroupsResponse;
       }
       await Promise.all([firstCall.promise]);
       once = true;
-      return defaultProps.fetchLogGroups();
+      return defaultLogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -188,12 +191,12 @@ describe('LogGroupsSelector', () => {
   });
 
   const labelText =
-    'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
+    'If you do not see an expected log group, try narrowing down your search.';
   it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return [];
+      return { results: [] } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -206,12 +209,14 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return Array(50).map((i) => ({
-        value: {
-          arn: `logGroup${i}`,
-          name: `logGroup${i}`,
-        },
-      }));
+      return {
+        results: Array(50).fill(null).map((_, i) => ({
+          value: {
+            arn: `logGroup${i}`,
+            name: `logGroup${i}`,
+          },
+        })),
+      } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -308,5 +313,62 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
     expect(screen.queryByText('Account label')).not.toBeInTheDocument();
     waitFor(() => expect(screen.queryByText('Account Name 123')).not.toBeInTheDocument());
+  });
+
+  it('should show Load more button when nextToken is present and append results on click', async () => {
+    let callCount = 0;
+    const fetchLogGroups = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          results: [
+            {
+              accountId: '123',
+              value: {
+                name: 'logGroup1',
+                arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+              },
+            },
+          ],
+          nextToken: 'page2_token',
+        } as LogGroupsResponse;
+      }
+      return {
+        results: [
+          {
+            accountId: '456',
+            value: {
+              name: 'logGroup2',
+              arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
+            },
+          },
+        ],
+      } as LogGroupsResponse;
+    });
+
+    render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByText('Select log groups'));
+
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+    expect(screen.getByText('Load more')).toBeInTheDocument();
+    expect(screen.queryByText('logGroup2')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Load more'));
+
+    await waitFor(() => expect(screen.getByText('logGroup2')).toBeInTheDocument());
+    expect(screen.getByText('logGroup1')).toBeInTheDocument();
+    expect(fetchLogGroups).toBeCalledTimes(2);
+    expect(fetchLogGroups).toHaveBeenLastCalledWith({
+      logGroupPattern: '',
+      accountId: 'all',
+      nextToken: 'page2_token',
+    });
+  });
+
+  it('should not show Load more button when nextToken is not present', async () => {
+    render(<LogGroupsSelector {...defaultProps} />);
+    await userEvent.click(screen.getByText('Select log groups'));
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -16,7 +16,7 @@ import {
 } from '@grafana/ui';
 
 import { type LogGroup } from '../../../dataquery.gen';
-import { type DescribeLogGroupsRequest, type ResourceResponse, type LogGroupResponse } from '../../../resources/types';
+import { type DescribeLogGroupsRequest, type LogGroupsResponse } from '../../../resources/types';
 import getStyles from '../../styles';
 import { Account, ALL_ACCOUNTS_OPTION } from '../Account';
 
@@ -25,7 +25,7 @@ import Search from './Search';
 type CrossAccountLogsQueryProps = {
   selectedLogGroups?: LogGroup[];
   accountOptions?: Array<SelectableValue<string>>;
-  fetchLogGroups: (params: Partial<DescribeLogGroupsRequest>) => Promise<Array<ResourceResponse<LogGroupResponse>>>;
+  fetchLogGroups: (params: Partial<DescribeLogGroupsRequest>) => Promise<LogGroupsResponse>;
   variables?: string[];
   onChange: (selectedLogGroups: LogGroup[]) => void;
   onBeforeOpen?: () => void;
@@ -45,6 +45,8 @@ export const LogGroupsSelector = ({
   const [searchPhrase, setSearchPhrase] = useState('');
   const [searchAccountId, setSearchAccountId] = useState(ALL_ACCOUNTS_OPTION.value);
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [nextToken, setNextToken] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
   const selectedLogGroupsCounter = useMemo(
     () => selectedLogGroups.filter((lg) => !lg.name?.startsWith('$')).length,
@@ -85,23 +87,52 @@ export const LogGroupsSelector = ({
 
   const searchFn = async (searchTerm?: string, accountId?: string) => {
     setIsLoading(true);
+    setNextToken(undefined);
     try {
-      const possibleLogGroups = await fetchLogGroups({
+      const response = await fetchLogGroups({
         logGroupPattern: searchTerm,
         accountId: accountId,
       });
       setSelectableLogGroups(
-        possibleLogGroups.map((lg) => ({
+        response.results.map((lg) => ({
           arn: lg.value.arn,
           name: lg.value.name,
           accountId: lg.accountId,
           accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
         }))
       );
+      setNextToken(response.nextToken);
     } catch (err) {
       setSelectableLogGroups([]);
     }
     setIsLoading(false);
+  };
+
+  const loadMore = async () => {
+    if (!nextToken) {
+      return;
+    }
+    setIsLoadingMore(true);
+    try {
+      const response = await fetchLogGroups({
+        logGroupPattern: searchPhrase,
+        accountId: searchAccountId,
+        nextToken,
+      });
+      setSelectableLogGroups((prev) => [
+        ...prev,
+        ...response.results.map((lg) => ({
+          arn: lg.value.arn,
+          name: lg.value.name,
+          accountId: lg.accountId,
+          accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
+        })),
+      ]);
+      setNextToken(response.nextToken);
+    } catch (err) {
+      // keep existing results on error
+    }
+    setIsLoadingMore(false);
   };
 
   const handleSelectCheckbox = (row: LogGroup, isChecked: boolean) => {
@@ -149,12 +180,11 @@ export const LogGroupsSelector = ({
         </div>
         <Space layout="block" v={2} />
         <div>
-          {!isLoading && selectableLogGroups.length >= 25 && (
+          {!isLoading && !nextToken && selectableLogGroups.length >= 25 && (
             <>
               <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
-                Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
-                search.
+                If you do not see an expected log group, try narrowing down your search.
                 <p>
                   A{' '}
                   <TextLink
@@ -214,6 +244,14 @@ export const LogGroupsSelector = ({
               </tbody>
             </table>
           </div>
+          {!isLoading && nextToken && (
+            <>
+              <Space layout="block" v={1} />
+              <Button variant="secondary" onClick={loadMore} disabled={isLoadingMore} type="button" fill="text">
+                {isLoadingMore ? 'Loading...' : 'Load more'}
+              </Button>
+            </>
+          )}
         </div>
         <Space layout="block" v={2} />
         <Label className={styles.logGroupCountLabel}>

--- a/public/app/plugins/datasource/cloudwatch/mocks/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/CloudWatchDataSource.ts
@@ -126,7 +126,7 @@ export function setupMockedDataSource({
   datasource.resources.getDimensionKeys = jest.fn().mockResolvedValue([]);
   datasource.resources.getMetrics = jest.fn().mockResolvedValue([]);
   datasource.resources.getAccounts = jest.fn().mockResolvedValue([]);
-  datasource.resources.getLogGroups = jest.fn().mockResolvedValue([]);
+  datasource.resources.getLogGroups = jest.fn().mockResolvedValue({ results: [] });
   datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(false);
   const fetchMock = jest.fn().mockReturnValue(of({}));
   setBackendSrv({

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -11,47 +11,32 @@ describe('ResourcesAPI', () => {
       expect(resourceRequestMock.mock.calls[1][1].region).toBe('eu-east');
     });
 
-    it('should return log groups as an array of options', async () => {
-      const response = [
-        {
-          text: '/aws/containerinsights/dev303-workshop/application',
-          value: '/aws/containerinsights/dev303-workshop/application',
-          label: '/aws/containerinsights/dev303-workshop/application',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/flowlogs',
-          value: '/aws/containerinsights/dev303-workshop/flowlogs',
-          label: '/aws/containerinsights/dev303-workshop/flowlogs',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/dataplane',
-          value: '/aws/containerinsights/dev303-workshop/dataplane',
-          label: '/aws/containerinsights/dev303-workshop/dataplane',
-        },
-      ];
+    it('should return log groups response with results', async () => {
+      const response = {
+        results: [
+          {
+            value: {
+              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
+              name: '/aws/containerinsights/dev303-workshop/application',
+            },
+          },
+          {
+            value: {
+              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
+              name: '/aws/containerinsights/dev303-workshop/flowlogs',
+            },
+          },
+        ],
+        nextToken: 'some_token',
+      };
 
       const { api } = setupMockedResourcesAPI({ response });
-      const expectedLogGroups = [
-        {
-          text: '/aws/containerinsights/dev303-workshop/application',
-          value: '/aws/containerinsights/dev303-workshop/application',
-          label: '/aws/containerinsights/dev303-workshop/application',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/flowlogs',
-          value: '/aws/containerinsights/dev303-workshop/flowlogs',
-          label: '/aws/containerinsights/dev303-workshop/flowlogs',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/dataplane',
-          value: '/aws/containerinsights/dev303-workshop/dataplane',
-          label: '/aws/containerinsights/dev303-workshop/dataplane',
-        },
-      ];
 
       const logGroups = await api.getLogGroups({ region: 'default' });
 
-      expect(logGroups).toEqual(expectedLogGroups);
+      expect(logGroups).toEqual(response);
+      expect(logGroups.results).toHaveLength(2);
+      expect(logGroups.nextToken).toBe('some_token');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -12,6 +12,7 @@ import {
   type ResourceResponse,
   type DescribeLogGroupsRequest,
   type LogGroupResponse,
+  type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,
   type GetDimensionValuesRequest,
@@ -69,13 +70,19 @@ export class ResourcesAPI extends CloudWatchRequest {
     );
   }
 
-  getLogGroups(params: DescribeLogGroupsRequest): Promise<Array<ResourceResponse<LogGroupResponse>>> {
-    return this.memoizedGetRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', {
+  getLogGroups(params: DescribeLogGroupsRequest): Promise<LogGroupsResponse> {
+    const requestParams: Record<string, string | string[] | number> = {
       ...params,
       region: this.templateSrv.replace(this.getActualRegion(params.region)),
       accountId: this.templateSrv.replace(params.accountId),
       listAllLogGroups: params.listAllLogGroups ? 'true' : 'false',
-    });
+    };
+    // When nextToken is present, bypass memoized cache to avoid stale results
+    if (params.nextToken) {
+      requestParams.nextToken = params.nextToken;
+      return this.getRequest<LogGroupsResponse>('log-groups', requestParams);
+    }
+    return this.memoizedGetRequest<LogGroupsResponse>('log-groups', requestParams);
   }
 
   getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -35,6 +35,7 @@ export interface DescribeLogGroupsRequest extends ResourceRequest {
   limit?: number;
   listAllLogGroups?: boolean;
   accountId?: string;
+  nextToken?: string;
 }
 
 export interface Account {
@@ -56,6 +57,11 @@ export interface MetricResponse {
 
 export interface RegionResponse {
   name: string;
+}
+
+export interface LogGroupsResponse {
+  results: Array<ResourceResponse<LogGroupResponse>>;
+  nextToken?: string;
 }
 
 export interface SelectableResourceValue extends SelectableValue<string> {

--- a/public/app/plugins/datasource/cloudwatch/variables.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.test.ts
@@ -27,7 +27,7 @@ const getEc2InstanceAttribute = jest.fn().mockResolvedValue([{ label: 'g', value
 const getResourceARNs = jest.fn().mockResolvedValue([{ label: 'h', value: 'h' }]);
 const getLogGroups = jest
   .fn()
-  .mockResolvedValue([{ value: { arn: 'a', name: 'a' } }, { value: { arn: 'b', name: 'b' } }]);
+  .mockResolvedValue({ results: [{ value: { arn: 'a', name: 'a' } }, { value: { arn: 'b', name: 'b' } }] });
 
 const variables = new CloudWatchVariableSupport(mock.datasource.resources);
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -71,8 +71,8 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
         logGroupNamePrefix: interpolatedPrefix,
         listAllLogGroups: true,
       })
-      .then((logGroups) =>
-        logGroups.map((lg) => {
+      .then((response) =>
+        response.results.map((lg) => {
           return {
             text: lg.value.name,
             value: lg.value.arn,


### PR DESCRIPTION
**What is this feature?**

Adds cursor-based pagination to the CloudWatch log groups selector modal using the AWS `NextToken` mechanism. Users can now load additional log groups beyond the initial 50 by clicking a "Load more" button.

**Why do we need this feature?**

Users monitoring log groups from multiple AWS accounts could only see the first 50 log groups due to the AWS `DescribeLogGroups` API page size limit. There was no way to access groups beyond that first page, limiting visibility into important log data.

**Who is this feature for?**

CloudWatch users with more than 50 log groups, especially those using cross-account observability with multiple AWS accounts.

**Which issue(s) does this PR fix?**

Fixes #118097

**Special notes for your reviewer:**

**Changes summary:**

Backend (Go):
- New `LogGroupsResponse` type wrapping results array with optional `nextToken`
- `LogGroupsRequest` accepts `nextToken` query parameter
- `GetLogGroups` service passes token to AWS SDK and returns it in response
- `listAllLogGroups=true` path (variable queries) unchanged — still loops through all pages

Frontend (TypeScript/React):
- `LogGroupsSelector` adds "Load more" button that appends results using cursor token
- `ResourcesAPI.getLogGroups` returns `LogGroupsResponse` and bypasses memoization for paginated calls
- Updated all consumers (`variables.ts`, `LogGroupsField.tsx`) for new response format

**Note:** The API response format changes from a flat array to `{ results: [...], nextToken?: "..." }`. This is an internal plugin resource endpoint — all consumers are updated in this PR.

---

**Generative AI disclosure:** This PR was co-authored with Claude (Anthropic).