### PR TITLE
PluginMeta: remove outdated comment and code

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.ts
@@ -152,10 +152,6 @@ export async function refetchPanelPluginMetas(): Promise<void> {
     const settings = await getBackendSrv().get('/api/frontend/settings');
     panels = settings.panels;
     panelsByAliasIDs = resolveAliasIDs(panels);
-
-    // TODO(@hugohaggmark) remove this as soon as all config.panels occurances have been replaced in core Grafana
-    // eslint-disable-next-line no-restricted-syntax
-    config.panels = settings.panels;
     return;
   }
 


### PR DESCRIPTION
**What is this feature?**

This pull request makes a small cleanup to the `refetchPanelPluginMetas` function by removing a temporary workaround that assigned `settings.panels` to `config.panels`. This code is no longer needed now that all references to `config.panels` have been replaced elsewhere in the codebase.

**Why do we need this feature?**

So we don't keep outdated comments and code

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
