### PR TITLE
Provisioning: Fix folder rename ref-not-found on new branch workflow

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -1154,6 +1154,53 @@ func TestUpdateFolderMetadata(t *testing.T) {
 			errContains: "read existing folder metadata",
 		},
 		{
+			name: "successful title update on new branch (ref not found fallback)",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				config := &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+					Spec: provisioning.RepositorySpec{
+						Type:      provisioning.GitRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow, provisioning.BranchWorkflow},
+						Git:       &provisioning.GitRepositoryConfig{Branch: "main"},
+						Sync:      provisioning.SyncOptions{Enabled: false},
+					},
+				}
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(config)
+				existingData := makeExistingData(t)
+				// First Read with new branch ref returns ErrRefNotFound
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "folder-rename/new-title").
+					Return(nil, repository.ErrRefNotFound).Once()
+				// Fallback Read with empty ref (configured branch) returns existing metadata
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "").
+					Return(&repository.FileInfo{Data: existingData, Hash: "main-hash"}, nil).Once()
+				// Update writes to the new branch (repo.Update calls ensureBranchExists)
+				rw.On("Update", mock.Anything, "myfolder/_folder.json", "folder-rename/new-title", mock.Anything, "rename folder").Return(nil)
+				// Re-read after update returns new hash from the newly created branch
+				rw.On("Read", mock.Anything, "myfolder/_folder.json", "folder-rename/new-title").
+					Return(&repository.FileInfo{Data: []byte("{}"), Hash: "new-branch-hash"}, nil).Once()
+
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				dw := &DualReadWriter{
+					repo:                  rw,
+					authorizer:            NewAuthorizer(config, rw, accessMock, false),
+					folderMetadataEnabled: true,
+				}
+				return dw, DualWriteOptions{
+					Path:    "myfolder/",
+					Ref:     "folder-rename/new-title",
+					Message: "rename folder",
+					Data:    makeSubmitBody(t, existingUID, "New Title"),
+				}
+			},
+			check: func(t *testing.T, result *provisioning.ResourceWrapper) {
+				assert.Equal(t, "folder-rename/new-title", result.Ref)
+				assert.Equal(t, "new-branch-hash", result.Hash)
+				assert.Equal(t, provisioning.ResourceActionUpdate, result.Resource.Action)
+			},
+		},
+		{
 			name: "sync enabled: updates Grafana DB and populates Upsert",
 			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
 				config := newSyncEnabledConfig("test-repo")

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -202,7 +202,16 @@ func WriteFolderMetadata(ctx context.Context, repo repository.ReaderWriter, fold
 func WriteFolderMetadataUpdate(ctx context.Context, repo repository.ReaderWriter, folderPath, ref, message string, submitted *folders.Folder) (string, error) {
 	existing, _, err := ReadFolderMetadata(ctx, repo, folderPath, ref)
 	if err != nil {
-		return "", fmt.Errorf("read existing folder metadata: %w", err)
+		// When the target branch doesn't exist yet, fall back to reading from
+		// the configured branch. ensureBranchExists (called by repo.Update)
+		// creates the new branch from the configured branch, so the content is
+		// identical at creation time.
+		if errors.Is(err, repository.ErrRefNotFound) {
+			existing, _, err = ReadFolderMetadata(ctx, repo, folderPath, "")
+		}
+		if err != nil {
+			return "", fmt.Errorf("read existing folder metadata: %w", err)
+		}
 	}
 
 	if submitted.Name != "" && submitted.Name != existing.Name {

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_test.go
@@ -821,6 +821,50 @@ func TestWriteFolderMetadataUpdate(t *testing.T) {
 		assert.Equal(t, "branch-hash", hash)
 		rw.AssertExpectations(t)
 	})
+
+	t.Run("falls back to configured branch when ref not found", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		// First read with new-branch ref returns ErrRefNotFound
+		rw.On("Read", mock.Anything, "myfolder/_folder.json", "new-branch").
+			Return(nil, repository.ErrRefNotFound).Once()
+		// Fallback read with empty ref (configured branch) returns existing data
+		rw.On("Read", mock.Anything, "myfolder/_folder.json", "").
+			Return(&repository.FileInfo{Data: existingData, Hash: "old-hash"}, nil).Once()
+		// Update writes to the new branch (ensureBranchExists creates it)
+		rw.On("Update", mock.Anything, "myfolder/_folder.json", "new-branch", mock.MatchedBy(func(b []byte) bool {
+			var f folders.Folder
+			if err := json.Unmarshal(b, &f); err != nil {
+				return false
+			}
+			return f.Name == existingUID && f.Spec.Title == "New Title"
+		}), "rename folder").Return(nil)
+		// Re-read after update to get new hash
+		rw.On("Read", mock.Anything, "myfolder/_folder.json", "new-branch").
+			Return(&repository.FileInfo{Data: []byte("{}"), Hash: "new-branch-hash"}, nil).Once()
+
+		submitted := NewFolderManifest(existingUID, "New Title")
+		hash, err := WriteFolderMetadataUpdate(ctx, rw, "myfolder/", "new-branch", "rename folder", submitted)
+
+		require.NoError(t, err)
+		assert.Equal(t, "new-branch-hash", hash)
+		rw.AssertExpectations(t)
+	})
+
+	t.Run("returns error when both ref and configured branch fail", func(t *testing.T) {
+		rw := repository.NewMockReaderWriter(t)
+		// First read with new-branch ref returns ErrRefNotFound
+		rw.On("Read", mock.Anything, "myfolder/_folder.json", "new-branch").
+			Return(nil, repository.ErrRefNotFound).Once()
+		// Fallback read with empty ref also fails
+		rw.On("Read", mock.Anything, "myfolder/_folder.json", "").
+			Return(nil, repository.ErrFileNotFound).Once()
+
+		submitted := NewFolderManifest("any-uid", "Title")
+		_, err := WriteFolderMetadataUpdate(ctx, rw, "myfolder/", "new-branch", "", submitted)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read existing folder metadata")
+	})
 }
 
 func TestGetFolderID(t *testing.T) {

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_git_test.go
@@ -1,0 +1,192 @@
+package foldermetadata
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch verifies that renaming
+// a provisioned folder with the "new branch" workflow succeeds. Before the fix,
+// WriteFolderMetadataUpdate read the existing _folder.json from the target ref;
+// because the branch didn't exist yet, resolveRefToHash failed with ErrRefNotFound.
+// The fix falls back to reading from the configured branch.
+func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const repoName = "update-folder-metadata-branch"
+	helper.CreateGitRepo(t, repoName, nil, "write", "branch")
+
+	// Create a folder on the default branch so we have a _folder.json to update.
+	resp := postFolderViaFilesAPI(t, helper, repoName, "rename-target/", "", "Create folder for rename test")
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "creating folder on default branch should succeed: %s", string(body))
+
+	originalUID := readFolderFieldOnRef(t, helper, ctx, repoName, "rename-target/_folder.json", "", "metadata", "name")
+	require.NotEmpty(t, originalUID, "setup: folder should have a UID")
+	originalTitle := readFolderFieldOnRef(t, helper, ctx, repoName, "rename-target/_folder.json", "", "spec", "title")
+	require.NotEmpty(t, originalTitle, "setup: folder should have a title")
+
+	t.Run("rename folder on new branch succeeds", func(t *testing.T) {
+		const newBranch = "rename-folder/new-title"
+
+		resp := putFolderViaFilesAPI(t, helper, repoName,
+			"rename-target/", newBranch, "Rename folder on new branch",
+			common.FolderBody(t, originalUID, "Renamed Title"))
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "PUT to rename folder on new branch should succeed: %s", string(body))
+
+		// The _folder.json on the new branch must have the updated title.
+		newTitle := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/_folder.json", newBranch, "spec", "title")
+		require.Equal(t, "Renamed Title", newTitle, "title should be updated on the new branch")
+
+		// The UID must be preserved.
+		newUID := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/_folder.json", newBranch, "metadata", "name")
+		require.Equal(t, originalUID, newUID, "UID must not change after rename")
+
+		// The default branch must be untouched.
+		defaultTitle := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/_folder.json", "", "spec", "title")
+		require.Equal(t, originalTitle, defaultTitle, "default branch title must not change")
+	})
+
+	t.Run("second rename on the same branch updates existing branch", func(t *testing.T) {
+		const branch = "rename-folder/second-rename"
+
+		// First rename creates the branch.
+		resp := putFolderViaFilesAPI(t, helper, repoName,
+			"rename-target/", branch, "First rename",
+			common.FolderBody(t, originalUID, "First Rename"))
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "first rename on new branch should succeed: %s", string(body))
+
+		// Second rename hits the branch that now exists (no fallback needed).
+		resp = putFolderViaFilesAPI(t, helper, repoName,
+			"rename-target/", branch, "Second rename",
+			common.FolderBody(t, originalUID, "Second Rename"))
+		body, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "second rename on existing branch should succeed: %s", string(body))
+
+		title := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/_folder.json", branch, "spec", "title")
+		require.Equal(t, "Second Rename", title, "title should reflect the second rename")
+
+		uid := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/_folder.json", branch, "metadata", "name")
+		require.Equal(t, originalUID, uid, "UID must not change after multiple renames")
+	})
+
+	t.Run("rename nested folder on new branch succeeds", func(t *testing.T) {
+		// Create a nested folder on the default branch.
+		resp := postFolderViaFilesAPI(t, helper, repoName, "rename-target/child/", "", "Create child folder")
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested folder should succeed: %s", string(body))
+
+		childUID := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/child/_folder.json", "", "metadata", "name")
+		require.NotEmpty(t, childUID, "child folder should have a UID")
+
+		const nestedBranch = "rename-folder/nested-child"
+
+		resp = putFolderViaFilesAPI(t, helper, repoName,
+			"rename-target/child/", nestedBranch, "Rename nested folder",
+			common.FolderBody(t, childUID, "Renamed Child"))
+		body, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "PUT to rename nested folder should succeed: %s", string(body))
+
+		title := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/child/_folder.json", nestedBranch, "spec", "title")
+		require.Equal(t, "Renamed Child", title, "nested folder title should be updated on the branch")
+
+		uid := readFolderFieldOnRef(t, helper, ctx, repoName,
+			"rename-target/child/_folder.json", nestedBranch, "metadata", "name")
+		require.Equal(t, childUID, uid, "nested folder UID must not change")
+	})
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+// putFolderViaFilesAPI sends a raw HTTP PUT to the files endpoint for a folder
+// path. We build the URL manually because the K8s REST client strips the
+// trailing slash that the files endpoint needs to distinguish folders from files.
+func putFolderViaFilesAPI(t *testing.T, helper *common.GitTestHelper, repoName, folderPath, ref, message string, body []byte) *http.Response {
+	t.Helper()
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	rawURL := fmt.Sprintf(
+		"http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/%s",
+		addr, repoName, folderPath,
+	)
+
+	parsedURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	params := parsedURL.Query()
+	if message != "" {
+		params.Set("message", message)
+	}
+	if ref != "" {
+		params.Set("ref", ref)
+	}
+	parsedURL.RawQuery = params.Encode()
+
+	req, err := http.NewRequest(http.MethodPut, parsedURL.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	return resp
+}
+
+// readFolderFieldOnRef reads a field from a _folder.json on a specific branch
+// via the files subresource API. Pass an empty ref to read from the default
+// branch. fields is the JSON path under "resource" → "file", e.g.
+// ("metadata", "name") or ("spec", "title").
+func readFolderFieldOnRef(
+	t *testing.T, helper *common.GitTestHelper, ctx context.Context,
+	repoName, filePath, ref string, fields ...string,
+) string {
+	t.Helper()
+
+	subresourceParts := append([]string{"files"}, strings.Split(filePath, "/")...)
+	req := helper.AdminREST.Get().
+		Namespace("default").
+		Resource("repositories").
+		Name(repoName).
+		SubResource(subresourceParts...)
+
+	if ref != "" {
+		req = req.Param("ref", ref)
+	}
+
+	result := req.Do(ctx)
+	require.NoError(t, result.Error(), "%s (ref=%q): should be readable via the files endpoint", filePath, ref)
+
+	wrapObj := &unstructured.Unstructured{}
+	require.NoError(t, result.Into(wrapObj), "%s (ref=%q): failed to decode response", filePath, ref)
+
+	keyPath := append([]string{"resource", "file"}, fields...)
+	val, _, _ := unstructured.NestedString(wrapObj.Object, keyPath...)
+	return val
+}


### PR DESCRIPTION
## What

When renaming a provisioned folder with the "new branch" workflow, `WriteFolderMetadataUpdate` reads the existing `_folder.json` from the target ref (the new branch name). Since the branch doesn't exist yet, `repo.Read()` → `resolveRefToHash()` fails with `ErrRefNotFound`, returning a 404.

## Why

The subsequent `repo.Update()` call would have been fine — it calls `ensureBranchExists()` which creates the branch from the configured branch. But the `ReadFolderMetadata` call happens first and fails.

## Fix

Fall back to reading from the configured branch (empty ref) when `ErrRefNotFound` is returned. This is safe because `ensureBranchExists` creates the new branch from the configured branch, so content is identical at creation time. Matches the precedent already in `CreateFolder` (dualwriter.go:194).

## Tests

- Unit test: `WriteFolderMetadataUpdate` fallback path and double-failure path
- Integration test: `UpdateFolderMetadata` end-to-end with new branch ref
