### PR TITLE
Trend: Add support for non-numerical data (X-Axis)

### DIFF
--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -1,10 +1,9 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import {
   type DataFrame,
   FieldMatcherID,
   fieldMatchers,
-  FieldType,
   type PanelProps,
   type TimeRange,
   useDataLinksContext,
@@ -19,7 +18,7 @@ import { TimeSeries } from 'app/core/components/TimeSeries/TimeSeries';
 import { TimeSeriesTooltip } from '../timeseries/TimeSeriesTooltip';
 
 import { type Options } from './panelcfg.gen';
-import { prepSeries } from './utils';
+import { findXFieldIndex, prepSeries } from './utils';
 
 export const TrendPanel = ({
   data,
@@ -37,17 +36,29 @@ export const TrendPanel = ({
 
   const userCanExecuteActions = useMemo(() => canExecuteActions?.() ?? false, [canExecuteActions]);
 
-  // Need to fallback to first number field if no xField is set in options otherwise panel crashes 😬
-  const trendXFieldName =
-    options.xField ?? data.series[0]?.fields.find((field) => field.type === FieldType.number)?.name;
-  const preparePlotFrameTimeless = (frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) => {
-    dimFields = {
-      ...dimFields,
-      x: fieldMatchers.get(FieldMatcherID.byName).get(trendXFieldName),
-    };
+  // Need to fallback to find an appropriate X field if not set in options otherwise panel crashes 😬
+  const trendXFieldName = useMemo(() => {
+    if (options.xField) {
+      return options.xField;
+    }
+    const fields = data.series[0]?.fields;
+    if (!fields) {
+      return undefined;
+    }
+    const idx = findXFieldIndex(fields);
+    return idx !== -1 ? fields[idx].name : undefined;
+  }, [options.xField, data.series]);
+  const preparePlotFrameTimeless = useCallback(
+    (frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) => {
+      dimFields = {
+        ...dimFields,
+        x: fieldMatchers.get(FieldMatcherID.byName).get(trendXFieldName),
+      };
 
-    return preparePlotFrame(frames, dimFields);
-  };
+      return preparePlotFrame(frames, dimFields);
+    },
+    [trendXFieldName]
+  );
 
   const info = useMemo(() => prepSeries(data.series, options.xField), [data.series, options.xField]);
 

--- a/public/app/plugins/panel/trend/module.tsx
+++ b/public/app/plugins/panel/trend/module.tsx
@@ -18,13 +18,13 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TrendPanel)
     builder.addFieldNamePicker({
       path: 'xField',
       name: t('trend.name-x-field', 'X field'),
-      description: t('trend.description-x-field', 'An increasing numeric value'),
+      description: t('trend.description-x-field', 'A numeric or categorical field for the X axis'),
       category,
       defaultValue: undefined,
       settings: {
         isClearable: true,
-        placeholderText: t('trend.placeholder-x-field', 'First numeric value'),
-        filter: (field: Field) => field.type === FieldType.number,
+        placeholderText: t('trend.placeholder-x-field', 'First numeric or string field'),
+        filter: (field: Field) => field.type === FieldType.number || field.type === FieldType.string,
       },
     });
 
@@ -32,10 +32,11 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TrendPanel)
     commonOptionsBuilder.addLegendOptions(builder, true, true);
   })
   .setSuggestionsSupplier((ds) => {
+    const hasStringX = ds.fieldCountByType(FieldType.string) > 0;
+    const minNumbers = hasStringX ? 1 : 2; // string X needs 1 number for Y; numeric X needs 2
     if (
       !ds.rawFrames ||
-      ds.fieldCountByType(FieldType.number) < 2 ||
-      ds.rowCountTotal < 2 ||
+      ds.fieldCountByType(FieldType.number) < minNumbers ||
       ds.rowCountTotal < 2 ||
       ds.frameCount > 1
     ) {
@@ -47,9 +48,11 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TrendPanel)
       return;
     }
 
+    const isStringX = hasStringX && ds.fieldCountByType(FieldType.time) === 0;
     return [
       {
-        score: VisualizationSuggestionScore.Good,
+        // Categorical data is more naturally a bar chart; rank below Bar Chart's default (OK=50)
+        score: isStringX ? VisualizationSuggestionScore.OK - 10 : VisualizationSuggestionScore.Good,
         fieldConfig: {
           defaults: {
             custom: {},

--- a/public/app/plugins/panel/trend/utils.test.ts
+++ b/public/app/plugins/panel/trend/utils.test.ts
@@ -1,0 +1,351 @@
+import { FieldType, toDataFrame } from '@grafana/data';
+import { ScaleDistribution } from '@grafana/schema';
+
+import { findXFieldIndex, prepSeries } from './utils';
+
+describe('findXFieldIndex', () => {
+  it('returns first number field when 2+ number fields exist', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'x', type: FieldType.number, values: [1, 2, 3] },
+        { name: 'y', type: FieldType.number, values: [4, 5, 6] },
+      ],
+    });
+    expect(findXFieldIndex(frame.fields)).toBe(0);
+  });
+
+  it('prefers string over numbers when no time field (primary categorical use case)', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'category', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'sales', type: FieldType.number, values: [1, 2, 3] },
+        { name: 'revenue', type: FieldType.number, values: [4, 5, 6] },
+      ],
+    });
+    expect(findXFieldIndex(frame.fields)).toBe(0);
+  });
+
+  it('does not prefer string over number when time field is present', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000, 3000] },
+        { name: 'host', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'cpu', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+    // Should pick the number field, not the string — time is the natural X
+    expect(findXFieldIndex(frame.fields)).toBe(2);
+  });
+
+  it('picks string over sole number when no time field exists', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'label', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+    expect(findXFieldIndex(frame.fields)).toBe(0);
+  });
+
+  it('falls back to number field when no string field exists', () => {
+    const frame = toDataFrame({
+      fields: [{ name: 'x', type: FieldType.number, values: [1, 2, 3] }],
+    });
+    expect(findXFieldIndex(frame.fields)).toBe(0);
+  });
+
+  it('returns -1 when no suitable fields exist', () => {
+    const frame = toDataFrame({
+      fields: [{ name: 'time', type: FieldType.time, values: [1000, 2000] }],
+    });
+    expect(findXFieldIndex(frame.fields)).toBe(-1);
+  });
+
+  it('ignores string field even when it precedes the time field, when time is present', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'host', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'time', type: FieldType.time, values: [1000, 2000, 3000] },
+        { name: 'cpu', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+    // String is at index 0, but time is present — should still return the number field
+    expect(findXFieldIndex(frame.fields)).toBe(2);
+  });
+
+  it('picks string over sole number even when string is not first', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        { name: 'label', type: FieldType.string, values: ['a', 'b', 'c'] },
+      ],
+    });
+    expect(findXFieldIndex(frame.fields)).toBe(1);
+  });
+});
+
+describe('prepSeries', () => {
+  it('returns warning for multiple frames', () => {
+    const frames = [
+      toDataFrame({ fields: [{ name: 'a', values: [1] }] }),
+      toDataFrame({ fields: [{ name: 'b', values: [2] }] }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toContain('Only one frame');
+  });
+
+  it('returns warning when xField is not found', () => {
+    const frames = [
+      toDataFrame({
+        fields: [{ name: 'a', type: FieldType.number, values: [1, 2] }],
+      }),
+    ];
+    const result = prepSeries(frames, 'nonexistent');
+    expect(result.warning).toContain('Unable to find field');
+  });
+
+  it('returns warning for non-ascending numeric X', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'x', type: FieldType.number, values: [3, 1, 2] },
+          { name: 'y', type: FieldType.number, values: [4, 5, 6] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toContain('ascending order');
+  });
+
+  it('creates synthetic numeric field for string X', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B', 'C'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+
+    // The X field should be converted to a numeric field with index values
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+    expect(xField).toBeDefined();
+    expect(xField!.type).toBe(FieldType.number);
+    expect(xField!.values).toEqual([0, 1, 2]);
+  });
+
+  it('sets ordinal scale distribution on synthetic field', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B', 'C'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+    expect(xField!.config.custom?.scaleDistribution?.type).toBe(ScaleDistribution.Ordinal);
+  });
+
+  it('sets min/max with padding on synthetic field', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B', 'C'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+    expect(xField!.config.min).toBe(-0.5);
+    expect(xField!.config.max).toBe(2.5);
+  });
+
+  it('display processor maps indices to original string labels', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['Alpha', 'Beta', 'Gamma'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+
+    expect(xField!.display!(0)).toMatchObject({ text: 'Alpha' });
+    expect(xField!.display!(1)).toMatchObject({ text: 'Beta' });
+    expect(xField!.display!(2)).toMatchObject({ text: 'Gamma' });
+  });
+
+  it('display processor rounds fractional indices to nearest label', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B', 'C'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+
+    expect(xField!.display!(0.4)).toMatchObject({ text: 'A' });
+    expect(xField!.display!(1.4)).toMatchObject({ text: 'B' });
+    expect(xField!.display!(1.6)).toMatchObject({ text: 'C' });
+  });
+
+  it('display processor clamps out-of-bounds indices', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B', 'C'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+
+    // Negative (from -0.5 padding)
+    expect(xField!.display!(-0.5)).toMatchObject({ text: 'A' });
+    expect(xField!.display!(-1)).toMatchObject({ text: 'A' });
+    // Beyond end (from max padding)
+    expect(xField!.display!(2.5)).toMatchObject({ text: 'C' });
+    expect(xField!.display!(99)).toMatchObject({ text: 'C' });
+  });
+
+  it('skips ascending check for string X fields', () => {
+    // String values in non-alphabetical order should still work
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['Z', 'A', 'M'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+  });
+
+  it('works with explicit xField pointing to a string field', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames, 'batch');
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+  });
+
+  it('display processor handles NaN and undefined gracefully', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'B'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+
+    expect(xField!.display!(NaN)).toMatchObject({ text: '', numeric: 0 });
+    expect(xField!.display!(null)).toMatchObject({ text: '', numeric: 0 });
+    expect(xField!.display!(undefined)).toMatchObject({ text: '', numeric: 0 });
+  });
+
+  it('works with a single data point', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['Only'] },
+          { name: 'yield', type: FieldType.number, values: [42] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+    expect(xField!.display!(0)).toMatchObject({ text: 'Only' });
+  });
+
+  it('handles null values in string field', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', null, 'C'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+  });
+
+  it('handles duplicate string labels', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'batch', type: FieldType.string, values: ['A', 'A', 'B'] },
+          { name: 'yield', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+    const xField = result.frames![0].fields.find((f) => f.name === 'batch');
+    expect(xField!.display!(0)).toMatchObject({ text: 'A' });
+    expect(xField!.display!(1)).toMatchObject({ text: 'A' });
+    expect(xField!.display!(2)).toMatchObject({ text: 'B' });
+  });
+
+  it('handles numeric-looking strings', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.string, values: ['100', '200', '300'] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    const xField = result.frames![0].fields.find((f) => f.name === 'id');
+    expect(xField!.display!(0)).toMatchObject({ text: '100' });
+    expect(xField!.display!(1)).toMatchObject({ text: '200' });
+  });
+
+  it('returns warning for empty frames', () => {
+    const result = prepSeries([toDataFrame({ fields: [] })]);
+    expect(result.warning).toBeDefined();
+  });
+
+  it('preserves original behavior for ascending numeric X with 2+ number fields', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'x', type: FieldType.number, values: [1, 2, 3] },
+          { name: 'y', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      }),
+    ];
+    const result = prepSeries(frames);
+    expect(result.warning).toBeUndefined();
+    expect(result.frames).not.toBeNull();
+  });
+});

