### PR TITLE
Splash Screen: Implement slide navigation and content configuration

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import classNames from 'classnames';
 import { Resizable } from 're-resizable';
 import { type PropsWithChildren, useEffect } from 'react';
@@ -38,6 +39,7 @@ export function AppChrome({ children }: Props) {
   } = useExtensionSidebarContext();
   const state = chrome.useState();
   const scopes = useScopes();
+  const isSplashScreenEnabled = useBooleanFlagValue('splashScreen', false);
 
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
   const isScopesDashboardsOpen = Boolean(
@@ -162,7 +164,7 @@ export function AppChrome({ children }: Props) {
       </div>
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
       {!state.chromeless && <CommandPalette />}
-      {!state.chromeless && <SplashScreenModal />}
+      {!state.chromeless && isSplashScreenEnabled && <SplashScreenModal />}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -5,9 +5,8 @@ import { Resizable } from 're-resizable';
 import { type PropsWithChildren, useEffect } from 'react';
 
 import { type GrafanaTheme2, store } from '@grafana/data';
-import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans } from '@grafana/i18n';
-import { config, locationSearchToObject, locationService, useScopes } from '@grafana/runtime';
+import { locationSearchToObject, locationService, useScopes } from '@grafana/runtime';
 import { ErrorBoundaryAlert, floatingUtils, getDragStyles, LinkButton, useStyles2 } from '@grafana/ui';
 import { SplashScreenModal } from 'app/core/components/SplashScreenModal/SplashScreenModal';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -165,9 +164,7 @@ export function AppChrome({ children }: Props) {
       </div>
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
       {!state.chromeless && <CommandPalette />}
-      {!state.chromeless && isSplashScreenEnabled && config.buildInfo.edition === GrafanaEdition.OpenSource && (
-        <SplashScreenModal />
-      )}
+      {!state.chromeless && isSplashScreenEnabled && <SplashScreenModal />}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -5,8 +5,9 @@ import { Resizable } from 're-resizable';
 import { type PropsWithChildren, useEffect } from 'react';
 
 import { type GrafanaTheme2, store } from '@grafana/data';
+import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans } from '@grafana/i18n';
-import { locationSearchToObject, locationService, useScopes } from '@grafana/runtime';
+import { config, locationSearchToObject, locationService, useScopes } from '@grafana/runtime';
 import { ErrorBoundaryAlert, floatingUtils, getDragStyles, LinkButton, useStyles2 } from '@grafana/ui';
 import { SplashScreenModal } from 'app/core/components/SplashScreenModal/SplashScreenModal';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -164,7 +165,9 @@ export function AppChrome({ children }: Props) {
       </div>
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
       {!state.chromeless && <CommandPalette />}
-      {!state.chromeless && isSplashScreenEnabled && <SplashScreenModal />}
+      {!state.chromeless && isSplashScreenEnabled && config.buildInfo.edition === GrafanaEdition.OpenSource && (
+        <SplashScreenModal />
+      )}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -1,27 +1,110 @@
+import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Button, IconButton } from '@grafana/ui';
+import { IconButton, LinkButton, useStyles2 } from '@grafana/ui';
 import { ModalBase } from '@grafana/ui/internal';
+
+import { SplashScreenNav } from './SplashScreenNav';
+import { SplashScreenSlide } from './SplashScreenSlide';
+import { getSplashScreenConfig } from './splashContent';
 
 export function SplashScreenModal() {
   const isSplashScreenEnabled = useBooleanFlagValue('splashScreen', false);
   const [isOpen, setIsOpen] = useState(true);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const styles = useStyles2(getStyles);
+  const config = getSplashScreenConfig();
+
+  const handleDismiss = useCallback(() => setIsOpen(false), []);
+
+  const total = config.features.length;
+  const goToPrev = useCallback(() => setActiveIndex((i) => (i - 1 + total) % total), [total]);
+  const goToNext = useCallback(() => setActiveIndex((i) => (i + 1) % total), [total]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        goToPrev();
+      } else if (e.key === 'ArrowRight') {
+        goToNext();
+      }
+    },
+    [goToPrev, goToNext]
+  );
 
   if (!isSplashScreenEnabled || !isOpen) {
     return null;
   }
 
