### PR TITLE
Combobox: Fix long option overflow in MultiCombobox when single item selected

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/ValuePill.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ValuePill.tsx
@@ -49,13 +49,9 @@ const getValuePillStyles = (theme: GrafanaTheme2, disabled?: boolean) => ({
     padding: theme.spacing(0.25),
     border: disabled ? `1px solid ${theme.colors.border.weak}` : 'none',
     fontSize: theme.typography.bodySmall.fontSize,
-    flexShrink: 0,
+    flexShrink: 1,
     minWidth: '50px',
     alignItems: 'center',
-
-    '&:first-child:has(+ div)': {
-      flexShrink: 1,
-    },
   }),
 
   text: css({

--- a/packages/grafana-ui/src/components/Combobox/getMultiComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getMultiComboboxStyles.ts
@@ -49,7 +49,7 @@ export const getMultiComboboxStyles = (
       background: 'transparent',
       flexGrow: 1,
       maxWidth: '100%',
-      minWidth: 40, // This is a bit arbitrary, but is used to leave some space for clicking. This will override the minWidth property
+      minWidth: 20, // This is a bit arbitrary, but is used to leave some space for clicking. This will override the minWidth property
       '&::placeholder': {
         color: theme.colors.text.disabled,
       },


### PR DESCRIPTION
**What is this feature?**

Fixes long selected items overflowing the `MultiCombobox` container when auto-size is disabled and only a single item is selected.

**Before**
<img width="301" height="115" alt="Screenshot 2026-03-31 at 15 44 55" src="https://github.com/user-attachments/assets/5853daf5-dd1d-41b6-8831-66f29b46a5c8" />

**After**
<img width="233" height="95" alt="Screenshot 2026-03-31 at 16 11 53" src="https://github.com/user-attachments/assets/5604b009-8bb6-4994-8350-dabe8dee74bb" />

**Why do we need this feature?**

`ValuePill` had `flexShrink: 0`, preventing it from shrinking within the flex container. There was a CSS selector workaround (`&:first-child:has(+ div)`) that enabled shrinking only when the overflow counter `...N` div was present — i.e. only when multiple items were truncated. This left the single-item case broken, with long text overflowing the container instead of being truncated with an ellipsis.

**Changes:**

- `ValuePill.tsx`: Set `flexShrink: 1` unconditionally, removing the now-redundant `&:first-child:has(+ div)` selector. The `minWidth: 50px` guard and existing `overflow: hidden; text-overflow: ellipsis` on the text span handle the rest.
- `getMultiComboboxStyles.ts`: Reduced the inner input's `minWidth` from `40` to `20` so it takes less space away from the pill.

**Who is this feature for?**

Users of `MultiCombobox` with a fixed width and long option labels.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.