### PR TITLE
WIP PoC: Tab-level panel colour setting

### DIFF
--- a/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
@@ -391,7 +391,7 @@ ValueMappingResult: {
 // `continuous-purples`: Continuous Purple palette mode
 // `shades`: Shades of a single color. Specify a single color, useful in an override rule.
 // `fixed`: Fixed color mode. Specify a single color, useful in an override rule.
-FieldColorModeId: "thresholds" | "palette-classic" | "palette-classic-by-name" | "continuous-viridis" | "continuous-magma" | "continuous-plasma" | "continuous-inferno" | "continuous-cividis" | "continuous-GrYlRd" | "continuous-RdYlGr" | "continuous-BlYlRd" | "continuous-YlRd" | "continuous-BlPu" | "continuous-YlBl" | "continuous-blues" | "continuous-reds" | "continuous-greens" | "continuous-purples" | "fixed" | "shades"
+FieldColorModeId: "thresholds" | "palette-classic" | "palette-classic-by-name" | "continuous-viridis" | "continuous-magma" | "continuous-plasma" | "continuous-inferno" | "continuous-cividis" | "continuous-GrYlRd" | "continuous-RdYlGr" | "continuous-BlYlRd" | "continuous-YlRd" | "continuous-BlPu" | "continuous-YlBl" | "continuous-blues" | "continuous-reds" | "continuous-greens" | "continuous-purples" | "fixed" | "shades" | "palette-ai-zeitgeist-v2" | "palette-vivid-spectrum" | "palette-classic-modernized" | "palette-modern-muted-v2" | "palette-new-editor"
 
 // Defines how to assign a series color from "by value" color schemes. For example for an aggregated data points like a timeseries, the color can be assigned by the min, max or last value.
 FieldColorSeriesByMode: "min" | "max" | "last"
@@ -609,6 +609,9 @@ GridLayoutItemSpec: {
 	height:  int
 	element: ElementReference // reference to a PanelKind from dashboard.spec.elements Expressed as JSON Schema reference
 	repeat?: RepeatOptions
+	// When true, the panel's color mode has been explicitly set by the user and
+	// will not be overwritten by a parent tab/row color palette.
+	colorPaletteOverride?: bool
 }
 
 GridLayoutItemKind: {
@@ -648,6 +651,8 @@ RowsLayoutRowSpec: {
 	repeat?:               RowRepeatOptions
 	layout:                GridLayoutKind | AutoGridLayoutKind | TabsLayoutKind | RowsLayoutKind
 	variables?:            [...VariableKind]
+	// ID of a color palette applied to all panels in this row that do not have colorPaletteOverride set.
+	colorPalette?: string
 }
 
 AutoGridLayoutKind: {
@@ -674,6 +679,9 @@ AutoGridLayoutItemSpec: {
 	element:               ElementReference
 	repeat?:               AutoGridRepeatOptions
 	conditionalRendering?: ConditionalRenderingGroupKind
+	// When true, the panel's color mode has been explicitly set by the user and
+	// will not be overwritten by a parent tab/row color palette.
+	colorPaletteOverride?: bool
 }
 
 TabsLayoutKind: {
@@ -696,6 +704,8 @@ TabsLayoutTabSpec: {
 	conditionalRendering?: ConditionalRenderingGroupKind
 	repeat?:               TabRepeatOptions
 	variables?:            [...VariableKind]
+	// ID of a color palette applied to all panels in this tab that do not have colorPaletteOverride set.
+	colorPalette?: string
 }
 
 PanelSpec: {

--- a/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
@@ -541,7 +541,7 @@ export const defaultFieldColor = (): FieldColor => ({
 // `continuous-purples`: Continuous Purple palette mode
 // `shades`: Shades of a single color. Specify a single color, useful in an override rule.
 // `fixed`: Fixed color mode. Specify a single color, useful in an override rule.
-export type FieldColorModeId = "thresholds" | "palette-classic" | "palette-classic-by-name" | "continuous-viridis" | "continuous-magma" | "continuous-plasma" | "continuous-inferno" | "continuous-cividis" | "continuous-GrYlRd" | "continuous-RdYlGr" | "continuous-BlYlRd" | "continuous-YlRd" | "continuous-BlPu" | "continuous-YlBl" | "continuous-blues" | "continuous-reds" | "continuous-greens" | "continuous-purples" | "fixed" | "shades";
+export type FieldColorModeId = "thresholds" | "palette-classic" | "palette-classic-by-name" | "continuous-viridis" | "continuous-magma" | "continuous-plasma" | "continuous-inferno" | "continuous-cividis" | "continuous-GrYlRd" | "continuous-RdYlGr" | "continuous-BlYlRd" | "continuous-YlRd" | "continuous-BlPu" | "continuous-YlBl" | "continuous-blues" | "continuous-reds" | "continuous-greens" | "continuous-purples" | "fixed" | "shades" | "palette-ai-zeitgeist-v2" | "palette-vivid-spectrum" | "palette-classic-modernized" | "palette-modern-muted-v2" | "palette-new-editor";
 
 export const defaultFieldColorModeId = (): FieldColorModeId => ("thresholds");
 
@@ -714,6 +714,9 @@ export interface GridLayoutItemSpec {
 	// reference to a PanelKind from dashboard.spec.elements Expressed as JSON Schema reference
 	element: ElementReference;
 	repeat?: RepeatOptions;
+	// When true, the panel's color mode has been explicitly set by the user and
+	// will not be overwritten by a parent tab/row color palette.
+	colorPaletteOverride?: boolean;
 }
 
 export const defaultGridLayoutItemSpec = (): GridLayoutItemSpec => ({
@@ -786,6 +789,8 @@ export interface RowsLayoutRowSpec {
 	repeat?: RowRepeatOptions;
 	layout: GridLayoutKind | AutoGridLayoutKind | TabsLayoutKind | RowsLayoutKind;
 	variables?: VariableKind[];
+	// ID of a color palette applied to all panels in this row that do not have colorPaletteOverride set.
+	colorPalette?: string;
 }
 
 export const defaultRowsLayoutRowSpec = (): RowsLayoutRowSpec => ({
@@ -924,6 +929,9 @@ export interface AutoGridLayoutItemSpec {
 	element: ElementReference;
 	repeat?: AutoGridRepeatOptions;
 	conditionalRendering?: ConditionalRenderingGroupKind;
+	// When true, the panel's color mode has been explicitly set by the user and
+	// will not be overwritten by a parent tab/row color palette.
+	colorPaletteOverride?: boolean;
 }
 
 export const defaultAutoGridLayoutItemSpec = (): AutoGridLayoutItemSpec => ({
@@ -974,6 +982,8 @@ export interface TabsLayoutTabSpec {
 	conditionalRendering?: ConditionalRenderingGroupKind;
 	repeat?: TabRepeatOptions;
 	variables?: VariableKind[];
+	// ID of a color palette applied to all panels in this tab that do not have colorPaletteOverride set.
+	colorPalette?: string;
 }
 
 export const defaultTabsLayoutTabSpec = (): TabsLayoutTabSpec => ({

--- a/public/app/features/dashboard-scene/panel-edit/palettes.ts
+++ b/public/app/features/dashboard-scene/panel-edit/palettes.ts
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------------
+// Palette definitions — hex colors used for rendering the picker swatches.
+// Full palettes are registered in packages/grafana-data/src/field/fieldColor.ts
+// via FieldColorSchemeMode. The IDs here must match FieldColorModeId values.
+// ---------------------------------------------------------------------------
+
+export interface PaletteDefinition {
+  id: string;
+  name: string;
+  colors: string[];
+}
+
+export const CLASSIC_PALETTE_ID = 'palette-classic';
+
+/** AI Zeitgeist v2 — muted/earthy tones */
+const AI_ZEITGEIST_V2: PaletteDefinition = {
+  id: 'palette-ai-zeitgeist-v2',
+  name: 'AI Zeitgeist v2',
+  colors: ['#1b9e86', '#ab6297', '#b09053', '#49709c', '#c95f5f', '#5e8c68', '#8771ab', '#cc7a43'],
+};
+
+/** Vivid Spectrum — saturated / high-contrast */
+const VIVID_SPECTRUM: PaletteDefinition = {
+  id: 'palette-vivid-spectrum',
+  name: 'Vivid Spectrum',
+  colors: ['#3a8ec5', '#d4703a', '#2aaa7a', '#c74a7a', '#7a68c8', '#a8b030', '#d05858', '#2a98a8'],
+};
+
+/** Classic Modernized — updated classic hues */
+const CLASSIC_MODERNIZED: PaletteDefinition = {
+  id: 'palette-classic-modernized',
+  name: 'Classic Modernized',
+  colors: ['#4da87a', '#c49838', '#3e9fb0', '#cc7040', '#c45858', '#3578be', '#a050a0', '#7060b0'],
+};
+
+/** Modern Muted v2 — soft professional tones */
+const MODERN_MUTED_V2: PaletteDefinition = {
+  id: 'palette-modern-muted-v2',
+  name: 'Modern Muted v2',
+  colors: ['#5c83b4', '#c88b64', '#6ba07d', '#b47996', '#4a9ea6', '#c0aa5e', '#8677bb', '#c46e6e'],
+};
+
+/** New Editor — golden-ratio hue distribution */
+const NEW_EDITOR: PaletteDefinition = {
+  id: 'palette-new-editor',
+  name: 'New Editor',
+  colors: ['#6191c2', '#c47384', '#53c15c', '#8c6ebf', '#c7a157', '#78c9c6', '#c157a7', '#96c270'],
+};
+
+/** All custom palettes shown in the Tab editor picker (Classic is added by the UI from theme). */
+export const CUSTOM_PALETTES: PaletteDefinition[] = [
+  AI_ZEITGEIST_V2,
+  VIVID_SPECTRUM,
+  CLASSIC_MODERNIZED,
+  MODERN_MUTED_V2,
+  NEW_EDITOR,
+];

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -32,6 +32,8 @@ export interface AutoGridItemState extends SceneObjectState {
   isHidden?: boolean;
   conditionalRendering?: ConditionalRenderingGroup;
   repeatedConditionalRendering?: ConditionalRenderingGroup[];
+  /** When true, this panel's color mode was explicitly set by the user and will not be overwritten by a tab/row color palette. */
+  colorPaletteOverride?: boolean;
 }
 
 export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements DashboardLayoutItem {

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemEditor.tsx
@@ -1,4 +1,5 @@
 import { t } from '@grafana/i18n';
+import { Switch } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect';
@@ -25,9 +26,25 @@ export function getOptions(model: AutoGridItem): OptionsPaneCategoryDescriptor[]
     })
   );
 
+  const colorPaletteCategory = new OptionsPaneCategoryDescriptor({
+    title: t('dashboard.auto-grid.item-options.color-palette.title', 'Color palette'),
+    id: 'color-palette-options',
+    isOpenDefault: false,
+  }).addItem(
+    new OptionsPaneItemDescriptor({
+      title: t('dashboard.auto-grid.item-options.color-palette.lock.title', 'Lock color'),
+      id: 'auto-grid-color-palette-lock',
+      description: t(
+        'dashboard.auto-grid.item-options.color-palette.lock.description',
+        'When enabled, this panel keeps its own color and ignores any color palette set at the tab or row level.'
+      ),
+      render: (descriptor) => <ColorPaletteLockOption id={descriptor.props.id} item={model} />,
+    })
+  );
+
   const conditionalRenderingCategory = useConditionalRenderingEditor(model.state.conditionalRendering)!;
 
-  return [repeatCategory, conditionalRenderingCategory];
+  return [repeatCategory, colorPaletteCategory, conditionalRenderingCategory];
 }
 
 function RepeatByOption({ item, id }: { item: AutoGridItem; id?: string }) {
@@ -44,6 +61,26 @@ function RepeatByOption({ item, id }: { item: AutoGridItem; id?: string }) {
           source: item,
           perform: () => item.setRepeatByVariable(value),
           undo: () => item.setRepeatByVariable(variableName),
+        });
+      }}
+    />
+  );
+}
+
+function ColorPaletteLockOption({ item, id }: { item: AutoGridItem; id?: string }) {
+  const { colorPaletteOverride } = item.useState();
+
+  return (
+    <Switch
+      id={id}
+      value={colorPaletteOverride ?? false}
+      onChange={(e) => {
+        const locked = e.currentTarget.checked;
+        dashboardEditActions.edit({
+          description: t('dashboard.edit-actions.panel-color-palette-lock', 'Lock panel color'),
+          source: item,
+          perform: () => item.setState({ colorPaletteOverride: locked }),
+          undo: () => item.setState({ colorPaletteOverride: colorPaletteOverride }),
         });
       }}
     />

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -35,6 +35,8 @@ export interface DashboardGridItemState extends SceneGridItemStateLike {
   itemHeight?: number;
   repeatDirection?: RepeatDirection;
   maxPerRow?: number;
+  /** When true, this panel's color mode was explicitly set by the user and will not be overwritten by a tab/row color palette. */
+  colorPaletteOverride?: boolean;
 }
 
 export type RepeatDirection = 'v' | 'h';

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -4,7 +4,7 @@ import { SelectableValue } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { sceneGraph, SceneGridLayout } from '@grafana/scenes';
-import { RadioButtonGroup, Select, TextLink } from '@grafana/ui';
+import { RadioButtonGroup, Select, Switch, TextLink } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect';
@@ -73,7 +73,23 @@ export function getDashboardGridItemOptions(gridItem: DashboardGridItem): Option
     </div>
   );
 
-  const options = [repeatCategory];
+  const colorPaletteCategory = new OptionsPaneCategoryDescriptor({
+    title: t('dashboard.default-layout.item-options.color-palette.title', 'Color palette'),
+    id: 'color-palette-options',
+    isOpenDefault: false,
+  }).addItem(
+    new OptionsPaneItemDescriptor({
+      title: t('dashboard.default-layout.item-options.color-palette.lock.title', 'Lock color'),
+      id: 'color-palette-lock',
+      description: t(
+        'dashboard.default-layout.item-options.color-palette.lock.description',
+        'When enabled, this panel keeps its own color and ignores any color palette set at the tab or row level.'
+      ),
+      render: (descriptor) => <ColorPaletteLockOption id={descriptor.props.id} gridItem={gridItem} />,
+    })
+  );
+
+  const options = [repeatCategory, colorPaletteCategory];
 
   if (config.featureToggles.dashboardNewLayouts) {
     options.push(conditionalRenderingCategory);
@@ -165,4 +181,24 @@ function RepeatByOption({ gridItem, id }: OptionComponentProps & { id?: string }
   );
 
   return <RepeatRowSelect2 id={id} sceneContext={gridItem} repeat={variableName} onChange={handleChange} />;
+}
+
+function ColorPaletteLockOption({ gridItem, id }: OptionComponentProps & { id?: string }) {
+  const { colorPaletteOverride } = gridItem.useState();
+
+  return (
+    <Switch
+      id={id}
+      value={colorPaletteOverride ?? false}
+      onChange={(e) => {
+        const locked = e.currentTarget.checked;
+        dashboardEditActions.edit({
+          description: t('dashboard.edit-actions.panel-color-palette-lock', 'Lock panel color'),
+          source: gridItem,
+          perform: () => gridItem.setState({ colorPaletteOverride: locked }),
+          undo: () => gridItem.setState({ colorPaletteOverride: colorPaletteOverride }),
+        });
+      }}
+    />
+  );
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -29,6 +29,7 @@ import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { AutoGridLayout } from '../layout-auto-grid/AutoGridLayout';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
+import { applyColorPaletteToLayout } from '../layouts-shared/colorPalette';
 import { clearClipboard } from '../layouts-shared/paste';
 import { scrollCanvasElementIntoView } from '../layouts-shared/scrollCanvasElementIntoView';
 import { BulkActionElement } from '../types/BulkActionElement';
@@ -55,6 +56,8 @@ export interface RowItemState extends SceneObjectState {
   repeatedRows?: RowItem[];
   /** Marks object as a repeated object and a key pointer to source object */
   repeatSourceKey?: string;
+  /** ID of a color palette applied to all panels in this row that do not have colorPaletteOverride set */
+  colorPalette?: string;
 }
 
 export class RowItem
@@ -84,6 +87,12 @@ export class RowItem
 
   private _activationHandler() {
     const deactivate = this.state.conditionalRendering?.activate();
+
+    // Re-apply the persisted palette on dashboard load so panels that haven't been
+    // manually overridden always reflect the row-level setting.
+    if (this.state.colorPalette) {
+      applyColorPaletteToLayout(this.getLayout(), this.state.colorPalette);
+    }
 
     return () => {
       if (deactivate) {
@@ -173,6 +182,11 @@ export class RowItem
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
   public duplicate(panelIdGenerator?: PanelIdGenerator): RowItem {
     return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
+  }
+
+  public onChangePalette(paletteId: string) {
+    this.setState({ colorPalette: paletteId });
+    applyColorPaletteToLayout(this.getLayout(), paletteId);
   }
 
   public serialize(): RowsLayoutRowKind {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -31,6 +31,7 @@ import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
+import { applyColorPaletteToLayout } from '../layouts-shared/colorPalette';
 import { clearClipboard } from '../layouts-shared/paste';
 import { scrollCanvasElementIntoView } from '../layouts-shared/scrollCanvasElementIntoView';
 import { BulkActionElement } from '../types/BulkActionElement';
@@ -54,6 +55,8 @@ export interface TabItemState extends SceneObjectState {
   repeatedTabs?: TabItem[];
   /** Marks object as a repeated object and a key pointer to source object */
   repeatSourceKey?: string;
+  /** Color palette applied to all panels in this tab */
+  colorPalette?: string;
 }
 
 export class TabItem
@@ -85,10 +88,14 @@ export class TabItem
   private _activationHandler() {
     const deactivate = this.state.conditionalRendering?.activate();
 
+    // Re-apply the persisted palette on dashboard load so panels that haven't been
+    // manually overridden always reflect the tab-level setting.
+    if (this.state.colorPalette) {
+      applyColorPaletteToLayout(this.getLayout(), this.state.colorPalette);
+    }
+
     return () => {
-      if (deactivate) {
-        deactivate();
-      }
+      deactivate?.();
     };
   }
 
@@ -204,6 +211,11 @@ export class TabItem
     } else {
       this.setState({ repeatedTabs: undefined, $variables: undefined, repeatByVariable: undefined });
     }
+  }
+
+  public onChangePalette(paletteId: string) {
+    this.setState({ colorPalette: paletteId });
+    applyColorPaletteToLayout(this.getLayout(), paletteId);
   }
 
   public setIsDropTarget(isDropTarget: boolean) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
@@ -1,16 +1,20 @@
-import { useMemo, useRef } from 'react';
+import { css, cx } from '@emotion/css';
+import { useMemo, useRef, useSyncExternalStore } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Field, Input, TextLink } from '@grafana/ui';
+import { Alert, Field, Input, TextLink, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { RepeatRowSelect2 } from 'app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
+import { getTeamPalettesSnapshot, subscribeTeamPalettes } from '../../../teams/teamPalettesStore';
 import { useConditionalRenderingEditor } from '../../conditional-rendering/hooks/useConditionalRenderingEditor';
 import { dashboardEditActions } from '../../edit-pane/shared';
+import { CLASSIC_PALETTE_ID, CUSTOM_PALETTES, PaletteDefinition } from '../../panel-edit/palettes';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { useLayoutCategory } from '../layouts-shared/DashboardLayoutSelector';
 import { generateUniqueTitle, useEditPaneInputAutoFocus } from '../layouts-shared/utils';
@@ -55,6 +59,22 @@ export function useEditOptions(this: TabItem, isNewElement: boolean): OptionsPan
 
   const layoutCategory = useLayoutCategory(layout);
 
+  const visualizationCategory = useMemo(
+    () =>
+      new OptionsPaneCategoryDescriptor({
+        title: t('dashboard.tabs-layout.tab-options.visualization.title', 'Visualization options'),
+        id: 'visualization-options',
+        isOpenDefault: true,
+      }).addItem(
+        new OptionsPaneItemDescriptor({
+          title: t('dashboard.tabs-layout.tab-options.visualization.palette', 'Color palette'),
+          id: 'tab-options-color-palette',
+          render: () => <TabVisualizationOptions tab={model} />,
+        })
+      ),
+    [model]
+  );
+
   const editOptions = [tabCategory, ...layoutCategory, repeatCategory];
 
   const conditionalRenderingCategory = useMemo(
@@ -65,6 +85,8 @@ export function useEditOptions(this: TabItem, isNewElement: boolean): OptionsPan
   if (conditionalRenderingCategory) {
     editOptions.push(conditionalRenderingCategory);
   }
+
+  editOptions.push(visualizationCategory);
 
   return editOptions;
 }
@@ -143,6 +165,82 @@ function TabRepeatSelect({ tab, id }: { tab: TabItem; id?: string }) {
       ) : undefined}
     </>
   );
+}
+
+function TabVisualizationOptions({ tab }: { tab: TabItem }) {
+  const { colorPalette } = tab.useState();
+  const theme = useTheme2();
+  const styles = useStyles2(getPaletteStyles);
+  const teamPalettes = useSyncExternalStore(subscribeTeamPalettes, getTeamPalettesSnapshot);
+
+  const classicPalette: PaletteDefinition = {
+    id: CLASSIC_PALETTE_ID,
+    name: t('dashboard.tabs-layout.tab-options.visualization.palette-classic', 'Classic'),
+    colors: theme.visualization.palette.slice(0, 8),
+  };
+
+  const allPalettes: PaletteDefinition[] = [
+    classicPalette,
+    ...CUSTOM_PALETTES,
+    ...teamPalettes.map((p) => ({ ...p, colors: p.colors.slice(0, 8) })),
+  ];
+
+  return (
+    <div className={styles.grid}>
+      {allPalettes.map((palette) => (
+        <Tooltip key={palette.id} content={palette.name} placement="top">
+          <button
+            type="button"
+            className={cx(styles.thumbnail, colorPalette === palette.id && styles.selected)}
+            onClick={() => tab.onChangePalette(palette.id)}
+            aria-label={palette.name}
+            aria-pressed={colorPalette === palette.id}
+          >
+            {palette.colors.map((color, i) => (
+              <span key={i} className={styles.swatch} style={{ backgroundColor: color }} />
+            ))}
+          </button>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+function getPaletteStyles(theme: GrafanaTheme2) {
+  return {
+    grid: css({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, 1fr)',
+      gap: theme.spacing(0.75),
+      width: '100%',
+    }),
+    thumbnail: css({
+      display: 'flex',
+      flexDirection: 'row',
+      height: 56,
+      width: '100%',
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+      border: `2px solid transparent`,
+      cursor: 'pointer',
+      padding: 0,
+      background: 'none',
+      outline: 'none',
+      '&:hover': {
+        border: `2px solid ${theme.colors.primary.border}`,
+      },
+      '&:focus-visible': {
+        border: `2px solid ${theme.colors.primary.border}`,
+      },
+    }),
+    selected: css({
+      border: `2px solid ${theme.colors.primary.main}`,
+    }),
+    swatch: css({
+      flex: 1,
+      height: '100%',
+    }),
+  };
 }
 
 function editTabTitleAction(tab: TabItem, title: string, prevTitle: string) {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/colorPalette.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/colorPalette.ts
@@ -1,0 +1,55 @@
+import { VizPanel } from '@grafana/scenes';
+
+import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
+import { DashboardGridItem } from '../layout-default/DashboardGridItem';
+import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
+
+/**
+ * Apply a color palette to all panels in a layout that do not have colorPaletteOverride set.
+ * Panels with colorPaletteOverride=true have been explicitly configured by the user and are skipped.
+ *
+ * @param layout - The layout manager containing the panels to update.
+ * @param paletteId - The color mode ID to apply (e.g. "palette-classic", "palette-ai-zeitgeist-v2").
+ */
+export function applyColorPaletteToLayout(layout: DashboardLayoutManager, paletteId: string): void {
+  for (const panel of layout.getVizPanels()) {
+    if (isPanelColorOverridden(panel)) {
+      continue;
+    }
+    const fieldConfig = panel.state.fieldConfig;
+    if (!fieldConfig) {
+      continue;
+    }
+    panel.onFieldConfigChange(
+      {
+        ...fieldConfig,
+        defaults: { ...fieldConfig.defaults, color: { mode: paletteId } },
+      },
+      true
+    );
+  }
+}
+
+/**
+ * Mark a panel's color as user-overridden so future tab/row palette changes leave it alone.
+ * The flag is stored on the parent layout item (DashboardGridItem or AutoGridItem) so it is
+ * serialized with the dashboard layout, not the panel element.
+ */
+export function setPanelColorOverride(panel: VizPanel, overridden: boolean): void {
+  const parent = panel.parent;
+  if (parent instanceof DashboardGridItem || parent instanceof AutoGridItem) {
+    parent.setState({ colorPaletteOverride: overridden });
+  }
+}
+
+/**
+ * Returns true when the parent layout item has colorPaletteOverride=true,
+ * meaning the user explicitly chose this panel's color and it should be left alone.
+ */
+export function isPanelColorOverridden(panel: VizPanel): boolean {
+  const parent = panel.parent;
+  if (parent instanceof DashboardGridItem || parent instanceof AutoGridItem) {
+    return parent.state.colorPaletteOverride === true;
+  }
+  return false;
+}

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
@@ -54,6 +54,7 @@ export function serializeAutoGridItem(item: AutoGridItem): AutoGridLayoutItemKin
         kind: 'ElementReference',
         name: elementKey,
       },
+      ...(item.state.colorPaletteOverride && { colorPaletteOverride: true }),
     },
   };
 
@@ -169,5 +170,6 @@ export function deserializeAutoGridItem(
     body: panel.kind === 'LibraryPanel' ? buildLibraryPanel(panel, id) : buildVizPanel(panel, id),
     variableName: item.spec.repeat?.value,
     conditionalRendering: getConditionalRendering(item),
+    colorPaletteOverride: item.spec.colorPaletteOverride,
   });
 }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -97,6 +97,7 @@ export function gridItemToGridLayoutItemKind(gridItem: DashboardGridItem, yOverr
         kind: 'ElementReference',
         name: elementKey,
       },
+      ...(gridItem_.state.colorPaletteOverride && { colorPaletteOverride: true }),
     },
   };
 
@@ -227,6 +228,7 @@ function buildGridItem(
     variableName: gridItem.repeat?.value,
     repeatDirection: gridItem.repeat?.direction,
     maxPerRow: gridItem.repeat?.maxPerRow,
+    colorPaletteOverride: gridItem.colorPaletteOverride,
   });
 }
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -45,6 +45,7 @@ export function serializeRow(row: RowItem, isSnapshot?: boolean): RowsLayoutRowK
       layout: layout,
       fillScreen: row.state.fillScreen,
       hideHeader: row.state.hideHeader,
+      ...(row.state.colorPalette && { colorPalette: row.state.colorPalette }),
       ...(row.state.repeatByVariable && {
         repeat: {
           mode: 'variable',
@@ -92,5 +93,6 @@ export function deserializeRow(
     repeatByVariable: row.spec.repeat?.value,
     layout: layoutDeserializerRegistry.get(layout.kind).deserialize(layout, elements, preload, panelIdGenerator),
     conditionalRendering: getConditionalRendering(row),
+    colorPalette: row.spec.colorPalette,
   });
 }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -25,6 +25,7 @@ export function serializeTab(tab: TabItem, isSnapshot?: boolean): TabsLayoutTabK
     spec: {
       title: tab.state.title,
       layout: layout,
+      ...(tab.state.colorPalette && { colorPalette: tab.state.colorPalette }),
       ...(tab.state.repeatByVariable && {
         repeat: {
           mode: 'variable',
@@ -73,5 +74,6 @@ export function deserializeTab(
     layout: layoutDeserializerRegistry.get(layout.kind).deserialize(layout, elements, preload, panelIdGenerator),
     repeatByVariable: tab.spec.repeat?.value,
     conditionalRendering: getConditionalRendering(tab),
+    colorPalette: tab.spec.colorPalette,
   });
 }

--- a/public/app/features/teams/TeamSettings.tsx
+++ b/public/app/features/teams/TeamSettings.tsx
@@ -9,6 +9,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { Team } from 'app/types/teams';
 
+import { TeamVisualizationOptions } from './TeamVisualizationOptions';
 import { useUpdateTeam } from './hooks';
 
 interface Props {
@@ -98,6 +99,7 @@ const TeamSettings = ({ team }: Props) => {
         </Button>
       </form>
       <SharedPreferences resourceUri={`teams/${team.id}`} disabled={!canWriteTeamSettings} preferenceType="team" />
+      <TeamVisualizationOptions team={team} />
     </Stack>
   );
 };

--- a/public/app/features/teams/TeamVisualizationOptions.tsx
+++ b/public/app/features/teams/TeamVisualizationOptions.tsx
@@ -1,0 +1,659 @@
+import { css } from '@emotion/css';
+import { useState, useSyncExternalStore } from 'react';
+
+import { useInlineAssistant } from '@grafana/assistant';
+import { GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import {
+  Alert,
+  Button,
+  ColorPickerInput,
+  Field,
+  FieldSet,
+  Input,
+  RadioButtonGroup,
+  Select,
+  Spinner,
+  Stack,
+  TextArea,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+import { Team } from 'app/types/teams';
+
+import { PALETTE_GENERATION_PROMPT, PALETTE_GENERATION_SKILL } from './paletteGenerationSkill';
+import { deleteTeamPalette, getTeamPalettesSnapshot, saveTeamPalette, subscribeTeamPalettes } from './teamPalettesStore';
+
+interface Props {
+  team: Team;
+}
+
+interface PaletteEntry {
+  hex: string;
+  name: string;
+  role: string;
+}
+
+const BRAND_CATEGORIES = [
+  { label: 'Technology', value: 'technology' },
+  { label: 'Finance', value: 'finance' },
+  { label: 'Healthcare', value: 'healthcare' },
+  { label: 'Retail', value: 'retail' },
+  { label: 'Education', value: 'education' },
+  { label: 'Other', value: 'other' },
+];
+
+const PALETTE_TYPES = [
+  { label: 'Primary', value: 'primary' },
+  { label: 'Secondary', value: 'secondary' },
+  { label: 'Accent', value: 'accent' },
+];
+
+const GENERATION_METHODS = [
+  { label: 'Upload File', value: 'upload' },
+  { label: 'AI from Images', value: 'ai-images' },
+  { label: 'AI from Colors', value: 'ai-colors' },
+];
+
+const DEFAULT_BRAND_COLORS = ['#F15B2A', '#3B82F6', '#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#14B8A6'];
+const BRAND_COLOR_COUNT = 7;
+
+function parsePaletteJson(text: string): PaletteEntry[] | null {
+  // Strip markdown fences if present
+  const stripped = text.replace(/```[a-z]*\n?/gi, '').trim();
+  // Find the first {...} block
+  const start = stripped.indexOf('{');
+  const end = stripped.lastIndexOf('}');
+  if (start === -1 || end === -1) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(stripped.slice(start, end + 1));
+    if (Array.isArray(parsed.palette) && parsed.palette.length > 0) {
+      return distributePalette(parsed.palette.filter((e) => isUsableColor(e)));
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}
+
+/**
+ * Reorder palette entries for maximum sequential contrast using greedy
+ * farthest-point sampling: each next color is the one whose minimum distance
+ * to all already-selected colors is greatest. This ensures no two adjacent
+ * entries look similar and the first N series colors are maximally spread.
+ */
+function distributePalette(entries: PaletteEntry[]): PaletteEntry[] {
+  if (entries.length <= 1) {
+    return entries;
+  }
+
+  const remaining = entries.map((e, originalIndex) => ({ entry: e, originalIndex }));
+  const result: Array<{ entry: PaletteEntry; originalIndex: number }> = [];
+
+  // Seed with the first entry
+  result.push(remaining.splice(0, 1)[0]);
+
+  while (remaining.length > 0) {
+    let bestIdx = 0;
+    let bestMinDist = -1;
+
+    for (let i = 0; i < remaining.length; i++) {
+      // Minimum distance from candidate to any already-selected color
+      let minDist = Infinity;
+      for (const selected of result) {
+        const d = rgbDistance(remaining[i].entry.hex, selected.entry.hex);
+        if (d < minDist) {
+          minDist = d;
+        }
+      }
+      if (minDist > bestMinDist) {
+        bestMinDist = minDist;
+        bestIdx = i;
+      }
+    }
+
+    result.push(remaining.splice(bestIdx, 1)[0]);
+  }
+
+  return result.map((r) => r.entry);
+}
+
+function rgbDistance(hexA: string, hexB: string): number {
+  const a = parseHex(hexA);
+  const b = parseHex(hexB);
+  if (!a || !b) {
+    return 0;
+  }
+  return Math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2);
+}
+
+/** Parse a hex string to [r, g, b] in 0–255. Returns null for invalid input. */
+function parseHex(hex: string): [number, number, number] | null {
+  // Normalise: strip #, lowercase, expand 3-char shorthand, strip alpha channel
+  let h = hex.replace(/^#/, '').toLowerCase();
+  if (h.length === 3) {
+    h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  } else if (h.length === 8) {
+    h = h.slice(0, 6); // Drop alpha
+  }
+  if (h.length !== 6 || !/^[0-9a-f]{6}$/.test(h)) {
+    return null;
+  }
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/**
+ * Drop entries that fall outside the usable visualization range:
+ * HSL lightness [25%, 85%] and saturation ≥ 20%.
+ * This removes near-blacks, near-whites, dark greys, and desaturated colors
+ * regardless of what the model produces.
+ */
+function isUsableColor(entry: PaletteEntry): boolean {
+  const rgb = parseHex(entry.hex);
+  if (!rgb) {
+    return false;
+  }
+  const r = rgb[0] / 255;
+  const g = rgb[1] / 255;
+  const b = rgb[2] / 255;
+  const cmax = Math.max(r, g, b);
+  const cmin = Math.min(r, g, b);
+  const l = (cmax + cmin) / 2;
+  const s = cmax === cmin ? 0 : l > 0.5 ? (cmax - cmin) / (2 - cmax - cmin) : (cmax - cmin) / (cmax + cmin);
+  return l * 100 >= 25 && l * 100 <= 85 && s * 100 >= 20;
+}
+
+export const TeamVisualizationOptions = ({ team }: Props) => {
+  const canWrite = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsWrite, team);
+  const styles = useStyles2(getStyles);
+
+  const [paletteName, setPaletteName] = useState('');
+  const [brandCategory, setBrandCategory] = useState<string | undefined>(undefined);
+  const [description, setDescription] = useState('');
+  const [paletteType, setPaletteType] = useState('primary');
+  const [generationMethod, setGenerationMethod] = useState('upload');
+  const [fileName, setFileName] = useState('');
+  const [brandColors, setBrandColors] = useState<string[]>(DEFAULT_BRAND_COLORS);
+  const [generatedPalette, setGeneratedPalette] = useState<PaletteEntry[] | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const { generate, isGenerating, error: generateError, reset: resetGenerate } = useInlineAssistant();
+  const notifyApp = useAppNotification();
+  const savedPalettes = useSyncExternalStore(subscribeTeamPalettes, getTeamPalettesSnapshot);
+
+  const updateBrandColor = (index: number, color: string) => {
+    setBrandColors((prev) => prev.map((c, i) => (i === index ? color : c)));
+  };
+
+  const handleGenerateWithAI = async () => {
+    setGeneratedPalette(null);
+    setParseError(null);
+    resetGenerate();
+
+    await generate({
+      origin: 'grafana/team-settings/palette-generation',
+      prompt: PALETTE_GENERATION_PROMPT(brandColors),
+      systemPrompt: PALETTE_GENERATION_SKILL,
+      onComplete: (text) => {
+        const palette = parsePaletteJson(text);
+        if (palette) {
+          setGeneratedPalette(palette);
+        } else {
+          setParseError(
+            t(
+              'teams.visualization-options.parse-error',
+              'The assistant did not return a valid palette. Please try again.'
+            )
+          );
+        }
+      },
+    });
+  };
+
+  const handleSave = () => {
+    const colors = generatedPalette!.map((e) => e.hex);
+    saveTeamPalette({
+      id: `team-palette-${paletteName.toLowerCase().replace(/\s+/g, '-')}-${Date.now()}`,
+      name: paletteName,
+      colors,
+    });
+    notifyApp.success(
+      t('teams.visualization-options.save-success', 'Palette "{{name}}" saved', { name: paletteName })
+    );
+  };
+
+  return (
+    <FieldSet label={t('teams.visualization-options.section-title', 'Visualization options')}>
+      <Stack direction="column" gap={2} maxWidth="600px">
+        <p className={styles.description}>
+          <Trans i18nKey="teams.visualization-options.description">
+            Custom palettes defined here are available across all dashboards for this team.
+          </Trans>
+        </p>
+
+        <h6 className={styles.subheading}>
+          <Trans i18nKey="teams.visualization-options.brand-info">Brand Information</Trans>
+        </h6>
+
+        <div className={styles.row}>
+          <Field
+            noMargin
+            label={t('teams.visualization-options.palette-name', 'Palette Name')}
+            required
+            className={styles.fieldHalf}
+          >
+            <Input
+              id="palette-name-input"
+              // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+              placeholder="e.g. Corporate Brand 2024"
+              value={paletteName}
+              onChange={(e) => setPaletteName(e.currentTarget.value)}
+              disabled={!canWrite}
+            />
+          </Field>
+          <Field
+            noMargin
+            label={t('teams.visualization-options.brand-category', 'Brand Category')}
+            className={styles.fieldHalf}
+          >
+            <Select
+              inputId="brand-category-select"
+              options={BRAND_CATEGORIES}
+              value={brandCategory}
+              onChange={(v) => setBrandCategory(v?.value)}
+              // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+              placeholder="Select category"
+              disabled={!canWrite}
+            />
+          </Field>
+        </div>
+
+        <Field noMargin label={t('teams.visualization-options.description-field', 'Description')}>
+          <TextArea
+            id="palette-description-input"
+            // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+            placeholder="Brief description of the palette and its intended use..."
+            value={description}
+            onChange={(e) => setDescription(e.currentTarget.value)}
+            rows={3}
+            disabled={!canWrite}
+          />
+        </Field>
+
+        <Field noMargin label={t('teams.visualization-options.palette-type', 'Palette Type')}>
+          <RadioButtonGroup
+            options={PALETTE_TYPES}
+            value={paletteType}
+            onChange={setPaletteType}
+            fullWidth
+            disabled={!canWrite}
+          />
+        </Field>
+
+        <h6 className={styles.subheading}>
+          <Trans i18nKey="teams.visualization-options.generate-title">Generate 50-Color Palette</Trans>
+        </h6>
+
+        <Field noMargin label={t('teams.visualization-options.generation-method', 'Generation Method')}>
+          <RadioButtonGroup
+            options={GENERATION_METHODS}
+            value={generationMethod}
+            onChange={setGenerationMethod}
+            fullWidth
+            disabled={!canWrite}
+          />
+        </Field>
+
+        {generationMethod === 'upload' && (
+          <div className={styles.methodBox}>
+            <p className={styles.methodTitle}>
+              <Trans i18nKey="teams.visualization-options.upload-title">Upload Color File</Trans>
+            </p>
+            <p className={styles.methodDesc}>
+              <Trans i18nKey="teams.visualization-options.upload-desc">
+                Upload a file containing at least 50 HEX or RGB color codes. Accepted formats: .txt, .csv, .json, .aco
+                (Adobe Color Swatch)
+              </Trans>
+            </p>
+            <div className={styles.fileInputRow}>
+              <label className={canWrite ? styles.chooseFileBtn : styles.chooseFileBtnDisabled}>
+                <Trans i18nKey="teams.visualization-options.choose-file">Choose file</Trans>
+                <input
+                  type="file"
+                  accept=".txt,.csv,.json,.aco"
+                  className={styles.hiddenInput}
+                  disabled={!canWrite}
+                  onChange={(e) => setFileName(e.currentTarget.files?.[0]?.name ?? '')}
+                />
+              </label>
+              <span className={styles.fileName}>{fileName || 'No file chosen'}</span>
+            </div>
+            <div className={styles.exampleBox}>
+              <p className={styles.exampleTitle}>
+                <Trans i18nKey="teams.visualization-options.example-title">Example file format:</Trans>
+              </p>
+              <code className={styles.exampleCode}>
+                {'#FF6B6B\n#4ECDC4\nrgb(69, 183, 209)\nor JSON: [{"hex": "#FF6B6B"}, ...]'}
+              </code>
+            </div>
+          </div>
+        )}
+
+        {generationMethod === 'ai-images' && (
+          <div className={styles.methodBox}>
+            <p className={styles.methodTitle}>
+              <Trans i18nKey="teams.visualization-options.ai-images-title">AI from Images</Trans>
+            </p>
+            <p className={styles.methodDesc}>
+              <Trans i18nKey="teams.visualization-options.ai-images-desc">
+                Upload brand images and AI will extract a 50-color palette from them.
+              </Trans>
+            </p>
+          </div>
+        )}
+
+        {generationMethod === 'ai-colors' && (
+          <div className={styles.methodBox}>
+            <p className={styles.methodTitle}>
+              <Trans i18nKey="teams.visualization-options.ai-colors-title">AI from Colors</Trans>
+            </p>
+            <p className={styles.methodDesc}>
+              <Trans i18nKey="teams.visualization-options.ai-colors-desc">
+                Enter your {BRAND_COLOR_COUNT} brand colors. The Grafana Assistant will generate a cohesive 50-color
+                palette following accessibility and color-harmony guardrails.
+              </Trans>
+            </p>
+
+            <div className={styles.colorGrid}>
+              {brandColors.map((color, index) => (
+                <div key={index} className={styles.colorEntry}>
+                  <span className={styles.colorLabel}>
+                    {t('teams.visualization-options.brand-color-label', 'Color {{n}}', { n: index + 1 })}
+                  </span>
+                  <ColorPickerInput
+                    value={color}
+                    onChange={(c) => updateBrandColor(index, c)}
+                    disabled={!canWrite}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <Button
+              variant="primary"
+              icon={isGenerating ? undefined : 'ai'}
+              onClick={handleGenerateWithAI}
+              disabled={!canWrite || brandColors.some((c) => !c) || isGenerating}
+              className={styles.generateBtn}
+            >
+              {isGenerating ? (
+                <>
+                  <Spinner inline className={styles.spinner} />
+                  <Trans i18nKey="teams.visualization-options.generating">Generating palette…</Trans>
+                </>
+              ) : (
+                <Trans i18nKey="teams.visualization-options.generate-btn">
+                  Generate palette with Grafana Assistant
+                </Trans>
+              )}
+            </Button>
+
+            {(generateError || parseError) && (
+              <Alert
+                severity="error"
+                title={t('teams.visualization-options.generation-failed', 'Generation failed')}
+                className={styles.alert}
+              >
+                {generateError?.message ?? parseError}
+              </Alert>
+            )}
+
+            {generatedPalette && (
+              <div className={styles.palettePreview}>
+                <p className={styles.palettePreviewLabel}>
+                  <Trans i18nKey="teams.visualization-options.palette-preview">
+                    Generated palette — {generatedPalette.length} colors
+                  </Trans>
+                </p>
+                <div className={styles.paletteStrip}>
+                  {generatedPalette.map((entry, i) => (
+                    // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+                    <Tooltip key={i} content={`${entry.name} ${entry.hex}`} placement="top">
+                      <span className={styles.paletteSwatch} style={{ backgroundColor: entry.hex }} />
+                    </Tooltip>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={!canWrite || !paletteName || (generationMethod === 'ai-colors' && !generatedPalette)}
+        >
+          <Trans i18nKey="teams.visualization-options.save-palette">Save Palette</Trans>
+        </Button>
+
+        {savedPalettes.length > 0 && (
+          <>
+            <h6 className={styles.subheading}>
+              <Trans i18nKey="teams.visualization-options.saved-palettes">Saved Palettes</Trans>
+            </h6>
+            <div className={styles.savedPalettesList}>
+              {savedPalettes.map((palette) => (
+                <div key={palette.id} className={styles.savedPaletteRow}>
+                  <div className={styles.savedPaletteThumbnail}>
+                    {palette.colors.slice(0, 8).map((color, i) => (
+                      <span key={i} className={styles.savedPaletteSwatch} style={{ backgroundColor: color }} />
+                    ))}
+                  </div>
+                  <span className={styles.savedPaletteName}>{palette.name}</span>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    icon="trash-alt"
+                    aria-label={t('teams.visualization-options.delete-palette', 'Delete palette {{name}}', {
+                      name: palette.name,
+                    })}
+                    disabled={!canWrite}
+                    onClick={() => {
+                      deleteTeamPalette(palette.id);
+                      notifyApp.success(
+                        t('teams.visualization-options.delete-success', 'Palette "{{name}}" deleted', {
+                          name: palette.name,
+                        })
+                      );
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </Stack>
+    </FieldSet>
+  );
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    description: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      margin: 0,
+    }),
+    subheading: css({
+      fontSize: theme.typography.body.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+      margin: 0,
+      paddingBottom: theme.spacing(0.75),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      width: '100%',
+    }),
+    row: css({
+      display: 'flex',
+      gap: theme.spacing(2),
+      width: '100%',
+    }),
+    fieldHalf: css({
+      flex: 1,
+      minWidth: 0,
+    }),
+    methodBox: css({
+      background: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.medium}`,
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(2),
+      width: '100%',
+    }),
+    methodTitle: css({
+      fontWeight: theme.typography.fontWeightMedium,
+      marginBottom: theme.spacing(0.5),
+    }),
+    methodDesc: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      marginBottom: theme.spacing(1.5),
+    }),
+    colorGrid: css({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(4, 1fr)',
+      gap: theme.spacing(1.5),
+      marginBottom: theme.spacing(2),
+    }),
+    colorEntry: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+    }),
+    colorLabel: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.secondary,
+    }),
+    generateBtn: css({
+      width: '100%',
+    }),
+    spinner: css({
+      marginRight: theme.spacing(1),
+    }),
+    alert: css({
+      marginTop: theme.spacing(1.5),
+    }),
+    palettePreview: css({
+      marginTop: theme.spacing(1.5),
+    }),
+    palettePreviewLabel: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.secondary,
+      marginBottom: theme.spacing(0.75),
+    }),
+    paletteStrip: css({
+      display: 'flex',
+      height: 32,
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+      width: '100%',
+    }),
+    paletteSwatch: css({
+      flex: 1,
+      height: '100%',
+    }),
+    fileInputRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      marginBottom: theme.spacing(1.5),
+    }),
+    chooseFileBtn: css({
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1.5)}`,
+      background: theme.colors.background.primary,
+      border: `1px solid ${theme.colors.border.strong}`,
+      borderRadius: theme.shape.radius.default,
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      cursor: 'pointer',
+      whiteSpace: 'nowrap',
+      '&:hover': {
+        background: theme.colors.action.hover,
+      },
+    }),
+    chooseFileBtnDisabled: css({
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1.5)}`,
+      background: theme.colors.background.primary,
+      border: `1px solid ${theme.colors.border.medium}`,
+      borderRadius: theme.shape.radius.default,
+      color: theme.colors.text.disabled,
+      fontSize: theme.typography.bodySmall.fontSize,
+      cursor: 'not-allowed',
+      whiteSpace: 'nowrap',
+    }),
+    hiddenInput: css({
+      display: 'none',
+    }),
+    fileName: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    exampleBox: css({
+      background: theme.colors.background.canvas,
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(1.5),
+    }),
+    exampleTitle: css({
+      fontWeight: theme.typography.fontWeightMedium,
+      fontSize: theme.typography.bodySmall.fontSize,
+      marginBottom: theme.spacing(0.5),
+    }),
+    exampleCode: css({
+      display: 'block',
+      fontFamily: theme.typography.fontFamilyMonospace,
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.secondary,
+      whiteSpace: 'pre',
+    }),
+    savedPalettesList: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+      width: '100%',
+    }),
+    savedPaletteRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1.5),
+      padding: theme.spacing(1),
+      background: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+    }),
+    savedPaletteThumbnail: css({
+      display: 'flex',
+      height: 24,
+      width: 120,
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+      flexShrink: 0,
+    }),
+    savedPaletteSwatch: css({
+      flex: 1,
+      height: '100%',
+    }),
+    savedPaletteName: css({
+      flex: 1,
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.primary,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }),
+  };
+}

