### PR TITLE
Teams: Disable sorting by membercount on TeamsList

### DIFF
--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -159,7 +159,6 @@ const TeamList = () => {
           }
           return value;
         },
-        sortType: 'number',
       },
       ...(displayRolePicker
         ? [


### PR DESCRIPTION
**What is this feature?**

Disable sorting by the `Members` column on the Teams list page.

**Why do we need this feature?**

New Search API won't be able to support sorting by membercount.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
