### PR TITLE
[release-12.3.7] Dashboards: Get annotations and dashboard endpoint performance improvements

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -210,6 +210,10 @@ transaction_retries = 5
 # Set to true to add metrics and tracing for database queries.
 instrument_queries = false
 
+# For MySQL: set to false to disable FORCE INDEX (IDX_dashboard_title) in dashboard search queries.
+# Disabling can improve performance when filters are selective (e.g. by uid); leave true for legacy behavior.
+force_dashboard_title_index = true
+
 # Set to true to delete auto-generated primary keys during migrations.
 # This is useful when databases have auto-generated primary keys enabled.
 delete_auto_gen_ids = false

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -245,7 +245,7 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	defer span.End()
 
 	assemble := func() ([]accesscontrol.Permission, error) {
-		permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
+		basicPermissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
 		if err != nil {
 			return nil, err
 		}
@@ -254,12 +254,17 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 		if err != nil {
 			return nil, err
 		}
-		permissions = append(permissions, teamsPermissions...)
 
 		userManagedPermissions, err := s.getCachedUserDirectPermissions(ctx, user, options)
 		if err != nil {
 			return nil, err
 		}
+
+		// Single allocation and copy to avoid repeated realloc when appending large slices
+		n := len(basicPermissions) + len(teamsPermissions) + len(userManagedPermissions)
+		permissions := make([]accesscontrol.Permission, 0, n)
+		permissions = append(permissions, basicPermissions...)
+		permissions = append(permissions, teamsPermissions...)
 		permissions = append(permissions, userManagedPermissions...)
 		span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
 

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -52,37 +53,69 @@ func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query acces
 	ctx, span := tracer.Start(ctx, "accesscontrol.database.GetUserPermissions")
 	defer span.End()
 
-	result := make([]accesscontrol.Permission, 0)
+	if query.UserID == 0 && len(query.TeamIDs) == 0 && len(query.Roles) == 0 {
+		return nil, nil
+	}
+
+	_, buildSpan := tracer.Start(ctx, "accesscontrol.database.GetUserPermissions.build_query")
+	filter, params := accesscontrol.UserRolesFilter(query.OrgID, query.UserID, query.TeamIDs, query.Roles, s.sql.GetDialect())
+
+	q := `
+	SELECT
+		permission.action,
+		permission.scope
+		FROM permission
+		INNER JOIN role ON role.id = permission.role_id
+	` + filter
+
+	if len(query.RolePrefixes) > 0 {
+		rolePrefixesFilter, filterParams := accesscontrol.RolePrefixesFilter(query.RolePrefixes)
+		q += rolePrefixesFilter
+		params = append(params, filterParams...)
+	}
+
+	buildSpan.End()
+
+	_, querySpan := tracer.Start(ctx, "accesscontrol.database.GetUserPermissions.query")
+	result, err := s.getUserPermissionsRaw(ctx, q, params)
+	if err != nil {
+		querySpan.End()
+		return nil, err
+	}
+	querySpan.SetAttributes(attribute.Int("result_count", len(result)))
+	querySpan.End()
+
+	return result, nil
+}
+
+// getUserPermissionsRaw scans rows directly into []Permission. This avoids xorm's
+// Find() reflection over 10k+ rows, which was adding tens of ms after the DB had
+// already returned. The query runs inside WithDbSession so retryable errors
+// (e.g. SQLite lock contention) and transaction-bound sessions from context are honored.
+func (s *AccessControlStore) getUserPermissionsRaw(ctx context.Context, q string, params []any) ([]accesscontrol.Permission, error) {
+	var out []accesscontrol.Permission
 	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
-		if query.UserID == 0 && len(query.TeamIDs) == 0 && len(query.Roles) == 0 {
-			// no permission to fetch
-			return nil
-		}
-
-		filter, params := accesscontrol.UserRolesFilter(query.OrgID, query.UserID, query.TeamIDs, query.Roles, s.sql.GetDialect())
-
-		q := `
-		SELECT
-			permission.action,
-			permission.scope
-			FROM permission
-			INNER JOIN role ON role.id = permission.role_id
-		` + filter
-
-		if len(query.RolePrefixes) > 0 {
-			rolePrefixesFilter, filterParams := accesscontrol.RolePrefixesFilter(query.RolePrefixes)
-			q += rolePrefixesFilter
-			params = append(params, filterParams...)
-		}
-
-		if err := sess.SQL(q, params...).Find(&result); err != nil {
+		rows, err := sess.QueryRows(q, params...)
+		if err != nil {
 			return err
 		}
+		defer func() { _ = rows.Close() }()
 
-		return nil
+		// Pre-allocate with a reasonable capacity to limit reallocations for large result sets.
+		out = make([]accesscontrol.Permission, 0, 512)
+		var action, scope string
+		for rows.Next() {
+			if err := rows.Scan(&action, &scope); err != nil {
+				return err
+			}
+			out = append(out, accesscontrol.Permission{Action: action, Scope: scope})
+		}
+		return rows.Err()
 	})
