### PR TITLE
Table: Restore cross-filtering and make it work with nested tables

### DIFF
--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -355,6 +355,75 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     // TODO -- saving for another day.
   });
 
+  test('Cross-filter: second filter popup only shows values reachable after first filter', async ({
+    gotoDashboardPage,
+    selectors,
+    page,
+  }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '1' }),
+    });
+
+    await expect(
+      dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Table - Kitchen Sink'))
+    ).toBeVisible();
+
+    await waitForTableLoad(page);
+
+    const table = page.locator('.rdg');
+
+    const infoColumnIdx = await getColumnIdx(table, 'Info');
+    const minColumnIdx = await getColumnIdx(table, 'Min');
+
+    // --- Baseline: collect the full set of Min option titles from the Min filter popup ---
+    const minHeader = page.getByRole('columnheader').nth(minColumnIdx);
+    await minHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    const minFilterContainer = dashboardPage.getByGrafanaSelector(
+      selectors.components.Panels.Visualization.TableNG.Filters.Container
+    );
+    await expect(minFilterContainer).toBeVisible();
+
+    // Count all option rows in the Min filter popup before any cross-filter is applied
+    const allMinOptions = await minFilterContainer.locator('[title]').allTextContents();
+    const allMinOptionCount = allMinOptions.length;
+
+    // Close without applying
+    await minFilterContainer.getByRole('button', { name: 'Cancel' }).click();
+    await expect(minFilterContainer).not.toBeVisible();
+
+    // --- Apply a filter on Info to only show "up" rows ---
+    const infoHeader = page.getByRole('columnheader').nth(infoColumnIdx);
+    await infoHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    const infoFilterContainer = dashboardPage.getByGrafanaSelector(
+      selectors.components.Panels.Visualization.TableNG.Filters.Container
+    );
+    await expect(infoFilterContainer).toBeVisible();
+
+    // Deselect all, then select only "up"
+    await infoFilterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    await infoFilterContainer.getByTitle('up', { exact: true }).locator('label').click();
+    await infoFilterContainer.getByRole('button', { name: 'Ok' }).click();
+    await expect(infoFilterContainer).not.toBeVisible();
+
+    // Table should now show only "up" rows
+    await expect(getCell(table, 1, infoColumnIdx)).toHaveText('up');
+
+    // --- Open the Min filter popup again; cross-filter should restrict the options ---
+    await minHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    await expect(minFilterContainer).toBeVisible();
+
+    const crossFilteredMinOptions = await minFilterContainer.locator('[title]').allTextContents();
+    const crossFilteredMinOptionCount = crossFilteredMinOptions.length;
+
+    // With Info filtered to "up" only, Min options must be a subset of (or equal to) the full set.
+    // In practice the data has multiple Info values, so the Min option list should be smaller.
+    expect(crossFilteredMinOptionCount).toBeLessThanOrEqual(allMinOptionCount);
+
+    // Close the filter popup
+    await minFilterContainer.getByRole('button', { name: 'Cancel' }).click();
+  });
+
   test('Tests tooltip interactions', async ({ gotoDashboardPage, selectors }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,

--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -382,43 +382,62 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     const minFilterContainer = dashboardPage.getByGrafanaSelector(
       selectors.components.Panels.Visualization.TableNG.Filters.Container
     );
-    await expect(minFilterContainer).toBeVisible();
+    await expect(minFilterContainer, 'filter popup for min is visible after click').toBeVisible();
 
-    // Count all option rows in the Min filter popup before any cross-filter is applied
-    const allMinOptions = await minFilterContainer.locator('[title]').allTextContents();
-    const allMinOptionCount = allMinOptions.length;
+    // Count all option rows in the Min filter popup before any cross-filter is applied.
+    // The List component is virtualized so we can't rely on DOM element count — instead click
+    // "Select all" (which operates on the full data array) and parse the "N selected" label.
+    await minFilterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    const allMinSelectAllText =
+      (await minFilterContainer
+        .getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll)
+        .textContent()) ?? '';
+    const allMinOptionCount = parseInt(allMinSelectAllText.match(/(\d+) selected/)?.[1] ?? '0', 10);
 
     // Close without applying
     await minFilterContainer.getByRole('button', { name: 'Cancel' }).click();
-    await expect(minFilterContainer).not.toBeVisible();
+    await expect(minFilterContainer, 'filter popup for min is not visible after close').not.toBeVisible();
+
+    // --- Sort by Info and confirm that the first value is not "up" to compare later in the test ---
+    const infoHeader = page.getByRole('columnheader').nth(infoColumnIdx);
+    await infoHeader.getByText('Info').click();
+    await expect(infoHeader, 'info column header is sorted ascending after click').toHaveAttribute(
+      'aria-sort',
+      'ascending'
+    );
+    const firstInfoCell = getCell(table, 1, infoColumnIdx);
+    expect(firstInfoCell, 'first info cell is not "up" after sorting').not.toHaveText('up');
 
     // --- Apply a filter on Info to only show "up" rows ---
-    const infoHeader = page.getByRole('columnheader').nth(infoColumnIdx);
     await infoHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
     const infoFilterContainer = dashboardPage.getByGrafanaSelector(
       selectors.components.Panels.Visualization.TableNG.Filters.Container
     );
-    await expect(infoFilterContainer).toBeVisible();
-
-    // Deselect all, then select only "up"
-    await infoFilterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    await expect(infoFilterContainer, 'filter popup for info is visible after click').toBeVisible();
     await infoFilterContainer.getByTitle('up', { exact: true }).locator('label').click();
     await infoFilterContainer.getByRole('button', { name: 'Ok' }).click();
     await expect(infoFilterContainer).not.toBeVisible();
 
     // Table should now show only "up" rows
-    await expect(getCell(table, 1, infoColumnIdx)).toHaveText('up');
+    await expect(firstInfoCell, 'first info cell is "up" after filtering').toHaveText('up');
 
     // --- Open the Min filter popup again; cross-filter should restrict the options ---
     await minHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
-    await expect(minFilterContainer).toBeVisible();
+    await expect(minFilterContainer, 'filter popup for min is visible after click').toBeVisible();
 
-    const crossFilteredMinOptions = await minFilterContainer.locator('[title]').allTextContents();
-    const crossFilteredMinOptionCount = crossFilteredMinOptions.length;
+    await minFilterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    const crossFilteredSelectAllText =
+      (await minFilterContainer
+        .getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll)
+        .textContent()) ?? '';
+    const crossFilteredMinOptionCount = parseInt(crossFilteredSelectAllText.match(/(\d+) selected/)?.[1] ?? '0', 10);
 
     // With Info filtered to "up" only, Min options must be a subset of (or equal to) the full set.
     // In practice the data has multiple Info values, so the Min option list should be smaller.
-    expect(crossFilteredMinOptionCount).toBeLessThanOrEqual(allMinOptionCount);
+    expect(
+      crossFilteredMinOptionCount,
+      'cross-filtered min option count is less than all min option count'
+    ).toBeLessThan(allMinOptionCount);
 
     // Close the filter popup
     await minFilterContainer.getByRole('button', { name: 'Cancel' }).click();

--- a/e2e-playwright/panels-suite/table-nested.spec.ts
+++ b/e2e-playwright/panels-suite/table-nested.spec.ts
@@ -196,6 +196,108 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     await expect(page.locator('.rdg')).toHaveCount(2);
   });
 
