### PR TITLE
Alerting: Include alert rule labels in annotation template data

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -156,7 +156,11 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 	// For now, do nothing with these errors as they are already logged in expand.
 	// In the future, we want to show these errors to the user somehow.
 	labels, _ := expand(ctx, log, alertRule.Title, alertRule.Labels, templateData, externalURL, result.EvaluatedAt)
-	annotations, _ := expand(ctx, log, alertRule.Title, alertRule.Annotations, templateData, externalURL, result.EvaluatedAt)
+
+	// Include the expanded alert rule labels in the template data used for annotations,
+	// so that manually set labels are available via $labels during annotation interpolation.
+	annotationTemplateData := template.NewData(mergeLabels(mergeLabels(extraLabels, resultLabels), labels), result)
+	annotations, _ := expand(ctx, log, alertRule.Title, alertRule.Annotations, annotationTemplateData, externalURL, result.EvaluatedAt)
 
 	// If the result contains an error, we want to add the ref_id and datasource_uid labels
 	// to the new state if the alert rule should be in the ErrorErrState.

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -168,6 +168,59 @@ func Test_mergeLabels(t *testing.T) {
 	})
 }
 
+func Test_expandAnnotationsAndLabels(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	t.Run("manually set labels are available in annotation templates via $labels", func(t *testing.T) {
+		alertRule := &models.AlertRule{
+			Title: "test-rule",
+			Labels: map[string]string{
+				"environment": "production",
+				"team":        "backend",
+			},
+			Annotations: map[string]string{
+				"summary": `Alert in {{ $labels.environment }} for {{ $labels.team }}`,
+			},
+		}
+
+		result := eval.Result{
+			Instance:    data.Labels{"instance": "host1"},
+			EvaluatedAt: time.Now(),
+		}
+
+		extraLabels := data.Labels{}
+
+		_, annotations := expandAnnotationsAndLabels(ctx, logger, alertRule, result, extraLabels, nil)
+
+		require.Equal(t, "Alert in production for backend", annotations["summary"])
+	})
+
+	t.Run("result labels take precedence over alert rule labels in annotations", func(t *testing.T) {
+		alertRule := &models.AlertRule{
+			Title: "test-rule",
+			Labels: map[string]string{
+				"environment": "production",
+			},
+			Annotations: map[string]string{
+				"summary": `Environment is {{ $labels.environment }}`,
+			},
+		}
+
+		result := eval.Result{
+			Instance:    data.Labels{"environment": "staging"},
+			EvaluatedAt: time.Now(),
+		}
+
+		extraLabels := data.Labels{}
+
+		_, annotations := expandAnnotationsAndLabels(ctx, logger, alertRule, result, extraLabels, nil)
+
+		// Result labels should take precedence over alert rule labels
+		require.Equal(t, "Environment is staging", annotations["summary"])
+	})
+}
+
 func TestCacheMetrics(t *testing.T) {
 	orgID := int64(1)
 


### PR DESCRIPTION
## What is this feature?

Ensures that manually set labels on alert rules are available via the `$labels` variable when expanding annotation templates.

## Why do we need this?

When users set custom labels on an alert rule (e.g., `environment: production`) and reference them in annotation templates using `{{ $labels.environment }}`, the label value was missing from the interpolated output. This is because the template engine was loaded with data before considering the labels defined on the alert rule.

The fix creates a new template data context for annotation expansion that includes the expanded alert rule labels, in addition to the evaluation result labels and system labels. Result labels and system labels still take precedence over alert rule labels when there are conflicts.

## Which issue(s) does this PR fix?

Fixes #116074