### PR TITLE
[release-12.4.3] Analytics: Keep internal dashboard id 

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2247,7 +2247,7 @@
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 22
+      "count": 23
     }
   },
   "public/app/features/dashboard/state/PanelModel.test.ts": {

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -9,6 +9,8 @@ import { EchoEvent, EchoEventType } from '../services/EchoSrv';
  * @public
  */
 export interface DashboardInfo {
+  /** @deprecated -- use UID not internal ID */
+  dashboardId: number;
   dashboardUid: string;
   dashboardName: string;
   folderName?: string;

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -388,6 +388,7 @@ abstract class DashboardScenePageStateManagerBase<T>
 
       if (options.route !== DashboardRoutes.New) {
         emitDashboardViewEvent({
+          id: dashboard.state.id,
           meta: dashboard.state.meta,
           uid: dashboard.state.uid,
           title: dashboard.state.title,

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -110,6 +110,9 @@ type CopiedPanelStyles = {
 };
 
 export interface DashboardSceneState extends SceneObjectState {
+  /** @deprecated */
+  id?: number | undefined;
+
   /** The title */
   title: string;
   /** The description */

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -53,6 +53,7 @@ import {
   AnnoKeyUpdatedTimestamp,
   AnnoKeyDashboardIsSnapshot,
   AnnoKeyEmbedded,
+  DeprecatedInternalId,
 } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import {
@@ -195,8 +196,11 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
     dashboardProfiler
   );
 
+  const deprecatedId = metadata.labels?.[DeprecatedInternalId];
+
   const dashboardScene = new DashboardScene(
     {
+      id: deprecatedId ? parseInt(deprecatedId, 10) : undefined,
       description: dashboard.description,
       editable: dashboard.editable,
       preload: dashboard.preload,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -411,6 +411,7 @@ export function createDashboardSceneFromDashboardModel(
 
   const dashboardScene = new DashboardScene(
     {
+      id: oldModel.id,
       uid,
       description: oldModel.description,
       editable: oldModel.editable,

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -33,6 +33,10 @@ export class DashboardModelCompatibilityWrapper {
     );
   }
 
+  public get id(): number | null {
+    return this._scene.state.id ?? null;
+  }
+
   public get uid() {
     return this._scene.state.uid ?? null;
   }

--- a/public/app/features/dashboard/state/DashboardMigratorSingleVersion.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigratorSingleVersion.test.ts
@@ -134,7 +134,7 @@ describe('Backend / Frontend single version migration result comparison', () => 
           }
         }
       }
-
+      delete frontendMigrationResult.id;
       expect(backendMigrationResult).toEqual(frontendMigrationResult);
     });
   });

--- a/public/app/features/dashboard/state/DashboardMigratorToBackend.devDashboards.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigratorToBackend.devDashboards.test.ts
@@ -108,6 +108,7 @@ describe('Dev Dashboard Backend / Frontend result comparison', () => {
 
       // version in the backend is never added because it is returned from the backend as metadata
       delete frontendMigrationResult.version;
+      delete frontendMigrationResult.id;
 
       expect(backendMigrationResult).toEqual(frontendMigrationResult);
     });

--- a/public/app/features/dashboard/state/DashboardMigratorToBackend.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigratorToBackend.test.ts
@@ -102,6 +102,9 @@ describe('Backend / Frontend result comparison', () => {
         }
       }
 
+      // The backend snapshots exclude the internal ids
+      delete frontendMigrationResult.id;
+
       expect(backendMigrationResult).toEqual(frontendMigrationResult);
     });
   });

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -67,6 +67,9 @@ export interface ScopeMeta {
 }
 
 export class DashboardModel implements TimeModel {
+  /** @deprecated use UID */
+  id?: any;
+
   // TODO: use proper type and fix all the places where uid is set to null
   uid: any;
   title: string;
@@ -141,6 +144,7 @@ export class DashboardModel implements TimeModel {
       targetSchemaVersion?: number;
     }
   ) {
+    this.id = data.id;
     this.getVariablesFromState = options?.getVariablesFromState ?? getVariablesByKey;
     this.events = new EventBusSrv();
     // UID is not there for newly created dashboards

--- a/public/app/features/dashboard/state/analyticsProcessor.ts
+++ b/public/app/features/dashboard/state/analyticsProcessor.ts
@@ -2,8 +2,9 @@ import { reportMetaAnalytics, MetaAnalyticsEventName, DashboardViewEventPayload 
 
 import { DashboardModel } from './DashboardModel';
 
-export function emitDashboardViewEvent(dashboard: Pick<DashboardModel, 'title' | 'uid' | 'meta'>) {
+export function emitDashboardViewEvent(dashboard: Pick<DashboardModel, 'title' | 'uid' | 'meta' | 'id'>) {
   const eventData: DashboardViewEventPayload = {
+    dashboardId: dashboard.id,
     dashboardName: dashboard.title,
     dashboardUid: dashboard.uid,
     folderName: dashboard.meta.folderTitle,

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -66,6 +66,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
 
     const dashboard = getDashboardSrv().getCurrent();
     if (dashboard) {
+      eventData.dashboardId = dashboard.id;
       eventData.dashboardName = dashboard.title;
       eventData.dashboardUid = dashboard.uid;
       eventData.folderName = dashboard.meta.folderTitle;


### PR DESCRIPTION
Backport 5e636006c96b5858c2018af8d1a460c5a987f9c0 from #119115

---

In https://github.com/grafana/grafana/pull/117398 we finally removed the internal id 🎉    but analytics is still using it 😢  so we need to keep it around longer.

This PR reverts as little as possible to keep analytics working.  When it is updated to work with UIDs, this can be removed.
