### PR TITLE
SuggestedDashboards: Filter provisioned dashboards that were removed

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.test.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.test.ts
@@ -341,6 +341,18 @@ describe('dashboardLibraryApi', () => {
       expect(result).toEqual([]);
     });
 
+    it('should filter out dashboards that have been removed', async () => {
+      const activeDashboard1 = createMockPluginDashboard({ uid: 'active', title: 'Active', removed: false });
+      const activeDashboard2 = createMockPluginDashboard({ uid: 'active2', title: 'Active2' });
+      const removedDashboard = createMockPluginDashboard({ uid: 'removed', title: 'Removed', removed: true });
+
+      mockGet.mockResolvedValue([activeDashboard1, activeDashboard2, removedDashboard]);
+
+      const result = await fetchProvisionedDashboards('prometheus');
+
+      expect(result).toEqual([activeDashboard1, activeDashboard2]);
+    });
+
     it('should return empty array for datasource with no provisioned dashboards', async () => {
       mockGet.mockResolvedValue([]);
 

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -125,7 +125,7 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     const dashboards = await getBackendSrv().get(`api/plugins/${datasourceType}/dashboards`, undefined, undefined, {
       showErrorAlert: false,
     });
-    return Array.isArray(dashboards) ? dashboards : [];
+    return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
     console.error('Error loading provisioned dashboards', error);
     return [];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Adds a test to verify that `fetchProvisionedDashboards` filters out dashboards with `removed: true`
- Ensures dashboards with default `removed: false` are also included in the result

**Why do we need this feature?**

There are broken suggested dashboards that are visible and should not.
The plugins API is returning a list of provisioned dashboards, even though they were removed from their side. Apparently, based on [this conversation](https://raintank-corp.slack.com/archives/C09DXGH5W6T/p1774538142625759) (it still needs to be confirmed), these dashboards are being returned because the instance imported them previously, and the backend is designed to track previously imported dashboards so they can be deleted.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.