### PR TITLE
Flag: Time comparison public preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -87,6 +87,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                              |
 | `pdfTables`                       | Enables generating table data as PDF in reporting                                                      |
 | `canvasPanelPanZoom`              | Allow pan and zoom in canvas panel                                                                     |
+| `timeComparison`                  | Enables time comparison option in supported panels                                                     |
 | `secretsManagementAppPlatformUI`  | Enable the secrets management app platform UI                                                          |
 | `alertingSaveStateCompressed`     | Enables the compressed protobuf-based alert state storage. Default is enabled.                         |
 | `queryLibrary`                    | Enables Saved queries (query library) feature                                                          |
@@ -102,6 +103,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `nestedFramesFieldOverrides`      | Enable field overrides for FieldType.nestedFrames fields (like in nested tables)                       |
 | `preventPanelChromeOverflow`      | Restrict PanelChrome contents with overflow: hidden;                                                   |
 | `newPanelPadding`                 | Increases panel padding globally                                                                       |
+| `panelTimeSettings`               | Enables a new panel time settings drawer                                                               |
 | `transformationsEmptyPlaceholder` | Show transformation quick-start cards in empty transformations state                                   |
 
 ## Development feature toggles

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -747,7 +747,7 @@ var (
 		{
 			Name:         "timeComparison",
 			Description:  "Enables time comparison option in supported panels",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStagePublicPreview,
 			FrontendOnly: true,
 			Owner:        grafanaDatavizSquad,
 			Expression:   "false",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2307,7 +2307,7 @@ var (
 			Name:            "panelTimeSettings",
 			Description:     "Enables a new panel time settings drawer",
 			FrontendOnly:    false,
-			Stage:           FeatureStageExperimental,
+			Stage:           FeatureStagePublicPreview,
 			Owner:           grafanaDashboardsSquad,
 			RequiresRestart: false,
 			HideFromDocs:    false,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -286,7 +286,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-10-20,onlyStoreActionSets,GA,@grafana/identity-access-team,false,false,false
 2026-02-18,excludeRedundantManagedPermissions,experimental,@grafana/identity-access-team,false,false,false
 2025-12-16,pluginInsights,experimental,@grafana/plugins-platform-backend,false,false,true
-2025-10-29,panelTimeSettings,experimental,@grafana/dashboards-squad,false,false,false
+2025-10-29,panelTimeSettings,preview,@grafana/dashboards-squad,false,false,false
 2025-12-15,elasticsearchRawDSLQuery,experimental,@grafana/partner-datasources,false,false,false
 2026-01-21,elasticsearchESQLQuery,experimental,@grafana/partner-datasources,false,false,false
 2025-11-12,awsDatasourcesHttpProxy,experimental,@grafana/aws-datasources,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -92,7 +92,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,reportingV2Layouts,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2026-02-19,reportRenderBinding,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2024-01-02,canvasPanelPanZoom,preview,@grafana/dataviz-squad,false,false,true
-2025-07-24,timeComparison,experimental,@grafana/dataviz-squad,false,false,true
+2025-07-24,timeComparison,preview,@grafana/dataviz-squad,false,false,true
 2023-12-13,tableSharedCrosshair,experimental,@grafana/dataviz-squad,false,false,true
 2024-01-10,cloudRBACRoles,preview,@grafana/identity-access-team,false,true,false
 2024-01-10,alertingQueryOptimization,GA,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4941,12 +4941,15 @@
     {
       "metadata": {
         "name": "timeComparison",
-        "resourceVersion": "1771434338561",
-        "creationTimestamp": "2025-07-24T20:07:28Z"
+        "resourceVersion": "1774893613588",
+        "creationTimestamp": "2025-07-24T20:07:28Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-03-30 18:00:13.588864 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables time comparison option in supported panels",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
         "expression": "false"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3822,12 +3822,15 @@
     {
       "metadata": {
         "name": "panelTimeSettings",
-        "resourceVersion": "1771434338561",
-        "creationTimestamp": "2025-10-29T08:06:23Z"
+        "resourceVersion": "1774893613588",
+        "creationTimestamp": "2025-10-29T08:06:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-03-30 18:00:13.588864 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a new panel time settings drawer",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/dashboards-squad",
         "expression": "false"
       }


### PR DESCRIPTION
This change corrects the feature flag status of both `timeComparison` and `panelTimeSettings` to be _public preview_ instead of _~experimental~_ because the code is currently inconsistent with the release status Grafana shared in October of last year:
- https://grafana.com/whats-new/2025-10-29-consolidated-panel-time-settings-and-time-comparison/

After this change the feature flag list docs will be updated to match as well:
- https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/#public-preview-feature-toggles

<img width="1231" height="818" alt="Screenshot 2026-03-30 at 15 08 26" src="https://github.com/user-attachments/assets/0f2718ae-5cb9-4b42-a0af-6040b2b7f0fc" />
