### PR TITLE
unified-storage: fix bulk rv generation in kv store 

### DIFF
--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -569,16 +569,17 @@ func stopAndDrainTimer(timer *time.Timer) {
 }
 
 type bulkRV struct {
-	max     int64
-	counter int64
+	max    int64
+	lastRV int64
 }
 
-// Used when executing a bulk import so that we can generate snowflake RVs in the past
+// Used when executing a bulk import so that we can generate snowflake RVs in the past.
+// The 30s offset ensures bulk-imported RVs don't clash with concurrent writes
+// that use the RV manager (both generate node=0 snowflakes in compatibility mode).
 func newBulkRV() *bulkRV {
-	t := snowflakeFromTime(time.Now())
+	t := snowflakeFromTime(time.Now().Add(-30 * time.Second))
 	return &bulkRV{
-		max:     t,
-		counter: 0,
+		max: t,
 	}
 }
 
@@ -596,15 +597,27 @@ func (x *bulkRV) next(obj metav1.Object) int64 {
 		ts = x.max
 	}
 
-	x.counter++
-	// Keep the sub-millisecond fraction under 1000 so that the snowflake-to-microRV
-	// roundtrip (RVFromSnowflake / SnowflakeFromRV) is lossless. When the counter
-	// exceeds 999, the overflow advances the millisecond portion of the snowflake.
+	// Use the object's timestamp as the base, but never go below the last
+	// emitted RV so that every value is unique regardless of iterator order.
+	base := ts
+	if base < x.lastRV {
+		base = x.lastRV
+	}
+
+	// Increment, keeping the sub-millisecond portion (low 22 bits) under 1000
+	// so that the snowflake ↔ microRV roundtrip (SnowflakeFromRV / RVFromSnowflake)
+	// is lossless.
 	// TODO: remove when backwards compatibility is no longer needed
 	shift := snowflake.NodeBits + snowflake.StepBits
