### PR TITLE
Unified Storage: Write temp Parquet file to data dir instead of /tmp/

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"math"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -120,7 +120,7 @@ func NewStorageBackend(
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
-			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"),
+			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"), // only used by the SQL backend path
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
 		})
@@ -259,6 +259,11 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		tmpDir:                  opts.TmpDir,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       garbageCollection,
+	}
+	if opts.TmpDir != "" {
+		if err := os.MkdirAll(opts.TmpDir, 0750); err != nil {
+			return nil, fmt.Errorf("create tmp dir: %w", err)
+		}
 	}
 	if err := backend.Init(ctx); err != nil {
 		return nil, err

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -120,6 +120,7 @@ func NewStorageBackend(
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
+			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"),
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
 		})
@@ -212,6 +213,11 @@ type BackendOptions struct {
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	MigrationParquetBuffer bool
 
+	// Directory for temporary Parquet files during bulk migration.
+	// Defaults to the OS temp dir when empty. Set to cfg.DataPath/tmp to
+	// support containers with readonlyRootFilesystem enabled.
+	TmpDir string
+
 	// testing
 	SimulatedNetworkLatency time.Duration // slows down the create transactions by a fixed amount
 
@@ -250,6 +256,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		bulkLock:                &bulkLock{running: make(map[string]bool)},
 		simulatedNetworkLatency: opts.SimulatedNetworkLatency,
 		migrationParquetBuffer:  opts.MigrationParquetBuffer,
+		tmpDir:                  opts.TmpDir,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       garbageCollection,
 	}
@@ -308,6 +315,9 @@ type backend struct {
 
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	migrationParquetBuffer bool
+
+	// tmpDir is the directory for temporary Parquet files; empty means OS default.
+	tmpDir string
 
 	// Fields to control the cleanup of "lastImportTime" rows (used to find indexes to rebuild)
 	lastImportTimeMaxAge       time.Duration

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -167,6 +167,7 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 	if !useParquet && clientCtx != nil {
 		useParquet = resource.ParquetBufferFromContext(clientCtx)
 	}
+
 	if useParquet && b.dialect.DialectName() == "sqlite" {
 		file, err := os.CreateTemp(b.tmpDir, "grafana-bulk-export-*.parquet")
 		if err != nil {
@@ -174,7 +175,10 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 				Error: resource.AsErrorResult(err),
 			}
 		}
-		defer os.Remove(file.Name())
+		defer func() {
+			_ = file.Close()
+			_ = os.Remove(file.Name())
+		}()
 
 		writer, err := parquet.NewParquetWriter(file)
 		if err != nil {
@@ -187,13 +191,6 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		rsp := writer.ProcessBulk(ctx, setting, iter)
 		if rsp.Error != nil {
 			return rsp
-		}
-
-		// Ensure the parquet file is flushed before the reader opens it
-		if err := file.Close(); err != nil {
-			return &resourcepb.BulkResponse{
-				Error: resource.AsErrorResult(err),
-			}
 		}
 
 		b.log.Info("using parquet buffer", "path", file.Name(), "processed", rsp.Processed)

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -168,12 +168,20 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		useParquet = resource.ParquetBufferFromContext(clientCtx)
 	}
 	if useParquet && b.dialect.DialectName() == "sqlite" {
-		file, err := os.CreateTemp("", "grafana-bulk-export-*.parquet")
+		if b.tmpDir != "" {
+			if err := os.MkdirAll(b.tmpDir, 0750); err != nil {
+				return &resourcepb.BulkResponse{
+					Error: resource.AsErrorResult(fmt.Errorf("create tmp dir: %w", err)),
+				}
+			}
+		}
+		file, err := os.CreateTemp(b.tmpDir, "grafana-bulk-export-*.parquet")
 		if err != nil {
 			return &resourcepb.BulkResponse{
 				Error: resource.AsErrorResult(err),
 			}
 		}
+		defer os.Remove(file.Name())
 
 		writer, err := parquet.NewParquetWriter(file)
 		if err != nil {

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -168,13 +168,6 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		useParquet = resource.ParquetBufferFromContext(clientCtx)
 	}
 	if useParquet && b.dialect.DialectName() == "sqlite" {
-		if b.tmpDir != "" {
-			if err := os.MkdirAll(b.tmpDir, 0750); err != nil {
-				return &resourcepb.BulkResponse{
-					Error: resource.AsErrorResult(fmt.Errorf("create tmp dir: %w", err)),
-				}
-			}
-		}
 		file, err := os.CreateTemp(b.tmpDir, "grafana-bulk-export-*.parquet")
 		if err != nil {
 			return &resourcepb.BulkResponse{
@@ -194,6 +187,13 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		rsp := writer.ProcessBulk(ctx, setting, iter)
 		if rsp.Error != nil {
 			return rsp
+		}
+
+		// Ensure the parquet file is flushed before the reader opens it
+		if err := file.Close(); err != nil {
+			return &resourcepb.BulkResponse{
+				Error: resource.AsErrorResult(err),
+			}
 		}
 
 		b.log.Info("using parquet buffer", "path", file.Name(), "processed", rsp.Processed)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Bulk migration now writes temporary Parquet files to `cfg.DataPath/tmp` instead of the OS default `/tmp/` directory. Also adds cleanup (`os.Remove`) and explicit `file.Close()` before the reader opens the file.

**Why do we need this feature?**

Grafana fails to start on containers with a read-only root filesystem when only `/var/lib/grafana` is writable. The startup migration tries to write a temp Parquet file to `/tmp/`, which is not available in that setup.

**Who is this feature for?**

Users running Grafana in containers with a read-only root filesystem and SQLite as the database backend.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #121283 

**Special notes for your reviewer:**

`TmpDir` is only set on the SQL backend code-path, since the Parquet buffer is only used there.

`backend.go`:
- New `TmpDir` field on `BackendOptions` and `backend` struct, set to `filepath.Join(cfg.DataPath, "tmp")` in `NewStorageBackend`
- Directory is created via `os.MkdirAll` in `NewBackend`
- When `TmpDir` is empty, `os.CreateTemp` falls back to the OS default = no behavior change for existing setups

`backend_bulk.go`:
- `os.CreateTemp(b.tmpDir, ...)` instead of `os.CreateTemp("", ...)` so the temp file lands in the configured data directory
- `defer os.Remove(file.Name())` to clean up the temp file after use (I think this was missing in the original code)
- Explicit `file.Close()` before the Parquet reader opens the file to ensure all data is flushed to disk

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