--- a/public/app/plugins/panel/trend/utils.ts
+++ b/public/app/plugins/panel/trend/utils.ts
@@ -1,8 +1,33 @@
-import { type DataFrame, FieldType, isLikelyAscendingVector } from '@grafana/data';
+import { type DataFrame, type Field, FieldType, isLikelyAscendingVector } from '@grafana/data';
+import { ScaleDistribution } from '@grafana/schema';
 import config from 'app/core/config';
 import { findFieldIndex } from 'app/features/dimensions/utils';
 
 import { prepareGraphableFields } from '../timeseries/utils';
+
+/**
+ * Auto-detect which field to use as X axis.
+ * - If a time field exists, use the first number field (standard Trend behavior).
+ * - If no time field: prefer a string field as X (categorical), keeping numbers for Y.
+ * - Fallback: first number field.
+ */
+export function findXFieldIndex(fields: Field[]): number {
+  const hasTimeField = fields.some((f) => f.type === FieldType.time);
+
+  // When time is present, always use first number as X (original Trend behavior)
+  if (hasTimeField) {
+    return fields.findIndex((f) => f.type === FieldType.number);
+  }
+
+  // No time field: prefer string as X so number fields remain for Y
+  const stringIdx = fields.findIndex((f) => f.type === FieldType.string);
+  if (stringIdx !== -1) {
+    return stringIdx;
+  }
+
+  // Fallback: first number field (needs 2+ for X + Y)
+  return fields.findIndex((f) => f.type === FieldType.number);
+}
 
 export function prepSeries(frames: DataFrame[], xField?: string): { warning?: string; frames: DataFrame[] | null } {
   if (frames.length > 1) {
@@ -22,18 +47,17 @@ export function prepSeries(frames: DataFrame[], xField?: string): { warning?: st
       };
     }
   } else {
-    // first number field
-    // Perhaps we can/should support any ordinal rather than an error here
-    xFieldIdx = frames[0] ? frames[0].fields.findIndex((f) => f.type === FieldType.number) : -1;
+    xFieldIdx = frames[0] ? findXFieldIndex(frames[0].fields) : -1;
+
     if (xFieldIdx === -1) {
       return {
-        warning: 'No numeric fields found for X axis',
+        warning: 'No numeric or string fields found for X axis',
         frames,
       };
     }
   }
 
