### PR TITLE
Fix mutation test to use v2 stable TransformationKind shape

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -511,9 +511,9 @@ describe('Panel mutation commands', () => {
                 spec: {
                   transformations: [
                     {
-                      kind: 'limit',
+                      kind: 'Transformation',
+                      group: 'limit',
                       spec: {
-                        id: 'limit',
                         disabled: false,
                         filter: { id: 'byName', options: 'temperature' },
                         topic: 'series',


### PR DESCRIPTION
## Summary

Quick fix — the `applies transformations with filter and topic` test in `panelCommands.test.ts` was merged with v2beta1 transformation shape (`kind: 'limit'`, `spec.id`) but the `transformationKindSchema` on main now expects v2 stable shape (`kind: 'Transformation'`, `group`). This causes the test to fail on main.

## Test plan

- [x] `panelCommands.test.ts` — 31/31 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
