### PR TITLE
Alerting: Declare dedicated structs for external Alertmanager APIs

### DIFF
--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -5286,6 +5286,40 @@
         },
         "type": "object"
       },
+      "ExternalAlertmanagerConfig": {
+        "properties": {
+          "alertmanager_config": {
+            "$ref": "#/components/schemas/Config"
+          },
+          "template_files": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ExternalAlertmanagerStatus": {
+        "properties": {
+          "cluster": {
+            "$ref": "#/components/schemas/clusterStatus"
+          },
+          "config": {
+            "$ref": "#/components/schemas/Config"
+          },
+          "uptime": {
+            "description": "uptime",
+            "format": "date-time",
+            "type": "string"
+          },
+          "versionInfo": {
+            "$ref": "#/components/schemas/versionInfo"
+          }
+        },
+        "required": ["cluster", "config", "uptime", "versionInfo"],
+        "type": "object"
+      },
       "ExtraConfiguration": {
         "properties": {
           "alertmanager_config": {

--- a/pkg/services/ngalert/api/forking_alertmanager.go
+++ b/pkg/services/ngalert/api/forking_alertmanager.go
@@ -112,15 +112,10 @@ func (f *AlertmanagerApiHandler) handleRouteGetSilences(ctx *contextmodel.ReqCon
 	return s.RouteGetSilences(ctx)
 }
 
-func (f *AlertmanagerApiHandler) handleRoutePostAlertingConfig(ctx *contextmodel.ReqContext, body apimodels.PostableUserConfig, dsUID string) response.Response {
+func (f *AlertmanagerApiHandler) handleRoutePostAlertingConfig(ctx *contextmodel.ReqContext, body apimodels.ExternalAlertmanagerConfig, dsUID string) response.Response {
 	s, err := f.getService(ctx)
 	if err != nil {
 		return errorToResponse(err)
-	}
-	for _, p := range body.AlertmanagerConfig.Receivers {
-		if p.HasGrafanaIntegrations() {
-			return errorToResponse(backendTypeDoesNotMatchPayloadTypeError(apimodels.AlertmanagerBackend, apimodels.GrafanaBackend.String()))
-		}
 	}
 	return s.RoutePostAlertingConfig(ctx, body)
 }

--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -151,7 +151,7 @@ func (f *AlertmanagerApiHandler) RoutePostAlertingConfig(ctx *contextmodel.ReqCo
 	// Parse Path Parameters
 	datasourceUIDParam := web.Params(ctx.Req)[":DatasourceUID"]
 	// Parse Request Body
-	conf := apimodels.PostableUserConfig{}
+	conf := apimodels.ExternalAlertmanagerConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}

--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -117,7 +117,7 @@ func (am *LotexAM) RouteGetAMStatus(ctx *contextmodel.ReqContext) response.Respo
 		"status",
 		nil,
 		nil,
-		jsonExtractor(&apimodels.GettableStatus{}),
+		jsonExtractor(&apimodels.ExternalAlertmanagerStatus{}),
 		nil,
 	)
 }
@@ -169,7 +169,7 @@ func (am *LotexAM) RouteGetAlertingConfig(ctx *contextmodel.ReqContext) response
 		"config",
 		nil,
 		nil,
-		yamlExtractor(&apimodels.GettableUserConfig{}),
+		yamlExtractor(&apimodels.ExternalAlertmanagerConfig{}),
 		nil,
 	)
 }
@@ -222,7 +222,7 @@ func (am *LotexAM) RouteGetSilences(ctx *contextmodel.ReqContext) response.Respo
 	)
 }
 
