### PR TITLE
CSP: Add configurable form-action directive via $FORM_ACTION_ADDITIONAL_HOSTS

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -459,7 +459,7 @@ content_security_policy = false
 # Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
 # $NONCE in the template includes a random nonce.
 # $ROOT_PATH is server.root_url without the protocol.
-content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;"""
 
 # Enable adding the Content-Security-Policy-Report-Only header to your requests.
 # Allows you to monitor the effects of a policy without enforcing it.
@@ -468,7 +468,12 @@ content_security_policy_report_only = false
 # Set Content Security Policy Report Only template used when adding the Content-Security-Policy-Report-Only header to your requests.
 # $NONCE in the template includes a random nonce.
 # $ROOT_PATH is server.root_url without the protocol.
-content_security_policy_report_only_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+content_security_policy_report_only_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;"""
+
+# Space-separated list of additional hostnames to allow in the CSP form-action directive.
+# $FORM_ACTION_ADDITIONAL_HOSTS in the CSP template is replaced with this value.
+# 'self' should be included directly in the CSP template; this setting adds extra hosts.
+form_action_additional_hosts =
 
 # The CSRF check will be executed even if the request has no login cookie.
 csrf_always_check = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -437,7 +437,7 @@
 # Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
 # $NONCE in the template includes a random nonce.
 # $ROOT_PATH is server.root_url without the protocol.
-;content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+;content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;"""
 
 # Enable adding the Content-Security-Policy-Report-Only header to your requests.
 # Allows you to monitor the effects of a policy without enforcing it.
@@ -446,7 +446,12 @@
 # Set Content Security Policy Report Only template used when adding the Content-Security-Policy-Report-Only header to your requests.
 # $NONCE in the template includes a random nonce.
 # $ROOT_PATH is server.root_url without the protocol.
-;content_security_policy_report_only_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+;content_security_policy_report_only_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;"""
+
+# Space-separated list of additional hostnames to allow in the CSP form-action directive.
+# $FORM_ACTION_ADDITIONAL_HOSTS in the CSP template is replaced with this value.
+# 'self' should be included directly in the CSP template; this setting adds extra hosts.
+;form_action_additional_hosts =
 
 # List of additional allowed URLs to pass by the CSRF check, separated by spaces. Suggested when authentication comes from an IdP.
 ;csrf_trusted_origins = example.com

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
       GF_DEFAULT_APP_MODE: development
       GF_DEFAULT_TARGET: frontend-server
       GF_SECURITY_CONTENT_SECURITY_POLICY: true
-      GF_SECURITY_CONTENT_SECURITY_POLICY_TEMPLATE: "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+      GF_SECURITY_CONTENT_SECURITY_POLICY_TEMPLATE: "object-src 'none'; base-uri 'self'; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS; frame-ancestors 'none'"
       GF_SERVER_ROUTER_LOGGING: true
       GF_LOG_LEVEL: info
       OTEL_SERVICE_NAME: frontend-service

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -198,7 +198,8 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 
 	if hs.Cfg.CSPEnabled {
 		data.CSPEnabled = true
-		data.CSPContent = middleware.ReplacePolicyVariables(hs.Cfg.CSPTemplate, appURL, []string{}, c.RequestNonce)
+		hosts := middleware.CSPHostLists{FormActionAdditionalHosts: hs.Cfg.FormActionAdditionalHosts}
+		data.CSPContent = middleware.ReplacePolicyVariables(hs.Cfg.CSPTemplate, appURL, hosts, c.RequestNonce)
 	}
 	userPermissions, err := hs.accesscontrolService.GetUserPermissions(c.Req.Context(), c.SignedInUser, ac.Options{ReloadCache: false})
 	if err != nil {

--- a/pkg/api/swagger.go
+++ b/pkg/api/swagger.go
@@ -35,7 +35,8 @@ func (hs *HTTPServer) registerSwaggerUI(r routing.RouteRegister) {
 		}
 		if hs.Cfg.CSPEnabled {
 			data["CSPEnabled"] = true
-			data["CSPContent"] = middleware.ReplacePolicyVariables(hs.Cfg.CSPTemplate, hs.Cfg.AppURL, []string{}, c.RequestNonce)
+			hosts := middleware.CSPHostLists{FormActionAdditionalHosts: hs.Cfg.FormActionAdditionalHosts}
+			data["CSPContent"] = middleware.ReplacePolicyVariables(hs.Cfg.CSPTemplate, hs.Cfg.AppURL, hosts, c.RequestNonce)
 		}
 
 		c.HTML(http.StatusOK, "swagger", data)

--- a/pkg/middleware/csp.go
+++ b/pkg/middleware/csp.go
@@ -45,7 +45,8 @@ func nonceMiddleware(next http.Handler, logger log.Logger) http.Handler {
 func cspMiddleware(cfg *setting.Cfg, next http.Handler, logger log.Logger) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		ctx := contexthandler.FromContext(req.Context())
-		policy := ReplacePolicyVariables(cfg.CSPTemplate, cfg.AppURL, []string{}, ctx.RequestNonce)
+		hosts := CSPHostLists{FormActionAdditionalHosts: cfg.FormActionAdditionalHosts}
+		policy := ReplacePolicyVariables(cfg.CSPTemplate, cfg.AppURL, hosts, ctx.RequestNonce)
 		rw.Header().Set("Content-Security-Policy", policy)
 		next.ServeHTTP(rw, req)
 	})
