### PR TITLE
Alerting: Replace provisioning banner with inline badge in rule detail view

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -45,12 +45,7 @@ import { getAlertRulesNavId } from '../../navigation/useAlertRulesNav';
 import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { normalizeHealth, normalizeState } from '../../rule-list/components/util';
 import { Annotation } from '../../utils/constants';
-import {
-  GRAFANA_RULES_SOURCE_NAME,
-  getRulesSourceUid,
-  isGrafanaRulesSource,
-  ruleIdentifierToRuleSourceIdentifier,
-} from '../../utils/datasource';
+import { getRulesSourceUid, ruleIdentifierToRuleSourceIdentifier } from '../../utils/datasource';
 import { labelsSize } from '../../utils/labels';
 import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
 import { createListFilterLink, groups } from '../../utils/navigation';
@@ -64,8 +59,7 @@ import {
   rulerRuleType,
 } from '../../utils/rules';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
-import { InhibitionRulesAlert } from '../InhibitionRulesAlert';
-import { ProvisionedResource, ProvisioningAlert } from '../Provisioning';
+import { ProvisioningBadge } from '../Provisioning';
 import { WithReturnButton } from '../WithReturnButton';
 import { decodeGrafanaNamespace } from '../expressions/util';
 import { RedirectToCloneRule } from '../rules/CloneRule';
@@ -110,7 +104,7 @@ const RuleViewer = () => {
   // of duplicating provisioned alert rules
   const [duplicateRuleIdentifier, setDuplicateRuleIdentifier] = useState<RuleIdentifier>();
   const { returnTo } = useReturnTo('/alerting/list');
-  const { annotations, promRule, rulerRule, namespace } = rule;
+  const { annotations, promRule, rulerRule } = rule;
 
   const hasError = isErrorHealth(promRule?.health);
 
@@ -132,6 +126,8 @@ const RuleViewer = () => {
         <Title
           name={title}
           paused={isPaused}
+          isProvisioned={isProvisioned}
+          provenance={rulerRuleType.grafana.rule(rulerRule) ? rulerRule.grafana_alert.provenance : undefined}
           state={prometheusRuleType.alertingRule(promRule) ? promRule.state : undefined}
           health={promRule?.health}
           ruleType={promRule?.type}
@@ -147,10 +143,6 @@ const RuleViewer = () => {
           {/* alerts and notifications and stuff */}
           {isPaused && <InfoPausedRule />}
           {isFederatedRule && <FederatedRuleWarning />}
-          {/* indicator for rules in a provisioned group */}
-          {isProvisioned && (
-            <ProvisioningAlert resource={ProvisionedResource.AlertRule} bottomSpacing={0} topSpacing={2} />
-          )}
           {/* error state */}
           {showError && (
             <Alert
@@ -170,10 +162,6 @@ const RuleViewer = () => {
       }
     >
       {shouldUseConsistencyCheck && <PrometheusConsistencyCheck ruleIdentifier={identifier} />}
-      {/* Show inhibition rules alert only for Grafana-managed rules */}
-      {isGrafanaRulesSource(namespace.rulesSource) && (
-        <InhibitionRulesAlert alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME} />
-      )}
       <div className={styles.layout}>
         <Stack direction="column" gap={2}>
           {/* tabs and tab content */}
@@ -315,6 +303,8 @@ const createMetadata = (rule: CombinedRule, styles: ReturnType<typeof getStyles>
 interface TitleProps {
   name: string;
   paused?: boolean;
+  isProvisioned?: boolean;
+  provenance?: string;
   // recording rules don't have a state
   state?: PromAlertingRuleState;
   health?: RuleHealth;
@@ -323,7 +313,17 @@ interface TitleProps {
   returnToHref?: string;
 }
 
-export const Title = ({ name, paused = false, state, health, ruleType, ruleOrigin, returnToHref = '' }: TitleProps) => {
+export const Title = ({
+  name,
+  paused = false,
+  isProvisioned,
+  provenance,
+  state,
+  health,
+  ruleType,
+  ruleOrigin,
+  returnToHref = '',
+}: TitleProps) => {
   const isRecordingRule = ruleType === PromRuleType.Recording;
 
   const { returnTo } = useReturnTo(returnToHref);
@@ -345,6 +345,7 @@ export const Title = ({ name, paused = false, state, health, ruleType, ruleOrigi
       <Text variant="h1" truncate>
         {name}
       </Text>
+      {isProvisioned && <ProvisioningBadge tooltip provenance={provenance} />}
       {/* recording rules won't have a state */}
       {state && <StateText type="alerting" state={textState} health={textHealth} isPaused={paused} />}
       {isRecordingRule && <StateText type="recording" health={textHealth} isPaused={paused} />}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the alert rule detail view, the full-width "provisioned" info banner (`ProvisioningAlert`) is replaced by the compact `ProvisioningBadge` component. The badge is rendered inline in the page title row, to the right of the rule name and to the left of the rule's state indicator.

<img width="1303" height="577" alt="image" src="https://github.com/user-attachments/assets/a85f2da2-a41b-4af2-a4c1-55d5a55fa804" />

**Why do we need this feature?**

The banner takes up significant vertical space and interrupts the page layout. The existing `ProvisioningBadge` component (already used in the rule list and other resource tables) communicates the same information more concisely and consistently with the rest of the UI. It also handles the "Imported" (converted Prometheus) variant automatically via the `provenance` prop.

**Who is this feature for?**

Users who view provisioned alert rules in the Grafana UI.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Changes in `RuleViewer.tsx`:**
- Remove `ProvisioningAlert` / `ProvisionedResource` imports; add `ProvisioningBadge`
- Add `isProvisioned` and `provenance` props to `TitleProps`
- Render `<ProvisioningBadge tooltip provenance={provenance} />` between the rule name `<Text>` and `<StateText>` in the `Title` component
- Pass `isProvisioned` and `provenance` to `<Title>` at the `renderTitle` call site
- Remove the `<ProvisioningAlert>` block from the `subTitle` slot