### PR TITLE
Feature Toggles: Support setting via configOverrides command-line flag

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -95,6 +95,7 @@ type Cfg struct {
 	configFiles                  []string
 	appliedCommandLineProperties []string
 	appliedEnvOverrides          []string
+	commandLineProps             map[string]string
 
 	// HTTP Server Settings
 	CertFile          string
@@ -1069,12 +1070,12 @@ func EnvKey(sectionName string, keyName string) string {
 	return "GF_" + envNameFromIniName(sectionName) + "_" + envNameFromIniName(keyName)
 }
 
-func (cfg *Cfg) applyCommandLineDefaultProperties(props map[string]string, file *ini.File) {
+func (cfg *Cfg) applyCommandLineDefaultProperties(file *ini.File) {
 	cfg.appliedCommandLineProperties = make([]string, 0)
 	for _, section := range file.Sections() {
 		for _, key := range section.Keys() {
 			keyString := fmt.Sprintf("default.%s.%s", section.Name(), key.Name())
-			value, exists := props[keyString]
+			value, exists := cfg.commandLineProps[keyString]
 			if exists {
 				key.SetValue(value)
 				cfg.appliedCommandLineProperties = append(cfg.appliedCommandLineProperties,
@@ -1084,7 +1085,7 @@ func (cfg *Cfg) applyCommandLineDefaultProperties(props map[string]string, file 
 	}
 }
 
-func (cfg *Cfg) applyCommandLineProperties(props map[string]string, file *ini.File) {
+func (cfg *Cfg) applyCommandLineProperties(file *ini.File) {
 	for _, section := range file.Sections() {
 		sectionName := section.Name() + "."
 		if section.Name() == ini.DefaultSection {
@@ -1092,7 +1093,7 @@ func (cfg *Cfg) applyCommandLineProperties(props map[string]string, file *ini.Fi
 		}
 		for _, key := range section.Keys() {
 			keyString := sectionName + key.Name()
-			value, exists := props[keyString]
+			value, exists := cfg.commandLineProps[keyString]
 			if exists {
 				cfg.appliedCommandLineProperties = append(cfg.appliedCommandLineProperties, fmt.Sprintf("%s=%s", keyString, value))
 				key.SetValue(value)
@@ -1189,9 +1190,9 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 	}
 
 	// command line props
-	commandLineProps := cfg.getCommandLineProperties(args.Args)
+	cfg.commandLineProps = cfg.getCommandLineProperties(args.Args)
 	// load default overrides
-	cfg.applyCommandLineDefaultProperties(commandLineProps, parsedFile)
+	cfg.applyCommandLineDefaultProperties(parsedFile)
 
 	// load specified config file
 	err = cfg.loadSpecifiedConfigFile(args.Config, parsedFile)
@@ -1211,7 +1212,7 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 	}
 
 	// apply command line overrides
-	cfg.applyCommandLineProperties(commandLineProps, parsedFile)
+	cfg.applyCommandLineProperties(parsedFile)
 
 	// evaluate config values containing environment variables
 	err = expandConfig(parsedFile)

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -80,9 +80,47 @@ func (cfg *Cfg) applyFeatureToggleEnvOverrides() {
 	}
 }
 
+// applyFeatureToggleCmdOverrides sets feature toggle values from command-line
+// properties (cfg:feature_toggles.<name>=<value>). The generic
+// applyCommandLineProperties method only overrides keys that already exist in
+// the ini file, so feature toggles that aren't in defaults.ini would be
+// silently ignored without this.
+func (cfg *Cfg) applyFeatureToggleCmdOverrides(file *ini.File) {
+	if len(cfg.commandLineProps) == 0 {
+		return
+	}
+
+	section := file.Section("feature_toggles")
+
+	already := make(map[string]bool, len(cfg.appliedCommandLineProperties))
+	for _, p := range cfg.appliedCommandLineProperties {
+		k, _, _ := strings.Cut(p, "=")
+		already[k] = true
+	}
+
+	for propKey, value := range cfg.commandLineProps {
+		if !strings.HasPrefix(propKey, "feature_toggles.") {
+			continue
+		}
+
+		keyName := strings.TrimPrefix(propKey, "feature_toggles.")
+		if keyName == "" || strings.Contains(keyName, ".") {
+			continue
+		}
+
+		section.Key(keyName).SetValue(value)
+		if !already[propKey] {
+			cfg.appliedCommandLineProperties = append(cfg.appliedCommandLineProperties,
+				fmt.Sprintf("%s=%s", propKey, RedactedValue(propKey, value)))
+		}
+	}
+}
+
 // Deprecated: should use `featuremgmt.FeatureToggles`
 func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 	cfg.applyFeatureToggleEnvOverrides()
+	cfg.applyFeatureToggleCmdOverrides(iniFile)
+
 	section := iniFile.Section("feature_toggles")
 	if section.Key("enable").String() != "" {
 		if os.Getenv(EnvKey("feature_toggles", "enable")) != "" {
@@ -91,6 +129,7 @@ func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 			cfg.Logger.Warn("[Deprecated] The feature_toggles.enable configuration setting is deprecated. Use individual feature toggle entries (e.g. featureName = <value>) instead.")
 		}
 	}
+
 	toggles, err := ReadFeatureTogglesFromInitFile(section)
 	if err != nil {
 		return err

--- a/pkg/setting/setting_feature_toggles_test.go
+++ b/pkg/setting/setting_feature_toggles_test.go
@@ -205,6 +205,120 @@ func TestFeatureToggleEnvOverrides(t *testing.T) {
 	})
 }
 
+func TestFeatureToggleCmdOverrides(t *testing.T) {
+	t.Run("cfg:feature_toggles.name creates a feature toggle", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{
+			HomePath: "../../",
+			Args:     []string{"cfg:feature_toggles.myToggle=true"},
+		})
+		require.NoError(t, err)
+
+		section := cfg.Raw.Section("feature_toggles")
+		require.Equal(t, "true", section.Key("myToggle").Value())
+	})
+
+	t.Run("cmd override overrides ini-defined toggle", func(t *testing.T) {
+		cfgFile := t.TempDir() + "/test.ini"
+		err := os.WriteFile(cfgFile, []byte("[feature_toggles]\nsomeToggle = true\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		err = cfg.Load(CommandLineArgs{
+			HomePath: "../../",
+			Config:   cfgFile,
+			Args:     []string{"cfg:feature_toggles.someToggle=false"},
+		})
+		require.NoError(t, err)
+
+		section := cfg.Raw.Section("feature_toggles")
+		require.Equal(t, "false", section.Key("someToggle").Value())
+	})
+
+	t.Run("cmd override is recorded in appliedCommandLineProperties", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{
+			HomePath: "../../",
+			Args:     []string{"cfg:feature_toggles.coolFeature=true"},
+		})
+		require.NoError(t, err)
+
+		found := false
+		for _, o := range cfg.appliedCommandLineProperties {
+			if strings.Contains(o, "feature_toggles.coolFeature") {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "cmd prop should appear in appliedCommandLineProperties")
+	})
+}
+
+func TestFeatureToggleSourcePrecedence(t *testing.T) {
+	t.Run("env var overrides ini file", func(t *testing.T) {
+		t.Setenv("GF_FEATURE_TOGGLES_myToggle", "false")
+
+		cfgFile := t.TempDir() + "/test.ini"
+		err := os.WriteFile(cfgFile, []byte("[feature_toggles]\nmyToggle = true\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		err = cfg.Load(CommandLineArgs{HomePath: "../../", Config: cfgFile})
+		require.NoError(t, err)
+
+		section := cfg.Raw.Section("feature_toggles")
+		require.Equal(t, "false", section.Key("myToggle").Value())
+	})
+
+	t.Run("cmd override wins over env var", func(t *testing.T) {
+		t.Setenv("GF_FEATURE_TOGGLES_myToggle", "false")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{
+			HomePath: "../../",
+			Args:     []string{"cfg:feature_toggles.myToggle=true"},
+		})
+		require.NoError(t, err)
+
+		section := cfg.Raw.Section("feature_toggles")
+		require.Equal(t, "true", section.Key("myToggle").Value(),
+			"command line should take precedence over env var")
+	})
+
+	t.Run("cmd override wins over both env var and ini file", func(t *testing.T) {
+		t.Setenv("GF_FEATURE_TOGGLES_myToggle", "false")
+
+		cfgFile := t.TempDir() + "/test.ini"
+		err := os.WriteFile(cfgFile, []byte("[feature_toggles]\nmyToggle = maybe\n"), 0644)
+		require.NoError(t, err)
+
+		cfg := NewCfg()
+		err = cfg.Load(CommandLineArgs{
+			HomePath: "../../",
+			Config:   cfgFile,
+			Args:     []string{"cfg:feature_toggles.myToggle=true"},
+		})
+		require.NoError(t, err)
+
+		section := cfg.Raw.Section("feature_toggles")
+		require.Equal(t, "true", section.Key("myToggle").Value(),
+			"command line should take precedence over env var and ini file")
+	})
+
+	t.Run("subsection cmd property does not create root toggle key", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{
+			HomePath: "../../",
+			Args:     []string{"cfg:feature_toggles.openfeature.provider=ofrep"},
+		})
+		require.NoError(t, err)
+
+		section := cfg.Raw.Section("feature_toggles")
+		require.False(t, section.HasKey("openfeature.provider"),
+			"subsection property should not appear as a root toggle key")
+	})
+}
+
 func TestFlagValueSerialization(t *testing.T) {
 	testCases := []memprovider.InMemoryFlag{
 		NewInMemoryFlag("int", 1),


### PR DESCRIPTION
**What is this feature?**

Previously, it was possible to enable boolean feature flags on the commandline with the `configOverrides` flag, like so:

```console
$ grafana server --configOverrides "cfg:feature_toggles.enable=myFlag ..."
```

**Why do we need this feature?**

However, the `enable` form is deprecated (as of #114047), and the supported form (which allows disabling boolean features and setting non-boolean values) didn't work:

```console
$ grafana server --configOverrides "cfg:feature_toggles.myFlag=myValue ..."
<silently ignores the flag setting>
```

The current behaviour is that `configOverrides` is only able to set an item when a default value is present in `defaults.ini`. This is undesirable for the `feature_toggles` section, which presumes the ability to set arbitrary names to arbitrary values.

I had to address this to solve #121271, and this PR extends that same approach to `configOverrides` handling.

**Who is this feature for?**

Grafana operators

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
