### PR TITLE
FS: Remove per-tenant CSP override

### DIFF
--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	settingservice "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -562,7 +563,7 @@ func TestFrontendService_CSP(t *testing.T) {
 		assert.Contains(t, cspHeader, "frame-ancestors *")
 	})
 
-	t.Run("should not add frame-ancestors to CSP when allow_embedding_hosts is empty", func(t *testing.T) {
+	t.Run("should disallow iframing when allow_embedding_hosts is empty", func(t *testing.T) {
 		cfg := &setting.Cfg{
 			Raw:            ini.Empty(),
 			HTTPPort:       "3000",
@@ -570,7 +571,7 @@ func TestFrontendService_CSP(t *testing.T) {
 			BuildVersion:   "10.3.0",
 			AppURL:         "https://grafana.example.com",
 			CSPEnabled:     true,
-			CSPTemplate:    "script-src 'self'",
+			CSPTemplate:    "script-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
 		}
 		service := createTestService(t, cfg)
 
@@ -584,7 +585,40 @@ func TestFrontendService_CSP(t *testing.T) {
 
 		assert.Equal(t, 200, recorder.Code)
 		cspHeader := recorder.Header().Get("Content-Security-Policy")
-		assert.NotContains(t, cspHeader, "frame-ancestors")
+		assert.Contains(t, cspHeader, "frame-ancestors 'none'")
+	})
+
+	t.Run("should apply per-tenant allow_embedding_hosts override to CSP header", func(t *testing.T) {
+		enableSettingsOverridesToggle(t)
+
+		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
+			HTTPPort:       "3000",
+			StaticRootPath: publicDir,
+			BuildVersion:   "10.3.0",
+			AppURL:         "https://grafana.example.com",
+			CSPEnabled:     true,
+			CSPTemplate:    "script-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
+		}
+		service := createTestService(t, cfg)
+		service.settingsService = &mockSettingsService{
+			settings: []*settingservice.Setting{
+				{Section: "security", Key: "allow_embedding_hosts", Value: "tenant.example.com wiki.example.com"},
+			},
+		}
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("baggage", "namespace=stacks-tenant-1")
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		cspHeader := recorder.Header().Get("Content-Security-Policy")
+		assert.Contains(t, cspHeader, "frame-ancestors tenant.example.com wiki.example.com")
 	})
 
 	t.Run("should use base config when Tenant-ID header is present", func(t *testing.T) {

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -126,10 +126,6 @@ func (c *FSRequestConfig) ApplyOverrides(settings *ini.File, logger log.Logger) 
 	// because we only want overrides, and not default values, we need to manually get them out of the ini structure.
 
 	// TODO: We should apply all overrides for values in FSRequestConfig
-	applyBool(settings, "security", "content_security_policy", &c.CSPEnabled, logger)
-	applyString(settings, "security", "content_security_policy_template", &c.CSPTemplate, logger)
-	applyBool(settings, "security", "content_security_policy_report_only", &c.CSPReportOnlyEnabled, logger)
-	applyString(settings, "security", "content_security_policy_report_only_template", &c.CSPReportOnlyTemplate, logger)
 	applyStringSlice(settings, "security", "allow_embedding_hosts", &c.AllowEmbeddingHosts, logger)
 
 	applyString(settings, "analytics", "rudderstack_write_key", &c.RudderstackWriteKey, logger)
@@ -168,18 +164,6 @@ func applyString(settings *ini.File, sectionName, keyName string, target *string
 func applyStringSlice(settings *ini.File, sectionName, keyName string, target *[]string, logger log.Logger) {
 	if key := getValue(settings, sectionName, keyName); key != nil {
 		*target = strings.Fields(key.String())
-
-		logger.Debug("applying request config override",
-			"section", sectionName,
-			"key", keyName,
-			"value", *target)
-	}
-}
-
-// applyBool applies a boolean value from ini settings to a target field if it exists.
-func applyBool(settings *ini.File, sectionName, keyName string, target *bool, logger log.Logger) {
-	if key := getValue(settings, sectionName, keyName); key != nil {
-		*target = key.MustBool(false)
 
 		logger.Debug("applying request config override",
 			"section", sectionName,

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -74,7 +74,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			Raw:         ini.Empty(),
 			HTTPPort:    "1234",
 			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'",
+			CSPTemplate: "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
 			AppURL:      "https://grafana.example.com",
 		}
 
@@ -98,7 +98,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
 		assert.True(t, capturedConfig.CSPEnabled)
-		assert.Equal(t, capturedConfig.CSPTemplate, "default-src 'self'")
+		assert.Equal(t, capturedConfig.CSPTemplate, "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS")
 		assert.Equal(t, capturedConfig.AppURL, "https://grafana.example.com")
 	})
 
@@ -108,7 +108,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			Raw:         ini.Empty(),
 			HTTPPort:    "1234",
 			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'",
+			CSPTemplate: "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
 			AppURL:      "https://grafana.example.com",
 		}
 
@@ -138,8 +138,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		// Create mock settings service that returns CSP overrides
 		mockSettingsService := &mockSettingsService{
 			settings: []*settingservice.Setting{
-				{Section: "security", Key: "content_security_policy", Value: "true"},
-				{Section: "security", Key: "content_security_policy_template", Value: "script-src 'self'"},
+				{Section: "security", Key: "allow_embedding_hosts", Value: "wiki.example.com foo.example.com"},
 			},
 		}
 
@@ -148,7 +147,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			Raw:         ini.Empty(),
 			HTTPPort:    "1234",
 			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'",
+			CSPTemplate: "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
 			AppURL:      "https://grafana.example.com",
 		}
 
@@ -175,8 +174,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
 		// Verify CSP overrides were applied
-		assert.True(t, capturedConfig.CSPEnabled)
-		assert.Equal(t, "script-src 'self'", capturedConfig.CSPTemplate)
+		assert.Equal(t, []string{"wiki.example.com", "foo.example.com"}, capturedConfig.AllowEmbeddingHosts)
 
 		// Verify other settings remain at base values (not overridden)
 		assert.Equal(t, "https://grafana.example.com", capturedConfig.AppURL)
@@ -201,7 +199,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			Raw:         ini.Empty(),
 			HTTPPort:    "1234",
 			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'",
+			CSPTemplate: "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
 			AppURL:      "https://base.example.com",
 		}
 
@@ -230,7 +228,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		// Verify base config was used (no overrides)
 		assert.Equal(t, "https://base.example.com", capturedConfig.AppURL)
 		assert.True(t, capturedConfig.CSPEnabled)
-		assert.Equal(t, "default-src 'self'", capturedConfig.CSPTemplate)
+		assert.Equal(t, "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS", capturedConfig.CSPTemplate)
 
 		// Verify settings service was called
 		assert.True(t, mockSettingsService.called)
@@ -279,7 +277,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 			Raw:         ini.Empty(),
 			HTTPPort:    "1234",
 			CSPEnabled:  true,
-			CSPTemplate: "default-src 'self'",
+			CSPTemplate: "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS",
 			AppURL:      "https://grafana.example.com",
 		}
 
@@ -308,7 +306,7 @@ func TestRequestConfigMiddleware(t *testing.T) {
 
 		// Base config should be used unchanged
 		assert.True(t, capturedConfig.CSPEnabled)
-		assert.Equal(t, "default-src 'self'", capturedConfig.CSPTemplate)
+		assert.Equal(t, "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS", capturedConfig.CSPTemplate)
 	})
 }
 

