### PR TITLE
Alerting: Preserve scroll position on Alert Activity refresh

### DIFF
--- a/public/app/features/alerting/unified/triage/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.tsx
@@ -264,7 +264,7 @@ export function Workbench({
                   <ScrollContainer height="100%" width="100%" scrollbarWidth="none" showScrollIndicators={showData}>
                     {isRefreshing && (
                       <div className={styles.loadingBarContainer}>
-                        <LoadingBar width={leftColumnWidth} />
+                        <LoadingBar width={leftColumnWidth + rightColumnWidth} />
                       </div>
                     )}
                     {isInitialLoading && (

--- a/public/app/features/alerting/unified/triage/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.tsx
@@ -6,7 +6,17 @@ import { useMeasure } from 'react-use';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { type SceneQueryRunner } from '@grafana/scenes';
-import { Box, Button, EmptyState, ScrollContainer, Stack, Text, useSplitter, useStyles2 } from '@grafana/ui';
+import {
+  Box,
+  Button,
+  EmptyState,
+  LoadingBar,
+  ScrollContainer,
+  Stack,
+  Text,
+  useSplitter,
+  useStyles2,
+} from '@grafana/ui';
 import { DEFAULT_PER_PAGE_PAGINATION } from 'app/core/constants';
 
 import LoadMoreHelper from '../rule-list/LoadMoreHelper';
@@ -28,7 +38,8 @@ type WorkbenchProps = {
   groupBy?: string[];
   filterBy?: Filter[];
   queryRunner: SceneQueryRunner;
-  isLoading?: boolean;
+  isInitialLoading?: boolean;
+  isRefreshing?: boolean;
   hasActiveFilters?: boolean;
 };
 
@@ -125,7 +136,8 @@ export function Workbench({
   data,
   queryRunner,
   groupBy,
-  isLoading = false,
+  isInitialLoading = false,
+  isRefreshing = false,
   hasActiveFilters = false,
 }: WorkbenchProps) {
   const styles = useStyles2(getStyles);
@@ -147,9 +159,8 @@ export function Workbench({
   // Calculate once: show folder metadata only if not grouping by grafana_folder
   const enableFolderMeta = !groupBy?.includes('grafana_folder');
 
-  // Determine UI state
-  const showEmptyState = !isLoading && data.length === 0;
-  const showData = !isLoading && data.length > 0;
+  const showEmptyState = !isInitialLoading && data.length === 0;
+  const showData = data.length > 0;
   // splitter for template and payload editor
   const splitter = useSplitter({
     direction: 'row',
@@ -251,7 +262,12 @@ export function Workbench({
                   collapseGeneration={collapseGeneration}
                 >
                   <ScrollContainer height="100%" width="100%" scrollbarWidth="none" showScrollIndicators={showData}>
-                    {isLoading && (
+                    {isRefreshing && (
+                      <div className={styles.loadingBarContainer}>
+                        <LoadingBar width={leftColumnWidth} />
+                      </div>
+                    )}
+                    {isInitialLoading && (
                       <>
                         <GenericRowSkeleton key="skeleton-1" width={leftColumnWidth} depth={0} />
                         <GenericRowSkeleton key="skeleton-2" width={leftColumnWidth} depth={0} />
@@ -300,6 +316,11 @@ export const getStyles = (theme: GrafanaTheme2) => {
     summaryContainer: css({
       marginBottom: theme.spacing(2),
       alignItems: 'stretch',
+    }),
+    loadingBarContainer: css({
+      position: 'sticky',
+      top: 0,
+      zIndex: 1,
     }),
     headerContainer: css({}),
     expandCollapseToolbar: css({

--- a/public/app/features/alerting/unified/triage/scene/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/scene/Workbench.tsx
@@ -76,7 +76,7 @@ export function WorkbenchRenderer() {
     return () => subscription.unsubscribe();
   }, [runner]);
 
-  const isDataLoading = data?.state === 'Loading';
+  const isDataLoading = data?.state === 'Loading' || data?.state === 'NotStarted' || data === undefined;
   const isInitialLoading = (isDataLoading || isPending) && rows.length === 0;
   const isRefreshing = isDataLoading && rows.length > 0;
 

--- a/public/app/features/alerting/unified/triage/scene/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/scene/Workbench.tsx
@@ -29,7 +29,7 @@ export function WorkbenchRenderer() {
   const { data } = runner.useState();
 
   const [rows, setRows] = useState<ReturnType<typeof convertToWorkbenchRows>>([]);
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
   const hasFiltersApplied = queryFilter.length > 0;
 
   // convertToWorkbenchRows is expensive when processing large datasets.
@@ -77,7 +77,8 @@ export function WorkbenchRenderer() {
   }, [runner]);
 
   const isDataLoading = data?.state === 'Loading';
-  const isLoading = isDataLoading || isPending;
+  const isInitialLoading = isDataLoading && rows.length === 0;
+  const isRefreshing = isDataLoading && rows.length > 0;
 
   return (
     <Workbench
@@ -85,7 +86,8 @@ export function WorkbenchRenderer() {
       domain={domain}
       queryRunner={runner}
       groupBy={groupByKeys}
-      isLoading={isLoading}
+      isInitialLoading={isInitialLoading}
+      isRefreshing={isRefreshing}
       hasActiveFilters={hasFiltersApplied}
     />
   );

--- a/public/app/features/alerting/unified/triage/scene/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/scene/Workbench.tsx
@@ -29,7 +29,7 @@ export function WorkbenchRenderer() {
   const { data } = runner.useState();
 
   const [rows, setRows] = useState<ReturnType<typeof convertToWorkbenchRows>>([]);
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
   const hasFiltersApplied = queryFilter.length > 0;
 
   // convertToWorkbenchRows is expensive when processing large datasets.
@@ -77,7 +77,7 @@ export function WorkbenchRenderer() {
   }, [runner]);
 
   const isDataLoading = data?.state === 'Loading';
-  const isInitialLoading = isDataLoading && rows.length === 0;
+  const isInitialLoading = (isDataLoading || isPending) && rows.length === 0;
   const isRefreshing = isDataLoading && rows.length > 0;
 
   return (

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -22,7 +22,7 @@ const COLLAPSED_WIDTH = 36;
  * Contains a state filter (firing / pending) and the full label breakdown.
  */
 export function LabelsColumn() {
-  const { labels, isLoading } = useLabelsBreakdown();
+  const { labels } = useLabelsBreakdown();
   const [open, toggleOpen] = useToggle(true);
   const [labelFilter, setLabelFilter] = useState('');
   const styles = useStyles2(getStyles);
@@ -73,7 +73,7 @@ export function LabelsColumn() {
                 className={styles.labelFilterInput}
               />
             </div>
-            {!isLoading && labels.length > 0 && <AllLabelsContent allLabels={labels} labelFilter={labelFilter} />}
+            {labels.length > 0 && <AllLabelsContent allLabels={labels} labelFilter={labelFilter} />}
           </div>
         </ScrollContainer>
       )}


### PR DESCRIPTION
## Summary
- Keep existing table rows visible during data refresh on the Alert Activity (Triage) page instead of replacing them with skeleton placeholders
- Show skeletons only on initial load (when no data exists yet); on subsequent refreshes, display a `LoadingBar` at the top of the scroll container — matching the `PanelChrome` pattern used throughout Grafana
- Remove `isPending` from the loading calculation as it was defeating the purpose of React's `useTransition` API (hiding old UI instead of keeping it visible during transition)

Before

https://github.com/user-attachments/assets/00bc590b-809b-4fc4-9343-7b572f300b27



After

https://github.com/user-attachments/assets/5a5a2690-a7a6-4856-a794-1c348dba773e




## Test plan
- [ ] Navigate to Alert Activity page (`/alerting/alerts`) with firing alerts
- [ ] Verify initial load shows skeleton placeholders as before
- [ ] Scroll down and expand some group rows
- [ ] Click the refresh button — rows should stay in place with a thin loading bar at the top
- [ ] Enable auto-refresh (e.g. 5s interval) — rows should remain stable across refresh cycles
- [ ] Verify scroll position and expanded/collapsed row state persist across refreshes
- [ ] Change a filter — verify old rows remain briefly visible with loading bar, then update to new results


Made with [Cursor](https://cursor.com)