### PR TITLE
Alerting: Fix legacy permissions being ignored in rbac notification settings page

### DIFF
--- a/public/app/features/alerting/unified/navigation/useNotificationConfigNav.test.ts
+++ b/public/app/features/alerting/unified/navigation/useNotificationConfigNav.test.ts
@@ -180,6 +180,40 @@ describe('useNotificationConfigNav', () => {
       expect(activeTabs?.[0].id).toBe('notification-config-time-intervals');
     });
 
+    it('should show all tabs when user has only legacy AlertingNotificationsRead permission', () => {
+      mockHasPermission.mockImplementation((action: AccessControlAction) => {
+        return action === AccessControlAction.AlertingNotificationsRead;
+      });
+
+      const { result } = renderHook(() => useNotificationConfigNav());
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(result.current.pageNav?.children).toHaveLength(4);
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(result.current.pageNav?.children?.[0].id).toBe('notification-config-contact-points');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(result.current.pageNav?.children?.[1].id).toBe('notification-config-policies');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(result.current.pageNav?.children?.[2].id).toBe('notification-config-templates');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(result.current.pageNav?.children?.[3].id).toBe('notification-config-time-intervals');
+    });
+
+    it('should show all tabs when user has legacy and some granular permissions', () => {
+      mockHasPermission.mockImplementation((action: AccessControlAction) => {
+        return (
+          action === AccessControlAction.AlertingNotificationsRead ||
+          action === AccessControlAction.AlertingReceiversRead
+        );
+      });
+
+      const { result } = renderHook(() => useNotificationConfigNav());
+
+      // Legacy permission covers all tabs; granular is redundant but harmless
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(result.current.pageNav?.children).toHaveLength(4);
+    });
+
     it('should not show tabs bar when only one tab is visible', () => {
       // Only allow contact points
       mockHasPermission.mockImplementation((action: AccessControlAction) => {

--- a/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
+++ b/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
@@ -19,31 +19,48 @@ export function getNotificationConfigNavId(): string {
 }
 
 /**
- * Check if user has permission to view contact points
+ * Check if user has permission to view contact points.
+ * Accepts both the legacy broad permission and the granular permission,
+ * matching the pattern used in useAbilities.ts toAbility().
  */
 function canViewContactPoints(): boolean {
-  return contextSrv.hasPermission(AccessControlAction.AlertingReceiversRead);
+  return (
+    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+    contextSrv.hasPermission(AccessControlAction.AlertingReceiversRead)
+  );
 }
 
 /**
- * Check if user has permission to view notification policies
+ * Check if user has permission to view notification policies.
+ * Accepts both the legacy broad permission and the granular permission.
  */
 function canViewNotificationPolicies(): boolean {
-  return contextSrv.hasPermission(AccessControlAction.AlertingRoutesRead);
+  return (
+    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+    contextSrv.hasPermission(AccessControlAction.AlertingRoutesRead)
+  );
 }
 
 /**
- * Check if user has permission to view templates
+ * Check if user has permission to view templates.
+ * Accepts both the legacy broad permission and the granular permission.
  */
 function canViewTemplates(): boolean {
-  return contextSrv.hasPermission(AccessControlAction.AlertingTemplatesRead);
+  return (
+    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+    contextSrv.hasPermission(AccessControlAction.AlertingTemplatesRead)
+  );
 }
 
 /**
- * Check if user has permission to view time intervals (mute timings)
+ * Check if user has permission to view time intervals (mute timings).
+ * Accepts both the legacy broad permission and the granular permission.
  */
 function canViewTimeIntervals(): boolean {
-  return contextSrv.hasPermission(AccessControlAction.AlertingTimeIntervalsRead);
+  return (
+    contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
+    contextSrv.hasPermission(AccessControlAction.AlertingTimeIntervalsRead)
+  );
 }
 
 function isSubPathOf(child: string, parent: string): boolean {


### PR DESCRIPTION
**Bug**
RBAC in [notification settings page](https://github.com/grafana/grafana/blob/main/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts) ignored legacy permissions 

**Fix**

Refactored `useNotificationConfigNav.ts` methods to checks `AlertingNotificationsRead` (legacy) or the granular permission `AlertingReceiversRead`, matching the pattern already used in `useAbilities.ts`
It also adds 2 regression tests:
  1. All 4 tabs show when user has only the legacy AlertingNotificationsRead permission
  2. All 4 tabs show with a mix of legacy + granular permissions

**Reproduction steps**
  1. Create a user (or use an existing non-admin user) with Viewer role
  2. Via the API or admin UI, grant them only the legacy alert.notifications:read permission (i.e. AlertingNotificationsRead) — do not grant any of the granular permissions
  (alert.notifications.receivers:read, alert.notifications.routes:read, etc.)
  3. Log in as that user
  4. Navigate to Alerting > Notification configuration (/alerting/notifications)
  5. Expected: All 4 tabs are visible — Contact points, Notification policies, Templates, Time intervals
  6. Before the fix: No tabs (or only one tab) would appear, effectively hiding the page content