-  const handleDismiss = () => setIsOpen(false);
+  const activeFeature = config.features[activeIndex];
+
+  const footer = (
+    <>
+      <SplashScreenNav
+        activeIndex={activeIndex}
+        total={total}
+        onPrev={goToPrev}
+        onNext={goToNext}
+        onGoTo={setActiveIndex}
+      />
+      <LinkButton
+        href={activeFeature.ctaUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        icon="external-link-alt"
+        variant="secondary"
+        fill="outline"
+        size="md"
+      >
+        {activeFeature.ctaText}
+      </LinkButton>
+    </>
+  );
 
   return (
-    <ModalBase isOpen onDismiss={handleDismiss} aria-label={t('splash-screen.title', 'Welcome to Grafana')}>
-      <IconButton name="times" size="xl" onClick={handleDismiss} aria-label={t('splash-screen.close', 'Close')} />
-      <p>{t('splash-screen.body', 'Splash screen content will go here.')}</p>
-      <Button variant="primary" onClick={handleDismiss}>
-        {t('splash-screen.get-started', 'Get started')}
-      </Button>
+    <ModalBase
+      isOpen
+      onDismiss={handleDismiss}
+      aria-label={t('splash-screen.aria-label', "What's new in Grafana")}
+      className={styles.modal}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div className={styles.container} onKeyDown={handleKeyDown} tabIndex={-1}>
+        <IconButton
+          name="times"
+          size="lg"
+          onClick={handleDismiss}
+          aria-label={t('splash-screen.close', 'Close')}
+          className={styles.closeButton}
+        />
+        <SplashScreenSlide feature={activeFeature} footer={footer} />
+      </div>
     </ModalBase>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  modal: css({
+    width: '860px',
+    maxWidth: '95vw',
+    height: '520px',
+    maxHeight: '85vh',
+    padding: 0,
+    overflow: 'hidden',
+  }),
+  container: css({
+    position: 'relative',
+    height: '100%',
+    outline: 'none',
+  }),
+  closeButton: css({
+    position: 'absolute',
+    top: theme.spacing(1),
+    right: theme.spacing(1),
+    zIndex: 1,
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useCallback, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -12,7 +11,6 @@ import { SplashScreenSlide } from './SplashScreenSlide';
 import { getSplashScreenConfig } from './splashContent';
 
 export function SplashScreenModal() {
-  const isSplashScreenEnabled = useBooleanFlagValue('splashScreen', false);
   const [isOpen, setIsOpen] = useState(true);
   const [activeIndex, setActiveIndex] = useState(0);
   const styles = useStyles2(getStyles);
@@ -35,7 +33,7 @@ export function SplashScreenModal() {
     [goToPrev, goToNext]
   );
 
-  if (!isSplashScreenEnabled || !isOpen) {
+  if (!isOpen) {
     return null;
   }
 
@@ -72,7 +70,7 @@ export function SplashScreenModal() {
       className={styles.modal}
     >
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      <div className={styles.container} onKeyDown={handleKeyDown} tabIndex={-1}>
+      <div className={styles.container} onKeyDown={handleKeyDown}>
         <IconButton
           name="times"
           size="lg"
@@ -98,7 +96,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     position: 'relative',
     height: '100%',
-    outline: 'none',
   }),
   closeButton: css({
     position: 'absolute',

--- a/public/app/core/components/SplashScreenModal/SplashScreenNav.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenNav.tsx
@@ -1,0 +1,97 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Button, Text, useStyles2 } from '@grafana/ui';
+
+interface SplashScreenNavProps {
+  activeIndex: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onGoTo: (index: number) => void;
+}
+
+export function SplashScreenNav({ activeIndex, total, onPrev, onNext, onGoTo }: SplashScreenNavProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.nav}>
+      <Button
+        icon="angle-left"
+        variant="secondary"
+        fill="outline"
+        size="sm"
+        onClick={onPrev}
+        aria-label={t('splash-screen.nav.prev', 'Previous')}
+        className={styles.navButton}
+      />
+      <div className={styles.dots}>
+        {Array.from({ length: total }, (_, i) => (
+          <button
+            key={i}
+            className={cx(styles.dotBase, i === activeIndex ? styles.dotActive : styles.dotInactive)}
+            onClick={() => onGoTo(i)}
+            aria-label={t('splash-screen.nav.go-to', 'Go to slide {{number}}', { number: i + 1 })}
+            aria-current={i === activeIndex ? 'step' : undefined}
+          />
+        ))}
+      </div>
+      <Button
+        icon="angle-right"
+        variant="secondary"
+        fill="outline"
+        size="sm"
+        onClick={onNext}
+        aria-label={t('splash-screen.nav.next', 'Next')}
+        className={styles.navButton}
+      />
+      <Text color="secondary" variant="bodySmall">
+        {activeIndex + 1}/{total}
+      </Text>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  nav: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  navButton: css({
+    width: theme.spacing(3),
+    minWidth: theme.spacing(3),
+    padding: 0,
+    justifyContent: 'center',
+  }),
+  dots: css({
+    display: 'flex',
+    alignItems: 'center',
+    // 5px gap matches design's 9px center-to-center dot spacing
+    gap: 5,
+  }),
+  dotBase: css({
+    borderRadius: theme.shape.radius.circle,
+    border: 'none',
+    padding: 0,
+    cursor: 'pointer',
+  }),
+  dotInactive: css({
+    width: 4,
+    height: 4,
+    backgroundColor: theme.colors.text.disabled,
+    opacity: 0.65,
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: theme.transitions.create('background-color'),
+    },
+    '&:hover': {
+      opacity: 1,
+    },
+  }),
+  dotActive: css({
+    width: 6,
+    height: 6,
+    backgroundColor: theme.colors.warning.text,
+  }),
+});

--- a/public/app/core/components/SplashScreenModal/SplashScreenSlide.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenSlide.tsx
@@ -1,0 +1,140 @@
+import { css } from '@emotion/css';
+import { type ReactNode } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Badge, Icon, useStyles2 } from '@grafana/ui';
+
+import { type SplashFeature } from './splashContent';
+
+interface SplashScreenSlideProps {
+  feature: SplashFeature;
+  footer?: ReactNode;
+}
+
+export function SplashScreenSlide({ feature, footer }: SplashScreenSlideProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.slide}>
+      <div className={styles.heroPanel}>
+        <img src={feature.heroImageUrl} alt="" className={styles.heroImage} />
+      </div>
+      <div className={styles.contentPanel}>
+        <Badge text={t('splash-screen.badge', 'NEW FEATURE')} color="green" className={styles.badge} />
+        <h2 className={styles.title}>{feature.title}</h2>
+        <div className={styles.body}>
+          <div className={styles.iconBox}>
+            <Icon name={feature.icon} size="xl" className={styles.iconBoxIcon} />
+          </div>
+          <p className={styles.subtitle}>{feature.subtitle}</p>
+          <ul className={styles.bulletList}>
+            {feature.bullets.map((bullet, i) => (
+              <li key={i} className={styles.bulletItem}>
+                <span className={styles.bulletDot} />
+                <span className={styles.bulletText}>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {footer && <div className={styles.footer}>{footer}</div>}
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  slide: css({
+    display: 'flex',
+    height: '100%',
+  }),
+  heroPanel: css({
+    flex: '0 0 45%',
+    backgroundColor: theme.colors.background.canvas,
+    borderRadius: `${theme.shape.radius.lg} 0 0 ${theme.shape.radius.lg}`,
+    overflow: 'hidden',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }),
+  heroImage: css({
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  }),
+  contentPanel: css({
+    flex: '1 1 55%',
+    padding: theme.spacing(4),
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    overflow: 'auto',
+  }),
+  badge: css({
+    alignSelf: 'flex-start',
+  }),
+  title: css({
+    fontSize: theme.typography.h3.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    lineHeight: theme.typography.h3.lineHeight,
+    color: theme.colors.text.primary,
+    margin: 0,
+  }),
+  body: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  }),
+  subtitle: css({
+    color: theme.colors.text.primary,
+    fontSize: theme.typography.body.fontSize,
+    lineHeight: theme.typography.body.lineHeight,
+    fontWeight: theme.typography.fontWeightRegular,
+    margin: 0,
+  }),
+  iconBox: css({
+    width: 40,
+    height: 40,
+    borderRadius: theme.shape.radius.default,
+    backgroundColor: theme.colors.warning.transparent,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }),
+  iconBoxIcon: css({
+    color: theme.colors.warning.text,
+  }),
+  bulletList: css({
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  }),
+  bulletItem: css({
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1.5),
+  }),
+  bulletDot: css({
+    width: 6,
+    height: 6,
+    minWidth: 6,
+    borderRadius: theme.shape.radius.circle,
+    backgroundColor: theme.colors.warning.text,
+    // Vertically aligns the dot with the first line of text
+    marginTop: theme.spacing(0.75),
+  }),
+  bulletText: css({
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    lineHeight: theme.typography.bodySmall.lineHeight,
+  }),
+  footer: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: theme.spacing(2),
+  }),
+});

