### PR TITLE
Dashboard: Fix JSON editor rejecting valid non-object matcher options

### DIFF
--- a/public/app/features/dashboard-scene/v2schema/dashboardSchemaFetcher.ts
+++ b/public/app/features/dashboard-scene/v2schema/dashboardSchemaFetcher.ts
@@ -108,12 +108,14 @@ function convertRefToDefinitionKey(key: string): string {
 // - kind fields are emitted as plain strings instead of const values
 // - scalar union types are emitted as structs instead of oneOf
 // - map[string]interface{} values are constrained to objects instead of any
+// - interface{} fields are constrained to objects instead of accepting any JSON value
 // - discriminated unions are emitted as struct properties instead of if/then
 
 function fixOpenAPIMismatches(definitions: Record<string, JSONSchema>): void {
   fixKindConstraints(definitions);
   fixScalarUnions(definitions);
   fixOpaqueMaps(definitions);
+  fixAnyValueProperties(definitions);
   fixDiscriminatedUnions(definitions);
 }
 
@@ -186,6 +188,28 @@ function fixOpaqueMaps(definitions: Record<string, JSONSchema>): void {
         for (const p of props) {
           if (schema.properties?.[p]) {
             schema.properties[p] = { type: 'object', additionalProperties: true };
+          }
+        }
+      }
+    }
+  }
+}
+
+// interface{} / any properties: the generator emits { type: object } for interface{},
+// but these fields accept any JSON value (string, number, array, object, etc.).
+const ANY_VALUE_PROPERTIES: Record<string, string[]> = {
+  DashboardMatcherConfig: ['options'],
+  DashboardDynamicConfigValue: ['value'],
+};
+
+function fixAnyValueProperties(definitions: Record<string, JSONSchema>): void {
+  for (const [key, schema] of Object.entries(definitions)) {
+    for (const [suffix, props] of Object.entries(ANY_VALUE_PROPERTIES)) {
+      if (key.endsWith(`_${suffix}`)) {
+        for (const p of props) {
+          if (schema.properties?.[p]) {
+            const { description } = schema.properties[p];
+            schema.properties[p] = description ? { description } : {};
           }
         }
       }


### PR DESCRIPTION
**What is this feature?**

Fixes the JSON schema validation in the dashboard JSON editor so that `matcher.options` and `DynamicConfigValue.value` accept any JSON value, not just objects.

**Why do we need this feature?**

The dashboard JSON editor currently shows a false-positive validation error for `byName` matcher options. When a user sets a field override with `"id": "byName"` and `"options": "some-field-name"`, the Monaco editor underlines the string value in red with:

> Incorrect type. Expected "object".

This happens because the OpenAPI schema generator translates CUE's `_` (any) type into `{ "type": "object" }` in the JSON schema served to Monaco. The CUE definition at `kinds/dashboard/dashboard_kind.cue` line 749 declares `options?: _`, which should accept any JSON value — strings, numbers, arrays, objects, etc.

The same issue affects `DynamicConfigValue.value`, which is also defined as `_` in CUE but gets constrained to object-only in the generated schema.

**Who is this feature for?**

Dashboard editors who use the JSON editor to view or edit field overrides, especially `byName` matchers.

**Which issue(s) does this PR fix?**:

Fixes #121296

**Special notes for your reviewer:**

The fix adds a new `fixAnyValueProperties()` function to the existing `fixOpenAPIMismatches()` pipeline in `dashboardSchemaFetcher.ts`. This follows the same pattern already used by `fixOpaqueMaps()` and the other fix functions — a lookup table of definition suffixes to property names, with the fix applied during schema post-processing.

For the affected properties, the fix replaces `{ "type": "object" }` with an empty schema `{}` (which validates any JSON value per JSON Schema spec), preserving the `description` field if one exists.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.