--- a/public/app/features/teams/paletteGenerationSkill.ts
+++ b/public/app/features/teams/paletteGenerationSkill.ts
@@ -1,0 +1,65 @@
+/**
+ * Inline skill instructions passed to the Grafana Assistant as a systemPrompt
+ * when generating a team colour palette via useInlineAssistant.
+ *
+ * The canonical source of truth for this skill lives in:
+ * grafana-assistant-app/apps/plugin/src/skills/palette-generation/SKILL.md
+ * Keep the guardrails here in sync with that file.
+ */
+export const PALETTE_GENERATION_SKILL = `
+# Team Palette Generation Skill
+
+Generate a 50-color Grafana visualization palette derived from a team's brand colors.
+
+## Output Format
+
+Respond with **only** a JSON object — no prose, no markdown fences:
+
+{
+  "palette": [
+    { "hex": "#ff6b6b", "name": "Brand Red", "role": "primary" },
+    ...
+  ]
+}
+
+The palette array must contain exactly 50 entries. Each entry:
+- hex: 6-digit lowercase hex prefixed with #
+- name: short human-readable label e.g. "Brand Red Light 1"
+- role: one of primary | secondary | accent | neutral | semantic
+
+## Color Distribution (total = 50)
+
+- Each of the 7 brand colors → 4 variants each = 28 colors
+  (base + 2 lighter tints + 1 darker shade)
+- 3 harmonically derived complementary/analogous colors × 3 variants = 9 colors
+- Neutral ramp (mid-tones only, brand-hue tinted, L between 30%–70%) = 8 colors
+- Semantic set (success, warning, error, info, unknown) = 5 colors
+
+## Guardrails
+
+### Accessibility
+- Text/icon colors must achieve WCAG AA (4.5:1) against dark (#0f0f0f) or light (#ffffff).
+- Semantic colors must be distinguishable with deuteranopia/protanopia (use brightness contrast, not just hue).
+
+### Color Harmony
+- Tints: increase HSL lightness 12–18% per step; cap at L=85%.
+- Shades: decrease HSL lightness 12–18% per step; floor at L=25%.
+- Complementary hue rotation: 150°–210° from the dominant brand color.
+- Analogous: ±25°–40° hue rotation.
+- No two adjacent palette entries with ΔE (CIE76) < 8.
+
+### Color Range — STRICT
+- **Every color must have HSL lightness between 25% and 85%.** Do not generate any color outside this range.
+- **Every color must have HSL saturation ≥ 20%.** Do not include greys, near-greys, or desaturated colors.
+- Neutral ramp: use mid-tones only (L 30%–70%) with 4–8% saturation. No near-blacks or near-whites.
+- Never output #000000, #ffffff, or any color with L < 25% or L > 85%.
+
+### Brand Fidelity
+- The 7 input brand colors must appear verbatim in the output (do NOT alter their hex values).
+- All colors should work on both Grafana dark and light themes.
+`;
+
+export const PALETTE_GENERATION_PROMPT = (colors: string[]) =>
+  `Generate a 50-color Grafana visualization palette from these 7 brand colors: ${colors.join(', ')}. ` +
+  `STRICT RULES: every color must have HSL lightness between 25%–85% and saturation ≥ 20% — no greys, no near-blacks, no near-whites. ` +
+  `Do not explain your reasoning. Output only a JSON object: {"palette":[{"hex":"...","name":"...","role":"..."},...]} — no markdown, no prose.`;

