### PR TITLE
Storybook: Enhance `ExampleFrame` to show code source

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -192,6 +192,7 @@
     "process": "^0.11.10",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-element-to-jsx-string": "^17.0.1",
     "react-select-event": "^5.1.0",
     "rimraf": "6.0.1",
     "rollup": "^4.22.4",

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.mdx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.mdx
@@ -12,10 +12,6 @@ You can use it or regular text input. When used, AutoSizeInput resizes itself to
 
 To add more context to the input, you can add either text or an icon before or after the input using the `prefix` and `suffix`. Here are some examples for you to try in the Preview!
 
-```jsx
-<AutoSizeInput prefix={<Icon name="search" />} />
-```
-
 <ExampleFrame>
   <AutoSizeInput prefix={<Icon name="search" />} />
 </ExampleFrame>
@@ -23,12 +19,6 @@ To add more context to the input, you can add either text or an icon before or a
 ## Usage in forms with Field
 
 Use `AutoSizeInput`with the`Field`component to get labels and descriptions. Also, you can use`AutoSizeInput`with the`required`attribute for validation. See the`Field` component for more information.
-
-```jsx
-<Field label="Important information" description="This information is very important, so you really need to fill it in">
-  <AutoSizeInput name="importantInput" required />
-</Field>
-```
 
 <ExampleFrame>
   <Field label="Important information!" description="Please enter the relevant information.">

--- a/packages/grafana-ui/src/components/Input/Input.mdx
+++ b/packages/grafana-ui/src/components/Input/Input.mdx
@@ -15,10 +15,6 @@ Used for regular text input. For an array of data or tree-structured data, consi
 
 To add more context to the input you can add either text or an icon before or after the input. You can use the `prefix` and `suffix` props for this. Try some examples in the Preview!
 
-```jsx
-<Input prefix={<Icon name="search" />} />
-```
-
 <ExampleFrame>
   <Input prefix={<Icon name="search" />} />
 </ExampleFrame>
@@ -26,12 +22,6 @@ To add more context to the input you can add either text or an icon before or af
 ## Usage in forms with Field
 
 `Input` should be used with the `Field` component to get labels and descriptions. It can also be used for validation by using the `required` attribute. See the `Field` component for more information.
-
-```jsx
-<Field label="Important information" description="This information is very important, so you really need to fill it in">
-  <Input name="importantInput" required />
-</Field>
-```
 
 <ExampleFrame>
   <Field

--- a/packages/grafana-ui/src/components/Link/TextLink.mdx
+++ b/packages/grafana-ui/src/components/Link/TextLink.mdx
@@ -103,12 +103,6 @@ but the rest will be kept. So, in this example, if the user renders an external 
   </TextLink>
 </ExampleFrame>
 
-```jsx
-<TextLink href="https://google.es" color="primary" inline={false} external>
-  This an external standalone link example
-</TextLink>
-```
-
 ### <a name="icons-behaviour"/>**Icons**:
 
 By default, **external _text links_** will show an `external-alt-icon`. If by design reasons, the user needs to set another icon it can be done through the correspondent prop.
@@ -119,12 +113,6 @@ By default, **external _text links_** will show an `external-alt-icon`. If by de
   </TextLink>
 </ExampleFrame>
 
-```jsx
-<TextLink href="https://google.es" external>
-  This an external with the default icon
-</TextLink>
-```
-
 Both, **external** and **internal** links can show a specific icon using the `icon` prop.
 
 <ExampleFrame>