-  // Make sure values are ascending
+  // Make sure values are ascending (only for numeric fields)
   if (xFieldIdx != null) {
     const field = frames[0].fields[xFieldIdx];
     if (field.type === FieldType.number && !isLikelyAscendingVector(field.values)) {
@@ -41,6 +65,42 @@ export function prepSeries(frames: DataFrame[], xField?: string): { warning?: st
         warning: `Values must be in ascending order`,
         frames,
       };
+    }
+
+    // For string X fields, create a synthetic numeric field with index values
+    if (field.type === FieldType.string) {
+      const labels = field.values.slice();
+      const indexValues = labels.map((_, i) => i);
+
+      const syntheticField: Field = {
+        name: field.name,
+        type: FieldType.number,
+        config: {
+          ...field.config,
+          min: -0.5,
+          max: labels.length - 0.5,
+          custom: {
+            ...field.config.custom,
+            scaleDistribution: { type: ScaleDistribution.Ordinal },
+          },
+        },
+        values: indexValues,
+        display: (value: unknown) => {
+          if (value == null || (typeof value === 'number' && isNaN(value))) {
+            return { text: '', numeric: 0 };
+          }
+          const num = typeof value === 'number' ? value : Number(value);
+          const idx = Math.max(0, Math.min(labels.length - 1, Math.round(num)));
+          return {
+            text: labels[idx] ?? String(value),
+            numeric: idx,
+          };
+        },
+      };
+
+      const newFields = [...frames[0].fields];
+      newFields[xFieldIdx] = syntheticField;
+      frames = [{ ...frames[0], fields: newFields }];
     }
   }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -16175,9 +16175,9 @@
   },
   "trend": {
     "category-x-axis": "X axis",
-    "description-x-field": "An increasing numeric value",
+    "description-x-field": "A numeric or categorical field for the X axis",
     "name-x-field": "X field",
-    "placeholder-x-field": "First numeric value"
+    "placeholder-x-field": "First numeric or string field"
   },
   "upgrade-box": {
     "discovery-text": "You’ve discovered a Pro feature!",


### PR DESCRIPTION
**What is this feature?**
This feature adds support for plotting trends where the X-axis is not a number

**Why do we need this feature?**
Because Grafana currently does not support plotting trends where the X-axis is not a number

**Who is this feature for?**
All grafana users

**Which issue(s) does this PR fix?**:
Fixes #115970
