### PR TITLE
Zanzana: Shadow zanzana requests to RBAC

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -85,7 +85,7 @@ func ProvideAuthZClient(
 	case clientModeCloud:
 		rbacClient, err := newRemoteRBACClient(authCfg, tracer, reg)
 		if zanzanaEnabled {
-			return zClient.WithShadowClient(rbacClient, zanzanaClient, reg)
+			return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
 		}
 		return rbacClient, err
 	default:
@@ -147,7 +147,7 @@ func ProvideAuthZClient(
 		)
 
 		if zanzanaEnabled {
-			return zClient.WithShadowClient(rbacClient, zanzanaClient, reg)
+			return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
 		}
 
 		return rbacClient, nil
@@ -188,10 +188,19 @@ func ProvideStandaloneAuthZClient(
 	}
 
 	if zanzanaEnabled {
-		return zClient.WithShadowClient(remoteRBACClient, zanzanaClient, reg)
+		return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, remoteRBACClient, zanzanaClient, reg)
 	}
 
 	return remoteRBACClient, nil
+}
+
+// newShadowClient returns either a ShadowClient (RBAC primary) or a
+// ShadowRBACClient (Zanzana primary) depending on the configured primary engine.
+func newShadowClient(engine setting.ZanzanaPrimaryEngine, rbacClient authlib.AccessClient, zanzanaClient authlib.AccessClient, reg prometheus.Registerer) (authlib.AccessClient, error) {
+	if engine == setting.ZanzanaPrimaryEngineZanzana {
+		return zClient.WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+	}
+	return zClient.WithShadowClient(rbacClient, zanzanaClient, reg)
 }
 
 func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, reg prometheus.Registerer) (authlib.AccessClient, error) {

--- a/pkg/services/authz/zanzana/client/shadow_rbac_client.go
+++ b/pkg/services/authz/zanzana/client/shadow_rbac_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
+
 var _ authlib.AccessClient = (*ShadowRBACClient)(nil)
 
 type ShadowRBACClient struct {
@@ -57,10 +58,10 @@ func (c *ShadowRBACClient) Check(ctx context.Context, id authlib.AuthInfo, req a
 
 		if zanzanaErr == nil {
 			if res.Allowed != zanzanaRes.Allowed {
-				c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
+				c.metrics.evaluationStatusTotal.WithLabelValues("error", "check", formatCheck(req), req.Namespace).Inc()
 				c.logger.Warn("RBAC check result does not match zanzana", "expected", zanzanaRes.Allowed, "actual", res.Allowed, "user", id.GetUID(), "request", req)
 			} else {
-				c.metrics.evaluationStatusTotal.WithLabelValues("success").Inc()
+				c.metrics.evaluationStatusTotal.WithLabelValues("success", "check", formatCheck(req), req.Namespace).Inc()
 			}
 		}
 	}()
@@ -119,10 +120,10 @@ func (c *ShadowRBACClient) Compile(ctx context.Context, id authlib.AuthInfo, req
 			if rbacItemChecker != nil {
 				rbacRes := rbacItemChecker(name, folder)
 				if rbacRes != zanzanaRes {
-					c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
+					c.metrics.evaluationStatusTotal.WithLabelValues("error", "compile", "other", req.Namespace).Inc()
 					c.logger.Warn("RBAC compile result does not match zanzana", "expected", zanzanaRes, "actual", rbacRes, "name", name, "folder", folder)
 				} else {
-					c.metrics.evaluationStatusTotal.WithLabelValues("success").Inc()
+					c.metrics.evaluationStatusTotal.WithLabelValues("success", "compile", "other", req.Namespace).Inc()
 				}
 			}
 		}()
@@ -173,19 +174,26 @@ func (c *ShadowRBACClient) BatchCheck(ctx context.Context, id authlib.AuthInfo, 
 // compareRBACBatchCheckResults compares the results from zanzana and RBAC batch checks
 // and logs any discrepancies.
 func (c *ShadowRBACClient) compareRBACBatchCheckResults(zanzanaRes, rbacRes authlib.BatchCheckResponse, id authlib.AuthInfo, req authlib.BatchCheckRequest) {
-	for key, zanzanaResult := range zanzanaRes.Results {
-		rbacResult, ok := rbacRes.Results[key]
+	checkItems := make(map[string]authlib.BatchCheckItem, len(req.Checks))
+	for _, checkItem := range req.Checks {
+		checkItems[checkItem.CorrelationID] = checkItem
+	}
+
+	for correlationID, zanzanaResult := range zanzanaRes.Results {
+		rbacResult, ok := rbacRes.Results[correlationID]
+		checkItem := checkItems[correlationID]
+
 		if !ok {
-			c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
-			c.logger.Warn("RBAC batch check missing result", "key", key, "user", id.GetUID())
+			c.metrics.evaluationStatusTotal.WithLabelValues("error", "batch_check", formatBatchCheck(checkItem), req.Namespace).Inc()
+			c.logger.Warn("RBAC batch check missing result", "item", checkItem, "user", id.GetUID())
 			continue
 		}
 
 		if zanzanaResult.Allowed != rbacResult.Allowed {
-			c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
-			c.logger.Warn("RBAC batch check result does not match zanzana", "key", key, "expected", zanzanaResult.Allowed, "actual", rbacResult.Allowed, "user", id.GetUID())
+			c.metrics.evaluationStatusTotal.WithLabelValues("error", "batch_check", formatBatchCheck(checkItem), req.Namespace).Inc()
+			c.logger.Warn("RBAC batch check result does not match zanzana", "expected", zanzanaResult.Allowed, "actual", rbacResult.Allowed, "item", checkItem, "user", id.GetUID())
 		} else {
-			c.metrics.evaluationStatusTotal.WithLabelValues("success").Inc()
+			c.metrics.evaluationStatusTotal.WithLabelValues("success", "batch_check", formatBatchCheck(checkItem), req.Namespace).Inc()
 		}
 	}
 }

--- a/pkg/services/authz/zanzana/client/shadow_rbac_client.go
+++ b/pkg/services/authz/zanzana/client/shadow_rbac_client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
-
 var _ authlib.AccessClient = (*ShadowRBACClient)(nil)
 
 type ShadowRBACClient struct {

--- a/pkg/services/authz/zanzana/client/shadow_rbac_client.go
+++ b/pkg/services/authz/zanzana/client/shadow_rbac_client.go
@@ -1,0 +1,191 @@
+package client
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	authlib "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+var _ authlib.AccessClient = (*ShadowRBACClient)(nil)
+
+type ShadowRBACClient struct {
+	logger        log.Logger
+	accessClient  authlib.AccessClient
+	zanzanaClient authlib.AccessClient
+	metrics       *shadowClientMetrics
+}
+
+// WithShadowRBACClient returns a new access client that runs legacy RBAC checks in the background.
+// Zanzana is the primary client whose results are returned; RBAC is used only for comparison.
+func WithShadowRBACClient(zanzanaClient authlib.AccessClient, accessClient authlib.AccessClient, reg prometheus.Registerer) (authlib.AccessClient, error) {
+	client := &ShadowRBACClient{
+		logger:        log.New("zanzana-shadow-rbac-client"),
+		accessClient:  accessClient,
+		zanzanaClient: zanzanaClient,
+		metrics:       newShadowClientMetrics(reg),
+	}
+	return client, nil
+}
+
+func (c *ShadowRBACClient) Check(ctx context.Context, id authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+	zanzanaResChan := make(chan authlib.CheckResponse, 1)
+	zanzanaErrChan := make(chan error, 1)
+
+	go func() {
+		if c.accessClient == nil {
+			return
+		}
+
+		rbacCtx := context.WithoutCancel(ctx)
+		rbacCtxTimeout, cancel := context.WithTimeout(rbacCtx, zanzanaTimeout)
+		defer cancel()
+
+		timer := prometheus.NewTimer(c.metrics.evaluationsSeconds.WithLabelValues("rbac"))
+		res, err := c.accessClient.Check(rbacCtxTimeout, id, req, folder)
+		if err != nil {
+			c.logger.Error("Failed to run rbac check", "error", err)
+		}
+		timer.ObserveDuration()
+
+		zanzanaRes := <-zanzanaResChan
+		zanzanaErr := <-zanzanaErrChan
+
+		if zanzanaErr == nil {
+			if res.Allowed != zanzanaRes.Allowed {
+				c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
+				c.logger.Warn("RBAC check result does not match zanzana", "expected", zanzanaRes.Allowed, "actual", res.Allowed, "user", id.GetUID(), "request", req)
+			} else {
+				c.metrics.evaluationStatusTotal.WithLabelValues("success").Inc()
+			}
+		}
+	}()
+
+	timer := prometheus.NewTimer(c.metrics.evaluationsSeconds.WithLabelValues("zanzana"))
+	res, err := c.zanzanaClient.Check(ctx, id, req, folder)
+	timer.ObserveDuration()
+	zanzanaResChan <- res
+	zanzanaErrChan <- err
+
+	return res, err
+}
+
+func (c *ShadowRBACClient) Compile(ctx context.Context, id authlib.AuthInfo, req authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	rbacItemCheckerChan := make(chan authlib.ItemChecker, 1)
+	var rbacItemChecker authlib.ItemChecker
+	var once sync.Once
+
+	go func() {
+		if c.accessClient == nil {
+			rbacItemCheckerChan <- nil
+			return
+		}
+
+		rbacCtx := context.WithoutCancel(ctx)
+		rbacCtxTimeout, cancel := context.WithTimeout(rbacCtx, zanzanaTimeout)
+		defer cancel()
+
+		timer := prometheus.NewTimer(c.metrics.compileSeconds.WithLabelValues("rbac"))
+		//nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
+		itemChecker, _, err := c.accessClient.Compile(rbacCtxTimeout, id, req) //nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
+		timer.ObserveDuration()
+		if err != nil {
+			c.logger.Warn("Failed to compile rbac item checker", "error", err)
+		}
+		rbacItemCheckerChan <- itemChecker
+	}()
+
+	timer := prometheus.NewTimer(c.metrics.compileSeconds.WithLabelValues("zanzana"))
+	//nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
+	zanzanaItemChecker, _, err := c.zanzanaClient.Compile(ctx, id, req) //nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
+	timer.ObserveDuration()
+	if err != nil {
+		return nil, authlib.NoopZookie{}, err
+	}
+
+	shadowItemChecker := func(name, folder string) bool {
+		zanzanaRes := zanzanaItemChecker(name, folder)
+
+		go func() {
+			// Wait for the rbac checker to be ready and then use it to compare against zanzana
+			once.Do(func() {
+				rbacItemChecker = <-rbacItemCheckerChan
+			})
+
+			if rbacItemChecker != nil {
+				rbacRes := rbacItemChecker(name, folder)
+				if rbacRes != zanzanaRes {
+					c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
+					c.logger.Warn("RBAC compile result does not match zanzana", "expected", zanzanaRes, "actual", rbacRes, "name", name, "folder", folder)
+				} else {
+					c.metrics.evaluationStatusTotal.WithLabelValues("success").Inc()
+				}
+			}
+		}()
+
+		return zanzanaRes
+	}
+
+	return shadowItemChecker, authlib.NoopZookie{}, err
+}
+
+func (c *ShadowRBACClient) BatchCheck(ctx context.Context, id authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	zanzanaResChan := make(chan authlib.BatchCheckResponse, 1)
+	zanzanaErrChan := make(chan error, 1)
+
+	go func() {
+		if c.accessClient == nil {
+			return
+		}
+
+		rbacCtx := context.WithoutCancel(ctx)
+		rbacCtxTimeout, cancel := context.WithTimeout(rbacCtx, zanzanaTimeout)
+		defer cancel()
+
+		timer := prometheus.NewTimer(c.metrics.batchCheckSeconds.WithLabelValues("rbac"))
+		res, err := c.accessClient.BatchCheck(rbacCtxTimeout, id, req)
+		if err != nil {
+			c.logger.Error("Failed to run rbac batch check", "error", err)
+		}
+		timer.ObserveDuration()
+
+		zanzanaRes := <-zanzanaResChan
+		zanzanaErr := <-zanzanaErrChan
+
+		if zanzanaErr == nil {
+			c.compareRBACBatchCheckResults(zanzanaRes, res, id, req)
+		}
+	}()
+
+	timer := prometheus.NewTimer(c.metrics.batchCheckSeconds.WithLabelValues("zanzana"))
+	res, err := c.zanzanaClient.BatchCheck(ctx, id, req)
+	timer.ObserveDuration()
+	zanzanaResChan <- res
+	zanzanaErrChan <- err
+
+	return res, err
+}
+
+// compareRBACBatchCheckResults compares the results from zanzana and RBAC batch checks
+// and logs any discrepancies.
+func (c *ShadowRBACClient) compareRBACBatchCheckResults(zanzanaRes, rbacRes authlib.BatchCheckResponse, id authlib.AuthInfo, req authlib.BatchCheckRequest) {
+	for key, zanzanaResult := range zanzanaRes.Results {
+		rbacResult, ok := rbacRes.Results[key]
+		if !ok {
+			c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
+			c.logger.Warn("RBAC batch check missing result", "key", key, "user", id.GetUID())
+			continue
+		}
+
+		if zanzanaResult.Allowed != rbacResult.Allowed {
+			c.metrics.evaluationStatusTotal.WithLabelValues("error").Inc()
+			c.logger.Warn("RBAC batch check result does not match zanzana", "key", key, "expected", zanzanaResult.Allowed, "actual", rbacResult.Allowed, "user", id.GetUID())
+		} else {
+			c.metrics.evaluationStatusTotal.WithLabelValues("success").Inc()
+		}
+	}
+}

--- a/pkg/services/authz/zanzana/client/shadow_rbac_client_test.go
+++ b/pkg/services/authz/zanzana/client/shadow_rbac_client_test.go
@@ -146,8 +146,16 @@ func TestShadowRBACClient_BatchCheck(t *testing.T) {
 			}
 
 			if tt.expectedSuccessMetric > 0 || tt.expectedErrorMetric > 0 {
-				successCounter, _ := shadowClient.metrics.evaluationStatusTotal.GetMetricWithLabelValues("success")
-				errorCounter, _ := shadowClient.metrics.evaluationStatusTotal.GetMetricWithLabelValues("error")
+				statusMetric, err := shadowClient.metrics.evaluationStatusTotal.CurryWith(prometheus.Labels{
+					"method":            "batch_check",
+					"resource":          "other",
+					"request_namespace": "org-1",
+				})
+				require.NoError(t, err)
+				successCounter, err := statusMetric.GetMetricWithLabelValues("success")
+				require.NoError(t, err)
+				errorCounter, err := statusMetric.GetMetricWithLabelValues("error")
+				require.NoError(t, err)
 
 				require.Eventually(t, func() bool {
 					successMatch := tt.expectedSuccessMetric == 0 || getCounterValue(successCounter) == tt.expectedSuccessMetric
@@ -269,7 +277,15 @@ func TestShadowRBACClient_Check_MetricsOnMismatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, res.Allowed, "should return zanzana result")
 
-	errorCounter, _ := shadowClient.metrics.evaluationStatusTotal.GetMetricWithLabelValues("error")
+	statusMetric, err := shadowClient.metrics.evaluationStatusTotal.CurryWith(prometheus.Labels{
+		"method":            "check",
+		"resource":          "other",
+		"request_namespace": "org-1",
+	})
+	require.NoError(t, err)
+	errorCounter, err := statusMetric.GetMetricWithLabelValues("error")
+	require.NoError(t, err)
+
 	require.Eventually(t, func() bool {
 		return getCounterValue(errorCounter) == 1
 	}, time.Second, 10*time.Millisecond, "error metric should be incremented on mismatch")

--- a/pkg/services/authz/zanzana/client/shadow_rbac_client_test.go
+++ b/pkg/services/authz/zanzana/client/shadow_rbac_client_test.go
@@ -1,0 +1,276 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authlib "github.com/grafana/authlib/types"
+)
+
+func TestShadowRBACClient_BatchCheck(t *testing.T) {
+	tests := []struct {
+		name            string
+		zanzanaResponse authlib.BatchCheckResponse
+		zanzanaErr      error
+		rbacResponse    authlib.BatchCheckResponse
+		rbacErr         error
+		hasRBAC         bool            // whether legacy RBAC client is present
+		expectedResult  map[string]bool // correlationID -> allowed
+		expectedErr     string
+		// metrics expectations (only checked if > 0)
+		expectedSuccessMetric float64
+		expectedErrorMetric   float64
+	}{
+		{
+			name: "returns zanzana result when both clients match",
+			zanzanaResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+					"check2": {Allowed: false},
+				},
+			},
+			hasRBAC: true,
+			rbacResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+					"check2": {Allowed: false},
+				},
+			},
+			expectedResult:        map[string]bool{"check1": true, "check2": false},
+			expectedSuccessMetric: 2,
+		},
+		{
+			name: "returns zanzana result when rbac client is nil",
+			zanzanaResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+				},
+			},
+			hasRBAC:        false,
+			expectedResult: map[string]bool{"check1": true},
+		},
+		{
+			name: "returns zanzana result even when rbac fails",
+			zanzanaResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+				},
+			},
+			hasRBAC:        true,
+			rbacErr:        errors.New("rbac error"),
+			expectedResult: map[string]bool{"check1": true},
+		},
+		{
+			name:        "returns error when zanzana fails",
+			zanzanaErr:  errors.New("zanzana error"),
+			hasRBAC:     false,
+			expectedErr: "zanzana error",
+		},
+		{
+			name: "increments error metric when results differ",
+			zanzanaResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+				},
+			},
+			hasRBAC: true,
+			rbacResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: false}, // differs from zanzana
+				},
+			},
+			expectedResult:      map[string]bool{"check1": true},
+			expectedErrorMetric: 1,
+		},
+		{
+			name: "increments error metric when rbac missing result",
+			zanzanaResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+					"check2": {Allowed: false},
+				},
+			},
+			hasRBAC: true,
+			rbacResponse: authlib.BatchCheckResponse{
+				Results: map[string]authlib.BatchCheckResult{
+					"check1": {Allowed: true},
+					// check2 is missing
+				},
+			},
+			expectedResult:        map[string]bool{"check1": true, "check2": false},
+			expectedSuccessMetric: 1,
+			expectedErrorMetric:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+
+			zanzanaClient := &mockAccessClient{
+				batchCheckFunc: func(ctx context.Context, id authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+					return tt.zanzanaResponse, tt.zanzanaErr
+				},
+			}
+
+			var rbacClient authlib.AccessClient
+			if tt.hasRBAC {
+				rbacClient = &mockAccessClient{
+					batchCheckFunc: func(ctx context.Context, id authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+						return tt.rbacResponse, tt.rbacErr
+					},
+				}
+			}
+
+			client, err := WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+			require.NoError(t, err)
+			shadowClient := client.(*ShadowRBACClient)
+
+			res, err := client.BatchCheck(context.Background(), newTestAuthInfo(), authlib.BatchCheckRequest{Namespace: "org-1"})
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+
+			for correlationID, expectedAllowed := range tt.expectedResult {
+				assert.Equal(t, expectedAllowed, res.Results[correlationID].Allowed, "unexpected result for %s", correlationID)
+			}
+
+			if tt.expectedSuccessMetric > 0 || tt.expectedErrorMetric > 0 {
+				successCounter, _ := shadowClient.metrics.evaluationStatusTotal.GetMetricWithLabelValues("success")
+				errorCounter, _ := shadowClient.metrics.evaluationStatusTotal.GetMetricWithLabelValues("error")
+
+				require.Eventually(t, func() bool {
+					successMatch := tt.expectedSuccessMetric == 0 || getCounterValue(successCounter) == tt.expectedSuccessMetric
+					errorMatch := tt.expectedErrorMetric == 0 || getCounterValue(errorCounter) == tt.expectedErrorMetric
+					return successMatch && errorMatch
+				}, time.Second, 10*time.Millisecond, "metrics did not match expected values")
+			}
+		})
+	}
+}
+
+func TestShadowRBACClient_Check(t *testing.T) {
+	tests := []struct {
+		name            string
+		zanzanaAllowed  bool
+		zanzanaErr      error
+		hasRBAC         bool
+		rbacAllowed     bool
+		expectedAllowed bool
+		expectedErr     string
+	}{
+		{
+			name:            "returns zanzana result when both succeed",
+			zanzanaAllowed:  true,
+			hasRBAC:         true,
+			rbacAllowed:     true,
+			expectedAllowed: true,
+		},
+		{
+			name:            "returns zanzana result when rbac client is nil",
+			zanzanaAllowed:  true,
+			hasRBAC:         false,
+			expectedAllowed: true,
+		},
+		{
+			name:            "returns zanzana denied result",
+			zanzanaAllowed:  false,
+			hasRBAC:         true,
+			rbacAllowed:     false,
+			expectedAllowed: false,
+		},
+		{
+			name:        "returns error when zanzana fails",
+			zanzanaErr:  errors.New("zanzana error"),
+			hasRBAC:     false,
+			expectedErr: "zanzana error",
+		},
+		{
+			name:            "returns zanzana result even when rbac fails",
+			zanzanaAllowed:  true,
+			hasRBAC:         true,
+			expectedAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+
+			zanzanaClient := &mockAccessClient{
+				checkFunc: func(ctx context.Context, id authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+					return authlib.CheckResponse{Allowed: tt.zanzanaAllowed}, tt.zanzanaErr
+				},
+			}
+
+			var rbacClient authlib.AccessClient
+			if tt.hasRBAC {
+				rbacClient = &mockAccessClient{
+					checkFunc: func(ctx context.Context, id authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+						return authlib.CheckResponse{Allowed: tt.rbacAllowed}, nil
+					},
+				}
+			}
+
+			client, err := WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+			require.NoError(t, err)
+
+			req := authlib.CheckRequest{
+				Namespace: "org-1",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+				Verb:      "get",
+				Name:      "dash1",
+			}
+
+			res, err := client.Check(context.Background(), newTestAuthInfo(), req, "folder1")
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedAllowed, res.Allowed)
+		})
+	}
+}
+
+func TestShadowRBACClient_Check_MetricsOnMismatch(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	zanzanaClient := &mockAccessClient{
+		checkFunc: func(ctx context.Context, id authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+			return authlib.CheckResponse{Allowed: true}, nil
+		},
+	}
+	rbacClient := &mockAccessClient{
+		checkFunc: func(ctx context.Context, id authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+			return authlib.CheckResponse{Allowed: false}, nil // differs from zanzana
+		},
+	}
+
+	client, err := WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+	require.NoError(t, err)
+	shadowClient := client.(*ShadowRBACClient)
+
+	res, err := client.Check(context.Background(), newTestAuthInfo(), authlib.CheckRequest{Namespace: "org-1"}, "")
+	require.NoError(t, err)
+	assert.True(t, res.Allowed, "should return zanzana result")
+
+	errorCounter, _ := shadowClient.metrics.evaluationStatusTotal.GetMetricWithLabelValues("error")
+	require.Eventually(t, func() bool {
+		return getCounterValue(errorCounter) == 1
+	}, time.Second, 10*time.Millisecond, "error metric should be incremented on mismatch")
+}

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -12,6 +12,21 @@ const (
 	ZanzanaModeEmbedded ZanzanaMode = "embedded"
 )
 
