### PR TITLE
MySQL: Preserve `#` inside quoted strings in SQL comment stripping

### DIFF
--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -14,21 +14,88 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
-var (
-	restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)
-	reBlockComment   = regexp.MustCompile(`(?s)/\*.*?\*/`)
-	reLineComment    = regexp.MustCompile(`--[^\n]*`)
-	reHashComment    = regexp.MustCompile(`#[^\n]*`)
-)
+var restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)
 
 // stripSQLComments removes SQL line comments (--, #) and block comments (/* */)
-// from the query string. MySQL supports # as a line comment delimiter in
-// addition to the standard -- and /* */ forms.
+// from the query string while preserving comment-like characters that appear
+// inside quoted strings (single-quoted, double-quoted, and backtick-quoted).
+// MySQL supports # as a line comment delimiter in addition to the standard
+// -- and /* */ forms.
 func stripSQLComments(sql string) string {
-	sql = reBlockComment.ReplaceAllString(sql, "")
-	sql = reLineComment.ReplaceAllString(sql, "")
-	sql = reHashComment.ReplaceAllString(sql, "")
-	return sql
+	var result strings.Builder
+	result.Grow(len(sql))
+
+	i := 0
+	for i < len(sql) {
+		// Handle quoted strings: pass through verbatim.
+		if sql[i] == '\'' || sql[i] == '"' || sql[i] == '`' {
+			quote := sql[i]
+			result.WriteByte(quote)
+			i++
+			for i < len(sql) {
+				if sql[i] == '\\' && i+1 < len(sql) {
+					// Escaped character – copy both bytes.
+					result.WriteByte(sql[i])
+					result.WriteByte(sql[i+1])
+					i += 2
+					continue
+				}
+				if sql[i] == quote {
+					if i+1 < len(sql) && sql[i+1] == quote {
+						// Doubled quote escape (e.g. '' or "").
+						result.WriteByte(sql[i])
+						result.WriteByte(sql[i+1])
+						i += 2
+						continue
+					}
+					// Closing quote.
+					result.WriteByte(sql[i])
+					i++
+					break
+				}
+				result.WriteByte(sql[i])
+				i++
+			}
+			continue
+		}
+
+		// Block comment: /* ... */
+		if i+1 < len(sql) && sql[i] == '/' && sql[i+1] == '*' {
+			i += 2
+			for i+1 < len(sql) {
+				if sql[i] == '*' && sql[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+			if i >= len(sql) {
+				break
+			}
+			continue
+		}
+
+		// Line comment: --
+		if i+1 < len(sql) && sql[i] == '-' && sql[i+1] == '-' {
+			for i < len(sql) && sql[i] != '\n' {
+				i++
+			}
+			continue
+		}
+
+		// Hash comment: #
+		if sql[i] == '#' {
+			for i < len(sql) && sql[i] != '\n' {
+				i++
+			}
+			continue
+		}
+
+		result.WriteByte(sql[i])
+		i++
+	}
+
+	return result.String()
 }
 
 type mySQLMacroEngine struct {

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -221,3 +221,81 @@ func TestMacroEngineConcurrency(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestStripSQLComments(t *testing.T) {
+	t.Run("strips block comments", func(t *testing.T) {
+		result := stripSQLComments("SELECT /* comment */ 1")
+		require.Equal(t, "SELECT  1", result)
+	})
+
+	t.Run("strips line comments with --", func(t *testing.T) {
+		result := stripSQLComments("SELECT 1 -- line comment\nFROM t")
+		require.Equal(t, "SELECT 1 \nFROM t", result)
+	})
+
+	t.Run("strips hash comments", func(t *testing.T) {
+		result := stripSQLComments("SELECT 1 # hash comment\nFROM t")
+		require.Equal(t, "SELECT 1 \nFROM t", result)
+	})
+
+	t.Run("preserves hash inside single-quoted string", func(t *testing.T) {
+		sql := `SELECT JSON_UNQUOTE(JSON_EXTRACT(t.properties, '$."Claim #"')) AS claim`
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("preserves hash inside double-quoted string", func(t *testing.T) {
+		sql := `SELECT "col#name" FROM t`
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("preserves hash inside backtick-quoted identifier", func(t *testing.T) {
+		sql := "SELECT `Claim #` FROM t"
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("preserves -- inside single-quoted string", func(t *testing.T) {
+		sql := `SELECT '--not-a-comment' FROM t`
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("preserves /* inside single-quoted string", func(t *testing.T) {
+		sql := `SELECT '/* not a comment */' FROM t`
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("handles escaped quotes inside strings", func(t *testing.T) {
+		sql := `SELECT 'it\'s a #test' FROM t`
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("handles doubled quotes inside strings", func(t *testing.T) {
+		sql := `SELECT 'it''s a #test' FROM t`
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("real-world JSON path with hash regression", func(t *testing.T) {
+		sql := "SELECT\n  JSON_UNQUOTE(JSON_EXTRACT(t.properties, '$.\"Claim #\"')) AS `Claim Number`\nFROM repairshopr.tickets t\nWHERE t.status = 'Resolved'"
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+
+	t.Run("hash comment after a quoted string with hash", func(t *testing.T) {
+		sql := "SELECT 'Claim #' # this is a comment\nFROM t"
+		expected := "SELECT 'Claim #' \nFROM t"
+		result := stripSQLComments(sql)
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("no comments returns unchanged", func(t *testing.T) {
+		sql := "SELECT 1 FROM t WHERE id = 42"
+		result := stripSQLComments(sql)
+		require.Equal(t, sql, result)
+	})
+}


### PR DESCRIPTION
## What is this PR doing

Fixes #121485

After upgrading from Grafana `12.3.3` to `12.4.2`, MySQL queries containing a literal `#` inside quoted strings (e.g. JSON path `'$."Claim #"'`) are truncated by the new `stripSQLComments` function, producing downstream SQL syntax errors.

## Root cause

The regex-based comment stripping (`reHashComment = regexp.MustCompile("#[^\n]*")`) treats **every** `#` as the start of a line comment, even when it appears inside single-quoted, double-quoted, or backtick-quoted SQL strings.

For example, this query:

```sql
SELECT JSON_UNQUOTE(JSON_EXTRACT(t.properties, '$."Claim #"')) AS `Claim Number`
```

becomes truncated after `#`:

```sql
SELECT JSON_UNQUOTE(JSON_EXTRACT(t.properties, '$."Claim
```

## Fix

Replace the three independent regex replacements with a single-pass character-by-character state machine that:

1. **Tracks quoted contexts** — single quotes (`'`), double quotes (`"`), and backticks (`` ` ``).
2. **Handles escape sequences** — both backslash escapes (`\'`) and SQL doubled-quote escapes (`''`).
3. **Only strips comments when outside string literals**.

All three SQL comment styles are handled: `/* ... */`, `-- ...`, and `# ...`.

## Tests added

- `TestStripSQLComments` — 12 test cases covering:
  - Basic `/* */`, `--`, and `#` comment stripping
  - `#` preserved inside single-quoted, double-quoted, and backtick-quoted strings
  - `--` and `/* */` preserved inside quoted strings
  - Backslash-escaped and doubled-quote escapes
  - Real-world JSON path regression (exact query from the issue)
  - Mixed case: `#` inside a string followed by a real `#` comment
