### PR TITLE
Alerting: Improve alerts activity UI part 2

### DIFF
--- a/public/app/features/alerting/unified/triage/constants.ts
+++ b/public/app/features/alerting/unified/triage/constants.ts
@@ -31,6 +31,14 @@ export const DATASOURCE_UID = config.unifiedAlerting.stateHistory?.prometheusTar
 export const METRIC_NAME = config.unifiedAlerting.stateHistory?.prometheusMetricName ?? 'GRAFANA_ALERTS';
 
 export const SERVICE_FILTER_LABEL_KEYS = ['service', 'service_name'] as const;
+export const CLUSTER_FILTER_LABEL_KEYS = ['cluster', 'cluster_name'] as const;
+export const NAMESPACE_FILTER_LABEL_KEYS = ['namespace', 'exported_namespace', 'namespace_extracted'] as const;
+
+export const COMBINED_FILTER_LABEL_KEYS = {
+  service: SERVICE_FILTER_LABEL_KEYS,
+  cluster: CLUSTER_FILTER_LABEL_KEYS,
+  namespace: NAMESPACE_FILTER_LABEL_KEYS,
+} as const;
 
 /**
  * Internal/structural labels to exclude from frequency counting.

--- a/public/app/features/alerting/unified/triage/constants.ts
+++ b/public/app/features/alerting/unified/triage/constants.ts
@@ -30,6 +30,8 @@ export const TRIAGE_STATE_URL_PARAMS = [
 export const DATASOURCE_UID = config.unifiedAlerting.stateHistory?.prometheusTargetDatasourceUID;
 export const METRIC_NAME = config.unifiedAlerting.stateHistory?.prometheusMetricName ?? 'GRAFANA_ALERTS';
 
+export const SERVICE_FILTER_LABEL_KEYS = ['service', 'service_name'] as const;
+
 /**
  * Internal/structural labels to exclude from frequency counting.
  *

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -55,7 +55,14 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
           </LinkButton>
         )}
         {shouldShowDeclareIncident && (
-          <LinkButton href={incidentURL} icon="fire" variant="secondary" size="sm">
+          <LinkButton
+            href={incidentURL}
+            icon="fire"
+            variant="secondary"
+            size="sm"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>
           </LinkButton>
         )}

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -66,7 +66,7 @@ export function LabelsColumn() {
                 <Trans i18nKey="alerting.triage.labels-column-title">Labels</Trans>
               </Text>
               <FilterInput
-                placeholder={t('alerting.triage.filter-labels-placeholder', 'Filter')}
+                placeholder={t('alerting.triage.filter-labels-placeholder', 'Search labels')}
                 value={labelFilter}
                 onChange={setLabelFilter}
                 aria-label={t('alerting.triage.filter-labels', 'Filter labels')}

--- a/public/app/features/alerting/unified/triage/scene/queries.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.test.ts
@@ -36,4 +36,21 @@ describe('triage queries service combined filter', () => {
     expect(query).toContain('service="payments"');
     expect(query).toContain('service_name="payments"');
   });
+
+  it('expands cluster key to cluster OR cluster_name', () => {
+    const query = summaryChartQuery('cluster="prod-a"').expr;
+
+    expect(query).toContain('cluster="prod-a"');
+    expect(query).toContain('cluster_name="prod-a"');
+    expect(query).toContain(' or ');
+  });
+
+  it('expands namespace key to namespace OR exported_namespace OR namespace_extracted', () => {
+    const query = uniqueAlertInstancesQuery('namespace="payments"').expr;
+
+    expect(query).toContain('namespace="payments"');
+    expect(query).toContain('exported_namespace="payments"');
+    expect(query).toContain('namespace_extracted="payments"');
+    expect(query).toContain(' or ');
+  });
 });

--- a/public/app/features/alerting/unified/triage/scene/queries.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.test.ts
@@ -1,0 +1,39 @@
+import { alertRuleInstancesQuery, getWorkbenchQueries, summaryChartQuery, uniqueAlertInstancesQuery } from './queries';
+
+describe('triage queries service combined filter', () => {
+  it('expands service key to service OR service_name in summary chart query', () => {
+    const query = summaryChartQuery('service="payments"').expr;
+
+    expect(query).toContain('service="payments"');
+    expect(query).toContain('service_name="payments"');
+    expect(query).toContain(' or ');
+  });
+
+  it('expands service key in workbench queries', () => {
+    const [rangeQuery, instantQuery] = getWorkbenchQueries(
+      'alertname, grafana_folder, grafana_rule_uid, alertstate',
+      'service="payments"'
+    );
+
+    expect(rangeQuery.expr).toContain('service="payments"');
+    expect(rangeQuery.expr).toContain('service_name="payments"');
+    expect(instantQuery.expr).toContain('service="payments"');
+    expect(instantQuery.expr).toContain('service_name="payments"');
+  });
+
+  it('expands service key in rule instances query while preserving rule uid matcher', () => {
+    const query = alertRuleInstancesQuery('rule-1', 'service="payments"').expr;
+
+    expect(query).toContain('grafana_rule_uid="rule-1"');
+    expect(query).toContain('service="payments"');
+    expect(query).toContain('service_name="payments"');
+  });
+
+  it('expands service key in unique instances query used for label breakdown', () => {
+    const query = uniqueAlertInstancesQuery('service="payments"').expr;
+
+    expect(query).toContain('last_over_time');
+    expect(query).toContain('service="payments"');
+    expect(query).toContain('service_name="payments"');
+  });
+});

--- a/public/app/features/alerting/unified/triage/scene/queries.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.ts
@@ -1,7 +1,7 @@
 import { SceneDataQuery } from '@grafana/scenes';
 
 import { parsePromQLStyleMatcherLooseSafe, quoteWithEscape } from '../../utils/matchers';
-import { METRIC_NAME, SERVICE_FILTER_LABEL_KEYS } from '../constants';
+import { COMBINED_FILTER_LABEL_KEYS, METRIC_NAME } from '../constants';
 
 import { getDataQuery } from './utils';
 
@@ -38,29 +38,38 @@ function serializeMatchers(matchers: MatcherExpr[]): string {
 
 /**
  * Builds one or more metric selectors from the current ad-hoc filter string.
- 
- * For Service filter: user-facing key is `service`, but data can be
- * labeled as either `service` or `service_name
+ *
+ * Combined filters use a single user-facing key (for example `service`) while
+ * alert series may have one of several backing label keys (`service`, `service_name`).
+ * We expand those matchers into OR selectors so filtering is consistent.
  */
 function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = []): string[] {
   const allMatchers = [...parseFilterMatchers(filter), ...extraMatchers];
-  const serviceCombinedMatchers = allMatchers.filter((m) => m.name === 'service');
-  const baseMatchers = allMatchers.filter((m) => m.name !== 'service');
+  const combinedMatchers = Object.entries(COMBINED_FILTER_LABEL_KEYS)
+    .map(([canonicalKey, labelKeys]) => ({
+      canonicalKey,
+      labelKeys,
+      matchers: allMatchers.filter((m) => m.name === canonicalKey),
+    }))
+    .filter((entry) => entry.matchers.length > 0);
 
-  if (serviceCombinedMatchers.length === 0) {
-    return [`${METRIC_NAME}{${serializeMatchers(baseMatchers)}}`];
+  const combinedCanonicalKeys = new Set(combinedMatchers.map((entry) => entry.canonicalKey));
+  const baseMatchers = allMatchers.filter((m) => !combinedCanonicalKeys.has(m.name));
+
+  let branches: MatcherExpr[][] = [baseMatchers];
+  for (const entry of combinedMatchers) {
+    branches = branches.flatMap((branch) =>
+      entry.labelKeys.map((labelKey) => [
+        ...branch,
+        ...entry.matchers.map((matcher) => ({
+          ...matcher,
+          name: labelKey,
+        })),
+      ])
+    );
   }
 
-  return SERVICE_FILTER_LABEL_KEYS.map((serviceKey) => {
-    const branchMatchers = [
-      ...baseMatchers,
-      ...serviceCombinedMatchers.map((matcher) => ({
-        ...matcher,
-        name: serviceKey,
-      })),
-    ];
-    return `${METRIC_NAME}{${serializeMatchers(branchMatchers)}}`;
-  });
+  return branches.map((branchMatchers) => `${METRIC_NAME}{${serializeMatchers(branchMatchers)}}`);
 }
 
 function orSelectors(selectors: string[]): string {

--- a/public/app/features/alerting/unified/triage/scene/queries.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.ts
@@ -1,12 +1,78 @@
 import { SceneDataQuery } from '@grafana/scenes';
 
-import { METRIC_NAME } from '../constants';
+import { parsePromQLStyleMatcherLooseSafe, quoteWithEscape } from '../../utils/matchers';
+import { METRIC_NAME, SERVICE_FILTER_LABEL_KEYS } from '../constants';
 
 import { getDataQuery } from './utils';
 
+type MatcherOperator = '=' | '!=' | '=~' | '!~';
+
+interface MatcherExpr {
+  name: string;
+  operator: MatcherOperator;
+  value: string;
+}
+
+function toMatcherOperator({ isRegex, isEqual }: { isRegex: boolean; isEqual: boolean }): MatcherOperator {
+  if (isRegex) {
+    return isEqual ? '=~' : '!~';
+  }
+  return isEqual ? '=' : '!=';
+}
+
+function parseFilterMatchers(filter: string): MatcherExpr[] {
+  if (!filter.trim()) {
+    return [];
+  }
+
+  return parsePromQLStyleMatcherLooseSafe(filter).map((matcher) => ({
+    name: matcher.name,
+    operator: toMatcherOperator(matcher),
+    value: matcher.value,
+  }));
+}
+
+function serializeMatchers(matchers: MatcherExpr[]): string {
+  return matchers.map((m) => `${m.name}${m.operator}${quoteWithEscape(m.value)}`).join(',');
+}
+
+/**
+ * Builds one or more metric selectors from the current ad-hoc filter string.
+ 
+ * For Service filter: user-facing key is `service`, but data can be
+ * labeled as either `service` or `service_name
+ */
+function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = []): string[] {
+  const allMatchers = [...parseFilterMatchers(filter), ...extraMatchers];
+  const serviceCombinedMatchers = allMatchers.filter((m) => m.name === 'service');
+  const baseMatchers = allMatchers.filter((m) => m.name !== 'service');
+
+  if (serviceCombinedMatchers.length === 0) {
+    return [`${METRIC_NAME}{${serializeMatchers(baseMatchers)}}`];
+  }
+
+  return SERVICE_FILTER_LABEL_KEYS.map((serviceKey) => {
+    const branchMatchers = [
+      ...baseMatchers,
+      ...serviceCombinedMatchers.map((matcher) => ({
+        ...matcher,
+        name: serviceKey,
+      })),
+    ];
+    return `${METRIC_NAME}{${serializeMatchers(branchMatchers)}}`;
+  });
+}
+
+function orSelectors(selectors: string[]): string {
+  if (selectors.length === 1) {
+    return selectors[0];
+  }
+  return `(${selectors.join(' or ')})`;
+}
+
 /** Time series for the summary bar chart: count by alertstate */
 export function summaryChartQuery(filter: string): SceneDataQuery {
-  return getDataQuery(`count by (alertstate) (${METRIC_NAME}{${filter}})`, {
+  return getDataQuery(`count by (alertstate) (${orSelectors(buildMetricSelectors(filter))})`, {
     legendFormat: '{{alertstate}}',
   });
 }
@@ -14,7 +80,7 @@ export function summaryChartQuery(filter: string): SceneDataQuery {
 /** Range table query (A) for tree rows + deduplicated instant query (B) for badge counts */
 export function getWorkbenchQueries(countBy: string, filter: string): [SceneDataQuery, SceneDataQuery] {
   return [
-    getDataQuery(`count by (${countBy}) (${METRIC_NAME}{${filter}})`, {
+    getDataQuery(`count by (${countBy}) (${orSelectors(buildMetricSelectors(filter))})`, {
       refId: 'A',
       format: 'table',
     }),
@@ -42,9 +108,9 @@ export function summaryRuleCountQuery(filter: string): SceneDataQuery {
 
 /** Instance timeseries for a specific alert rule */
 export function alertRuleInstancesQuery(ruleUID: string, filter: string): SceneDataQuery {
-  const filters = filter ? `grafana_rule_uid="${ruleUID}",${filter}` : `grafana_rule_uid="${ruleUID}"`;
+  const selectors = buildMetricSelectors(filter, [{ name: 'grafana_rule_uid', operator: '=', value: ruleUID }]);
   return getDataQuery(
-    `count without (alertname, grafana_alertstate, grafana_folder, grafana_rule_uid) (${METRIC_NAME}{${filters}})`,
+    `count without (alertname, grafana_alertstate, grafana_folder, grafana_rule_uid) (${orSelectors(selectors)})`,
     { format: 'timeseries', legendFormat: '{{alertstate}}' }
   );
 }
@@ -59,13 +125,13 @@ export function alertRuleInstancesQuery(ruleUID: string, filter: string): SceneD
  * counted only once in their firing state.
  */
 function uniqueAlertInstancesExpr(filter: string): string {
-  const firingFilter = filter ? `alertstate="firing",${filter}` : 'alertstate="firing"';
-  const pendingFilter = filter ? `alertstate="pending",${filter}` : 'alertstate="pending"';
+  const firingSelectors = buildMetricSelectors(filter, [{ name: 'alertstate', operator: '=', value: 'firing' }]);
+  const pendingSelectors = buildMetricSelectors(filter, [{ name: 'alertstate', operator: '=', value: 'pending' }]);
+  const firingExpr = orSelectors(firingSelectors.map((selector) => `last_over_time(${selector}[$__range])`));
+  const pendingExpr = orSelectors(pendingSelectors.map((selector) => `last_over_time(${selector}[$__range])`));
+
   return (
-    `last_over_time(${METRIC_NAME}{${firingFilter}}[$__range]) or ` +
-    `(last_over_time(${METRIC_NAME}{${pendingFilter}}[$__range]) ` +
-    `unless ignoring(alertstate, grafana_alertstate) ` +
-    `last_over_time(${METRIC_NAME}{${firingFilter}}[$__range]))`
+    `${firingExpr} or ` + `(${pendingExpr} ` + `unless ignoring(alertstate, grafana_alertstate) ` + `${firingExpr})`
   );
 }
 

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -82,6 +82,7 @@ describe('tagKeysProviders', () => {
           { text: 'alertname', value: 'alertname' },
           { text: 'grafana_folder', value: 'grafana_folder' },
           { text: 'severity', value: 'severity' },
+          { text: 'environment', value: 'environment' },
           { text: '__name__', value: '__name__' },
           { text: 'team', value: 'team' },
         ] satisfies MetricFindValue[]),
@@ -93,13 +94,21 @@ describe('tagKeysProviders', () => {
       const result = await getAdHocTagKeysProvider(variable, null);
 
       expect(result.replace).toBe(true);
-      expect(result.values).toEqual([
-        { value: 'alertstate', text: 'State', group: 'Common' },
-        { value: 'alertname', text: 'Rule name', group: 'Common' },
-        { value: 'grafana_folder', text: 'Folder', group: 'Common' },
-        { text: 'severity', value: 'severity', group: 'All' },
-        { text: 'team', value: 'team', group: 'All' },
-      ]);
+      expect(result.values).toEqual(
+        expect.arrayContaining([
+          { value: 'alertstate', text: 'State', group: 'Common' },
+          { value: 'alertname', text: 'Rule name', group: 'Common' },
+          { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+          { value: 'service', text: 'Service', group: 'Common' },
+          { text: 'Severity', value: 'severity', group: 'Common' },
+          { text: 'Team', value: 'team', group: 'Common' },
+          { text: 'environment', value: 'environment', group: 'All' },
+        ])
+      );
+      expect(result.values).not.toEqual(expect.arrayContaining([{ text: 'service', value: 'service', group: 'All' }]));
+      expect(result.values).not.toEqual(
+        expect.arrayContaining([{ text: 'service_name', value: 'service_name', group: 'All' }])
+      );
     });
   });
 
@@ -117,6 +126,42 @@ describe('tagKeysProviders', () => {
 
       expect(result.replace).toBe(true);
       expect(result.values).toEqual(tagValues);
+    });
+
+    it('merges and deduplicates values for combined service key', async () => {
+      const getTagValues = jest.fn().mockImplementation(({ key }: { key: string }) => {
+        if (key === 'service') {
+          return [
+            { text: 'payments', value: 'payments' },
+            { text: 'checkout', value: 'checkout' },
+          ];
+        }
+        if (key === 'service_name') {
+          return [
+            { text: 'payments', value: 'payments' },
+            { text: 'api', value: 'api' },
+          ];
+        }
+        return [];
+      });
+
+      mockGetDataSourceSrv({ getTagValues });
+
+      const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
+      activateWithScene(variable);
+
+      const result = await getAdHocTagValuesProvider(variable, {
+        key: 'service',
+        operator: '=',
+        value: '',
+      });
+
+      expect(result.replace).toBe(true);
+      expect(result.values).toEqual([
+        { text: 'api', value: 'api' },
+        { text: 'checkout', value: 'checkout' },
+        { text: 'payments', value: 'payments' },
+      ]);
     });
   });
 

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -111,8 +111,8 @@ describe('tagKeysProviders', () => {
           { value: 'alertname', text: 'Rule name', group: 'Common' },
           { value: 'grafana_folder', text: 'Folder', group: 'Common' },
           { value: 'service', text: 'Service', group: 'Common' },
-          { text: 'Severity', value: 'severity', group: 'Common' },
           { text: 'Team', value: 'team', group: 'Common' },
+          { text: 'Namespace', value: 'namespace', group: 'Common' },
           { text: 'environment', value: 'environment', group: 'All' },
         ])
       );

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -40,6 +40,8 @@ describe('tagKeysProviders', () => {
     it('should show promoted labels first and remaining sorted under All', async () => {
       mockGetDataSourceSrv({
         getTagKeys: jest.fn().mockResolvedValue([
+          { text: 'cluster_name', value: 'cluster_name' },
+          { text: 'exported_namespace', value: 'exported_namespace' },
           { text: 'severity', value: 'severity' },
           { text: 'grafana_folder', value: 'grafana_folder' },
           { text: '__name__', value: '__name__' },
@@ -55,6 +57,8 @@ describe('tagKeysProviders', () => {
       expect(result.replace).toBe(true);
       expect(result.values).toEqual([
         { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+        { value: 'cluster', text: 'Cluster', group: 'Common' },
+        { value: 'namespace', text: 'Namespace', group: 'Common' },
         { text: 'severity', value: 'severity', group: 'All' },
         { text: 'team', value: 'team', group: 'All' },
       ]);
@@ -70,7 +74,11 @@ describe('tagKeysProviders', () => {
 
       const result = await getGroupByTagKeysProvider(variable, null);
 
-      expect(result.values).toEqual([{ value: 'grafana_folder', text: 'Folder', group: 'Common' }]);
+      expect(result.values).toEqual([
+        { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+        { value: 'cluster', text: 'Cluster', group: 'Common' },
+        { value: 'namespace', text: 'Namespace', group: 'Common' },
+      ]);
     });
   });
 
@@ -81,6 +89,9 @@ describe('tagKeysProviders', () => {
           { text: 'alertstate', value: 'alertstate' },
           { text: 'alertname', value: 'alertname' },
           { text: 'grafana_folder', value: 'grafana_folder' },
+          { text: 'cluster_name', value: 'cluster_name' },
+          { text: 'exported_namespace', value: 'exported_namespace' },
+          { text: 'namespace_extracted', value: 'namespace_extracted' },
           { text: 'severity', value: 'severity' },
           { text: 'environment', value: 'environment' },
           { text: '__name__', value: '__name__' },
@@ -108,6 +119,15 @@ describe('tagKeysProviders', () => {
       expect(result.values).not.toEqual(expect.arrayContaining([{ text: 'service', value: 'service', group: 'All' }]));
       expect(result.values).not.toEqual(
         expect.arrayContaining([{ text: 'service_name', value: 'service_name', group: 'All' }])
+      );
+      expect(result.values).not.toEqual(
+        expect.arrayContaining([{ text: 'cluster_name', value: 'cluster_name', group: 'All' }])
+      );
+      expect(result.values).not.toEqual(
+        expect.arrayContaining([{ text: 'exported_namespace', value: 'exported_namespace', group: 'All' }])
+      );
+      expect(result.values).not.toEqual(
+        expect.arrayContaining([{ text: 'namespace_extracted', value: 'namespace_extracted', group: 'All' }])
       );
     });
   });
@@ -163,6 +183,85 @@ describe('tagKeysProviders', () => {
         { text: 'payments', value: 'payments' },
       ]);
     });
+
+    it('merges and deduplicates values for combined cluster key', async () => {
+      const getTagValues = jest.fn().mockImplementation(({ key }: { key: string }) => {
+        if (key === 'cluster') {
+          return [
+            { text: 'prod-a', value: 'prod-a' },
+            { text: 'prod-b', value: 'prod-b' },
+          ];
+        }
+        if (key === 'cluster_name') {
+          return [
+            { text: 'prod-a', value: 'prod-a' },
+            { text: 'prod-c', value: 'prod-c' },
+          ];
+        }
+        return [];
+      });
+
+      mockGetDataSourceSrv({ getTagValues });
+
+      const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
+      activateWithScene(variable);
+
+      const result = await getAdHocTagValuesProvider(variable, {
+        key: 'cluster',
+        operator: '=',
+        value: '',
+      });
+
+      expect(result.replace).toBe(true);
+      expect(result.values).toEqual([
+        { text: 'prod-a', value: 'prod-a' },
+        { text: 'prod-b', value: 'prod-b' },
+        { text: 'prod-c', value: 'prod-c' },
+      ]);
+    });
+
+    it('merges and deduplicates values for combined namespace key', async () => {
+      const getTagValues = jest.fn().mockImplementation(({ key }: { key: string }) => {
+        if (key === 'namespace') {
+          return [
+            { text: 'payments', value: 'payments' },
+            { text: 'checkout', value: 'checkout' },
+          ];
+        }
+        if (key === 'exported_namespace') {
+          return [
+            { text: 'checkout', value: 'checkout' },
+            { text: 'identity', value: 'identity' },
+          ];
+        }
+        if (key === 'namespace_extracted') {
+          return [
+            { text: 'payments', value: 'payments' },
+            { text: 'observability', value: 'observability' },
+          ];
+        }
+        return [];
+      });
+
+      mockGetDataSourceSrv({ getTagValues });
+
+      const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
+      activateWithScene(variable);
+
+      const result = await getAdHocTagValuesProvider(variable, {
+        key: 'namespace',
+        operator: '=',
+        value: '',
+      });
+
+      expect(result.replace).toBe(true);
+      expect(result.values).toEqual([
+        { text: 'checkout', value: 'checkout' },
+        { text: 'identity', value: 'identity' },
+        { text: 'observability', value: 'observability' },
+        { text: 'payments', value: 'payments' },
+      ]);
+    });
   });
 
   describe('edge cases', () => {
@@ -174,7 +273,11 @@ describe('tagKeysProviders', () => {
 
       const result = await getGroupByTagKeysProvider(variable, null);
 
-      expect(result.values).toEqual([{ value: 'grafana_folder', text: 'Folder', group: 'Common' }]);
+      expect(result.values).toEqual([
+        { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+        { value: 'cluster', text: 'Cluster', group: 'Common' },
+        { value: 'namespace', text: 'Namespace', group: 'Common' },
+      ]);
     });
   });
 });

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -17,7 +17,6 @@ const FILTER_PROMOTED: MetricFindValue[] = [
   { value: 'alertstate', text: 'State', group: COMMON_GROUP },
   { value: 'alertname', text: 'Rule name', group: COMMON_GROUP },
   { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
-  { value: 'severity', text: 'Severity', group: COMMON_GROUP },
   { value: 'service', text: 'Service', group: COMMON_GROUP },
   { value: 'team', text: 'Team', group: COMMON_GROUP },
   { value: 'namespace', text: 'Namespace', group: COMMON_GROUP },

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -3,7 +3,7 @@ import { PromQuery } from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFilterWithLabels, AdHocFiltersVariable, GroupByVariable, sceneGraph } from '@grafana/scenes';
 
-import { DATASOURCE_UID, METRIC_NAME } from '../constants';
+import { DATASOURCE_UID, METRIC_NAME, SERVICE_FILTER_LABEL_KEYS } from '../constants';
 
 const COMMON_GROUP = 'Common';
 const ALL_GROUP = 'All';
@@ -17,10 +17,14 @@ const FILTER_PROMOTED: MetricFindValue[] = [
   { value: 'alertstate', text: 'State', group: COMMON_GROUP },
   { value: 'alertname', text: 'Rule name', group: COMMON_GROUP },
   { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
+  { value: 'severity', text: 'Severity', group: COMMON_GROUP },
+  { value: 'service', text: 'Service', group: COMMON_GROUP },
+  { value: 'team', text: 'Team', group: COMMON_GROUP },
+  { value: 'namespace', text: 'Namespace', group: COMMON_GROUP },
 ];
 
 /** Labels that should never appear in dropdowns */
-const EXCLUDED = new Set(['__name__']);
+const EXCLUDED = new Set<string>(['__name__', 'service_name']);
 
 /** Query used to scope label lookups to the alerting metric */
 const metricQuery: PromQuery = { refId: 'keys', expr: METRIC_NAME };
@@ -107,6 +111,17 @@ export async function getAdHocTagValuesProvider(
   filter: AdHocFilterWithLabels
 ): Promise<{ replace: boolean; values: MetricFindValue[] }> {
   const timeRange = sceneGraph.getTimeRange(variable).state.value;
+  if (filter.key === 'service') {
+    const [serviceValues, serviceNameValues] = await Promise.all(
+      SERVICE_FILTER_LABEL_KEYS.map((key) => fetchTagValues(timeRange, key))
+    );
+    const allValues = [...serviceValues, ...serviceNameValues];
+    const dedupedValues = Array.from(new Map(allValues.map((v) => [String(v.value ?? v.text ?? ''), v])).values()).sort(
+      (a, b) => collator.compare(String(a.text ?? a.value ?? ''), String(b.text ?? b.value ?? ''))
+    );
+    return { replace: true, values: dedupedValues };
+  }
+
   const values = await fetchTagValues(timeRange, filter.key);
   return { replace: true, values };
 }

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -3,14 +3,23 @@ import { PromQuery } from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFilterWithLabels, AdHocFiltersVariable, GroupByVariable, sceneGraph } from '@grafana/scenes';
 
-import { DATASOURCE_UID, METRIC_NAME, SERVICE_FILTER_LABEL_KEYS } from '../constants';
+import { COMBINED_FILTER_LABEL_KEYS, DATASOURCE_UID, METRIC_NAME } from '../constants';
 
 const COMMON_GROUP = 'Common';
 const ALL_GROUP = 'All';
 const collator = new Intl.Collator();
+type CombinedFilterKey = keyof typeof COMBINED_FILTER_LABEL_KEYS;
+
+function isCombinedFilterKey(key: string): key is CombinedFilterKey {
+  return key in COMBINED_FILTER_LABEL_KEYS;
+}
 
 /** Labels promoted to the top of the GroupBy dropdown */
-const GROUPBY_PROMOTED: MetricFindValue[] = [{ value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP }];
+const GROUPBY_PROMOTED: MetricFindValue[] = [
+  { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
+  { value: 'cluster', text: 'Cluster', group: COMMON_GROUP },
+  { value: 'namespace', text: 'Namespace', group: COMMON_GROUP },
+];
 
 /** Labels promoted to the top of the Filter dropdown */
 const FILTER_PROMOTED: MetricFindValue[] = [
@@ -23,7 +32,10 @@ const FILTER_PROMOTED: MetricFindValue[] = [
 ];
 
 /** Labels that should never appear in dropdowns */
-const EXCLUDED = new Set<string>(['__name__', 'service_name']);
+const EXCLUDED = new Set<string>([
+  '__name__',
+  ...Object.values(COMBINED_FILTER_LABEL_KEYS).flatMap((keys) => keys.slice(1)),
+]);
 
 /** Query used to scope label lookups to the alerting metric */
 const metricQuery: PromQuery = { refId: 'keys', expr: METRIC_NAME };
@@ -110,11 +122,9 @@ export async function getAdHocTagValuesProvider(
   filter: AdHocFilterWithLabels
 ): Promise<{ replace: boolean; values: MetricFindValue[] }> {
   const timeRange = sceneGraph.getTimeRange(variable).state.value;
-  if (filter.key === 'service') {
-    const [serviceValues, serviceNameValues] = await Promise.all(
-      SERVICE_FILTER_LABEL_KEYS.map((key) => fetchTagValues(timeRange, key))
-    );
-    const allValues = [...serviceValues, ...serviceNameValues];
+  if (isCombinedFilterKey(filter.key)) {
+    const combinedKeys = COMBINED_FILTER_LABEL_KEYS[filter.key];
+    const allValues = (await Promise.all(combinedKeys.map((key) => fetchTagValues(timeRange, key)))).flat();
     const dedupedValues = Array.from(new Map(allValues.map((v) => [String(v.value ?? v.text ?? ''), v])).values()).sort(
       (a, b) => collator.compare(String(a.text ?? a.value ?? ''), String(b.text ?? b.value ?? ''))
     );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3562,7 +3562,7 @@
       "expand-all": "Expand all",
       "expand-sidebar": "Expand sidebar",
       "filter-labels": "Filter labels",
-      "filter-labels-placeholder": "Filter",
+      "filter-labels-placeholder": "Search labels",
       "group-row": {
         "no-label": "No {{label}}"
       },


### PR DESCRIPTION
This PR:
- Rename labels search placeholder: Filter -> Search labels (e.g. aligns with Entity search in entity catalog)
- Update quick actions navigation: Silence & Declare Incident open as a new page to avoid losing context
- Expands Filter common options to include service, team & namespace
