### PR TITLE
Dashboard: Use preferredVersion from discovery endpoint for API version negotiation

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -447,6 +447,9 @@ abstract class DashboardScenePageStateManagerBase<T>
   private async loadScene(options: LoadDashboardOptions): Promise<DashboardScene | null> {
     this.setState({ dashboard: undefined, isLoading: true });
 
+    // Resolve API versions before synchronous getV1()/getV2() calls downstream.
+    await dashboardAPIVersionResolver.resolve();
+
     // Home dashboard is not handled through legacy API and is not versioned.
     // Handling home dashboard flow separately from regular dashboard flow.
     if (options.route === DashboardRoutes.Home) {

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -11,12 +11,13 @@ const mockGetBackendSrv = getBackendSrv as jest.MockedFunction<typeof getBackend
 
 const BETA_FALLBACK = { v1: 'v1beta1', v2: 'v2beta1' };
 
-function mockDiscoveryResponse(versions: string[]) {
+function mockDiscoveryResponse(versions: string[], preferred?: string) {
+  const preferredVersion = preferred ?? versions[0];
   mockGetBackendSrv.mockReturnValue({
     get: jest.fn().mockResolvedValue({
       name: 'dashboard.grafana.app',
       versions: versions.map((v) => ({ groupVersion: `dashboard.grafana.app/${v}`, version: v })),
-      preferredVersion: { groupVersion: `dashboard.grafana.app/${versions[0]}`, version: versions[0] },
+      preferredVersion: { groupVersion: `dashboard.grafana.app/${preferredVersion}`, version: preferredVersion },
     }),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any);
@@ -38,17 +39,59 @@ describe('DashboardAPIVersionResolver', () => {
   });
 
   describe('resolve', () => {
-    it.each([
-      { versions: ['v2', 'v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2' }, desc: 'both stable' },
-      { versions: ['v2beta1', 'v1beta1'], expected: BETA_FALLBACK, desc: 'beta only' },
-      { versions: ['v2beta1', 'v1', 'v1beta1'], expected: { v1: 'v1', v2: 'v2beta1' }, desc: 'v1 stable only' },
-      { versions: ['v2', 'v2beta1', 'v1beta1'], expected: { v1: 'v1beta1', v2: 'v2' }, desc: 'v2 stable only' },
-    ])('should resolve correctly when $desc are available', async ({ versions, expected }) => {
-      mockDiscoveryResponse(versions);
+    describe('preferredVersion-based resolution', () => {
+      it.each([
+        {
+          versions: ['v2', 'v2beta1', 'v1', 'v1beta1'],
+          expected: { v1: 'v1', v2: 'v2' },
+          desc: 'both stable, preferred=v2 (first in list)',
+        },
+        { versions: ['v2beta1', 'v1beta1'], expected: BETA_FALLBACK, desc: 'beta only, preferred=v2beta1' },
+        {
+          versions: ['v2beta1', 'v1', 'v1beta1'],
+          expected: { v1: 'v1', v2: 'v2beta1' },
+          desc: 'v1 stable only, preferred=v2beta1',
+        },
+        {
+          versions: ['v2', 'v2beta1', 'v1beta1'],
+          expected: { v1: 'v1beta1', v2: 'v2' },
+          desc: 'v2 stable only, preferred=v2',
+        },
+      ])(
+        'should resolve correctly when $desc are available (preferred defaults to first version)',
+        async ({ versions, expected }) => {
+          mockDiscoveryResponse(versions);
 
-      const result = await dashboardAPIVersionResolver.resolve();
+          const result = await dashboardAPIVersionResolver.resolve();
 
-      expect(result).toEqual(expected);
+          expect(result).toEqual(expected);
+        }
+      );
+
+      it('should respect preferredVersion=v1beta1 even when v1 is available', async () => {
+        mockDiscoveryResponse(['v2', 'v2beta1', 'v1', 'v1beta1'], 'v1beta1');
+
+        const result = await dashboardAPIVersionResolver.resolve();
+
+        expect(result).toEqual({ v1: 'v1beta1', v2: 'v2' });
+      });
+
+      it('should respect preferredVersion=v2beta1 even when v2 is available', async () => {
+        mockDiscoveryResponse(['v2', 'v2beta1', 'v1', 'v1beta1'], 'v2beta1');
+
+        const result = await dashboardAPIVersionResolver.resolve();
+
+        expect(result).toEqual({ v1: 'v1', v2: 'v2beta1' });
+      });
+
+      it('should fall back to version scanning when preferredVersion is for a different family', async () => {
+        // preferred is v1, so v2 falls back to scanning available versions
+        mockDiscoveryResponse(['v2', 'v2beta1', 'v1', 'v1beta1'], 'v1');
+
+        const result = await dashboardAPIVersionResolver.resolve();
+
+        expect(result).toEqual({ v1: 'v1', v2: 'v2' });
+      });
     });
 
     it('should call discovery endpoint with showErrorAlert disabled', async () => {

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
@@ -73,11 +73,17 @@ class DashboardAPIVersionResolver {
       showErrorAlert: false,
     });
     const availableVersions = new Set(group.versions.map((v) => v.version));
+    const preferred = group.preferredVersion?.version;
 
-    const v1: DashboardV1Version = availableVersions.has('v1') ? 'v1' : BETA_V1;
-    const v2: DashboardV2Version = availableVersions.has('v2') ? 'v2' : BETA_V2;
+    const v1: DashboardV1Version =
+      preferred === 'v1' || preferred === 'v1beta1' ? preferred : availableVersions.has('v1') ? 'v1' : BETA_V1;
 
-    debugLog(`Version negotiation: v1=${v1}, v2=${v2} (available: ${Array.from(availableVersions).join(', ')})`);
+    const v2: DashboardV2Version =
+      preferred === 'v2' || preferred === 'v2beta1' ? preferred : availableVersions.has('v2') ? 'v2' : BETA_V2;
+
+    debugLog(
+      `Version negotiation: v1=${v1}, v2=${v2}, preferred=${preferred ?? 'none'} (available: ${Array.from(availableVersions).join(', ')})`
+    );
 
     return { v1, v2 };
   }


### PR DESCRIPTION
_To enable console debug log_: `  localStorage.setItem('grafana.debug.dashboardAPI', 'true')`


  - Frontend version resolver now reads `preferredVersion` from the `GET /apis/dashboard.grafana.app/` discovery
   response instead of hardcoded version selection logic
  - Allows backend operators to control which API version the frontend uses via the `preferred_api_version` ini
  config (backend support: #121256)
  - Fixes a race condition where `getV1()`/`getV2()` were called before version discovery completed, always
  falling back to beta versions

  ## Test plan
  - [x] Manual: set `preferred_api_version = dashboard.grafana.app/XXX` in `[grafana-apiserver]` config,
  verify frontend uses XXX paths
  - [x] Manual: verify home dashboard loads with correct resolved version (no beta fallback)