### PR TITLE
TraceView: Separate instrumentation scope attributes from span attributes

### DIFF
--- a/packages/grafana-data/src/types/trace.ts
+++ b/packages/grafana-data/src/types/trace.ts
@@ -48,6 +48,7 @@ export interface TraceSpanRow {
   statusMessage?: string;
   instrumentationLibraryName?: string;
   instrumentationLibraryVersion?: string;
+  instrumentationLibraryTags?: TraceKeyValuePair[];
   traceState?: string;
   warnings?: string[];
   stackTraces?: string[];

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -91,6 +91,7 @@ export function TraceView(props: Props) {
     detailLogItemToggle,
     detailLogsToggle,
     detailProcessToggle,
+    detailInstrumentationScopeToggle,
     detailReferencesToggle,
     detailReferenceItemToggle,
     detailTagsToggle,
@@ -232,6 +233,7 @@ export function TraceView(props: Props) {
             detailReferencesToggle={detailReferencesToggle}
             detailReferenceItemToggle={detailReferenceItemToggle}
             detailProcessToggle={detailProcessToggle}
+            detailInstrumentationScopeToggle={detailInstrumentationScopeToggle}
             detailTagsToggle={detailTagsToggle}
             detailToggle={toggleDetail}
             addHoverIndentGuideId={addHoverIndentGuideId}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/DetailState.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/DetailState.tsx
@@ -22,6 +22,7 @@ import { type TraceSpanReference } from '../../types/trace';
 export default class DetailState {
   isTagsOpen: boolean;
   isProcessOpen: boolean;
+  isInstrumentationScopeOpen: boolean;
   logs: { isOpen: boolean; openedItems: Set<TraceLog> };
   references: { isOpen: boolean; openedItems: Set<TraceSpanReference> };
   isWarningsOpen: boolean;
@@ -32,6 +33,7 @@ export default class DetailState {
     const {
       isTagsOpen,
       isProcessOpen,
+      isInstrumentationScopeOpen,
       isReferencesOpen,
       isWarningsOpen,
       isStackTracesOpen,
@@ -40,6 +42,7 @@ export default class DetailState {
     }: DetailState | Record<string, undefined> = oldState || {};
     this.isTagsOpen = Boolean(isTagsOpen);
     this.isProcessOpen = Boolean(isProcessOpen);
+    this.isInstrumentationScopeOpen = Boolean(isInstrumentationScopeOpen);
     this.isReferencesOpen = Boolean(isReferencesOpen);
     this.isWarningsOpen = Boolean(isWarningsOpen);
     this.isStackTracesOpen = Boolean(isStackTracesOpen);
@@ -62,6 +65,12 @@ export default class DetailState {
   toggleProcess() {
     const next = new DetailState(this);
     next.isProcessOpen = !this.isProcessOpen;
+    return next;
+  }
+
+  toggleInstrumentationScope() {
+    const next = new DetailState(this);
+    next.isInstrumentationScopeOpen = !this.isInstrumentationScopeOpen;
     return next;
   }
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -64,6 +64,7 @@ describe('<SpanDetail>', () => {
     logItemToggle: jest.fn(),
     logsToggle: jest.fn(),
     processToggle: jest.fn(),
+    instrumentationScopeToggle: jest.fn(),
     tagsToggle: jest.fn(),
     warningsToggle: jest.fn(),
     referencesToggle: jest.fn(),
@@ -228,6 +229,29 @@ describe('<SpanDetail>', () => {
     render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
     await userEvent.click(screen.getByRole('switch', { name: /Resource attributes/ }));
     expect(props.processToggle).toHaveBeenLastCalledWith(span.spanID);
+  });
+
+  it('renders the instrumentation scope attributes section when present', async () => {
+    const spanWithScopeAttrs = {
+      ...span,
+      instrumentationLibraryTags: [
+        { key: 'tailsampling.policy', value: 'test-policy' },
+        { key: 'scope.attr', value: 'scope-value' },
+      ],
+    };
+    const propsWithScopeAttrs = {
+      ...props,
+      span: spanWithScopeAttrs,
+      detailState: new DetailState()
+        .toggleLogs()
+        .toggleProcess()
+        .toggleReferences()
+        .toggleTags()
+        .toggleInstrumentationScope(),
+    };
+    render(<SpanDetail {...(propsWithScopeAttrs as unknown as SpanDetailProps)} />);
+    await userEvent.click(screen.getByRole('switch', { name: /Instrumentation scope attributes/ }));
+    expect(props.instrumentationScopeToggle).toHaveBeenLastCalledWith(spanWithScopeAttrs.spanID);
   });
 
   it('renders the logs', async () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -243,6 +243,7 @@ export type SpanDetailProps = {
   logItemToggle: (spanID: string, log: TraceLog) => void;
   logsToggle: (spanID: string) => void;
   processToggle: (spanID: string) => void;
+  instrumentationScopeToggle: (spanID: string) => void;
   span: TraceSpan;
   traceToProfilesOptions?: TraceToProfilesOptions;
   timeZone: TimeZone;
@@ -273,6 +274,7 @@ export default function SpanDetail(props: SpanDetailProps) {
     logItemToggle,
     logsToggle,
     processToggle,
+    instrumentationScopeToggle,
     span,
     tagsToggle,
     traceStartTime,
@@ -296,6 +298,7 @@ export default function SpanDetail(props: SpanDetailProps) {
   const {
     isTagsOpen,
     isProcessOpen,
+    isInstrumentationScopeOpen,
     logs: logsState,
     isWarningsOpen,
     references: referencesState,
@@ -437,6 +440,20 @@ export default function SpanDetail(props: SpanDetailProps) {
         linksGetter={resourceLinksGetter}
         isOpen={isProcessOpen}
         onToggle={() => processToggle(spanID)}
+      />
+    );
+  }
+
+  if (span.instrumentationLibraryTags && span.instrumentationLibraryTags.length > 0) {
+    listOfContentCards.push(
+      <AccordianKeyValues
+        data={span.instrumentationLibraryTags}
+        label={t(
+          'explore.span-detail.label-instrumentation-scope-attributes',
+          'Instrumentation scope attributes'
+        )}
+        isOpen={isInstrumentationScopeOpen}
+        onToggle={() => instrumentationScopeToggle(spanID)}
       />
     );
   }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
@@ -91,6 +91,7 @@ export type SpanDetailRowProps = {
   logItemToggle: (spanID: string, log: TraceLog) => void;
   logsToggle: (spanID: string) => void;
   processToggle: (spanID: string) => void;
+  instrumentationScopeToggle: (spanID: string) => void;
   referenceItemToggle: (spanID: string, reference: TraceSpanReference) => void;
   referencesToggle: (spanID: string) => void;
   warningsToggle: (spanID: string) => void;
@@ -126,6 +127,7 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
     logItemToggle,
     logsToggle,
     processToggle,
+    instrumentationScopeToggle,
     referenceItemToggle,
     referencesToggle,
     warningsToggle,
@@ -178,6 +180,7 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
               logItemToggle={logItemToggle}
               logsToggle={logsToggle}
               processToggle={processToggle}
+              instrumentationScopeToggle={instrumentationScopeToggle}
               referenceItemToggle={referenceItemToggle}
               referencesToggle={referencesToggle}
               warningsToggle={warningsToggle}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -90,6 +90,7 @@ type TVirtualizedTraceViewOwnProps = {
   detailReferencesToggle: (spanID: string) => void;
   detailReferenceItemToggle: (spanID: string, reference: TraceSpanReference) => void;
   detailProcessToggle: (spanID: string) => void;
+  detailInstrumentationScopeToggle: (spanID: string) => void;
   detailTagsToggle: (spanID: string) => void;
   detailToggle: (spanID: string) => void;
   setSpanNameColumnWidth: (width: number) => void;
@@ -528,6 +529,7 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
       detailLogItemToggle,
       detailLogsToggle,
       detailProcessToggle,
+      detailInstrumentationScopeToggle,
       detailReferencesToggle,
       detailReferenceItemToggle,
       detailWarningsToggle,
@@ -571,6 +573,7 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
           logItemToggle={detailLogItemToggle}
           logsToggle={detailLogsToggle}
           processToggle={detailProcessToggle}
+          instrumentationScopeToggle={detailInstrumentationScopeToggle}
           referenceItemToggle={detailReferenceItemToggle}
           referencesToggle={detailReferencesToggle}
           warningsToggle={detailWarningsToggle}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -93,6 +93,7 @@ export type TProps = {
   detailReferencesToggle: (spanID: string) => void;
   detailReferenceItemToggle: (spanID: string, reference: TraceSpanReference) => void;
   detailProcessToggle: (spanID: string) => void;
+  detailInstrumentationScopeToggle: (spanID: string) => void;
   detailTagsToggle: (spanID: string) => void;
   detailToggle: (spanID: string) => void;
   addHoverIndentGuideId: (spanID: string) => void;

--- a/public/app/features/explore/TraceView/components/types/trace.ts
+++ b/public/app/features/explore/TraceView/components/types/trace.ts
@@ -53,6 +53,7 @@ export type TraceSpanData = {
   statusMessage?: string;
   instrumentationLibraryName?: string;
   instrumentationLibraryVersion?: string;
+  instrumentationLibraryTags?: TraceKeyValuePair[];
   traceState?: string;
   references?: TraceSpanReference[];
   warnings?: string[] | null;

--- a/public/app/features/explore/TraceView/useDetailState.ts
+++ b/public/app/features/explore/TraceView/useDetailState.ts
@@ -82,6 +82,11 @@ export function useDetailState(frame: DataFrame) {
       (spanID: string) => makeDetailSubsectionToggle('process', detailStates, setDetailStates)(spanID),
       [detailStates]
     ),
+    detailInstrumentationScopeToggle: useCallback(
+      (spanID: string) =>
+        makeDetailSubsectionToggle('instrumentationScope', detailStates, setDetailStates)(spanID),
+      [detailStates]
+    ),
     detailTagsToggle: useCallback(
       (spanID: string) => makeDetailSubsectionToggle('tags', detailStates, setDetailStates)(spanID),
       [detailStates]
@@ -90,7 +95,7 @@ export function useDetailState(frame: DataFrame) {
 }
 
 function makeDetailSubsectionToggle(
-  subSection: 'tags' | 'process' | 'logs' | 'warnings' | 'references' | 'stackTraces',
+  subSection: 'tags' | 'process' | 'instrumentationScope' | 'logs' | 'warnings' | 'references' | 'stackTraces',
   detailStates: Map<string, DetailState>,
   setDetailStates: (detailStates: Map<string, DetailState>) => void
 ) {
@@ -104,6 +109,8 @@ function makeDetailSubsectionToggle(
       detailState = old.toggleTags();
     } else if (subSection === 'process') {
       detailState = old.toggleProcess();
+    } else if (subSection === 'instrumentationScope') {
+      detailState = old.toggleInstrumentationScope();
     } else if (subSection === 'warnings') {
       detailState = old.toggleWarnings();
     } else if (subSection === 'references') {

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -91,6 +91,28 @@ function getSpanTags(span: collectorTypes.opentelemetryProto.trace.v1.Span): Tra
   return spanTags;
 }
 
+function getInstrumentationLibraryTags(
+  instrumentationLibrary: collectorTypes.opentelemetryProto.common.v1.InstrumentationLibrary | undefined
+): TraceKeyValuePair[] {
+  const tags: TraceKeyValuePair[] = [];
+
+  // The InstrumentationScope (formerly InstrumentationLibrary) may contain attributes
+  // that are scope-level metadata and should not be mixed with span-level attributes.
+  const libWithAttrs = instrumentationLibrary as
+    | (collectorTypes.opentelemetryProto.common.v1.InstrumentationLibrary & {
+        attributes?: collectorTypes.opentelemetryProto.common.v1.KeyValue[];
+      })
+    | undefined;
+
+  if (libWithAttrs?.attributes) {
+    for (const attribute of libWithAttrs.attributes) {
+      tags.push({ key: attribute.key, value: getAttributeValue(attribute.value) });
+    }
+  }
+
+  return tags;
+}
+
 function getSpanKind(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
   let kind = undefined;
   if (span.kind) {
@@ -159,6 +181,7 @@ export function transformFromOTLP(
       { name: 'logs', type: FieldType.other, values: [] },
       { name: 'references', type: FieldType.other, values: [] },
       { name: 'tags', type: FieldType.other, values: [] },
+      { name: 'instrumentationLibraryTags', type: FieldType.other, values: [] },
     ],
     meta: {
       preferredVisualisationType: 'trace',
@@ -191,6 +214,7 @@ export function transformFromOTLP(
             tags: getSpanTags(span),
             logs: getLogs(span),
             references: getReferences(span),
+            instrumentationLibraryTags: getInstrumentationLibraryTags(librarySpan.instrumentationLibrary),
           });
         }
       }

--- a/public/app/plugins/datasource/tempo/test/testResponse.ts
+++ b/public/app/plugins/datasource/tempo/test/testResponse.ts
@@ -178,6 +178,12 @@ export const otlpDataFrameFromResponse = new MutableDataFrame({
         ],
       ],
     },
+    {
+      name: 'instrumentationLibraryTags',
+      type: FieldType.other,
+      config: {},
+      values: [[]],
+    },
   ],
   length: 1,
 });


### PR DESCRIPTION
## What is this feature?

Introduces a dedicated "Instrumentation scope attributes" collapsible section in the trace span detail view. This separates OpenTelemetry instrumentation scope-level attributes from span-level attributes.

## Why do we need this?

Instrumentation scope attributes (e.g., `tailsampling.policy`) belong to the instrumentation scope, not individual spans. When they were rendered alongside span attributes, users were misled into thinking these were span-level attributes. This caused confusion when attempting to query these attributes at the span level, which would return no results.

Changes include:
- Added `instrumentationLibraryTags` field to the dataframe schema
- Extract instrumentation scope attributes during OTLP transformation
- Added `instrumentationLibraryTags` to `TraceSpanRow` and `TraceSpanData` types
- New collapsible "Instrumentation scope attributes" section in SpanDetail
- Toggle state management through the existing DetailState pattern

## Which issue(s) does this PR fix?

Fixes grafana/grafana-tempo-datasource#189