### PR TITLE
IAM: Extract subresource authorizer for reuse

### DIFF
--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -2,7 +2,6 @@ package iam
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	authlib "github.com/grafana/authlib/types"
@@ -98,43 +97,6 @@ func (s *iamAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribute
 	return authz.Authorize(ctx, attr)
 }
 
-// subresourceCheck is a function that performs authorization check for a specific subresource.
-// It receives the context, identity, and attributes, and returns the authorization decision.
-type subresourceCheck func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error)
-
-// newAuthorizerWithCustomSubCheck creates an authorizer that handles specific subresources
-// with custom permission checks, delegating to the standard ResourceAuthorizer for direct
-// resource access (no subresource). Unregistered subresources are denied so that authorization
-// for every subresource must be explicitly specified.
-func newAuthorizerWithCustomSubCheck(
-	accessClient authlib.AccessClient,
-	checks map[string]subresourceCheck,
-) authorizer.Authorizer {
-	delegate := gfauthorizer.NewResourceAuthorizer(accessClient)
-	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		if !attr.IsResourceRequest() {
-			return authorizer.DecisionNoOpinion, "", nil
-		}
-
-		sub := attr.GetSubresource()
-		if sub == "" {
-			return delegate.Authorize(ctx, attr)
-		}
-
-		check, ok := checks[sub]
-		if !ok {
-			return authorizer.DecisionDeny, "", fmt.Errorf("no authorizer for subresource %q", sub)
-		}
-
-		ident, ok := authlib.AuthInfoFrom(ctx)
-		if !ok {
-			return authorizer.DecisionDeny, "", errors.New("no identity found")
-		}
-
-		return check(ctx, ident, attr)
-	})
-}
-
 // newTeamAuthorizer creates an authorizer for teams that handles the "members" and "groups" subresources
 // with a get_permissions check on the parent team resource.
 func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
@@ -154,7 +116,7 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 		}
 		return authorizer.DecisionAllow, "", nil
 	}
-	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
+	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"members": check,
 		"groups":  check,
 	})
@@ -164,7 +126,7 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 // "teams" is read-only (Connecter/GET), so it checks user get.
 // "status" supports both GET and PUT, so the check verb mirrors the request verb.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
+	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"teams": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
 				Verb:      utils.VerbGet,
@@ -208,7 +170,7 @@ func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 // with a get check on the parent service account resource.
 // This follows the legacy permission pattern where viewing tokens requires serviceaccounts:read on serviceaccounts:id:<id>.
 func newServiceAccountAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
-	return newAuthorizerWithCustomSubCheck(accessClient, map[string]subresourceCheck{
+	return gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
 		"tokens": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
 				Verb:      utils.VerbGet,

--- a/pkg/services/apiserver/auth/authorizer/resource.go
+++ b/pkg/services/apiserver/auth/authorizer/resource.go
@@ -3,6 +3,7 @@ package authorizer
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
@@ -47,4 +48,36 @@ func (r ResourceAuthorizer) Authorize(ctx context.Context, attr authorizer.Attri
 	}
 
 	return authorizer.DecisionAllow, "", nil
+}
+
+// SubresourceCheck performs an authorization check for a specific subresource.
+type SubresourceCheck func(ctx context.Context, ident claims.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error)
+
+// NewResourceAuthorizerWithSubresourceHandlers creates an authorizer that:
+//   - delegates to ResourceAuthorizer when subresource is empty,
+//   - runs the matching SubresourceCheck for known subresources,
+//   - denies unknown subresources outright.
+func NewResourceAuthorizerWithSubresourceHandlers(
+	c claims.AccessChecker,
+	checks map[string]SubresourceCheck,
+) authorizer.Authorizer {
+	delegate := NewResourceAuthorizer(c)
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if !attr.IsResourceRequest() {
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+		sub := attr.GetSubresource()
+		if sub == "" {
+			return delegate.Authorize(ctx, attr)
+		}
+		check, ok := checks[sub]
+		if !ok {
+			return authorizer.DecisionDeny, "", fmt.Errorf("no authorizer for subresource %q", sub)
+		}
+		ident, ok := claims.AuthInfoFrom(ctx)
+		if !ok {
+			return authorizer.DecisionDeny, "", errors.New("no identity found")
+		}
+		return check(ctx, ident, attr)
+	})
 }

