### PR TITLE
RBAC: Increase permission.kind length to allow k8s permissions

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -222,4 +222,8 @@ func AddMigration(mg *migrator.Migrator) {
 	mg.AddMigration("add permission role_id scope index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
 		Cols: []string{"role_id", "scope"},
 	}))
+
+	mg.AddMigration("alter permission.kind to length 80", migrator.NewRawSQLMigration("").
+		Postgres("ALTER TABLE permission ALTER COLUMN kind TYPE VARCHAR(80);").
+		Mysql("ALTER TABLE permission MODIFY kind VARCHAR(80);"))
 }


### PR DESCRIPTION
This PR adds a migration to allow for longer scope kinds (e.g. `notifications.alerting.grafana.app/routingtrees`) this is particularly useful in the scope of allowing apps to define forward compatible roles and permissions as we move to the app platform.

For context, the desired form for permission scopes, for an easier migration to openFGA is:
`apiGroup/resource:uid:name`