### PR TITLE
datasources: querier: add log to error case

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -128,7 +128,7 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 		b.reportStatus(ctx, statusCode)
 	}
 
-	responder := newRawResponderWrapper(ctx, w, responderOnObjectFn, responderOnErrorFn)
+	responder := newRawResponderWrapper(ctx, w, connectLogger, responderOnObjectFn, responderOnErrorFn)
 
 	raw := &query.QueryDataRequest{}
 	err := web.Bind(httpreq, raw)
@@ -339,14 +339,16 @@ type rawResponderWrapper struct {
 	ctx        context.Context
 	onObjectFn func(statusCode *int, obj runtime.Object)
 	onErrorFn  func(err error)
+	logger     log.Logger
 }
 
-func newRawResponderWrapper(ctx context.Context, w http.ResponseWriter, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) rest.Responder {
+func newRawResponderWrapper(ctx context.Context, w http.ResponseWriter, logger log.Logger, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) rest.Responder {
 	return &rawResponderWrapper{
 		w:          w,
 		ctx:        ctx,
 		onObjectFn: onObjectFn,
 		onErrorFn:  onErrorFn,
+		logger:     logger,
 	}
 }
 
@@ -362,6 +364,7 @@ func (r rawResponderWrapper) Object(statusCode int, obj runtime.Object) {
 	r.w.Header().Set("Content-Type", "application/json")
 	r.w.WriteHeader(statusCode)
 	if err := json.NewEncoder(r.w).Encode(obj); err != nil {
+		r.logger.Error("querier output: json serialisation failed", "error", err)
 		http.Error(r.w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -23,6 +25,7 @@ import (
 	queryapi "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -307,6 +310,23 @@ func (m mockClient) GetSettings() clientapi.InstanceConfigurationSettings {
 	}
 }
 
+type nonMarshalableRuntimeObject struct {
+	Broken chan int `json:"broken"`
+}
+
+func (o *nonMarshalableRuntimeObject) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (o *nonMarshalableRuntimeObject) DeepCopyObject() runtime.Object {
+	if o == nil {
+		return nil
+	}
+
+	out := *o
+	return &out
+}
+
 type mockLegacyDataSourceLookup struct{}
 
 func (m *mockLegacyDataSourceLookup) GetDataSourceFromDeprecatedFields(ctx context.Context, name string, id int64) (*dataapi.DataSourceRef, error) {
@@ -314,6 +334,19 @@ func (m *mockLegacyDataSourceLookup) GetDataSourceFromDeprecatedFields(ctx conte
 		UID:  "demo-prom",
 		Type: "prometheus",
 	}, nil
+}
+
+func TestRawResponderWrapperObjectLogsSerializationError(t *testing.T) {
+	logger := &logtest.Fake{}
+	recorder := httptest.NewRecorder()
+	responder := newRawResponderWrapper(context.Background(), recorder, logger, nil, nil)
+
+	responder.Object(http.StatusOK, &nonMarshalableRuntimeObject{
+		Broken: make(chan int),
+	})
+
+	require.Equal(t, 1, logger.ErrorLogs.Calls)
+	require.Equal(t, "querier output: json serialisation failed", logger.ErrorLogs.Message)
 }
 
 func TestMergeHeaders(t *testing.T) {


### PR DESCRIPTION
when the query service outputs it's response as JSON, and the json-serialisation fails, we are not able to set a new http-response-code anymore.

the alternative is to serialise to an in-memory buffer first, but that means increased memory use.

we think the current solution is a good compromise, but to be sure, we add a log if this problem happens.