### PR TITLE
Dashboards: Let users scroll the dashboards controls menu if it exceeds their viewport

### DIFF
--- a/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx
@@ -4,7 +4,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type SceneDataLayerProvider, type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink } from '@grafana/schema';
-import { Box, Menu, useStyles2 } from '@grafana/ui';
+import { Menu, ScrollContainer, useStyles2 } from '@grafana/ui';
 
 import { sortDefaultLinksFirst, sortDefaultVarsFirst } from '../../utils/dashboardControls';
 import { DashboardLinkRenderer } from '../DashboardLinkRenderer';
@@ -34,20 +34,22 @@ export function DashboardControlsMenu({
   const styles = useStyles2(getStyles);
 
   return (
-    <Box
+    <ScrollContainer
       minWidth={32}
       borderColor={'weak'}
       borderStyle={'solid'}
       boxShadow={'z3'}
       borderRadius={'default'}
       backgroundColor={'primary'}
+      maxHeight={'calc(100vh - 80px)'}
+      overflowX={'hidden'}
       onClick={(e) => {
         // Normally, clicking the overlay closes the dropdown.
         // We stop event propagation here to keep it open while users interact with variable controls.
         e.stopPropagation();
       }}
     >
-      <div className={styles.scrollable}>
+      <div className={styles.items}>
         {/* Variables */}
         {sortDefaultVarsFirst(variables).map((variable) => (
           <div key={variable.state.key}>
@@ -80,7 +82,7 @@ export function DashboardControlsMenu({
           </>
         )}
       </div>
-    </Box>
+    </ScrollContainer>
   );
 }
 
@@ -95,14 +97,11 @@ function MenuDivider() {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  scrollable: css({
+  items: css({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(0.5),
     padding: theme.spacing(1),
-    maxHeight: 'calc(100vh - 80px)',
-    overflowY: 'auto',
-    scrollbarWidth: 'thin',
   }),
   divider: css({
     marginTop: theme.spacing(1),

--- a/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx
@@ -31,6 +31,7 @@ export function DashboardControlsMenu({
 }: DashboardControlsMenuProps) {
   const isEditingNewLayouts = isEditing && config.featureToggles.dashboardNewLayouts;
   const fullLinks = dashboard.state.links ?? [];
+  const styles = useStyles2(getStyles);
 
   return (
     <Box
@@ -38,49 +39,47 @@ export function DashboardControlsMenu({
       borderColor={'weak'}
       borderStyle={'solid'}
       boxShadow={'z3'}
-      display={'flex'}
-      direction={'column'}
       borderRadius={'default'}
       backgroundColor={'primary'}
-      padding={1}
-      gap={0.5}
       onClick={(e) => {
         // Normally, clicking the overlay closes the dropdown.
         // We stop event propagation here to keep it open while users interact with variable controls.
         e.stopPropagation();
       }}
     >
-      {/* Variables */}
-      {sortDefaultVarsFirst(variables).map((variable, index) => (
-        <div key={variable.state.key}>
-          <VariableValueSelectWrapper variable={variable} inMenu isEditingNewLayouts={isEditingNewLayouts} />
-        </div>
-      ))}
-
-      {/* Annotation layers */}
-      {annotations.length > 0 &&
-        annotations.map((layer, index) => (
-          <div key={layer.state.key}>
-            <DataLayerControl layer={layer} inMenu />
+      <div className={styles.scrollable}>
+        {/* Variables */}
+        {sortDefaultVarsFirst(variables).map((variable) => (
+          <div key={variable.state.key}>
+            <VariableValueSelectWrapper variable={variable} inMenu isEditingNewLayouts={isEditingNewLayouts} />
           </div>
         ))}
 
-      {/* Links */}
-      {links.length > 0 && dashboardUID && (
-        <>
-          {(variables.length > 0 || annotations.length > 0) && <MenuDivider />}
-          {sortDefaultLinksFirst(links).map((link, index) => (
-            <div key={`${link.title}-${index}`}>
-              <DashboardLinkRenderer
-                link={link}
-                dashboardUID={dashboardUID}
-                inMenu
-                linkIndex={fullLinks.indexOf(link)}
-              />
+        {/* Annotation layers */}
+        {annotations.length > 0 &&
+          annotations.map((layer) => (
+            <div key={layer.state.key}>
+              <DataLayerControl layer={layer} inMenu />
             </div>
           ))}
-        </>
-      )}
+
+        {/* Links */}
+        {links.length > 0 && dashboardUID && (
+          <>
+            {(variables.length > 0 || annotations.length > 0) && <MenuDivider />}
+            {sortDefaultLinksFirst(links).map((link, index) => (
+              <div key={`${link.title}-${index}`}>
+                <DashboardLinkRenderer
+                  link={link}
+                  dashboardUID={dashboardUID}
+                  inMenu
+                  linkIndex={fullLinks.indexOf(link)}
+                />
+              </div>
+            ))}
+          </>
+        )}
+      </div>
     </Box>
   );
 }
@@ -96,6 +95,15 @@ function MenuDivider() {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  scrollable: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(1),
+    maxHeight: 'calc(100vh - 80px)',
+    overflowY: 'auto',
+    scrollbarWidth: 'thin',
+  }),
   divider: css({
     marginTop: theme.spacing(1),
     padding: theme.spacing(0, 0.5),


### PR DESCRIPTION
Wraps the controls menu content in a div that's scrollable.

<img width="501" height="682" alt="image" src="https://github.com/user-attachments/assets/27f63dbc-12cc-44bf-acde-754369aedf12" />
