### PR TITLE
Tempo: Fix Ctrl+/ comment toggle in TraceQL editor

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/traceql.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/traceql.test.ts
@@ -27,6 +27,12 @@ describe('TraceQL grammar', () => {
       expect(withParameters).toContain('most_recent');
     });
 
+    it('should configure line comment for Ctrl+/ toggle support', () => {
+      const { languageConfiguration } = languageDefinition.def;
+      expect(languageConfiguration.comments).toBeDefined();
+      expect(languageConfiguration.comments?.lineComment).toBe('//');
+    });
+
     it('should include compare function in the functions list', () => {
       const { functions } = languageDefinition.def.language;
       expect(functions).toContain('compare');

--- a/public/app/plugins/datasource/tempo/traceql/traceql.ts
+++ b/public/app/plugins/datasource/tempo/traceql/traceql.ts
@@ -4,6 +4,9 @@ import { type Grammar } from 'prismjs';
 export const languageConfiguration: languages.LanguageConfiguration = {
   // the default separators except `@$`
   wordPattern: /(-?\d*\.\d\w*)|([^`~!#%^&*()\-=+\[{\]}\\|;:'",.<>\/?\s]+)/g,
+  comments: {
+    lineComment: '//',
+  },
   brackets: [
     ['{', '}'],
     ['(', ')'],


### PR DESCRIPTION
## What is this feature?

Restores the Ctrl+/ (Cmd+/ on macOS) keyboard shortcut for toggling line comments in the TraceQL Monaco editor.

## Why do we need this?

The comment toggle shortcut stopped working because the TraceQL language configuration was missing the `comments` property. Monaco requires this property to know how to handle the toggle comment keyboard shortcut. The tokenizer already supported `//` line comments for syntax highlighting, but the language configuration needed to declare the comment syntax for the keybinding to function.

## Which issue(s) does this PR fix?

Fixes #115334