+  test('cross-filter in nested table: second filter popup shows only values from filtered rows', async ({
+    gotoDashboardPage,
+    selectors,
+    page,
+  }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '4' }),
+    });
+
+    await expect(
+      dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Nested tables'))
+    ).toBeVisible();
+
+    await waitForTableLoad(page);
+
+    // Expand both nested tables so we can interact with them
+    await dashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.RowExpander)
+      .first()
+      .click();
+    await dashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.RowExpander)
+      .last()
+      .click();
+
+    const firstNestedTable = page.locator('.rdg').nth(1);
+    const secondNestedTable = page.locator('.rdg').nth(2);
+
+    const infoColumnIdx = await getColumnIdx(firstNestedTable, 'Info');
+    const minColumnIdx = await getColumnIdx(firstNestedTable, 'Min');
+
+    // --- Baseline: collect Min options from first nested table before any cross-filter ---
+    const minHeader = firstNestedTable.getByRole('columnheader').nth(minColumnIdx);
+    await minHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    const filterContainer = dashboardPage.getByGrafanaSelector(
+      selectors.components.Panels.Visualization.TableNG.Filters.Container
+    );
+    await expect(filterContainer).toBeVisible();
+
+    const allMinOptionCount = await filterContainer.locator('[title]').count();
+
+    await filterContainer.getByRole('button', { name: 'Cancel' }).click();
+    await expect(filterContainer).not.toBeVisible();
+
+    // --- Apply Info=up filter on the first nested table ---
+    const infoColumnHeader = firstNestedTable.getByRole('columnheader').nth(infoColumnIdx);
+    await infoColumnHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    await expect(filterContainer).toBeVisible();
+
+    // Deselect all, then select only "up"
+    await filterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    await filterContainer.getByTitle('up', { exact: true }).locator('label').click();
+    await filterContainer.getByRole('button', { name: 'Ok' }).click();
+    await expect(filterContainer).not.toBeVisible();
+
+    // Verify the nested table rows are filtered
+    await expect(getCell(firstNestedTable, 1, infoColumnIdx)).toHaveText('up');
+
+    // --- Open Min filter popup: cross-filter should restrict options ---
+    await minHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    await expect(filterContainer).toBeVisible();
+
+    const crossFilteredMinOptionCount = await filterContainer.locator('[title]').count();
+
+    // With Info filtered to "up", Min options must be a subset of the unfiltered set
+    expect(crossFilteredMinOptionCount).toBeLessThanOrEqual(allMinOptionCount);
+
+    await filterContainer.getByRole('button', { name: 'Cancel' }).click();
+    await expect(filterContainer).not.toBeVisible();
+
+    // --- Verify filter is scoped to the first nested table only ---
+    // The second nested table should be unaffected by the first nested table's filter.
+    const secondNestedInfoColumnIdx = await getColumnIdx(secondNestedTable, 'Info');
+    const secondNestedMinColumnIdx = await getColumnIdx(secondNestedTable, 'Min');
+
+    const secondMinHeader = secondNestedTable.getByRole('columnheader').nth(secondNestedMinColumnIdx);
+    await secondMinHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
+    await expect(filterContainer).toBeVisible();
+
+    const secondNestedMinOptionCount = await filterContainer.locator('[title]').count();
+
+    // Second nested table sees its own full set of Min options (not restricted by first table's filter)
+    expect(secondNestedMinOptionCount).toBeGreaterThanOrEqual(crossFilteredMinOptionCount);
+
+    await filterContainer.getByRole('button', { name: 'Cancel' }).click();
+    // Verify second nested table still shows all Info values (not filtered)
+    const secondNestedRowCount = await secondNestedTable.locator('[role="row"]').count();
+    expect(secondNestedRowCount).toBeGreaterThan(1); // header + at least one row
+
+    // Cross-check: second nested table should show both "up" and non-"up" rows
+    const secondTableInfoValues = new Set<string>();
+    for (let i = 1; i < secondNestedRowCount; i++) {
+      const text = await getCell(secondNestedTable, i, secondNestedInfoColumnIdx).textContent();
+      if (text) {
+        secondTableInfoValues.add(text.trim().split(' ')[0]); // normalize "up fast" → "up"
+      }
+    }
+    // The second table should have rows that are not "up" (since its filter is not restricted)
+    expect(secondTableInfoValues.size).toBeGreaterThan(0);
+  });
+
   test('word wrap, hover overflow, max cell height, and cell inspect', async ({
     gotoPanelEditPage,
     selectors,

--- a/e2e-playwright/panels-suite/table-nested.spec.ts
+++ b/e2e-playwright/panels-suite/table-nested.spec.ts
@@ -236,36 +236,66 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     );
     await expect(filterContainer).toBeVisible();
 
-    const allMinOptionCount = await filterContainer.locator('[title]').count();
+    await filterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    const allMinOptionCount = parseInt(
+      (
+        (await filterContainer
+          .getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll)
+          .textContent()) ?? ''
+      ).match(/(\d+) selected/)?.[1] ?? '0',
+      10
+    );
 
     await filterContainer.getByRole('button', { name: 'Cancel' }).click();
     await expect(filterContainer).not.toBeVisible();
 
-    // --- Apply Info=up filter on the first nested table ---
+    // sort the info column descending to ensure the "down fast" value is first
+    const infoHeader = firstNestedTable.getByRole('columnheader').nth(infoColumnIdx);
+    await infoHeader.getByText('Info').click({ modifiers: ['ControlOrMeta'] });
+    await infoHeader.getByText('Info').click({ modifiers: ['ControlOrMeta'] });
+    const firstInfoCell = getCell(firstNestedTable, 1, infoColumnIdx);
+    await expect(
+      firstInfoCell,
+      'first info cell has "down fast" after adding Info column descending sort to first nested table with two clicks'
+    ).toContainText('down fast');
+
+    // --- Apply Info=down filter on the first nested table ---
     const infoColumnHeader = firstNestedTable.getByRole('columnheader').nth(infoColumnIdx);
     await infoColumnHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
-    await expect(filterContainer).toBeVisible();
+    await expect(filterContainer, 'filter container is visible after clicking info column header').toBeVisible();
 
-    // Deselect all, then select only "up"
-    await filterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
-    await filterContainer.getByTitle('up', { exact: true }).locator('label').click();
+    // select only "down"
+    await filterContainer.getByTitle('down', { exact: true }).locator('label').click();
     await filterContainer.getByRole('button', { name: 'Ok' }).click();
-    await expect(filterContainer).not.toBeVisible();
+    await expect(filterContainer, 'filter container is closed after applying filter').not.toBeVisible();
 
     // Verify the nested table rows are filtered
-    await expect(getCell(firstNestedTable, 1, infoColumnIdx)).toHaveText('up');
+    await expect(firstInfoCell, 'first info cell is filtered after applying Info=down filter').not.toHaveText(
+      'down fast'
+    );
 
     // --- Open Min filter popup: cross-filter should restrict options ---
     await minHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
-    await expect(filterContainer).toBeVisible();
+    await expect(filterContainer, 'filter container is visible after clicking min column header').toBeVisible();
 
-    const crossFilteredMinOptionCount = await filterContainer.locator('[title]').count();
+    await filterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    const crossFilteredMinOptionCount = parseInt(
+      (
+        (await filterContainer
+          .getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll)
+          .textContent()) ?? ''
+      ).match(/(\d+) selected/)?.[1] ?? '0',
+      10
+    );
 
     // With Info filtered to "up", Min options must be a subset of the unfiltered set
-    expect(crossFilteredMinOptionCount).toBeLessThanOrEqual(allMinOptionCount);
+    expect(
+      crossFilteredMinOptionCount,
+      'cross-filtered min option count is less than all min option count'
+    ).toBeLessThanOrEqual(allMinOptionCount);
 
     await filterContainer.getByRole('button', { name: 'Cancel' }).click();
-    await expect(filterContainer).not.toBeVisible();
+    await expect(filterContainer, 'filter container is closed after clicking cancel').not.toBeVisible();
 
     // --- Verify filter is scoped to the first nested table only ---
     // The second nested table should be unaffected by the first nested table's filter.
@@ -274,28 +304,42 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
 
     const secondMinHeader = secondNestedTable.getByRole('columnheader').nth(secondNestedMinColumnIdx);
     await secondMinHeader.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton).click();
-    await expect(filterContainer).toBeVisible();
+    await expect(filterContainer, 'filter container is visible after clicking min column header').toBeVisible();
 
-    const secondNestedMinOptionCount = await filterContainer.locator('[title]').count();
+    await filterContainer.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll).click();
+    const secondNestedMinOptionCount = parseInt(
+      (
+        (await filterContainer
+          .getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.SelectAll)
+          .textContent()) ?? ''
+      ).match(/(\d+) selected/)?.[1] ?? '0',
+      10
+    );
 
     // Second nested table sees its own full set of Min options (not restricted by first table's filter)
-    expect(secondNestedMinOptionCount).toBeGreaterThanOrEqual(crossFilteredMinOptionCount);
+    expect(
+      secondNestedMinOptionCount,
+      'second nested table min option count is greater than cross-filtered min option count'
+    ).toBeGreaterThan(crossFilteredMinOptionCount);
 
     await filterContainer.getByRole('button', { name: 'Cancel' }).click();
     // Verify second nested table still shows all Info values (not filtered)
     const secondNestedRowCount = await secondNestedTable.locator('[role="row"]').count();
-    expect(secondNestedRowCount).toBeGreaterThan(1); // header + at least one row
+    expect(
+      secondNestedRowCount,
+      'second nested table still has rows after first nested table applied filters'
+    ).toBeGreaterThan(1); // header + at least one row
 
     // Cross-check: second nested table should show both "up" and non-"up" rows
     const secondTableInfoValues = new Set<string>();
     for (let i = 1; i < secondNestedRowCount; i++) {
       const text = await getCell(secondNestedTable, i, secondNestedInfoColumnIdx).textContent();
       if (text) {
-        secondTableInfoValues.add(text.trim().split(' ')[0]); // normalize "up fast" → "up"
+        secondTableInfoValues.add(text.trim());
       }
     }
     // The second table should have rows that are not "up" (since its filter is not restricted)
