### PR TITLE
chore: refactor annotation app registry

### DIFF
--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -1,0 +1,69 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+
+	authtypes "github.com/grafana/authlib/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+)
+
+// GetAuthorizer returns the authorizer for the annotation app.
+func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(
+		ctx context.Context, attr authorizer.Attributes,
+	) (authorized authorizer.Decision, reason string, err error) {
+		if !attr.IsResourceRequest() {
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+
+		// Allow all authenticated users; fine-grained authz is handled per-operation in k8sRESTAdapter.
+		return authorizer.DecisionAllow, "", nil
+	})
+}
+
+// canAccessAnnotation checks that the caller has permission to perform verb on anno,
+// using the legacy annotation authorization model (dashboard-scoped or org-scoped).
+func canAccessAnnotation(ctx context.Context, accessClient authtypes.AccessClient, namespace string, anno *annotationV0.Annotation, verb string) (bool, error) {
+	if anno == nil {
+		return false, apierrors.NewBadRequest("annotation must not be nil")
+	}
+
+	authInfo, ok := authtypes.AuthInfoFrom(ctx)
+	if !ok {
+		return false, apierrors.NewUnauthorized("no identity found for request")
+	}
+
+	var checkReq authtypes.CheckRequest
+
+	if anno.Spec.DashboardUID == nil || *anno.Spec.DashboardUID == "" {
+		// Org-level annotation: scope is annotations:type:organization.
+		checkReq = authtypes.CheckRequest{
+			Verb:      verb,
+			Group:     "annotation.grafana.app",
+			Resource:  "annotations",
+			Namespace: namespace,
+			Name:      "organization",
+		}
+	} else {
+		// Dashboard annotation: use dashboard.grafana.app/annotations virtual resource,
+		// which maps to annotation actions scoped to dashboards:uid:<dashboardUID>.
+		checkReq = authtypes.CheckRequest{
+			Verb:      verb,
+			Group:     "dashboard.grafana.app",
+			Resource:  "annotations",
+			Namespace: namespace,
+			Name:      *anno.Spec.DashboardUID,
+		}
+	}
+
+	resp, err := accessClient.Check(ctx, authInfo, checkReq, "")
+	if err != nil {
+		return false, fmt.Errorf("authz check failed: %w", err)
+	}
+
+	return resp.Allowed, nil
+}

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -1,0 +1,315 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	authtypes "github.com/grafana/authlib/types"
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+var (
+	_ rest.Scoper               = (*k8sRESTAdapter)(nil)
+	_ rest.SingularNameProvider = (*k8sRESTAdapter)(nil)
+	_ rest.Getter               = (*k8sRESTAdapter)(nil)
+	_ rest.Storage              = (*k8sRESTAdapter)(nil)
+	_ rest.Creater              = (*k8sRESTAdapter)(nil)
+	_ rest.Updater              = (*k8sRESTAdapter)(nil)
+	_ rest.GracefulDeleter      = (*k8sRESTAdapter)(nil)
+)
+
+// k8sRESTAdapter adapts the Store interface to Kubernetes REST storage interface.
+// This layer handles K8s API conventions (fieldSelectors, ListOptions, runtime.Object, etc.)
+// and delegates actual storage operations to the Store interface.
+type k8sRESTAdapter struct {
+	store          Store
+	tableConverter rest.TableConvertor
+	accessClient   authtypes.AccessClient
+	installer      *AppInstaller
+}
+
+func (s *k8sRESTAdapter) New() runtime.Object {
+	return annotationV0.AnnotationKind().ZeroValue()
+}
+
+func (s *k8sRESTAdapter) Destroy() {
+	// Stop background cleanup goroutines
+	if s.installer != nil && s.installer.cleanupCancel != nil {
+		s.installer.cleanupCancel()
+		s.installer.cleanupWg.Wait()
+	}
+
+	// Call Close() on the PostgreSQL store to cleanup connection pool
+	// TODO: add Close() to the Store interface so we can do proper cleanup for other store types
+	if pg, ok := s.store.(*PostgreSQLStore); ok {
+		pg.Close()
+	}
+}
+
+func (s *k8sRESTAdapter) NamespaceScoped() bool {
+	return true // namespace == org
+}
+
+func (s *k8sRESTAdapter) GetSingularName() string {
+	return "annotation"
+}
+
+func (s *k8sRESTAdapter) NewList() runtime.Object {
+	return annotationV0.AnnotationKind().ZeroListValue()
+}
+
+func (s *k8sRESTAdapter) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return s.tableConverter.ConvertToTable(ctx, object, tableOptions)
+}
+
+func (s *k8sRESTAdapter) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	namespace := request.NamespaceValue(ctx)
+
+	opts := ListOptions{}
+	if options.FieldSelector != nil {
+		// Parse K8s field selectors into Store ListOptions
+		for _, r := range options.FieldSelector.Requirements() {
+			switch r.Field {
+			case "spec.dashboardUID":
+				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
+					opts.DashboardUID = r.Value
+				} else {
+					return nil, fmt.Errorf("unsupported operator %s for spec.dashboardUID (only = supported)", r.Operator)
+				}
+
+			case "spec.panelID":
+				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
+					panelID, err := strconv.ParseInt(r.Value, 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("invalid panelID value %q: %w", r.Value, err)
+					}
+					opts.PanelID = panelID
+				} else {
+					return nil, fmt.Errorf("unsupported operator %s for spec.panelID (only = supported)", r.Operator)
+				}
+			case "spec.time":
+				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
+					from, err := strconv.ParseInt(r.Value, 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("invalid time value %q: %w", r.Value, err)
+					}
+					opts.From = from
+				} else {
+					return nil, fmt.Errorf("unsupported operator %s for spec.from (only = supported)", r.Operator)
+				}
+			case "spec.timeEnd":
+				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
+					to, err := strconv.ParseInt(r.Value, 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
+					}
+					opts.To = to
+				} else {
+					return nil, fmt.Errorf("unsupported operator %s for spec.to (only = supported)", r.Operator)
+				}
+			default:
+				return nil, fmt.Errorf("unsupported field selector: %s", r.Field)
+			}
+		}
+	}
+
+	opts.Limit = 100
+	if options.Limit > 0 {
+		opts.Limit = options.Limit
+	}
+
+	// Extract continue token from request
+	if options.Continue != "" {
+		opts.Continue = options.Continue
+	}
+
+	result, err := s.store.List(ctx, namespace, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: post-fetch filtering breaks pagination - cursor advances by opts.Limit regardless of authz results.
+	filtered := make([]annotationV0.Annotation, 0, len(result.Items))
+	for _, anno := range result.Items {
+		allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, &anno, utils.VerbList)
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			filtered = append(filtered, anno)
+		}
+	}
+
+	return &annotationV0.AnnotationList{
+		Items:    filtered,
+		ListMeta: metav1.ListMeta{Continue: result.Continue},
+	}, nil
+}
+
+func (s *k8sRESTAdapter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	namespace := request.NamespaceValue(ctx)
+
+	annotation, err := s.store.Get(ctx, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbGet)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		// Return NotFound to avoid leaking existence.
+		return nil, apierrors.NewNotFound(
+			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(), name,
+		)
+	}
+
+	return annotation, nil
+}
+
+func (s *k8sRESTAdapter) Create(ctx context.Context,
+	obj runtime.Object,
+	createValidation rest.ValidateObjectFunc,
+	options *metav1.CreateOptions,
+) (runtime.Object, error) {
+	annotation, ok := obj.(*annotationV0.Annotation)
+	if !ok {
+		return nil, fmt.Errorf("expected annotation")
+	}
+
+	namespace := request.NamespaceValue(ctx)
+
+	allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbCreate)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		return nil, apierrors.NewForbidden(
+			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
+			annotation.Name, fmt.Errorf("insufficient permissions"),
+		)
+	}
+
+	if annotation.Name == "" && annotation.GenerateName == "" {
+		return nil, apierrors.NewBadRequest("metadata.name or metadata.generateName is required")
+	}
+
+	if annotation.Name == "" && annotation.GenerateName != "" {
+		annotation.Name = annotation.GenerateName + util.GenerateShortUID()
+	}
+
+	return s.store.Create(ctx, annotation)
+}
+
+func (s *k8sRESTAdapter) Update(ctx context.Context,
+	name string,
+	objInfo rest.UpdatedObjectInfo,
+	createValidation rest.ValidateObjectFunc,
+	updateValidation rest.ValidateObjectUpdateFunc,
+	forceAllowCreate bool,
+	options *metav1.UpdateOptions,
+) (runtime.Object, bool, error) {
+	namespace := request.NamespaceValue(ctx)
+
+	// Fetch the existing annotation for patch merging and to verify authz on the pre-update resource.
+	existing, err := s.store.Get(ctx, namespace, name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, existing)
+	if err != nil {
+		return nil, false, err
+	}
+
+	resource, ok := obj.(*annotationV0.Annotation)
+	if !ok {
+		return nil, false, fmt.Errorf("expected annotation")
+	}
+
+	if resource.Name != name {
+		return nil, false, fmt.Errorf("name in URL does not match name in body")
+	}
+
+	if resource.Namespace != namespace {
+		return nil, false, fmt.Errorf("namespace in URL does not match namespace in body")
+	}
+
+	// Check authz on both existing and new body: prevents privilege escalation via scope changes.
+	allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, existing, utils.VerbUpdate)
+	if err != nil {
+		return nil, false, err
+	}
+	if !allowed {
+		return nil, false, apierrors.NewForbidden(
+			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
+			existing.Name, fmt.Errorf("insufficient permissions"),
+		)
+	}
+	allowed, err = canAccessAnnotation(ctx, s.accessClient, namespace, resource, utils.VerbUpdate)
+	if err != nil {
+		return nil, false, err
+	}
+	if !allowed {
+		return nil, false, apierrors.NewForbidden(
+			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
+			resource.Name, fmt.Errorf("insufficient permissions"),
+		)
+	}
+
+	updated, err := s.store.Update(ctx, resource)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return updated, false, nil
+}
+
+func (s *k8sRESTAdapter) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	namespace := request.NamespaceValue(ctx)
+
+	annotation, err := s.store.Get(ctx, namespace, name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	allowedDelete, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbDelete)
+	if err != nil {
+		return nil, false, err
+	}
+	if !allowedDelete {
+		// Return 404 if caller can't read (don't leak existence), 403 if readable but not deletable.
+		allowedRead, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbGet)
+		if err != nil {
+			return nil, false, err
+		}
+		if !allowedRead {
+			return nil, false, apierrors.NewNotFound(
+				annotationV0.AnnotationKind().GroupVersionResource().GroupResource(), name,
+			)
+		}
+		return nil, false, apierrors.NewForbidden(
+			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
+			name, fmt.Errorf("insufficient permissions"),
+		)
+	}
+
+	err = s.store.Delete(ctx, namespace, name)
+	return nil, false, err
+}
+
+func (s *k8sRESTAdapter) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *internalversion.ListOptions) (runtime.Object, error) {
+	return nil, fmt.Errorf("DeleteCollection for annotation is not available")
+}

