### PR TITLE
Logs Table: Empty state and reordering fixes

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1093,7 +1093,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             </div>
           )}
 
-          {enableNewLogsTable && visualisationType === 'table' && (
+          {enableNewLogsTable && visualisationType === 'table' && hasData && (
             <ExploreLogsTable
               eventBus={eventBus}
               data={panelData}
@@ -1306,27 +1306,27 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
               )}
             </div>
           )}
-          {!loading && !hasData && !scanning && (
-            <div className={styles.noDataWrapper}>
-              <div className={styles.noData}>
-                <Trans i18nKey="explore.logs.no-logs-found">No logs found.</Trans>
-                <Button size="sm" variant="secondary" className={styles.scanButton} onClick={onClickScan}>
-                  <Trans i18nKey="explore.logs.scan-for-older-logs">Scan for older logs</Trans>
-                </Button>
-              </div>
-            </div>
-          )}
-          {scanning && (
-            <div className={styles.noDataWrapper}>
-              <div className={styles.noData}>
-                <span>{scanText}</span>
-                <Button size="sm" variant="secondary" className={styles.scanButton} onClick={onClickStopScan}>
-                  <Trans i18nKey="explore.logs.stop-scan">Stop scan</Trans>
-                </Button>
-              </div>
-            </div>
-          )}
         </div>
