### PR TITLE
OpenFeature: Add client-side response cache for flag evaluations  

### DIFF
--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -273,6 +273,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.15.1 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
+	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	github.com/redis/go-redis/v9 v9.14.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/apps/advisor/go.sum
+++ b/apps/advisor/go.sum
@@ -1023,6 +1023,8 @@ github.com/prometheus/prometheus v0.303.1 h1:He/2jRE6sB23Ew38AIoR1WRR3fCMgPlJA2E
 github.com/prometheus/prometheus v0.303.1/go.mod h1:WEq2ogBPZoLjj9x5K67VEk7ECR0nRD9XCjaOt1lsYck=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
+github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.14.0 h1:u4tNCjXOyzfgeLN+vAZaW1xUooqWDqVEsZN0U01jfAE=
 github.com/redis/go-redis/v9 v9.14.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=

--- a/apps/dashvalidator/go.mod
+++ b/apps/dashvalidator/go.mod
@@ -228,6 +228,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.15.1 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
+	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	github.com/redis/go-redis/v9 v9.14.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/apps/dashvalidator/go.sum
+++ b/apps/dashvalidator/go.sum
@@ -1029,6 +1029,8 @@ github.com/protocolbuffers/txtpbfmt v0.0.0-20251124094003-fcb97cc64c7b h1:fPVI9E
 github.com/protocolbuffers/txtpbfmt v0.0.0-20251124094003-fcb97cc64c7b/go.mod h1:JSbkp0BviKovYYt9XunS95M3mLPibE9bGg+Y95DsEEY=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
+github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.14.0 h1:u4tNCjXOyzfgeLN+vAZaW1xUooqWDqVEsZN0U01jfAE=
 github.com/redis/go-redis/v9 v9.14.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=

--- a/apps/plugins/go.mod
+++ b/apps/plugins/go.mod
@@ -187,6 +187,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.15.1 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
+	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/apps/plugins/go.sum
+++ b/apps/plugins/go.sum
@@ -460,6 +460,8 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
+github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -328,6 +328,7 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/puzpuzpuz/xsync/v2 v2.5.1 // indirect
+	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect

--- a/apps/quotas/go.sum
+++ b/apps/quotas/go.sum
@@ -1058,6 +1058,8 @@ github.com/protocolbuffers/txtpbfmt v0.0.0-20251124094003-fcb97cc64c7b h1:fPVI9E
 github.com/protocolbuffers/txtpbfmt v0.0.0-20251124094003-fcb97cc64c7b/go.mod h1:JSbkp0BviKovYYt9XunS95M3mLPibE9bGg+Y95DsEEY=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
+github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.14.0 h1:u4tNCjXOyzfgeLN+vAZaW1xUooqWDqVEsZN0U01jfAE=
 github.com/redis/go-redis/v9 v9.14.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2167,6 +2167,8 @@ enable =
 enable_api = true
 provider = static
 url =
+# cache_ttl sets the TTL for client-side caching of flag evaluation responses. Set to 0 to disable.
+cache_ttl = 1m
 
 [feature_toggles.openfeature.context]
 # This is EXPERIMENTAL. Please, do not use this section

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/prometheus/common v0.67.5 // @grafana/alerting-backend
 	github.com/prometheus/prometheus v0.303.1 // @grafana/alerting-backend
 	github.com/prometheus/sigv4 v0.1.2 // @grafana/alerting-backend
-	github.com/puzpuzpuz/xsync/v4 v4.2.0 // @grafana/grafana-backend-group
+	github.com/puzpuzpuz/xsync/v4 v4.4.0 // @grafana/grafana-backend-group
 	github.com/redis/go-redis/v9 v9.14.0 // @grafana/alerting-backend
 	github.com/robfig/cron/v3 v3.0.1 // @grafana/grafana-backend-group
 	github.com/rs/cors v1.11.1 // @grafana/identity-access-team

--- a/go.sum
+++ b/go.sum
@@ -2332,8 +2332,8 @@ github.com/protocolbuffers/txtpbfmt v0.0.0-20251124094003-fcb97cc64c7b h1:fPVI9E
 github.com/protocolbuffers/txtpbfmt v0.0.0-20251124094003-fcb97cc64c7b/go.mod h1:JSbkp0BviKovYYt9XunS95M3mLPibE9bGg+Y95DsEEY=
 github.com/puzpuzpuz/xsync/v2 v2.5.1 h1:mVGYAvzDSu52+zaGyNjC+24Xw2bQi3kTr4QJ6N9pIIU=
 github.com/puzpuzpuz/xsync/v2 v2.5.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
