### PR TITLE
Logs table: Update container styles to prevent overflows

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -439,29 +439,26 @@ describe('Language completion provider', () => {
       throwError: true,
     };
 
-    const expectedResponse: DetectedFieldsResult = {
-      fields: [
-        {
-          label: 'bytes',
-          type: 'bytes',
-          cardinality: 6,
-          parsers: ['logfmt'],
-        },
-        {
-          label: 'traceID',
-          type: 'string',
-          cardinality: 50,
-          parsers: null,
-        },
-        {
-          label: 'active_series',
-          type: 'int',
-          cardinality: 8,
-          parsers: ['logfmt'],
-        },
-      ],
-      limit: 999,
-    };
+    const expectedResponse: DetectedFieldsResult = [
+      {
+        label: 'bytes',
+        type: 'bytes',
+        cardinality: 6,
+        parsers: ['logfmt'],
+      },
+      {
+        label: 'traceID',
+        type: 'string',
+        cardinality: 50,
+        parsers: null,
+      },
+      {
+        label: 'active_series',
+        type: 'int',
+        cardinality: 8,
+        parsers: ['logfmt'],
+      },
+    ];
 
     const datasource = detectedFieldsSetup(expectedResponse, {
       end: mockTimeRange.to.valueOf(),
@@ -957,7 +954,7 @@ describe('Query imports', () => {
             query: '{job="grafana"}',
           },
           false,
-          undefined
+          { showErrorAlert: false, showSuccessAlert: false }
         );
       });
     });

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -474,7 +474,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
       expect(labelValues).toEqual(expectedResponse);
     });
     it('should return values', async () => {
@@ -487,7 +487,7 @@ describe('Language completion provider', () => {
 
       const nextLabelValues = await provider.fetchDetectedFields(options);
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
       expect(nextLabelValues).toEqual(expectedResponse);
     });
     it('should encode special characters', async () => {
@@ -495,7 +495,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, false, undefined);
+      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, true, undefined);
     });
   });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -28,34 +28,69 @@ const mockTimeRange = {
 
 describe('Language completion provider', () => {
   describe('start', () => {
-    const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+    describe('when detectedEndpointsSupported is false (detected_labels returns non-array)', () => {
+      let datasource: LokiDatasource;
 
-    it('should fetch labels on initial start', async () => {
-      const languageProvider = new LanguageProvider(datasource);
-      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
-      await languageProvider.start();
-      expect(fetchSpy).toHaveBeenCalled();
+      beforeEach(() => {
+        datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+      });
+
+      it('should complete start after probe without calling fetchLabels', async () => {
+        const languageProvider = new LanguageProvider(datasource);
+        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
+        const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+        await languageProvider.start();
+        expect(languageProvider.started).toBe(true);
+        expect(
+          metadataSpy.mock.calls.filter(
+            (call) =>
+              call[0] === 'detected_labels' && call[1]?.start === 1560153109000 && call[1]?.end === 1560163909000
+          )
+        ).toHaveLength(1);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+
+      it('should not re-run detected_labels probe on second start with same time range', async () => {
+        const languageProvider = new LanguageProvider(datasource);
+        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
+        await languageProvider.start();
+        await languageProvider.start();
+        expect(metadataSpy.mock.calls.filter((call) => call[0] === 'detected_labels')).toHaveLength(1);
+      });
+
+      it('should not re-run detected_labels probe when time range changes (probe result already cached)', async () => {
+        const languageProvider = new LanguageProvider(datasource);
+        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
+        await languageProvider.start();
+        jest.mocked(datasource.getTimeRangeParams).mockRestore();
+        jest.spyOn(datasource, 'getTimeRangeParams').mockImplementation((range: TimeRange) => ({
+          start: range.from.valueOf(),
+          end: range.to.valueOf(),
+        }));
+        await languageProvider.start(mockTimeRange);
+        await languageProvider.start(mockTimeRange);
+        expect(metadataSpy.mock.calls.filter((call) => call[0] === 'detected_labels')).toHaveLength(1);
+      });
     });
 
-    it('should not again fetch labels on second start', async () => {
-      const languageProvider = new LanguageProvider(datasource);
-      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
-      await languageProvider.start();
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      await languageProvider.start();
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-    });
+    describe('when detectedEndpointsSupported is true', () => {
+      let datasource: LokiDatasource;
 
-    it('should again fetch labels on second start with different timerange', async () => {
-      const languageProvider = new LanguageProvider(datasource);
-      jest.mocked(datasource.getTimeRangeParams).mockRestore();
-      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
-      await languageProvider.start();
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      await languageProvider.start(mockTimeRange);
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
-      await languageProvider.start(mockTimeRange);
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      beforeEach(() => {
+        datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] }, undefined, {
+          detectedEndpointsSupported: true,
+        });
+      });
+
+      it('should not call fetchLabels on start when detected_labels probe succeeds', async () => {
+        const languageProvider = new LanguageProvider(datasource);
+        const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
+        await languageProvider.start();
+        expect(languageProvider.started).toBe(true);
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(metadataSpy.mock.calls.some((call) => call[0] === 'detected_labels')).toBe(true);
+      });
     });
   });
 
@@ -146,6 +181,7 @@ describe('Language completion provider', () => {
   });
 
   describe('fetchLabelValues', () => {
+    // getLanguageProvider runs start(); setup() makes detected_labels return non-array so detectedEndpointsSupported is false.
     it('should fetch label values if not cached', async () => {
       const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
@@ -437,7 +473,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
       expect(labelValues).toEqual(expectedResponse);
     });
     it('should return values', async () => {
@@ -450,7 +486,7 @@ describe('Language completion provider', () => {
 
       const nextLabelValues = await provider.fetchDetectedFields(options);
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
       expect(nextLabelValues).toEqual(expectedResponse);
     });
     it('should encode special characters', async () => {
@@ -458,139 +494,190 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, true, undefined);
+      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, false, undefined);
     });
   });
 
   describe('fetchLabels', () => {
-    it('should return labels', async () => {
-      const datasourceWithLabels = setup({ other: [] });
+    describe('when detectedEndpointsSupported is false (default / no start)', () => {
+      it('should return labels', async () => {
+        const datasourceWithLabels = setup({ other: [] });
 
-      const instance = new LanguageProvider(datasourceWithLabels);
-      const labels = await instance.fetchLabels();
-      expect(labels).toEqual(['other']);
-    });
-
-    it('should set labels', async () => {
-      const datasourceWithLabels = setup({ other: [] });
-
-      const instance = new LanguageProvider(datasourceWithLabels);
-      await instance.fetchLabels();
-      expect(instance.labelKeys).toEqual(['other']);
-    });
-
-    it('should return empty array', async () => {
-      const datasourceWithLabels = setup({});
-
-      const instance = new LanguageProvider(datasourceWithLabels);
-      const labels = await instance.fetchLabels();
-      expect(labels).toEqual([]);
-    });
-
-    it('should set empty array', async () => {
-      const datasourceWithLabels = setup({});
-
-      const instance = new LanguageProvider(datasourceWithLabels);
-      await instance.fetchLabels();
-      expect(instance.labelKeys).toEqual([]);
-    });
-
-    it('should use time range param', async () => {
-      const datasourceWithLabels = setup({});
-      datasourceWithLabels.languageProvider.request = jest.fn();
-
-      const instance = new LanguageProvider(datasourceWithLabels);
-      instance.request = jest.fn();
-      await instance.fetchLabels({ timeRange: mockTimeRange });
-      expect(instance.request).toHaveBeenCalledWith('labels', datasourceWithLabels.getTimeRangeParams(mockTimeRange));
-    });
-
-    describe('without labelNames feature toggle', () => {
-      const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
-      beforeAll(() => {
-        config.featureToggles.lokiLabelNamesQueryApi = false;
-      });
-      afterAll(() => {
-        config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
+        const instance = new LanguageProvider(datasourceWithLabels);
+        const labels = await instance.fetchLabels();
+        expect(labels).toEqual(['other']);
       });
 
-      it('should use series endpoint for request with stream selector', async () => {
+      it('should set labels', async () => {
+        const datasourceWithLabels = setup({ other: [] });
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        await instance.fetchLabels();
+        expect(instance.labelKeys).toEqual(['other']);
+      });
+
+      it('should return empty array', async () => {
+        const datasourceWithLabels = setup({});
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        const labels = await instance.fetchLabels();
+        expect(labels).toEqual([]);
+      });
+
+      it('should set empty array', async () => {
+        const datasourceWithLabels = setup({});
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        await instance.fetchLabels();
+        expect(instance.labelKeys).toEqual([]);
+      });
+
+      it('should use time range param', async () => {
         const datasourceWithLabels = setup({});
         datasourceWithLabels.languageProvider.request = jest.fn();
 
         const instance = new LanguageProvider(datasourceWithLabels);
         instance.request = jest.fn();
-        await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
-        expect(instance.request).toHaveBeenCalledWith('series', {
-          end: 1560163909000,
-          'match[]': '{foo="bar"}',
-          start: 1560153109000,
+        await instance.fetchLabels({ timeRange: mockTimeRange });
+        expect(instance.request).toHaveBeenCalledWith('labels', datasourceWithLabels.getTimeRangeParams(mockTimeRange));
+      });
+
+      describe('without labelNames feature toggle', () => {
+        const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
+        beforeAll(() => {
+          config.featureToggles.lokiLabelNamesQueryApi = false;
         });
+        afterAll(() => {
+          config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
+        });
+
+        it('should use series endpoint for request with stream selector', async () => {
+          const datasourceWithLabels = setup({});
+          datasourceWithLabels.languageProvider.request = jest.fn();
+
+          const instance = new LanguageProvider(datasourceWithLabels);
+          instance.request = jest.fn();
+          await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
+          expect(instance.request).toHaveBeenCalledWith('series', {
+            end: 1560163909000,
+            'match[]': '{foo="bar"}',
+            start: 1560153109000,
+          });
+        });
+      });
+
+      describe('with labelNames feature toggle', () => {
+        const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
+        beforeAll(() => {
+          config.featureToggles.lokiLabelNamesQueryApi = true;
+        });
+        afterAll(() => {
+          config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
+        });
+
+        it('should exclude empty vector selector', async () => {
+          const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
+
+          const instance = new LanguageProvider(datasourceWithLabels);
+          instance.request = jest.fn();
+          await instance.fetchLabels({ streamSelector: '{}' });
+          expect(instance.request).toBeCalledWith('labels', { end: 1560163909000, start: 1560153109000 });
+        });
+
+        it('should use series endpoint for request with stream selector', async () => {
+          const datasourceWithLabels = setup({});
+          datasourceWithLabels.languageProvider.request = jest.fn();
+
+          const instance = new LanguageProvider(datasourceWithLabels);
+          instance.request = jest.fn();
+          await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
+          expect(instance.request).toHaveBeenCalledWith('labels', {
+            end: 1560163909000,
+            query: '{foo="bar"}',
+            start: 1560153109000,
+          });
+        });
+
+        it('should interpolate variables in stream selector', async () => {
+          const datasource = setup({});
+          jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue({ start: 0, end: 1 });
+          jest
+            .spyOn(datasource, 'interpolateString')
+            .mockImplementation((string: string) => string.replace(/\$test_var/g, 'age'));
+
+          const languageProvider = new LanguageProvider(datasource);
+          languageProvider.request = jest.fn().mockResolvedValue([]);
+          await languageProvider.fetchLabels({ streamSelector: '{age="new", $test_var="new"}' });
+          expect(languageProvider.request).toHaveBeenCalledWith('labels', {
+            end: 1,
+            query: '{age="new", age="new"}',
+            start: 0,
+          });
+        });
+      });
+
+      it('should filter internal labels', async () => {
+        const datasourceWithLabels = setup({
+          foo: [],
+          bar: [],
+          __name__: [],
+          __stream_shard__: [],
+          __aggregated_metric__: [],
+        });
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        const labels = await instance.fetchLabels();
+        expect(labels).toEqual(['__name__', 'bar', 'foo']);
       });
     });
 
-    describe('with labelNames feature toggle', () => {
-      const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
-      beforeAll(() => {
-        config.featureToggles.lokiLabelNamesQueryApi = true;
-      });
-      afterAll(() => {
-        config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
-      });
-
-      it('should exclude empty vector selector', async () => {
-        const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
-
+    describe('when detectedEndpointsSupported is true', () => {
+      it('should fetch label names via detected_labels', async () => {
+        const datasourceWithLabels = setup({ alpha: [], zed: [] }, undefined, { detectedEndpointsSupported: true });
         const instance = new LanguageProvider(datasourceWithLabels);
-        instance.request = jest.fn();
-        await instance.fetchLabels({ streamSelector: '{}' });
-        expect(instance.request).toBeCalledWith('labels', { end: 1560163909000, start: 1560153109000 });
+        await instance.start();
+        const requestSpy = jest.spyOn(instance, 'request');
+        const labels = await instance.fetchLabels();
+        expect(requestSpy).toHaveBeenCalledWith(
+          'detected_labels',
+          { start: 1560153109000, end: 1560163909000 },
+          true,
+          undefined
+        );
+        expect(labels).toEqual(['alpha', 'zed']);
       });
 
-      it('should use series endpoint for request with stream selector', async () => {
-        const datasourceWithLabels = setup({});
-        datasourceWithLabels.languageProvider.request = jest.fn();
-
+      it('should pass stream selector as query to detected_labels', async () => {
+        const datasourceWithLabels = setup({ job: [] }, undefined, { detectedEndpointsSupported: true });
         const instance = new LanguageProvider(datasourceWithLabels);
-        instance.request = jest.fn();
+        await instance.start();
+        const requestSpy = jest.spyOn(instance, 'request');
         await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
-        expect(instance.request).toHaveBeenCalledWith('labels', {
-          end: 1560163909000,
-          query: '{foo="bar"}',
-          start: 1560153109000,
-        });
+        expect(requestSpy).toHaveBeenCalledWith(
+          'detected_labels',
+          { start: 1560153109000, end: 1560163909000, query: '{foo="bar"}' },
+          true,
+          undefined
+        );
       });
 
-      it('should interpolate variables in stream selector', async () => {
-        const datasource = setup({});
-        jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue({ start: 0, end: 1 });
-        jest
-          .spyOn(datasource, 'interpolateString')
-          .mockImplementation((string: string) => string.replace(/\$test_var/g, 'age'));
-
-        const languageProvider = new LanguageProvider(datasource);
-        languageProvider.request = jest.fn().mockResolvedValue([]);
-        await languageProvider.fetchLabels({ streamSelector: '{age="new", $test_var="new"}' });
-        expect(languageProvider.request).toHaveBeenCalledWith('labels', {
-          end: 1,
-          query: '{age="new", age="new"}',
-          start: 0,
-        });
+      it('should use time range when calling detected_labels', async () => {
+        const datasourceWithLabels = setup({ other: [] }, undefined, { detectedEndpointsSupported: true });
+        datasourceWithLabels.getTimeRangeParams = jest
+          .fn()
+          .mockImplementation((range: TimeRange) => ({ start: range.from.valueOf(), end: range.to.valueOf() }));
+        const instance = new LanguageProvider(datasourceWithLabels);
+        await instance.start();
+        const requestSpy = jest.spyOn(instance, 'request');
+        await instance.fetchLabels({ timeRange: mockTimeRange });
+        expect(datasourceWithLabels.getTimeRangeParams).toHaveBeenCalledWith(mockTimeRange);
+        expect(requestSpy).toHaveBeenCalledWith(
+          'detected_labels',
+          { start: mockTimeRange.from.valueOf(), end: mockTimeRange.to.valueOf() },
+          true,
+          undefined
+        );
       });
-    });
-
-    it('should filter internal labels', async () => {
-      const datasourceWithLabels = setup({
-        foo: [],
-        bar: [],
-        __name__: [],
-        __stream_shard__: [],
-        __aggregated_metric__: [],
-      });
-
-      const instance = new LanguageProvider(datasourceWithLabels);
-      const labels = await instance.fetchLabels();
-      expect(labels).toEqual(['__name__', 'bar', 'foo']);
     });
   });
 });
@@ -695,128 +782,184 @@ describe('Query imports', () => {
   });
 
   describe('getParserAndLabelKeys()', () => {
-    let datasource: LokiDatasource, languageProvider: LanguageProvider;
-    const extractLogParserFromDataFrameMock = jest.mocked(extractLogParserFromDataFrame);
-    const extractedLabelKeys = ['extracted', 'label'];
-    const structuredMetadataKeys = ['structured', 'metadata'];
-    const parsedKeys = ['parsed', 'label'];
-    const unwrapLabelKeys = ['unwrap', 'labels'];
+    describe('when detectedEndpointsSupported is false', () => {
+      let datasource: LokiDatasource, languageProvider: LanguageProvider;
+      const extractLogParserFromDataFrameMock = jest.mocked(extractLogParserFromDataFrame);
+      const extractedLabelKeys = ['extracted', 'label'];
+      const structuredMetadataKeys = ['structured', 'metadata'];
+      const parsedKeys = ['parsed', 'label'];
+      const unwrapLabelKeys = ['unwrap', 'labels'];
 
-    beforeEach(() => {
-      datasource = createLokiDatasource();
-      languageProvider = new LanguageProvider(datasource);
-      jest.mocked(extractLabelKeysFromDataFrame).mockImplementation((_, type) => {
-        if (type === LabelType.Indexed || !type) {
-          return extractedLabelKeys;
-        } else if (type === LabelType.StructuredMetadata) {
-          return structuredMetadataKeys;
-        } else if (type === LabelType.Parsed) {
-          return parsedKeys;
-        } else {
-          return [];
-        }
+      beforeEach(() => {
+        datasource = createLokiDatasource();
+        languageProvider = new LanguageProvider(datasource);
+        jest.mocked(extractLabelKeysFromDataFrame).mockImplementation((_, type) => {
+          if (type === LabelType.Indexed || !type) {
+            return extractedLabelKeys;
+          } else if (type === LabelType.StructuredMetadata) {
+            return structuredMetadataKeys;
+          } else if (type === LabelType.Parsed) {
+            return parsedKeys;
+          } else {
+            return [];
+          }
+        });
+        jest.mocked(extractUnwrapLabelKeysFromDataFrame).mockReturnValue(unwrapLabelKeys);
       });
-      jest.mocked(extractUnwrapLabelKeysFromDataFrame).mockReturnValue(unwrapLabelKeys);
+
+      it('identifies selectors with JSON parser data', async () => {
+        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
+        extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: false, hasJSON: true, hasPack: false });
+
+        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+          extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
+          unwrapLabelKeys,
+          structuredMetadataKeys,
+          hasJSON: true,
+          hasLogfmt: false,
+          hasPack: false,
+        });
+      });
+
+      it('identifies selectors with Logfmt parser data', async () => {
+        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
+        extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: true, hasJSON: false, hasPack: false });
+
+        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+          extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
+          unwrapLabelKeys,
+          structuredMetadataKeys,
+          hasJSON: false,
+          hasLogfmt: true,
+          hasPack: false,
+        });
+      });
+
+      it('correctly processes empty data', async () => {
+        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+        extractLogParserFromDataFrameMock.mockClear();
+
+        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+          extractedLabelKeys: [],
+          unwrapLabelKeys: [],
+          structuredMetadataKeys: [],
+          hasJSON: false,
+          hasLogfmt: false,
+          hasPack: false,
+        });
+        expect(extractLogParserFromDataFrameMock).not.toHaveBeenCalled();
+      });
+
+      it('calls dataSample with correct default maxLines', async () => {
+        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+
+        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+          extractedLabelKeys: [],
+          unwrapLabelKeys: [],
+          structuredMetadataKeys: [],
+          hasJSON: false,
+          hasLogfmt: false,
+          hasPack: false,
+        });
+        expect(datasource.getDataSamples).toHaveBeenCalledWith(
+          {
+            expr: '{place="luna"}',
+            maxLines: DEFAULT_MAX_LINES_SAMPLE,
+            refId: 'data-samples',
+          },
+          // We are not interested in the time range here
+          expect.any(Object)
+        );
+      });
+
+      it('calls dataSample with correctly set sampleSize', async () => {
+        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+
+        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}', { maxLines: 5 })).toEqual({
+          extractedLabelKeys: [],
+          unwrapLabelKeys: [],
+          structuredMetadataKeys: [],
+          hasJSON: false,
+          hasLogfmt: false,
+          hasPack: false,
+        });
+        expect(datasource.getDataSamples).toHaveBeenCalledWith(
+          {
+            expr: '{place="luna"}',
+            maxLines: 5,
+            refId: 'data-samples',
+          },
+          // We are not interested in the time range here
+          expect.any(Object)
+        );
+      });
+
+      it('calls dataSample with correctly set time range', async () => {
+        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+        languageProvider.getParserAndLabelKeys('{place="luna"}', { timeRange: mockTimeRange });
+        expect(datasource.getDataSamples).toHaveBeenCalledWith(
+          {
+            expr: '{place="luna"}',
+            maxLines: 10,
+            refId: 'data-samples',
+          },
+          mockTimeRange
+        );
+      });
     });
 
-    it('identifies selectors with JSON parser data', async () => {
-      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
-      extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: false, hasJSON: true, hasPack: false });
+    describe('when detectedEndpointsSupported is true', () => {
+      const detectedFieldsSample: DetectedFieldsResult = [
+        { label: 'msg', type: 'string', cardinality: 1, parsers: ['json'] },
+        { label: 'cnt', type: 'int', cardinality: 2, parsers: ['logfmt'] },
+        { label: 'trace', type: 'string', cardinality: 3, parsers: null },
+        { label: '_entry', type: 'string', cardinality: 4, parsers: null },
+      ];
 
-      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
-        unwrapLabelKeys,
-        structuredMetadataKeys,
-        hasJSON: true,
-        hasLogfmt: false,
-        hasPack: false,
+      it('derives parser and label keys from detected_fields instead of getDataSamples', async () => {
+        const ds = setup({}, undefined, {
+          detectedEndpointsSupported: true,
+          detectedFieldsResponse: detectedFieldsSample,
+        });
+        jest.spyOn(ds, 'getDataSamples');
+        const lp = new LanguageProvider(ds);
+        await lp.start();
+
+        expect(await lp.getParserAndLabelKeys('{job="grafana"}')).toEqual({
+          extractedLabelKeys: ['msg', 'cnt', 'trace', '_entry'],
+          structuredMetadataKeys: ['trace', '_entry'],
+          unwrapLabelKeys: ['cnt'],
+          hasJSON: true,
+          hasLogfmt: true,
+          hasPack: true,
+        });
+        expect(ds.getDataSamples).not.toHaveBeenCalled();
       });
-    });
 
-    it('identifies selectors with Logfmt parser data', async () => {
-      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
-      extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: true, hasJSON: false, hasPack: false });
-
-      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
-        unwrapLabelKeys,
-        structuredMetadataKeys,
-        hasJSON: false,
-        hasLogfmt: true,
-        hasPack: false,
+      it('passes maxLines as limit to detected_fields', async () => {
+        const ds = setup({}, undefined, {
+          detectedEndpointsSupported: true,
+          detectedFieldsResponse: detectedFieldsSample,
+        });
+        ds.getTimeRangeParams = jest
+          .fn()
+          .mockImplementation((range: TimeRange) => ({ start: range.from.valueOf(), end: range.to.valueOf() }));
+        const lp = new LanguageProvider(ds);
+        await lp.start();
+        const requestSpy = jest.spyOn(lp, 'request');
+        await lp.getParserAndLabelKeys('{job="grafana"}', { maxLines: 5, timeRange: mockTimeRange });
+        expect(requestSpy).toHaveBeenCalledWith(
+          'detected_fields',
+          {
+            start: mockTimeRange.from.valueOf(),
+            end: mockTimeRange.to.valueOf(),
+            limit: 5,
+            query: '{job="grafana"}',
+          },
+          false,
+          undefined
+        );
       });
-    });
-
-    it('correctly processes empty data', async () => {
-      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-      extractLogParserFromDataFrameMock.mockClear();
-
-      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys: [],
-        unwrapLabelKeys: [],
-        structuredMetadataKeys: [],
-        hasJSON: false,
-        hasLogfmt: false,
-        hasPack: false,
-      });
-      expect(extractLogParserFromDataFrameMock).not.toHaveBeenCalled();
-    });
-
-    it('calls dataSample with correct default maxLines', async () => {
-      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-
-      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys: [],
-        unwrapLabelKeys: [],
-        structuredMetadataKeys: [],
-        hasJSON: false,
-        hasLogfmt: false,
-        hasPack: false,
-      });
-      expect(datasource.getDataSamples).toHaveBeenCalledWith(
-        {
-          expr: '{place="luna"}',
-          maxLines: DEFAULT_MAX_LINES_SAMPLE,
-          refId: 'data-samples',
-        },
-        // We are not interested in the time range here
-        expect.any(Object)
-      );
-    });
-
-    it('calls dataSample with correctly set sampleSize', async () => {
-      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-
-      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}', { maxLines: 5 })).toEqual({
-        extractedLabelKeys: [],
-        unwrapLabelKeys: [],
-        structuredMetadataKeys: [],
-        hasJSON: false,
-        hasLogfmt: false,
-        hasPack: false,
-      });
-      expect(datasource.getDataSamples).toHaveBeenCalledWith(
-        {
-          expr: '{place="luna"}',
-          maxLines: 5,
-          refId: 'data-samples',
-        },
-        // We are not interested in the time range here
-        expect.any(Object)
-      );
-    });
-
-    it('calls dataSample with correctly set time range', async () => {
-      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-      languageProvider.getParserAndLabelKeys('{place="luna"}', { timeRange: mockTimeRange });
-      expect(datasource.getDataSamples).toHaveBeenCalledWith(
-        {
-          expr: '{place="luna"}',
-          maxLines: 10,
-          refId: 'data-samples',
-        },
-        mockTimeRange
-      );
     });
   });
 });