@@ -54,13 +55,20 @@ func cspMiddleware(cfg *setting.Cfg, next http.Handler, logger log.Logger) http.
 func cspReportOnlyMiddleware(cfg *setting.Cfg, next http.Handler, logger log.Logger) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		ctx := contexthandler.FromContext(req.Context())
-		policy := ReplacePolicyVariables(cfg.CSPReportOnlyTemplate, cfg.AppURL, []string{}, ctx.RequestNonce)
+		hosts := CSPHostLists{FormActionAdditionalHosts: cfg.FormActionAdditionalHosts}
+		policy := ReplacePolicyVariables(cfg.CSPReportOnlyTemplate, cfg.AppURL, hosts, ctx.RequestNonce)
 		rw.Header().Set("Content-Security-Policy-Report-Only", policy)
 		next.ServeHTTP(rw, req)
 	})
 }
 
-func ReplacePolicyVariables(policyTemplate, appURL string, frameAncestorHosts []string, nonce string) string {
+// CSPHostLists contains per-directive host lists for CSP template variable replacement.
+type CSPHostLists struct {
+	FrameAncestorHosts        []string
+	FormActionAdditionalHosts []string
+}
+
+func ReplacePolicyVariables(policyTemplate, appURL string, hosts CSPHostLists, nonce string) string {
 	policy := strings.ReplaceAll(policyTemplate, "$NONCE", fmt.Sprintf("'nonce-%s'", nonce))
 	re := regexp.MustCompile(`^\w+:(//)?`)
 	rootPath := re.ReplaceAllString(appURL, "")
@@ -69,12 +77,16 @@ func ReplacePolicyVariables(policyTemplate, appURL string, frameAncestorHosts []
 	// If the CSP directive has a $ALLOW_EMBEDDING_HOSTS variable, and the frameAncestorHosts is empty
 	// then we deny all embedding by setting it to 'none'.
 	var hostList string
-	if len(frameAncestorHosts) == 0 {
+	if len(hosts.FrameAncestorHosts) == 0 {
 		hostList = "'none'"
 	} else {
-		hostList = strings.Join(frameAncestorHosts, " ")
+		hostList = strings.Join(hosts.FrameAncestorHosts, " ")
 	}
 	policy = strings.ReplaceAll(policy, "$ALLOW_EMBEDDING_HOSTS", hostList)
+
+	// $FORM_ACTION_ADDITIONAL_HOSTS is replaced with the configured additional form-action hosts.
+	// When empty, it resolves to an empty string — 'self' should be included directly in the template.
+	policy = strings.ReplaceAll(policy, "$FORM_ACTION_ADDITIONAL_HOSTS", strings.Join(hosts.FormActionAdditionalHosts, " "))
 
 	return policy
 }

--- a/pkg/middleware/csp_test.go
+++ b/pkg/middleware/csp_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplacePolicyVariables(t *testing.T) {
+	t.Run("replaces $NONCE", func(t *testing.T) {
+		result := ReplacePolicyVariables("script-src $NONCE", "https://grafana.example.com", CSPHostLists{}, "abc123")
+		assert.Equal(t, "script-src 'nonce-abc123'", result)
+	})
+
+	t.Run("replaces $ROOT_PATH", func(t *testing.T) {
+		result := ReplacePolicyVariables("connect-src ws://$ROOT_PATH", "https://grafana.example.com/", CSPHostLists{}, "abc123")
+		assert.Equal(t, "connect-src ws://grafana.example.com/", result)
+	})
+
+	t.Run("replaces $ALLOW_EMBEDDING_HOSTS with 'none' when empty", func(t *testing.T) {
+		result := ReplacePolicyVariables("frame-ancestors $ALLOW_EMBEDDING_HOSTS", "https://grafana.example.com", CSPHostLists{}, "abc123")
+		assert.Equal(t, "frame-ancestors 'none'", result)
+	})
+
+	t.Run("replaces $ALLOW_EMBEDDING_HOSTS with host list", func(t *testing.T) {
+		hosts := CSPHostLists{FrameAncestorHosts: []string{"wiki.example.com", "foo.example.com"}}
+		result := ReplacePolicyVariables("frame-ancestors $ALLOW_EMBEDDING_HOSTS", "https://grafana.example.com", hosts, "abc123")
+		assert.Equal(t, "frame-ancestors wiki.example.com foo.example.com", result)
+	})
+
+	t.Run("replaces $FORM_ACTION_ADDITIONAL_HOSTS with empty string when no hosts configured", func(t *testing.T) {
+		result := ReplacePolicyVariables("form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS", "https://grafana.example.com", CSPHostLists{}, "abc123")
+		assert.Equal(t, "form-action 'self' ", result)
+	})
+
+	t.Run("replaces $FORM_ACTION_ADDITIONAL_HOSTS with additional hosts", func(t *testing.T) {
+		hosts := CSPHostLists{FormActionAdditionalHosts: []string{"login.example.com", "auth.example.com"}}
+		result := ReplacePolicyVariables("form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS", "https://grafana.example.com", hosts, "abc123")
+		assert.Equal(t, "form-action 'self' login.example.com auth.example.com", result)
+	})
+
+	t.Run("replaces $FORM_ACTION_ADDITIONAL_HOSTS with wildcard", func(t *testing.T) {
+		hosts := CSPHostLists{FormActionAdditionalHosts: []string{"*"}}
+		result := ReplacePolicyVariables("form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS", "https://grafana.example.com", hosts, "abc123")
+		assert.Equal(t, "form-action 'self' *", result)
+	})
+
+	t.Run("replaces both $ALLOW_EMBEDDING_HOSTS and $FORM_ACTION_ADDITIONAL_HOSTS in same template", func(t *testing.T) {
+		hosts := CSPHostLists{
+			FrameAncestorHosts:        []string{"embed.example.com"},
+			FormActionAdditionalHosts: []string{"login.example.com"},
+		}
+		template := "frame-ancestors $ALLOW_EMBEDDING_HOSTS; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS"
+		result := ReplacePolicyVariables(template, "https://grafana.example.com", hosts, "abc123")
+		assert.Equal(t, "frame-ancestors embed.example.com; form-action 'self' login.example.com", result)
+	})
+
+	t.Run("replaces all variables in a full CSP template", func(t *testing.T) {
+		hosts := CSPHostLists{
+			FrameAncestorHosts:        []string{"embed.example.com"},
+			FormActionAdditionalHosts: []string{"login.example.com"},
+		}
+		template := "script-src 'self' $NONCE; connect-src ws://$ROOT_PATH; frame-ancestors $ALLOW_EMBEDDING_HOSTS; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS"
+		result := ReplacePolicyVariables(template, "https://grafana.example.com/", hosts, "testnonce")
+		assert.Equal(t, "script-src 'self' 'nonce-testnonce'; connect-src ws://grafana.example.com/; frame-ancestors embed.example.com; form-action 'self' login.example.com", result)
+	})
+}

--- a/pkg/services/frontend/csp_middleware.go
+++ b/pkg/services/frontend/csp_middleware.go
@@ -28,6 +28,7 @@ func CSPMiddleware() web.Middleware {
 				"enabled", requestConfig.CSPEnabled,
 				"report_only_enabled", requestConfig.CSPReportOnlyEnabled,
 				"allow_embedding_hosts", requestConfig.AllowEmbeddingHosts,
+				"form_action_additional_hosts", requestConfig.FormActionAdditionalHosts,
 			)
 
 			// Bail early if CSP is not enabled for this tenant
@@ -45,15 +46,20 @@ func CSPMiddleware() web.Middleware {
 			// Stored on the context so the index handler can put it in the HTML
 			reqCtx.RequestNonce = nonce
 
+			hosts := middleware.CSPHostLists{
+				FrameAncestorHosts:        requestConfig.AllowEmbeddingHosts,
+				FormActionAdditionalHosts: requestConfig.FormActionAdditionalHosts,
+			}
+
 			if requestConfig.CSPEnabled && requestConfig.CSPTemplate != "" {
 				logger.Debug("Setting Content-Security-Policy header")
-				policy := middleware.ReplacePolicyVariables(requestConfig.CSPTemplate, requestConfig.AppURL, requestConfig.AllowEmbeddingHosts, nonce)
+				policy := middleware.ReplacePolicyVariables(requestConfig.CSPTemplate, requestConfig.AppURL, hosts, nonce)
 				w.Header().Set("Content-Security-Policy", policy)
 			}
 
 			if requestConfig.CSPReportOnlyEnabled && requestConfig.CSPReportOnlyTemplate != "" {
 				logger.Debug("Setting Content-Security-Policy-Report-Only header")
-				policy := middleware.ReplacePolicyVariables(requestConfig.CSPReportOnlyTemplate, requestConfig.AppURL, requestConfig.AllowEmbeddingHosts, nonce)
+				policy := middleware.ReplacePolicyVariables(requestConfig.CSPReportOnlyTemplate, requestConfig.AppURL, hosts, nonce)
 				w.Header().Set("Content-Security-Policy-Report-Only", policy)
 			}
 

--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -621,6 +621,118 @@ func TestFrontendService_CSP(t *testing.T) {
 		assert.Contains(t, cspHeader, "frame-ancestors tenant.example.com wiki.example.com")
 	})
 
+	t.Run("should expand $FORM_ACTION_ADDITIONAL_HOSTS in CSP template with specific hosts", func(t *testing.T) {
+		raw := ini.Empty()
+		raw.Section("security").Key("form_action_additional_hosts").SetValue("login.example.com,auth.example.com")
+		cfg := &setting.Cfg{
+			Raw:            raw,
+			HTTPPort:       "3000",
+			StaticRootPath: publicDir,
+			BuildVersion:   "10.3.0",
+			AppURL:         "https://grafana.example.com",
+			CSPEnabled:     true,
+			CSPTemplate:    "script-src 'self' $NONCE; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS",
+		}
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		cspHeader := recorder.Header().Get("Content-Security-Policy")
+		assert.Contains(t, cspHeader, "form-action 'self' login.example.com auth.example.com")
+	})
+
+	t.Run("should keep just 'self' in form-action when form_action_additional_hosts is empty", func(t *testing.T) {
+		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
+			HTTPPort:       "3000",
+			StaticRootPath: publicDir,
+			BuildVersion:   "10.3.0",
+			AppURL:         "https://grafana.example.com",
+			CSPEnabled:     true,
+			CSPTemplate:    "script-src 'self'; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS",
+		}
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		cspHeader := recorder.Header().Get("Content-Security-Policy")
+		assert.Contains(t, cspHeader, "form-action 'self'")
+	})
+
+	t.Run("should expand $FORM_ACTION_ADDITIONAL_HOSTS in CSP template with wildcard", func(t *testing.T) {
+		raw := ini.Empty()
+		raw.Section("security").Key("form_action_additional_hosts").SetValue("*")
+		cfg := &setting.Cfg{
+			Raw:            raw,
+			HTTPPort:       "3000",
+			StaticRootPath: publicDir,
+			BuildVersion:   "10.3.0",
+			AppURL:         "https://grafana.example.com",
+			CSPEnabled:     true,
+			CSPTemplate:    "script-src 'self' $NONCE; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS",
+		}
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		cspHeader := recorder.Header().Get("Content-Security-Policy")
+		assert.Contains(t, cspHeader, "form-action 'self' *")
+	})
+
+	t.Run("should apply per-tenant form_action_additional_hosts override to CSP header", func(t *testing.T) {
+		enableSettingsOverridesToggle(t)
+
+		cfg := &setting.Cfg{
+			Raw:            ini.Empty(),
+			HTTPPort:       "3000",
+			StaticRootPath: publicDir,
+			BuildVersion:   "10.3.0",
+			AppURL:         "https://grafana.example.com",
+			CSPEnabled:     true,
+			CSPTemplate:    "script-src 'self'; form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS",
+		}
+		service := createTestService(t, cfg)
+		service.settingsService = &mockSettingsService{
+			settings: []*settingservice.Setting{
+				{Section: "security", Key: "form_action_additional_hosts", Value: "tenant-login.example.com tenant-auth.example.com"},
+			},
+		}
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("baggage", "namespace=stacks-tenant-1")
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		cspHeader := recorder.Header().Get("Content-Security-Policy")
+		assert.Contains(t, cspHeader, "form-action 'self' tenant-login.example.com tenant-auth.example.com")
+	})
+
 	t.Run("should use base config when Tenant-ID header is present", func(t *testing.T) {
 		cfg := &setting.Cfg{
 			Raw:            ini.Empty(),

--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -511,7 +511,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should expand $ALLOW_EMBEDDING_HOSTS in CSP template with specific hosts", func(t *testing.T) {
 		raw := ini.Empty()
-		raw.Section("security").Key("allow_embedding_hosts").SetValue("wiki.example.com,foo.example.com")
+		raw.Section("security").Key("allow_embedding_hosts").SetValue("wiki.example.com foo.example.com")
 		cfg := &setting.Cfg{
 			Raw:            raw,
 			HTTPPort:       "3000",
@@ -623,7 +623,7 @@ func TestFrontendService_CSP(t *testing.T) {
 
 	t.Run("should expand $FORM_ACTION_ADDITIONAL_HOSTS in CSP template with specific hosts", func(t *testing.T) {
 		raw := ini.Empty()
-		raw.Section("security").Key("form_action_additional_hosts").SetValue("login.example.com,auth.example.com")
+		raw.Section("security").Key("form_action_additional_hosts").SetValue("login.example.com auth.example.com")
 		cfg := &setting.Cfg{
 			Raw:            raw,
 			HTTPPort:       "3000",

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -25,6 +25,9 @@ type FSRequestConfig struct {
 	// AllowEmbeddingHosts is the list of hostnames allowed to embed Grafana in an iframe via CSP frame-ancestors.
 	// Use ["*"] to allow all hosts. Empty means embedding is not allowed.
 	AllowEmbeddingHosts []string
+	// FormActionAdditionalHosts is the list of additional hostnames for the CSP form-action directive.
+	// These are appended to the template; 'self' should be in the template itself.
+	FormActionAdditionalHosts []string
 }
 
 // NewFSRequestConfig creates a new FSRequestConfig from the global configuration.
@@ -65,15 +68,17 @@ func NewFSRequestConfig(cfg *setting.Cfg, license licensing.Licensing) FSRequest
 
 	securitySection := cfg.SectionWithEnvOverrides("security")
 	allowEmbeddingHosts := securitySection.Key("allow_embedding_hosts").Strings(",")
+	formActionHosts := securitySection.Key("form_action_additional_hosts").Strings(",")
 
 	return FSRequestConfig{
-		FSFrontendSettings:    frontendSettings,
-		CSPEnabled:            cfg.CSPEnabled,
-		CSPTemplate:           cfg.CSPTemplate,
-		CSPReportOnlyEnabled:  cfg.CSPReportOnlyEnabled,
-		CSPReportOnlyTemplate: cfg.CSPReportOnlyTemplate,
-		AppURL:                cfg.AppURL,
-		AllowEmbeddingHosts:   allowEmbeddingHosts,
+		FSFrontendSettings:        frontendSettings,
+		CSPEnabled:                cfg.CSPEnabled,
+		CSPTemplate:               cfg.CSPTemplate,
+		CSPReportOnlyEnabled:      cfg.CSPReportOnlyEnabled,
+		CSPReportOnlyTemplate:     cfg.CSPReportOnlyTemplate,
+		AppURL:                    cfg.AppURL,
+		AllowEmbeddingHosts:       allowEmbeddingHosts,
+		FormActionAdditionalHosts: formActionHosts,
 	}
 }
 
@@ -127,6 +132,7 @@ func (c *FSRequestConfig) ApplyOverrides(settings *ini.File, logger log.Logger) 
 
 	// TODO: We should apply all overrides for values in FSRequestConfig
 	applyStringSlice(settings, "security", "allow_embedding_hosts", &c.AllowEmbeddingHosts, logger)
+	applyStringSlice(settings, "security", "form_action_additional_hosts", &c.FormActionAdditionalHosts, logger)
 
 	applyString(settings, "analytics", "rudderstack_write_key", &c.RudderstackWriteKey, logger)
 	applyString(settings, "analytics", "rudderstack_data_plane_url", &c.RudderstackDataPlaneUrl, logger)

--- a/pkg/services/frontend/request_config.go
+++ b/pkg/services/frontend/request_config.go
@@ -67,8 +67,8 @@ func NewFSRequestConfig(cfg *setting.Cfg, license licensing.Licensing) FSRequest
 	}
 
 	securitySection := cfg.SectionWithEnvOverrides("security")
-	allowEmbeddingHosts := securitySection.Key("allow_embedding_hosts").Strings(",")
-	formActionHosts := securitySection.Key("form_action_additional_hosts").Strings(",")
+	allowEmbeddingHosts := securitySection.Key("allow_embedding_hosts").Strings(" ")
+	formActionHosts := securitySection.Key("form_action_additional_hosts").Strings(" ")
 
 	return FSRequestConfig{
 		FSFrontendSettings:        frontendSettings,
@@ -169,7 +169,7 @@ func applyString(settings *ini.File, sectionName, keyName string, target *string
 // applyStringSlice applies a space-separated string value from ini settings to a target []string field if it exists.
 func applyStringSlice(settings *ini.File, sectionName, keyName string, target *[]string, logger log.Logger) {
 	if key := getValue(settings, sectionName, keyName); key != nil {
-		*target = strings.Fields(key.String())
+		*target = key.Strings(" ")
 
 		logger.Debug("applying request config override",
 			"section", sectionName,

--- a/pkg/services/frontend/request_config_test.go
+++ b/pkg/services/frontend/request_config_test.go
@@ -102,4 +102,44 @@ func TestFSRequestConfig_ApplyOverrides(t *testing.T) {
 
 		assert.Equal(t, []string{"*"}, config.AllowEmbeddingHosts)
 	})
+
+	t.Run("should override form_action_additional_hosts from settings service", func(t *testing.T) {
+		config := FSRequestConfig{
+			FormActionAdditionalHosts: nil,
+		}
+
+		iniFile := ini.Empty()
+		securitySection, _ := iniFile.NewSection("security")
+		_, _ = securitySection.NewKey("form_action_additional_hosts", "login.example.com auth.example.com")
+
+		config.ApplyOverrides(iniFile, log.New("test"))
+
+		assert.Equal(t, []string{"login.example.com", "auth.example.com"}, config.FormActionAdditionalHosts)
+	})
+
+	t.Run("should override form_action_additional_hosts with wildcard from settings service", func(t *testing.T) {
+		config := FSRequestConfig{
+			FormActionAdditionalHosts: nil,
+		}
+
+		iniFile := ini.Empty()
+		securitySection, _ := iniFile.NewSection("security")
+		_, _ = securitySection.NewKey("form_action_additional_hosts", "*")
+
+		config.ApplyOverrides(iniFile, log.New("test"))
+
+		assert.Equal(t, []string{"*"}, config.FormActionAdditionalHosts)
+	})
+
+	t.Run("should preserve form_action_additional_hosts when not overridden", func(t *testing.T) {
+		config := FSRequestConfig{
+			FormActionAdditionalHosts: []string{"base.example.com"},
+		}
+
+		iniFile := ini.Empty()
+
+		config.ApplyOverrides(iniFile, log.New("test"))
+
+		assert.Equal(t, []string{"base.example.com"}, config.FormActionAdditionalHosts)
+	})
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1886,7 +1886,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.CSPTemplate = security.Key("content_security_policy_template").MustString("")
 	cfg.CSPReportOnlyEnabled = security.Key("content_security_policy_report_only").MustBool(false)
 	cfg.CSPReportOnlyTemplate = security.Key("content_security_policy_report_only_template").MustString("")
-	cfg.FormActionAdditionalHosts = security.Key("form_action_additional_hosts").Strings(",")
+	cfg.FormActionAdditionalHosts = security.Key("form_action_additional_hosts").Strings(" ")
 
 	enableFrontendSandboxForPlugins := security.Key("enable_frontend_sandbox_for_plugins").MustString("")
 	for _, plug := range strings.Split(enableFrontendSandboxForPlugins, ",") {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -207,7 +207,10 @@ type Cfg struct {
 	// CSPReportEnabled toggles Content Security Policy Report Only support.
 	CSPReportOnlyEnabled bool
 	// CSPReportOnlyTemplate contains the Content Security Policy Report Only template.
-	CSPReportOnlyTemplate           string
+	CSPReportOnlyTemplate string
+	// FormActionAdditionalHosts is the list of additional hostnames for the CSP form-action directive.
+	// These are appended to the template; 'self' should be in the template itself.
+	FormActionAdditionalHosts       []string
 	EnableFrontendSandboxForPlugins []string
 	DisableGravatar                 bool
 	DataProxyWhiteList              map[string]bool
@@ -1883,6 +1886,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.CSPTemplate = security.Key("content_security_policy_template").MustString("")
 	cfg.CSPReportOnlyEnabled = security.Key("content_security_policy_report_only").MustBool(false)
 	cfg.CSPReportOnlyTemplate = security.Key("content_security_policy_report_only_template").MustString("")
+	cfg.FormActionAdditionalHosts = security.Key("form_action_additional_hosts").Strings(",")
 
 	enableFrontendSandboxForPlugins := security.Key("enable_frontend_sandbox_for_plugins").MustString("")
 	for _, plug := range strings.Split(enableFrontendSandboxForPlugins, ",") {

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -41,7 +41,7 @@ func TestIntegrationIndexView(t *testing.T) {
 
 		// nolint:bodyclose
 		resp, html := makeRequest(t, addr, nil)
-		assert.Regexp(t, `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' 'nonce-[^']+';object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src \* data:;base-uri 'self';connect-src 'self' grafana.com ws://localhost:3000/ wss://localhost:3000/;manifest-src 'self';media-src 'none';form-action 'self';`, resp.Header.Get("Content-Security-Policy"))
+		assert.Regexp(t, `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' 'nonce-[^']+';object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src \* data:;base-uri 'self';connect-src 'self' grafana.com ws://localhost:3000/ wss://localhost:3000/;manifest-src 'self';media-src 'none';form-action 'self' ;`, resp.Header.Get("Content-Security-Policy"))
 		assert.Regexp(t, `<script nonce="[^"]+"`, html)
 	})
 


### PR DESCRIPTION
**What is this feature?**

Adds a new `[security] form_action_additional_hosts` config setting and corresponding `$FORM_ACTION_ADDITIONAL_HOSTS` CSP template variable. This allows operators to specify additional hosts (beyond `'self'`) permitted in the CSP `form-action` directive. The default CSP templates are updated to use `form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;`, so `'self'` is always included and the variable is purely additive.

**Why do we need this feature?**

Some deployments need forms to POST to external hosts (e.g. external identity providers for SAML/OAuth flows). Previously, this required replacing the entire CSP template. This setting makes it configurable without touching the template, following the same pattern as `allow_embedding_hosts` for `frame-ancestors`.

**Who is this feature for?**

Operators who need to allow form submissions to external hosts while keeping CSP enabled. In the frontend service, this is a per-tenant setting fetched from the settings service.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The `ReplacePolicyVariables` function signature changed from a bare `[]string` to a `CSPHostLists` struct to cleanly carry both `FrameAncestorHosts` and `FormActionAdditionalHosts`
- When `form_action_additional_hosts` is empty, `$FORM_ACTION_ADDITIONAL_HOSTS` resolves to an empty string (not `'self'`) — `'self'` lives in the template itself
- Supported in both the standard Grafana codepath and the frontend service codepath with per-tenant override support

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.