### PR TITLE
Security: Upgrade minimatch to fix CVE-2026-27903 and CVE-2026-27904

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13924,6 +13924,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  languageName: node
+  linkType: hard
+
 "brace@npm:0.11.1":
   version: 0.11.1
   resolution: "brace@npm:0.11.1"
@@ -24870,11 +24879,11 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.2.2":
-  version: 10.2.2
-  resolution: "minimatch@npm:10.2.2"
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10/e135be7b502ac97c02bcee42ccc1c55dc26dbac036c0f4acde69e42fe339d7fb53fae711e57b3546cb533426382ea492c73a073c7f78832e0453d120d48dd015
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10/19e87a931aff60ee7b9d80f39f817b8bfc54f61f8356ee3549fbf636dbccacacfec8d803eac73293955c4527cd085247dfc064bce4a5e349f8f3b85e2bf5da0f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrades minimatch from 10.2.2 to 10.2.5 to remediate two ReDoS vulnerabilities (CVSS 7.5 HIGH each):
  - **CVE-2026-27903**: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments
  - **CVE-2026-27904**: nested *() extglobs generate catastrophically backtracking regular expressions
- minimatch is a transitive dependency used by glob, @npmcli/*, and @tufjs/models
- Only `yarn.lock` changes — fix versions are within existing semver ranges (`^10.0.3`, `^10.1.1`, `^10.2.2`)

## Test plan
- [ ] Verify `grep 'minimatch@npm:10.2.2' yarn.lock` returns empty (vulnerable version removed)
- [ ] Verify `yarn install --immutable` passes with updated lockfile
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)