-func (am *LotexAM) RoutePostAlertingConfig(ctx *contextmodel.ReqContext, config apimodels.PostableUserConfig) response.Response {
+func (am *LotexAM) RoutePostAlertingConfig(ctx *contextmodel.ReqContext, config apimodels.ExternalAlertmanagerConfig) response.Response {
 	yml, err := yaml.Marshal(&config)
 	if err != nil {
 		return ErrResp(500, err, "Failed marshal alert manager configuration ")

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1145,6 +1145,45 @@
    },
    "type": "object"
   },
+  "ExternalAlertmanagerConfig": {
+   "properties": {
+    "alertmanager_config": {
+     "$ref": "#/definitions/Config"
+    },
+    "template_files": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    }
+   },
+   "type": "object"
+  },
+  "ExternalAlertmanagerStatus": {
+   "properties": {
+    "cluster": {
+     "$ref": "#/definitions/clusterStatus"
+    },
+    "config": {
+     "$ref": "#/definitions/Config"
+    },
+    "uptime": {
+     "description": "uptime",
+     "format": "date-time",
+     "type": "string"
+    },
+    "versionInfo": {
+     "$ref": "#/definitions/versionInfo"
+    }
+   },
+   "required": [
+    "cluster",
+    "config",
+    "uptime",
+    "versionInfo"
+   ],
+   "type": "object"
+  },
   "ExtraConfiguration": {
    "properties": {
     "alertmanager_config": {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -48,7 +48,7 @@ import (
 // gets an Alerting config
 //
 //     Responses:
-//       200: GettableUserConfig
+//       200: ExternalAlertmanagerConfig
 //       400: ValidationError
 //       404: NotFound
 
@@ -96,7 +96,7 @@ import (
 // get alertmanager status and configuration
 //
 //     Responses:
-//       200: GettableStatus
+//       200: ExternalAlertmanagerStatus
 //       400: ValidationError
 //       404: NotFound
 
@@ -654,7 +654,7 @@ type PostableAlerts struct {
 // swagger:parameters RoutePostAlertingConfig RoutePostGrafanaAlertingConfig
 type BodyAlertingConfig struct {
 	// in:body
-	Body PostableUserConfig
+	Body ExternalAlertmanagerConfig
 }
 
 // swagger:parameters RoutePostGrafanaAlertingConfigHistoryActivate
@@ -1127,3 +1127,128 @@ type GettableGrafanaReceivers struct {
 }
 
 type EncryptFn func(ctx context.Context, payload []byte) ([]byte, error)
+
+// swagger:model
+type ExternalAlertmanagerConfig struct {
+	TemplateFiles      map[string]string `yaml:"template_files" json:"template_files"`
+	AlertmanagerConfig config.Config     `yaml:"alertmanager_config" json:"alertmanager_config"`
+	// amSimple stores a map[string]interface of the decoded alertmanager config.
+	// This enables circumventing the underlying alertmanager secret type
+	// which redacts itself during encoding.
+	amSimple map[string]interface{} `yaml:"-" json:"-"`
+}
+
+func (c *ExternalAlertmanagerConfig) MarshalJSON() ([]byte, error) {
+	type plain struct {
+		TemplateFiles      map[string]string      `yaml:"template_files" json:"template_files"`
+		AlertmanagerConfig map[string]interface{} `yaml:"alertmanager_config" json:"alertmanager_config"`
+	}
+
+	tmp := plain{
+		TemplateFiles:      c.TemplateFiles,
+		AlertmanagerConfig: c.amSimple,
+	}
+
+	return json.Marshal(tmp)
+}
+
+func (c *ExternalAlertmanagerConfig) UnmarshalJSON(b []byte) error {
+	type plain ExternalAlertmanagerConfig
+	if err := json.Unmarshal(b, (*plain)(c)); err != nil {
+		return err
+	}
+
+	type intermediate struct {
+		AlertmanagerConfig map[string]interface{} `yaml:"alertmanager_config" json:"alertmanager_config"`
+	}
+
+	var tmp intermediate
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	// store the map[string]interface{} variant for re-encoding later without redaction
+	c.amSimple = tmp.AlertmanagerConfig
+
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaller.
+func (c *ExternalAlertmanagerConfig) MarshalYAML() (interface{}, error) {
+	yml, err := yaml.Marshal(c.amSimple)
+	if err != nil {
+		return nil, err
+	}
+	// cortex/loki actually pass the AM config as a string.
+	cortexPostableUserConfig := struct {
+		TemplateFiles      map[string]string `yaml:"template_files" json:"template_files"`
+		AlertmanagerConfig string            `yaml:"alertmanager_config" json:"alertmanager_config"`
+	}{
+		TemplateFiles:      c.TemplateFiles,
+		AlertmanagerConfig: string(yml),
+	}
+	return cortexPostableUserConfig, nil
+}
+
+func (c *ExternalAlertmanagerConfig) UnmarshalYAML(value *yaml.Node) error {
+	// cortex/loki actually pass the AM config as a string.
+	type cortexPostableUserConfig struct {
+		TemplateFiles      map[string]string `yaml:"template_files" json:"template_files"`
+		AlertmanagerConfig string            `yaml:"alertmanager_config" json:"alertmanager_config"`
+	}
+
+	var tmp cortexPostableUserConfig
+
+	if err := value.Decode(&tmp); err != nil {
+		return err
+	}
+
+	if err := yaml.Unmarshal([]byte(tmp.AlertmanagerConfig), &c.AlertmanagerConfig); err != nil {
+		return err
+	}
+
+	// store the map[string]interface{} variant for re-encoding later without redaction
+	if err := yaml.Unmarshal([]byte(tmp.AlertmanagerConfig), &c.amSimple); err != nil {
+		return err
+	}
+
+	c.TemplateFiles = tmp.TemplateFiles
+	return nil
+}
+
+// swagger:model
+type ExternalAlertmanagerStatus struct {
+	// cluster
+	// Required: true
+	Cluster *amv2.ClusterStatus `json:"cluster"`
+
+	// config
+	// Required: true
+	Config *config.Config `json:"config"`
+
+	// uptime
+	// Required: true
+	// Format: date-time
+	Uptime *strfmt.DateTime `json:"uptime"`
+
+	// version info
+	// Required: true
+	VersionInfo *amv2.VersionInfo `json:"versionInfo"`
+}
+
+func (s *ExternalAlertmanagerStatus) UnmarshalJSON(b []byte) error {
+	amStatus := amv2.AlertmanagerStatus{}
+	if err := json.Unmarshal(b, &amStatus); err != nil {
+		return err
+	}
+
+	c := config.Config{}
+	if err := yaml.Unmarshal([]byte(*amStatus.Config.Original), &c); err != nil {
+		return err
+	}
+
+	s.Cluster = amStatus.Cluster
+	s.Config = &c
+	s.Uptime = amStatus.Uptime
+	s.VersionInfo = amStatus.VersionInfo
+	return nil
+}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -1139,6 +1139,12 @@ type ExternalAlertmanagerConfig struct {
 }
 
 func (c *ExternalAlertmanagerConfig) MarshalJSON() ([]byte, error) {
+	// amSimple is populated by UnmarshalJSON/UnmarshalYAML and holds the raw alertmanager config
+	// without secret redaction. Marshaling without it would silently lose secret fields.
+	if c.amSimple == nil {
+		return nil, fmt.Errorf("cannot marshal ExternalAlertmanagerConfig to JSON: alertmanager config was not decoded")
+	}
+
 	type plain struct {
 		TemplateFiles      map[string]string      `yaml:"template_files" json:"template_files"`
 		AlertmanagerConfig map[string]interface{} `yaml:"alertmanager_config" json:"alertmanager_config"`
@@ -1174,6 +1180,12 @@ func (c *ExternalAlertmanagerConfig) UnmarshalJSON(b []byte) error {
 
 // MarshalYAML implements yaml.Marshaller.
 func (c *ExternalAlertmanagerConfig) MarshalYAML() (interface{}, error) {
+	// amSimple is populated by UnmarshalJSON/UnmarshalYAML and holds the raw alertmanager config
+	// without secret redaction. Marshaling without it would silently lose secret fields.
+	if c.amSimple == nil {
+		return nil, fmt.Errorf("cannot marshal ExternalAlertmanagerConfig to YAML: alertmanager config was not decoded")
+	}
+
 	yml, err := yaml.Marshal(c.amSimple)
 	if err != nil {
 		return nil, err
@@ -1239,6 +1251,10 @@ func (s *ExternalAlertmanagerStatus) UnmarshalJSON(b []byte) error {
 	amStatus := amv2.AlertmanagerStatus{}
 	if err := json.Unmarshal(b, &amStatus); err != nil {
 		return err
+	}
+
+	if amStatus.Config == nil || amStatus.Config.Original == nil {
+		return fmt.Errorf("alertmanager status response missing config")
 	}
 
 	c := config.Config{}

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1145,6 +1145,45 @@
    },
    "type": "object"
   },
+  "ExternalAlertmanagerConfig": {
+   "properties": {
+    "alertmanager_config": {
+     "$ref": "#/definitions/Config"
+    },
+    "template_files": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    }
+   },
+   "type": "object"
+  },
+  "ExternalAlertmanagerStatus": {
+   "properties": {
+    "cluster": {
+     "$ref": "#/definitions/clusterStatus"
+    },
+    "config": {
+     "$ref": "#/definitions/Config"
+    },
+    "uptime": {
+     "description": "uptime",
+     "format": "date-time",
+     "type": "string"
+    },
+    "versionInfo": {
+     "$ref": "#/definitions/versionInfo"
+    }
+   },
+   "required": [
+    "cluster",
+    "config",
+    "uptime",
+    "versionInfo"
+   ],
+   "type": "object"
+  },
   "ExtraConfiguration": {
    "properties": {
     "alertmanager_config": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -910,9 +910,9 @@
         ],
         "responses": {
           "200": {
-            "description": "GettableStatus",
+            "description": "ExternalAlertmanagerStatus",
             "schema": {
-              "$ref": "#/definitions/GettableStatus"
+              "$ref": "#/definitions/ExternalAlertmanagerStatus"
             }
           },
           "400": {
@@ -948,9 +948,9 @@
         ],
         "responses": {
           "200": {
-            "description": "GettableUserConfig",
+            "description": "ExternalAlertmanagerConfig",
             "schema": {
-              "$ref": "#/definitions/GettableUserConfig"
+              "$ref": "#/definitions/ExternalAlertmanagerConfig"
             }
           },
           "400": {
@@ -978,7 +978,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/PostableUserConfig"
+              "$ref": "#/definitions/ExternalAlertmanagerConfig"
             }
           },
           {
@@ -5714,6 +5714,45 @@
         },
         "wechat_configs": {
           "$ref": "#/definitions/WechatConfig"
+        }
+      }
+    },
+    "ExternalAlertmanagerConfig": {
+      "type": "object",
+      "properties": {
+        "alertmanager_config": {
+          "$ref": "#/definitions/Config"
+        },
+        "template_files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExternalAlertmanagerStatus": {
+      "type": "object",
+      "required": [
+        "cluster",
+        "config",
+        "uptime",
+        "versionInfo"
+      ],
+      "properties": {
+        "cluster": {
+          "$ref": "#/definitions/clusterStatus"
+        },
+        "config": {
+          "$ref": "#/definitions/Config"
+        },
+        "uptime": {
+          "description": "uptime",
+          "type": "string",
+          "format": "date-time"
+        },
+        "versionInfo": {
+          "$ref": "#/definitions/versionInfo"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15629,6 +15629,45 @@
         }
       }
     },
+    "ExternalAlertmanagerConfig": {
+      "type": "object",
+      "properties": {
+        "alertmanager_config": {
+          "$ref": "#/definitions/Config"
+        },
+        "template_files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExternalAlertmanagerStatus": {
+      "type": "object",
+      "required": [
+        "cluster",
+        "config",
+        "uptime",
+        "versionInfo"
+      ],
+      "properties": {
+        "cluster": {
+          "$ref": "#/definitions/clusterStatus"
+        },
+        "config": {
+          "$ref": "#/definitions/Config"
+        },
+        "uptime": {
+          "description": "uptime",
+          "type": "string",
+          "format": "date-time"
+        },
+        "versionInfo": {
+          "$ref": "#/definitions/versionInfo"
+        }
+      }
+    },
     "ExtraConfiguration": {
       "type": "object",
       "properties": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -5414,6 +5414,45 @@
         },
         "type": "object"
       },
+      "ExternalAlertmanagerConfig": {
+        "properties": {
+          "alertmanager_config": {
+            "$ref": "#/components/schemas/Config"
+          },
+          "template_files": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ExternalAlertmanagerStatus": {
+        "properties": {
+          "cluster": {
+            "$ref": "#/components/schemas/clusterStatus"
+          },
+          "config": {
+            "$ref": "#/components/schemas/Config"
+          },
+          "uptime": {
+            "description": "uptime",
+            "format": "date-time",
+            "type": "string"
+          },
+          "versionInfo": {
+            "$ref": "#/components/schemas/versionInfo"
+          }
+        },
+        "required": [
+          "cluster",
+          "config",
+          "uptime",
+          "versionInfo"
+        ],
+        "type": "object"
+      },
       "ExtraConfiguration": {
         "properties": {
           "alertmanager_config": {


### PR DESCRIPTION
Create dedicated structs for external Alertmanager APIs. Currently, we reuse structs with storage model of Grafana alertmanager  and it causes many issues
The new stucts have custom marshaling logic that keeps the semantic of remarshaling yaml to json without losing secret fields.  

Note: It become obvious that this re-marshaling struct does not need to be fully structured. It's main purpose is to go from YAML to JSON. Validation on Grafana side is redundant and counter-productive. So, in a follow up PR I plan to replace `config.Config` with `map[string]any`