@@ -132,11 +120,6 @@ Both, **external** and **internal** links can show a specific icon using the `ic
     {'This an external with a specific icon'}
   </TextLink>
 </ExampleFrame>
-```jsx
-<TextLink href="https://google.es" icon="google" external>
-  This an external with a specific icon
-</TextLink>
-```
 
 ## <a name="propstable"/>Props table
 

--- a/packages/grafana-ui/src/components/Text/Text.mdx
+++ b/packages/grafana-ui/src/components/Text/Text.mdx
@@ -75,28 +75,12 @@ The Text component is mainly comprised by itself. In occasions, the Text compone
   </Text>
 </ExampleFrame>
 
-```jsx
-<Text color="primary" element="p">
-  If you need more help of how to write in Grafana you can go to our
-  <TextLink href="https://grafana.com/docs/writers-toolkit/" external>
-    Writer’s Toolkit
-  </TextLink>
-</Text>
-```
-
 <ExampleFrame>
   <Text color="primary" element="p">
     {'And Forrest Gump said: '}
     <Text italic>{"Life is like a box of chocolates. You never know what you're gonna get."}</Text>
   </Text>
 </ExampleFrame>
-
-```jsx
-<Text color="primary" element="p">
-  And Forrest Gump said:
-  <Text italic>Life is like a box of chocolates. You never know what you're gonna get.</Text>
-</Text>
-```
 
 ### <a name="behaviour"/>**Behaviour**:
 
@@ -112,13 +96,6 @@ The Text component can be truncated. However, the Text component element rendere
   </Text>
 </ExampleFrame>
 
-```jsx
-<Text color="primary" element="p" truncate>
-  And Forrest Gump said:
-  <Text italic>Life is like a box of chocolates. You never know what you are gonna get.</Text>
-</Text>
-```
-
 2. The parent element is not a Text component: the user has to add `overflow: hidden`, `text-overflow: ellipsis` and `whiteSpace: 'nowrap'` to it. In this case, the user should wrap up this container with a Tooltip, so when the text is truncated its content can still be seen hovering on the text.
 
 <ExampleFrame>
@@ -130,15 +107,6 @@ The Text component can be truncated. However, the Text component element rendere
     </div>
   </Tooltip>
 </ExampleFrame>
-```jsx
-<Tooltip content="This is a example of a span element truncated by its parent container">
-  <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-    <Text color="primary" variant="body">
-      {'This is a example of a span element truncated by its parent container.'}
-    </Text>
-  </div>
-</Tooltip>
-```
 
 ### <a name="accessibility"/>**Accessibility**:
 

--- a/packages/grafana-ui/src/utils/storybook/ExampleFrame.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ExampleFrame.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/css';
-import { Source, Unstyled } from '@storybook/blocks';
+import { css, cx } from '@emotion/css';
+import { Source } from '@storybook/blocks';
 import { Children, isValidElement, type ReactNode, useMemo, useState } from 'react';
 import reactElementToJSXString from 'react-element-to-jsx-string';
 
@@ -31,11 +31,9 @@ export function ExampleFrame(props: ExampleFrameProps) {
   }, [children]);
 
   return (
-    <div className={styles.wrapper}>
+    <div className={cx(styles.wrapper, 'sb-unstyled')}>
       <Stack gap={0} direction="column">
-        <Unstyled>
-          <div className={styles.preview}>{children}</div>
-        </Unstyled>
+        <div className={styles.preview}>{children}</div>
         {isExpanded && (
           <div className={styles.source}>
             <Source dark={theme.isDark} code={sourceString} language="tsx" />
@@ -43,7 +41,7 @@ export function ExampleFrame(props: ExampleFrameProps) {
         )}
         <button className={styles.toggle} onClick={() => setIsExpanded(!isExpanded)}>
           {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
-          {isExpanded ? 'Hide source' : 'Show source'}
+          {isExpanded ? 'Hide code' : 'Show code'}
         </button>
       </Stack>
     </div>
@@ -55,6 +53,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css({
       border: `1px solid ${theme.colors.border.medium}`,
       borderRadius: theme.shape.radius.default,
+      margin: theme.spacing(2, 0),
       overflow: 'hidden',
     }),
     preview: css({
@@ -64,7 +63,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       borderTop: `1px solid ${theme.colors.border.medium}`,
       // Reset Storybook Source margins/border-radius so it sits flush
       '& .docblock-source': {
-        background: 'unset',
         border: 'none',
         borderRadius: 'unset',
         margin: 0,

--- a/packages/grafana-ui/src/utils/storybook/ExampleFrame.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ExampleFrame.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
-import { Unstyled } from '@storybook/blocks';
-import { type ReactNode } from 'react';
+import { Source, Unstyled } from '@storybook/blocks';
+import { Children, isValidElement, type ReactNode, useMemo, useState } from 'react';
+import reactElementToJSXString from 'react-element-to-jsx-string';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 
-import { useStyles2 } from '../../themes/ThemeContext';
+import { Stack } from '../../components/Layout/Stack/Stack';
+import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 
 interface ExampleFrameProps {
   children: ReactNode;
@@ -12,28 +14,77 @@ interface ExampleFrameProps {
 
 /**
  * Wraps children with a border for nicer presentation in Storybook docs.
- *
- * This is intended to be used temporarily to move away from our <Preview> patch until
- * we have something more long term.
+ * Includes a collapsible code block that shows the JSX source of the children.
  */
 export function ExampleFrame(props: ExampleFrameProps) {
   const { children } = props;
+  const theme = useTheme2();
   const styles = useStyles2(getStyles);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const sourceString = useMemo(() => {
+    const opts = { sortProps: false };
+    return Children.toArray(children)
+      .filter(isValidElement)
+      .map((child) => reactElementToJSXString(child, opts))
+      .join('\n');
+  }, [children]);
 
   return (
-    <Unstyled>
-      <div className={styles.container}>{children}</div>
-    </Unstyled>
+    <div className={styles.wrapper}>
+      <Stack gap={0} direction="column">
+        <Unstyled>
+          <div className={styles.preview}>{children}</div>
+        </Unstyled>
+        {isExpanded && (
+          <div className={styles.source}>
+            <Source dark={theme.isDark} code={sourceString} language="tsx" />
+          </div>
+        )}
+        <button className={styles.toggle} onClick={() => setIsExpanded(!isExpanded)}>
+          {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
+          {isExpanded ? 'Hide source' : 'Show source'}
+        </button>
+      </Stack>
+    </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    container: css({
+    wrapper: css({
       border: `1px solid ${theme.colors.border.medium}`,
       borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+    }),
+    preview: css({
       padding: theme.spacing(2),
-      marginBottom: theme.spacing(4),
+    }),
+    source: css({
+      borderTop: `1px solid ${theme.colors.border.medium}`,
+      // Reset Storybook Source margins/border-radius so it sits flush
+      '& .docblock-source': {
+        background: 'unset',
+        border: 'none',
+        borderRadius: 'unset',
+        margin: 0,
+
+        '& pre': {
+          border: 'none',
+        },
+      },
+    }),
+    toggle: css({
+      background: 'none',
+      border: 'unset',
+      borderTop: `1px solid ${theme.colors.border.medium}`,
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1.5)}`,
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      '&:hover': {
+        color: theme.colors.text.primary,
+        background: theme.colors.action.hover,
+      },
     }),
   };
 };

