### PR TITLE
Fix Prometheus data source tracking to use specific plugin IDs

### DIFF
--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -66,6 +66,8 @@ const failDataSourceTest = async (error: object) => {
           testDatasource: jest.fn().mockImplementation(() => {
             throw error;
           }),
+          meta: { id: 'azure-monitor' },
+          uid: 'azM0nit0R',
         }),
       }) as Pick<DataSourceSrv, 'get'>,
     getBackendSrv: getBackendSrvMock,
@@ -228,7 +230,7 @@ describe('testDataSource', () => {
                 status: 'success',
                 message: '',
               }),
-              type: 'cloudwatch',
+              meta: { id: 'cloudwatch' },
               uid: 'CW1234',
             }),
           }) as Pick<DataSourceSrv, 'get'>,
@@ -263,7 +265,7 @@ describe('testDataSource', () => {
               testDatasource: jest.fn().mockImplementation(() => {
                 throw new Error('Error testing datasource');
               }),
-              type: 'azure-monitor',
+              meta: { id: 'azure-monitor' },
               uid: 'azM0nit0R',
             }),
           }) as Pick<DataSourceSrv, 'get'>,
@@ -348,7 +350,7 @@ describe('testDataSource', () => {
               status: 'success',
               message: '',
             }),
-            type: 'cloudwatch',
+            meta: { id: 'cloudwatch' },
             uid: 'CW1234',
           }),
         }),
@@ -371,6 +373,66 @@ describe('testDataSource', () => {
       };
       await failDataSourceTest(error);
       expect(appEvents.publish).toHaveBeenCalledWith({ type: 'datasource-test-failed' });
+    });
+
+    it('tracks the specific plugin id for Prometheus-based datasources on success', async () => {
+      // Prometheus subclasses (e.g. Amazon Managed Prometheus, Azure Prometheus) override
+      // this.type = 'prometheus' in their constructor, so dsApi.type is always 'prometheus'.
+      // We must use dsApi.meta.id to get the actual plugin identifier.
+      const dependencies: TestDataSourceDependencies = {
+        getDatasourceSrv: () =>
+          ({
+            get: jest.fn().mockReturnValue({
+              testDatasource: jest.fn().mockReturnValue({
+                status: 'success',
+                message: '',
+              }),
+              type: 'prometheus', // simulates the class-level override
+              meta: { id: 'grafana-amazon-prometheus-datasource' },
+              uid: 'amp-uid-1',
+            }),
+          }) as Pick<DataSourceSrv, 'get'>,
+        getBackendSrv: getBackendSrvMock,
+      };
+      await thunkTester({})
+        .givenThunk(testDataSource)
+        .whenThunkIsDispatched('Amazon Prometheus', DATASOURCES_ROUTES.Edit, dependencies);
+
+      expect(trackDataSourceTested).toHaveBeenCalledWith(
+        expect.objectContaining({
+          plugin_id: 'grafana-amazon-prometheus-datasource',
+          datasource_uid: 'amp-uid-1',
+          success: true,
+        })
+      );
+    });
+
+    it('tracks the specific plugin id for Prometheus-based datasources on failure', async () => {
+      const dependencies: TestDataSourceDependencies = {
+        getDatasourceSrv: () =>
+          ({
+            get: jest.fn().mockReturnValue({
+              testDatasource: jest.fn().mockImplementation(() => {
+                throw new Error('connection refused');
+              }),
+              type: 'prometheus', // simulates the class-level override
+              meta: { id: 'grafana-azure-prometheus-datasource' },
+              uid: 'azprom-uid-1',
+            }),
+          }) as Pick<DataSourceSrv, 'get'>,
+        getBackendSrv: getBackendSrvMock,
+      };
+      await thunkTester({})
+        .givenThunk(testDataSource)
+        .whenThunkIsDispatched('Azure Prometheus', DATASOURCES_ROUTES.Edit, dependencies);
+
+      expect(trackDataSourceTested).toHaveBeenCalledWith(
+        expect.objectContaining({
+          plugin_id: 'grafana-azure-prometheus-datasource',
+          datasource_uid: 'azprom-uid-1',
+          success: false,
+        })
+      );
     });
   });
 });

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -162,7 +162,7 @@ export const testDataSource = (
 
         trackDataSourceTested({
           grafana_version: config.buildInfo.version,
-          plugin_id: dsApi.type,
+          plugin_id: dsApi.meta.id,
           plugin_version: getPluginVersion(dsApi),
           datasource_uid: dsApi.uid,
           success: true,
@@ -175,7 +175,7 @@ export const testDataSource = (
         dispatch(testDataSourceFailed({ ...formattedError }));
         trackDataSourceTested({
           grafana_version: config.buildInfo.version,
-          plugin_id: dsApi.type,
+          plugin_id: dsApi.meta.id,
           plugin_version: getPluginVersion(dsApi),
           datasource_uid: dsApi.uid,
           success: false,


### PR DESCRIPTION
The `trackDataSourceTested` event was recording `plugin_id: dsApi.type` for all datasources. For Prometheus-based plugins (Amazon Managed Prometheus, Azure Prometheus, etc.), this always resolved to 'prometheus' because the Prometheus base class hardcodes this.type = 'prometheus' in its constructor, overwriting the instance-specific value set by DataSourceApi.

Switched to `dsApi.meta.id`, which correctly identifies grafana-amazon-prometheus-datasource, grafana-azure-prometheus-datasource, etc. For all other datasources, `meta.id === type` so there is no behavior change.

Updated existing tests to mock meta.id instead of type, and added two new tests that assert Prometheus-based datasources emit their specific plugin ID rather than the generic 'prometheus'.