### PR TITLE
Dashboards: Handle unknown special value match types gracefully instead of crashing

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.test.ts
@@ -1,0 +1,48 @@
+import { SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
+import { MappingType as MappingTypeV1 } from '@grafana/schema';
+import type { FieldConfigSource, SpecialValueMatch } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { transformMappingsToV1 } from './transformToV1TypesUtils';
+
+describe('transformToV1TypesUtils', () => {
+  describe('transformMappingsToV1', () => {
+    function makeFieldConfig(mappings: FieldConfigSource['defaults']['mappings']): FieldConfigSource {
+      return {
+        defaults: { mappings },
+        overrides: [],
+      };
+    }
+
+    function makeSpecialMapping(match: SpecialValueMatch) {
+      return {
+        type: 'special' as const,
+        options: { match, result: { text: 'mapped' } },
+      };
+    }
+
+    it.each<{ v2: SpecialValueMatch; v1: SpecialValueMatchV1 }>([
+      { v2: 'true', v1: SpecialValueMatchV1.True },
+      { v2: 'false', v1: SpecialValueMatchV1.False },
+      { v2: 'null', v1: SpecialValueMatchV1.Null },
+      { v2: 'nan', v1: SpecialValueMatchV1.NaN },
+      { v2: 'null+nan', v1: SpecialValueMatchV1.NullAndNaN },
+      { v2: 'empty', v1: SpecialValueMatchV1.Empty },
+    ])('should transform special value match "$v2" to V1', ({ v2, v1 }) => {
+      const result = transformMappingsToV1(makeFieldConfig([makeSpecialMapping(v2)]));
+      expect(result.defaults.mappings).toHaveLength(1);
+      expect(result.defaults.mappings![0]).toMatchObject({
+        type: MappingTypeV1.SpecialValue,
+        options: { match: v1, result: { text: 'mapped' } },
+      });
+    });
+
+    it('should drop special value mappings with unknown match type', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const result = transformMappingsToV1(makeFieldConfig([makeSpecialMapping('unknown_value' as SpecialValueMatch)]));
+
+      expect(result.defaults.mappings).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith('Skipping special value mapping with unknown match type: "unknown_value"');
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -98,7 +98,8 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      throw new Error(`Unknown match type: ${match}`);
+      console.warn(`Unknown special value match type: "${match}", falling back to "null"`);
+      return SpecialValueMatchV1.Null;
   }
 }
 

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -83,7 +83,7 @@ export function transformCursorSyncV2ToV1(cursorSync: DashboardCursorSync): Dash
   }
 }
 
-function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueMatchV1 {
+function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueMatchV1 | undefined {
   switch (match) {
     case 'true':
       return SpecialValueMatchV1.True;
@@ -98,8 +98,8 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Unknown special value match type: "${match}", falling back to "null"`);
-      return SpecialValueMatchV1.Null;
+      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      return undefined;
   }
 }
 
@@ -120,7 +120,7 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
   };
 
   if (fieldConfig.defaults.mappings) {
-    transformedDefaults.mappings = fieldConfig.defaults.mappings.map((mapping) => {
+    transformedDefaults.mappings = fieldConfig.defaults.mappings.flatMap((mapping) => {
       switch (mapping.type) {
         case 'value':
           return {
@@ -137,15 +137,22 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
             ...mapping,
             type: MappingTypeV1.RegexToText,
           };
-        case 'special':
+        case 'special': {
+          const v1Match = transformSpecialValueMatchToV1(mapping.options.match);
+
+          if (v1Match === undefined) {
+            return [];
+          }
+
           return {
             ...mapping,
             options: {
               ...mapping.options,
-              match: transformSpecialValueMatchToV1(mapping.options.match),
+              match: v1Match,
             },
             type: MappingTypeV1.SpecialValue,
           };
+        }
         default:
           return mapping;
       }

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1386,7 +1386,8 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      throw new Error(`Unknown match type: ${match}`);
+      console.warn(`Unknown special value match type: "${match}", falling back to "null"`);
+      return SpecialValueMatchV1.Null;
   }
 }
 

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1272,7 +1272,7 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
   };
 
   if (fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length > 0) {
-    transformedDefaults.mappings = fieldConfig.defaults.mappings.map((mapping) => {
+    transformedDefaults.mappings = fieldConfig.defaults.mappings.flatMap((mapping) => {
       switch (mapping.type) {
         case 'value':
           return {
@@ -1289,15 +1289,20 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
             ...mapping,
             type: MappingTypeV1.RegexToText,
           };
-        case 'special':
+        case 'special': {
+          const v1Match = transformSpecialValueMatchToV1(mapping.options.match);
+          if (v1Match === undefined) {
+            return [];
+          }
           return {
             ...mapping,
             options: {
               ...mapping.options,
-              match: transformSpecialValueMatchToV1(mapping.options.match),
+              match: v1Match,
             },
             type: MappingTypeV1.SpecialValue,
           };
+        }
         default:
           return mapping;
       }
@@ -1371,7 +1376,7 @@ function colorIdToEnumv1(colorId: FieldColorModeId): FieldColorModeIdV1 {
   }
 }
 
-function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueMatchV1 {
+function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueMatchV1 | undefined {
   switch (match) {
     case 'true':
       return SpecialValueMatchV1.True;
@@ -1386,8 +1391,8 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Unknown special value match type: "${match}", falling back to "null"`);
-      return SpecialValueMatchV1.Null;
+      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      return undefined;
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

Changes `transformSpecialValueMatchToV1` in both `ResponseTransformers.ts` and `transformToV1TypesUtils.ts` to log a warning and fall back to `SpecialValueMatchV1.Null` instead of throwing when encountering an unknown or missing `match` field in special value mappings.

