### PR TITLE
Prometheus: Clear sigV4 properties when changing auth type

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -170,6 +170,11 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
               ...options.jsonData,
               azureCredentials: method === azureAuthId ? options.jsonData.azureCredentials : undefined,
               sigV4Auth: method === sigV4Id,
+              sigV4AuthType: method === sigV4Id ? options.jsonData.sigV4AuthType : undefined,
+              sigV4AssumeRoleArn: method === sigV4Id ? options.jsonData.sigV4AssumeRoleArn : undefined,
+              sigV4ExternalId: method === sigV4Id ? options.jsonData.sigV4ExternalId : undefined,
+              sigV4Profile: method === sigV4Id ? options.jsonData.sigV4Profile : undefined,
+              sigV4Region: method === sigV4Id ? options.jsonData.sigV4Region : undefined,
               oauthPassThru: method === AuthMethod.OAuthForward,
             },
           });


### PR DESCRIPTION
**What is this feature?**

Clears sigV4 configuration properties from jsonData when the user switches away from sigV4 authentication. Previously only the `sigV4Auth` boolean was toggled, leaving stale config behind.

**Why do we need this feature?**

Switching from sigV4 to another auth method leaves `sigV4AuthType`, `sigV4AssumeRoleArn`, `sigV4ExternalId`, `sigV4Profile`, and `sigV4Region` in jsonData. Stale properties can cause unexpected behavior. The fix follows the same pattern already used for `azureCredentials` cleanup on the line above.

**Who is this feature for?**

Users configuring Prometheus data sources who switch between auth methods.

**Which issue(s) does this PR fix?**:

Fixes #111239

**Special notes for your reviewer:**

The change adds 5 lines to the `onAuthMethodSelect` handler in `DataSourceHttpSettingsOverhaulPackage.tsx`. Each sigV4 property is preserved when sigV4 is selected and cleared to `undefined` otherwise. This matches the existing `azureCredentials` cleanup on line 171.

The `packages/grafana-prometheus/` version of this component doesn't handle sigV4 at all, so it's left unchanged.

This contribution was developed with AI assistance (Codex).