### PR TITLE
CI: Coverage job more like other pr/main comparison jobs, use yarn-install

### DIFF
--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -39,11 +39,22 @@ jobs:
       contents: read
     outputs:
       changed-files: ${{ steps.changed-files.outputs.all_changed_files }}
+      main-sha: ${{ steps.get-main-sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true
-          fetch-depth: 2
+          fetch-depth: 0
+
+      - name: Get main SHA
+        id: get-main-sha
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch origin "$BASE_REF"
+          MAIN_SHA=$(git rev-parse "origin/$BASE_REF")
+          echo "sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
+          echo "Main branch SHA: $MAIN_SHA"
 
       - name: Detect changed files
         id: changed-files
@@ -242,7 +253,7 @@ jobs:
         if: steps.check-affected.outputs.affected == 'true'
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ needs.detect-changes.outputs.main-sha }}
           path: './main'
           persist-credentials: false
 
@@ -265,7 +276,7 @@ jobs:
         env:
           SHOULD_OPEN_COVERAGE_REPORT: 'false'
           CI: 'true'
-          GITHUB_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_SHA: ${{ needs.detect-changes.outputs.main-sha }}
 
       - name: Save main coverage summary
         if: steps.check-affected.outputs.affected == 'true'

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -172,102 +172,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   coverage:
-    name: Coverage ${{ matrix.branch }} - ${{ matrix.codeowner }}
+    name: Coverage - ${{ matrix.codeowner }}
     needs: [setup, detect-changes]
     if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
     runs-on: ubuntu-x64-large
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
-        branch: [pr, main]
-    steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js for manifest generation
-        uses: ./.github/actions/setup-node
-
-      - name: Install dependencies for manifest generation
-        run: yarn install --immutable # TODO: switch to ./.github/actions/yarn-install for better caching
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: true
-          CYPRESS_INSTALL_BINARY: 0
-
-      - name: Generate codeowners manifest
-        run: yarn codeowners-manifest
-
-      - name: Check if codeowner affected by changes
-        id: check-affected
-        run: |
-          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" "${{ needs.detect-changes.outputs.changed-files }}")
-          echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
-          echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
-
-      - name: Checkout target branch
-        if: steps.check-affected.outputs.affected == 'true'
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ matrix.branch == 'main' && github.event.pull_request.base.ref || github.event.pull_request.head.sha }}
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Merge main into PR branch
-        if: steps.check-affected.outputs.affected == 'true' && matrix.branch == 'pr'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${BASE_REF}"
-          git merge "origin/${BASE_REF}" --no-edit
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-
-      - name: Setup Node.js
-        if: steps.check-affected.outputs.affected == 'true'
-        uses: ./.github/actions/setup-node
-
-      - name: Install dependencies
-        if: steps.check-affected.outputs.affected == 'true'
-        run: yarn install --immutable # TODO: switch to ./.github/actions/yarn-install for better caching
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: true
-          CYPRESS_INSTALL_BINARY: 0
-
-      - name: Get codeowner slug
-        if: steps.check-affected.outputs.affected == 'true'
-        id: codeowner-slug
-        run: |
-          SLUG=$(node -e "
-            const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
-            console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
-          ")
-          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
-
-      - name: Run coverage for ${{ matrix.codeowner }}
-        if: steps.check-affected.outputs.affected == 'true'
-        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}" --maxWorkers=1
-        env:
-          SHOULD_OPEN_COVERAGE_REPORT: 'false'
-          CI: 'true'
-          GITHUB_SHA: ${{ matrix.branch == 'main' && github.event.pull_request.base.sha || github.event.pull_request.head.sha }}
-
-      - name: Upload coverage summary
-        if: steps.check-affected.outputs.affected == 'true'
-        uses: actions/upload-artifact@v5
-        with:
-          name: coverage-${{ matrix.branch }}-${{ steps.codeowner-slug.outputs.slug }}
-          path: coverage-summary.json
-          retention-days: 1
-
-  compare-and-report:
-    name: Compare & Report - ${{ matrix.codeowner }}
-    needs: [setup, detect-changes, coverage]
-    if: "!contains(github.event.pull_request.labels.*.name, 'no-check-frontend-test-coverage')"
-    runs-on: ubuntu-x64-small
     permissions:
       contents: read
       pull-requests: write
@@ -277,21 +185,33 @@ jobs:
       matrix:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
         with:
+          path: './pr'
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+      - name: Setup Node.js for manifest generation
+        uses: ./pr/.github/actions/setup-node
+        with:
+          cwd: './pr'
 
-      - name: Install dependencies for manifest and comparison
-        run: yarn install --immutable # TODO: switch to ./.github/actions/yarn-install for better caching
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: true
-          CYPRESS_INSTALL_BINARY: 0
+      - name: Install dependencies for manifest generation
+        uses: ./pr/.github/actions/yarn-install
+        with:
+          cwd: './pr'
 
       - name: Generate codeowners manifest
+        working-directory: './pr'
         run: yarn codeowners-manifest