--- a/public/app/features/teams/teamPalettesStore.ts
+++ b/public/app/features/teams/teamPalettesStore.ts
@@ -1,0 +1,81 @@
+/**
+ * localStorage-backed store for team-saved palettes.
+ * Uses @grafana/data store (which wraps localStorage and handles cross-tab sync)
+ * and exposes a useSyncExternalStore-compatible API.
+ *
+ * Each palette is also registered with fieldColorModeRegistry so that panels
+ * whose color.mode is set to the palette ID resolve correctly.
+ *
+ * The snapshot is cached so that useSyncExternalStore receives a stable reference
+ * between mutations — preventing the "Maximum update depth exceeded" infinite loop.
+ */
+
+import { Field, FieldColorMode, GrafanaTheme2, fieldColorModeRegistry, store } from '@grafana/data';
+
+import { PaletteDefinition } from '../dashboard-scene/panel-edit/palettes';
+
+const STORAGE_KEY = 'grafana.teamPalettes';
+
+let cachedSnapshot: PaletteDefinition[] = store.getObject<PaletteDefinition[]>(STORAGE_KEY) ?? [];
+
+function invalidateCache(): void {
+  cachedSnapshot = store.getObject<PaletteDefinition[]>(STORAGE_KEY) ?? [];
+}
+
+function registerPaletteColorMode(palette: PaletteDefinition): void {
+  if (fieldColorModeRegistry.getIfExists(palette.id)) {
+    return; // Already registered in this session
+  }
+  const colors = palette.colors;
+  const mode: FieldColorMode = {
+    id: palette.id,
+    name: palette.name,
+    isContinuous: false,
+    isByValue: false,
+    getColors: (_theme: GrafanaTheme2) => colors,
+    getCalculator: (field: Field, theme: GrafanaTheme2) => {
+      const resolvedColors = colors.map((c) => theme.visualization.getColorByName(c));
+      return (_value: number, _percent: number) => {
+        const seriesIndex = field.state?.seriesIndex ?? 0;
+        return resolvedColors[seriesIndex % resolvedColors.length];
+      };
+    },
+  };
+  fieldColorModeRegistry.register(mode);
+}
+
+// Register all persisted palettes at module load time so panels resolve on page refresh
+for (const palette of cachedSnapshot) {
+  registerPaletteColorMode(palette);
+}
+
+export function getTeamPalettesSnapshot(): PaletteDefinition[] {
+  return cachedSnapshot;
+}
+
+export function saveTeamPalette(palette: PaletteDefinition): void {
+  const current = [...cachedSnapshot];
+  const idx = current.findIndex((p) => p.id === palette.id);
+  if (idx >= 0) {
+    current[idx] = palette;
+  } else {
+    current.push(palette);
+  }
+  store.setObject(STORAGE_KEY, current);
+  invalidateCache();
+  registerPaletteColorMode(palette);
+}
+
+export function deleteTeamPalette(id: string): void {
+  const current = cachedSnapshot.filter((p) => p.id !== id);
+  store.setObject(STORAGE_KEY, current);
+  invalidateCache();
+}
+
+/** Subscribe function for useSyncExternalStore */
+export function subscribeTeamPalettes(onStoreChange: () => void): () => void {
+  return store.subscribe(STORAGE_KEY, () => {
+    invalidateCache();
+    onStoreChange();
+  });
+}


