### PR TITLE
Alerting: Skip TestAlertmanager_HashStabilityAndChangeDetection

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -266,6 +266,9 @@ receivers:
 }
 
 func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
+	// TODO: Remove the line below once the race condition is fixed.
+	t.Skip()
+
 	baseConfig := func(receivers ...string) *definitions.PostableUserConfig {
 		postableReceivers := make([]*definitions.PostableApiReceiver, 0, len(receivers))
 		for _, r := range receivers {


### PR DESCRIPTION
The test triggers a race condition that causes panics in our CI. Skipping it until we fix the underlying issue.

```bash
GOMAXPROCS=1 go test -count=1000 -run TestAlertmanager_HashStabilityAndChangeDetection
panic: close of closed channel

goroutine 744 [running]:
github.com/prometheus/alertmanager/dispatch.(*Dispatcher).Run(0xc001982160)
	/home/santiago-grafana/go/pkg/mod/github.com/grafana/prometheus-alertmanager@v0.25.1-0.20260225120258-18275ca76b0c/dispatch/dispatch.go:158 +0x136
github.com/grafana/alerting/notify.(*GrafanaAlertmanager).ApplyConfig.func1()
	/home/santiago-grafana/go/pkg/mod/github.com/grafana/alerting@v0.0.0-20260312173859-6fc4227d9c4c/notify/grafana_alertmanager.go:888 +0x53
created by github.com/grafana/alerting/notify.(*GrafanaAlertmanager).ApplyConfig in goroutine 626
	/home/santiago-grafana/go/pkg/mod/github.com/grafana/alerting@v0.0.0-20260312173859-6fc4227d9c4c/notify/grafana_alertmanager.go:886 +0x1385
exit status 2
FAIL	github.com/grafana/grafana/pkg/services/ngalert/notifier	30.106s
```