-
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (s *AccessControlStore) GetBasicRolesPermissions(ctx context.Context, query accesscontrol.GetUserPermissionsQuery) ([]accesscontrol.Permission, error) {
@@ -93,19 +126,6 @@ func (s *AccessControlStore) GetBasicRolesPermissions(ctx context.Context, query
 	})
 }
 
-type teamPermission struct {
-	TeamID int64 `xorm:"team_id"`
-	Action string
-	Scope  string
-}
-
-func (p teamPermission) Permission() accesscontrol.Permission {
-	return accesscontrol.Permission{
-		Action: p.Action,
-		Scope:  p.Scope,
-	}
-}
-
 func (s *AccessControlStore) GetTeamsPermissions(ctx context.Context, query accesscontrol.GetUserPermissionsQuery) (map[int64][]accesscontrol.Permission, error) {
 	ctx, span := tracer.Start(ctx, "accesscontrol.database.GetTeamsPermissions")
 	defer span.End()
@@ -113,14 +133,12 @@ func (s *AccessControlStore) GetTeamsPermissions(ctx context.Context, query acce
 	teams := query.TeamIDs
 	orgID := query.OrgID
 	rolePrefixes := query.RolePrefixes
-	result := make([]teamPermission, 0)
-	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
-		if len(teams) == 0 {
-			// no permission to fetch
-			return nil
-		}
 
-		q := `
+	if len(teams) == 0 {
+		return nil, nil
+	}
+
+	q := `
 		SELECT
 			permission.action,
 			permission.scope,
@@ -134,34 +152,44 @@ func (s *AccessControlStore) GetTeamsPermissions(ctx context.Context, query acce
 		) as all_role ON role.id = all_role.role_id
 		`
 
-		params := make([]any, 0)
-		for _, team := range teams {
-			params = append(params, team)
-		}
-		params = append(params, orgID)
+	params := make([]any, 0, len(teams)+1)
+	for _, team := range teams {
+		params = append(params, team)
+	}
+	params = append(params, orgID)
 
-		if len(rolePrefixes) > 0 {
-			rolePrefixesFilter, filterParams := accesscontrol.RolePrefixesFilter(rolePrefixes)
-			q += rolePrefixesFilter
-			params = append(params, filterParams...)
-		}
+	if len(rolePrefixes) > 0 {
+		rolePrefixesFilter, filterParams := accesscontrol.RolePrefixesFilter(rolePrefixes)
+		q += rolePrefixesFilter
+		params = append(params, filterParams...)
+	}
 
-		if err := sess.SQL(q, params...).Find(&result); err != nil {
+	var teamPermissions map[int64][]accesscontrol.Permission
+	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+		rows, err := sess.QueryRows(q, params...)
+		if err != nil {
 			return err
 		}
+		defer func() { _ = rows.Close() }()
 
-		return nil
-	})
-
-	teamPermissions := make(map[int64][]accesscontrol.Permission)
-	for _, teamPermission := range result {
-		tp := teamPermissions[teamPermission.TeamID]
-		if tp == nil {
-			tp = make([]accesscontrol.Permission, 0)
+		teamPermissions = make(map[int64][]accesscontrol.Permission)
+		var action, scope string
+		var teamID int64
+		for rows.Next() {
+			if err := rows.Scan(&action, &scope, &teamID); err != nil {
+				return err
+			}
+			if _, ok := teamPermissions[teamID]; !ok {
+				teamPermissions[teamID] = make([]accesscontrol.Permission, 0, 32)
+			}
+			teamPermissions[teamID] = append(teamPermissions[teamID], accesscontrol.Permission{Action: action, Scope: scope})
 		}
-		teamPermissions[teamPermission.TeamID] = append(tp, teamPermission.Permission())
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return teamPermissions, err
+	return teamPermissions, nil
 }
 
 // SearchUsersPermissions returns the list of user permissions in specific organization indexed by UserID

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -787,22 +787,37 @@ func (s *InMemoryActionSets) ResolveActionSet(actionSet string) []string {
 }
 
 func (s *InMemoryActionSets) ExpandActionSetsWithFilter(permissions []accesscontrol.Permission, actionMatcher func(action string) bool) []accesscontrol.Permission {
-	var expandedPermissions []accesscontrol.Permission
+	// Count output size to avoid repeated reallocations when expanding action sets.
+	var n int
 	for _, permission := range permissions {
 		resolvedActions := s.ResolveActionSet(permission.Action)
 		if len(resolvedActions) == 0 {
-			expandedPermissions = append(expandedPermissions, permission)
+			n++
+			continue
+		}
+		for _, action := range resolvedActions {
+			if actionMatcher(action) {
+				n++
+			}
+		}
+	}
+
+	// here we know the size of the output, so we can allocate the array once
+	out := make([]accesscontrol.Permission, 0, n)
+	for _, permission := range permissions {
+		resolvedActions := s.ResolveActionSet(permission.Action)
+		if len(resolvedActions) == 0 {
+			out = append(out, permission)
 			continue
 		}
 		for _, action := range resolvedActions {
 			if !actionMatcher(action) {
 				continue
 			}
-			permission.Action = action
-			expandedPermissions = append(expandedPermissions, permission)
+			out = append(out, accesscontrol.Permission{Action: action, Scope: permission.Scope})
 		}
 	}
-	return expandedPermissions
+	return out
 }
 
 func (s *InMemoryActionSets) StoreActionSet(name string, actions []string) {

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -909,7 +909,12 @@ func (d *dashboardStore) FindDashboards(ctx context.Context, query *dashboards.F
 	filters = append(filters, searchstore.DeletedFilter{Deleted: query.IsDeleted})
 
 	var res []dashboards.DashboardSearchProjection
-	sb := &searchstore.Builder{Dialect: d.store.GetDialect(), Filters: filters, Features: d.features}
+	sb := &searchstore.Builder{
+		Dialect:                  d.store.GetDialect(),
+		Filters:                  filters,
+		Features:                 d.features,
+		ForceDashboardTitleIndex: d.cfg.DatabaseForceDashboardTitleIndex,
+	}
 
 	limit := query.Limit
 	if limit < 1 {

--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -218,4 +218,8 @@ func AddMigration(mg *migrator.Migrator) {
 	mg.AddMigration("Remove permission role_id index", migrator.NewDropIndexMigration(permissionV1, &migrator.Index{
 		Cols: []string{"role_id"},
 	}))
+
+	mg.AddMigration("add permission role_id scope index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
+		Cols: []string{"role_id", "scope"},
+	}))
 }

--- a/pkg/services/sqlstore/searchstore/builder.go
+++ b/pkg/services/sqlstore/searchstore/builder.go
@@ -19,6 +19,9 @@ type Builder struct {
 	Dialect  migrator.Dialect
 	Features featuremgmt.FeatureToggles
 
+	// ForceDashboardTitleIndex (MySQL only): when true, uses FORCE INDEX (IDX_dashboard_title). Set from config.
+	ForceDashboardTitleIndex bool
+
 	params []any
 	sql    bytes.Buffer
 }
@@ -137,7 +140,7 @@ func (b *Builder) applyFilters() (ordering string) {
 	}
 
 	forceIndex := ""
-	if b.Dialect.DriverName() == migrator.MySQL {
+	if b.Dialect.DriverName() == migrator.MySQL && b.ForceDashboardTitleIndex {
 		forceIndex = " FORCE INDEX (IDX_dashboard_title) "
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -540,6 +540,10 @@ type Cfg struct {
 	// sqlstore package and HTTP middlewares.
 	DatabaseInstrumentQueries bool
 
+	// DatabaseForceDashboardTitleIndex (MySQL only): when true, dashboard search uses FORCE INDEX (IDX_dashboard_title).
+	// Set to false to let the optimizer choose the index (can be faster for selective filters).
+	DatabaseForceDashboardTitleIndex bool
+
 	// Public dashboards
 	PublicDashboardsEnabled bool
 
@@ -1427,6 +1431,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	databaseSection := iniFile.Section("database")
 	cfg.DatabaseInstrumentQueries = databaseSection.Key("instrument_queries").MustBool(false)
+	cfg.DatabaseForceDashboardTitleIndex = databaseSection.Key("force_dashboard_title_index").MustBool(true)
 
 	logSection := iniFile.Section("log")
 	cfg.UserFacingDefaultError = logSection.Key("user_facing_default_error").MustString("please inspect Grafana server log for details")

--- a/pkg/util/xorm/session_raw.go
+++ b/pkg/util/xorm/session_raw.go
@@ -221,3 +221,10 @@ func (session *Session) Exec(sqlOrArgs ...any) (sql.Result, error) {
 
 	return session.exec(sqlStr, args...)
 }
+
+// QueryRows executes a raw SQL query on the session's database connection (including
+// any active transaction). The SQL is processed through dialect filters. The caller
+// must close the returned rows.
+func (session *Session) QueryRows(sqlStr string, args ...any) (*core.Rows, error) {
+	return session.queryRows(sqlStr, args...)
+}


### PR DESCRIPTION
Backport 1da06fc1a997d89aebc04cfa6134fd91fce2e9fd from #119378

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR contains general performance improvements for **Get Annotation** and **Create Dashboard** endpoints

**Enterprise PR**: https://github.com/grafana/grafana-enterprise/pull/11257

Here's a quick list of changes included in this PR:

- **GetUserPermissions** – DB time was low but total time high due to xorm’s reflection over many rows → run the query with QueryContext and scan directly into a slice (no xorm Find()).
- **getCachedUserPermissions** – Repeated appends caused many reallocations when merging three permission slices → pre-allocate one slice with the total length, then copy the three into it.
- **ExpandActionSetsWithFilter** – Growing the result with many appends and reusing a single struct was slow and fragile → count the final size first, allocate once, then fill without mutating the input.
- **Dashboard search (MySQL)** – FORCE INDEX (IDX_dashboard_title) could hurt when filters are very selective → add force_dashboard_title_index (default true) so it can be turned off to let the optimizer choose the index.
- **Permission lookups** – Queries by role/scope were not indexed → add migration for index on permission(role_id, scope).

**Why do we need this feature?**

With many dashboards (e.g. 10k+), **latency grew linearly with the number of permissions** because most time was spent in Go after the DB responded: xorm reflection over many rows, repeated slice reallocations when merging/expanding permissions, and a forced MySQL index that could hurt selective queries. The changes reduce that post-DB work (direct row scanning, single allocations, optional index) so latency scales with DB time instead of permission count.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
