### PR TITLE
Alerting: Fix flaky TestRuleRoutine and TestRecordingRule

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -1063,13 +1063,19 @@ func TestRuleRoutine(t *testing.T) {
 			rule:        rule,
 		})
 
-		// Because we are using a mock clock, first we need to wait until the rule evaluation
-		// reaches the point where it sleeps for the duration of the retry interval.
-		time.Sleep(200 * time.Millisecond)
-		// Then advance the mock clock to trigger the retry.
-		clk.Add(2 * time.Second)
-
-		waitForTimeChannel(t, evalAppliedChan)
+		// Advance the mock clock to trigger retries. We poll WaitForAllTimers
+		// which advances the clock just enough to fire each registered timer.
+		// This avoids the race of a fixed time.Sleep before clk.Add, where the
+		// goroutine may not have registered its timer yet.
+		require.Eventually(t, func() bool {
+			clk.WaitForAllTimers()
+			select {
+			case <-evalAppliedChan:
+				return true
+			default:
+				return false
+			}
+		}, 10*time.Second, 10*time.Millisecond)
 
 		t.Run("it should increase failure counter by 1 and attempt failure counter by 3", func(t *testing.T) {
 			// duration metric has 0 values because of mocked clock that do not advance

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -609,13 +609,19 @@ func testRecordingRule_Integration(t *testing.T, writeTarget *writer.TestRemoteW
 			folderTitle: folderTitle,
 		})
 
-		// Because we are using a mock clock, first we need to wait until the rule evaluation
-		// reaches the point where it sleeps for the duration of the retry interval.
-		time.Sleep(200 * time.Millisecond)
-		// Then advance the mock clock to trigger the retry.
-		clk.Add(2 * time.Second)
-
-		_ = waitForTimeChannel(t, evalDoneChan)
+		// Advance the mock clock to trigger retries. We poll WaitForAllTimers
+		// which advances the clock just enough to fire each registered timer.
+		// This avoids the race of a fixed time.Sleep before clk.Add, where the
+		// goroutine may not have registered its timer yet.
+		require.Eventually(t, func() bool {
+			clk.WaitForAllTimers()
+			select {
+			case <-evalDoneChan:
+				return true
+			default:
+				return false
+			}
+		}, 10*time.Second, 10*time.Millisecond)
 
 		t.Run("reports basic evaluation metrics", func(t *testing.T) {
 			expectedMetric := fmt.Sprintf(
@@ -754,13 +760,19 @@ func testRecordingRule_Integration(t *testing.T, writeTarget *writer.TestRemoteW
 			folderTitle: folderTitle,
 		})
 
-		// Because we are using a mock clock, first we need to wait until the rule evaluation
-		// reaches the point where it sleeps for the duration of the retry interval.
-		time.Sleep(200 * time.Millisecond)
-		// Then advance the mock clock to trigger the retry.
-		clk.Add(2 * time.Second)
-
-		_ = waitForTimeChannel(t, evalDoneChan)
+		// Advance the mock clock to trigger retries. We poll WaitForAllTimers
+		// which advances the clock just enough to fire each registered timer.
+		// This avoids the race of a fixed time.Sleep before clk.Add, where the
+		// goroutine may not have registered its timer yet.
+		require.Eventually(t, func() bool {
+			clk.WaitForAllTimers()
+			select {
+			case <-evalDoneChan:
+				return true
+			default:
+				return false
+			}
+		}, 10*time.Second, 10*time.Millisecond)
 
 		t.Run("status shows evaluation", func(t *testing.T) {
 			status := process.(*recordingRule).Status()


### PR DESCRIPTION
The `time.Sleep(200ms)` before `clk.Add(2s)` in the retry tests has two problems:

1. 200ms isn't always enough for the goroutine to register its timer on the mock clock. If `clk.Add` runs first, the advance is lost.
2. Even when timing works out, `clk.Add(2s)` only fires the first retry timer. The second timer is created after Add returns, so nobody fires it.

This replaces the sleep+add pattern with a polling loop over `clk.WaitForAllTimers()`, which advances the mock clock just enough to fire each retry timer as it gets registered. Same fix applied to three spots: one in `alert_rule_test.go` and two in `recording_rule_test.go`.