--- a/pkg/services/apiserver/auth/authorizer/resource_test.go
+++ b/pkg/services/apiserver/auth/authorizer/resource_test.go
@@ -1,0 +1,306 @@
+package authorizer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/authlib/authn"
+	"github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// fakeAccessChecker is a fake implementation of claims.AccessChecker for testing
+type fakeAccessChecker struct {
+	checkFunc func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error)
+}
+
+func (m *fakeAccessChecker) Check(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+	return m.checkFunc(ctx, ident, req, extra)
+}
+
+// mockAttributes is a mock implementation of authorizer.Attributes for testing
+type mockAttributes struct {
+	authorizer.Attributes
+	isResourceRequest bool
+	verb              string
+	apiGroup          string
+	resource          string
+	namespace         string
+	name              string
+	subresource       string
+	path              string
+}
+
+func (a mockAttributes) IsResourceRequest() bool { return a.isResourceRequest }
+func (a mockAttributes) GetVerb() string         { return a.verb }
+func (a mockAttributes) GetAPIGroup() string     { return a.apiGroup }
+func (a mockAttributes) GetResource() string     { return a.resource }
+func (a mockAttributes) GetNamespace() string    { return a.namespace }
+func (a mockAttributes) GetName() string         { return a.name }
+func (a mockAttributes) GetSubresource() string  { return a.subresource }
+func (a mockAttributes) GetPath() string         { return a.path }
+
+// newTestAuthInfo returns a minimal AuthInfo for use in authorization tests.
+func newTestAuthInfo() types.AuthInfo {
+	return authn.NewIDTokenAuthInfo(
+		authn.Claims[authn.AccessTokenClaims]{},
+		&authn.Claims[authn.IDTokenClaims]{},
+	)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_EmptySubresource_DelegatesToResourceAuthorizer(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{
+		"test": func(ctx context.Context, ident types.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionDeny, "should not be called", nil
+		},
+	})
+
+	// Empty subresource should delegate to ResourceAuthorizer
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "", // empty subresource
+	}
+
+	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.NoError(t, err)
+	require.Equal(t, authorizer.DecisionAllow, decision)
+	require.Empty(t, reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_KnownSubresource_RunsSubresourceCheck(t *testing.T) {
+	checkCalled := false
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	subresourceCheck := func(ctx context.Context, ident types.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		checkCalled = true
+		// Verify the attributes are passed correctly
+		require.Equal(t, "testresource", attr.GetResource())
+		require.Equal(t, "testsub", attr.GetSubresource())
+		return authorizer.DecisionAllow, "", nil
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{
+		"testsub": subresourceCheck,
+	})
+
+	// Add auth info to context so it's not denied due to missing identity
+	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "testsub",
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.NoError(t, err)
+	require.True(t, checkCalled, "subresource check should have been called")
+	require.Equal(t, authorizer.DecisionAllow, decision)
+	require.Empty(t, reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_KnownSubresource_Denied(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	subresourceCheck := func(ctx context.Context, ident types.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionDeny, "custom denial reason", nil
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{
+		"testsub": subresourceCheck,
+	})
+
+	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "testsub",
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.NoError(t, err)
+	require.Equal(t, authorizer.DecisionDeny, decision)
+	require.Equal(t, "custom denial reason", reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_UnknownSubresource_ReturnsDeny(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{
+		"knownsub": func(ctx context.Context, ident types.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		},
+	})
+
+	ctx := context.Background()
+
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "unknownsub",
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no authorizer for subresource")
+	require.Equal(t, authorizer.DecisionDeny, decision)
+	require.Empty(t, reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_NonResourceRequest_ReturnsNoOpinion(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{
+		"testsub": func(ctx context.Context, ident types.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		},
+	})
+
+	ctx := context.Background()
+
+	attrs := mockAttributes{
+		isResourceRequest: false, // not a resource request
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "testsub",
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.NoError(t, err)
+	require.Equal(t, authorizer.DecisionNoOpinion, decision)
+	require.Empty(t, reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_NoIdentity_ReturnsDeny(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: true}, nil
+		},
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{
+		"testsub": func(ctx context.Context, ident types.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		},
+	})
+
+	// No auth info in context
+	ctx := context.Background()
+
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "testsub",
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no identity found")
+	require.Equal(t, authorizer.DecisionDeny, decision)
+	require.Empty(t, reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_DelegateCheckError(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{}, errors.New("check failed")
+		},
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{})
+
+	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "", // empty subresource
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "check failed")
+	require.Equal(t, authorizer.DecisionDeny, decision)
+	require.Empty(t, reason)
+}
+
+func TestNewResourceAuthorizerWithSubresourceHandlers_DelegateCheckDenied(t *testing.T) {
+	mockChecker := &fakeAccessChecker{
+		checkFunc: func(ctx context.Context, ident types.AuthInfo, req types.CheckRequest, extra string) (types.CheckResponse, error) {
+			return types.CheckResponse{Allowed: false}, nil
+		},
+	}
+
+	auth := NewResourceAuthorizerWithSubresourceHandlers(mockChecker, map[string]SubresourceCheck{})
+
+	ctx := types.WithAuthInfo(context.Background(), newTestAuthInfo())
+
+	attrs := mockAttributes{
+		isResourceRequest: true,
+		verb:              "get",
+		apiGroup:          "test.group",
+		resource:          "testresource",
+		namespace:         "testns",
+		name:              "testname",
+		subresource:       "", // empty subresource
+	}
+
+	decision, reason, err := auth.Authorize(ctx, attrs)
+	require.NoError(t, err)
+	require.Equal(t, authorizer.DecisionDeny, decision)
+	require.Equal(t, "unauthorized request", reason)
+}


### PR DESCRIPTION
## Why the change

The IAM authorizer logic for subresources (user status, team groups) was embedded directly in the IAM package. This extraction allows other packages to reuse the same authorization pattern for their subresources.

## Summary
- Extract `SubresourceAuthorizer` interface and implementation from IAM
- Add reusable authorizer in `pkg/services/apiserver/auth/authorizer/resource.go`
- Add comprehensive tests for the subresource authorization logic


Made with [Cursor](https://cursor.com)