### PR TITLE
Alerting: Improve alerts activity UI RBAC

### DIFF
--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -45,9 +45,9 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
 
               {receiverInGroup && (
                 <MetaText icon="at">
-                  <Trans i18nKey="alerting.alert-group.delivered-to" values={{ name: group.receiver.name }}>
-                    Delivered to{' '}
-                    {canViewContactPoint ? (
+                  {canViewContactPoint ? (
+                    <Trans i18nKey="alerting.alert-group.delivered-to" values={{ name: group.receiver.name }}>
+                      Delivered to{' '}
                       <TextLink
                         href={createContactPointSearchLink(contactPoint, alertManagerSourceName)}
                         variant="bodySmall"
@@ -56,17 +56,21 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
                       >
                         {'{{name}}'}
                       </TextLink>
-                    ) : (
-                      <Tooltip
-                        content={t(
-                          'alerting.alert-group.view-contact-point-no-permission',
-                          'You do not have permission to view contact points'
-                        )}
-                      >
-                        <span className={styles.disabledContactPointName}>{'{{name}}'}</span>
-                      </Tooltip>
-                    )}
-                  </Trans>
+                    </Trans>
+                  ) : (
+                    <Tooltip
+                      content={t(
+                        'alerting.alert-group.view-contact-point-no-permission',
+                        'You do not have permission to view contact points'
+                      )}
+                    >
+                      <span>
+                        <Trans i18nKey="alerting.alert-group.delivered-to" values={{ name: group.receiver.name }}>
+                          Delivered to <span className={styles.disabledContactPointName}>{'{{name}}'}</span>
+                        </Trans>
+                      </span>
+                    </Tooltip>
+                  )}
                 </MetaText>
               )}
             </Stack>

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -65,9 +65,9 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
                       )}
                     >
                       <span>