-	msOffset := x.counter / 1000
-	subMs := x.counter % 1000
-	return ts + (msOffset << shift) + subMs
+	subMs := base & ((1 << shift) - 1)
+	if subMs >= 999 {
+		base = ((base >> shift) + 1) << shift
+	} else {
+		base++
+	}
+
+	x.lastRV = base
+	return base
 }
 
 type BulkLock struct {

--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bwmarrin/snowflake"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
@@ -596,7 +597,14 @@ func (x *bulkRV) next(obj metav1.Object) int64 {
 	}
 
 	x.counter++
-	return ts + x.counter
+	// Keep the sub-millisecond fraction under 1000 so that the snowflake-to-microRV
+	// roundtrip (RVFromSnowflake / SnowflakeFromRV) is lossless. When the counter
+	// exceeds 999, the overflow advances the millisecond portion of the snowflake.
+	// TODO: remove when backwards compatibility is no longer needed
+	shift := snowflake.NodeBits + snowflake.StepBits
+	msOffset := x.counter / 1000
+	subMs := x.counter % 1000
+	return ts + (msOffset << shift) + subMs
 }
 
 type BulkLock struct {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1991,7 +1991,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 
 		// Fill in legacy columns on the resource_history row that was just inserted with only key_path and value.
 		if rvManagerDB != nil {
-			microRV := rvmanager.RVFromBulkSnowflake(dataKey.ResourceVersion)
+			microRV := rvmanager.RVFromSnowflake(dataKey.ResourceVersion)
 			generation := obj.GetGeneration()
 			if action == DataActionDeleted {
 				generation = 0

--- a/pkg/storage/unified/sql/rvmanager/rv_manager.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager.go
@@ -371,18 +371,6 @@ func RVFromSnowflake(snowflakeID int64) int64 {
 	return ((snowflakeID>>(snowflake.NodeBits+snowflake.StepBits))+snowflake.Epoch)*1000 + microSecFraction
 }
 
-// RVFromBulkSnowflake is like RVFromSnowflake but preserves the full low-order
-// (NodeBits + StepBits) bits as the sub-millisecond fraction. Bulk-import
-// snowflake IDs are produced by snowflakeFromTime (which zeroes the low 22
-// bits) plus a monotonic counter, so the counter can spill past StepBits into
-// NodeBits. Using only StepBits (12) would wrap at 4096 entries per
-// millisecond; using all 22 low bits pushes that limit to ~4 million.
-func RVFromBulkSnowflake(snowflakeID int64) int64 {
-	totalLowBits := snowflake.NodeBits + snowflake.StepBits
-	subMilliFraction := snowflakeID & ((1 << totalLowBits) - 1)
-	return ((snowflakeID>>totalLowBits)+snowflake.Epoch)*1000 + subMilliFraction
-}
-
 // helper utility to compare two RVs. The first RV must be in snowflake format. Will convert rv2 to snowflake and retry
 // if comparison fails
 func IsRvEqual(rv1, rv2 int64) bool {

--- a/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
@@ -2,8 +2,10 @@ package rvmanager
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bwmarrin/snowflake"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -72,4 +74,37 @@ func TestSnowflakeFromRVRoundtrips(t *testing.T) {
 		ts := offset + n
 		require.Equal(t, ts, RVFromSnowflake(SnowflakeFromRV(ts)))
 	}
+}
+
+func TestBulkSnowflakeRoundtrip(t *testing.T) {
+	// Replicate the snowflakeFromTime formula from resource/eventstore.go:
+	// snowflake id with node and step bits zeroed out.
+	shift := snowflake.NodeBits + snowflake.StepBits
+	base := (time.Now().UnixMilli() - snowflake.Epoch) << shift
+
+	t.Run("old formula fails for counter >= 1000", func(t *testing.T) {
+		for counter := int64(1000); counter <= 1005; counter++ {
+			snowflakeID := base + counter // old: directly add counter
+			microRV := RVFromSnowflake(snowflakeID)
+			roundtripped := SnowflakeFromRV(microRV)
+			require.NotEqual(t, snowflakeID, roundtripped,
+				"expected roundtrip to fail at counter=%d with old formula", counter)
+		}
+	})
+
+	t.Run("new formula roundtrips for all counters", func(t *testing.T) {
+		for counter := int64(1); counter <= 2000; counter++ {
+			// New formula: overflow into ms portion when counter >= 1000
+			msOffset := counter / 1000
+			subMs := counter % 1000
+			snowflakeID := base + (msOffset << shift) + subMs
+
+			microRV := RVFromSnowflake(snowflakeID)
+			roundtripped := SnowflakeFromRV(microRV)
+
+			require.Equal(t, snowflakeID, roundtripped,
+				"roundtrip failed at counter=%d: snowflake=%d -> microRV=%d -> roundtripped=%d",
+				counter, snowflakeID, microRV, roundtripped)
+		}
+	})
 }

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -82,6 +82,7 @@ func RunSQLStorageBackendCompatibilityTest(t *testing.T, newSqlBackend NewBacken
 		{"concurrent operations stress", runTestConcurrentOperationsStress},
 		{"optimistic locking database integrity", runTestOptimisticLockingDatabaseIntegrity},
 		{"bulk import compatibility", runTestBulkImportCompatibility},
+		{"bulk import large counter CRUD", runTestBulkImportLargeCounterCRUD},
 		{"last import time cross backend", runTestLastImportTimeCrossBackend},
 		{"cluster scoped resources compatibility", runTestClusterScopedResources},
 	}
@@ -957,6 +958,165 @@ func runTestBulkImportCompatibility(t *testing.T, sqlBackend, kvBackend resource
 		require.GreaterOrEqual(t, len(records), 1, "Expected at least 1 resource_version record")
 		require.Greater(t, records[0].ResourceVersion, int64(0), "resource_version should be positive")
 	})
+}
+
+// runTestBulkImportLargeCounterCRUD bulk-imports >1000 items via one backend
+// (pushing the bulkRV counter past 999) and then performs CRUD+List through
+// ResourceServers wrapping BOTH backends to verify cross-backend consistency.
+func runTestBulkImportLargeCounterCRUD(t *testing.T, sqlBackend, kvBackend resource.StorageBackend, nsPrefix string, _ sqldb.DB) {
+	t.Run("import via kv", func(t *testing.T) {
+		bulkImportLargeCounterCRUD(t, kvBackend, sqlBackend, kvBackend, nsPrefix+"-lc-kv")
+	})
+	t.Run("import via sql", func(t *testing.T) {
+		bulkImportLargeCounterCRUD(t, sqlBackend, sqlBackend, kvBackend, nsPrefix+"-lc-sql")
+	})
+}
+
+// bulkImportLargeCounterCRUD bulk-imports 1010 items through importBackend,
+// then verifies that both SQL and KV servers can List and Read the data, mutates
+// through the import server, and confirms both servers see the final state.
+func bulkImportLargeCounterCRUD(t *testing.T, importBackend, sqlBackend, kvBackend resource.StorageBackend, ns string) {
+	ctx := newIntegrationTestContext(t)
+
+	group := "playlist.grafana.app"
+	resourceType := "playlists"
+	listKey := &resourcepb.ResourceKey{Namespace: ns, Group: group, Resource: resourceType}
+
+	const totalItems = 1010
+
+	// Build 1010 ADDED requests so the bulkRV counter exceeds 999.
+	bulkRequests := make([]*resourcepb.BulkRequest, 0, totalItems)
+	for i := 1; i <= totalItems; i++ {
+		name := fmt.Sprintf("pl-%04d", i)
+		bulkRequests = append(bulkRequests, &resourcepb.BulkRequest{
+			Key:    &resourcepb.ResourceKey{Namespace: ns, Group: group, Resource: resourceType, Name: name},
+			Action: resourcepb.BulkRequest_ADDED,
+			Value: createPlaylistJSON(PlaylistResourceOptions{
+				Name: name, Namespace: ns, UID: fmt.Sprintf("uid-%04d", i),
+				Generation: 1, Title: fmt.Sprintf("Playlist %d", i),
+			}),
+		})
+	}
+
+	bulk, ok := importBackend.(resource.BulkProcessingBackend)
+	require.True(t, ok)
+	resp := bulk.ProcessBulk(ctx, resource.BulkSettings{
+		Collection: []*resourcepb.ResourceKey{listKey},
+	}, toBulkIterator(bulkRequests))
+	require.Nil(t, resp.Error)
+	require.Empty(t, resp.Rejected)
+
+	sqlServer := createStorageServer(t, sqlBackend)
+	kvServer := createStorageServer(t, kvBackend)
+	importServer := createStorageServer(t, importBackend)
+
+	// Pick 20 items around the spill boundary (counters 990-1009) for targeted CRUD.
+	const spillStart = 990
+	const spillCount = 20
+	spillNames := make([]string, spillCount)
+	for i := range spillNames {
+		spillNames[i] = fmt.Sprintf("pl-%04d", spillStart+i)
+	}
+
+	// Split into update and delete sets, alternating so each straddles the boundary.
+	// Even indices → update, odd indices → delete.
+	var updateNames, deleteNames []string
+	for i, name := range spillNames {
+		if i%2 == 0 {
+			updateNames = append(updateNames, name)
+		} else {
+			deleteNames = append(deleteNames, name)
+		}
+	}
+
+	// --- Phase 1: both backends can List and Read the imported data ---
+	for label, server := range map[string]resource.ResourceServer{"sql": sqlServer, "kv": kvServer} {
+		t.Run(label+" list after import", func(t *testing.T) {
+			list, err := server.List(ctx, &resourcepb.ListRequest{
+				Limit: totalItems + 1,
+				Options: &resourcepb.ListOptions{Key: listKey},
+			})
+			require.NoError(t, err)
+			require.Nil(t, list.Error)
+			require.Equal(t, totalItems, len(list.Items))
+		})
+
+		t.Run(label+" read spill-boundary items", func(t *testing.T) {
+			for _, name := range spillNames {
+				key := createPlaylistKey(ns, name)
+				readResp, err := server.Read(ctx, &resourcepb.ReadRequest{Key: key})
+				require.NoError(t, err, "read failed for %s", name)
+				require.Nil(t, readResp.Error, "read error for %s: %v", name, readResp.Error)
+				require.Greater(t, readResp.ResourceVersion, int64(0))
+				require.Equal(t, name, extractResourceNameFromJSON(t, readResp.Value))
+			}
+		})
+	}
+
+	// --- Phase 2: mutate through the import server ---
+	// Read current RVs from the import server
+	rvByName := make(map[string]int64)
+	for _, name := range spillNames {
+		key := createPlaylistKey(ns, name)
+		readResp, err := importServer.Read(ctx, &resourcepb.ReadRequest{Key: key})
+		require.NoError(t, err)
+		require.Nil(t, readResp.Error)
+		rvByName[name] = readResp.ResourceVersion
+	}
+
+	t.Run("update spill-boundary items", func(t *testing.T) {
+		for _, name := range updateNames {
+			updated := updatePlaylistResource(t, importServer, ctx, PlaylistResourceOptions{
+				Name: name, Namespace: ns, UID: "uid-" + name[3:],
+				Generation: 2, Title: name + " Updated",
+			}, rvByName[name])
+			rvByName[name] = updated.ResourceVersion
+		}
+	})
+
+	t.Run("delete spill-boundary items", func(t *testing.T) {
+		for _, name := range deleteNames {
+			deletePlaylistResource(t, importServer, ctx, ns, name, rvByName[name])
+		}
+	})
+
+	numDeleted := len(deleteNames)
+
+	// --- Phase 3: both backends see the mutations ---
+	for label, server := range map[string]resource.ResourceServer{"sql": sqlServer, "kv": kvServer} {
+		t.Run(label+" list after mutations", func(t *testing.T) {
+			list, err := server.List(ctx, &resourcepb.ListRequest{
+				Limit: totalItems + 1,
+				Options: &resourcepb.ListOptions{Key: listKey},
+			})
+			require.NoError(t, err)
+			require.Nil(t, list.Error)
+			require.Equal(t, totalItems-numDeleted, len(list.Items),
+				"%d items were deleted, rest should remain", numDeleted)
+		})
+
+		t.Run(label+" verify updated content", func(t *testing.T) {
+			for _, name := range updateNames {
+				key := createPlaylistKey(ns, name)
+				readResp, err := server.Read(ctx, &resourcepb.ReadRequest{Key: key})
+				require.NoError(t, err, "read-after-update failed for %s", name)
+				require.Nil(t, readResp.Error)
+				require.Contains(t, string(readResp.Value), name+" Updated",
+					"updated title should be present for %s", name)
+			}
+		})
+
+		t.Run(label+" verify deleted items gone", func(t *testing.T) {
+			for _, name := range deleteNames {
+				key := createPlaylistKey(ns, name)
+				readResp, err := server.Read(ctx, &resourcepb.ReadRequest{Key: key})
+				require.NoError(t, err)
+				require.NotNil(t, readResp.Error, "deleted item %s should return an error", name)
+				require.Equal(t, int32(http.StatusNotFound), readResp.Error.Code,
+					"deleted item %s should be 404", name)
+			}
+		})
+	}
 }
 
 // runTestLastImportTimeCrossBackend verifies that last import times written by one backend

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -1033,7 +1033,7 @@ func bulkImportLargeCounterCRUD(t *testing.T, importBackend, sqlBackend, kvBacke
 	for label, server := range map[string]resource.ResourceServer{"sql": sqlServer, "kv": kvServer} {
 		t.Run(label+" list after import", func(t *testing.T) {
 			list, err := server.List(ctx, &resourcepb.ListRequest{
-				Limit: totalItems + 1,
+				Limit:   totalItems + 1,
 				Options: &resourcepb.ListOptions{Key: listKey},
 			})
 			require.NoError(t, err)
@@ -1086,7 +1086,7 @@ func bulkImportLargeCounterCRUD(t *testing.T, importBackend, sqlBackend, kvBacke
 	for label, server := range map[string]resource.ResourceServer{"sql": sqlServer, "kv": kvServer} {
 		t.Run(label+" list after mutations", func(t *testing.T) {
 			list, err := server.List(ctx, &resourcepb.ListRequest{
-				Limit: totalItems + 1,
+				Limit:   totalItems + 1,
 				Options: &resourcepb.ListOptions{Key: listKey},
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
It breaks backwards compatibility with the sql backend. 

To maintain this compatibility, we can't store snowflakes with the node bits set. We can only populate the timestamp and the counter bits. With the current approach, we store all the bulk imported items with the same millisecond timestamp and just increment the counter. With the node bits we can import up to 2^22 (~4 mil) items before an RV collision, which is more than enough for bulk import. 

But to be able to convert back and forth in backwards compatibility mode, we get a microsecond a rv, store the millisecond part in the timestamp, and store the microsecond remainder in the counter bits (1000, which fit comfortably in the 2^10 counter bits (4096)). This PR changes the logic to increment the millisecond when spilling over instead.