-github.com/puzpuzpuz/xsync/v4 v4.2.0 h1:dlxm77dZj2c3rxq0/XNvvUKISAmovoXF4a4qM6Wvkr0=
-github.com/puzpuzpuz/xsync/v4 v4.2.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/quagmt/udecimal v1.9.0 h1:TLuZiFeg0HhS6X8VDa78Y6XTaitZZfh+z5q4SXMzpDQ=
 github.com/quagmt/udecimal v1.9.0/go.mod h1:ScmJ/xTGZcEoYiyMMzgDLn79PEJHcMBiJ4NNRT3FirA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/infra/features/cache.go
+++ b/pkg/infra/features/cache.go
@@ -2,6 +2,7 @@ package features
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -71,6 +72,7 @@ func (c *cachedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 func entryToResponse(e *cachedEntry) *http.Response {
 	return &http.Response{
 		StatusCode: e.status,
+		Status:     fmt.Sprintf("%d %s", e.status, http.StatusText(e.status)),
 		Header:     e.headers.Clone(),
 		Body:       io.NopCloser(bytes.NewReader(e.body)),
 	}

--- a/pkg/infra/features/cache.go
+++ b/pkg/infra/features/cache.go
@@ -1,0 +1,85 @@
+package features
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/puzpuzpuz/xsync/v4"
+)
+
+type cachedEntry struct {
+	body    []byte
+	status  int
+	headers http.Header
+	expiry  time.Time
+}
+
+type cachedRoundTripper struct {
+	next  http.RoundTripper
+	cache *xsync.Map[uint64, *cachedEntry]
+	ttl   time.Duration
+}
+
+func (c *cachedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	key := xxhash.Sum64String(req.URL.String() + string(bodyBytes))
+
+	if entry, ok := c.cache.Load(key); ok && time.Now().Before(entry.expiry) {
+		return entryToResponse(entry), nil
+	}
+
+	// TODO: concurrent requests with the same key all miss the cache and hit the backend. Add singleflight if this becomes a problem.
+	resp, err := c.next.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		defer func() { _ = resp.Body.Close() }()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		entry := &cachedEntry{
+			body:    respBody,
+			status:  resp.StatusCode,
+			headers: resp.Header.Clone(),
+			expiry:  time.Now().Add(c.ttl),
+		}
+		c.cache.Store(key, entry)
+
+		return entryToResponse(entry), nil
+	}
+
+	return resp, nil
+}
+
+func entryToResponse(e *cachedEntry) *http.Response {
+	return &http.Response{
+		StatusCode: e.status,
+		Header:     e.headers.Clone(),
+		Body:       io.NopCloser(bytes.NewReader(e.body)),
+	}
+}
+
+func newCacheMiddleware(ttl time.Duration) sdkhttpclient.Middleware {
+	cache := xsync.NewMap[uint64, *cachedEntry]()
+
+	return sdkhttpclient.MiddlewareFunc(func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return &cachedRoundTripper{next: next, cache: cache, ttl: ttl}
+	})
+}

--- a/pkg/infra/features/cache_test.go
+++ b/pkg/infra/features/cache_test.go
@@ -1,0 +1,115 @@
+package features
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTransport is an http.RoundTripper that returns a fixed response and counts calls.
+type fakeTransport struct {
+	calls  int
+	status int
+}
+
+func (f *fakeTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	f.calls++
+	return &http.Response{
+		StatusCode: f.status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"key":"myFlag","value":true,"reason":"STATIC","variant":"true"}`)),
+	}, nil
+}
+
+func newTestRoundTripper(ttl time.Duration, next http.RoundTripper) *cachedRoundTripper {
+	return &cachedRoundTripper{
+		next:  next,
+		cache: xsync.NewMap[uint64, *cachedEntry](),
+		ttl:   ttl,
+	}
+}
+
+func makeReq(t *testing.T, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	return req
+}
+
+func TestCachedRoundTripperCacheHit(t *testing.T) {
+	backend := &fakeTransport{status: 200}
+	rt := newTestRoundTripper(time.Minute, backend)
+
+	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, backend.calls)
+	assert.Equal(t, 200, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"key":"myFlag","value":true,"reason":"STATIC","variant":"true"}`, string(body))
+}
+
+func TestCachedRoundTripperExpiredEntry(t *testing.T) {
+	backend := &fakeTransport{status: 200}
+	rt := newTestRoundTripper(-time.Second, backend) // negative TTL means entries are already expired on insertion
+
+	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, backend.calls)
+	assert.Equal(t, 200, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"key":"myFlag","value":true,"reason":"STATIC","variant":"true"}`, string(body))
+}
+
+func TestCachedRoundTripperNon2xxNotCached(t *testing.T) {
+	backend := &fakeTransport{status: 429}
+	rt := newTestRoundTripper(time.Minute, backend)
+
+	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, backend.calls)
+	assert.Equal(t, 429, resp.StatusCode)
+}
+
+func TestCachedRoundTripperDifferentFlagsCachedIndependently(t *testing.T) {
+	backend := &fakeTransport{status: 200}
+	rt := newTestRoundTripper(time.Minute, backend)
+
+	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/flagA", `{"context":{}}`))
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/flagB", `{"context":{}}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, backend.calls)
+}
+
+func TestCachedRoundTripperDifferentTenantsCachedIndependently(t *testing.T) {
+	backend := &fakeTransport{status: 200}
+	rt := newTestRoundTripper(time.Minute, backend)
+
+	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
+	require.NoError(t, err)
+	_, err = rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-2"}}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, backend.calls)
+}

