### PR TITLE
Provisioning: Switch provisioningFolderMetadata toggle to OpenFeature

### DIFF
--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, testWithFeatureToggles, userEvent } from 'test/test-utils';
+import { render, screen, userEvent } from 'test/test-utils';
 
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { appEvents } from 'app/core/app_events';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { ShowModalReactEvent } from 'app/types/events';
@@ -201,7 +202,9 @@ describe('browse-dashboards FolderActionsButton', () => {
   });
 
   describe('with provisioningFolderMetadata feature flag', () => {
-    testWithFeatureToggles({ enable: ['provisioningFolderMetadata'] });
+    beforeEach(() => {
+      setTestFlags({ provisioningFolderMetadata: true });
+    });
 
     it('renders the "Manage permissions" option for provisioned folders', async () => {
       render(<FolderActionsButton folder={{ ...mockFolder, managedBy: ManagerKind.Repo, parentUid: '123' }} />);

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useState } from 'react';
 
 import { AppEvents } from '@grafana/data';
@@ -39,6 +40,7 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const [moveFolder] = useMoveFolderMutationFacade();
   const isProvisionedInstance = useIsProvisionedInstance();
   const deleteFolder = useDeleteFolderMutationFacade();
+  const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
 
   const {
     canEditFolders,
@@ -54,8 +56,7 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   // Can only delete folders when the folder has the right permission and is not provisioned root folder
   const canDeleteFolders = canDeleteFoldersPermissions && !isProvisionedRootFolder && !isReadOnlyRepo;
   // Show permissions only if the folder is not provisioned, or if the provisioningFolderMetadata flag is enabled
-  const canShowPermissions =
-    canViewPermissions && (!isProvisionedFolder || !!config.featureToggles.provisioningFolderMetadata);
+  const canShowPermissions = canViewPermissions && (!isProvisionedFolder || provisioningFolderMetadataEnabled);
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID: destinationUID });

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -1,9 +1,9 @@
 import { css, cx } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Box, Card, type CellProps, Grid, InteractiveTable, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type Repository, type ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -29,7 +29,7 @@ function getColumnCount(hasWebhook: boolean): { xxlColumn: 5 | 4; lgColumn: 3 | 
 export function RepositoryOverview({ repo }: { repo: Repository }) {
   const styles = useStyles2(getStyles);
   const repoName = repo.metadata?.name ?? '';
-  const showFolderMetadataCheck = config.featureToggles.provisioningFolderMetadata;
+  const showFolderMetadataCheck = useBooleanFlagValue('provisioningFolderMetadata', false);
 
   const status = repo.status;
   const { conditions, quota } = status ?? {};

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import {
   type CellProps,
   type Column,
@@ -53,6 +53,7 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
   const resourcesQuery = useGetRepositoryResourcesQuery({ name });
 
   const [searchQuery, setSearchQuery] = useState('');
+  const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
 
   const isLoading = filesQuery.isLoading || resourcesQuery.isLoading;
 
@@ -100,7 +101,7 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         header: t('provisioning.resource-tree.header-status', 'Status'),
         cell: ({ row: { original } }: TreeCell) => {
           const { status, missingFolderMetadata } = original.item;
-          if (config.featureToggles.provisioningFolderMetadata && missingFolderMetadata) {
+          if (provisioningFolderMetadataEnabled && missingFolderMetadata) {
             return (
               <Tooltip
                 content={t('provisioning.resource-tree.missing-folder-metadata', 'Missing folder metadata file')}
@@ -191,7 +192,7 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         },
       },
     ],
-    [repo.spec, styles]
+    [provisioningFolderMetadataEnabled, repo.spec, styles]
   );
 
   if (isLoading) {

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -54,6 +55,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
     setStepStatusInfo,
   });
   const [job, setJob] = useState<Job>();
+  const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
 
   useEffect(() => {
     // This useEffect is used to update the step status info based on the repository status and the form errors
@@ -160,7 +162,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
                   Alerts and library panels are not supported in provisioned folders.
                 </Trans>
               </li>
-              {!config.featureToggles.provisioningFolderMetadata && (
+              {!provisioningFolderMetadataEnabled && (
                 <li>
                   <Trans i18nKey="provisioning.wizard.alert-point-permissions">
                     Fine-grained permissions are not supported. Default permissions apply: Admin, Editor, and Viewer

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.test.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, testWithFeatureToggles } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { type FolderMetadataStatus } from '../../hooks/useFolderMetadataStatus';
 
@@ -71,10 +72,14 @@ describe('MissingFolderMetadataBanner', () => {
 });
 
 describe('FolderPermissions', () => {
-  testWithFeatureToggles({ enable: ['provisioning', 'provisioningFolderMetadata'] });
+  testWithFeatureToggles({ enable: ['provisioning'] });
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    setTestFlags({ provisioningFolderMetadata: true });
   });
 
   it('renders permissions directly when folder is not provisioned', () => {

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
@@ -75,11 +76,9 @@ interface FolderPermissionsProps {
 }
 
 export function FolderPermissions({ folderUID, canSetPermissions, isProvisionedFolder }: FolderPermissionsProps) {
-  if (
-    !isProvisionedFolder ||
-    !config.featureToggles.provisioning ||
-    !config.featureToggles.provisioningFolderMetadata
-  ) {
+  const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
+
+  if (!isProvisionedFolder || !config.featureToggles.provisioning || !provisioningFolderMetadataEnabled) {
     return <Permissions resource="folders" resourceId={folderUID} canSetPermissions={canSetPermissions} />;
   }
 


### PR DESCRIPTION
**What is this feature?**

Switches the `provisioningFolderMetadata` feature toggle from boot data (`config.featureToggles.provisioningFolderMetadata`) to OpenFeature (`useBooleanFlagValue` from `@openfeature/react-sdk`) across all 5 frontend component files that read it. Updates 2 test files to use `setTestFlags` from `@grafana/test-utils/unstable` instead of `testWithFeatureToggles`.

**Why do we need this feature?**

Reading from boot data means the toggle cannot be controlled per-cluster via goff. Switching to OpenFeature enables evaluated feature toggle support, allowing the toggle to be managed dynamically at the cluster level rather than requiring a full config deployment.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1046