-                        <Trans i18nKey="alerting.alert-group.delivered-to" values={{ name: group.receiver.name }}>
-                          Delivered to <span className={styles.disabledContactPointName}>{'{{name}}'}</span>
-                        </Trans>
+                        {t('alerting.alert-group.delivered-to-disabled', 'Delivered to {{name}}', {
+                          name: contactPoint,
+                        })}
                       </span>
                     </Tooltip>
                   )}

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -6,8 +6,8 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Stack, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types/accessControl';
 import { type AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { createContactPointSearchLink } from '../../utils/misc';
 import { CollapseToggle } from '../CollapseToggle';

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -3,8 +3,10 @@ import { useState } from 'react';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
-import { Stack, TextLink, useStyles2 } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { Stack, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 import { type AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
 
 import { createContactPointSearchLink } from '../../utils/misc';
@@ -26,6 +28,9 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
   // When group is grouped, receiver.name is 'NONE' as it can contain multiple receivers
   const receiverInGroup = group.receiver.name !== 'NONE';
   const contactPoint = group.receiver.name;
+  const canViewContactPoint =
+    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+    contextSrv.hasPermission(AccessControlAction.AlertingReceiversRead);
 
   return (
     <div className={styles.wrapper}>
@@ -45,14 +50,25 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
                 <MetaText icon="at">
                   <Trans i18nKey="alerting.alert-group.delivered-to" values={{ name: group.receiver.name }}>
                     Delivered to{' '}
-                    <TextLink
-                      href={createContactPointSearchLink(contactPoint, alertManagerSourceName)}
-                      variant="bodySmall"
-                      color="primary"
-                      inline={false}
-                    >
-                      {'{{name}}'}
-                    </TextLink>
+                    {canViewContactPoint ? (
+                      <TextLink
+                        href={createContactPointSearchLink(contactPoint, alertManagerSourceName)}
+                        variant="bodySmall"
+                        color="primary"
+                        inline={false}
+                      >
+                        {'{{name}}'}
+                      </TextLink>
+                    ) : (
+                      <Tooltip
+                        content={t(
+                          'alerting.alert-group.view-contact-point-no-permission',
+                          'You do not have permission to view contact points'
+                        )}
+                      >
+                        <span className={styles.disabledContactPointName}>{'{{name}}'}</span>
+                      </Tooltip>
+                    )}
                   </Trans>
                 </MetaText>
               )}
@@ -91,5 +107,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+  }),
+  disabledContactPointName: css({
+    opacity: 0.7,
+    cursor: 'not-allowed',
   }),
 });

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -5,10 +5,9 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Stack, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
 import { type AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
-import { AccessControlAction } from 'app/types/accessControl';
 
+import { useCanViewContactPoints } from '../../hooks/useAbilities';
 import { createContactPointSearchLink } from '../../utils/misc';
 import { CollapseToggle } from '../CollapseToggle';
 import { MetaText } from '../MetaText';
@@ -24,13 +23,11 @@ interface Props {
 export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
   const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
   const styles = useStyles2(getStyles);
+  const canViewContactPoint = useCanViewContactPoints();
 
   // When group is grouped, receiver.name is 'NONE' as it can contain multiple receivers
   const receiverInGroup = group.receiver.name !== 'NONE';
   const contactPoint = group.receiver.name;
-  const canViewContactPoint =
-    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
-    contextSrv.hasPermission(AccessControlAction.AlertingReceiversRead);
 
   return (
     <div className={styles.wrapper}>

--- a/public/app/features/alerting/unified/components/bridges/DeclareIncidentButton.tsx
+++ b/public/app/features/alerting/unified/components/bridges/DeclareIncidentButton.tsx
@@ -1,7 +1,7 @@
 import { t } from '@grafana/i18n';
 import { Menu, Tooltip } from '@grafana/ui';
 
-import { useIrmPlugin } from '../../hooks/usePluginBridge';
+import { canAccessPluginPage, useIrmPlugin } from '../../hooks/usePluginBridge';
 import { SupportedPlugin } from '../../types/pluginBridges';
 import { createBridgeURL } from '../PluginBridge';
 
@@ -13,12 +13,14 @@ interface Props {
 
 export const DeclareIncidentMenuItem = ({ title = '', severity = '', url = '' }: Props) => {
   const { pluginId, loading, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
+  const incidentPath = '/incidents/declare';
 
-  const bridgeURL = createBridgeURL(pluginId, '/incidents/declare', {
+  const bridgeURL = createBridgeURL(pluginId, incidentPath, {
     title,
     severity,
     url,
   });
+  const hasAccess = settings ? canAccessPluginPage(settings, createBridgeURL(pluginId, incidentPath)) : false;
 
   return (
     <>
@@ -43,7 +45,21 @@ export const DeclareIncidentMenuItem = ({ title = '', severity = '', url = '' }:
           />
         </Tooltip>
       )}
-      {settings && (
+      {settings && !hasAccess && (
+        <Tooltip
+          content={t(
+            'alerting.declare-incident-menu-item.content-you-do-not-have-permission-to-access-incident',
+            'You do not have permission to access Incident'
+          )}
+        >
+          <Menu.Item
+            label={t('alerting.declare-incident-menu-item.label-declare-incident', 'Declare incident')}
+            icon="fire"
+            disabled
+          />
+        </Tooltip>
+      )}
+      {settings && hasAccess && (
         <Menu.Item
           label={t('alerting.declare-incident-menu-item.label-declare-incident', 'Declare incident')}
           url={bridgeURL}

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -198,6 +198,26 @@ export const useAlertingAbility = (action: AlertingAction): Ability => {
 };
 
 /**
+ * UI-only permission helper for places that need contact point visibility checks
+ * without requiring AlertmanagerContext.
+ */
+export function useCanViewContactPoints(): boolean {
+  return useMemo(
+    () =>
+      ctx.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+      ctx.hasPermission(AccessControlAction.AlertingReceiversRead),
+    []
+  );
+}
+
+/**
+ * UI-only permission helper for actions that create silences.
+ */
+export function useCanCreateSilences(): boolean {
+  return useMemo(() => ctx.hasPermission(AccessControlAction.AlertingInstanceCreate), []);
+}
+
+/**
  * This one will check for enrichment abilities
  */
 export const useEnrichmentAbilities = (): Abilities<EnrichmentAction> => {

--- a/public/app/features/alerting/unified/hooks/usePluginBridge.test.tsx
+++ b/public/app/features/alerting/unified/hooks/usePluginBridge.test.tsx
@@ -262,6 +262,7 @@ describe('canAccessPluginPage', () => {
       includes: [
         {
           type: PluginIncludeType.page,
+          name: 'Declare incident',
           path: '/a/grafana-incident-app/incidents/declare',
           action: 'grafana-incident-app.incidents:write',
         },
@@ -278,6 +279,7 @@ describe('canAccessPluginPage', () => {
       includes: [
         {
           type: PluginIncludeType.page,
+          name: 'Declare incident',
           path: '/a/grafana-incident-app/incidents/declare',
           action: 'grafana-incident-app.incidents:write',
         },
@@ -295,6 +297,7 @@ describe('canAccessPluginPage', () => {
       includes: [
         {
           type: PluginIncludeType.page,
+          name: 'Declare incident',
           path: '/a/grafana-incident-app/incidents/declare',
           role: OrgRole.Editor,
         },

--- a/public/app/features/alerting/unified/hooks/usePluginBridge.test.tsx
+++ b/public/app/features/alerting/unified/hooks/usePluginBridge.test.tsx
@@ -1,10 +1,13 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { OrgRole, PluginIncludeType } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
+
 import { useGetPluginSettingsQuery } from '../api/pluginsApi';
 import { pluginMeta } from '../testSetup/plugins';
 import { SupportedPlugin } from '../types/pluginBridges';
 
-import { useIrmPlugin } from './usePluginBridge';
+import { canAccessPluginPage, useIrmPlugin } from './usePluginBridge';
 
 jest.mock('../api/pluginsApi');
 
@@ -236,5 +239,68 @@ describe('useIrmPlugin', () => {
     expect(result.current.pluginId).toBe(SupportedPlugin.Irm);
     expect(result.current.installed).toBe(true);
     expect(result.current.settings).toEqual(pluginMeta[SupportedPlugin.Irm]);
+  });
+});
+
+describe('canAccessPluginPage', () => {
+  const previousRole = contextSrv.user.orgRole;
+  const previousPermissions = contextSrv.user.permissions;
+  const previousIsEditor = contextSrv.isEditor;
+  const previousIsGrafanaAdmin = contextSrv.isGrafanaAdmin;
+
+  afterEach(() => {
+    contextSrv.user.orgRole = previousRole;
+    contextSrv.user.permissions = previousPermissions;
+    contextSrv.isEditor = previousIsEditor;
+    contextSrv.isGrafanaAdmin = previousIsGrafanaAdmin;
+  });
+
+  it('returns false when include requires action and user lacks permission', () => {
+    contextSrv.user.permissions = {};
+    const settings = {
+      ...pluginMeta[SupportedPlugin.Incident],
+      includes: [
+        {
+          type: PluginIncludeType.page,
+          path: '/a/grafana-incident-app/incidents/declare',
+          action: 'grafana-incident-app.incidents:write',
+        },
+      ],
+    };
+
+    expect(canAccessPluginPage(settings, '/a/grafana-incident-app/incidents/declare')).toBe(false);
+  });
+
+  it('returns true when include requires action and user has permission', () => {
+    contextSrv.user.permissions = { 'grafana-incident-app.incidents:write': true };
+    const settings = {
+      ...pluginMeta[SupportedPlugin.Incident],
+      includes: [
+        {
+          type: PluginIncludeType.page,
+          path: '/a/grafana-incident-app/incidents/declare',
+          action: 'grafana-incident-app.incidents:write',
+        },
+      ],
+    };
+
+    expect(canAccessPluginPage(settings, '/a/grafana-incident-app/incidents/declare')).toBe(true);
+  });
+
+  it('returns false when include role is editor and user is viewer', () => {
+    contextSrv.user.orgRole = OrgRole.Viewer;
+    contextSrv.isEditor = false;
+    const settings = {
+      ...pluginMeta[SupportedPlugin.Incident],
+      includes: [
+        {
+          type: PluginIncludeType.page,
+          path: '/a/grafana-incident-app/incidents/declare',
+          role: OrgRole.Editor,
+        },
+      ],
+    };
+
+    expect(canAccessPluginPage(settings, '/a/grafana-incident-app/incidents/declare')).toBe(false);
   });
 });

--- a/public/app/features/alerting/unified/hooks/usePluginBridge.ts
+++ b/public/app/features/alerting/unified/hooks/usePluginBridge.ts
@@ -1,5 +1,6 @@
-import { type PluginMeta } from '@grafana/data';
+import { OrgRole, type PluginMeta } from '@grafana/data';
 import { isFetchError } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { useGetPluginSettingsQuery } from '../api/pluginsApi';
 import { type PluginID } from '../components/PluginBridge';
@@ -44,6 +45,34 @@ export interface PluginBridgeResult {
   installed?: boolean;
   error?: Error;
   settings?: PluginMeta<{}>;
+}
+
+/**
+ * Checks access to a specific plugin page path using the same include role/action
+ * semantics as the core app plugin route guard.
+ */
+export function canAccessPluginPage(settings: PluginMeta<{}>, pluginPagePath: string): boolean {
+  const requestedPath = pluginPagePath.split('?')[0];
+  const pluginInclude = settings.includes?.find((include) => include.path === requestedPath);
+
+  if (!pluginInclude) {
+    return true;
+  }
+
+  if (pluginInclude.action) {
+    return contextSrv.hasPermission(pluginInclude.action);
+  }
+
+  if (contextSrv.isGrafanaAdmin || contextSrv.user.orgRole === OrgRole.Admin) {
+    return true;
+  }
+
+  const includeRole = pluginInclude.role ?? '';
+  if (!includeRole || (contextSrv.isEditor && includeRole === OrgRole.Viewer)) {
+    return true;
+  }
+
+  return contextSrv.hasRole(includeRole);
 }
 /**
  * Hook that checks for IRM plugin first, falls back to specified plugin.

--- a/public/app/features/alerting/unified/notifications/NotificationDetailActions.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailActions.tsx
@@ -2,8 +2,10 @@ import { type CreateNotificationqueryNotificationEntry } from '@grafana/api-clie
 import { useAssistant } from '@grafana/assistant';
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Dropdown, Menu } from '@grafana/ui';
+import { Dropdown, Menu, Tooltip } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import MoreButton from '../components/MoreButton';
 import { DeclareIncidentMenuItem } from '../components/bridges/DeclareIncidentButton';
@@ -22,16 +24,35 @@ export function NotificationActionsMenu({ notification }: NotificationActionsMen
   const shouldShowDeclareIncident = !isOpenSourceEdition() || isLocalDevEnv();
 
   const hasSilenceableLabels = notification.groupLabels && Object.keys(notification.groupLabels).length > 0;
+  const canViewContactPoint =
+    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+    contextSrv.hasPermission(AccessControlAction.AlertingReceiversRead);
+  const canSilence = contextSrv.hasPermission(AccessControlAction.AlertingInstanceCreate);
 
   const ruleUIDs = notification.ruleUIDs ?? [];
 
   const menuItems = (
     <>
-      <Menu.Item
-        label={t('alerting.notification-detail.menu-view-contact-point', 'View contact point')}
-        icon="at"
-        url={createRelativeUrl(`/alerting/notifications?search=${encodeURIComponent(notification.receiver)}`)}
-      />
+      {canViewContactPoint ? (
+        <Menu.Item
+          label={t('alerting.notification-detail.menu-view-contact-point', 'View contact point')}
+          icon="at"
+          url={createRelativeUrl(`/alerting/notifications?search=${encodeURIComponent(notification.receiver)}`)}
+        />
+      ) : (
+        <Tooltip
+          content={t(
+            'alerting.notification-detail.menu-view-contact-point-no-permission',
+            'You do not have permission to view contact points'
+          )}
+        >
+          <Menu.Item
+            label={t('alerting.notification-detail.menu-view-contact-point', 'View contact point')}
+            icon="at"
+            disabled
+          />
+        </Tooltip>
+      )}
       {ruleUIDs.length === 1 && (
         <Menu.Item
           label={t('alerting.notification-detail.menu-view-rule', 'View alert rule')}
@@ -51,13 +72,27 @@ export function NotificationActionsMenu({ notification }: NotificationActionsMen
           />
         ))}
       <Menu.Divider />
-      {hasSilenceableLabels && (
-        <Menu.Item
-          label={t('alerting.notification-detail.menu-silence', 'Silence notifications')}
-          icon="bell-slash"
-          url={makeLabelBasedSilenceLink('grafana', notification.groupLabels!)}
-        />
-      )}
+      {hasSilenceableLabels &&
+        (canSilence ? (
+          <Menu.Item
+            label={t('alerting.notification-detail.menu-silence', 'Silence notifications')}
+            icon="bell-slash"
+            url={makeLabelBasedSilenceLink('grafana', notification.groupLabels!)}
+          />
+        ) : (
+          <Tooltip
+            content={t(
+              'alerting.notification-detail.menu-silence-no-permission',
+              'You do not have permission to create silences'
+            )}
+          >
+            <Menu.Item
+              label={t('alerting.notification-detail.menu-silence', 'Silence notifications')}
+              icon="bell-slash"
+              disabled
+            />
+          </Tooltip>
+        ))}
       {shouldShowDeclareIncident && (
         <DeclareIncidentMenuItem title={pickHeadingLabel(notification.groupLabels)} url="" />
       )}

--- a/public/app/features/alerting/unified/notifications/NotificationDetailActions.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailActions.tsx
@@ -4,11 +4,10 @@ import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Dropdown, Menu, Tooltip } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
-import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types/accessControl';
 
 import MoreButton from '../components/MoreButton';
 import { DeclareIncidentMenuItem } from '../components/bridges/DeclareIncidentButton';
+import { useCanCreateSilences, useCanViewContactPoints } from '../hooks/useAbilities';
 import { isLocalDevEnv, isOpenSourceEdition, makeLabelBasedSilenceLink } from '../utils/misc';
 import { createRelativeUrl } from '../utils/url';
 
@@ -20,14 +19,12 @@ interface NotificationActionsMenuProps {
 
 export function NotificationActionsMenu({ notification }: NotificationActionsMenuProps) {
   const { isAvailable: isAssistantAvailable, openAssistant } = useAssistant();
+  const canViewContactPoint = useCanViewContactPoints();
+  const canSilence = useCanCreateSilences();
 
   const shouldShowDeclareIncident = !isOpenSourceEdition() || isLocalDevEnv();
 
   const hasSilenceableLabels = notification.groupLabels && Object.keys(notification.groupLabels).length > 0;
-  const canViewContactPoint =
-    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
-    contextSrv.hasPermission(AccessControlAction.AlertingReceiversRead);
-  const canSilence = contextSrv.hasPermission(AccessControlAction.AlertingInstanceCreate);
 
   const ruleUIDs = notification.ruleUIDs ?? [];
 

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -4,11 +4,11 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import { type Labels } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Box, Button, LinkButton, Stack, Text, Tooltip } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
 import { createBridgeURL } from '../../components/PluginBridge';
+import { useCanCreateSilences } from '../../hooks/useAbilities';
 import { stringifyFolder, useFolder } from '../../hooks/useFolder';
 import { canAccessPluginPage, useIrmPlugin } from '../../hooks/usePluginBridge';
 import { SupportedPlugin } from '../../types/pluginBridges';
@@ -25,6 +25,7 @@ interface InstanceDetailsDrawerTitleProps {
 export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDetailsDrawerTitleProps) {
   const { folder } = useFolder(rule?.namespace_uid);
   const { pluginId, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
+  const canCreateSilence = useCanCreateSilences();
 
   const silenceLink = useMemo(() => {
     if (!rule) {
@@ -40,9 +41,8 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
   const canAccessIncident = settings
     ? canAccessPluginPage(settings, createBridgeURL(pluginId, '/incidents/declare'))
     : false;
-  const hasGlobalSilencePermission = contextSrv.hasPermission(AccessControlAction.AlertingInstanceCreate);
   const hasFolderSilencePermission = folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
-  const canSilence = hasGlobalSilencePermission || hasFolderSilencePermission;
+  const canSilence = canCreateSilence || hasFolderSilencePermission;
 
   return (
     <Stack direction="column" gap={2}>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -75,7 +75,14 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
           </Tooltip>
         )}
         {shouldShowDeclareIncident && canAccessIncident && (
-          <LinkButton href={incidentURL} icon="fire" variant="secondary" size="sm" target="_blank" rel="noopener noreferrer">
+          <LinkButton
+            href={incidentURL}
+            icon="fire"
+            variant="secondary"
+            size="sm"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>
           </LinkButton>
         )}

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -5,6 +5,8 @@ import { type Labels } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Box, Button, LinkButton, Stack, Text, Tooltip } from '@grafana/ui';
 import { type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { createBridgeURL } from '../../components/PluginBridge';
 import { stringifyFolder, useFolder } from '../../hooks/useFolder';
@@ -38,6 +40,9 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
   const canAccessIncident = settings
     ? canAccessPluginPage(settings, createBridgeURL(pluginId, '/incidents/declare'))
     : false;
+  const hasGlobalSilencePermission = contextSrv.hasPermission(AccessControlAction.AlertingInstanceCreate);
+  const hasFolderSilencePermission = folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
+  const canSilence = hasGlobalSilencePermission || hasFolderSilencePermission;
 
   return (
     <Stack direction="column" gap={2}>
@@ -45,7 +50,7 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
         <Trans i18nKey="alerting.triage.instance-details-drawer.instance-details">Instance details</Trans>
       </Text>
       <Stack direction="row" gap={1}>
-        {silenceLink && (
+        {silenceLink && canSilence && (
           <LinkButton
             href={silenceLink}
             icon="bell-slash"
@@ -57,7 +62,18 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
             <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
           </LinkButton>
         )}
-<<<<<<< HEAD
+        {silenceLink && !canSilence && (
+          <Tooltip
+            content={t(
+              'alerting.triage.instance-details-drawer.silence-no-permission',
+              'You do not have permission to create silences'
+            )}
+          >
+            <Button icon="bell-slash" variant="secondary" size="sm" disabled>
+              <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
+            </Button>
+          </Tooltip>
+        )}
         {shouldShowDeclareIncident && canAccessIncident && (
           <LinkButton href={incidentURL} icon="fire" variant="secondary" size="sm" target="_blank" rel="noopener noreferrer">
             <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -4,9 +4,9 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import { type Labels } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Box, Button, LinkButton, Stack, Text, Tooltip } from '@grafana/ui';
-import { type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
+import { type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
 import { createBridgeURL } from '../../components/PluginBridge';
 import { stringifyFolder, useFolder } from '../../hooks/useFolder';

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -3,12 +3,12 @@ import { useMemo } from 'react';
 import { AlertLabels } from '@grafana/alerting/unstable';
 import { type Labels } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Box, LinkButton, Stack, Text } from '@grafana/ui';
+import { Box, Button, LinkButton, Stack, Text, Tooltip } from '@grafana/ui';
 import { type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
 import { createBridgeURL } from '../../components/PluginBridge';
 import { stringifyFolder, useFolder } from '../../hooks/useFolder';
-import { useIrmPlugin } from '../../hooks/usePluginBridge';
+import { canAccessPluginPage, useIrmPlugin } from '../../hooks/usePluginBridge';
 import { SupportedPlugin } from '../../types/pluginBridges';
 import { MATCHER_ALERT_RULE_UID } from '../../utils/constants';
 import { isLocalDevEnv, isOpenSourceEdition, makeLabelBasedSilenceLink } from '../../utils/misc';
@@ -35,6 +35,9 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
 
   const shouldShowDeclareIncident = (!isOpenSourceEdition() || isLocalDevEnv()) && installed && settings;
   const incidentURL = createBridgeURL(pluginId, '/incidents/declare', { title: rule?.title ?? '' });
+  const canAccessIncident = settings
+    ? canAccessPluginPage(settings, createBridgeURL(pluginId, '/incidents/declare'))
+    : false;
 
   return (
     <Stack direction="column" gap={2}>
@@ -54,17 +57,23 @@ export function InstanceDetailsDrawerTitle({ instanceLabels, rule }: InstanceDet
             <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
           </LinkButton>
         )}
-        {shouldShowDeclareIncident && (
-          <LinkButton
-            href={incidentURL}
-            icon="fire"
-            variant="secondary"
-            size="sm"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+<<<<<<< HEAD
+        {shouldShowDeclareIncident && canAccessIncident && (
+          <LinkButton href={incidentURL} icon="fire" variant="secondary" size="sm" target="_blank" rel="noopener noreferrer">
             <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>
           </LinkButton>
+        )}
+        {shouldShowDeclareIncident && !canAccessIncident && (
+          <Tooltip
+            content={t(
+              'alerting.triage.instance-details-drawer.declare-incident-no-permission',
+              'You do not have permission to access Incident'
+            )}
+          >
+            <Button icon="fire" variant="secondary" size="sm" disabled>
+              <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>
+            </Button>
+          </Tooltip>
         )}
       </Stack>
       <Box>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1064,6 +1064,7 @@
     },
     "declare-incident-menu-item": {
       "content-grafana-incident-installed-configured-correctly": "Grafana Incident is not installed or is not configured correctly",
+      "content-you-do-not-have-permission-to-access-incident": "You do not have permission to access Incident",
       "label-declare-incident": "Declare incident"
     },
     "delete-rule-modal": {
@@ -3577,6 +3578,7 @@
       },
       "instance-details-drawer": {
         "declare-incident": "Declare incident",
+        "declare-incident-no-permission": "You do not have permission to access Incident",
         "instance-details": "Instance details",
         "silence-button": "Silence"
       },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -403,8 +403,9 @@
       "silence": "Silence"
     },
     "alert-group": {
-      "delivered-to": "Delivered to <2>{{name}}</2>",
-      "no-grouping": "No grouping"
+      "delivered-to": "Delivered to <2></2>",
+      "no-grouping": "No grouping",
+      "view-contact-point-no-permission": "You do not have permission to view contact points"
     },
     "alert-group-alerts-table": {
       "columns": {
@@ -2251,7 +2252,9 @@
       "menu-analyze": "Analyze alert notification",
       "menu-copy-link": "Copy link",
       "menu-silence": "Silence notifications",
+      "menu-silence-no-permission": "You do not have permission to create silences",
       "menu-view-contact-point": "View contact point",
+      "menu-view-contact-point-no-permission": "You do not have permission to view contact points",
       "menu-view-rule": "View alert rule",
       "menu-view-rule-n": "View alert rule ({{n}})",
       "more-details-heading": "More details",
@@ -3580,7 +3583,8 @@
         "declare-incident": "Declare incident",
         "declare-incident-no-permission": "You do not have permission to access Incident",
         "instance-details": "Instance details",
-        "silence-button": "Silence"
+        "silence-button": "Silence",
+        "silence-no-permission": "You do not have permission to create silences"
       },
       "labels-column-title": "Labels",
       "no-firing-or-pending-instances": "You have no alert instances in a firing or pending state for the selected time range.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -403,7 +403,8 @@
       "silence": "Silence"
     },
     "alert-group": {
-      "delivered-to": "Delivered to <2></2>",
+      "delivered-to": "Delivered to <2>{{name}}</2>",
+      "delivered-to-disabled": "Delivered to {{name}}",
       "no-grouping": "No grouping",
       "view-contact-point-no-permission": "You do not have permission to view contact points"
     },


### PR DESCRIPTION
This PR adds RBAC-aware gating for Declare incident in Alerts Activity and Notification Detail actions, using plugin page access checks

- Updates Declare incident UX to avoid broken redirects: shows disabled action with explanatory tooltip when access is denied.
- Adds permission checks for Silence actions in Activity surfaces (instance drawer + notification detail menu), with disabled + tooltip when user lacks silence permissions.
- Adds permission checks for View contact point in Notification Detail actions and Active Notifications “Delivered to …” link, with disabled + tooltip when denied.

<img width="1203" height="738" alt="Screenshot 2026-03-30 at 15 12 27" src="https://github.com/user-attachments/assets/6599986a-9605-45f6-a978-a8706b19e8ba" />

