### PR TITLE
Alerting: Move filters to sidebar alerts activity

### DIFF
--- a/public/app/features/alerting/unified/triage/constants.ts
+++ b/public/app/features/alerting/unified/triage/constants.ts
@@ -33,11 +33,21 @@ export const METRIC_NAME = config.unifiedAlerting.stateHistory?.prometheusMetric
 export const SERVICE_FILTER_LABEL_KEYS = ['service', 'service_name'] as const;
 export const CLUSTER_FILTER_LABEL_KEYS = ['cluster', 'cluster_name'] as const;
 export const NAMESPACE_FILTER_LABEL_KEYS = ['namespace', 'exported_namespace', 'namespace_extracted'] as const;
+export const SEVERITY_FILTER_LABEL_KEYS = [
+  'severity',
+  'priority',
+  'level',
+  'loglevel',
+  'logLevel',
+  'lvl',
+  'detected_level',
+] as const;
 
 export const COMBINED_FILTER_LABEL_KEYS = {
   service: SERVICE_FILTER_LABEL_KEYS,
   cluster: CLUSTER_FILTER_LABEL_KEYS,
   namespace: NAMESPACE_FILTER_LABEL_KEYS,
+  severity: SEVERITY_FILTER_LABEL_KEYS,
 } as const;
 
 /**

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -11,7 +11,7 @@ import { COMBINED_FILTER_LABEL_KEYS } from '../../constants';
 import { countInstances } from '../SummaryStats';
 import { summaryInstanceCountQuery } from '../queries';
 import { type LabelStats, useLabelsBreakdown } from '../useLabelsBreakdown';
-import { addOrReplaceFilter, removeFilter, useFilterValue, useQueryFilter } from '../utils';
+import { addOrReplaceFilter, removeFilter, useFilterValue, useQueryFilter, useRegexFilterValue } from '../utils';
 
 import { AllLabelsContent } from './LabelsContent';
 import { SeverityFilter } from './SeverityFilter';
@@ -29,7 +29,7 @@ export function LabelsColumn() {
   const [open, toggleOpen] = useToggle(true);
   const [labelFilter, setLabelFilter] = useState('');
   const styles = useStyles2(getStyles);
-  const activeSeverityValue = useFilterValue('severity');
+  const activeSeverityValue = useRegexFilterValue('severity');
   const activeSidebarFilterValues: Record<SidebarFilterKey, string | undefined> = {
     alertname: useFilterValue('alertname'),
     grafana_folder: useFilterValue('grafana_folder'),

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -151,8 +151,10 @@ function StateFilter() {
   );
 }
 
-type SidebarFilterKey = 'service' | 'team' | 'namespace';
+type SidebarFilterKey = 'alertname' | 'grafana_folder' | 'service' | 'team' | 'namespace';
 const SIDEBAR_FILTERS: Array<{ key: SidebarFilterKey; label: string }> = [
+  { key: 'alertname', label: 'Rule name' },
+  { key: 'grafana_folder', label: 'Folder' },
   { key: 'service', label: 'Service' },
   { key: 'team', label: 'Team' },
   { key: 'namespace', label: 'Namespace' },

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -7,12 +7,14 @@ import { Trans, t } from '@grafana/i18n';
 import { useQueryRunner, useSceneContext } from '@grafana/scenes-react';
 import { FilterInput, Icon, ScrollContainer, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
+import { COMBINED_FILTER_LABEL_KEYS } from '../../constants';
 import { countInstances } from '../SummaryStats';
 import { summaryInstanceCountQuery } from '../queries';
-import { useLabelsBreakdown } from '../useLabelsBreakdown';
+import { type LabelStats, useLabelsBreakdown } from '../useLabelsBreakdown';
 import { addOrReplaceFilter, removeFilter, useFilterValue, useQueryFilter } from '../utils';
 
 import { AllLabelsContent } from './LabelsContent';
+import { SeverityFilter } from './SeverityFilter';
 
 export const LABELS_COLUMN_WIDTH = 250;
 const COLLAPSED_WIDTH = 36;
@@ -61,6 +63,24 @@ export function LabelsColumn() {
               <StateFilter />
             </div>
             <div className={styles.divider} />
+            <div className={styles.section}>
+              <Text weight="medium" variant="bodySmall" color="secondary">
+                <Trans i18nKey="alerting.triage.severity-filter-title">Severity</Trans>
+              </Text>
+              <SeverityFilter labels={labels} />
+            </div>
+            <div className={styles.divider} />
+            {SIDEBAR_FILTERS.map(({ key, label }) => (
+              <div key={key}>
+                <div className={styles.section}>
+                  <Text weight="medium" variant="bodySmall" color="secondary">
+                    {label}
+                  </Text>
+                  <SidebarFilterGroup labels={labels} filterKey={key} />
+                </div>
+                <div className={styles.divider} />
+              </div>
+            ))}
             <div className={styles.labelsSectionHeader}>
               <Text weight="medium" variant="bodySmall" color="secondary">
                 <Trans i18nKey="alerting.triage.labels-column-title">Labels</Trans>
@@ -119,6 +139,84 @@ function StateFilter() {
       </button>
     </Stack>
   );
+}
+
+type SidebarFilterKey = 'service' | 'team' | 'namespace';
+const SIDEBAR_FILTERS: Array<{ key: SidebarFilterKey; label: string }> = [
+  { key: 'service', label: 'Service' },
+  { key: 'team', label: 'Team' },
+  { key: 'namespace', label: 'Namespace' },
+];
+const sidebarCollator = new Intl.Collator();
+const MAX_VISIBLE_VALUES = 8;
+
+function SidebarFilterGroup({ labels, filterKey }: { labels: LabelStats[]; filterKey: SidebarFilterKey }) {
+  const styles = useStyles2(getStyles);
+  const sceneContext = useSceneContext();
+  const activeValue = useFilterValue(filterKey);
+  const values = getSidebarFilterValues(labels, filterKey);
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column" gap={0.25}>
+      {values.slice(0, MAX_VISIBLE_VALUES).map((value) => {
+        const isActive = activeValue === value.value;
+        return (
+          <button
+            key={value.value}
+            className={cx(styles.stateButton, isActive && styles.stateButtonActive)}
+            onClick={() => {
+              if (isActive) {
+                removeFilter(sceneContext, filterKey);
+              } else {
+                addOrReplaceFilter(sceneContext, filterKey, '=', value.value);
+              }
+            }}
+          >
+            <span className={styles.stateLabel}>{value.value}</span>
+            <span className={styles.stateCount}>{value.firing + value.pending}</span>
+          </button>
+        );
+      })}
+    </Stack>
+  );
+}
+
+function getSidebarFilterValues(labels: LabelStats[], key: SidebarFilterKey) {
+  const keys = key === 'service' || key === 'namespace' ? COMBINED_FILTER_LABEL_KEYS[key] : ([key] as const);
+  const merged = new Map<string, { value: string; firing: number; pending: number; total: number }>();
+
+  for (const labelKey of keys) {
+    const stat = labels.find((label) => label.key === labelKey);
+    if (!stat) {
+      continue;
+    }
+    for (const value of stat.values) {
+      const existing = merged.get(value.value);
+      if (!existing) {
+        merged.set(value.value, {
+          value: value.value,
+          firing: value.firing,
+          pending: value.pending,
+          total: value.firing + value.pending,
+        });
+      } else {
+        existing.firing += value.firing;
+        existing.pending += value.pending;
+        existing.total += value.firing + value.pending;
+      }
+    }
+  }
+
+  return Array.from(merged.values()).sort((a, b) => {
+    if (b.total !== a.total) {
+      return b.total - a.total;
+    }
+    return sidebarCollator.compare(a.value, b.value);
+  });
 }
 
 /**

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -15,6 +15,7 @@ import { addOrReplaceFilter, removeFilter, useFilterValue, useQueryFilter } from
 
 import { AllLabelsContent } from './LabelsContent';
 import { SeverityFilter } from './SeverityFilter';
+import { canonicalSeverity } from './severity';
 
 export const LABELS_COLUMN_WIDTH = 250;
 const COLLAPSED_WIDTH = 36;
@@ -28,6 +29,11 @@ export function LabelsColumn() {
   const [open, toggleOpen] = useToggle(true);
   const [labelFilter, setLabelFilter] = useState('');
   const styles = useStyles2(getStyles);
+  const showSeverityFilter = hasSeverityFilterValues(labels);
+  const visibleSidebarFilters = SIDEBAR_FILTERS.map((filter) => ({
+    ...filter,
+    values: getSidebarFilterValues(labels, filter.key),
+  })).filter((filter) => filter.values.length > 0);
 
   return (
     <div className={cx(styles.column, !open && styles.columnCollapsed)}>
@@ -63,20 +69,24 @@ export function LabelsColumn() {
               <StateFilter />
             </div>
             <div className={styles.divider} />
-            <div className={styles.section}>
-              <Text weight="medium" variant="bodySmall" color="secondary">
-                <Trans i18nKey="alerting.triage.severity-filter-title">Severity</Trans>
-              </Text>
-              <SeverityFilter labels={labels} />
-            </div>
-            <div className={styles.divider} />
-            {SIDEBAR_FILTERS.map(({ key, label }) => (
+            {showSeverityFilter && (
+              <>
+                <div className={styles.section}>
+                  <Text weight="medium" variant="bodySmall" color="secondary">
+                    <Trans i18nKey="alerting.triage.severity-filter-title">Severity</Trans>
+                  </Text>
+                  <SeverityFilter labels={labels} />
+                </div>
+                <div className={styles.divider} />
+              </>
+            )}
+            {visibleSidebarFilters.map(({ key, label, values }) => (
               <div key={key}>
                 <div className={styles.section}>
                   <Text weight="medium" variant="bodySmall" color="secondary">
                     {label}
                   </Text>
-                  <SidebarFilterGroup labels={labels} filterKey={key} />
+                  <SidebarFilterGroup filterKey={key} values={values} />
                 </div>
                 <div className={styles.divider} />
               </div>
@@ -150,15 +160,17 @@ const SIDEBAR_FILTERS: Array<{ key: SidebarFilterKey; label: string }> = [
 const sidebarCollator = new Intl.Collator();
 const MAX_VISIBLE_VALUES = 8;
 
-function SidebarFilterGroup({ labels, filterKey }: { labels: LabelStats[]; filterKey: SidebarFilterKey }) {
+type SidebarFilterValue = {
+  value: string;
+  firing: number;
+  pending: number;
+  total: number;
+};
+
+function SidebarFilterGroup({ filterKey, values }: { filterKey: SidebarFilterKey; values: SidebarFilterValue[] }) {
   const styles = useStyles2(getStyles);
   const sceneContext = useSceneContext();
   const activeValue = useFilterValue(filterKey);
-  const values = getSidebarFilterValues(labels, filterKey);
-
-  if (values.length === 0) {
-    return null;
-  }
 
   return (
     <Stack direction="column" gap={0.25}>
@@ -185,9 +197,17 @@ function SidebarFilterGroup({ labels, filterKey }: { labels: LabelStats[]; filte
   );
 }
 
-function getSidebarFilterValues(labels: LabelStats[], key: SidebarFilterKey) {
+function hasSeverityFilterValues(labels: LabelStats[]): boolean {
+  return COMBINED_FILTER_LABEL_KEYS.severity.some((key) =>
+    labels.some(
+      (label) => label.key === key && label.values.some((value) => canonicalSeverity(value.value) !== undefined)
+    )
+  );
+}
+
+function getSidebarFilterValues(labels: LabelStats[], key: SidebarFilterKey): SidebarFilterValue[] {
   const keys = key === 'service' || key === 'namespace' ? COMBINED_FILTER_LABEL_KEYS[key] : ([key] as const);
-  const merged = new Map<string, { value: string; firing: number; pending: number; total: number }>();
+  const merged = new Map<string, SidebarFilterValue>();
 
   for (const labelKey of keys) {
     const stat = labels.find((label) => label.key === labelKey);

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsColumn.tsx
@@ -29,11 +29,20 @@ export function LabelsColumn() {
   const [open, toggleOpen] = useToggle(true);
   const [labelFilter, setLabelFilter] = useState('');
   const styles = useStyles2(getStyles);
-  const showSeverityFilter = hasSeverityFilterValues(labels);
-  const visibleSidebarFilters = SIDEBAR_FILTERS.map((filter) => ({
-    ...filter,
-    values: getSidebarFilterValues(labels, filter.key),
-  })).filter((filter) => filter.values.length > 0);
+  const activeSeverityValue = useFilterValue('severity');
+  const activeSidebarFilterValues: Record<SidebarFilterKey, string | undefined> = {
+    alertname: useFilterValue('alertname'),
+    grafana_folder: useFilterValue('grafana_folder'),
+    service: useFilterValue('service'),
+    team: useFilterValue('team'),
+    namespace: useFilterValue('namespace'),
+  };
+  const showSeverityFilter = hasSeverityFilterValues(labels) || Boolean(activeSeverityValue);
+  const visibleSidebarFilters = SIDEBAR_FILTERS.map((filter) => {
+    const values = getSidebarFilterValues(labels, filter.key);
+    const activeValue = activeSidebarFilterValues[filter.key];
+    return { ...filter, values, activeValue };
+  }).filter((filter) => filter.values.length > 0 || Boolean(filter.activeValue));
 
   return (
     <div className={cx(styles.column, !open && styles.columnCollapsed)}>
@@ -80,13 +89,13 @@ export function LabelsColumn() {
                 <div className={styles.divider} />
               </>
             )}
-            {visibleSidebarFilters.map(({ key, label, values }) => (
+            {visibleSidebarFilters.map(({ key, labelI18nKey, defaultLabel, values, activeValue }) => (
               <div key={key}>
                 <div className={styles.section}>
                   <Text weight="medium" variant="bodySmall" color="secondary">
-                    {label}
+                    {t(labelI18nKey, defaultLabel)}
                   </Text>
-                  <SidebarFilterGroup filterKey={key} values={values} />
+                  <SidebarFilterGroup filterKey={key} values={values} activeValue={activeValue} />
                 </div>
                 <div className={styles.divider} />
               </div>
@@ -152,12 +161,12 @@ function StateFilter() {
 }
 
 type SidebarFilterKey = 'alertname' | 'grafana_folder' | 'service' | 'team' | 'namespace';
-const SIDEBAR_FILTERS: Array<{ key: SidebarFilterKey; label: string }> = [
-  { key: 'alertname', label: 'Rule name' },
-  { key: 'grafana_folder', label: 'Folder' },
-  { key: 'service', label: 'Service' },
-  { key: 'team', label: 'Team' },
-  { key: 'namespace', label: 'Namespace' },
+const SIDEBAR_FILTERS: Array<{ key: SidebarFilterKey; labelI18nKey: string; defaultLabel: string }> = [
+  { key: 'alertname', labelI18nKey: 'alerting.triage.rule-name-filter-title', defaultLabel: 'Rule name' },
+  { key: 'grafana_folder', labelI18nKey: 'alerting.triage.folder-filter-title', defaultLabel: 'Folder' },
+  { key: 'service', labelI18nKey: 'alerting.triage.service-filter-title', defaultLabel: 'Service' },
+  { key: 'team', labelI18nKey: 'alerting.triage.team-filter-title', defaultLabel: 'Team' },
+  { key: 'namespace', labelI18nKey: 'alerting.triage.namespace-filter-title', defaultLabel: 'Namespace' },
 ];
 const sidebarCollator = new Intl.Collator();
 const MAX_VISIBLE_VALUES = 8;
@@ -169,10 +178,17 @@ type SidebarFilterValue = {
   total: number;
 };
 
-function SidebarFilterGroup({ filterKey, values }: { filterKey: SidebarFilterKey; values: SidebarFilterValue[] }) {
+function SidebarFilterGroup({
+  filterKey,
+  values,
+  activeValue,
+}: {
+  filterKey: SidebarFilterKey;
+  values: SidebarFilterValue[];
+  activeValue: string | undefined;
+}) {
   const styles = useStyles2(getStyles);
   const sceneContext = useSceneContext();
-  const activeValue = useFilterValue(filterKey);
 
   return (
     <Stack direction="column" gap={0.25}>

--- a/public/app/features/alerting/unified/triage/scene/filters/SeverityFilter.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/SeverityFilter.tsx
@@ -156,10 +156,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   bar_low: css({
     background: theme.colors.success.text,
   }),
-  bar_medium: css({
+  bar_minor: css({
     background: theme.colors.warning.text,
   }),
-  bar_high: css({
+  bar_major: css({
     background: theme.colors.warning.main,
   }),
   bar_critical: css({

--- a/public/app/features/alerting/unified/triage/scene/filters/SeverityFilter.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/SeverityFilter.tsx
@@ -1,0 +1,168 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { useSceneContext } from '@grafana/scenes-react';
+import { Stack, Tooltip, useStyles2 } from '@grafana/ui';
+
+import { COMBINED_FILTER_LABEL_KEYS } from '../../constants';
+import { type LabelStats } from '../useLabelsBreakdown';
+import { addOrReplaceFilter, removeFilter, useFilterValue } from '../utils';
+
+import { SEVERITY_DEFINITIONS, type SeverityLevel, canonicalSeverity, severityFilterRegex } from './severity';
+
+interface SeverityCount {
+  firing: number;
+  pending: number;
+}
+
+function useSeverityCounts(labels: LabelStats[]): Map<SeverityLevel, SeverityCount> {
+  const severityKeys = COMBINED_FILTER_LABEL_KEYS.severity;
+  const counts = new Map<SeverityLevel, SeverityCount>();
+
+  for (const key of severityKeys) {
+    const severityStats = labels.find((l) => l.key === key);
+    if (!severityStats) {
+      continue;
+    }
+
+    for (const { value, firing, pending } of severityStats.values) {
+      const level = canonicalSeverity(value);
+      if (!level) {
+        continue;
+      }
+      const existing = counts.get(level) ?? { firing: 0, pending: 0 };
+      counts.set(level, { firing: existing.firing + firing, pending: existing.pending + pending });
+    }
+  }
+
+  return counts;
+}
+
+interface SeverityFilterProps {
+  labels: LabelStats[];
+}
+
+export function SeverityFilter({ labels }: SeverityFilterProps) {
+  const styles = useStyles2(getStyles);
+  const sceneContext = useSceneContext();
+  const activeValue = useFilterValue('severity');
+  const counts = useSeverityCounts(labels);
+
+  const activeLevel = SEVERITY_DEFINITIONS.find((d) => activeValue === severityFilterRegex(d.level))?.level;
+
+  const toggle = (level: SeverityLevel) => {
+    const regex = severityFilterRegex(level);
+    if (activeLevel === level) {
+      removeFilter(sceneContext, 'severity');
+    } else {
+      addOrReplaceFilter(sceneContext, 'severity', '=~', regex);
+    }
+  };
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      {SEVERITY_DEFINITIONS.map((def) => {
+        const count = counts.get(def.level);
+        return (
+          <Tooltip key={def.level} content={def.values.slice(1).join(', ')} placement="right">
+            <button
+              className={cx(styles.severityButton, activeLevel === def.level && styles.severityButtonActive)}
+              onClick={() => toggle(def.level)}
+            >
+              <SeverityBars level={def.level} />
+              <span className={styles.severityLabel}>
+                <Trans i18nKey={`alerting.triage.severity-${def.level}`}>{capitalise(def.level)}</Trans>
+              </span>
+              <span className={styles.severityCount}>{count ? count.firing + count.pending : 0}</span>
+            </button>
+          </Tooltip>
+        );
+      })}
+    </Stack>
+  );
+}
+
+interface SeverityBarsProps {
+  level: SeverityLevel;
+}
+
+function SeverityBars({ level }: SeverityBarsProps) {
+  const styles = useStyles2(getStyles);
+  const def = SEVERITY_DEFINITIONS.find((d) => d.level === level);
+  const filled = def?.bars ?? 0;
+  const heights = [4, 7, 10, 13];
+
+  return (
+    <span className={styles.bars} aria-hidden>
+      {Array.from({ length: 4 }, (_, i) => (
+        <span
+          key={i}
+          className={cx(styles.bar, i < filled ? styles[`bar_${level}`] : styles.barEmpty)}
+          style={{ height: heights[i] }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function capitalise(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  severityButton: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    width: '100%',
+    padding: theme.spacing(0.5, 0.75),
+    background: 'none',
+    border: `1px solid transparent`,
+    borderRadius: theme.shape.radius.default,
+    cursor: 'pointer',
+    color: theme.colors.text.secondary,
+    textAlign: 'left',
+    '&:hover': {
+      background: theme.colors.action.hover,
+    },
+  }),
+  severityButtonActive: css({
+    background: theme.colors.action.selected,
+  }),
+  severityLabel: css({
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  severityCount: css({
+    marginLeft: 'auto',
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    fontVariantNumeric: 'tabular-nums',
+  }),
+  bars: css({
+    display: 'inline-flex',
+    alignItems: 'flex-end',
+    gap: 2,
+    flexShrink: 0,
+  }),
+  bar: css({
+    width: 4,
+    borderRadius: theme.shape.radius.default,
+  }),
+  barEmpty: css({
+    background: theme.colors.border.medium,
+  }),
+  bar_low: css({
+    background: theme.colors.success.text,
+  }),
+  bar_medium: css({
+    background: theme.colors.warning.text,
+  }),
+  bar_high: css({
+    background: theme.colors.warning.main,
+  }),
+  bar_critical: css({
+    background: theme.colors.error.text,
+  }),
+});

--- a/public/app/features/alerting/unified/triage/scene/filters/SeverityFilter.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/SeverityFilter.tsx
@@ -7,7 +7,7 @@ import { Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { COMBINED_FILTER_LABEL_KEYS } from '../../constants';
 import { type LabelStats } from '../useLabelsBreakdown';
-import { addOrReplaceFilter, removeFilter, useFilterValue } from '../utils';
+import { addOrReplaceFilter, removeFilter, useRegexFilterValue } from '../utils';
 
 import { SEVERITY_DEFINITIONS, type SeverityLevel, canonicalSeverity, severityFilterRegex } from './severity';
 
@@ -46,7 +46,7 @@ interface SeverityFilterProps {
 export function SeverityFilter({ labels }: SeverityFilterProps) {
   const styles = useStyles2(getStyles);
   const sceneContext = useSceneContext();
-  const activeValue = useFilterValue('severity');
+  const activeValue = useRegexFilterValue('severity');
   const counts = useSeverityCounts(labels);
 
   const activeLevel = SEVERITY_DEFINITIONS.find((d) => activeValue === severityFilterRegex(d.level))?.level;

--- a/public/app/features/alerting/unified/triage/scene/filters/severity.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/filters/severity.test.ts
@@ -1,0 +1,78 @@
+import { SEVERITY_DEFINITIONS, canonicalSeverity, severityFilterRegex } from './severity';
+
+describe('SEVERITY_DEFINITIONS', () => {
+  it('defines four severity levels in ascending order', () => {
+    expect(SEVERITY_DEFINITIONS.map((d) => d.level)).toEqual(['low', 'minor', 'major', 'critical']);
+  });
+
+  it('assigns correct bar counts', () => {
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'low')?.bars).toBe(1);
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'minor')?.bars).toBe(2);
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'major')?.bars).toBe(3);
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'critical')?.bars).toBe(4);
+  });
+
+  it('includes SEV variants in the correct levels', () => {
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'low')?.values).toContain('SEV4');
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'minor')?.values).toContain('SEV3');
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'major')?.values).toContain('SEV2');
+    expect(SEVERITY_DEFINITIONS.find((d) => d.level === 'critical')?.values).toContain('SEV1');
+  });
+});
+
+describe('severityFilterRegex', () => {
+  it('returns a case-insensitive regex for low', () => {
+    expect(severityFilterRegex('low')).toBe('(?i)low|info|notice|SEV4');
+  });
+
+  it('returns a case-insensitive regex for minor', () => {
+    expect(severityFilterRegex('minor')).toBe('(?i)minor|medium|warning|warn|moderate|SEV3');
+  });
+
+  it('returns a case-insensitive regex for major', () => {
+    expect(severityFilterRegex('major')).toBe('(?i)major|high|SEV2');
+  });
+
+  it('returns a case-insensitive regex for critical', () => {
+    expect(severityFilterRegex('critical')).toBe('(?i)critical|crit|fatal|SEV1');
+  });
+});
+
+describe('canonicalSeverity', () => {
+  it.each([
+    ['low', 'low'],
+    ['info', 'low'],
+    ['notice', 'low'],
+    ['SEV4', 'low'],
+    ['minor', 'minor'],
+    ['medium', 'minor'],
+    ['warning', 'minor'],
+    ['warn', 'minor'],
+    ['moderate', 'minor'],
+    ['SEV3', 'minor'],
+    ['major', 'major'],
+    ['high', 'major'],
+    ['SEV2', 'major'],
+    ['critical', 'critical'],
+    ['crit', 'critical'],
+    ['fatal', 'critical'],
+    ['SEV1', 'critical'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(canonicalSeverity(input)).toBe(expected);
+  });
+
+  it('is case-insensitive', () => {
+    expect(canonicalSeverity('LOW')).toBe('low');
+    expect(canonicalSeverity('WARNING')).toBe('minor');
+    expect(canonicalSeverity('HIGH')).toBe('major');
+    expect(canonicalSeverity('CRITICAL')).toBe('critical');
+    expect(canonicalSeverity('sev1')).toBe('critical');
+    expect(canonicalSeverity('sev4')).toBe('low');
+  });
+
+  it('returns undefined for unknown values', () => {
+    expect(canonicalSeverity('unknown')).toBeUndefined();
+    expect(canonicalSeverity('')).toBeUndefined();
+    expect(canonicalSeverity('error')).toBeUndefined();
+  });
+});

--- a/public/app/features/alerting/unified/triage/scene/filters/severity.ts
+++ b/public/app/features/alerting/unified/triage/scene/filters/severity.ts
@@ -23,5 +23,5 @@ export function severityFilterRegex(level: SeverityLevel): string {
 
 export function canonicalSeverity(value: string): SeverityLevel | undefined {
   const lower = value.toLowerCase();
-  return SEVERITY_DEFINITIONS.find((d) => d.values.includes(lower))?.level;
+  return SEVERITY_DEFINITIONS.find((d) => d.values.some((v) => v.toLowerCase() === lower))?.level;
 }

--- a/public/app/features/alerting/unified/triage/scene/filters/severity.ts
+++ b/public/app/features/alerting/unified/triage/scene/filters/severity.ts
@@ -1,0 +1,27 @@
+export type SeverityLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface SeverityDefinition {
+  level: SeverityLevel;
+  values: string[];
+  bars: number;
+}
+
+export const SEVERITY_DEFINITIONS: SeverityDefinition[] = [
+  { level: 'low', values: ['low', 'info', 'notice'], bars: 1 },
+  { level: 'medium', values: ['medium', 'warning', 'warn', 'minor', 'moderate'], bars: 2 },
+  { level: 'high', values: ['high', 'major'], bars: 3 },
+  { level: 'critical', values: ['critical', 'crit', 'fatal'], bars: 4 },
+];
+
+export function severityFilterRegex(level: SeverityLevel): string {
+  const def = SEVERITY_DEFINITIONS.find((d) => d.level === level);
+  if (!def) {
+    return level;
+  }
+  return `(?i)${def.values.join('|')}`;
+}
+
+export function canonicalSeverity(value: string): SeverityLevel | undefined {
+  const lower = value.toLowerCase();
+  return SEVERITY_DEFINITIONS.find((d) => d.values.includes(lower))?.level;
+}

--- a/public/app/features/alerting/unified/triage/scene/filters/severity.ts
+++ b/public/app/features/alerting/unified/triage/scene/filters/severity.ts
@@ -1,4 +1,4 @@
-export type SeverityLevel = 'low' | 'medium' | 'high' | 'critical';
+export type SeverityLevel = 'low' | 'minor' | 'major' | 'critical';
 
 export interface SeverityDefinition {
   level: SeverityLevel;
@@ -7,10 +7,10 @@ export interface SeverityDefinition {
 }
 
 export const SEVERITY_DEFINITIONS: SeverityDefinition[] = [
-  { level: 'low', values: ['low', 'info', 'notice'], bars: 1 },
-  { level: 'medium', values: ['medium', 'warning', 'warn', 'minor', 'moderate'], bars: 2 },
-  { level: 'high', values: ['high', 'major'], bars: 3 },
-  { level: 'critical', values: ['critical', 'crit', 'fatal'], bars: 4 },
+  { level: 'low', values: ['low', 'info', 'notice', 'SEV4'], bars: 1 },
+  { level: 'minor', values: ['minor', 'medium', 'warning', 'warn', 'moderate', 'SEV3'], bars: 2 },
+  { level: 'major', values: ['major', 'high', 'SEV2'], bars: 3 },
+  { level: 'critical', values: ['critical', 'crit', 'fatal', 'SEV1'], bars: 4 },
 ];
 
 export function severityFilterRegex(level: SeverityLevel): string {

--- a/public/app/features/alerting/unified/triage/scene/queries.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.test.ts
@@ -53,4 +53,17 @@ describe('triage queries service combined filter', () => {
     expect(query).toContain('namespace_extracted="payments"');
     expect(query).toContain(' or ');
   });
+
+  it('expands severity key across severity-adjacent label keys', () => {
+    const query = summaryChartQuery('severity=~"(?i)critical|crit|fatal"').expr;
+
+    expect(query).toContain('severity=~"(?i)critical|crit|fatal"');
+    expect(query).toContain('priority=~"(?i)critical|crit|fatal"');
+    expect(query).toContain('level=~"(?i)critical|crit|fatal"');
+    expect(query).toContain('loglevel=~"(?i)critical|crit|fatal"');
+    expect(query).toContain('logLevel=~"(?i)critical|crit|fatal"');
+    expect(query).toContain('lvl=~"(?i)critical|crit|fatal"');
+    expect(query).toContain('detected_level=~"(?i)critical|crit|fatal"');
+    expect(query).toContain(' or ');
+  });
 });

--- a/public/app/features/alerting/unified/triage/scene/queries.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.test.ts
@@ -37,6 +37,14 @@ describe('triage queries service combined filter', () => {
     expect(query).toContain('service_name="payments"');
   });
 
+  it('keeps service alias expansion when sidebar filter value came from service_name', () => {
+    const query = summaryChartQuery('service="auth",alertname="login-errors"').expr;
+
+    expect(query).toContain('alertname="login-errors",service="auth"');
+    expect(query).toContain('alertname="login-errors",service_name="auth"');
+    expect(query).toContain(' or ');
+  });
+
   it('expands cluster key to cluster OR cluster_name', () => {
     const query = summaryChartQuery('cluster="prod-a"').expr;
 

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -107,9 +107,9 @@ describe('tagKeysProviders', () => {
       expect(result.replace).toBe(true);
       expect(result.values).toEqual(
         expect.arrayContaining([
-          { value: 'alertstate', text: 'State', group: 'Common' },
           { value: 'alertname', text: 'Rule name', group: 'Common' },
           { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+          { text: 'alertstate', value: 'alertstate', group: 'All' },
           { text: 'environment', value: 'environment', group: 'All' },
           { text: 'severity', value: 'severity', group: 'All' },
           { text: 'team', value: 'team', group: 'All' },

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -83,7 +83,7 @@ describe('tagKeysProviders', () => {
   });
 
   describe('getAdHocTagKeysProvider', () => {
-    it('should show promoted labels first and remaining sorted under All', async () => {
+    it('should return all labels sorted under All', async () => {
       mockGetDataSourceSrv({
         getTagKeys: jest.fn().mockResolvedValue([
           { text: 'alertstate', value: 'alertstate' },
@@ -107,14 +107,15 @@ describe('tagKeysProviders', () => {
       expect(result.replace).toBe(true);
       expect(result.values).toEqual(
         expect.arrayContaining([
-          { value: 'alertname', text: 'Rule name', group: 'Common' },
-          { value: 'grafana_folder', text: 'Folder', group: 'Common' },
           { text: 'alertstate', value: 'alertstate', group: 'All' },
+          { text: 'alertname', value: 'alertname', group: 'All' },
+          { text: 'grafana_folder', value: 'grafana_folder', group: 'All' },
           { text: 'environment', value: 'environment', group: 'All' },
           { text: 'severity', value: 'severity', group: 'All' },
           { text: 'team', value: 'team', group: 'All' },
         ])
       );
+      expect(result.values).not.toEqual(expect.arrayContaining([expect.objectContaining({ group: 'Common' })]));
       expect(result.values).not.toEqual(
         expect.arrayContaining([
           { value: 'service', text: 'Service', group: 'Common' },

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -110,10 +110,16 @@ describe('tagKeysProviders', () => {
           { value: 'alertstate', text: 'State', group: 'Common' },
           { value: 'alertname', text: 'Rule name', group: 'Common' },
           { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+          { text: 'environment', value: 'environment', group: 'All' },
+          { text: 'severity', value: 'severity', group: 'All' },
+          { text: 'team', value: 'team', group: 'All' },
+        ])
+      );
+      expect(result.values).not.toEqual(
+        expect.arrayContaining([
           { value: 'service', text: 'Service', group: 'Common' },
           { text: 'Team', value: 'team', group: 'Common' },
           { text: 'Namespace', value: 'namespace', group: 'Common' },
-          { text: 'environment', value: 'environment', group: 'All' },
         ])
       );
       expect(result.values).not.toEqual(expect.arrayContaining([{ text: 'service', value: 'service', group: 'All' }]));
@@ -260,6 +266,38 @@ describe('tagKeysProviders', () => {
         { text: 'identity', value: 'identity' },
         { text: 'observability', value: 'observability' },
         { text: 'payments', value: 'payments' },
+      ]);
+    });
+
+    it('merges and deduplicates values for combined severity key', async () => {
+      const getTagValues = jest.fn().mockImplementation(({ key }: { key: string }) => {
+        if (key === 'severity') {
+          return [{ text: 'critical', value: 'critical' }];
+        }
+        if (key === 'priority') {
+          return [{ text: 'P1', value: 'P1' }];
+        }
+        if (key === 'loglevel') {
+          return [{ text: 'critical', value: 'critical' }];
+        }
+        return [];
+      });
+
+      mockGetDataSourceSrv({ getTagValues });
+
+      const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
+      activateWithScene(variable);
+
+      const result = await getAdHocTagValuesProvider(variable, {
+        key: 'severity',
+        operator: '=',
+        value: '',
+      });
+
+      expect(result.replace).toBe(true);
+      expect(result.values).toEqual([
+        { text: 'critical', value: 'critical' },
+        { text: 'P1', value: 'P1' },
       ]);
     });
   });

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -31,9 +31,6 @@ const FILTER_PROMOTED: MetricFindValue[] = [
   { value: 'alertstate', text: 'State', group: COMMON_GROUP },
   { value: 'alertname', text: 'Rule name', group: COMMON_GROUP },
   { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
-  { value: 'service', text: 'Service', group: COMMON_GROUP },
-  { value: 'team', text: 'Team', group: COMMON_GROUP },
-  { value: 'namespace', text: 'Namespace', group: COMMON_GROUP },
 ];
 
 /** Labels that should never appear in dropdowns */

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -26,9 +26,6 @@ const GROUPBY_PROMOTED: MetricFindValue[] = [
   { value: 'namespace', text: 'Namespace', group: COMMON_GROUP },
 ];
 