--- a/pkg/infra/features/cache_test.go
+++ b/pkg/infra/features/cache_test.go
@@ -46,15 +46,17 @@ func TestCachedRoundTripperCacheHit(t *testing.T) {
 	backend := &fakeTransport{status: 200}
 	rt := newTestRoundTripper(time.Minute, backend)
 
-	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
+	resp1, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp1.Body.Close() }()
 
-	resp, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
+	resp2, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
 
 	assert.Equal(t, 1, backend.calls)
-	assert.Equal(t, 200, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
+	assert.Equal(t, 200, resp2.StatusCode)
+	body, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"key":"myFlag","value":true,"reason":"STATIC","variant":"true"}`, string(body))
 }
@@ -63,15 +65,17 @@ func TestCachedRoundTripperExpiredEntry(t *testing.T) {
 	backend := &fakeTransport{status: 200}
 	rt := newTestRoundTripper(-time.Second, backend) // negative TTL means entries are already expired on insertion
 
-	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	resp1, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp1.Body.Close() }()
 
-	resp, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	resp2, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
 
 	assert.Equal(t, 2, backend.calls)
-	assert.Equal(t, 200, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
+	assert.Equal(t, 200, resp2.StatusCode)
+	body, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"key":"myFlag","value":true,"reason":"STATIC","variant":"true"}`, string(body))
 }
@@ -80,24 +84,29 @@ func TestCachedRoundTripperNon2xxNotCached(t *testing.T) {
 	backend := &fakeTransport{status: 429}
 	rt := newTestRoundTripper(time.Minute, backend)
 
-	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	resp1, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp1.Body.Close() }()
 
-	resp, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
+	resp2, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
 
 	assert.Equal(t, 2, backend.calls)
-	assert.Equal(t, 429, resp.StatusCode)
+	assert.Equal(t, 429, resp2.StatusCode)
 }
 
 func TestCachedRoundTripperDifferentFlagsCachedIndependently(t *testing.T) {
 	backend := &fakeTransport{status: 200}
 	rt := newTestRoundTripper(time.Minute, backend)
 
-	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/flagA", `{"context":{}}`))
+	resp1, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/flagA", `{"context":{}}`))
 	require.NoError(t, err)
-	_, err = rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/flagB", `{"context":{}}`))
+	defer func() { _ = resp1.Body.Close() }()
+
+	resp2, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/flagB", `{"context":{}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
 
 	assert.Equal(t, 2, backend.calls)
 }
@@ -106,10 +115,13 @@ func TestCachedRoundTripperDifferentTenantsCachedIndependently(t *testing.T) {
 	backend := &fakeTransport{status: 200}
 	rt := newTestRoundTripper(time.Minute, backend)
 
-	_, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
+	resp1, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-1"}}`))
 	require.NoError(t, err)
-	_, err = rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-2"}}`))
+	defer func() { _ = resp1.Body.Close() }()
+
+	resp2, err := rt.RoundTrip(makeReq(t, "http://localhost/ofrep/v1/evaluate/flags/myFlag", `{"context":{"namespace":"stack-2"}}`))
 	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
 
 	assert.Equal(t, 2, backend.calls)
 }

