### PR TITLE
Dashboard Import: Fix missing default permissions when importing via K8s API

### DIFF
--- a/public/app/features/manage-dashboards/import/components/ImportOverviewV1.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverviewV1.tsx
@@ -5,6 +5,7 @@ import { locationService, reportInteraction } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
 import { Form } from 'app/core/components/Form/Form';
+import { AnnoKeyGrantPermissions } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -67,6 +68,7 @@ export function ImportOverviewV1({ dashboard, inputs, meta, source, folderUid, o
         k8s: {
           annotations: {
             'grafana.app/folder': form.folder.uid,
+            [AnnoKeyGrantPermissions]: 'default',
           },
         },
       };

--- a/public/app/features/manage-dashboards/import/components/ImportOverviewV2.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverviewV2.tsx
@@ -5,6 +5,7 @@ import { locationService, reportInteraction } from '@grafana/runtime';
 import { Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { appEvents } from 'app/core/app_events';
 import { Form } from 'app/core/components/Form/Form';
+import { AnnoKeyGrantPermissions } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 
 import { DashboardInputs, DashboardSource, ImportFormDataV2 } from '../../types';
@@ -73,7 +74,7 @@ export function ImportOverviewV2({ dashboard, dashboardUid, inputs, meta, source
           folderUid: folderUid,
           k8s: {
             ...(dashboardUid !== undefined ? { name: dashboardUid } : {}),
-            annotations: { 'grafana.app/folder': folderUid },
+            annotations: { 'grafana.app/folder': folderUid, [AnnoKeyGrantPermissions]: 'default' },
           },
         }}
         validateOnMount


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Escalation AI Agent -- Fix Proposed**

**What was the issue**

When a user with Editor basic role imports a dashboard to the root (General) folder via the Grafana UI in v12.4.0+, the dashboard is created successfully but **no default managed permissions** are applied to it. This means:
- The importing Editor user gets a "Failed to load dashboard Forbidden" message immediately after import
- The dashboard has no Editor=Edit or Viewer=View permissions; only Org Admins can access it
- This regression only affects the **import** path; creating a new dashboard via "New Dashboard" works correctly

The root cause is in the frontend K8s import path introduced by PR [#116482](https://github.com/grafana/grafana/pull/116482). Starting in v12.4.0, the `kubernetesDashboards` feature toggle became GA (`expression: "true"`), causing the dashboard import UI to use a new component (`DashboardImportK8s`) that saves dashboards directly via the K8s API instead of the legacy `/api/dashboards/import` endpoint.

The new K8s import path calls `K8sDashboardAPI.saveDashboard()` (or `K8sDashboardV2API.saveDashboard()`). When the imported dashboard JSON has a `uid` field (which is common), the frontend uses the `update` (PUT) code path, which does **not** include the `grafana.app/grant-permissions: default` annotation:

```typescript
// public/app/features/dashboard/api/v1.ts lines 91-106
if (dashboard.uid) {
    obj.metadata.name = dashboard.uid;
    // NO AnnoKeyGrantPermissions annotation set here
    return this.client.update(obj, { fieldValidation: 'Ignore' }).then(...)
}
// Only the create path (no uid) sets the annotation:
obj.metadata.annotations = {
    ...obj.metadata.annotations,
    [AnnoKeyGrantPermissions]: 'default',
};
return this.client.create(obj, { fieldValidation: 'Ignore' }).then(...)
```
([GitHub permalink](https://github.com/grafana/grafana/blob/381cc6555db58316542d6eccb2c4e3027d372f4a/public/app/features/dashboard/api/v1.ts#L91-L106))

When K8s receives the PUT for a non-existent resource, it performs an upsert (`AllowCreateOnUpdate=true`), calling `Storage.Create()`. But since the `grafana.app/grant-permissions` annotation is absent, the K8s storage layer's `afterCreatePermissionCreator` returns nil and no permissions are set ([`pkg/storage/unified/apistore/permissions.go` L24](https://github.com/grafana/grafana/blob/381cc6555db58316542d6eccb2c4e3027d372f4a/pkg/storage/unified/apistore/permissions.go#L24)).

The legacy import path (`/api/dashboards/import`) did not have this issue because the backend's `DashboardServiceImpl.ImportDashboard()` explicitly called `SetDefaultPermissions()` after saving ([`pkg/services/dashboards/service/dashboard_service.go` L1294](https://github.com/grafana/grafana/blob/381cc6555db58316542d6eccb2c4e3027d372f4a/pkg/services/dashboards/service/dashboard_service.go#L1294)).

**Affected versions**: v12.4.0, v12.4.1, v12.4.2, and `main` (any version where `kubernetesDashboards` is enabled)

**Proposed fix**

Add `AnnoKeyGrantPermissions: 'default'` to the K8s annotations in both `ImportOverviewV1.tsx` and `ImportOverviewV2.tsx` import components. This ensures the K8s storage layer sets default permissions when creating a dashboard during import.

The fix is safe for the overwrite (update) case because `prepareObjectForUpdate` in the K8s storage layer explicitly strips the `grant-permissions` annotation on line 204 of `pkg/storage/unified/apistore/prepare.go`.

**Before** (ImportOverviewV1.tsx):
```typescript
k8s: {
  annotations: {
    'grafana.app/folder': form.folder.uid,
  },
},
```

**After**:
```typescript
k8s: {
  annotations: {
    'grafana.app/folder': form.folder.uid,
    [AnnoKeyGrantPermissions]: 'default',
  },
},
```

**Workaround**

Until the fix is merged and released, customers can use any of these workarounds:

1. **Import to a subfolder, not the General (root) folder.** If the subfolder has Editor/Viewer permissions, the imported dashboard will inherit those permissions.
2. **After importing, have an Admin user manually add permissions** to the imported dashboard via Dashboard Settings → Permissions → Add Editor=Edit and Viewer=View.
3. **Disable the `kubernetesDashboards` feature toggle** to revert to the legacy import path: add `kubernetesDashboards = false` under `[feature_toggles]` in `grafana.ini` or `custom.ini` and restart Grafana. This forces the import to use the legacy `/api/dashboards/import` endpoint which correctly sets permissions.

**Impact**

- **Data integrity**: No data is corrupted or lost. Dashboards are created correctly; only the managed permission records are missing.
- **Data remediation**: For dashboards already imported without permissions, an Org Admin can manually add `Editor=Edit` and `Viewer=View` permissions via each dashboard's Permissions settings. Alternatively, a bulk fix can be done via the API: `POST /api/dashboards/uid/:uid/permissions` with the appropriate permission payload.
- **Introducing PR**: [#116482](https://github.com/grafana/grafana/pull/116482) — "Refactor dashboard import to separate k8s and legacy paths" (commit `381cc6555db`). This PR introduced the new `DashboardImportK8s` component that bypasses the legacy import endpoint's `SetDefaultPermissions` call. Note: The escalation initially suspected [#116885](https://github.com/grafana/grafana/pull/116885) ("API: Add missing scope check on dashboards"), but that PR only tightened authorization scope checks on permission endpoints and is not the cause of this bug.

**Validation checklist**

- [ ] Editor user importing a dashboard to the General (root) folder via UI gets default permissions (creator=Admin, Editor=Edit, Viewer=View) applied to the newly imported dashboard
- [ ] Editor user can immediately access the dashboard after import without getting "Forbidden"
- [ ] Importing to a subfolder still works correctly (subfolder dashboards get creator=Admin only, inheriting folder permissions)
- [ ] Overwriting an existing dashboard via import does not reset its permissions
- [ ] Normal dashboard creation (non-import) is unaffected
- [ ] All existing frontend tests pass

**Repo likelihood**

| Repository | Confidence | Reason |
|---|---|---|
| grafana/grafana | 95% | Root cause is in the frontend import components (`ImportOverviewV1.tsx`, `ImportOverviewV2.tsx`) and the K8s dashboard API client (`v1.ts`), all in the main grafana/grafana repo. |
| grafana/scenes | 2% | The scenes library is not involved in the dashboard import flow. |
| grafana/grafana-enterprise | 3% | Enterprise overrides exist for some dashboard services, but the import path and K8s storage layer are OSS code. |

CC: @forsethc, @idastambuk
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-397ba0a0-82d5-4b84-8696-515cdc80091e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-397ba0a0-82d5-4b84-8696-515cdc80091e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

