### PR TITLE
Added Query with Assistant button for MySQL and Postgres

### DIFF
--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@emotion/css": "11.13.5",
+    "@grafana/assistant": "^0.1.24",
     "@grafana/data": "13.0.0-pre",
     "@grafana/e2e-selectors": "13.0.0-pre",
     "@grafana/i18n": "13.0.0-pre",

--- a/packages/grafana-sql/src/components/QueryEditor.tsx
+++ b/packages/grafana-sql/src/components/QueryEditor.tsx
@@ -24,6 +24,7 @@ export default function SqlQueryEditor({
   onChange,
   onRunQuery,
   range,
+  app,
   queryHeaderProps,
 }: SqlQueryEditorProps) {
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
@@ -101,6 +102,8 @@ export default function SqlQueryEditor({
         hideFormatSelector={queryHeaderProps?.hideFormatSelector}
         hideRunButton={queryHeaderProps?.hideRunButton}
         dialect={dialect}
+        dataSourceInstanceSettings={datasource.instanceSettings}
+        app={app}
       />
 
       <Space v={0.5} />

--- a/packages/grafana-sql/src/components/QueryHeader.tsx
+++ b/packages/grafana-sql/src/components/QueryHeader.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useId, useState } from 'react';
 import { useCopyToClipboard } from 'react-use';
 
-import { type SelectableValue } from '@grafana/data';
+import { QueryWithAssistantButton } from '@grafana/assistant';
+import { CoreApp, type DataSourceInstanceSettings, type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { EditorField, EditorHeader, EditorMode, EditorRow, FlexItem, InlineSelect } from '@grafana/plugin-ui';
-import { reportInteraction } from '@grafana/runtime';
+import { reportInteraction, config } from '@grafana/runtime';
 import { Button, InlineSwitch, RadioButtonGroup, Tooltip, Space } from '@grafana/ui';
 
 import { type QueryWithDefaults } from '../defaults';
@@ -34,6 +35,8 @@ export interface QueryHeaderProps {
   queryRowFilter: QueryRowFilter;
   hideFormatSelector?: boolean;
   hideRunButton?: boolean;
+  dataSourceInstanceSettings?: DataSourceInstanceSettings;
+  app?: CoreApp;
 }
 
 export function QueryHeader({
@@ -48,6 +51,8 @@ export function QueryHeader({
   queryRowFilter,
   hideFormatSelector,
   hideRunButton,
+  dataSourceInstanceSettings,
+  app,
 }: QueryHeaderProps) {
   const { editorMode } = query;
   const [_, copyToClipboard] = useCopyToClipboard();
@@ -55,6 +60,12 @@ export function QueryHeader({
   const toRawSql = db.toRawSql;
 
   const htmlId = useId();
+
+  const showAssistant =
+    config.featureToggles.queryWithAssistant &&
+    (dataSourceInstanceSettings?.type === 'mysql' ||
+      dataSourceInstanceSettings?.type === 'grafana-postgresql-datasource') &&
+    (app === CoreApp.Explore || app === CoreApp.Dashboard || app === CoreApp.PanelEditor);
 
   const editorModes = [
     {
@@ -134,6 +145,16 @@ export function QueryHeader({
   return (
     <>
       <EditorHeader>
+        {showAssistant && (
+          <QueryWithAssistantButton
+            currentQuery={query}
+            queries={[query]}
+            dataSourceInstanceSettings={dataSourceInstanceSettings!}
+            datasourceApi={null}
+            app={app}
+          />
+        )}
+
         {!hideFormatSelector && (
           <InlineSelect
             label={t('grafana-sql.components.query-header.label-format', 'Format')}

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -45,7 +45,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   dialect: SQLDialect = 'other';
 
   constructor(
-    instanceSettings: DataSourceInstanceSettings<SQLOptions>,
+    public instanceSettings: DataSourceInstanceSettings<SQLOptions>,
     protected readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);

--- a/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
+++ b/public/app/plugins/datasource/influxdb/fsql/datasource.flightsql.ts
@@ -15,7 +15,7 @@ export class FlightSQLDatasource extends SqlDatasource {
   sqlLanguageDefinition: LanguageDefinition | undefined;
 
   constructor(
-    private instanceSettings: DataSourceInstanceSettings<FlightSQLOptions>,
+    instanceSettings: DataSourceInstanceSettings<FlightSQLOptions>,
     protected readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);

--- a/public/app/plugins/datasource/mysql/MySqlDatasource.ts
+++ b/public/app/plugins/datasource/mysql/MySqlDatasource.ts
@@ -22,7 +22,7 @@ import { type MySQLOptions } from './types';
 export class MySqlDatasource extends SqlDatasource {
   sqlLanguageDefinition: LanguageDefinition | undefined;
 
-  constructor(private instanceSettings: DataSourceInstanceSettings<MySQLOptions>) {
+  constructor(instanceSettings: DataSourceInstanceSettings<MySQLOptions>) {
     super(instanceSettings);
     this.variables = new SQLVariableSupport(this);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,6 +3962,7 @@ __metadata:
   resolution: "@grafana/sql@workspace:packages/grafana-sql"
   dependencies:
     "@emotion/css": "npm:11.13.5"
+    "@grafana/assistant": "npm:^0.1.24"
     "@grafana/data": "npm:13.0.0-pre"
     "@grafana/e2e-selectors": "npm:13.0.0-pre"
     "@grafana/i18n": "npm:13.0.0-pre"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Added the Query with Assistant button to MySQL and Postgres

**Why do we need this feature?**

This allows us to create an additional entry point to Grafana Assistant and enable the user to use NL to explore their data 

**Who is this feature for?**

Anyone using Grafana and Grafana Assistant

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

MySQL 
<img width="2557" height="798" alt="Screenshot 2026-03-30 at 3 29 23 PM" src="https://github.com/user-attachments/assets/1519d09b-4943-421b-a3da-a46f1499316d" />

MySQL after clicking button
<img width="2554" height="1316" alt="Screenshot 2026-03-30 at 3 29 31 PM" src="https://github.com/user-attachments/assets/f53a8f1f-7829-4ce3-af7b-ec39fddd4a6e" />

Postgres
<img width="2551" height="772" alt="Screenshot 2026-03-30 at 3 37 39 PM" src="https://github.com/user-attachments/assets/9145719b-ee64-469f-9aa2-d4b3a3c930f0" />

Postgres after clicking button 
<img width="2556" height="1313" alt="Screenshot 2026-03-30 at 3 37 45 PM" src="https://github.com/user-attachments/assets/5e410459-00a5-4a95-b156-0f30d6df89ac" />