--- a/public/app/core/components/SplashScreenModal/splashContent.ts
+++ b/public/app/core/components/SplashScreenModal/splashContent.ts
@@ -1,0 +1,95 @@
+import { t } from '@grafana/i18n';
+import { type IconName } from '@grafana/ui';
+
+export interface SplashFeature {
+  id: string;
+  icon: IconName;
+  title: string;
+  subtitle: string;
+  bullets: string[];
+  ctaText: string;
+  ctaUrl: string;
+  heroImageUrl: string;
+}
+
+export interface SplashScreenConfig {
+  version: string;
+  features: SplashFeature[];
+}
+
+export function getSplashScreenConfig(): SplashScreenConfig {
+  return {
+    version: '13.0.0',
+    features: [
+      {
+        id: 'assistant',
+        icon: 'comment-alt-message',
+        title: t('splash-screen.assistant.title', 'Grafana Assistant is now available in OSS'),
+        subtitle: t(
+          'splash-screen.assistant.subtitle',
+          'Say no to lengthy config work and troubleshooting. Use the Assistant to be faster than ever.'
+        ),
+        bullets: [
+          t('splash-screen.assistant.bullet-1', 'Build complex dashboards in minutes'),
+          t('splash-screen.assistant.bullet-2', 'Correlate metrics, logs and traces and gain insights in minutes'),
+          t('splash-screen.assistant.bullet-3', 'Onboard new team members in a week instead of a month'),
+        ],
+        ctaText: t('splash-screen.assistant.cta', 'Show me'),
+        ctaUrl: '/a/grafana-assistant-app',
+        heroImageUrl: 'https://placehold.co/600x700/2A1F4E/8B5CF6?text=Assistant',
+      },
+      {
+        id: 'git-sync',
+        icon: 'code-branch',
+        title: t(
+          'splash-screen.git-sync.title',
+          'Connect Grafana to your preferred git repository and keep them always in sync'
+        ),
+        subtitle: t(
+          'splash-screen.git-sync.subtitle',
+          'Combine the benefit of managing dashboards as code with the simplicity of creating and editing them in Grafana UI.'
+        ),
+        bullets: [
+          t('splash-screen.git-sync.bullet-1', 'Store your dashboard configuration safely in any git repository'),
+          t('splash-screen.git-sync.bullet-2', 'Keep track of the changes — and who made them!'),
+          t('splash-screen.git-sync.bullet-3', 'Works with many deployment scenarios'),
+        ],
+        ctaText: t('splash-screen.git-sync.cta', 'Show me'),
+        ctaUrl: '/admin/provisioning',
+        heroImageUrl: 'https://placehold.co/500x600/1A2E1A/4ADE80?text=Git+Sync',
+      },
+      {
+        id: 'library',
+        icon: 'apps',
+        title: t('splash-screen.library.title', 'Dashboard creation with saved queries and templates'),
+        subtitle: t('splash-screen.library.subtitle', 'Now you can build faster with reusable assets'),
+        bullets: [
+          t('splash-screen.library.bullet-1', 'Saved queries is redesigned to make reusing queries easier'),
+          t('splash-screen.library.bullet-2', 'Gather inspiration from templates and customize them to your needs'),
+          t('splash-screen.library.bullet-3', 'Jump-start dashboard creation with suggestions tailored to your data'),
+        ],
+        ctaText: t('splash-screen.library.cta', 'Show me'),
+        ctaUrl: '/dashboards',
+        heroImageUrl: 'https://placehold.co/550x650/1E293B/F59E0B?text=Templates',
+      },
+      {
+        // TODO: Replace with real 4th feature content once confirmed
+        id: 'explore',
+        icon: 'compass',
+        title: t('splash-screen.explore.title', 'Explore your data with a new experience'),
+        subtitle: t(
+          'splash-screen.explore.subtitle',
+          'A redesigned Explore makes it easier to query, visualize, and understand your data.'
+        ),
+        bullets: [
+          t('splash-screen.explore.bullet-1', 'Streamlined query building across all data sources'),
+          t('splash-screen.explore.bullet-2', 'Side-by-side comparison of metrics, logs, and traces'),
+          t('splash-screen.explore.bullet-3', 'Save and share your explorations with your team'),
+        ],
+        ctaText: t('splash-screen.explore.cta', 'Show me'),
+        ctaUrl: '/explore',
+        heroImageUrl: 'https://placehold.co/480x580/0F172A/38BDF8?text=Explore',
+      },
+    ],
+  };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14670,10 +14670,46 @@
     "select-aria-label": "Sort"
   },
   "splash-screen": {
-    "body": "Splash screen content will go here.",
+    "aria-label": "What's new in Grafana",
+    "assistant": {
+      "bullet-1": "Build complex dashboards in minutes",
+      "bullet-2": "Correlate metrics, logs and traces and gain insights in minutes",
+      "bullet-3": "Onboard new team members in a week instead of a month",
+      "cta": "Show me",
+      "subtitle": "Say no to lengthy config work and troubleshooting. Use the Assistant to be faster than ever.",
+      "title": "Grafana Assistant is now available in OSS"
+    },
+    "badge": "NEW FEATURE",
     "close": "Close",
-    "get-started": "Get started",
-    "title": "Welcome to Grafana"
+    "explore": {
+      "bullet-1": "Streamlined query building across all data sources",
+      "bullet-2": "Side-by-side comparison of metrics, logs, and traces",
+      "bullet-3": "Save and share your explorations with your team",
+      "cta": "Show me",
+      "subtitle": "A redesigned Explore makes it easier to query, visualize, and understand your data.",
+      "title": "Explore your data with a new experience"
+    },
+    "git-sync": {
+      "bullet-1": "Store your dashboard configuration safely in any git repository",
+      "bullet-2": "Keep track of the changes — and who made them!",
+      "bullet-3": "Works with many deployment scenarios",
+      "cta": "Show me",
+      "subtitle": "Combine the benefit of managing dashboards as code with the simplicity of creating and editing them in Grafana UI.",
+      "title": "Connect Grafana to your preferred git repository and keep them always in sync"
+    },
+    "library": {
+      "bullet-1": "Saved queries is redesigned to make reusing queries easier",
+      "bullet-2": "Gather inspiration from templates and customize them to your needs",
+      "bullet-3": "Jump-start dashboard creation with suggestions tailored to your data",
+      "cta": "Show me",
+      "subtitle": "Now you can build faster with reusable assets",
+      "title": "Dashboard creation with saved queries and templates"
+    },
+    "nav": {
+      "go-to": "Go to slide {{number}}",
+      "next": "Next",
+      "prev": "Previous"
+    }
   },
   "sql-expressions": {
     "add-query-tooltip": "Add at least one data query to generate SQL suggestions",


### PR DESCRIPTION
## Summary

- Adds multi-slide carousel with infinite navigation (arrow buttons, dots, keyboard arrows)
- Two-column layout: hero image panel + content panel (badge, title, icon, subtitle, bullets, CTA)
- Content driven by a typed `SplashScreenConfig` with `t()` translations and versioned resurfacing support
- Uses `ModalBase` from `@grafana/ui/internal`, `Button`, `LinkButton`, `Badge`, `Icon` from `@grafana/ui`
- Placeholder images via placehold.co; 4th feature is a placeholder pending content confirmation

## Test plan

- [ ] Enable `splashScreen` feature flag, verify slides render with correct content
- [ ] Arrow buttons and keyboard left/right cycle through slides infinitely
- [ ] Dot indicators reflect active slide and are clickable
- [ ] CTA links open correct URLs in new tab
- [ ] Modal height stays fixed across slides with varying content length
- [ ] Close button and Escape key dismiss the modal