### PR TITLE
Rendering: Prohibit usage of empty/default render auth token in JWT mode

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -111,21 +111,24 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, remot
 	var renderKeyProvider renderKeyProvider
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if features.IsEnabledGlobally(featuremgmt.FlagRenderAuthJWT) {
-		if strings.TrimSpace(cfg.RendererAuthToken) == "" {
-			err := "Using an empty [rendering]renderer_token is not allowed, set it to another value. " +
-				"Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security"
-			logger.Error(err)
-			return nil, fmt.Errorf("failed to start rendering service: %v", err)
-		}
-
-		if cfg.RendererAuthToken == setting.DefaultRendererAuthToken {
-			if cfg.Env == setting.Dev {
-				logger.Warn("Using the default [rendering]renderer_token is not allowed for production settings, and Grafana will refuse to start.")
-			} else {
-				err := "Using the default [rendering]renderer_token is not allowed for production settings, set it to another value. " +
+		// only check if the renderer is configured otherwise we dont need to force changing the default.
+		if cfg.RendererServerUrl != "" {
+			if strings.TrimSpace(cfg.RendererAuthToken) == "" {
+				err := "Using an empty [rendering]renderer_token is not allowed, set it to another value. " +
 					"Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security"
 				logger.Error(err)
 				return nil, fmt.Errorf("failed to start rendering service: %v", err)
+			}
+
+			if cfg.RendererAuthToken == setting.DefaultRendererAuthToken {
+				if cfg.Env == setting.Dev {
+					logger.Warn("Using the default [rendering]renderer_token is not allowed for production settings, and Grafana will refuse to start.")
+				} else {
+					err := "Using the default [rendering]renderer_token is not allowed for production settings, set it to another value. " +
+						"Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security"
+					logger.Error(err)
+					return nil, fmt.Errorf("failed to start rendering service: %v", err)
+				}
 			}
 		}
 

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -111,6 +111,24 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, remot
 	var renderKeyProvider renderKeyProvider
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if features.IsEnabledGlobally(featuremgmt.FlagRenderAuthJWT) {
+		if strings.TrimSpace(cfg.RendererAuthToken) == "" {
+			err := "Using an empty [rendering]renderer_token is not allowed, set it to another value. " +
+				"Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security"
+			logger.Error(err)
+			return nil, fmt.Errorf("failed to start rendering service: %v", err)
+		}
+
+		if cfg.RendererAuthToken == setting.DefaultRendererAuthToken {
+			if cfg.Env == setting.Dev {
+				logger.Warn("Using the default [rendering]renderer_token is not allowed for production settings, and Grafana will refuse to start.")
+			} else {
+				err := "Using the default [rendering]renderer_token is not allowed for production settings, set it to another value. " +
+					"Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security"
+				logger.Error(err)
+				return nil, fmt.Errorf("failed to start rendering service: %v", err)
+			}
+		}
+
 		renderKeyProvider = &jwtRenderKeyProvider{
 			log:       logger,
 			authToken: []byte(cfg.RendererAuthToken),

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -341,7 +341,7 @@ func TestProvideService(t *testing.T) {
 		t.Run("with an empty renderer auth token", func(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.AppURL = "http://app-url"
-			cfg.RendererCallbackUrl = "https://public-grafana.com/"
+			cfg.RendererServerUrl = "https://public-grafana.com/"
 			cfg.ImagesDir = filepath.Join(t.TempDir(), "images")
 			cfg.CSVsDir = filepath.Join(t.TempDir(), "csvs")
 			cfg.PDFsDir = filepath.Join(t.TempDir(), "pdfs")
@@ -363,7 +363,7 @@ func TestProvideService(t *testing.T) {
 		t.Run("with the default renderer auth token", func(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.AppURL = "http://app-url"
-			cfg.RendererCallbackUrl = "https://public-grafana.com/"
+			cfg.RendererServerUrl = "https://public-grafana.com/"
 			cfg.ImagesDir = filepath.Join(t.TempDir(), "images")
 			cfg.CSVsDir = filepath.Join(t.TempDir(), "csvs")
 			cfg.PDFsDir = filepath.Join(t.TempDir(), "pdfs")
@@ -386,7 +386,7 @@ func TestProvideService(t *testing.T) {
 		t.Run("with non-default renderer auth token", func(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.AppURL = "http://app-url"
-			cfg.RendererCallbackUrl = "https://public-grafana.com/"
+			cfg.RendererServerUrl = "https://public-grafana.com/"
 			cfg.ImagesDir = filepath.Join(t.TempDir(), "images")
 			cfg.CSVsDir = filepath.Join(t.TempDir(), "csvs")
 			cfg.PDFsDir = filepath.Join(t.TempDir(), "pdfs")

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -336,4 +336,75 @@ func TestProvideService(t *testing.T) {
 		_, err := ProvideService(cfg, featuremgmt.WithFeatures(), nil, &dummyPluginManager{})
 		require.Error(t, err)
 	})
+
+	t.Run("renderAuthJWT", func(t *testing.T) {
+		t.Run("with an empty renderer auth token", func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AppURL = "http://app-url"
+			cfg.RendererCallbackUrl = "https://public-grafana.com/"
+			cfg.ImagesDir = filepath.Join(t.TempDir(), "images")
+			cfg.CSVsDir = filepath.Join(t.TempDir(), "csvs")
+			cfg.PDFsDir = filepath.Join(t.TempDir(), "pdfs")
+			cfg.RendererAuthToken = "   "
+
+			t.Run("in dev mode returns an error", func(t *testing.T) {
+				cfg.Env = setting.Dev
+				_, err := ProvideService(cfg, featuremgmt.WithFeatures(featuremgmt.FlagRenderAuthJWT), nil, &dummyPluginManager{})
+				require.Error(t, err)
+			})
+
+			t.Run("in prod mode returns an error", func(t *testing.T) {
+				cfg.Env = setting.Prod
+				_, err := ProvideService(cfg, featuremgmt.WithFeatures(featuremgmt.FlagRenderAuthJWT), nil, &dummyPluginManager{})
+				require.Error(t, err)
+			})
+		})
+
+		t.Run("with the default renderer auth token", func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AppURL = "http://app-url"
+			cfg.RendererCallbackUrl = "https://public-grafana.com/"
+			cfg.ImagesDir = filepath.Join(t.TempDir(), "images")
+			cfg.CSVsDir = filepath.Join(t.TempDir(), "csvs")
+			cfg.PDFsDir = filepath.Join(t.TempDir(), "pdfs")
+			cfg.RendererAuthToken = setting.DefaultRendererAuthToken
+
+			t.Run("in dev mode does not return an error", func(t *testing.T) {
+				cfg.Env = setting.Dev
+				rs, err := ProvideService(cfg, featuremgmt.WithFeatures(featuremgmt.FlagRenderAuthJWT), nil, &dummyPluginManager{})
+				require.NoError(t, err)
+				require.NotNil(t, rs)
+			})
+
+			t.Run("in prod mode returns an error", func(t *testing.T) {
+				cfg.Env = setting.Prod
+				_, err := ProvideService(cfg, featuremgmt.WithFeatures(featuremgmt.FlagRenderAuthJWT), nil, &dummyPluginManager{})
+				require.Error(t, err)
+			})
+		})
+
+		t.Run("with non-default renderer auth token", func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AppURL = "http://app-url"
+			cfg.RendererCallbackUrl = "https://public-grafana.com/"
+			cfg.ImagesDir = filepath.Join(t.TempDir(), "images")
+			cfg.CSVsDir = filepath.Join(t.TempDir(), "csvs")
+			cfg.PDFsDir = filepath.Join(t.TempDir(), "pdfs")
+			cfg.RendererAuthToken = "some-value"
+
+			t.Run("in dev mode does not return an error", func(t *testing.T) {
+				cfg.Env = setting.Env
+				rs, err := ProvideService(cfg, featuremgmt.WithFeatures(featuremgmt.FlagRenderAuthJWT), nil, &dummyPluginManager{})
+				require.NoError(t, err)
+				require.NotNil(t, rs)
+			})
+
+			t.Run("in prod mode does not return an error", func(t *testing.T) {
+				cfg.Env = setting.Prod
+				rs, err := ProvideService(cfg, featuremgmt.WithFeatures(featuremgmt.FlagRenderAuthJWT), nil, &dummyPluginManager{})
+				require.NoError(t, err)
+				require.NotNil(t, rs)
+			})
+		})
+	})
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -56,6 +56,9 @@ const (
 // zoneInfo names environment variable for setting the path to look for the timezone database in go
 const zoneInfo = "ZONEINFO"
 
+// Default renderer auth token from [rendering]renderer_token.
+const DefaultRendererAuthToken = "-"
+
 var (
 	customInitPath = "conf/custom.ini"
 
@@ -2070,7 +2073,7 @@ func (cfg *Cfg) readRenderingSettings(iniFile *ini.File) {
 	renderSec := iniFile.Section("rendering")
 	cfg.RendererServerUrl = valueAsString(renderSec, "server_url", "")
 	cfg.RendererCallbackUrl = valueAsString(renderSec, "callback_url", "")
-	cfg.RendererAuthToken = valueAsString(renderSec, "renderer_token", "-")
+	cfg.RendererAuthToken = valueAsString(renderSec, "renderer_token", DefaultRendererAuthToken)
 
 	cfg.RendererConcurrentRequestLimit = renderSec.Key("concurrent_render_request_limit").MustInt(30)
 	cfg.RendererRenderKeyLifeTime = renderSec.Key("render_key_lifetime").MustDuration(5 * time.Minute)


### PR DESCRIPTION
**What is this feature?**

Adds some guards when using `renderAuthJWT` mode, to avoid allowing usage of the empty/default renderer_token.

In dev mode, warns only, but in prod mode does not let Grafana start.

**Why do we need this feature?**

Because the renderer_token signs JWTs, we should not be allowing the usage of default credentials.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


# Release notice breaking change

When using the `renderAuthJWT` feature toggle, you now need to set a `[rendering]renderer_token` that is not empty or the default value, otherwise Grafana will not start.

When updating this value, you also need to make the same change in your Image Renderer configuration. Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security