-/** Labels promoted to the top of the Filter dropdown */
-const FILTER_PROMOTED: MetricFindValue[] = [];
-
 /** Labels that should never appear in dropdowns */
 const EXCLUDED = new Set<string>([
   '__name__',
@@ -72,12 +69,12 @@ async function fetchTagValues(timeRange: TimeRange, key: string): Promise<Metric
 }
 
 /**
- * Fetch tag keys from the datasource, exclude promoted and hidden labels,
+ * Fetch tag keys from the datasource, exclude hidden labels and any promoted labels,
  * and return promoted labels first followed by the rest alphabetically.
  */
 async function buildTagKeysResult(
   timeRange: TimeRange,
-  promoted: MetricFindValue[]
+  promoted: MetricFindValue[] = []
 ): Promise<{ replace: boolean; values: MetricFindValue[] }> {
   const dsKeys = await fetchTagKeys(timeRange);
   const promotedValues = new Set(promoted.map((p) => String(p.value)));
@@ -108,7 +105,7 @@ export function getGroupByTagKeysProvider(variable: GroupByVariable, _currentKey
  */
 export function getAdHocTagKeysProvider(variable: AdHocFiltersVariable, _currentKey: string | null) {
   const timeRange = sceneGraph.getTimeRange(variable).state.value;
-  return buildTagKeysResult(timeRange, FILTER_PROMOTED);
+  return buildTagKeysResult(timeRange);
 }
 
 /**

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -27,10 +27,7 @@ const GROUPBY_PROMOTED: MetricFindValue[] = [
 ];
 
 /** Labels promoted to the top of the Filter dropdown */
-const FILTER_PROMOTED: MetricFindValue[] = [
-  { value: 'alertname', text: 'Rule name', group: COMMON_GROUP },
-  { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
-];
+const FILTER_PROMOTED: MetricFindValue[] = [];
 
 /** Labels that should never appear in dropdowns */
 const EXCLUDED = new Set<string>([
@@ -107,7 +104,7 @@ export function getGroupByTagKeysProvider(variable: GroupByVariable, _currentKey
 
 /**
  * Provider for the AdHoc Filters variable.
- * Shows promoted labels in "Common" group, remaining labels under "Labels".
+ * Returns datasource labels under the "All" group.
  */
 export function getAdHocTagKeysProvider(variable: AdHocFiltersVariable, _currentKey: string | null) {
   const timeRange = sceneGraph.getTimeRange(variable).state.value;

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -28,7 +28,6 @@ const GROUPBY_PROMOTED: MetricFindValue[] = [
 
 /** Labels promoted to the top of the Filter dropdown */
 const FILTER_PROMOTED: MetricFindValue[] = [
-  { value: 'alertstate', text: 'State', group: COMMON_GROUP },
   { value: 'alertname', text: 'Rule name', group: COMMON_GROUP },
   { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
 ];

--- a/public/app/features/alerting/unified/triage/scene/utils.ts
+++ b/public/app/features/alerting/unified/triage/scene/utils.ts
@@ -113,6 +113,15 @@ export function useFilterValue(key: string): string | undefined {
 }
 
 /**
+ * Returns the current regex-match (=~) value of a filter by key, or undefined if not set.
+ */
+export function useRegexFilterValue(key: string): string | undefined {
+  const filters = useAdHocFilters();
+  const filter = filters.find((f) => f.key === key && f.operator === '=~');
+  return filter?.value;
+}
+
+/**
  * Returns true if the key has an "any value" regex filter (key=~".+").
  */
 export function useIsAnyFilter(key: string): boolean {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3587,13 +3587,10 @@
       "no-matching-instances-with-filters": "No alert instances match your current set of filters for the selected time range.",
       "open-in-sidebar": "Open in sidebar",
       "open-rule-details": "Open rule details",
-      "folder-filter-title": "Folder",
-      "namespace-filter-title": "Namespace",
       "rule-details": {
         "subtitle": "Rule details and conditions",
         "title": "Rule Details"
       },
-      "rule-name-filter-title": "Rule name",
       "rule-not-found": {
         "description": "The requested rule could not be found.",
         "title": "Rule not found"
@@ -3615,9 +3612,7 @@
       "showing-groups-count_other": "Showing {{count}} groups",
       "state-filter-title": "State",
       "state-firing": "Firing",
-      "state-pending": "Pending",
-      "service-filter-title": "Service",
-      "team-filter-title": "Team"
+      "state-pending": "Pending"
     },
     "type-selector-button": {
       "add-expression": "Add expression"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3602,6 +3602,7 @@
           "folder-only": "Grouped by folder"
         }
       },
+      "severity-filter-title": "Severity",
       "show-all-labels_one": "Show all ({{ count }})",
       "show-all-labels_other": "Show all ({{ count }})",
       "show-all-values_one": "Show all ({{ count }})",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3587,10 +3587,13 @@
       "no-matching-instances-with-filters": "No alert instances match your current set of filters for the selected time range.",
       "open-in-sidebar": "Open in sidebar",
       "open-rule-details": "Open rule details",
+      "folder-filter-title": "Folder",
+      "namespace-filter-title": "Namespace",
       "rule-details": {
         "subtitle": "Rule details and conditions",
         "title": "Rule Details"
       },
+      "rule-name-filter-title": "Rule name",
       "rule-not-found": {
         "description": "The requested rule could not be found.",
         "title": "Rule not found"
@@ -3612,7 +3615,9 @@
       "showing-groups-count_other": "Showing {{count}} groups",
       "state-filter-title": "State",
       "state-firing": "Firing",
-      "state-pending": "Pending"
+      "state-pending": "Pending",
+      "service-filter-title": "Service",
+      "team-filter-title": "Team"
     },
     "type-selector-button": {
       "add-expression": "Add expression"


### PR DESCRIPTION
This PR moves the common filters in Alerts Activity to the sidebar: severity, state, rule name, team, service, namespace
Filter keys are hidden if there are no values in filtered results. 

<img width="1512" height="732" alt="image" src="https://github.com/user-attachments/assets/c0543f98-ef8d-42e9-bcc7-0282316f6c4f" />


https://github.com/user-attachments/assets/c812a838-0685-4c28-9db9-bdeadfe4527e