+        {!loading && !hasData && !scanning && (
+          <div className={styles.noDataWrapper}>
+            <div className={styles.noData}>
+              <Trans i18nKey="explore.logs.no-logs-found">No logs found.</Trans>
+              <Button size="sm" variant="secondary" className={styles.scanButton} onClick={onClickScan}>
+                <Trans i18nKey="explore.logs.scan-for-older-logs">Scan for older logs</Trans>
+              </Button>
+            </div>
+          </div>
+        )}
+        {scanning && (
+          <div className={styles.noDataWrapper}>
+            <div className={styles.noData}>
+              <span>{scanText}</span>
+              <Button size="sm" variant="secondary" className={styles.scanButton} onClick={onClickStopScan}>
+                <Trans i18nKey="explore.logs.stop-scan">Stop scan</Trans>
+              </Button>
+            </div>
+          </div>
+        )}
       </PanelChrome>
     </>
   );

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -61,7 +61,7 @@ export function TableNGWrap({
 
   const [controlsExpanded, setControlsExpanded] = useState(controlsExpandedFromStore);
   const controlsWidth = !showControls ? 0 : controlsExpanded ? CONTROLS_WIDTH_EXPANDED : LOG_LIST_CONTROLS_WIDTH;
-  const styles = useStyles2(getStyles, height, tableWidth, controlsWidth);
+  const styles = useStyles2(getStyles, fieldSelectorWidth, height, tableWidth, controlsWidth, !!title);
 
   // Callbacks
   const onTableOptionsChange = useCallback(
@@ -138,17 +138,32 @@ export function TableNGWrap({
   );
 }
 
-const getStyles = (_: GrafanaTheme2, height: number, tableWidth: number, controlsWidth: number) => {
+const getStyles = (
+  theme: GrafanaTheme2,
+  fieldSelectorWidth: number,
+  height: number,
+  tableWidth: number,
+  controlsWidth: number,
+  hasTitle: boolean
+) => {
+  const listControlsWrapperTableHeaderOffset = '-5px';
   return {
     listControlsWrapper: css({
       height: '100%',
       width: controlsWidth,
       label: 'listControlsWrapper',
+      // Needed to keep the panel menu from overlapping the logs options when there's no title
+      marginTop: hasTitle
+        ? 0
+        : `calc(${theme.spacing.gridSize * theme.components.panel.headerHeight}px + ${listControlsWrapperTableHeaderOffset})`,
+      position: 'absolute',
+      right: 0,
+      top: 0,
     }),
     tableWrapper: css({
       position: 'relative',
-      display: 'flex',
-      flexDirection: 'row-reverse',
+      paddingLeft: fieldSelectorWidth,
+      paddingRight: controlsWidth,
       height,
       width: tableWidth,
     }),

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -61,7 +61,7 @@ export function TableNGWrap({
 
   const [controlsExpanded, setControlsExpanded] = useState(controlsExpandedFromStore);
   const controlsWidth = !showControls ? 0 : controlsExpanded ? CONTROLS_WIDTH_EXPANDED : LOG_LIST_CONTROLS_WIDTH;
-  const styles = useStyles2(getStyles, fieldSelectorWidth, height, tableWidth, controlsWidth, !!title);
+  const styles = useStyles2(getStyles, height, tableWidth, controlsWidth);
 
   // Callbacks
   const onTableOptionsChange = useCallback(
@@ -138,14 +138,7 @@ export function TableNGWrap({
   );
 }
 
-const getStyles = (
-  theme: GrafanaTheme2,
-  fieldSelectorWidth: number,
-  height: number,
-  tableWidth: number,
-  controlsWidth: number,
-  hasTitle: boolean
-) => {
+const getStyles = (_: GrafanaTheme2, height: number, tableWidth: number, controlsWidth: number) => {
   return {
     listControlsWrapper: css({
       height: '100%',

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -146,24 +146,16 @@ const getStyles = (
   controlsWidth: number,
   hasTitle: boolean
 ) => {
-  const listControlsWrapperTableHeaderOffset = '-5px';
   return {
     listControlsWrapper: css({
       height: '100%',
       width: controlsWidth,
       label: 'listControlsWrapper',
-      // Needed to keep the panel menu from overlapping the logs options when there's no title
-      marginTop: hasTitle
-        ? 0
-        : `calc(${theme.spacing.gridSize * theme.components.panel.headerHeight}px + ${listControlsWrapperTableHeaderOffset})`,
-      position: 'absolute',
-      right: 0,
-      top: 0,
     }),
     tableWrapper: css({
       position: 'relative',
-      paddingLeft: fieldSelectorWidth,
-      paddingRight: controlsWidth,
+      display: 'flex',
+      flexDirection: 'row-reverse',
       height,
       width: tableWidth,
     }),

--- a/public/app/plugins/panel/logstable/constants.ts
+++ b/public/app/plugins/panel/logstable/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_FIRST_FIELD_WIDTH = 200;
+export const DEFAULT_TIME_FIELD_WIDTH = 200;
 export const DEFAULT_LOG_LEVEL_FIELD_WIDTH = 150;
 export const ROW_ACTION_BUTTON_WIDTH = 55;
 export const SETTING_KEY_ROOT = 'grafana.explore.logs';

--- a/public/app/plugins/panel/logstable/fields/getFieldWidth.test.ts
+++ b/public/app/plugins/panel/logstable/fields/getFieldWidth.test.ts
@@ -1,40 +1,40 @@
-import { DEFAULT_FIRST_FIELD_WIDTH, ROW_ACTION_BUTTON_WIDTH } from '../constants';
+import { DEFAULT_TIME_FIELD_WIDTH, ROW_ACTION_BUTTON_WIDTH } from '../constants';
 
-import { getFieldWidth } from './getFieldWidth';
+import { getTimeFieldWidth } from './getFieldWidth';
 
-describe('getFieldWidth', () => {
+describe('getTimeFieldWidth', () => {
   it('Should return undefined', () => {
-    expect(getFieldWidth(undefined, 1, {})).toEqual(undefined);
+    expect(getTimeFieldWidth(undefined, 1, {})).toEqual(undefined);
   });
   it('Should return default width for first field', () => {
-    expect(getFieldWidth(undefined, 0, {})).toEqual(200);
+    expect(getTimeFieldWidth(undefined, 0, {})).toEqual(200);
   });
   it('Should return width', () => {
-    expect(getFieldWidth(300, 0, {})).toEqual(300);
+    expect(getTimeFieldWidth(300, 0, {})).toEqual(300);
   });
   it('Should not return timestamp field width', () => {
-    expect(getFieldWidth(undefined, 1, {})).toEqual(undefined);
+    expect(getTimeFieldWidth(undefined, 1, {})).toEqual(undefined);
   });
 
   it('Should return timestamp field width', () => {
-    expect(getFieldWidth(undefined, 0, {})).toEqual(DEFAULT_FIRST_FIELD_WIDTH);
+    expect(getTimeFieldWidth(undefined, 0, {})).toEqual(DEFAULT_TIME_FIELD_WIDTH);
   });
   it('Should return timestamp field width with padding for copyLogLine', () => {
-    expect(getFieldWidth(undefined, 0, { showCopyLogLink: true })).toEqual(
-      DEFAULT_FIRST_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2
+    expect(getTimeFieldWidth(undefined, 0, { showCopyLogLink: true })).toEqual(
+      DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2
     );
   });
   it('Should return timestamp field width with padding for showInspectLogLine', () => {
-    expect(getFieldWidth(undefined, 0, { showInspectLogLine: true })).toEqual(
-      DEFAULT_FIRST_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2
+    expect(getTimeFieldWidth(undefined, 0, { showInspectLogLine: true })).toEqual(
+      DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2
     );
   });
   it('Should return timestamp field width with padding for both options', () => {
     expect(
-      getFieldWidth(undefined, 0, {
+      getTimeFieldWidth(undefined, 0, {
         showInspectLogLine: true,
         showCopyLogLink: true,
       })
-    ).toEqual(DEFAULT_FIRST_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH);
+    ).toEqual(DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH);
   });
 });

--- a/public/app/plugins/panel/logstable/fields/getFieldWidth.ts
+++ b/public/app/plugins/panel/logstable/fields/getFieldWidth.ts
@@ -1,25 +1,23 @@
-import { DEFAULT_FIRST_FIELD_WIDTH, ROW_ACTION_BUTTON_WIDTH } from '../constants';
+import { DEFAULT_TIME_FIELD_WIDTH, ROW_ACTION_BUTTON_WIDTH } from '../constants';
 import type { Options as LogsTableOptions } from '../panelcfg.gen';
 
-export function getFieldWidth(width: number | undefined, fieldIndex: number, options: LogsTableOptions) {
+export function getTimeFieldWidth(width: number | undefined, fieldIndex: number, options: LogsTableOptions) {
   if (width !== undefined) {
     return width;
   }
 
-  return getDefaultFieldWidth(fieldIndex, options);
+  return getDefaultTimeFieldWidth(fieldIndex, options);
 }
 
-function getDefaultFieldWidth(fieldIndex: number, options: LogsTableOptions): number | undefined {
+function getDefaultTimeFieldWidth(fieldIndex: number, options: LogsTableOptions): number | undefined {
   if (fieldIndex !== 0) {
     return undefined;
   }
 
   if (options.showInspectLogLine && options.showCopyLogLink) {
-    return DEFAULT_FIRST_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH;
+    return DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH;
   } else if (options.showInspectLogLine || options.showCopyLogLink) {
-    return DEFAULT_FIRST_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2;
+    return DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2;
   }
-  return DEFAULT_FIRST_FIELD_WIDTH;
-
-  return undefined;
+  return DEFAULT_TIME_FIELD_WIDTH;
 }

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -4,6 +4,7 @@ import { type DataFrame, DataFrameType, FieldType, toDataFrame } from '@grafana/
 // Internal package imports, but not exposed to end users, how do we expect plugin developers to test anything that contains a transform?
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { TableCellDisplayMode } from '@grafana/ui';
+import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, parseLogsFrame } from 'app/features/logs/logsFrame';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 
@@ -184,6 +185,51 @@ describe('useOrganizeFields', () => {
       await waitFor(() => {
         expect(organizedFields.current.organizedFrame).not.toBeNull();
         expect(organizedFields.current.organizedFrame?.fields[0].config.custom.cellOptions).not.toBeDefined();
+      });
+    });
+
+    test('log line body has no cellOptions when it is moved from the first position', async () => {
+      const optionsBodyFirst = {
+        displayedFields: [LOG_LINE_BODY_FIELD_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, 'level'],
+        showInspectLogLine: true,
+      };
+      const optionsBodySecond = {
+        displayedFields: [LOGS_DATAPLANE_TIMESTAMP_NAME, LOG_LINE_BODY_FIELD_NAME, 'level'],
+        showInspectLogLine: true,
+      };
+
+      const { result, rerender } = renderHook(
+        (options: typeof optionsBodyFirst, frame = extractedFrame) =>
+          useOrganizeFields({
+            extractedFrame: frame,
+            bodyFieldName: LOGS_DATAPLANE_BODY_NAME,
+            levelFieldName: 'level',
+            logsFrame: testLogsFrame,
+            onPermalinkClick: () => null,
+            options,
+            supportsPermalink: false,
+            timeFieldName: LOGS_DATAPLANE_TIMESTAMP_NAME,
+            fieldConfig: { defaults: {}, overrides: [] },
+          }),
+        { initialProps: optionsBodyFirst }
+      );
+
+      await waitFor(() => {
+        const frame = result.current.organizedFrame;
+        expect(frame).not.toBeNull();
+        expect(frame!.fields[0].name).toBe(LOGS_DATAPLANE_BODY_NAME);
+        const bodyField = frame!.fields.find((f) => f.name === LOGS_DATAPLANE_BODY_NAME);
+        expect(bodyField?.config.custom?.cellOptions).toBeDefined();
+      });
+
+      rerender(optionsBodySecond);
+
+      await waitFor(() => {
+        const frame = result.current.organizedFrame;
+        expect(frame).not.toBeNull();
+        expect(frame!.fields[1].name).toBe(LOGS_DATAPLANE_BODY_NAME);
+        const bodyField = frame!.fields.find((f) => f.name === LOGS_DATAPLANE_BODY_NAME);
+        expect(bodyField?.config.custom?.cellOptions).not.toBeDefined();
       });
     });
 

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -9,7 +9,7 @@ import { type LogsFrame } from 'app/features/logs/logsFrame';
 import { LOG_LINE_BODY_FIELD_NAME } from '../../../../features/logs/components/fieldSelector/logFields';
 import { LogsTableCustomCellRenderer } from '../cells/LogsTableCustomCellRenderer';
 import { getLogLevelColumnEnhancements } from '../fields/defaultLogLevelColumnConfig';
-import { getFieldWidth } from '../fields/getFieldWidth';
+import { getTimeFieldWidth } from '../fields/getFieldWidth';
 import { normalizeLogLevelFieldInPlace } from '../fields/normalizeLogLevelField';
 import { doesFieldSupportAdHocFiltering, doesFieldSupportInspector } from '../fields/supports';
 import { getDisplayedFields } from '../options/getDisplayedFields';
@@ -157,7 +157,10 @@ const organizeFields = async (
         filterable: field.config?.filterable ?? doesFieldSupportAdHocFiltering(field, timeFieldName, bodyFieldName),
         custom: {
           ...configAfterLevel.custom,
-          width: getFieldWidth(configAfterLevel.custom?.width, fieldIndex, options),
+          width:
+            field.name === timeFieldName
+              ? getTimeFieldWidth(configAfterLevel.custom?.width, fieldIndex, options)
+              : configAfterLevel.custom?.width,
           inspect: configAfterLevel.custom?.inspect ?? doesFieldSupportInspector(field),
           cellOptions:
             isFirstField && bodyFieldName && (supportsPermalink || options.showInspectLogLine)

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -149,7 +149,7 @@ const organizeFields = async (
 
       // We are mutating fields. Would it be possible to avoid it?
       if (configAfterLevel.custom?.cellOptions?.cellComponent) {
-        configAfterLevel.custom.cellOptions.cellComponent = undefined;
+        configAfterLevel.custom.cellOptions = undefined;
       }
 
       field.config = {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/116688

- Fixes an issue when moving body to be the first column.

https://github.com/user-attachments/assets/5f2909ce-b437-448a-bd48-0c801b867081

- Fixes the log line column which was shrinking when moving

https://github.com/user-attachments/assets/52ccd50f-b66e-42b9-8650-a099e8622da1

- Additionally, it fixes the empty state (no data) for Logs in Explore, which was currently broken in every view.

<img width="1150" height="165" alt="Broken" src="https://github.com/user-attachments/assets/ec16ad00-9fbe-476d-9d36-531da68eb028" />

<img width="1145" height="160" alt="Broken 2" src="https://github.com/user-attachments/assets/61660143-f33d-4f7d-9373-602c2d3c602b" />

Demo.

https://github.com/user-attachments/assets/1b3c2a11-4812-491f-9a16-beea9645bebd