--- a/pkg/infra/features/client.go
+++ b/pkg/infra/features/client.go
@@ -22,6 +22,8 @@ type HTTPClientOptions struct {
 	InsecureSkipVerify bool
 	// Middlewares to apply to the HTTP client
 	Middlewares []sdkhttpclient.Middleware
+	// CacheTTL enables response caching with the given TTL. Zero disables caching.
+	CacheTTL time.Duration
 }
 
 // TokenExchangeConfig holds all authentication configuration for token exchange.
@@ -41,6 +43,11 @@ func CreateHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		timeout = 10 * time.Second
 	}
 
+	middlewares := opts.Middlewares
+	if opts.CacheTTL > 0 {
+		middlewares = append(middlewares, newCacheMiddleware(opts.CacheTTL))
+	}
+
 	options := sdkhttpclient.Options{
 		TLS: &sdkhttpclient.TLSOptions{
 			InsecureSkipVerify: opts.InsecureSkipVerify,
@@ -48,7 +55,7 @@ func CreateHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		Timeouts: &sdkhttpclient.TimeoutOptions{
 			Timeout: timeout,
 		},
-		Middlewares: opts.Middlewares,
+		Middlewares: middlewares,
 	}
 
 	httpcli, err := sdkhttpclient.NewProvider().New(options)

--- a/pkg/infra/features/client.go
+++ b/pkg/infra/features/client.go
@@ -45,7 +45,7 @@ func CreateHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 
 	middlewares := opts.Middlewares
 	if opts.CacheTTL > 0 {
-		middlewares = append(middlewares, newCacheMiddleware(opts.CacheTTL))
+		middlewares = append([]sdkhttpclient.Middleware{newCacheMiddleware(opts.CacheTTL)}, middlewares...)
 	}
 
 	options := sdkhttpclient.Options{

--- a/pkg/infra/features/go.mod
+++ b/pkg/infra/features/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.65.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect

--- a/pkg/infra/features/go.mod
+++ b/pkg/infra/features/go.mod
@@ -3,15 +3,18 @@ module github.com/grafana/grafana/pkg/infra/features
 go 1.25.8
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/grafana/authlib v0.0.0-20260316143530-e1d123886039
 	github.com/grafana/grafana-plugin-sdk-go v0.290.1
 	github.com/open-feature/go-sdk v1.17.1
 	github.com/open-feature/go-sdk-contrib/providers/ofrep v0.1.7
+	github.com/puzpuzpuz/xsync/v4 v4.4.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -26,11 +29,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
-	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.65.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
@@ -48,4 +51,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/infra/features/go.sum
+++ b/pkg/infra/features/go.sum
@@ -131,6 +131,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
+github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -80,7 +80,10 @@ func createRemoteProvider(cfg *setting.Cfg) (openfeature.FeatureProvider, error)
 	httpcli, err := features.CreateHTTPClientForProvider(
 		cfg.OpenFeature.ProviderType,
 		authConfig,
-		features.HTTPClientOptions{InsecureSkipVerify: true},
+		features.HTTPClientOptions{
+			InsecureSkipVerify: true,
+			CacheTTL:           cfg.OpenFeature.CacheTTL,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/setting/setting_openfeature.go
+++ b/pkg/setting/setting_openfeature.go
@@ -3,6 +3,7 @@ package setting
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/grafana/grafana/pkg/infra/features"
 )
@@ -25,6 +26,7 @@ type OpenFeatureSettings struct {
 	URL          *url.URL
 	TargetingKey string
 	ContextAttrs map[string]string
+	CacheTTL     time.Duration
 }
 
 func (cfg *Cfg) readOpenFeatureSettings() error {
@@ -87,5 +89,7 @@ func (cfg *Cfg) readOpenFeatureSettings() error {
 	}
 
 	cfg.OpenFeature.ContextAttrs = attrs
+
+	cfg.OpenFeature.CacheTTL = config.Key("cache_ttl").MustDuration(time.Minute)
 	return nil
 }


### PR DESCRIPTION
Flag evaluations via the OFREP provider hit the features service on every call. Under load (e.g. `kubernetesTeamSync` evaluated on every auth event) this causes 429 errors from the features service.                                         
                                                                                  
This adds a caching http.RoundTripper middleware that caches successful responses by URL+body hash (so responses don't leak between tenants) with a configurable TTL (default 1 min, set via `cache_ttl` in `[feature_toggles.openfeature]` section of config.ini).                       
Non-2xx responses are not cached.