@@ -829,9 +972,17 @@ async function getLanguageProvider(datasource: LokiDatasource, start = true) {
   return instance;
 }
 
+type SetupOptions = {
+  /** When true, the `detected_labels` probe succeeds and label/parser flows use detected_* APIs. */
+  detectedEndpointsSupported?: boolean;
+  /** Optional body for `detected_fields` when composing metadata mocks (e.g. parser/label key tests). */
+  detectedFieldsResponse?: DetectedFieldsResult;
+};
+
 function setup(
   labelsAndValues: Record<string, string[]>,
-  series?: Record<string, Array<Record<string, string>>>
+  series?: Record<string, Array<Record<string, string>>>,
+  options?: SetupOptions
 ): LokiDatasource {
   const datasource = createLokiDatasource();
 
@@ -841,7 +992,21 @@ function setup(
   };
 
   jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue(rangeMock);
-  jest.spyOn(datasource, 'metadataRequest').mockImplementation(createMetadataRequest(labelsAndValues, series));
+  const baseRequest = createMetadataRequest(labelsAndValues, series);
+  jest
+    .spyOn(datasource, 'metadataRequest')
+    .mockImplementation(async (url: string, params?: Record<string, string | number>) => {
+      if (url === 'detected_labels') {
+        if (options?.detectedEndpointsSupported) {
+          return Object.keys(labelsAndValues).map((label) => ({ label }));
+        }
+        return null;
+      }
+      if (url === 'detected_fields' && options?.detectedFieldsResponse !== undefined) {
+        return options.detectedFieldsResponse;
+      }
+      return baseRequest(url, params);
+    });
   jest.spyOn(datasource, 'interpolateString').mockImplementation((string: string) => string);
 
   return datasource;

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -437,7 +437,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
       expect(labelValues).toEqual(expectedResponse);
     });
     it('should return values', async () => {
@@ -450,7 +450,7 @@ describe('Language completion provider', () => {
 
       const nextLabelValues = await provider.fetchDetectedFields(options);
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
       expect(nextLabelValues).toEqual(expectedResponse);
     });
     it('should encode special characters', async () => {
@@ -458,7 +458,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, true, undefined);
+      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, false, undefined);
     });
   });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -28,69 +28,34 @@ const mockTimeRange = {
 
 describe('Language completion provider', () => {
   describe('start', () => {
-    describe('when detectedEndpointsSupported is false (detected_labels returns non-array)', () => {
-      let datasource: LokiDatasource;
+    const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
 
-      beforeEach(() => {
-        datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
-      });
-
-      it('should complete start after probe without calling fetchLabels', async () => {
-        const languageProvider = new LanguageProvider(datasource);
-        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
-        const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
-        await languageProvider.start();
-        expect(languageProvider.started).toBe(true);
-        expect(
-          metadataSpy.mock.calls.filter(
-            (call) =>
-              call[0] === 'detected_labels' && call[1]?.start === 1560153109000 && call[1]?.end === 1560163909000
-          )
-        ).toHaveLength(1);
-        expect(fetchSpy).not.toHaveBeenCalled();
-      });
-
-      it('should not re-run detected_labels probe on second start with same time range', async () => {
-        const languageProvider = new LanguageProvider(datasource);
-        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
-        await languageProvider.start();
-        await languageProvider.start();
-        expect(metadataSpy.mock.calls.filter((call) => call[0] === 'detected_labels')).toHaveLength(1);
-      });
-
-      it('should not re-run detected_labels probe when time range changes (probe result already cached)', async () => {
-        const languageProvider = new LanguageProvider(datasource);
-        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
-        await languageProvider.start();
-        jest.mocked(datasource.getTimeRangeParams).mockRestore();
-        jest.spyOn(datasource, 'getTimeRangeParams').mockImplementation((range: TimeRange) => ({
-          start: range.from.valueOf(),
-          end: range.to.valueOf(),
-        }));
-        await languageProvider.start(mockTimeRange);
-        await languageProvider.start(mockTimeRange);
-        expect(metadataSpy.mock.calls.filter((call) => call[0] === 'detected_labels')).toHaveLength(1);
-      });
+    it('should fetch labels on initial start', async () => {
+      const languageProvider = new LanguageProvider(datasource);
+      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalled();
     });
 
-    describe('when detectedEndpointsSupported is true', () => {
-      let datasource: LokiDatasource;
+    it('should not again fetch labels on second start', async () => {
+      const languageProvider = new LanguageProvider(datasource);
+      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
 
-      beforeEach(() => {
-        datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] }, undefined, {
-          detectedEndpointsSupported: true,
-        });
-      });
-
-      it('should not call fetchLabels on start when detected_labels probe succeeds', async () => {
-        const languageProvider = new LanguageProvider(datasource);
-        const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
-        const metadataSpy = jest.spyOn(datasource, 'metadataRequest');
-        await languageProvider.start();
-        expect(languageProvider.started).toBe(true);
-        expect(fetchSpy).not.toHaveBeenCalled();
-        expect(metadataSpy.mock.calls.some((call) => call[0] === 'detected_labels')).toBe(true);
-      });
+    it('should again fetch labels on second start with different timerange', async () => {
+      const languageProvider = new LanguageProvider(datasource);
+      jest.mocked(datasource.getTimeRangeParams).mockRestore();
+      const fetchSpy = jest.spyOn(languageProvider, 'fetchLabels').mockResolvedValue([]);
+      await languageProvider.start();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await languageProvider.start(mockTimeRange);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      await languageProvider.start(mockTimeRange);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -181,7 +146,6 @@ describe('Language completion provider', () => {
   });
 
   describe('fetchLabelValues', () => {
-    // getLanguageProvider runs start(); setup() makes detected_labels return non-array so detectedEndpointsSupported is false.
     it('should fetch label values if not cached', async () => {
       const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
@@ -439,26 +403,29 @@ describe('Language completion provider', () => {
       throwError: true,
     };
 
-    const expectedResponse: DetectedFieldsResult = [
-      {
-        label: 'bytes',
-        type: 'bytes',
-        cardinality: 6,
-        parsers: ['logfmt'],
-      },
-      {
-        label: 'traceID',
-        type: 'string',
-        cardinality: 50,
-        parsers: null,
-      },
-      {
-        label: 'active_series',
-        type: 'int',
-        cardinality: 8,
-        parsers: ['logfmt'],
-      },
-    ];
+    const expectedResponse: DetectedFieldsResult = {
+      fields: [
+        {
+          label: 'bytes',
+          type: 'bytes',
+          cardinality: 6,
+          parsers: ['logfmt'],
+        },
+        {
+          label: 'traceID',
+          type: 'string',
+          cardinality: 50,
+          parsers: null,
+        },
+        {
+          label: 'active_series',
+          type: 'int',
+          cardinality: 8,
+          parsers: ['logfmt'],
+        },
+      ],
+      limit: 999,
+    };
 
     const datasource = detectedFieldsSetup(expectedResponse, {
       end: mockTimeRange.to.valueOf(),
@@ -470,7 +437,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
       expect(labelValues).toEqual(expectedResponse);
     });
     it('should return values', async () => {
@@ -483,7 +450,7 @@ describe('Language completion provider', () => {
 
       const nextLabelValues = await provider.fetchDetectedFields(options);
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, false, undefined);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_fields`, expectedOptions, true, undefined);
       expect(nextLabelValues).toEqual(expectedResponse);
     });
     it('should encode special characters', async () => {
@@ -491,190 +458,139 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       await provider.fetchDetectedFields(options);
 
-      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, false, undefined);
+      expect(requestSpy).toHaveBeenCalledWith('detected_fields', expectedOptions, true, undefined);
     });
   });
 
   describe('fetchLabels', () => {
-    describe('when detectedEndpointsSupported is false (default / no start)', () => {
-      it('should return labels', async () => {
-        const datasourceWithLabels = setup({ other: [] });
+    it('should return labels', async () => {
+      const datasourceWithLabels = setup({ other: [] });
 
-        const instance = new LanguageProvider(datasourceWithLabels);
-        const labels = await instance.fetchLabels();
-        expect(labels).toEqual(['other']);
+      const instance = new LanguageProvider(datasourceWithLabels);
+      const labels = await instance.fetchLabels();
+      expect(labels).toEqual(['other']);
+    });
+
+    it('should set labels', async () => {
+      const datasourceWithLabels = setup({ other: [] });
+
+      const instance = new LanguageProvider(datasourceWithLabels);
+      await instance.fetchLabels();
+      expect(instance.labelKeys).toEqual(['other']);
+    });
+
+    it('should return empty array', async () => {
+      const datasourceWithLabels = setup({});
+
+      const instance = new LanguageProvider(datasourceWithLabels);
+      const labels = await instance.fetchLabels();
+      expect(labels).toEqual([]);
+    });
+
+    it('should set empty array', async () => {
+      const datasourceWithLabels = setup({});
+
+      const instance = new LanguageProvider(datasourceWithLabels);
+      await instance.fetchLabels();
+      expect(instance.labelKeys).toEqual([]);
+    });
+
+    it('should use time range param', async () => {
+      const datasourceWithLabels = setup({});
+      datasourceWithLabels.languageProvider.request = jest.fn();
+
+      const instance = new LanguageProvider(datasourceWithLabels);
+      instance.request = jest.fn();
+      await instance.fetchLabels({ timeRange: mockTimeRange });
+      expect(instance.request).toHaveBeenCalledWith('labels', datasourceWithLabels.getTimeRangeParams(mockTimeRange));
+    });
+
+    describe('without labelNames feature toggle', () => {
+      const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
+      beforeAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = false;
+      });
+      afterAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
       });
 
-      it('should set labels', async () => {
-        const datasourceWithLabels = setup({ other: [] });
-
-        const instance = new LanguageProvider(datasourceWithLabels);
-        await instance.fetchLabels();
-        expect(instance.labelKeys).toEqual(['other']);
-      });
-
-      it('should return empty array', async () => {
-        const datasourceWithLabels = setup({});
-
-        const instance = new LanguageProvider(datasourceWithLabels);
-        const labels = await instance.fetchLabels();
-        expect(labels).toEqual([]);
-      });
-
-      it('should set empty array', async () => {
-        const datasourceWithLabels = setup({});
-
-        const instance = new LanguageProvider(datasourceWithLabels);
-        await instance.fetchLabels();
-        expect(instance.labelKeys).toEqual([]);
-      });
-
-      it('should use time range param', async () => {
+      it('should use series endpoint for request with stream selector', async () => {
         const datasourceWithLabels = setup({});
         datasourceWithLabels.languageProvider.request = jest.fn();
 
         const instance = new LanguageProvider(datasourceWithLabels);
         instance.request = jest.fn();
-        await instance.fetchLabels({ timeRange: mockTimeRange });
-        expect(instance.request).toHaveBeenCalledWith('labels', datasourceWithLabels.getTimeRangeParams(mockTimeRange));
-      });
-
-      describe('without labelNames feature toggle', () => {
-        const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
-        beforeAll(() => {
-          config.featureToggles.lokiLabelNamesQueryApi = false;
+        await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
+        expect(instance.request).toHaveBeenCalledWith('series', {
+          end: 1560163909000,
+          'match[]': '{foo="bar"}',
+          start: 1560153109000,
         });
-        afterAll(() => {
-          config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
-        });
-
-        it('should use series endpoint for request with stream selector', async () => {
-          const datasourceWithLabels = setup({});
-          datasourceWithLabels.languageProvider.request = jest.fn();
-
-          const instance = new LanguageProvider(datasourceWithLabels);
-          instance.request = jest.fn();
-          await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
-          expect(instance.request).toHaveBeenCalledWith('series', {
-            end: 1560163909000,
-            'match[]': '{foo="bar"}',
-            start: 1560153109000,
-          });
-        });
-      });
-
-      describe('with labelNames feature toggle', () => {
-        const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
-        beforeAll(() => {
-          config.featureToggles.lokiLabelNamesQueryApi = true;
-        });
-        afterAll(() => {
-          config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
-        });
-
-        it('should exclude empty vector selector', async () => {
-          const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
-
-          const instance = new LanguageProvider(datasourceWithLabels);
-          instance.request = jest.fn();
-          await instance.fetchLabels({ streamSelector: '{}' });
-          expect(instance.request).toBeCalledWith('labels', { end: 1560163909000, start: 1560153109000 });
-        });
-
-        it('should use series endpoint for request with stream selector', async () => {
-          const datasourceWithLabels = setup({});
-          datasourceWithLabels.languageProvider.request = jest.fn();
-
-          const instance = new LanguageProvider(datasourceWithLabels);
-          instance.request = jest.fn();
-          await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
-          expect(instance.request).toHaveBeenCalledWith('labels', {
-            end: 1560163909000,
-            query: '{foo="bar"}',
-            start: 1560153109000,
-          });
-        });
-
-        it('should interpolate variables in stream selector', async () => {
-          const datasource = setup({});
-          jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue({ start: 0, end: 1 });
-          jest
-            .spyOn(datasource, 'interpolateString')
-            .mockImplementation((string: string) => string.replace(/\$test_var/g, 'age'));
-
-          const languageProvider = new LanguageProvider(datasource);
-          languageProvider.request = jest.fn().mockResolvedValue([]);
-          await languageProvider.fetchLabels({ streamSelector: '{age="new", $test_var="new"}' });
-          expect(languageProvider.request).toHaveBeenCalledWith('labels', {
-            end: 1,
-            query: '{age="new", age="new"}',
-            start: 0,
-          });
-        });
-      });
-
-      it('should filter internal labels', async () => {
-        const datasourceWithLabels = setup({
-          foo: [],
-          bar: [],
-          __name__: [],
-          __stream_shard__: [],
-          __aggregated_metric__: [],
-        });
-
-        const instance = new LanguageProvider(datasourceWithLabels);
-        const labels = await instance.fetchLabels();
-        expect(labels).toEqual(['__name__', 'bar', 'foo']);
       });
     });
 
-    describe('when detectedEndpointsSupported is true', () => {
-      it('should fetch label names via detected_labels', async () => {
-        const datasourceWithLabels = setup({ alpha: [], zed: [] }, undefined, { detectedEndpointsSupported: true });
-        const instance = new LanguageProvider(datasourceWithLabels);
-        await instance.start();
-        const requestSpy = jest.spyOn(instance, 'request');
-        const labels = await instance.fetchLabels();
-        expect(requestSpy).toHaveBeenCalledWith(
-          'detected_labels',
-          { start: 1560153109000, end: 1560163909000 },
-          true,
-          undefined
-        );
-        expect(labels).toEqual(['alpha', 'zed']);
+    describe('with labelNames feature toggle', () => {
+      const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
+      beforeAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = true;
+      });
+      afterAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
       });
 
-      it('should pass stream selector as query to detected_labels', async () => {
-        const datasourceWithLabels = setup({ job: [] }, undefined, { detectedEndpointsSupported: true });
+      it('should exclude empty vector selector', async () => {
+        const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
+
         const instance = new LanguageProvider(datasourceWithLabels);
-        await instance.start();
-        const requestSpy = jest.spyOn(instance, 'request');
+        instance.request = jest.fn();
+        await instance.fetchLabels({ streamSelector: '{}' });
+        expect(instance.request).toBeCalledWith('labels', { end: 1560163909000, start: 1560153109000 });
+      });
+
+      it('should use series endpoint for request with stream selector', async () => {
+        const datasourceWithLabels = setup({});
+        datasourceWithLabels.languageProvider.request = jest.fn();
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        instance.request = jest.fn();
         await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
-        expect(requestSpy).toHaveBeenCalledWith(
-          'detected_labels',
-          { start: 1560153109000, end: 1560163909000, query: '{foo="bar"}' },
-          true,
-          undefined
-        );
+        expect(instance.request).toHaveBeenCalledWith('labels', {
+          end: 1560163909000,
+          query: '{foo="bar"}',
+          start: 1560153109000,
+        });
       });
 
-      it('should use time range when calling detected_labels', async () => {
-        const datasourceWithLabels = setup({ other: [] }, undefined, { detectedEndpointsSupported: true });
-        datasourceWithLabels.getTimeRangeParams = jest
-          .fn()
-          .mockImplementation((range: TimeRange) => ({ start: range.from.valueOf(), end: range.to.valueOf() }));
-        const instance = new LanguageProvider(datasourceWithLabels);
-        await instance.start();
-        const requestSpy = jest.spyOn(instance, 'request');
-        await instance.fetchLabels({ timeRange: mockTimeRange });
-        expect(datasourceWithLabels.getTimeRangeParams).toHaveBeenCalledWith(mockTimeRange);
-        expect(requestSpy).toHaveBeenCalledWith(
-          'detected_labels',
-          { start: mockTimeRange.from.valueOf(), end: mockTimeRange.to.valueOf() },
-          true,
-          undefined
-        );
+      it('should interpolate variables in stream selector', async () => {
+        const datasource = setup({});
+        jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue({ start: 0, end: 1 });
+        jest
+          .spyOn(datasource, 'interpolateString')
+          .mockImplementation((string: string) => string.replace(/\$test_var/g, 'age'));
+
+        const languageProvider = new LanguageProvider(datasource);
+        languageProvider.request = jest.fn().mockResolvedValue([]);
+        await languageProvider.fetchLabels({ streamSelector: '{age="new", $test_var="new"}' });
+        expect(languageProvider.request).toHaveBeenCalledWith('labels', {
+          end: 1,
+          query: '{age="new", age="new"}',
+          start: 0,
+        });
       });
+    });
+
+    it('should filter internal labels', async () => {
+      const datasourceWithLabels = setup({
+        foo: [],
+        bar: [],
+        __name__: [],
+        __stream_shard__: [],
+        __aggregated_metric__: [],
+      });
+
+      const instance = new LanguageProvider(datasourceWithLabels);
+      const labels = await instance.fetchLabels();
+      expect(labels).toEqual(['__name__', 'bar', 'foo']);
     });
   });
 });
@@ -779,184 +695,128 @@ describe('Query imports', () => {
   });
 
   describe('getParserAndLabelKeys()', () => {
-    describe('when detectedEndpointsSupported is false', () => {
-      let datasource: LokiDatasource, languageProvider: LanguageProvider;
-      const extractLogParserFromDataFrameMock = jest.mocked(extractLogParserFromDataFrame);
-      const extractedLabelKeys = ['extracted', 'label'];
-      const structuredMetadataKeys = ['structured', 'metadata'];
-      const parsedKeys = ['parsed', 'label'];
-      const unwrapLabelKeys = ['unwrap', 'labels'];
+    let datasource: LokiDatasource, languageProvider: LanguageProvider;
+    const extractLogParserFromDataFrameMock = jest.mocked(extractLogParserFromDataFrame);
+    const extractedLabelKeys = ['extracted', 'label'];
+    const structuredMetadataKeys = ['structured', 'metadata'];
+    const parsedKeys = ['parsed', 'label'];
+    const unwrapLabelKeys = ['unwrap', 'labels'];
 
-      beforeEach(() => {
-        datasource = createLokiDatasource();
-        languageProvider = new LanguageProvider(datasource);
-        jest.mocked(extractLabelKeysFromDataFrame).mockImplementation((_, type) => {
-          if (type === LabelType.Indexed || !type) {
-            return extractedLabelKeys;
-          } else if (type === LabelType.StructuredMetadata) {
-            return structuredMetadataKeys;
-          } else if (type === LabelType.Parsed) {
-            return parsedKeys;
-          } else {
-            return [];
-          }
-        });
-        jest.mocked(extractUnwrapLabelKeysFromDataFrame).mockReturnValue(unwrapLabelKeys);
+    beforeEach(() => {
+      datasource = createLokiDatasource();
+      languageProvider = new LanguageProvider(datasource);
+      jest.mocked(extractLabelKeysFromDataFrame).mockImplementation((_, type) => {
+        if (type === LabelType.Indexed || !type) {
+          return extractedLabelKeys;
+        } else if (type === LabelType.StructuredMetadata) {
+          return structuredMetadataKeys;
+        } else if (type === LabelType.Parsed) {
+          return parsedKeys;
+        } else {
+          return [];
+        }
       });
+      jest.mocked(extractUnwrapLabelKeysFromDataFrame).mockReturnValue(unwrapLabelKeys);
+    });
 
-      it('identifies selectors with JSON parser data', async () => {
-        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
-        extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: false, hasJSON: true, hasPack: false });
+    it('identifies selectors with JSON parser data', async () => {
+      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
+      extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: false, hasJSON: true, hasPack: false });
 
-        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-          extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
-          unwrapLabelKeys,
-          structuredMetadataKeys,
-          hasJSON: true,
-          hasLogfmt: false,
-          hasPack: false,
-        });
-      });
-
-      it('identifies selectors with Logfmt parser data', async () => {
-        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
-        extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: true, hasJSON: false, hasPack: false });
-
-        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-          extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
-          unwrapLabelKeys,
-          structuredMetadataKeys,
-          hasJSON: false,
-          hasLogfmt: true,
-          hasPack: false,
-        });
-      });
-
-      it('correctly processes empty data', async () => {
-        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-        extractLogParserFromDataFrameMock.mockClear();
-
-        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-          extractedLabelKeys: [],
-          unwrapLabelKeys: [],
-          structuredMetadataKeys: [],
-          hasJSON: false,
-          hasLogfmt: false,
-          hasPack: false,
-        });
-        expect(extractLogParserFromDataFrameMock).not.toHaveBeenCalled();
-      });
-
-      it('calls dataSample with correct default maxLines', async () => {
-        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-
-        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-          extractedLabelKeys: [],
-          unwrapLabelKeys: [],
-          structuredMetadataKeys: [],
-          hasJSON: false,
-          hasLogfmt: false,
-          hasPack: false,
-        });
-        expect(datasource.getDataSamples).toHaveBeenCalledWith(
-          {
-            expr: '{place="luna"}',
-            maxLines: DEFAULT_MAX_LINES_SAMPLE,
-            refId: 'data-samples',
-          },
-          // We are not interested in the time range here
-          expect.any(Object)
-        );
-      });
-
-      it('calls dataSample with correctly set sampleSize', async () => {
-        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-
-        expect(await languageProvider.getParserAndLabelKeys('{place="luna"}', { maxLines: 5 })).toEqual({
-          extractedLabelKeys: [],
-          unwrapLabelKeys: [],
-          structuredMetadataKeys: [],
-          hasJSON: false,
-          hasLogfmt: false,
-          hasPack: false,
-        });
-        expect(datasource.getDataSamples).toHaveBeenCalledWith(
-          {
-            expr: '{place="luna"}',
-            maxLines: 5,
-            refId: 'data-samples',
-          },
-          // We are not interested in the time range here
-          expect.any(Object)
-        );
-      });
-
-      it('calls dataSample with correctly set time range', async () => {
-        jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
-        languageProvider.getParserAndLabelKeys('{place="luna"}', { timeRange: mockTimeRange });
-        expect(datasource.getDataSamples).toHaveBeenCalledWith(
-          {
-            expr: '{place="luna"}',
-            maxLines: 10,
-            refId: 'data-samples',
-          },
-          mockTimeRange
-        );
+      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+        extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
+        unwrapLabelKeys,
+        structuredMetadataKeys,
+        hasJSON: true,
+        hasLogfmt: false,
+        hasPack: false,
       });
     });
 
-    describe('when detectedEndpointsSupported is true', () => {
-      const detectedFieldsSample: DetectedFieldsResult = [
-        { label: 'msg', type: 'string', cardinality: 1, parsers: ['json'] },
-        { label: 'cnt', type: 'int', cardinality: 2, parsers: ['logfmt'] },
-        { label: 'trace', type: 'string', cardinality: 3, parsers: null },
-        { label: '_entry', type: 'string', cardinality: 4, parsers: null },
-      ];
+    it('identifies selectors with Logfmt parser data', async () => {
+      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([{}] as DataFrame[]);
+      extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: true, hasJSON: false, hasPack: false });
 
-      it('derives parser and label keys from detected_fields instead of getDataSamples', async () => {
-        const ds = setup({}, undefined, {
-          detectedEndpointsSupported: true,
-          detectedFieldsResponse: detectedFieldsSample,
-        });
-        jest.spyOn(ds, 'getDataSamples');
-        const lp = new LanguageProvider(ds);
-        await lp.start();
-
-        expect(await lp.getParserAndLabelKeys('{job="grafana"}')).toEqual({
-          extractedLabelKeys: ['msg', 'cnt', 'trace', '_entry'],
-          structuredMetadataKeys: ['trace', '_entry'],
-          unwrapLabelKeys: ['cnt'],
-          hasJSON: true,
-          hasLogfmt: true,
-          hasPack: true,
-        });
-        expect(ds.getDataSamples).not.toHaveBeenCalled();
+      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+        extractedLabelKeys: [...extractedLabelKeys, ...parsedKeys],
+        unwrapLabelKeys,
+        structuredMetadataKeys,
+        hasJSON: false,
+        hasLogfmt: true,
+        hasPack: false,
       });
+    });
 
-      it('passes maxLines as limit to detected_fields', async () => {
-        const ds = setup({}, undefined, {
-          detectedEndpointsSupported: true,
-          detectedFieldsResponse: detectedFieldsSample,
-        });
-        ds.getTimeRangeParams = jest
-          .fn()
-          .mockImplementation((range: TimeRange) => ({ start: range.from.valueOf(), end: range.to.valueOf() }));
-        const lp = new LanguageProvider(ds);
-        await lp.start();
-        const requestSpy = jest.spyOn(lp, 'request');
-        await lp.getParserAndLabelKeys('{job="grafana"}', { maxLines: 5, timeRange: mockTimeRange });
-        expect(requestSpy).toHaveBeenCalledWith(
-          'detected_fields',
-          {
-            start: mockTimeRange.from.valueOf(),
-            end: mockTimeRange.to.valueOf(),
-            limit: 5,
-            query: '{job="grafana"}',
-          },
-          false,
-          { showErrorAlert: false, showSuccessAlert: false }
-        );
+    it('correctly processes empty data', async () => {
+      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+      extractLogParserFromDataFrameMock.mockClear();
+
+      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+        extractedLabelKeys: [],
+        unwrapLabelKeys: [],
+        structuredMetadataKeys: [],
+        hasJSON: false,
+        hasLogfmt: false,
+        hasPack: false,
       });
+      expect(extractLogParserFromDataFrameMock).not.toHaveBeenCalled();
+    });
+
+    it('calls dataSample with correct default maxLines', async () => {
+      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+
+      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
+        extractedLabelKeys: [],
+        unwrapLabelKeys: [],
+        structuredMetadataKeys: [],
+        hasJSON: false,
+        hasLogfmt: false,
+        hasPack: false,
+      });
+      expect(datasource.getDataSamples).toHaveBeenCalledWith(
+        {
+          expr: '{place="luna"}',
+          maxLines: DEFAULT_MAX_LINES_SAMPLE,
+          refId: 'data-samples',
+        },
+        // We are not interested in the time range here
+        expect.any(Object)
+      );
+    });
+
+    it('calls dataSample with correctly set sampleSize', async () => {
+      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+
+      expect(await languageProvider.getParserAndLabelKeys('{place="luna"}', { maxLines: 5 })).toEqual({
+        extractedLabelKeys: [],
+        unwrapLabelKeys: [],
+        structuredMetadataKeys: [],
+        hasJSON: false,
+        hasLogfmt: false,
+        hasPack: false,
+      });
+      expect(datasource.getDataSamples).toHaveBeenCalledWith(
+        {
+          expr: '{place="luna"}',
+          maxLines: 5,
+          refId: 'data-samples',
+        },
+        // We are not interested in the time range here
+        expect.any(Object)
+      );
+    });
+
+    it('calls dataSample with correctly set time range', async () => {
+      jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
+      languageProvider.getParserAndLabelKeys('{place="luna"}', { timeRange: mockTimeRange });
+      expect(datasource.getDataSamples).toHaveBeenCalledWith(
+        {
+          expr: '{place="luna"}',
+          maxLines: 10,
+          refId: 'data-samples',
+        },
+        mockTimeRange
+      );
     });
   });
 });
@@ -969,17 +829,9 @@ async function getLanguageProvider(datasource: LokiDatasource, start = true) {
   return instance;
 }
 
-type SetupOptions = {
-  /** When true, the `detected_labels` probe succeeds and label/parser flows use detected_* APIs. */
-  detectedEndpointsSupported?: boolean;
-  /** Optional body for `detected_fields` when composing metadata mocks (e.g. parser/label key tests). */
-  detectedFieldsResponse?: DetectedFieldsResult;
-};
-
 function setup(
   labelsAndValues: Record<string, string[]>,
-  series?: Record<string, Array<Record<string, string>>>,
-  options?: SetupOptions
+  series?: Record<string, Array<Record<string, string>>>
 ): LokiDatasource {
   const datasource = createLokiDatasource();
 
@@ -989,21 +841,7 @@ function setup(
   };
 
   jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue(rangeMock);
-  const baseRequest = createMetadataRequest(labelsAndValues, series);
-  jest
-    .spyOn(datasource, 'metadataRequest')
-    .mockImplementation(async (url: string, params?: Record<string, string | number>) => {
-      if (url === 'detected_labels') {
-        if (options?.detectedEndpointsSupported) {
-          return Object.keys(labelsAndValues).map((label) => ({ label }));
-        }
-        return null;
-      }
-      if (url === 'detected_fields' && options?.detectedFieldsResponse !== undefined) {
-        return options.detectedFieldsResponse;
-      }
-      return baseRequest(url, params);
-    });
+  jest.spyOn(datasource, 'metadataRequest').mockImplementation(createMetadataRequest(labelsAndValues, series));
   jest.spyOn(datasource, 'interpolateString').mockImplementation((string: string) => string);
 
   return datasource;

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -403,29 +403,26 @@ describe('Language completion provider', () => {
       throwError: true,
     };
 
-    const expectedResponse: DetectedFieldsResult = {
-      fields: [
-        {
-          label: 'bytes',
-          type: 'bytes',
-          cardinality: 6,
-          parsers: ['logfmt'],
-        },
-        {
-          label: 'traceID',
-          type: 'string',
-          cardinality: 50,
-          parsers: null,
-        },
-        {
-          label: 'active_series',
-          type: 'int',
-          cardinality: 8,
-          parsers: ['logfmt'],
-        },
-      ],
-      limit: 999,
-    };
+    const expectedResponse: DetectedFieldsResult = [
+      {
+        label: 'bytes',
+        type: 'bytes',
+        cardinality: 6,
+        parsers: ['logfmt'],
+      },
+      {
+        label: 'traceID',
+        type: 'string',
+        cardinality: 50,
+        parsers: null,
+      },
+      {
+        label: 'active_series',
+        type: 'int',
+        cardinality: 8,
+        parsers: ['logfmt'],
+      },
+    ];
 
     const datasource = detectedFieldsSetup(expectedResponse, {
       end: mockTimeRange.to.valueOf(),

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -57,6 +57,46 @@ describe('Language completion provider', () => {
       await languageProvider.start(mockTimeRange);
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
+
+    it('should probe detected_labels on start and use it when fetching labels', async () => {
+      const rangeMock = { start: 1560153109000, end: 1560163909000 };
+      const detectedDatasource = createLokiDatasource();
+      jest.spyOn(detectedDatasource, 'getTimeRangeParams').mockReturnValue(rangeMock);
+      jest.spyOn(detectedDatasource, 'interpolateString').mockImplementation((s: string) => s);
+
+      const detectedLabelsResponse = [{ label: 'service' }, { label: 'job' }];
+      const metadataSpy = jest.spyOn(detectedDatasource, 'metadataRequest').mockImplementation(async (url, params) => {
+        if (url === 'detected_labels') {
+          return detectedLabelsResponse;
+        }
+        throw new Error(`Unexpected url: ${url}`);
+      });
+
+      const languageProvider = new LanguageProvider(detectedDatasource);
+      const fetchLabelsSpy = jest.spyOn(languageProvider, 'fetchLabels');
+
+      await languageProvider.start();
+
+      expect(fetchLabelsSpy).not.toHaveBeenCalled();
+      expect(metadataSpy).toHaveBeenCalledWith(
+        'detected_labels',
+        { start: rangeMock.start, end: rangeMock.end },
+        expect.objectContaining({ showErrorAlert: false, showSuccessAlert: false })
+      );
+      expect(languageProvider.started).toBe(true);
+      expect(languageProvider.getLabelKeys()).toEqual(['service', 'job']);
+
+      const labels = await languageProvider.fetchLabels();
+      expect(labels).toEqual(['job', 'service']);
+      expect(metadataSpy).toHaveBeenCalledTimes(2);
+      expect(metadataSpy).toHaveBeenNthCalledWith(
+        2,
+        'detected_labels',
+        { start: rangeMock.start, end: rangeMock.end },
+        undefined
+      );
+      expect(languageProvider.labelKeys).toEqual(['job', 'service']);
+    });
   });
 
   describe('fetchSeries', () => {

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -363,7 +363,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
     params.query = interpolatedExpr;
 
     try {
-      const data = await this.request(url, params, false, requestOptions);
+      const data = await this.request(url, params, true, requestOptions);
       return data;
     } catch (error) {
       console.error('error', error);

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -7,7 +7,7 @@ import { BackendSrvRequest, config } from '@grafana/runtime';
 import { LokiQueryType } from './dataquery.gen';
 import { DEFAULT_MAX_LINES_SAMPLE, LokiDatasource } from './datasource';
 import { abstractQueryToExpr, mapAbstractOperatorsToOp, processLabels } from './languageUtils';
-import { getStreamSelectorsFromQuery } from './queryUtils';
+import { getStreamSelectorsFromQuery, isQueryWithError } from './queryUtils';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 import {
   extractLabelKeysFromDataFrame,
@@ -297,7 +297,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
     try {
       const data = await this.request('detected_labels', params, true, requestOptions);
       if (Array.isArray(data)) {
-        return data;
+        this.labelKeys = data.map((label) => label.label);
+        return this.labelKeys;
       }
     } catch (error) {
       console.error('error', error);
@@ -326,7 +327,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
       scopedVars?: ScopedVars;
     },
     requestOptions?: Partial<BackendSrvRequest>
-  ): Promise<DetectedFieldsResult | Error> {
+  ): Promise<DetectedFieldsResult> {
+    console.log(queryOptions);
     const interpolatedExpr =
       queryOptions.expr && queryOptions.expr !== EMPTY_SELECTOR
         ? this.datasource.interpolateString(queryOptions.expr, queryOptions.scopedVars)
@@ -336,6 +338,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
       throw new Error('fetchDetectedFields requires query expression');
     }
 
+    if (isQueryWithError(interpolatedExpr)) {
+      console.error('fetchDetectedFields: invalid query');
+      return [];
+    }
+
     const url = `detected_fields`;
     const range = queryOptions?.timeRange ?? this.getDefaultTimeRange();
     const rangeParams = this.datasource.getTimeRangeParams(range);
@@ -343,15 +350,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const params: KeyValue<string | number> = { start, end, limit: queryOptions?.limit ?? 1000 };
     params.query = interpolatedExpr;
 
-    return new Promise(async (resolve, reject) => {
-      try {
-        const data = await this.request(url, params, true, requestOptions);
-        resolve(data);
-      } catch (error) {
-        console.error('error', error);
-        reject(error);
-      }
-    });
+    try {
+      const data = await this.request(url, params, false, requestOptions);
+      return data;
+    } catch (error) {
+      console.error('error', error);
+    }
+    return [];
   }
 
   async fetchDetectedFieldValues(
@@ -599,7 +604,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       hasLogfmt: false,
     };
 
-    if (fields instanceof Error) {
+    if (!Array.isArray(fields)) {
       return response;
     }
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -93,11 +93,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
   /**
    * Probes whether the `detected_labels` metadata API exists. Runs at most once per language provider instance.
    */
-  private attemptDetectedEndpointsStart(timeRange: TimeRange) {
+  private async attemptDetectedEndpointsStart(timeRange: TimeRange) {
     if (this.detectedEndpointsSupported === undefined) {
-      return this.checkDetectedLabelsExists(timeRange);
+      await this.checkDetectedLabelsExists(timeRange);
     }
-    return Promise.resolve(this.detectedEndpointsSupported);
+    if (this.detectedEndpointsSupported === false) {
+      await this.fetchLabels({ timeRange });
+    }
   }
 
   private async checkDetectedLabelsExists(timeRange: TimeRange): Promise<void> {
@@ -110,7 +112,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
       this.detectedEndpointsSupported = Array.isArray(res);
     } catch (e) {
       this.detectedEndpointsSupported = false;
-      await this.fetchLabels({ timeRange });
     }
   }
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -307,7 +307,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
     try {
       const data = await this.request('detected_labels', params, true, requestOptions);
       if (Array.isArray(data)) {
-        this.labelKeys = data.map((label) => label.label);
+        this.labelKeys = data
+          .map((label) => label.label)
+          .sort()
+          .filter((label: string) => HIDDEN_LABELS.includes(label) === false);
         return this.labelKeys;
       }
     } catch (error) {

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -26,6 +26,9 @@ export default class LokiLanguageProvider extends LanguageProvider {
   startedTimeRange?: TimeRange;
   datasource: LokiDatasource;
 
+  /** True when the Loki `detected_labels` and `detected_fields` endpoints are available (probed once in {@link LokiLanguageProvider.start}). */
+  private detectedEndpointsSupported?: boolean;
+
   /**
    *  Cache for labels of series. This is bit simplistic in the sense that it just counts responses each as a 1 and does
    *  not account for different size of a response. If that is needed a `length` function can be added in the options.
@@ -78,7 +81,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       newRangeParams.end !== prevRangeParams.end
     ) {
       this.startedTimeRange = range;
-      this.startTask = this.fetchLabels({ timeRange: range }).then(() => {
+      this.startTask = this.attemptDetectedEndpointsStart(range).then(() => {
         this.started = true;
         return [];
       });
@@ -86,6 +89,27 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
     return this.startTask;
   };
+
+  /**
+   * Probes whether the `detected_labels` metadata API exists. Runs at most once per language provider instance.
+   */
+  private attemptDetectedEndpointsStart(timeRange: TimeRange) {
+    if (this.detectedEndpointsSupported === undefined) {
+      return this.checkDetectedLabelsExists(timeRange);
+    }
+    return Promise.resolve(this.detectedEndpointsSupported);
+  }
+
+  private async checkDetectedLabelsExists(timeRange: TimeRange): Promise<void> {
+    try {
+      const { start, end } = this.datasource.getTimeRangeParams(timeRange);
+      const res = await this.request('detected_labels', { start, end });
+      this.detectedEndpointsSupported = Array.isArray(res);
+    } catch (e) {
+      this.detectedEndpointsSupported = false;
+      await this.fetchLabels({ timeRange });
+    }
+  }
 
   /**
    * Returns the label keys that have been fetched.
@@ -146,9 +170,15 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * @returns A promise containing an array of label keys.
    * @throws An error if the fetch operation fails.
    */
-  async fetchLabels(options?: { streamSelector?: string; timeRange?: TimeRange }): Promise<string[]> {
+  async fetchLabels(options: { streamSelector?: string; timeRange?: TimeRange } = {}): Promise<string[]> {
+    if (this.detectedEndpointsSupported) {
+      return this.fetchDetectedLabels({
+        expr: options.streamSelector,
+        timeRange: options.timeRange,
+      });
+    }
     // We'll default to use `/labels`. If the flag is disabled, and there's a streamSelector, we'll use the series endpoint.
-    if (config.featureToggles.lokiLabelNamesQueryApi || !options?.streamSelector) {
+    else if (config.featureToggles.lokiLabelNamesQueryApi || !options?.streamSelector) {
       return this.fetchLabelsByLabelsEndpoint(options);
     } else {
       const data = await this.fetchSeriesLabels(options.streamSelector, { timeRange: options.timeRange });
@@ -242,6 +272,39 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const params = { 'match[]': match, start, end };
     return await this.request(url, params);
   };
+
+  async fetchDetectedLabels(
+    queryOptions: {
+      expr?: string;
+      timeRange?: TimeRange;
+      scopedVars?: ScopedVars;
+    },
+    requestOptions?: Partial<BackendSrvRequest>
+  ): Promise<string[]> {
+    const interpolatedExpr =
+      queryOptions.expr && queryOptions.expr !== EMPTY_SELECTOR
+        ? this.datasource.interpolateString(queryOptions.expr, queryOptions.scopedVars)
+        : undefined;
+
+    const range = queryOptions?.timeRange ?? this.getDefaultTimeRange();
+    const rangeParams = this.datasource.getTimeRangeParams(range);
+    const { start, end } = rangeParams;
+    const params: KeyValue<string | number> = { start, end };
+    if (interpolatedExpr) {
+      params.query = interpolatedExpr;
+    }
+
+    try {
+        const data = await this.request('detected_labels', params, true, requestOptions);
+        console.log(data);
+        if (Array.isArray(data)) {
+          return data;
+        }
+      } catch (error) {
+        console.error('error', error);
+      }
+      return [];
+  }
 
   // Cache key is a bit different here. We round up to a minute the intervals.
   // The rounding may seem strange but makes relative intervals like now-1h less prone to need separate request every

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -103,7 +103,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
   private async checkDetectedLabelsExists(timeRange: TimeRange): Promise<void> {
     try {
       const { start, end } = this.datasource.getTimeRangeParams(timeRange);
-      const res = await this.request('detected_labels', { start, end });
+      const res = await this.request('detected_labels', { start, end }, false, {
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      });
       this.detectedEndpointsSupported = Array.isArray(res);
     } catch (e) {
       this.detectedEndpointsSupported = false;
@@ -592,7 +595,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
       expr: queryOptions.expr,
       timeRange: queryOptions?.timeRange,
       limit: queryOptions?.limit,
-    });
+    },  {
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      });
 
     const response: ParserAndLabelKeysResult = {
       extractedLabelKeys: [],

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -328,7 +328,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
     },
     requestOptions?: Partial<BackendSrvRequest>
   ): Promise<DetectedFieldsResult> {
-    console.log(queryOptions);
     const interpolatedExpr =
       queryOptions.expr && queryOptions.expr !== EMPTY_SELECTOR
         ? this.datasource.interpolateString(queryOptions.expr, queryOptions.scopedVars)
@@ -614,6 +613,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
     response.hasLogfmt = fields.some((field) => field.parsers && field.parsers.includes('logfmt'));
     response.extractedLabelKeys = fields.map((field) => field.label);
     response.structuredMetadataKeys = fields.filter((field) => field.parsers === null).map((field) => field.label);
+    // See https://github.com/grafana/grafana/blob/722aac6cbac64b84c4424d1194661c5c32b2f8ca/public/app/plugins/datasource/loki/responseUtils.ts#L84
+    response.unwrapLabelKeys = fields.filter((field) => field.type !== 'string').map((field) => field.label);
 
     return response;
   }

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -105,11 +105,17 @@ export default class LokiLanguageProvider extends LanguageProvider {
   private async checkDetectedLabelsExists(timeRange: TimeRange): Promise<void> {
     try {
       const { start, end } = this.datasource.getTimeRangeParams(timeRange);
-      const res = await this.request('detected_labels', { start, end }, false, {
+      const data = await this.request('detected_labels', { start, end }, true, {
         showErrorAlert: false,
         showSuccessAlert: false,
       });
-      this.detectedEndpointsSupported = Array.isArray(res);
+      // Endpoint does not throw and return labels
+      if (Array.isArray(data)) {
+        this.labelKeys = data.map((label) => label.label);
+        this.detectedEndpointsSupported = true;
+      } else {
+        this.detectedEndpointsSupported = false;
+      }
     } catch (e) {
       this.detectedEndpointsSupported = false;
     }

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -295,15 +295,14 @@ export default class LokiLanguageProvider extends LanguageProvider {
     }
 
     try {
-        const data = await this.request('detected_labels', params, true, requestOptions);
-        console.log(data);
-        if (Array.isArray(data)) {
-          return data;
-        }
-      } catch (error) {
-        console.error('error', error);
+      const data = await this.request('detected_labels', params, true, requestOptions);
+      if (Array.isArray(data)) {
+        return data;
       }
-      return [];
+    } catch (error) {
+      console.error('error', error);
+    }
+    return [];
   }
 
   // Cache key is a bit different here. We round up to a minute the intervals.
@@ -532,6 +531,14 @@ export default class LokiLanguageProvider extends LanguageProvider {
     streamSelector: string,
     options?: { maxLines?: number; timeRange?: TimeRange }
   ): Promise<ParserAndLabelKeysResult> {
+    if (this.detectedEndpointsSupported) {
+      return this.getParserAndLabelKeysByDetectedLabels({
+        expr: streamSelector,
+        timeRange: options?.timeRange,
+        limit: options?.maxLines,
+      });
+    }
+
     const empty = {
       extractedLabelKeys: [],
       structuredMetadataKeys: [],
@@ -567,6 +574,43 @@ export default class LokiLanguageProvider extends LanguageProvider {
       hasPack,
       hasLogfmt,
     };
+  }
+
+  /**
+   * Wrapper for fetchDetectedFields to be used by getParserAndLabelKeys.
+   */
+  private async getParserAndLabelKeysByDetectedLabels(queryOptions: {
+    expr: string;
+    timeRange?: TimeRange;
+    limit?: number;
+  }): Promise<ParserAndLabelKeysResult> {
+    const fields = await this.fetchDetectedFields({
+      expr: queryOptions.expr,
+      timeRange: queryOptions?.timeRange,
+      limit: queryOptions?.limit,
+    });
+
+    const response: ParserAndLabelKeysResult = {
+      extractedLabelKeys: [],
+      structuredMetadataKeys: [],
+      unwrapLabelKeys: [],
+      hasJSON: false,
+      hasPack: false,
+      hasLogfmt: false,
+    };
+
+    if (fields instanceof Error) {
+      return response;
+    }
+
+    response.hasJSON = fields.some((field) => field.parsers && field.parsers.includes('json'));
+    // See https://github.com/grafana/grafana/blob/8cb77e1eae906e9b4a2343ad80a5fac21b040f8f/public/app/plugins/datasource/loki/lineParser.ts#L20
+    response.hasPack = fields.some((field) => field.label === '_entry');
+    response.hasLogfmt = fields.some((field) => field.parsers && field.parsers.includes('logfmt'));
+    response.extractedLabelKeys = fields.map((field) => field.label);
+    response.structuredMetadataKeys = fields.filter((field) => field.parsers === null).map((field) => field.label);
+
+    return response;
   }
 
   /**

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -591,14 +591,17 @@ export default class LokiLanguageProvider extends LanguageProvider {
     timeRange?: TimeRange;
     limit?: number;
   }): Promise<ParserAndLabelKeysResult> {
-    const fields = await this.fetchDetectedFields({
-      expr: queryOptions.expr,
-      timeRange: queryOptions?.timeRange,
-      limit: queryOptions?.limit,
-    },  {
+    const fields = await this.fetchDetectedFields(
+      {
+        expr: queryOptions.expr,
+        timeRange: queryOptions?.timeRange,
+        limit: queryOptions?.limit,
+      },
+      {
         showErrorAlert: false,
         showSuccessAlert: false,
-      });
+      }
+    );
 
     const response: ParserAndLabelKeysResult = {
       extractedLabelKeys: [],

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1718,7 +1718,8 @@ describe('LokiDatasource', () => {
     });
 
     it('keeps all labels when no labels are loaded', async () => {
-      ds.getResource = <T>() => Promise.resolve({ data: [] } as T);
+      ds.getResource = <T>(url: string) =>
+        url === 'detected_labels' ? Promise.reject('Error') : Promise.resolve({ data: [] } as T);
       const queries = await ds.importFromAbstractQueries([
         {
           refId: 'A',
@@ -1732,7 +1733,8 @@ describe('LokiDatasource', () => {
     });
 
     it('filters out non existing labels', async () => {
-      ds.getResource = <T>() => Promise.resolve({ data: ['foo'] } as T);
+      ds.getResource = <T>(url: string) =>
+        url === 'detected_labels' ? Promise.reject('Error') : Promise.resolve({ data: ['foo'] } as T);
       const queries = await ds.importFromAbstractQueries([
         {
           refId: 'A',

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -535,7 +535,7 @@ export class LokiDatasource
 
     const res = await this.getResource(url, params, options);
 
-    // detected_field/${label}/values has different structure then other metadata responses
+    // detected_field/${label}/values has different structure than other metadata responses
     if (!res.data && res.values) {
       return res.values ?? [];
     }
@@ -545,7 +545,7 @@ export class LokiDatasource
       return res.detectedLabels ?? [];
     }
 
-    // detected_fields has a different return structure then other metadata responses
+    // detected_fields has a different return structure than other metadata responses
     if (!res.data && res.fields) {
       return res.fields ?? [];
     }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -540,6 +540,11 @@ export class LokiDatasource
       return res.values ?? [];
     }
 
+    // detected_labels has different structure then other metadata responses
+    if (res && 'detectedLabels' in res && Array.isArray(res.detectedLabels)) {
+      return res.detectedLabels ?? [];
+    }
+
     // detected_fields has a different return structure then other metadata responses
     if (!res.data && res.fields) {
       return res.fields ?? [];

--- a/public/app/plugins/datasource/loki/mocks/metadataRequest.ts
+++ b/public/app/plugins/datasource/loki/mocks/metadataRequest.ts
@@ -9,6 +9,10 @@ export function createMetadataRequest(
   const labels = Object.keys(labelsAndValues);
 
   return async function metadataRequestMock(url: string, params?: Record<string, string | number>) {
+    if (url === 'detected_labels') {
+      // Empty array: endpoint exists; language provider treats non-array / errors as unsupported.
+      return [];
+    }
     if (url === lokiLabelsEndpoint) {
       return labels;
     } else {

--- a/public/app/plugins/datasource/loki/mocks/metadataRequest.ts
+++ b/public/app/plugins/datasource/loki/mocks/metadataRequest.ts
@@ -10,7 +10,6 @@ export function createMetadataRequest(
 
   return async function metadataRequestMock(url: string, params?: Record<string, string | number>) {
     if (url === 'detected_labels') {
-      // Empty array: endpoint exists; language provider treats non-array / errors as unsupported.
       return null;
     }
     if (url === lokiLabelsEndpoint) {

--- a/public/app/plugins/datasource/loki/mocks/metadataRequest.ts
+++ b/public/app/plugins/datasource/loki/mocks/metadataRequest.ts
@@ -11,7 +11,7 @@ export function createMetadataRequest(
   return async function metadataRequestMock(url: string, params?: Record<string, string | number>) {
     if (url === 'detected_labels') {
       // Empty array: endpoint exists; language provider treats non-array / errors as unsupported.
-      return [];
+      return null;
     }
     if (url === lokiLabelsEndpoint) {
       return labels;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -99,14 +99,11 @@ export interface ParserAndLabelKeysResult {
   unwrapLabelKeys: string[];
 }
 
-export interface DetectedFieldsResult {
-  fields: Array<{
-    label: string;
-    type: 'bytes' | 'float' | 'int' | 'string' | 'duration';
-    cardinality: number;
-    parsers: Array<'logfmt' | 'json'> | null;
-  }>;
-  limit: number;
-}
+export type DetectedFieldsResult = Array<{
+  label: string;
+  type: 'bytes' | 'float' | 'int' | 'string' | 'duration';
+  cardinality: number;
+  parsers: Array<'logfmt' | 'json'> | null;
+}>;
 
 export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[] };

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -145,21 +145,16 @@ const getStyles = (
   tableWidth: number,
   controlsWidth: number
 ) => {
-  const listControlsWrapperTableHeaderOffset = '-5px';
   return {
     listControlsWrapper: css({
       height: '100%',
       width: controlsWidth,
       label: 'listControlsWrapper',
-      marginTop: `calc(${theme.spacing.gridSize * theme.components.panel.headerHeight}px + ${listControlsWrapperTableHeaderOffset})`,
-      position: 'absolute',
-      right: 0,
-      top: 0,
     }),
     tableWrapper: css({
       position: 'relative',
-      paddingLeft: fieldSelectorWidth,
-      paddingRight: controlsWidth,
+      display: 'flex',
+      flexDirection: 'row-reverse',
       height,
       width: tableWidth,
     }),


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/116688

Updates styles to prevent overflows, such as:

<img width="1263" height="1111" alt="imagen" src="https://github.com/user-attachments/assets/20024f55-3a46-4ea2-8caf-089b57d40b57" />

Additionally, the controls position matches the one from the Logs visualization.

Demo.

https://github.com/user-attachments/assets/1b3c2a11-4812-491f-9a16-beea9645bebd

