### PR TITLE
ci: assign permissions on ci checks

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -59,6 +59,8 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend-strict == 'true' && needs.detect-changes.outputs.backend-strict == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for exception label
         run: |


### PR DESCRIPTION
We need the separation check to have read access to PRs. PR commands wants issues.