### PR DESCRIPTION
## Summary

PoC for tab/row-level colour palette inheritance on dashboards.

**What this adds:**
- `colorPalette` field on tabs and rows — persisted in the dashboard JSON (CUE schema + generated types for v2beta1)
- `colorPaletteOverride` flag on individual grid/auto-grid items — opt a panel out of inherited palette
- Cascade re-applies on page load from persisted schema (no longer lost on refresh)
- Shared `applyColorPaletteToLayout` utility used by both `TabItem` and `RowItem`
- **Lock color** toggle in panel edit pane for both grid and auto-grid layouts
- Team palette generation via Grafana AI Assistant (`useInlineAssistant`) in Team Settings
- Team palette store (`teamPalettesStore`) with `fieldColorModeRegistry` registration

## Known limitations / not production-ready

- Team palettes stored in **localStorage**, not backend DB — per-user, per-browser
- Cascade applied at **write-time**, not render-time (no field config middleware hook in `@grafana/scenes` yet)
- No RBAC on palette management
- Dashboard root-level `colorPalette` not yet wired up
- No server-side palette registry (PDF export / image rendering won't resolve custom palettes)

## Test plan

- Apply palette on a tab → save → reload → panels retain palette ✓
- Lock a panel → change tab palette → locked panel unchanged ✓
- Unlock panel → change tab palette again → panel now follows tab ✓
- Check dashboard JSON (`Settings → JSON model`) for `colorPalette` on tab spec and `colorPaletteOverride` on locked grid items ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)