### PR TITLE
Suggestions: Limit series and data points in preview cards

### DIFF
--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -371,4 +371,29 @@ describe('lttbPreviewData', () => {
     expect(result.series[0].length).toBe(30);
     expect(result.series[0].fields[0].values).toEqual(range(30));
   });
+
+  it('clears interval on the time field to prevent gaps', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: range(500), config: { interval: 10000 } },
+        { name: 'value', type: FieldType.number, values: range(500) },
+      ],
+    });
+    const result = lttbPreviewData({ series: [frame] } as PanelData);
+
+    const timeField = result.series[0].fields[0];
+    expect(timeField.config.interval).toBeUndefined();
+  });
+
+  it('does not modify config on frames below the threshold', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: range(3), config: { interval: 10000 } },
+        { name: 'value', type: FieldType.number, values: range(3) },
+      ],
+    });
+    const result = lttbPreviewData({ series: [frame] } as PanelData);
+
+    expect(result.series[0].fields[0].config.interval).toBe(10000);
+  });
 });

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -443,6 +443,9 @@ export function lttbPreviewData(data: PanelData, threshold = LTTB_THRESHOLD): Pa
         fields: frame.fields.map((field) => ({
           ...field,
           values: indices.map((i) => field.values[i]),
+          ...(field.type === FieldType.time && {
+            config: { ...field.config, interval: undefined },
+          }),
         })),
       };
     }),

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -444,6 +444,7 @@ export function lttbPreviewData(data: PanelData, threshold = LTTB_THRESHOLD): Pa
           ...field,
           values: indices.map((i) => field.values[i]),
           ...(field.type === FieldType.time && {
+            // since lttb may pick points further apart than timeField.config.interval, we clear it out to avoid gap insertion
             config: { ...field.config, interval: undefined },
           }),
         })),


### PR DESCRIPTION
This PR clears the interval in the lbbt function.

before:

<img width="1829" height="624" alt="Screenshot 2026-03-31 at 1 17 54 PM" src="https://github.com/user-attachments/assets/00ef4e68-8374-4f89-9e4c-836e860f54b5" />


after:

<img width="1826" height="624" alt="Screenshot 2026-03-31 at 1 40 21 PM" src="https://github.com/user-attachments/assets/43bb0631-fbf6-4311-bd75-6ef5a0f919b4" />

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
