### PR TITLE
fix: disable a11y test link-name rule

### DIFF
--- a/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
+++ b/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
@@ -19,7 +19,9 @@ test.describe(
   () => {
     (
       [
-        { url: '/?orgId=1' },
+        // DISABLED: The RSS panel on the home-page currently shows links that violate the a11y rules.
+        //   We need to get this fixed before re-enabling.
+        // { url: '/?orgId=1' },
         { url: '/d/O6f11TZWk/panel-tests-bar-gauge' },
 
         // Dashboard settings

--- a/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
+++ b/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
@@ -37,7 +37,12 @@ test.describe(
         { url: '/d/O6f11TZWk/panel-tests-bar-gauge?orgId=1&editview=dashboard_json' },
 
         // Misc
-        { url: '/?orgId=1&search=open' },
+        {
+          url: '/?orgId=1&search=open',
+          // DISABLED: The RSS panel on the home-page currently shows links that violate the a11y rules.
+          //   We need to get this fixed before re-enabling.
+          ignoredRules: ['link-name'],
+        },
         { url: '/alerting/list', ignoredRules: ['button-name'] },
         { url: '/datasources' },
         { url: '/org/users' },

--- a/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
+++ b/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
@@ -19,9 +19,12 @@ test.describe(
   () => {
     (
       [
-        // DISABLED: The RSS panel on the home-page currently shows links that violate the a11y rules.
-        //   We need to get this fixed before re-enabling.
-        // { url: '/?orgId=1' },
+        {
+          url: '/?orgId=1',
+          // DISABLED: The RSS panel on the home-page currently shows links that violate the a11y rules.
+          //   We need to get this fixed before re-enabling.
+          ignoredRules: ['link-name'],
+        },
         { url: '/d/O6f11TZWk/panel-tests-bar-gauge' },
 
         // Dashboard settings


### PR DESCRIPTION
This is currently blocking all of Grafana from working. The RSS panel looks like this:

<img width="745" height="302" alt="image" src="https://github.com/user-attachments/assets/3526e0b3-4240-4246-9e4c-cf32a2efe6b4" />

hence why the test fails.