--- a/pkg/registry/apps/annotation/lifecycle.go
+++ b/pkg/registry/apps/annotation/lifecycle.go
@@ -1,0 +1,50 @@
+package annotation
+
+import (
+	"context"
+	"time"
+)
+
+// startCleanup starts a background goroutine that periodically runs cleanup on the store
+func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr LifecycleManager, retentionTTL time.Duration) {
+	ctx, cancel := context.WithCancel(parentCtx)
+	a.cleanupCancel = cancel
+
+	a.cleanupWg.Add(1)
+	go func() {
+		defer a.cleanupWg.Done()
+
+		ticker := time.NewTicker(cleanupInterval)
+		defer ticker.Stop()
+
+		a.logger.Info("Starting annotation cleanup loop", "interval", cleanupInterval, "retention", retentionTTL)
+
+		// Run immediately on startup
+		a.runCleanup(ctx, lifecycleMgr)
+
+		for {
+			select {
+			case <-ticker.C:
+				a.runCleanup(ctx, lifecycleMgr)
+			case <-ctx.Done():
+				a.logger.Info("Stopping annotation cleanup loop")
+				return
+			}
+		}
+	}()
+}
+
+// runCleanup executes the cleanup operation with a timeout
+func (a *AppInstaller) runCleanup(ctx context.Context, lifecycleMgr LifecycleManager) {
+	// Set a 5-minute timeout for the cleanup
+	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	deleted, err := lifecycleMgr.Cleanup(cleanupCtx)
+	if err != nil {
+		a.logger.Error("Annotation cleanup failed", "error", err, "duration", time.Since(start))
+	} else if deleted > 0 {
+		a.logger.Info("Annotation cleanup completed", "rows_deleted", deleted, "duration", time.Since(start))
+	}
+}

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -6,24 +6,14 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"sync"
-	"time"
 
 	authtypes "github.com/grafana/authlib/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
 
 	"github.com/grafana/grafana-app-sdk/app"