+
+      - name: Check if codeowner affected by changes
+        id: check-affected
+        working-directory: './pr'
+        run: |
+          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" "${{ needs.detect-changes.outputs.changed-files }}")
+          echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
+          echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
 
       - name: Get Vault secrets
         if: github.event.pull_request.head.repo.fork == false
@@ -310,13 +230,6 @@ jobs:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
-      - name: Check if codeowner affected by changes
-        id: check-affected
-        run: |
-          AFFECTED=$(node scripts/check-codeowner-affected.js "${{ matrix.codeowner }}" "${{ needs.detect-changes.outputs.changed-files }}")
-          echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
-          echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
-
       - name: Delete old coverage comment if not affected
         if: steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
@@ -325,36 +238,58 @@ jobs:
           delete: true
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      - name: Get codeowner slug
+      - name: Checkout main branch
         if: steps.check-affected.outputs.affected == 'true'
-        id: codeowner-slug
-        run: |
-          SLUG=$(node -e "
-            const { createCodeownerSlug } = require('./scripts/codeowners-manifest/utils.js');
-            console.log(createCodeownerSlug('${{ matrix.codeowner }}'));
-          ")
-          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
-
-      - name: Download PR coverage
-        if: steps.check-affected.outputs.affected == 'true'
-        uses: actions/download-artifact@v6
+        uses: actions/checkout@v5
         with:
-          name: coverage-pr-${{ steps.codeowner-slug.outputs.slug }}
-          path: ./coverage-pr
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: './main'
+          persist-credentials: false
 
-      - name: Download main coverage
+      - name: Setup Node.js for main branch
         if: steps.check-affected.outputs.affected == 'true'
-        uses: actions/download-artifact@v6
+        uses: ./pr/.github/actions/setup-node
         with:
-          name: coverage-main-${{ steps.codeowner-slug.outputs.slug }}
-          path: ./coverage-main
+          cwd: './main'
+
+      - name: Install dependencies for main branch
+        if: steps.check-affected.outputs.affected == 'true'
+        uses: ./pr/.github/actions/yarn-install
+        with:
+          cwd: './main'
+
+      - name: Run coverage for main branch
+        if: steps.check-affected.outputs.affected == 'true'
+        working-directory: './main'
+        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}" --maxWorkers=1
+        env:
+          SHOULD_OPEN_COVERAGE_REPORT: 'false'
+          CI: 'true'
+          GITHUB_SHA: ${{ github.event.pull_request.base.sha }}
+
+      - name: Save main coverage summary
+        if: steps.check-affected.outputs.affected == 'true'
+        run: mkdir -p ./coverage-main && cp ./main/coverage-summary.json ./coverage-main/coverage-summary.json
+
+      - name: Run coverage for PR branch
+        if: steps.check-affected.outputs.affected == 'true'
+        working-directory: './pr'
+        run: yarn test:coverage:by-codeowner "${{ matrix.codeowner }}" --maxWorkers=1
+        env:
+          SHOULD_OPEN_COVERAGE_REPORT: 'false'
+          CI: 'true'
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Save PR coverage summary
+        if: steps.check-affected.outputs.affected == 'true'
+        run: mkdir -p ./coverage-pr && cp ./pr/coverage-summary.json ./coverage-pr/coverage-summary.json
 
       - name: Compare coverage
         if: steps.check-affected.outputs.affected == 'true'
         id: compare
         run: |
-          # Run comparison and capture exit code
-          if node scripts/compare-coverage-by-codeowner.js; then
+          # Run comparison from workspace root where coverage-main/ and coverage-pr/ live
+          if node ./pr/scripts/compare-coverage-by-codeowner.js; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
           else
             echo "passed=false" >> "$GITHUB_OUTPUT"
@@ -383,7 +318,7 @@ jobs:
 
   all-coverage-checks-pass:
     name: All coverage checks pass
-    needs: [setup, compare-and-report]
+    needs: [setup, coverage]
     if: always()
     runs-on: ubuntu-x64-small
     steps:
@@ -401,7 +336,7 @@ jobs:
       - name: Verify all checks passed
         if: steps.check-skip.outputs.skipped == 'false'
         run: |
-          if [[ "${{ needs.compare-and-report.result }}" != "success" ]]; then
+          if [[ "${{ needs.coverage.result }}" != "success" ]]; then
             echo "❌ Coverage checks failed for one or more teams"
             exit 1
           fi


### PR DESCRIPTION
## Summary

fixes https://github.com/grafana/grafana/issues/121321

- updates this job to work more like other PR/main comparison jobs in the repo, like [detect-breaking-changes-levitate](https://github.com/grafana/grafana/blob/main/.github/workflows/detect-breaking-changes-levitate.yml)
  - ~~this may slow the job down somewhat, but it does use fewer agents. let's see what it does in the preview here...~~ _jk, this definitely speeds the job up_ 🎉 .  
- use `yarn-install` custom action instead of direct calls to `yarn install` to be sure we can use the cache as designed.

## Background

@joshhunt asked us to make this change a couple weeks ago, finally getting around to it.