### PR TITLE
Teams: Fix team modal not closing when deleting a team

### DIFF
--- a/public/app/features/teams/TeamDeleteModal.tsx
+++ b/public/app/features/teams/TeamDeleteModal.tsx
@@ -43,7 +43,10 @@ export const TeamDeleteModal = ({ isOpen, onConfirm, onDismiss, teamName, ownedF
         </>
       }
       onDismiss={onDismiss}
-      onConfirm={onConfirm}
+      onConfirm={async () => {
+        await onConfirm();
+        onDismiss();
+      }}
       confirmText={t('teams.team-list.columns.delete-modal.confirm-button', 'Delete')}
       disabled={ownedFolder}
     />

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, userEvent, waitFor } from 'test/test-utils';
+import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { MOCK_TEAMS } from '@grafana/test-utils/unstable';
+import { ModalRoot } from '@grafana/ui';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -60,6 +61,33 @@ describe('TeamList', () => {
       render(<TeamList />);
 
       expect(await screen.findByRole('link', { name: /new team/i })).toHaveStyle('pointer-events: none');
+    });
+  });
+
+  it('should close the delete modal after confirming team deletion', async () => {
+    const mockTeam = MOCK_TEAMS[0];
+    render(
+      <>
+        <TeamList />
+        <ModalRoot />
+      </>
+    );
+
+    // Click the delete button to open the modal
+    await userEvent.click(await screen.findByRole('button', { name: `Delete ${mockTeam.spec.title}` }));
+
+    // The modal should be visible with a Delete heading
+    const modalTitle = await screen.findByRole('heading', { name: /delete/i });
+    expect(modalTitle).toBeInTheDocument();
+
+    // Click the confirm delete button in the modal (the one inside the dialog, not the icon buttons)
+    const modal = screen.getByRole('dialog');
+    const confirmButton = within(modal).getByRole('button', { name: /delete/i });
+    await userEvent.click(confirmButton);
+
+    // The modal should close after deletion
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: /delete/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -256,9 +256,9 @@ const TeamList = () => {
               new ShowModalReactEvent({
                 component: TeamDeleteModal,
                 props: {
-                  onConfirm: () => {
+                  onConfirm: async () => {
                     reportInteraction('grafana_teams_list_delete_modal_confirm_clicked');
-                    deleteTeam({ uid: original.uid });
+                    await deleteTeam({ uid: original.uid });
                   },
                   teamName: original.name,
                   ownedFolder: ownedFolders && ownedFolders.length > 0,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- correctly closes the "Delete team" modal after deleting a team
- adds a unit test to prevent regressions
- see slack context here: https://raintank-corp.slack.com/archives/CHKLEJ668/p1774852965231649?thread_ts=1774012035.757749&cid=CHKLEJ668

**Why do we need this feature?**

- so the modal closes properly

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