@@ -38,7 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -78,34 +67,20 @@ func NewAppInstaller(
 		logger: log.New("annotation.app"),
 	}
 
-	var store Store
-	var err error
-	switch cfg.StoreBackend {
-	case "memory":
-		store = NewMemoryStore()
-	case "grpc":
-		store, err = newGRPCStore(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create gRPC store: %w", err)
-		}
-	case "postgres":
-		store, err = newPostgresStore(context.Background(), cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Postgres store: %w", err)
-		}
-	case "legacy-sql":
-		// legacy-sql is the default, but we allow explicitly specifying it for clarity
-		fallthrough
-	default:
-		// Layer 1→2: Wrap old annotations.Repository with sqlAdapter (implements Store interface)
-		store = NewSQLAdapter(service, cleaner, cfg.CleanupSettings)
+	ctx := context.Background()
+
+	// Create the appropriate store backend
+	store, err := createStore(ctx, cfg, service, cleaner)
+	if err != nil {
+		return nil, err
 	}
 
 	// Start background cleanup if the store supports lifecycle management
 	if lifecycleMgr, ok := store.(LifecycleManager); ok {
-		installer.startCleanup(context.Background(), lifecycleMgr, cfg.RetentionTTL)
+		installer.startCleanup(ctx, lifecycleMgr, cfg.RetentionTTL)
 	}
 
+	// Create K8s REST adapter
 	installer.k8sAdapter = &k8sRESTAdapter{
 		store:        store,
 		accessClient: accessClient,
@@ -140,6 +115,24 @@ func NewAppInstaller(
 	installer.AppInstaller = i
 
 	return installer, nil
+}
+
+// createStore creates the appropriate store backend based on configuration
+func createStore(ctx context.Context, cfg Config, service annotations.Repository, cleaner annotations.Cleaner) (Store, error) {
+	switch cfg.StoreBackend {
+	case "memory":
+		return NewMemoryStore(), nil
+	case "grpc":
+		return newGRPCStore(cfg)
+	case "postgres":
+		return newPostgresStore(ctx, cfg)
+	case "legacy-sql":
+		// legacy-sql is the default, but we allow explicitly specifying it for clarity
+		fallthrough
+	default:
+		// Wrap old annotations.Repository with sqlAdapter (implements Store interface)
+		return NewSQLAdapter(service, cleaner, cfg.CleanupSettings), nil
+	}
 }
 
 func newGRPCStore(cfg Config) (Store, error) {
@@ -205,63 +198,6 @@ func newPostgresStore(ctx context.Context, cfg Config) (Store, error) {
 	return NewPostgreSQLStore(ctx, pgCfg)
 }
 
-// startCleanup starts a background goroutine that periodically runs cleanup on the store
-func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr LifecycleManager, retentionTTL time.Duration) {
-	ctx, cancel := context.WithCancel(parentCtx)
-	a.cleanupCancel = cancel
-
-	a.cleanupWg.Add(1)
-	go func() {
-		defer a.cleanupWg.Done()
-
-		ticker := time.NewTicker(cleanupInterval)
-		defer ticker.Stop()
-
-		a.logger.Info("Starting annotation cleanup loop", "interval", cleanupInterval, "retention", retentionTTL)
-
-		// Run immediately on startup
-		a.runCleanup(ctx, lifecycleMgr)
-
-		for {
-			select {
-			case <-ticker.C:
-				a.runCleanup(ctx, lifecycleMgr)
-			case <-ctx.Done():
-				a.logger.Info("Stopping annotation cleanup loop")
-				return
-			}
-		}
-	}()
-}
-
-// runCleanup executes the cleanup operation with a timeout
-func (a *AppInstaller) runCleanup(ctx context.Context, lifecycleMgr LifecycleManager) {
-	// Set a 5-minute timeout for the cleanup
-	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
-	start := time.Now()
-	deleted, err := lifecycleMgr.Cleanup(cleanupCtx)
-	if err != nil {
-		a.logger.Error("Annotation cleanup failed", "error", err, "duration", time.Since(start))
-	} else if deleted > 0 {
-		a.logger.Info("Annotation cleanup completed", "rows_deleted", deleted, "duration", time.Since(start))
-	}
-}
-
-func (a *AppInstaller) GetAuthorizer() authorizer.Authorizer {
-	return authorizer.AuthorizerFunc(func(
-		ctx context.Context, attr authorizer.Attributes,
-	) (authorized authorizer.Decision, reason string, err error) {
-		if !attr.IsResourceRequest() {
-			return authorizer.DecisionNoOpinion, "", nil
-		}
-
-		// Allow all authenticated users; fine-grained authz is handled per-operation in k8sRESTAdapter.
-		return authorizer.DecisionAllow, "", nil
-	})
-}
-
 // GetLegacyStorage returns the K8s REST storage implementation for the annotation resource.
 // Called by the app platform to get the storage backend.
 func (a *AppInstaller) GetLegacyStorage(requested schema.GroupVersionResource) apiserverrest.Storage {
@@ -296,342 +232,4 @@ func (a *AppInstaller) GetLegacyStorage(requested schema.GroupVersionResource) a
 	)
 
 	return a.k8sAdapter
-}
-
-var (
-	_ rest.Scoper               = (*k8sRESTAdapter)(nil)
-	_ rest.SingularNameProvider = (*k8sRESTAdapter)(nil)
-	_ rest.Getter               = (*k8sRESTAdapter)(nil)
-	_ rest.Storage              = (*k8sRESTAdapter)(nil)
-	_ rest.Creater              = (*k8sRESTAdapter)(nil)
-	_ rest.Updater              = (*k8sRESTAdapter)(nil)
-	_ rest.GracefulDeleter      = (*k8sRESTAdapter)(nil)
-)
-
-// k8sRESTAdapter adapts the Store interface to Kubernetes REST storage interface.
-// This layer handles K8s API conventions (fieldSelectors, ListOptions, runtime.Object, etc.)
-// and delegates actual storage operations to the Store interface.
-type k8sRESTAdapter struct {
-	store          Store
-	tableConverter rest.TableConvertor
-	accessClient   authtypes.AccessClient
-	installer      *AppInstaller
-}
-
-func (s *k8sRESTAdapter) New() runtime.Object {
-	return annotationV0.AnnotationKind().ZeroValue()
-}
-
-func (s *k8sRESTAdapter) Destroy() {
-	// Stop background cleanup goroutines
-	if s.installer != nil && s.installer.cleanupCancel != nil {
-		s.installer.cleanupCancel()
-		s.installer.cleanupWg.Wait()
-	}
-
-	// Call Close() on the PostgreSQL store to cleanup connection pool
-	// TODO: add Close() to the Store interface so we can do proper cleanup for other store types
-	if pg, ok := s.store.(*PostgreSQLStore); ok {
-		pg.Close()
-	}
-}
-
-func (s *k8sRESTAdapter) NamespaceScoped() bool {
-	return true // namespace == org
-}
-
-func (s *k8sRESTAdapter) GetSingularName() string {
-	return strings.ToLower(annotationV0.AnnotationKind().Kind())
-}
-
-func (s *k8sRESTAdapter) NewList() runtime.Object {
-	return annotationV0.AnnotationKind().ZeroListValue()
-}
-
-func (s *k8sRESTAdapter) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
-	return s.tableConverter.ConvertToTable(ctx, object, tableOptions)
-}
-
-func (s *k8sRESTAdapter) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	namespace := request.NamespaceValue(ctx)
-
-	opts := ListOptions{}
-	if options.FieldSelector != nil {
-		// Parse K8s field selectors into Store ListOptions
-		for _, r := range options.FieldSelector.Requirements() {
-			switch r.Field {
-			case "spec.dashboardUID":
-				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
-					opts.DashboardUID = r.Value
-				} else {
-					return nil, fmt.Errorf("unsupported operator %s for spec.dashboardUID (only = supported)", r.Operator)
-				}
-
-			case "spec.panelID":
-				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
-					panelID, err := strconv.ParseInt(r.Value, 10, 64)
-					if err != nil {
-						return nil, fmt.Errorf("invalid panelID value %q: %w", r.Value, err)
-					}
-					opts.PanelID = panelID
-				} else {
-					return nil, fmt.Errorf("unsupported operator %s for spec.panelID (only = supported)", r.Operator)
-				}
-			case "spec.time":
-				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
-					from, err := strconv.ParseInt(r.Value, 10, 64)
-					if err != nil {
-						return nil, fmt.Errorf("invalid time value %q: %w", r.Value, err)
-					}
-					opts.From = from
-				} else {
-					return nil, fmt.Errorf("unsupported operator %s for spec.from (only = supported)", r.Operator)
-				}
-			case "spec.timeEnd":
-				if r.Operator == selection.Equals || r.Operator == selection.DoubleEquals {
-					to, err := strconv.ParseInt(r.Value, 10, 64)
-					if err != nil {
-						return nil, fmt.Errorf("invalid timeEnd value %q: %w", r.Value, err)
-					}
-					opts.To = to
-				} else {
-					return nil, fmt.Errorf("unsupported operator %s for spec.to (only = supported)", r.Operator)
-				}
-			default:
-				return nil, fmt.Errorf("unsupported field selector: %s", r.Field)
-			}
-		}
-	}
-
-	opts.Limit = 100
-	if options.Limit > 0 {
-		opts.Limit = options.Limit
-	}
-
-	// Extract continue token from request
-	if options.Continue != "" {
-		opts.Continue = options.Continue
-	}
-
-	result, err := s.store.List(ctx, namespace, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: post-fetch filtering breaks pagination - cursor advances by opts.Limit regardless of authz results.
-	filtered := make([]annotationV0.Annotation, 0, len(result.Items))
-	for _, anno := range result.Items {
-		allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, &anno, utils.VerbList)
-		if err != nil {
-			return nil, err
-		}
-		if allowed {
-			filtered = append(filtered, anno)
-		}
-	}
-
-	return &annotationV0.AnnotationList{
-		Items:    filtered,
-		ListMeta: metav1.ListMeta{Continue: result.Continue},
-	}, nil
-}
-
-func (s *k8sRESTAdapter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	namespace := request.NamespaceValue(ctx)
-
-	annotation, err := s.store.Get(ctx, namespace, name)
-	if err != nil {
-		return nil, err
-	}
-
-	allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbGet)
-	if err != nil {
-		return nil, err
-	}
-	if !allowed {
-		// Return NotFound to avoid leaking existence.
-		return nil, apierrors.NewNotFound(
-			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(), name,
-		)
-	}
-
-	return annotation, nil
-}
-
-func (s *k8sRESTAdapter) Create(ctx context.Context,
-	obj runtime.Object,
-	createValidation rest.ValidateObjectFunc,
-	options *metav1.CreateOptions,
-) (runtime.Object, error) {
-	annotation, ok := obj.(*annotationV0.Annotation)
-	if !ok {
-		return nil, fmt.Errorf("expected annotation")
-	}
-
-	namespace := request.NamespaceValue(ctx)
-
-	allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbCreate)
-	if err != nil {
-		return nil, err
-	}
-	if !allowed {
-		return nil, apierrors.NewForbidden(
-			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
-			annotation.Name, fmt.Errorf("insufficient permissions"),
-		)
-	}
-
-	if annotation.Name == "" && annotation.GenerateName == "" {
-		return nil, apierrors.NewBadRequest("metadata.name or metadata.generateName is required")
-	}
-
-	if annotation.Name == "" && annotation.GenerateName != "" {
-		annotation.Name = annotation.GenerateName + util.GenerateShortUID()
-	}
-
-	return s.store.Create(ctx, annotation)
-}
-
-func (s *k8sRESTAdapter) Update(ctx context.Context,
-	name string,
-	objInfo rest.UpdatedObjectInfo,
-	createValidation rest.ValidateObjectFunc,
-	updateValidation rest.ValidateObjectUpdateFunc,
-	forceAllowCreate bool,
-	options *metav1.UpdateOptions,
-) (runtime.Object, bool, error) {
-	namespace := request.NamespaceValue(ctx)
-
-	// Fetch the existing annotation for patch merging and to verify authz on the pre-update resource.
-	existing, err := s.store.Get(ctx, namespace, name)
-	if err != nil {
-		return nil, false, err
-	}
-
-	obj, err := objInfo.UpdatedObject(ctx, existing)
-	if err != nil {
-		return nil, false, err
-	}
-
-	resource, ok := obj.(*annotationV0.Annotation)
-	if !ok {
-		return nil, false, fmt.Errorf("expected annotation")
-	}
-
-	if resource.Name != name {
-		return nil, false, fmt.Errorf("name in URL does not match name in body")
-	}
-
-	if resource.Namespace != namespace {
-		return nil, false, fmt.Errorf("namespace in URL does not match namespace in body")
-	}
-
-	// Check authz on both existing and new body: prevents privilege escalation via scope changes.
-	allowed, err := canAccessAnnotation(ctx, s.accessClient, namespace, existing, utils.VerbUpdate)
-	if err != nil {
-		return nil, false, err
-	}
-	if !allowed {
-		return nil, false, apierrors.NewForbidden(
-			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
-			existing.Name, fmt.Errorf("insufficient permissions"),
-		)
-	}
-	allowed, err = canAccessAnnotation(ctx, s.accessClient, namespace, resource, utils.VerbUpdate)
-	if err != nil {
-		return nil, false, err
-	}
-	if !allowed {
-		return nil, false, apierrors.NewForbidden(
-			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
-			resource.Name, fmt.Errorf("insufficient permissions"),
-		)
-	}
-
-	updated, err := s.store.Update(ctx, resource)
-	if err != nil {
-		return nil, false, err
-	}
-
-	return updated, false, nil
-}
-
-func (s *k8sRESTAdapter) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	namespace := request.NamespaceValue(ctx)
-
-	annotation, err := s.store.Get(ctx, namespace, name)
-	if err != nil {
-		return nil, false, err
-	}
-
-	allowedDelete, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbDelete)
-	if err != nil {
-		return nil, false, err
-	}
-	if !allowedDelete {
-		// Return 404 if caller can't read (don't leak existence), 403 if readable but not deletable.
-		allowedRead, err := canAccessAnnotation(ctx, s.accessClient, namespace, annotation, utils.VerbGet)
-		if err != nil {
-			return nil, false, err
-		}
-		if !allowedRead {
-			return nil, false, apierrors.NewNotFound(
-				annotationV0.AnnotationKind().GroupVersionResource().GroupResource(), name,
-			)
-		}
-		return nil, false, apierrors.NewForbidden(
-			annotationV0.AnnotationKind().GroupVersionResource().GroupResource(),
-			name, fmt.Errorf("insufficient permissions"),
-		)
-	}
-
-	err = s.store.Delete(ctx, namespace, name)
-	return nil, false, err
-}
-
-func (s *k8sRESTAdapter) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *internalversion.ListOptions) (runtime.Object, error) {
-	return nil, fmt.Errorf("DeleteCollection for annotation is not available")
-}
-
-// canAccessAnnotation checks that the caller has permission to perform verb on anno,
-// using the legacy annotation authorization model (dashboard-scoped or org-scoped).
-func canAccessAnnotation(ctx context.Context, accessClient authtypes.AccessClient, namespace string, anno *annotationV0.Annotation, verb string) (bool, error) {
-	if anno == nil {
-		return false, apierrors.NewBadRequest("annotation must not be nil")
-	}
-
-	authInfo, ok := authtypes.AuthInfoFrom(ctx)
-	if !ok {
-		return false, apierrors.NewUnauthorized("no identity found for request")
-	}
-
-	var checkReq authtypes.CheckRequest
-
-	if anno.Spec.DashboardUID == nil || *anno.Spec.DashboardUID == "" {
-		// Org-level annotation: scope is annotations:type:organization.
-		checkReq = authtypes.CheckRequest{
-			Verb:      verb,
-			Group:     "annotation.grafana.app",
-			Resource:  "annotations",
-			Namespace: namespace,
-			Name:      "organization",
-		}
-	} else {
-		// Dashboard annotation: use dashboard.grafana.app/annotations virtual resource,
-		// which maps to annotation actions scoped to dashboards:uid:<dashboardUID>.
-		checkReq = authtypes.CheckRequest{
-			Verb:      verb,
-			Group:     "dashboard.grafana.app",
-			Resource:  "annotations",
-			Namespace: namespace,
-			Name:      *anno.Spec.DashboardUID,
-		}
-	}
-
-	resp, err := accessClient.Check(ctx, authInfo, checkReq, "")
-	if err != nil {
-		return false, fmt.Errorf("authz check failed: %w", err)
-	}
-
-	return resp.Allowed, nil
 }


### PR DESCRIPTION
This PR cleans up the annotation app's `register.go` file as it was starting to get large and was not entirely related to app initialization and registration anymore. The changes include:
* K8s REST logic moved to `k8s_adapter.go`
* Authz logic moved to `authz.go`
* Cleanup lifecycle logic moved to `lifecycle.go`