### PR TITLE
fix(prometheus): fetch labels on blur instead of on every keystroke in limit input

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -14,6 +14,12 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+  const [localLimit, setLocalLimit] = useState(seriesLimit);
+
+  // Keep local state in sync when seriesLimit changes externally
+  useEffect(() => {
+    setLocalLimit(seriesLimit);
+  }, [seriesLimit]);
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -51,12 +57,13 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setLocalLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onBlur={() => setSeriesLimit(localLimit)}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={localLimit}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>


### PR DESCRIPTION
## Summary

Fixes #120727

The series limit input in the Prometheus metrics browser was triggering a new fetch request on every keystroke via `onChange`. Even though there was a 300ms debounce in `useMetricsLabelsValues`, this still caused unnecessary network requests while the user was still typing a number.

## Fix

- Added local state (`localLimit`) for the input value so typing updates are immediate
- Changed the input to use `onChange` for display-only updates (local state)
- Added `onBlur` handler that commits the value to `setSeriesLimit` (triggering the actual fetch)
- Added a `useEffect` to sync local state when `seriesLimit` changes externally

This ensures the fetch only fires when the user finishes editing and moves focus away from the input.

## Testing

Verified that the component logic is correct by reviewing `MetricsBrowserContext.tsx` and `useMetricsLabelsValues.ts` — the debounced effect in `useMetricsLabelsValues` that watches `[seriesLimit]` will now only trigger after the blur event instead of on each keystroke.