--- a/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
+++ b/packages/grafana-ui/src/utils/storybook/ThemedDocsContainer.tsx
@@ -2,7 +2,7 @@
 import { DocsContainer, type DocsContextProps } from '@storybook/addon-docs';
 import * as React from 'react';
 
-import { getThemeById } from '@grafana/data';
+import { getThemeById, ThemeContext } from '@grafana/data';
 
 import { createStorybookTheme } from '../../../.storybook/storybookTheme';
 import { GlobalStyles } from '../../themes/GlobalStyles/GlobalStyles';
@@ -25,8 +25,10 @@ export const ThemedDocsContainer = ({ children, context }: Props) => {
 
   return (
     <DocsContainer theme={createStorybookTheme(theme)} context={context}>
-      <GlobalStyles />
-      {children}
+      <ThemeContext.Provider value={theme}>
+        <GlobalStyles />
+        {children}
+      </ThemeContext.Provider>
     </DocsContainer>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@base2/pretty-print-object@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@base2/pretty-print-object@npm:1.0.2"
+  checksum: 10/8a0c84c7d1ed7c92493238b9815be2eed412d70c13bc889ba6cc3ec6146b886121fe0fbbea01699a1681927c659a37a67b77a8971a009ad35556f064e131e335
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
@@ -4147,6 +4154,7 @@ __metadata:
     react-data-grid: "grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed"
     react-dom: "npm:18.3.1"
     react-dropzone: "npm:14.3.8"
+    react-element-to-jsx-string: "npm:^17.0.1"
     react-highlight-words: "npm:0.21.0"
     react-hook-form: "npm:^7.49.2"
     react-i18next: "npm:^15.0.0"
@@ -21983,6 +21991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-object@npm:5.0.0, is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
 "is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
@@ -21996,13 +22011,6 @@ __metadata:
   version: 3.0.1
   resolution: "is-plain-object@npm:3.0.1"
   checksum: 10/d13fe75db350d4ac669595cdfe0242ae87fcecddf2bca858d2dd443a6ed6eb1f69951fac8c2fa85b16106c6b0d7738fea86c2aca2ecee7fd61de15c1574f2cc5
-  languageName: node
-  linkType: hard
-
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
   languageName: node
   linkType: hard
 
@@ -28781,6 +28789,20 @@ __metadata:
   dependencies:
     prop-types: "npm:^15.5.8"
   checksum: 10/69bb2d366d412441b024c802f03b524f63d494d7b72632380ecce485aa1c08eb87cc9a5ffffa23c7e8dcd190834d15b76458f59ca91c8710d12aa27c084a111d
+  languageName: node
+  linkType: hard
+
+"react-element-to-jsx-string@npm:^17.0.1":
+  version: 17.0.1
+  resolution: "react-element-to-jsx-string@npm:17.0.1"
+  dependencies:
+    "@base2/pretty-print-object": "npm:1.0.2"
+    is-plain-object: "npm:5.0.0"
+  peerDependencies:
+    react: ^19.0.0
+    react-dom: ^19.0.0
+    react-is: ^19.0.0
+  checksum: 10/d5d611f55d3bb8a29dcc253cdf78d6b7eed6ad76466dccfb8d866988bbf7007d2ba3471b4b251bcb4f806331c6d71eb493497dd8bc016270abec4a51a3d3f247
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- enhances `ExampleFrame` to be able to show the source of an example
  - would like some opinions on this...
  - it adds a new devdep to return the jsx string, which i'm not a huge fan of
  - there is _sort of_ another way to do this using storybook built-in components, but it requires creating a separate story for every example, hiding them from the sidebar, and rendering them with the `Canvas` component inside the .mdx file. my immediate 2c is that is worse than this 😅 
  - maybe someone knows a better way? 🙏 
- fixes a bug with docs pages where it wasn't correctly applying the relevant theme to child components in the mdx

|  |  |
| --- | --- |
| before | <img width="1074" height="176" alt="image" src="https://github.com/user-attachments/assets/1d492a1c-019b-40a7-a03a-a79b3d033c31" /> |
| after | <img width="1109" height="190" alt="image" src="https://github.com/user-attachments/assets/fbb6cf12-9eba-4800-9782-8bd0b040dffc" /> |
| after expanded | <img width="1083" height="747" alt="image" src="https://github.com/user-attachments/assets/89738433-67d4-462f-a557-57a645f96851" /> |

**Why do we need this feature?**

- prereq to being able to move content over from saga

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/design-system/issues/170

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