--- a/pkg/services/frontend/request_config_test.go
+++ b/pkg/services/frontend/request_config_test.go
@@ -41,12 +41,12 @@ func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 
 		iniFile := ini.Empty()
 		securitySection, _ := iniFile.NewSection("security")
-		_, _ = securitySection.NewKey("content_security_policy", "true")
+		_, _ = securitySection.NewKey("allow_embedding_hosts", "foo.example.com")
 
 		config.ApplyOverrides(iniFile, log.New("test"))
 
 		// CSP overridden field
-		assert.True(t, config.CSPEnabled)
+		assert.Equal(t, []string{"foo.example.com"}, config.AllowEmbeddingHosts)
 
 		// Non-overridden fields should be preserved
 		assert.Equal(t, "https://base.example.com", config.AppURL)
@@ -101,41 +101,5 @@ func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 		config.ApplyOverrides(iniFile, log.New("test"))
 
 		assert.Equal(t, []string{"*"}, config.AllowEmbeddingHosts)
-	})
-
-	t.Run("should apply multiple CSP overrides at once", func(t *testing.T) {
-		config := FSRequestConfig{
-			FSFrontendSettings: FSFrontendSettings{
-				AnonymousEnabled:  false,
-				DisableLoginForm:  false,
-				DisableUserSignUp: false,
-			},
-			AppURL:                "https://base.example.com",
-			CSPEnabled:            false,
-			CSPTemplate:           "",
-			CSPReportOnlyEnabled:  false,
-			CSPReportOnlyTemplate: "",
-		}
-
-		iniFile := ini.Empty()
-
-		securitySection, _ := iniFile.NewSection("security")
-		_, _ = securitySection.NewKey("content_security_policy", "true")
-		_, _ = securitySection.NewKey("content_security_policy_template", "script-src 'self'")
-		_, _ = securitySection.NewKey("content_security_policy_report_only", "true")
-		_, _ = securitySection.NewKey("content_security_policy_report_only_template", "default-src 'none'")
-
-		config.ApplyOverrides(iniFile, log.New("test"))
-
-		// All CSP settings should be overridden
-		assert.True(t, config.CSPEnabled)
-		assert.Equal(t, "script-src 'self'", config.CSPTemplate)
-		assert.True(t, config.CSPReportOnlyEnabled)
-		assert.Equal(t, "default-src 'none'", config.CSPReportOnlyTemplate)
-
-		// Other settings should remain unchanged
-		assert.Equal(t, "https://base.example.com", config.AppURL)
-		assert.False(t, config.DisableLoginForm)
-		assert.False(t, config.AnonymousEnabled)
 	})
 }


### PR DESCRIPTION
Since https://github.com/grafana/grafana/pull/120702, we no longer need the CSP overrides, and instead just rely on the allow_embedding_hosts.