-    expect(secondTableInfoValues.size).toBeGreaterThan(0);
+    expect(secondTableInfoValues.size, 'second nested table should show both "up" and "up fast" rows').toBe(2);
   });
 
   test('word wrap, hover overflow, max cell height, and cell inspect', async ({

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -24,14 +24,24 @@ interface Props {
   field?: Field;
   iconClassName?: string;
   parentIndex?: number;
-  /** Cross-filter rows keyed by filter key. Each entry holds the rows available
-   *  *before* that filter was applied. '__tail' holds rows surviving all active
-   *  filters and is used for brand-new (not-yet-active) filter popups. */
+  /** Cross-filter rows keyed by filter key. Each entry holds the rows available *before* that filter was applied.  */
   crossFilterRows: Record<string, TableRow[]>;
+  /** Rows surviving all active filters. Used for brand-new (not-yet-active) filter popups. */
+  crossFilterTailRows: TableRow[];
 }
 
 export const Filter = memo(
-  ({ name, rows, filter, setFilter, field, iconClassName, parentIndex, crossFilterRows }: Props) => {
+  ({
+    name,
+    rows,
+    filter,
+    setFilter,
+    field,
+    iconClassName,
+    parentIndex,
+    crossFilterRows,
+    crossFilterTailRows,
+  }: Props) => {
     const filterKey = typeof parentIndex === 'number' ? `${name}-${parentIndex}` : name;
     const filterValue = filter[filterKey]?.filtered;
 
@@ -48,8 +58,7 @@ export const Filter = memo(
     // - Active filter: rows available before that filter was applied (keeps its own options visible).
     // - New filter: rows surviving all active filters (the tail).
     // - No active filters at all: fall back to raw rows.
-    const rowsForPopup =
-      filterKey in crossFilterRows ? crossFilterRows[filterKey] : (crossFilterRows['__tail'] ?? rows);
+    const rowsForPopup = filterKey in crossFilterRows ? crossFilterRows[filterKey] : crossFilterTailRows;
 
     return (
       <button

--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -24,75 +24,88 @@ interface Props {
   field?: Field;
   iconClassName?: string;
   parentIndex?: number;
+  /** Cross-filter rows keyed by filter key. Each entry holds the rows available
+   *  *before* that filter was applied. '__tail' holds rows surviving all active
+   *  filters and is used for brand-new (not-yet-active) filter popups. */
+  crossFilterRows: Record<string, TableRow[]>;
 }
 
-export const Filter = memo(({ name, rows, filter, setFilter, field, iconClassName, parentIndex }: Props) => {
-  const filterKey = typeof parentIndex === 'number' ? `${name}-${parentIndex}` : name;
-  const filterValue = filter[filterKey]?.filtered;
+export const Filter = memo(
+  ({ name, rows, filter, setFilter, field, iconClassName, parentIndex, crossFilterRows }: Props) => {
+    const filterKey = typeof parentIndex === 'number' ? `${name}-${parentIndex}` : name;
+    const filterValue = filter[filterKey]?.filtered;
 
-  const ref = useRef<HTMLButtonElement>(null);
-  const [isPopoverVisible, setPopoverVisible] = useState<boolean>(false);
-  const styles = useStyles2(getStyles);
-  const filterEnabled = Boolean(filterValue);
-  const [searchFilter, setSearchFilter] = useState(filter[filterKey]?.searchFilter || '');
-  const [operator, setOperator] = useState<SelectableValue<FilterOperator>>(
-    filter[filterKey]?.operator ?? operatorSelectableValues()[FilterOperator.CONTAINS]
-  );
+    const ref = useRef<HTMLButtonElement>(null);
+    const [isPopoverVisible, setPopoverVisible] = useState<boolean>(false);
+    const styles = useStyles2(getStyles);
+    const filterEnabled = Boolean(filterValue);
+    const [searchFilter, setSearchFilter] = useState(filter[filterKey]?.searchFilter || '');
+    const [operator, setOperator] = useState<SelectableValue<FilterOperator>>(
+      filter[filterKey]?.operator ?? operatorSelectableValues()[FilterOperator.CONTAINS]
+    );
 
-  return (
-    <button
-      className={styles.headerFilter}
-      ref={ref}
-      type="button"
-      aria-haspopup="dialog"
-      aria-pressed={isPopoverVisible}
-      aria-label={t('grafana-ui.table.filter.button', `Filter {{name}}`, {
-        name: field ? getDisplayName(field) : '',
-      })}
-      data-testid={selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton}
-      tabIndex={0}
-      onKeyDown={(ev) => {
-        // can't use tabindex alone to handle this, because column sort would intercept the keypress.
-        if (ev.target === ref.current && (ev.key === 'Enter' || ev.key === ' ')) {
-          setPopoverVisible(true);
-          ev.stopPropagation();
-          ev.preventDefault();
-        }
-      }}
-      onClick={(ev) => {
-        ev.stopPropagation();
-        if (!isPopoverVisible) {
-          setPopoverVisible(true);
-        }
-      }}
-    >
-      <Icon name="filter" className={clsx(iconClassName, filterEnabled ? styles.filterIconEnabled : '')} />
-      {isPopoverVisible && ref.current && (
-        <Popover
-          content={
-            <FilterPopup
-              name={name}
-              rows={rows}
-              filterValue={filterValue}
-              setFilter={setFilter}
-              field={field}
-              onClose={() => setPopoverVisible(false)}
-              searchFilter={searchFilter}
-              setSearchFilter={setSearchFilter}
-              operator={operator}
-              setOperator={setOperator}
-              buttonElement={ref.current}
-              parentIndex={parentIndex}
-            />
+    // Show options scoped to the current cross-filter state:
+    // - Active filter: rows available before that filter was applied (keeps its own options visible).
+    // - New filter: rows surviving all active filters (the tail).
+    // - No active filters at all: fall back to raw rows.
+    const rowsForPopup =
+      filterKey in crossFilterRows ? crossFilterRows[filterKey] : (crossFilterRows['__tail'] ?? rows);
+
+    return (
+      <button
+        className={styles.headerFilter}
+        ref={ref}
+        type="button"
+        aria-haspopup="dialog"
+        aria-pressed={isPopoverVisible}
+        aria-label={t('grafana-ui.table.filter.button', `Filter {{name}}`, {
+          name: field ? getDisplayName(field) : '',
+        })}
+        data-testid={selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton}
+        tabIndex={0}
+        onKeyDown={(ev) => {
+          // can't use tabindex alone to handle this, because column sort would intercept the keypress.
+          if (ev.target === ref.current && (ev.key === 'Enter' || ev.key === ' ')) {
+            setPopoverVisible(true);
+            ev.stopPropagation();
+            ev.preventDefault();
           }
-          placement="bottom-start"
-          referenceElement={ref.current}
-          show
-        />
-      )}
-    </button>
-  );
-});
+        }}
+        onClick={(ev) => {
+          ev.stopPropagation();
+          if (!isPopoverVisible) {
+            setPopoverVisible(true);
+          }
+        }}
+      >
+        <Icon name="filter" className={clsx(iconClassName, filterEnabled ? styles.filterIconEnabled : '')} />
+        {isPopoverVisible && ref.current && (
+          <Popover
+            content={
+              <FilterPopup
+                name={name}
+                rows={rowsForPopup}
+                filterValue={filterValue}
+                setFilter={setFilter}
+                field={field}
+                onClose={() => setPopoverVisible(false)}
+                searchFilter={searchFilter}
+                setSearchFilter={setSearchFilter}
+                operator={operator}
+                setOperator={setOperator}
+                buttonElement={ref.current}
+                parentIndex={parentIndex}
+              />
+            }
+            placement="bottom-start"
+            referenceElement={ref.current}
+            show
+          />
+        )}
+      </button>
+    );
+  }
+);
 
 Filter.displayName = 'Filter';
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -1314,6 +1314,148 @@ describe('TableNG', () => {
       expect(filteredFooterTexts[1]).toBe('1');
     });
 
+    it('cross-filter: second filter popup shows only values reachable after first filter is applied', async () => {
+      // Category A rows have Status=up; Category B rows have Status=down.
+      // Once we filter to Category=A, the Status filter popup should only offer "up".
+      const crossFilterFrame = withFieldOverrides(
+        toDataFrame({
+          name: 'CrossFilterData',
+          length: 4,
+          fields: [
+            {
+              name: 'Category',
+              type: FieldType.string,
+              values: ['A', 'A', 'B', 'B'],
+              config: {
+                custom: { filterable: true, cellOptions: { type: TableCellDisplayMode.Auto } },
+              },
+              display: displayString,
+              ...stdField,
+            },
+            {
+              name: 'Status',
+              type: FieldType.string,
+              values: ['up', 'up', 'down', 'down'],
+              config: {
+                custom: { filterable: true, cellOptions: { type: TableCellDisplayMode.Auto } },
+              },
+              display: displayString,
+              ...stdField,
+            },
+          ],
+        })
+      );
+
+      render(<TableNG enableVirtualization={false} data={crossFilterFrame} width={800} height={600} />);
+
+      // Two filter buttons: [0]=Category, [1]=Status
+      const filterButtons = screen.getAllByTestId(
+        selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton
+      );
+      expect(filterButtons).toHaveLength(2);
+
+      // --- Apply Category = A ---
+      await user.click(filterButtons[0]);
+      const popup1 = screen.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.Container);
+      expect(popup1).toBeInTheDocument();
+
+      // Select "A": click the checkbox (not the wrapper div) so onChange fires
+      await user.click(screen.getByRole('checkbox', { name: 'A' }));
+      await user.click(screen.getByRole('button', { name: 'Ok' }));
+
+      // Category filter is now active; only rows with Category=A are visible
+      const rowsAfterCategoryFilter = screen.getAllByRole('row');
+      // header row + 2 data rows
+      expect(rowsAfterCategoryFilter).toHaveLength(3);
+
+      // --- Open Status filter popup ---
+      await user.click(filterButtons[1]);
+      expect(
+        screen.getByTestId(selectors.components.Panels.Visualization.TableNG.Filters.Container)
+      ).toBeInTheDocument();
+
+      // Cross-filter: rows passed to this popup are the 2 category-A rows (both Status=up).
+      // "up" must be an option; "down" must NOT be present.
+      expect(screen.getByTitle('up')).toBeInTheDocument();
+      expect(screen.queryByTitle('down')).not.toBeInTheDocument();
+    });
+
+    it('cross-filter: top-level filter does not affect nested table filter options', async () => {
+      // Nested tables use their own parentIndex-scoped cross-filter chain, independent of
+      // top-level filters. A top-level filter on Column A should not restrict nested options.
+      const nestedCrossFilterFrame = withFieldOverrides(
+        toDataFrame({
+          name: 'NestedCrossFilter',
+          length: 2,
+          fields: [
+            {
+              name: 'Column A',
+              type: FieldType.string,
+              values: ['A1', 'A2'],
+              config: {
+                custom: { filterable: true, cellOptions: { type: TableCellDisplayMode.Auto } },
+              },
+              display: displayString,
+              ...stdField,
+            },
+            {
+              name: '__nestedFrames',
+              type: FieldType.nestedFrames,
+              values: [
+                [
+                  withFieldOverrides(
+                    toDataFrame({
+                      fields: [
+                        {
+                          name: 'Nested Col',
+                          type: FieldType.string,
+                          values: ['X', 'Y'],
+                          config: { custom: { filterable: true } },
+                          display: displayString,
+                          ...stdField,
+                        },
+                      ],
+                    })
+                  ),
+                ],
+                [
+                  withFieldOverrides(
+                    toDataFrame({
+                      fields: [
+                        {
+                          name: 'Nested Col',
+                          type: FieldType.string,
+                          values: ['X', 'Z'],
+                          config: { custom: { filterable: true } },
+                          display: displayString,
+                          ...stdField,
+                        },
+                      ],
+                    })
+                  ),
+                ],
+              ],
+              config: { custom: {} },
+            },
+          ],
+        })
+      );
+
+      render(<TableNG enableVirtualization={false} data={nestedCrossFilterFrame} width={800} height={600} />);
+
+      // Apply top-level Column A filter to keep only row A1
+      const filterButtons = screen.getAllByTestId(
+        selectors.components.Panels.Visualization.TableNG.Filters.HeaderButton
+      );
+      await user.click(filterButtons[0]);
+      await user.click(screen.getByRole('checkbox', { name: 'A1' }));
+      await user.click(screen.getByRole('button', { name: 'Ok' }));
+
+      // Only A1 row is visible at the top level
+      expect(screen.getByText('A1')).toBeInTheDocument();
+      expect(screen.queryByText('A2')).not.toBeInTheDocument();
+    });
+
     it('filters rows with case-insensitive text matching', () => {
       // Create a case-insensitive filtered frame (filtering for 'a1' should match 'A1')
       const baseFrame = createBasicDataFrame();

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -91,6 +91,7 @@ import {
   calculateFooterHeight,
   canFieldBeColorized,
   compileFrameToRecords,
+  computeCrossFilterRows,
   createTypographyContext,
   displayJsonValue,
   extractPixelValue,
@@ -553,6 +554,11 @@ export function TableNG(props: TableNGProps) {
         cellRootRenderers: {},
       };
 
+      // Compute cross-filter rows scoped to the nesting level of this table instance.
+      // For top-level tables parentIndex is undefined; for nested tables it matches the parent row index.
+      const parentIndex = visibleRows[0]?.__parentIndex;
+      const { crossFilterRows } = computeCrossFilterRows(rawRows, filter, f, parentIndex);
+
       let lastRowIdx = -1;
       // shared when whole row will be styled by a single cell's color
       let rowCellStyle: Partial<CSSProperties> = {
@@ -824,7 +830,8 @@ export function TableNG(props: TableNGProps) {
               disableKeyboardEvents={disableKeyboardEvents}
               direction={sortDirection}
               showTypeIcons={showTypeIcons}
-              parentIndex={visibleRows[0]?.__parentIndex}
+              parentIndex={parentIndex}
+              crossFilterRows={crossFilterRows}
               selectFirstCell={() => {
                 gridRef.current?.selectCell({ rowIdx: 0, idx: 0 });
               }}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -88,7 +88,6 @@ import {
   type TableSummaryRow,
 } from './types';
 import {
-  applyFilter,
   calculateFooterHeight,
   canFieldBeColorized,
   compileFrameToRecords,
@@ -554,12 +553,12 @@ export function TableNG(props: TableNGProps) {
         cellRootRenderers: {},
       };
 
-      // Compute cross-filter rows scoped to the nesting level of this table instance.
-      // For top-level tables, reuse the result already computed by useFilteredRows (free).
-      // For nested tables, parentIndex is defined and we must compute their own scoped result.
+      // Reuse pre-computed filter results — no re-scanning of rows needed.
+      // Top-level tables use filterResult from useFilteredRows; nested tables use the
+      // filterResult stored on their NestedRowEntry by useNestedRows.
       const parentIndex = visibleRows[0]?.__parentIndex;
       const { crossFilterRows, crossFilterTailRows } =
-        parentIndex == null ? filterResult : applyFilter(rawRows, filter, f, false, parentIndex);
+        parentIndex == null ? filterResult : nestedRows[parentIndex].filterResult;
 
       let lastRowIdx = -1;
       // shared when whole row will be styled by a single cell's color
@@ -857,26 +856,27 @@ export function TableNG(props: TableNGProps) {
       return result;
     },
     [
-      theme,
-      onCellFilterAdded,
-      rowHeight,
-      maxRowHeight,
       applyToRowBgFn,
-      frozenColumns,
-      numFrozenColsFullyInView,
-      getCellColorInlineStyles,
-      rowHeightFn,
-      timeRange,
-      getCellActions,
+      disableKeyboardEvents,
       disableSanitizeHtml,
-      getTextColorForBackground,
       filter,
       filterResult,
-      setFilter,
-      disableKeyboardEvents,
-      showTypeIcons,
       footers,
+      frozenColumns,
+      getCellActions,
+      getCellColorInlineStyles,
+      getTextColorForBackground,
       isUniformFooter,
+      maxRowHeight,
+      nestedRows,
+      numFrozenColsFullyInView,
+      onCellFilterAdded,
+      rowHeight,
+      rowHeightFn,
+      setFilter,
+      showTypeIcons,
+      theme,
+      timeRange,
     ]
   );
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -557,7 +557,7 @@ export function TableNG(props: TableNGProps) {
       // Compute cross-filter rows scoped to the nesting level of this table instance.
       // For top-level tables parentIndex is undefined; for nested tables it matches the parent row index.
       const parentIndex = visibleRows[0]?.__parentIndex;
-      const { crossFilterRows } = computeCrossFilterRows(rawRows, filter, f, parentIndex);
+      const { crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(rawRows, filter, f, parentIndex);
 
       let lastRowIdx = -1;
       // shared when whole row will be styled by a single cell's color
@@ -832,6 +832,7 @@ export function TableNG(props: TableNGProps) {
               showTypeIcons={showTypeIcons}
               parentIndex={parentIndex}
               crossFilterRows={crossFilterRows}
+              crossFilterTailRows={crossFilterTailRows}
               selectFirstCell={() => {
                 gridRef.current?.selectCell({ rowIdx: 0, idx: 0 });
               }}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -88,10 +88,10 @@ import {
   type TableSummaryRow,
 } from './types';
 import {
+  applyFilter,
   calculateFooterHeight,
   canFieldBeColorized,
   compileFrameToRecords,
-  computeCrossFilterRows,
   createTypographyContext,
   displayJsonValue,
   extractPixelValue,
@@ -205,7 +205,7 @@ export function TableNG(props: TableNGProps) {
   const nestedFields = useMemo(() => firstRowNestedData?.fields ?? [], [firstRowNestedData]);
   const nestedVisibleFields = useMemo(() => getVisibleFields(nestedFields), [nestedFields]);
 
-  const { rows: filteredRows, filter, setFilter } = useFilteredRows(rows, data.fields, hasNestedFrames);
+  const { rows: filteredRows, filter, setFilter, filterResult } = useFilteredRows(rows, data.fields, hasNestedFrames);
 
   const {
     rows: sortedRows,
@@ -555,9 +555,11 @@ export function TableNG(props: TableNGProps) {
       };
 
       // Compute cross-filter rows scoped to the nesting level of this table instance.
-      // For top-level tables parentIndex is undefined; for nested tables it matches the parent row index.
+      // For top-level tables, reuse the result already computed by useFilteredRows (free).
+      // For nested tables, parentIndex is defined and we must compute their own scoped result.
       const parentIndex = visibleRows[0]?.__parentIndex;
-      const { crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(rawRows, filter, f, parentIndex);
+      const { crossFilterRows, crossFilterTailRows } =
+        parentIndex == null ? filterResult : applyFilter(rawRows, filter, f, false, parentIndex);
 
       let lastRowIdx = -1;
       // shared when whole row will be styled by a single cell's color
@@ -869,6 +871,7 @@ export function TableNG(props: TableNGProps) {
       disableSanitizeHtml,
       getTextColorForBackground,
       filter,
+      filterResult,
       setFilter,
       disableKeyboardEvents,
       showTypeIcons,

--- a/packages/grafana-ui/src/components/Table/TableNG/__snapshots__/hooks.test.ts.snap
+++ b/packages/grafana-ui/src/components/Table/TableNG/__snapshots__/hooks.test.ts.snap
@@ -1,59 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableNG hooks useNestedRows should apply sorting and filtering 1`] = `
-[
-  {
-    "final": [
-      {
-        "__depth": 0,
-        "__index": 1,
-        "__parentIndex": 0,
-        "active": false,
-        "age": 25,
-        "name": "Bob",
-      },
-      {
-        "__depth": 0,
-        "__index": 0,
-        "__parentIndex": 0,
-        "active": true,
-        "age": 30,
-        "name": "Alice",
-      },
-    ],
-    "raw": [
-      {
-        "__depth": 0,
-        "__index": 0,
-        "__parentIndex": 0,
-        "active": true,
-        "age": 30,
-        "name": "Alice",
-      },
-      {
-        "__depth": 0,
-        "__index": 1,
-        "__parentIndex": 0,
-        "active": false,
-        "age": 25,
-        "name": "Bob",
-      },
-      {
-        "__depth": 0,
-        "__index": 2,
-        "__parentIndex": 0,
-        "active": true,
-        "age": 35,
-        "name": "Charlie",
-      },
-    ],
-  },
-]
-`;
-
 exports[`TableNG hooks useNestedRows should return the nested rows 1`] = `
 [
   {
+    "filterResult": {
+      "crossFilterOrder": [],
+      "crossFilterRows": {},
+      "crossFilterTailRows": [
+        {
+          "__depth": 0,
+          "__index": 0,
+          "__parentIndex": 0,
+          "active": true,
+          "age": 30,
+          "name": "Alice",
+        },
+        {
+          "__depth": 0,
+          "__index": 1,
+          "__parentIndex": 0,
+          "active": false,
+          "age": 25,
+          "name": "Bob",
+        },
+        {
+          "__depth": 0,
+          "__index": 2,
+          "__parentIndex": 0,
+          "active": true,
+          "age": 35,
+          "name": "Charlie",
+        },
+      ],
+      "filteredRows": [
+        {
+          "__depth": 0,
+          "__index": 0,
+          "__parentIndex": 0,
+          "active": true,
+          "age": 30,
+          "name": "Alice",
+        },
+        {
+          "__depth": 0,
+          "__index": 1,
+          "__parentIndex": 0,
+          "active": false,
+          "age": 25,
+          "name": "Bob",
+        },
+        {
+          "__depth": 0,
+          "__index": 2,
+          "__parentIndex": 0,
+          "active": true,
+          "age": 35,
+          "name": "Charlie",
+        },
+      ],
+    },
     "final": [
       {
         "__depth": 0,

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -26,6 +26,7 @@ interface HeaderCellProps {
   disableKeyboardEvents?: boolean;
   parentIndex?: number;
   crossFilterRows: Record<string, TableRow[]>;
+  crossFilterTailRows: TableRow[];
 }
 
 export const HeaderCell: React.FC<HeaderCellProps> = ({
@@ -40,6 +41,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
   showTypeIcons,
   parentIndex,
   crossFilterRows,
+  crossFilterTailRows,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const headerCellWrap = field.config.custom?.wrapHeaderText ?? false;
@@ -116,6 +118,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
           iconClassName={styles.headerCellIcon}
           parentIndex={parentIndex}
           crossFilterRows={crossFilterRows}
+          crossFilterTailRows={crossFilterTailRows}
         />
       )}
     </Stack>

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -25,6 +25,7 @@ interface HeaderCellProps {
   selectFirstCell: () => void;
   disableKeyboardEvents?: boolean;
   parentIndex?: number;
+  crossFilterRows: Record<string, TableRow[]>;
 }
 
 export const HeaderCell: React.FC<HeaderCellProps> = ({
@@ -38,6 +39,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
   setFilter,
   showTypeIcons,
   parentIndex,
+  crossFilterRows,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const headerCellWrap = field.config.custom?.wrapHeaderText ?? false;
@@ -113,6 +115,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
           field={field}
           iconClassName={styles.headerCellIcon}
           parentIndex={parentIndex}
+          crossFilterRows={crossFilterRows}
         />
       )}
     </Stack>

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -412,17 +412,23 @@ describe('TableNG hooks', () => {
 
       const frameToRecords = compileFrameToRecords(frame, 'nested');
 
+      // parentIndex must be set on the filter entry — this is how the UI always scopes filters
+      // for nested tables. Without it the filter is silently skipped (regression test).
       const { result } = renderHook(() =>
         useNestedRows(
           frameToRecords(frame),
           frame.fields[1].values[0],
           true,
           'nested',
-          { name: { filteredSet: new Set(['Alice', 'Bob']), displayName: 'name' } },
+          { 'name-0': { filteredSet: new Set(['Alice', 'Bob']), displayName: 'name', parentIndex: 0 } },
           [{ columnKey: 'age', direction: 'ASC' }]
         )
       );
-      expect(result.current).toMatchSnapshot();
+
+      // filtering reduced raw (3 rows) to final (2 rows: Alice + Bob), sorted by age ASC
+      expect(result.current[0].raw).toHaveLength(3);
+      expect(result.current[0].final).toHaveLength(2);
+      expect(result.current[0].final.map((r: { name: string }) => r.name)).toEqual(['Bob', 'Alice']);
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -15,7 +15,9 @@ import {
   useNestedRows,
 } from './hooks';
 import { type TableRow } from './types';
-import { createTypographyContext, compileFrameToRecords } from './utils';
+import { applyFilter, createTypographyContext, compileFrameToRecords } from './utils';
+
+const emptyFilterResult = applyFilter([], {}, []);
 
 describe('TableNG hooks', () => {
   function setupData() {
@@ -428,7 +430,7 @@ describe('TableNG hooks', () => {
       // filtering reduced raw (3 rows) to final (2 rows: Alice + Bob), sorted by age ASC
       expect(result.current[0].raw).toHaveLength(3);
       expect(result.current[0].final).toHaveLength(2);
-      expect(result.current[0].final.map((r: { name: string }) => r.name)).toEqual(['Bob', 'Alice']);
+      expect(result.current[0].final.map((r) => r['name'])).toEqual(['Bob', 'Alice']);
     });
   });
 
@@ -621,7 +623,7 @@ describe('TableNG hooks', () => {
               defaultNestedHeight: 40,
               typographyCtx: typographyCtx,
               hasNestedFrames: true,
-              nestedRows: [{ raw: nestedRows, final: nestedRows }],
+              nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
               nestedFields: fields,
               nestedColWidths: [100, 100, 100],
               visibleNestedRowCounts: [null],
@@ -653,7 +655,7 @@ describe('TableNG hooks', () => {
               defaultNestedHeight: 40,
               typographyCtx: typographyCtx,
               hasNestedFrames: true,
-              nestedRows: [{ raw: nestedRows, final: nestedRows }],
+              nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
               nestedFields: fields,
               nestedColWidths: [100, 100, 100],
               visibleNestedRowCounts: [0],
@@ -690,7 +692,7 @@ describe('TableNG hooks', () => {
               defaultNestedHeight: defaultHeight,
               typographyCtx: typographyCtx,
               hasNestedFrames: true,
-              nestedRows: [{ raw: nestedRows, final: nestedRows }],
+              nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
               nestedFields: fields,
               nestedColWidths: [100, 100, 100],
               visibleNestedRowCounts: [3],
@@ -727,7 +729,7 @@ describe('TableNG hooks', () => {
               defaultNestedHeight,
               typographyCtx: typographyCtx,
               hasNestedFrames: true,
-              nestedRows: [{ raw: nestedRows, final: nestedRows }],
+              nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
               nestedFields: fields,
               nestedColWidths: [100, 100, 100],
               visibleNestedRowCounts: [3],
@@ -764,7 +766,7 @@ describe('TableNG hooks', () => {
               defaultNestedHeight: 'min-content',
               typographyCtx: typographyCtx,
               hasNestedFrames: true,
-              nestedRows: [{ raw: nestedRows, final: nestedRows }],
+              nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
               nestedFields: fields,
               nestedColWidths: [100, 100, 100],
               visibleNestedRowCounts: [3],
@@ -795,6 +797,7 @@ describe('TableNG hooks', () => {
                 {
                   raw: nestedRecords,
                   final: nestedRecords,
+                  filterResult: emptyFilterResult,
                 },
               ],
               nestedFields: fields,
@@ -946,7 +949,7 @@ describe('TableNG hooks', () => {
             typographyCtx: { ...typographyCtx, measureHeight: measureHeightFn, estimateHeight: estimateHeightFn },
             hasNestedFrames: true,
             visibleNestedRowCounts: [3],
-            nestedRows: [{ raw: nestedRows, final: nestedRows }],
+            nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
             nestedFields: fieldsWithWrappedText,
             nestedColWidths: [100, 100, 100],
           });
@@ -1007,7 +1010,7 @@ describe('TableNG hooks', () => {
             typographyCtx: { ...typographyCtx, measureHeight: measureHeightFn, estimateHeight: estimateHeightFn },
             hasNestedFrames: true,
             visibleNestedRowCounts: [3],
-            nestedRows: [{ raw: nestedRows, final: nestedRows }],
+            nestedRows: [{ raw: nestedRows, final: nestedRows, filterResult: emptyFilterResult }],
             nestedFields: nestedFieldsWithTime,
             nestedColWidths: [200],
           });

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -299,7 +299,7 @@ export const useNestedRows = (
       }
 
       const rawRows = frameToRecords(nestedFrame, parentRow.__index);
-      const filterResult = applyFilter(rawRows, filter, nestedFrame.fields);
+      const filterResult = applyFilter(rawRows, filter, nestedFrame.fields, false, parentRow.__index);
       const sortedRows = applySort(
         filterResult.filteredRows,
         nestedFrame.fields,

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -45,11 +45,11 @@ export interface FilteredRowsOptions {
 
 export function useFilteredRows(rows: TableRow[], fields: Field[], hasNestedFrames?: boolean) {
   const [filter, setFilter] = useState<FilterType>({});
-  const filteredRows = useMemo(
+  const filterResult = useMemo(
     () => applyFilter(rows, filter, fields, hasNestedFrames),
     [rows, filter, fields, hasNestedFrames]
   );
-  return { rows: filteredRows, filter, setFilter };
+  return { rows: filterResult.filteredRows, filter, setFilter, filterResult };
 }
 
 export interface SortedRowsOptions {
@@ -299,7 +299,7 @@ export const useNestedRows = (
       }
 
       const rawRows = frameToRecords(nestedFrame, parentRow.__index);
-      const filteredRows = applyFilter(rawRows, filter, nestedFrame.fields);
+      const { filteredRows } = applyFilter(rawRows, filter, nestedFrame.fields);
       const sortedRows = applySort(filteredRows, nestedFrame.fields, sortColumns, getColumnTypes(nestedFrame.fields));
       result[parentRow.__index] = { raw: rawRows, final: sortedRows };
     }

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -299,9 +299,14 @@ export const useNestedRows = (
       }
 
       const rawRows = frameToRecords(nestedFrame, parentRow.__index);
-      const { filteredRows } = applyFilter(rawRows, filter, nestedFrame.fields);
-      const sortedRows = applySort(filteredRows, nestedFrame.fields, sortColumns, getColumnTypes(nestedFrame.fields));
-      result[parentRow.__index] = { raw: rawRows, final: sortedRows };
+      const filterResult = applyFilter(rawRows, filter, nestedFrame.fields);
+      const sortedRows = applySort(
+        filterResult.filteredRows,
+        nestedFrame.fields,
+        sortColumns,
+        getColumnTypes(nestedFrame.fields)
+      );
+      result[parentRow.__index] = { raw: rawRows, final: sortedRows, filterResult };
     }
 
     return result;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -19,7 +19,7 @@ import { type TableCellHeight, type TableFieldOptions } from '@grafana/schema';
 import { type TableCellInspectorMode } from '../TableCellInspector';
 import { type TableCellOptions } from '../types';
 
-import { type TextAlign } from './utils';
+import { type ApplyFilterResult, type TextAlign } from './utils';
 
 export const FILTER_FOR_OPERATOR = '=';
 export const FILTER_OUT_OPERATOR = '!=';
@@ -291,6 +291,7 @@ export type FrameToRowsConverter = (frame: DataFrame, nestedRowIndex?: number) =
 export interface NestedRowEntry {
   raw: TableRow[];
   final: TableRow[];
+  filterResult: ApplyFilterResult;
 }
 
 // Type for mapping column names to their field types

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1822,6 +1822,44 @@ describe('TableNG utils', () => {
       ]);
     });
 
+    it('ignores scoped filter entries when parentIndex is not passed (regression: useNestedRows must pass parentIndex)', () => {
+      // This is the bug: calling applyFilter without parentIndex when all filter entries have
+      // parentIndex set causes them to be treated as top-level and silently skipped, leaving
+      // the nested table unfiltered. The fix is to always pass parentRow.__index.
+      const frame = createDataFrame({
+        fields: [
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [10, 20, 30],
+            display: (v) => ({ text: String(v), numeric: NaN }),
+          },
+        ],
+      });
+      const frameToRecords = compileFrameToRecords(frame, 'nested');
+      const records = frameToRecords(frame, 5);
+
+      // Bug: no parentIndex arg — scoped filter is ignored, all rows returned
+      const { filteredRows: buggy } = applyFilter(
+        records,
+        { value: { filteredSet: new Set(['10']), displayName: 'value', parentIndex: 5 } },
+        frame.fields,
+        false
+      );
+      expect(buggy).toHaveLength(3); // filter had no effect
+
+      // Fix: pass parentIndex — scoped filter is applied correctly
+      const { filteredRows: fixed } = applyFilter(
+        records,
+        { value: { filteredSet: new Set(['10']), displayName: 'value', parentIndex: 5 } },
+        frame.fields,
+        false,
+        5
+      );
+      expect(fixed).toHaveLength(1);
+      expect(fixed).toMatchObject([{ value: 10 }]);
+    });
+
     it('filters the records by the filter columns with a nested frame and a parent index', () => {
       const frame = createDataFrame({
         fields: [

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -23,7 +23,6 @@ import { type MeasureCellHeightEntry, type TableRow } from './types';
 import {
   applyFilter,
   applySort,
-  computeCrossFilterRows,
   buildCellHeightMeasurers,
   buildHeaderHeightMeasurers,
   buildInspectValue,
@@ -1707,7 +1706,7 @@ describe('TableNG utils', () => {
         ],
       });
       const frameToRecords = compileFrameToRecords(frame);
-      const filtered = applyFilter(frameToRecords(frame), {}, frame.fields, false);
+      const { filteredRows: filtered } = applyFilter(frameToRecords(frame), {}, frame.fields, false);
       expect(filtered).toMatchObject([
         { time: 1, value: 10 },
         { time: 1, value: 20 },
@@ -1734,7 +1733,7 @@ describe('TableNG utils', () => {
       });
       const frameToRecords = compileFrameToRecords(frame);
       const records = frameToRecords(frame);
-      const filtered = applyFilter(
+      const { filteredRows: filtered } = applyFilter(
         records,
         { time: { filteredSet: new Set(['1']), displayName: 'time' } },
         frame.fields,
@@ -1764,7 +1763,7 @@ describe('TableNG utils', () => {
         ],
       });
       const frameToRecords = compileFrameToRecords(frame);
-      const filtered = applyFilter(
+      const { filteredRows: filtered } = applyFilter(
         frameToRecords(frame),
         {
           time: { filteredSet: new Set(['1', '2']), displayName: 'time' },
@@ -1804,7 +1803,7 @@ describe('TableNG utils', () => {
       });
       const frameToRecords = compileFrameToRecords(frame, 'nested');
       const records = frameToRecords(frame);
-      const filtered = applyFilter(
+      const { filteredRows: filtered } = applyFilter(
         records,
         {
           time: { filteredSet: new Set(['1']), displayName: 'time' },
@@ -1842,11 +1841,12 @@ describe('TableNG utils', () => {
       });
       const frameToRecords = compileFrameToRecords(frame, 'nested');
       const records = frameToRecords(frame, 3);
-      const filtered = applyFilter(
+      const { filteredRows: filtered } = applyFilter(
         records,
         { time: { filteredSet: new Set(['1']), displayName: 'time', parentIndex: 3 } },
         frame.fields,
-        false
+        false,
+        3
       );
       expect(filtered).toMatchObject([
         { time: 1, value: 10 },
@@ -1854,7 +1854,7 @@ describe('TableNG utils', () => {
       ]);
 
       // using a parent index that doesn't match the rows in the set, the rows should not be filtered.
-      const filtered2 = applyFilter(
+      const { filteredRows: filtered2 } = applyFilter(
         records,
         { time: { filteredSet: new Set(['1']), displayName: 'time', parentIndex: 2 } },
         frame.fields,
@@ -1886,7 +1886,7 @@ describe('TableNG utils', () => {
       });
       const frameToRecords = compileFrameToRecords(frame);
       const records = frameToRecords(frame);
-      const filtered = applyFilter(
+      const { filteredRows: filtered } = applyFilter(
         records,
         { time: { filteredSet: new Set(['1']), displayName: 'time' } },
         frame.fields,
@@ -1904,7 +1904,7 @@ describe('TableNG utils', () => {
     });
   });
 
-  describe('computeCrossFilterRows', () => {
+  describe('cross-filter metadata', () => {
     const makeField = (name: string, values: unknown[]) => ({
       name,
       type: FieldType.string,
@@ -1930,7 +1930,7 @@ describe('TableNG utils', () => {
     ];
 
     it('returns empty crossFilterOrder and full rows as tail when no filters active', () => {
-      const { crossFilterOrder, crossFilterTailRows } = computeCrossFilterRows(rows, {}, fields);
+      const { crossFilterOrder, crossFilterTailRows } = applyFilter(rows, {}, fields);
       expect(crossFilterOrder).toEqual([]);
       expect(crossFilterTailRows).toHaveLength(rows.length);
     });
@@ -1939,7 +1939,7 @@ describe('TableNG utils', () => {
       const filter = {
         category: { filteredSet: new Set(['A']), displayName: 'category' },
       };
-      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(rows, filter, fields);
+      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = applyFilter(rows, filter, fields);
       expect(crossFilterOrder).toEqual(['category']);
       // before the first filter: all rows
       expect(crossFilterRows['category']).toHaveLength(5);
@@ -1953,7 +1953,7 @@ describe('TableNG utils', () => {
         category: { filteredSet: new Set(['A', 'B']), displayName: 'category' },
         status: { filteredSet: new Set(['up']), displayName: 'status' },
       };
-      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(rows, filter, fields);
+      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = applyFilter(rows, filter, fields);
       expect(crossFilterOrder).toEqual(['category', 'status']);
       // before category filter: all 5 rows
       expect(crossFilterRows['category']).toHaveLength(5);
@@ -1972,7 +1972,7 @@ describe('TableNG utils', () => {
       const filter = {
         category: { filteredSet: new Set(['A']), displayName: 'category' },
       };
-      const { crossFilterRows } = computeCrossFilterRows(mixedRows, filter, fields);
+      const { crossFilterRows } = applyFilter(mixedRows, filter, fields);
       // depth-1 row must not be counted
       expect(crossFilterRows['category']).toHaveLength(5);
     });
@@ -1986,10 +1986,11 @@ describe('TableNG utils', () => {
       const filter = {
         'category-7': { filteredSet: new Set(['A']), displayName: 'category', parentIndex: 7 },
       };
-      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(
+      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = applyFilter(
         nestedRows,
         filter,
         fields,
+        false,
         7
       );
       expect(crossFilterOrder).toEqual(['category-7']);
@@ -2005,7 +2006,7 @@ describe('TableNG utils', () => {
         category: { filteredSet: new Set(['A']), displayName: 'category' },
         'status-7': { filteredSet: new Set(['up']), displayName: 'status', parentIndex: 7 },
       };
-      const { crossFilterOrder } = computeCrossFilterRows(rows, filter, fields, 7);
+      const { crossFilterOrder } = applyFilter(rows, filter, fields, false, 7);
       // only the nested filter for parentIndex 7 should appear
       expect(crossFilterOrder).toEqual(['status-7']);
     });

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -23,6 +23,7 @@ import { type MeasureCellHeightEntry, type TableRow } from './types';
 import {
   applyFilter,
   applySort,
+  computeCrossFilterRows,
   buildCellHeightMeasurers,
   buildHeaderHeightMeasurers,
   buildInspectValue,
@@ -1900,6 +1901,108 @@ describe('TableNG utils', () => {
         { time: 1, value: 10 },
         { time: 1, value: 20 },
       ]);
+    });
+  });
+
+  describe('computeCrossFilterRows', () => {
+    const makeField = (name: string, values: unknown[]) => ({
+      name,
+      type: FieldType.string,
+      values,
+      config: {},
+      display: (v: unknown) => ({ text: String(v), numeric: NaN }),
+    });
+
+    const makeRows = (values: Array<{ category: string; status: string }>): TableRow[] =>
+      values.map((v, i) => ({ __depth: 0, __index: i, category: v.category, status: v.status }));
+
+    const rows = makeRows([
+      { category: 'A', status: 'up' },
+      { category: 'A', status: 'down' },
+      { category: 'B', status: 'up' },
+      { category: 'B', status: 'down' },
+      { category: 'C', status: 'up' },
+    ]);
+
+    const fields = [
+      makeField('category', ['A', 'A', 'B', 'B', 'C']),
+      makeField('status', ['up', 'down', 'up', 'down', 'up']),
+    ];
+
+    it('returns empty crossFilterOrder and full rows as tail when no filters active', () => {
+      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(rows, {}, fields);
+      expect(crossFilterOrder).toEqual([]);
+      expect(crossFilterRows['__tail']).toHaveLength(rows.length);
+    });
+
+    it('stores all rows before the first filter and the filtered subset as tail', () => {
+      const filter = {
+        category: { filteredSet: new Set(['A']), displayName: 'category' },
+      };
+      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(rows, filter, fields);
+      expect(crossFilterOrder).toEqual(['category']);
+      // before the first filter: all rows
+      expect(crossFilterRows['category']).toHaveLength(5);
+      // tail: only rows with category A
+      expect(crossFilterRows['__tail']).toHaveLength(2);
+      expect(crossFilterRows['__tail'].every((r) => r['category'] === 'A')).toBe(true);
+    });
+
+    it('builds a cascading chain for multiple filters', () => {
+      const filter = {
+        category: { filteredSet: new Set(['A', 'B']), displayName: 'category' },
+        status: { filteredSet: new Set(['up']), displayName: 'status' },
+      };
+      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(rows, filter, fields);
+      expect(crossFilterOrder).toEqual(['category', 'status']);
+      // before category filter: all 5 rows
+      expect(crossFilterRows['category']).toHaveLength(5);
+      // before status filter: rows passing category (A or B) = 4 rows
+      expect(crossFilterRows['status']).toHaveLength(4);
+      // tail: rows passing both = A-up and B-up
+      expect(crossFilterRows['__tail']).toHaveLength(2);
+    });
+
+    it('scopes top-level cross-filter to depth-0 rows only', () => {
+      const mixedRows: TableRow[] = [
+        ...rows,
+        // simulate a depth-1 nested container row that should be ignored
+        { __depth: 1, __index: 0 },
+      ];
+      const filter = {
+        category: { filteredSet: new Set(['A']), displayName: 'category' },
+      };
+      const { crossFilterRows } = computeCrossFilterRows(mixedRows, filter, fields);
+      // depth-1 row must not be counted
+      expect(crossFilterRows['category']).toHaveLength(5);
+    });
+
+    it('scopes nested cross-filter to matching parentIndex only', () => {
+      const nestedRows: TableRow[] = [
+        { __depth: 0, __index: 0, __parentIndex: 7, category: 'A', status: 'up' },
+        { __depth: 0, __index: 1, __parentIndex: 7, category: 'B', status: 'down' },
+        { __depth: 0, __index: 2, __parentIndex: 7, category: 'A', status: 'down' },
+      ];
+      const filter = {
+        'category-7': { filteredSet: new Set(['A']), displayName: 'category', parentIndex: 7 },
+      };
+      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(nestedRows, filter, fields, 7);
+      expect(crossFilterOrder).toEqual(['category-7']);
+      // before the filter: all 3 nested rows
+      expect(crossFilterRows['category-7']).toHaveLength(3);
+      // tail: only the 2 rows with category A
+      expect(crossFilterRows['__tail']).toHaveLength(2);
+    });
+
+    it('ignores filters from a different nesting scope', () => {
+      const filter = {
+        // top-level filter — should be ignored when parentIndex=7 is requested
+        category: { filteredSet: new Set(['A']), displayName: 'category' },
+        'status-7': { filteredSet: new Set(['up']), displayName: 'status', parentIndex: 7 },
+      };
+      const { crossFilterOrder } = computeCrossFilterRows(rows, filter, fields, 7);
+      // only the nested filter for parentIndex 7 should appear
+      expect(crossFilterOrder).toEqual(['status-7']);
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1930,22 +1930,22 @@ describe('TableNG utils', () => {
     ];
 
     it('returns empty crossFilterOrder and full rows as tail when no filters active', () => {
-      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(rows, {}, fields);
+      const { crossFilterOrder, crossFilterTailRows } = computeCrossFilterRows(rows, {}, fields);
       expect(crossFilterOrder).toEqual([]);
-      expect(crossFilterRows['__tail']).toHaveLength(rows.length);
+      expect(crossFilterTailRows).toHaveLength(rows.length);
     });
 
     it('stores all rows before the first filter and the filtered subset as tail', () => {
       const filter = {
         category: { filteredSet: new Set(['A']), displayName: 'category' },
       };
-      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(rows, filter, fields);
+      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(rows, filter, fields);
       expect(crossFilterOrder).toEqual(['category']);
       // before the first filter: all rows
       expect(crossFilterRows['category']).toHaveLength(5);
       // tail: only rows with category A
-      expect(crossFilterRows['__tail']).toHaveLength(2);
-      expect(crossFilterRows['__tail'].every((r) => r['category'] === 'A')).toBe(true);
+      expect(crossFilterTailRows).toHaveLength(2);
+      expect(crossFilterTailRows.every((r) => r['category'] === 'A')).toBe(true);
     });
 
     it('builds a cascading chain for multiple filters', () => {
@@ -1953,14 +1953,14 @@ describe('TableNG utils', () => {
         category: { filteredSet: new Set(['A', 'B']), displayName: 'category' },
         status: { filteredSet: new Set(['up']), displayName: 'status' },
       };
-      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(rows, filter, fields);
+      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(rows, filter, fields);
       expect(crossFilterOrder).toEqual(['category', 'status']);
       // before category filter: all 5 rows
       expect(crossFilterRows['category']).toHaveLength(5);
       // before status filter: rows passing category (A or B) = 4 rows
       expect(crossFilterRows['status']).toHaveLength(4);
       // tail: rows passing both = A-up and B-up
-      expect(crossFilterRows['__tail']).toHaveLength(2);
+      expect(crossFilterTailRows).toHaveLength(2);
     });
 
     it('scopes top-level cross-filter to depth-0 rows only', () => {
@@ -1986,12 +1986,17 @@ describe('TableNG utils', () => {
       const filter = {
         'category-7': { filteredSet: new Set(['A']), displayName: 'category', parentIndex: 7 },
       };
-      const { crossFilterOrder, crossFilterRows } = computeCrossFilterRows(nestedRows, filter, fields, 7);
+      const { crossFilterOrder, crossFilterRows, crossFilterTailRows } = computeCrossFilterRows(
+        nestedRows,
+        filter,
+        fields,
+        7
+      );
       expect(crossFilterOrder).toEqual(['category-7']);
       // before the filter: all 3 nested rows
       expect(crossFilterRows['category-7']).toHaveLength(3);
       // tail: only the 2 rows with category A
-      expect(crossFilterRows['__tail']).toHaveLength(2);
+      expect(crossFilterTailRows).toHaveLength(2);
     });
 
     it('ignores filters from a different nesting scope', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -713,57 +713,35 @@ export function applySort(
     : [...rows].sort(compareRows);
 }
 
-export function applyFilter(
-  rows: TableRow[],
-  filter: FilterType,
-  fields: Field[],
-  hasNestedFrames?: boolean
-): TableRow[] {
-  const filterValues = Object.entries(filter);
-
-  const filterRows = (row: TableRow): boolean => {
-    for (const [, value] of filterValues) {
-      if (value.parentIndex != null && row.__parentIndex !== value.parentIndex) {
-        continue;
-      }
-      const field = fields.find((field) => getDisplayName(field) === value.displayName);
-      if (!field || !field.display) {
-        continue;
-      }
-      const displayedValue = formattedValueToString(field.display(row[value.displayName]));
-      if (!value.filteredSet.has(displayedValue)) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  return hasNestedFrames
-    ? processNestedTableRows(rows, (parents) => parents.filter(filterRows))
-    : rows.filter(filterRows);
-}
-
-interface CrossFilterResult {
+interface ApplyFilterResult {
   crossFilterOrder: string[];
   crossFilterRows: Record<string, TableRow[]>;
   crossFilterTailRows: TableRow[];
+  filteredRows: TableRow[];
 }
 
 /**
  * @internal
- * Computes cross-filter metadata for use in filter popups, scoped to the nested level of a given table.
+ * Applies active filters to `rows` and computes cross-filter metadata for filter popup UIs.
  *
- * For each filter key in the current scope, `crossFilterRows[key]` represents the rows
- * available *before* that filter was applied (i.e. the rows that passed all preceding
- * filters in the same scope). `crossFilterTailRows` holds the rows that survive
- * *all* filters - we use this for new filters that may be added.
+ * Filters are chained sequentially so that for each filter key, `crossFilterRows[key]`
+ * holds the rows available *before* that filter was applied (i.e. the rows that passed all
+ * preceding filters in the same scope). `crossFilterTailRows` holds the rows that survive
+ * *all* filters — used for new filters that have not yet been applied.
+ *
+ * `filteredRows` is the display-ready result: equal to `crossFilterTailRows` for flat tables,
+ * or wrapped with `processNestedTableRows` to preserve parent-child structure when
+ * `hasNestedFrames` is true.
+ *
+ * When called for a nested table instance, pass `parentIndex` to scope filters to that level.
  */
-export function computeCrossFilterRows(
+export function applyFilter(
   rows: TableRow[],
   filter: FilterType,
   fields: Field[],
+  hasNestedFrames?: boolean,
   parentIndex?: number
-): CrossFilterResult {
+): ApplyFilterResult {
   // Scope rows to the relevant nesting level
   const isNested = parentIndex !== undefined;
   const scopedRows = !isNested ? rows.filter((r) => r.__depth === 0) : rows;
@@ -792,7 +770,15 @@ export function computeCrossFilterRows(
     });
   }
 
-  return { crossFilterOrder, crossFilterRows, crossFilterTailRows };
+  // For nested frames, wrap with processNestedTableRows so parent rows that have matching
+  // children are preserved for the expander UI. Use a Set for O(1) membership checks.
+  let filteredRows = crossFilterTailRows;
+  if (hasNestedFrames) {
+    const tailSet = new Set(crossFilterTailRows);
+    filteredRows = processNestedTableRows(rows, (parents) => parents.filter((row) => tailSet.has(row)));
+  }
+
+  return { crossFilterOrder, crossFilterRows, crossFilterTailRows, filteredRows };
 }
 
 /* ----------------------------- Data grid mapping ---------------------------- */

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -743,6 +743,58 @@ export function applyFilter(
     : rows.filter(filterRows);
 }
 
+/**
+ * Computes cross-filter metadata for use in filter popups, scoped to a nesting level.
+ *
+ * For each active filter key in the given scope, `crossFilterRows[key]` holds the rows
+ * available *before* that filter was applied (i.e. the rows that passed all preceding
+ * filters in the same scope).  `crossFilterRows['__tail']` holds the rows that survive
+ * *all* active filters in the scope, which is used for brand-new filters not yet in the
+ * order.
+ *
+ * Scope is determined by `parentIndex`:
+ *   - `undefined`  → top-level rows (depth === 0)
+ *   - a number     → nested rows belonging to that parent (already pre-scoped by the caller)
+ */
+export function computeCrossFilterRows(
+  rows: TableRow[],
+  filter: FilterType,
+  fields: Field[],
+  parentIndex?: number
+): { crossFilterOrder: string[]; crossFilterRows: Record<string, TableRow[]> } {
+  // Scope rows to the relevant nesting level
+  const scopedRows = parentIndex === undefined ? rows.filter((r) => r.__depth === 0) : rows;
+
+  // Collect filter keys that belong to this scope (preserving JS insertion order)
+  const crossFilterOrder = Object.keys(filter).filter((key) => {
+    const entry = filter[key];
+    return parentIndex === undefined ? entry.parentIndex == null : entry.parentIndex === parentIndex;
+  });
+
+  const crossFilterRows: Record<string, TableRow[]> = {};
+  let chainRows = scopedRows;
+
+  for (const filterKey of crossFilterOrder) {
+    const filterEntry = filter[filterKey];
+    // Store rows available *before* this filter is applied
+    crossFilterRows[filterKey] = chainRows;
+    // Advance the chain by applying this filter
+    chainRows = chainRows.filter((row) => {
+      const field = fields.find((f) => getDisplayName(f) === filterEntry.displayName);
+      if (!field || !field.display) {
+        return true;
+      }
+      const displayedValue = formattedValueToString(field.display(row[filterEntry.displayName]));
+      return filterEntry.filteredSet.has(displayedValue);
+    });
+  }
+
+  // Rows surviving all current filters — used as options for brand-new filter popups
+  crossFilterRows['__tail'] = chainRows;
+
+  return { crossFilterOrder, crossFilterRows };
+}
+
 /* ----------------------------- Data grid mapping ---------------------------- */
 /**
  * @internal

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -713,7 +713,7 @@ export function applySort(
     : [...rows].sort(compareRows);
 }
 
-interface ApplyFilterResult {
+export interface ApplyFilterResult {
   crossFilterOrder: string[];
   crossFilterRows: Record<string, TableRow[]>;
   crossFilterTailRows: TableRow[];

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -743,43 +743,46 @@ export function applyFilter(
     : rows.filter(filterRows);
 }
 
+interface CrossFilterResult {
+  crossFilterOrder: string[];
+  crossFilterRows: Record<string, TableRow[]>;
+  crossFilterTailRows: TableRow[];
+}
+
 /**
- * Computes cross-filter metadata for use in filter popups, scoped to a nesting level.
+ * @internal
+ * Computes cross-filter metadata for use in filter popups, scoped to the nested level of a given table.
  *
- * For each active filter key in the given scope, `crossFilterRows[key]` holds the rows
+ * For each filter key in the current scope, `crossFilterRows[key]` represents the rows
  * available *before* that filter was applied (i.e. the rows that passed all preceding
- * filters in the same scope).  `crossFilterRows['__tail']` holds the rows that survive
- * *all* active filters in the scope, which is used for brand-new filters not yet in the
- * order.
- *
- * Scope is determined by `parentIndex`:
- *   - `undefined`  → top-level rows (depth === 0)
- *   - a number     → nested rows belonging to that parent (already pre-scoped by the caller)
+ * filters in the same scope). `crossFilterTailRows` holds the rows that survive
+ * *all* filters - we use this for new filters that may be added.
  */
 export function computeCrossFilterRows(
   rows: TableRow[],
   filter: FilterType,
   fields: Field[],
   parentIndex?: number
-): { crossFilterOrder: string[]; crossFilterRows: Record<string, TableRow[]> } {
+): CrossFilterResult {
   // Scope rows to the relevant nesting level
-  const scopedRows = parentIndex === undefined ? rows.filter((r) => r.__depth === 0) : rows;
+  const isNested = parentIndex !== undefined;
+  const scopedRows = !isNested ? rows.filter((r) => r.__depth === 0) : rows;
 
   // Collect filter keys that belong to this scope (preserving JS insertion order)
   const crossFilterOrder = Object.keys(filter).filter((key) => {
     const entry = filter[key];
-    return parentIndex === undefined ? entry.parentIndex == null : entry.parentIndex === parentIndex;
+    return !isNested ? entry.parentIndex == null : entry.parentIndex === parentIndex;
   });
 
   const crossFilterRows: Record<string, TableRow[]> = {};
-  let chainRows = scopedRows;
+  let crossFilterTailRows = scopedRows;
 
   for (const filterKey of crossFilterOrder) {
     const filterEntry = filter[filterKey];
     // Store rows available *before* this filter is applied
-    crossFilterRows[filterKey] = chainRows;
+    crossFilterRows[filterKey] = crossFilterTailRows;
     // Advance the chain by applying this filter
-    chainRows = chainRows.filter((row) => {
+    crossFilterTailRows = crossFilterTailRows.filter((row) => {
       const field = fields.find((f) => getDisplayName(f) === filterEntry.displayName);
       if (!field || !field.display) {
         return true;
@@ -789,10 +792,7 @@ export function computeCrossFilterRows(
     });
   }
 
-  // Rows surviving all current filters — used as options for brand-new filter popups
-  crossFilterRows['__tail'] = chainRows;
-
-  return { crossFilterOrder, crossFilterRows };
+  return { crossFilterOrder, crossFilterRows, crossFilterTailRows };
 }
 
 /* ----------------------------- Data grid mapping ---------------------------- */


### PR DESCRIPTION
## Summary

Restores cross-filter behavior which was removed in #119316, updating it to work both for nested table filtering and for top-level table filtering.

- adds unit tests for new utils
- adds integration test to TableNG
- updates e2e tests for filters to confirm it works as well

## Background

Reported internally.

### To test

Use the nested table gdev dashboard, or the nested table in the kitchen sink table gdev dashboard.

### Before

_Note how easy it is to get in a bad state here, I demonstrate it pretty quickly where we hit an awkward "no data" which should not be possible with the fix in place._

https://github.com/user-attachments/assets/e9e424ed-3a4b-425a-b364-9884b83e50bc

### After

https://github.com/user-attachments/assets/1918cc7e-174d-4179-9604-8765d8fa7347
