### PR TITLE
Provisioning: add dashboardCount and folderCount to /files endpoint response

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -635,6 +635,12 @@ type FileList struct {
 
 	// +listType=atomic
 	Items []FileItem `json:"items"`
+
+	// Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree
+	DashboardCount int64 `json:"dashboardCount,omitempty"`
+
+	// Number of folders (directory entries) found in the repository tree
+	FolderCount int64 `json:"folderCount,omitempty"`
 }
 
 func (FileList) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -795,6 +795,20 @@ func schema_pkg_apis_provisioning_v0alpha1_FileList(ref common.ReferenceCallback
 							},
 						},
 					},
+					"dashboardCount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"folderCount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Number of folders (directory entries) found in the repository tree",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 				},
 				Required: []string{"items"},
 			},

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1112,6 +1112,10 @@ export type UpdateRepositoryApiArg = {
 export type GetRepositoryFilesApiResponse = /** status 200 OK */ {
   /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
   apiVersion?: string;
+  /** Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree */
+  dashboardCount?: number;
+  /** Number of folders (directory entries) found in the repository tree */
+  folderCount?: number;
   items: any[];
   /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
   kind?: string;

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -2539,6 +2539,16 @@
                       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                       "type": "string"
                     },
+                    "dashboardCount": {
+                      "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "folderCount": {
+                      "description": "Number of folders (directory entries) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
                     "items": {
                       "type": "array",
                       "items": {
@@ -4219,6 +4229,16 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "dashboardCount": {
+            "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
+          },
+          "folderCount": {
+            "description": "Number of folders (directory entries) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
           },
           "items": {
             "type": "array",

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -2539,6 +2539,16 @@
                       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                       "type": "string"
                     },
+                    "dashboardCount": {
+                      "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "folderCount": {
+                      "description": "Number of folders (directory entries) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
                     "items": {
                       "type": "array",
                       "items": {
@@ -4115,6 +4125,16 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "dashboardCount": {
+            "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
+          },
+          "folderCount": {
+            "description": "Number of folders (directory entries) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
           },
           "items": {
             "type": "array",

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -353,8 +353,10 @@ func (c *filesConnector) listFolderFiles(ctx context.Context, filePath string, r
 	}
 
 	items := make([]provisioning.FileItem, 0, len(rsp))
+	var folderCount, dashboardCount int64
 	for _, v := range rsp {
 		if !v.Blob {
+			folderCount++
 			continue
 		}
 		items = append(items, provisioning.FileItem{
@@ -362,9 +364,16 @@ func (c *filesConnector) listFolderFiles(ctx context.Context, filePath string, r
 			Size: v.Size,
 			Hash: v.Hash,
 		})
+		if resources.IsPathSupported(v.Path) == nil && !resources.IsFolderMetadataFile(v.Path) {
+			dashboardCount++
+		}
 	}
 
-	return &provisioning.FileList{Items: items}, nil
+	return &provisioning.FileList{
+		Items:          items,
+		DashboardCount: dashboardCount,
+		FolderCount:    folderCount,
+	}, nil
 }
 
 // checkQuota verifies that the repository resource quota allows the operation.

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -2677,6 +2677,16 @@
                       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                       "type": "string"
                     },
+                    "dashboardCount": {
+                      "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "folderCount": {
+                      "description": "Number of folders (directory entries) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
                     "items": {
                       "type": "array",
                       "items": {
@@ -4577,6 +4587,16 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "dashboardCount": {
+            "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
+          },
+          "folderCount": {
+            "description": "Number of folders (directory entries) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
           },
           "items": {
             "type": "array",

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -2677,6 +2677,16 @@
                       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                       "type": "string"
                     },
+                    "dashboardCount": {
+                      "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "folderCount": {
+                      "description": "Number of folders (directory entries) found in the repository tree",
+                      "type": "integer",
+                      "format": "int64"
+                    },
                     "items": {
                       "type": "array",
                       "items": {
@@ -4473,6 +4483,16 @@
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
             "type": "string"
+          },
+          "dashboardCount": {
+            "description": "Number of dashboard files (supported extensions: .json, .yaml, .yml) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
+          },
+          "folderCount": {
+            "description": "Number of folders (directory entries) found in the repository tree",
+            "type": "integer",
+            "format": "int64"
           },
           "items": {
             "type": "array",


### PR DESCRIPTION
**What is this feature?**

- The `/repositories/{name}/files/` endpoint's `FileList` response now includes `dashboardCount` and `folderCount` fields. 
- These counts are derived from the existing ReadTree call - directory (non-blob) entries are counted as folders, and supported files (.json, .yaml, .yml) excluding _folder.json metadata files are counted as dashboards. This enables the frontend to accurately estimate total resources for pre-sync quota validation.
- **Made with cursor**

**Why do we need this feature?**

The backend quota enforcement counts both dashboards and folders as resources. However, the /files endpoint only returned blob entries — it filtered out directory/tree entries from ReadTree. The frontend used fileCount (blob count) for the quota comparison, meaning folders were invisible. A repo with 90 dashboards in 20 folders against a limit of 100 would show "90 files" (looks fine) but sync would create 110 resources (exceeds quota).


**Who is this feature for?**

Git sync onboarding flow wizard

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1048

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
