### PR TITLE
Tempo: Sort search dropdown values alphabetically

### DIFF
--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -171,7 +171,7 @@ export default class TempoLanguageProvider extends LanguageProvider {
         }
       });
     }
-    return options.sort((a, b) => (a.value?.toLowerCase()! < b.value?.toLowerCase()! ? -1 : 1));
+    return options.sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
   }
 
   getTimeRangeForTags = (timeRangeForTags: number, range: TimeRange) => {


### PR DESCRIPTION
## What is this feature?

Sorts the dropdown values returned by `TempoLanguageProvider.getOptionsV2()` alphabetically by label. This affects all search dropdowns in the Tempo query editor including Service Name, Span Name, and Status.

## Why do we need this?

The current dropdown values are displayed in backend response order, which makes them harder to scan and inconsistent for users searching traces. Tags dropdown was already sorted, but other dropdowns were not.

## Which issue(s) does this PR fix?

Fixes #120728