### PR TITLE
Security: Upgrade handlebars to fix CVE-2026-33937

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20457,8 +20457,8 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:^4.7.7, handlebars@npm:^4.7.8":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -20470,7 +20470,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10/bd528f4dd150adf67f3f857118ef0fa43ff79a153b1d943fa0a770f2599e38b25a7a0dbac1a3611a4ec86970fd2325a81310fb788b5c892308c9f8743bd02e11
+  checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrades handlebars from 4.7.8 to 4.7.9 to remediate CVE-2026-33937 (JavaScript Injection via AST Type Confusion, CVSS 9.8 CRITICAL)
- handlebars is a transitive devDependency via `lerna` and `plop`
- Only `yarn.lock` changes — 4.7.9 is within existing semver ranges (`^4.7.7` / `^4.7.8`)

## Test plan
- [ ] Verify `yarn why handlebars` shows only 4.7.9
- [ ] Verify `yarn install --immutable` passes with updated lockfile
- [ ] CI passes (no runtime impact — devDependency only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)