### PR TITLE
Tempo: Fix span duration NaN when durationNanos is missing

### DIFF
--- a/public/app/features/explore/TraceView/utils/transform.test.ts
+++ b/public/app/features/explore/TraceView/utils/transform.test.ts
@@ -19,7 +19,7 @@ describe('transformTraceDataFrame()', () => {
       spans: [
         {
           dataFrameRowIndex: 0,
-          duration: NaN,
+          duration: 0,
           flags: 0,
           kind: 'server',
           logs: [],
@@ -27,7 +27,7 @@ describe('transformTraceDataFrame()', () => {
           processID: 'span1',
           references: [],
           spanID: 'span1',
-          startTime: NaN,
+          startTime: 0,
           tags: [{ key: 'key1', value: 'value1' }],
           traceID: 'trace1',
         },

--- a/public/app/features/explore/TraceView/utils/transform.ts
+++ b/public/app/features/explore/TraceView/utils/transform.ts
@@ -49,8 +49,8 @@ export function transformTraceDataFrame(frame: DataFrame): TraceResponse | null 
       }
       return {
         ...s,
-        duration: s.duration * 1000,
-        startTime: s.startTime * 1000,
+        duration: (s.duration || 0) * 1000,
+        startTime: (s.startTime || 0) * 1000,
         processID: s.spanID,
         flags: 0,
         references,

--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -395,6 +395,34 @@ describe('createTableFrameFromTraceQlQueryAsSpans()', () => {
     // No more fields
     expect(frame.fields.length).toBe(7);
   });
+
+  test('handles spans with missing durationNanos gracefully (no NaN)', () => {
+    const traces: TraceSearchMetadata[] = [
+      {
+        traceID: '1',
+        rootServiceName: 'test-service',
+        rootTraceName: 'test-operation',
+        startTimeUnixNano: '1702984850354934104',
+        durationMs: 1,
+        spanSet: {
+          spans: [
+            {
+              spanID: '11',
+              startTimeUnixNano: '1702984850354934104',
+              // durationNanos intentionally omitted to simulate incomplete span
+            },
+          ],
+          matched: 1,
+        },
+      },
+    ];
+    const frameList = createTableFrameFromTraceQlQueryAsSpans(traces as TraceSearchMetadata[], defaultSettings);
+    const frame = frameList[0];
+    const durationField = frame.fields.find((f) => f.name === 'duration');
+    expect(durationField).toBeDefined();
+    expect(durationField!.values[0]).toBe(0);
+    expect(Number.isNaN(durationField!.values[0])).toBe(false);
+  });
 });
 
 describe('transformFromOTLP()', () => {
@@ -426,5 +454,43 @@ describe('transformFromOTLP()', () => {
         ],
       },
     }).not.toBeFalsy();
+  });
+
+  test('handles spans with missing endTimeUnixNano gracefully (no NaN)', () => {
+    const otlpWithMissingEnd: collectorTypes.opentelemetryProto.trace.v1.ResourceSpans[] = [
+      {
+        resource: {
+          attributes: [{ key: 'service.name', value: { stringValue: 'test-service' } }],
+          droppedAttributesCount: 0,
+        },
+        instrumentationLibrarySpans: [
+          {
+            spans: [
+              {
+                traceId: 'AAAAAAAAAABguiq7RPE+rg==',
+                spanId: 'cmteMBAvwNA=',
+                parentSpanId: '',
+                name: 'incomplete-span',
+                kind: 'SPAN_KIND_SERVER' as any,
+                startTimeUnixNano: 1627471657255809000,
+                endTimeUnixNano: undefined as unknown as number,
+                attributes: [],
+                droppedAttributesCount: 0,
+                droppedEventsCount: 0,
+                droppedLinksCount: 0,
+                status: { code: 0 },
+                events: [],
+                links: [],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const res = transformFromOTLP(otlpWithMissingEnd, false);
+    const durationField = res.data[0].fields.find((f: { name: string }) => f.name === 'duration');
+    expect(durationField).toBeDefined();
+    expect(durationField!.values[0]).toBe(0);
+    expect(Number.isNaN(durationField!.values[0])).toBe(false);
   });
 });

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -186,8 +186,11 @@ export function transformFromOTLP(
             instrumentationLibraryVersion: librarySpan.instrumentationLibrary?.version,
             traceState: span.traceState,
             serviceTags,
-            startTime: span.startTimeUnixNano! / 1000000,
-            duration: (span.endTimeUnixNano! - span.startTimeUnixNano!) / 1000000,
+            startTime: (span.startTimeUnixNano ?? 0) / 1000000,
+            duration:
+              span.endTimeUnixNano && span.startTimeUnixNano
+                ? (span.endTimeUnixNano - span.startTimeUnixNano) / 1000000
+                : 0,
             tags: getSpanTags(span),
             logs: getLogs(span),
             references: getReferences(span),
@@ -939,7 +942,7 @@ function transformSpanToTraceData(span: Span, spanSet: Spanset, trace: TraceSear
     traceName: trace.rootTraceName || '',
     spanID: span.spanID,
     time: spanStartTimeUnixMs,
-    duration: parseInt(span.durationNanos, 10),
+    duration: span.durationNanos ? parseInt(span.durationNanos, 10) : 0,
     name: span.name,
   };
 


### PR DESCRIPTION
## What is this feature?

Fixes the display of span duration as "NaN" in the trace view when a span has zero duration or is missing the `durationNanos`/`endTimeUnixNano` fields. This can happen with incomplete or in-progress spans from OpenTelemetry instrumentation.

## Why do we need this?

When viewing traces that contain incomplete spans (spans without an end timestamp), the trace view displays "NaN" for the duration instead of a sensible value like "0ms". This is confusing for users and makes the trace view harder to read.

The fix ensures:
- `transformFromOTLP()`: Missing `endTimeUnixNano` defaults duration to `0` instead of `NaN`
- `transformSpanToTraceData()`: Missing `durationNanos` defaults to `0` instead of `NaN`
- `transformTraceDataFrame()`: Missing `duration`/`startTime` defaults to `0` instead of `NaN`

## Which issue(s) does this PR fix?

Fixes grafana/grafana-tempo-datasource#159