+// ZanzanaPrimaryEngine controls which engine is on the hot path when the shadow
+// client is active (i.e. the Zanzana feature flag is enabled but
+// ZanzanaNoLegacyClient is not). The other engine runs in the background for
+// comparison only.
+type ZanzanaPrimaryEngine string
+
+const (
+	// ZanzanaPrimaryEngineRBAC uses legacy RBAC as the primary engine and runs
+	// Zanzana checks in the background (default – preserves existing behaviour).
+	ZanzanaPrimaryEngineRBAC ZanzanaPrimaryEngine = "rbac"
+	// ZanzanaPrimaryEngineZanzana uses Zanzana as the primary engine and runs
+	// legacy RBAC checks in the background.
+	ZanzanaPrimaryEngineZanzana ZanzanaPrimaryEngine = "zanzana"
+)
+
 type ZanzanaClientSettings struct {
 	// Mode can either be embedded or client.
 	Mode ZanzanaMode
@@ -29,6 +44,9 @@ type ZanzanaClientSettings struct {
 	TokenExchangeURL string
 	// Namespace to use for the token.
 	TokenNamespace string
+	// PrimaryEngine selects which engine is on the hot path when the shadow
+	// client is active. Accepted values: "rbac" (default) and "zanzana".
+	PrimaryEngine ZanzanaPrimaryEngine
 }
 
 type ZanzanaReconcilerMode string
@@ -289,6 +307,13 @@ func (cfg *Cfg) readZanzanaSettings() {
 	}
 	if tokenExchangeURL != "" {
 		zc.TokenExchangeURL = tokenExchangeURL
+	}
+
+	zc.PrimaryEngine = ZanzanaPrimaryEngine(clientSec.Key("primary_engine").MustString(string(ZanzanaPrimaryEngineRBAC)))
+	validEngines := []ZanzanaPrimaryEngine{ZanzanaPrimaryEngineRBAC, ZanzanaPrimaryEngineZanzana}
+	if !slices.Contains(validEngines, zc.PrimaryEngine) {
+		cfg.Logger.Warn("Invalid zanzana primary_engine", "expected", validEngines, "got", zc.PrimaryEngine)
+		zc.PrimaryEngine = ZanzanaPrimaryEngineRBAC
 	}
 
 	cfg.ZanzanaClient = zc


### PR DESCRIPTION
**What is this feature?**

Do opposite to zanzana shadow client - use zanzana as a source of truth, but send shadow requests to the legacy RBAC engine to compare and log inconsistency. Use this option to enable zanzana and shadow requests to rbac:

```ini
[zanzana.client]
primary_engine = zanzana
```

Should be rebased and merged after https://github.com/grafana/grafana/pull/121521

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
