### PR TITLE
Auth: Allow backslashes when parsing external group name

### DIFF
--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -219,20 +218,30 @@ func (m *OrgRoleMapper) getAllOrgs() (map[int64]bool, error) {
 
 func splitOrgMapping(mapping string) []string {
 	result := make([]string, 0, 3)
-	matches := separatorRegexp.FindAllStringIndex(mapping, -1)
-	from := 0
+	current := ""
 
-	for _, match := range matches {
-		// match[0] is the start, match[1] is the end of the match
-		start, end := match[0], match[1]
-		// Check if the match is not preceded by two backslashes
-		if start == 0 || mapping[start-1:start] != escapeStr {
-			result = append(result, strings.ReplaceAll(mapping[from:end-1], escapeStr, ""))
-			from = end
+	for i := 0; i < len(mapping); i++ {
+		switch mapping[i] {
+		case ':':
+			// Split on unescaped separators only.
+			result = append(result, current)
+			current = ""
+		// Note that this case is matching against an a single backslash.
+		case '\\':
+			// Only `\:` is a special escape sequence for org_mapping parsing.
+			// Preserve backslashes verbatim for values like domain\\group.
+			if i+1 < len(mapping) && mapping[i+1] == ':' {
+				current += ":"
+				i++
+				continue
+			}
+			current += string(mapping[i])
+		default:
+			current += string(mapping[i])
 		}
 	}
 
-	result = append(result, mapping[from:])
+	result = append(result, current)
 	if len(result) > 3 {
 		return []string{}
 	}

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -3,7 +3,6 @@ package connectors
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -11,12 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-const (
-	mapperMatchAllOrgID = -1
-	escapeStr           = `\`
-)
-
-var separatorRegexp = regexp.MustCompile(":")
+const mapperMatchAllOrgID = -1
 
 // OrgRoleMapper maps external orgs/groups to Grafana orgs and basic roles.
 type OrgRoleMapper struct {
@@ -226,7 +220,7 @@ func splitOrgMapping(mapping string) []string {
 			// Split on unescaped separators only.
 			result = append(result, current)
 			current = ""
-		// Note that this case is matching against an a single backslash.
+		// Note that this case is matching against a single backslash.
 		case '\\':
 			// Only `\:` is a special escape sequence for org_mapping parsing.
 			// Preserve backslashes verbatim for values like domain\\group.

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -304,6 +304,12 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{`my.domain\my-group`: {1: org.RoleViewer}}, false),
 		},
 		{
+			name:       "should preserve backslashes when the external org name contains escaped colons",
+			rawMapping: []string{`my.domain\group\:sub:1:Viewer`},
+			roleStrict: false,
+			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{`my.domain\group:sub`: {1: org.RoleViewer}}, false),
+		},
+		{
 			name:       "should preserve double backslashes in the external org name",
 			rawMapping: []string{`my.domain\\my-group:1:Viewer`},
 			roleStrict: false,

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -298,6 +298,18 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 			expected: NewMappingConfiguration(map[string]map[int64]org.RoleType{"Group1": {1: org.RoleViewer}}, false),
 		},
 		{
+			name:       "should preserve backslashes in the external org name",
+			rawMapping: []string{`my.domain\my-group:1:Viewer`},
+			roleStrict: false,
+			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{`my.domain\my-group`: {1: org.RoleViewer}}, false),
+		},
+		{
+			name:       "should preserve double backslashes in the external org name",
+			rawMapping: []string{`my.domain\\my-group:1:Viewer`},
+			roleStrict: false,
+			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{`my.domain\\my-group`: {1: org.RoleViewer}}, false),
+		},
+		{
 			name:       "should return empty mapping when org mapping is nil",
 			rawMapping: nil,
 			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false),


### PR DESCRIPTION
This PR is in response to this issue https://github.com/grafana/grafana/issues/120891. These changes address a bug that removed backslashes from external group names while parsing the org mapping settings.

@mgyongyosi, I've added you as a reviewer because is seems you will be most familiar, even if it was a couple years ago 😄 https://github.com/grafana/grafana/commit/4f06568f8ae93e36b4a7f72e9549cf3729bbc583.