### PR TITLE
Suggestions: Remove lttb downsampling from preview cards

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
@@ -5,7 +5,6 @@ import { type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
 import { type GrafanaTheme2, type PanelData, type PanelPluginVisualizationSuggestion } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Tooltip, useStyles2 } from '@grafana/ui';
-import { LTTB_THRESHOLD, lttbPreviewData } from 'app/plugins/panel/timeseries/utils';
 
 import { PanelRenderer } from '../PanelRenderer';
 
@@ -48,11 +47,6 @@ export function VisualizationSuggestionCard({ data, suggestion, width, className
     const maxSeries = cardOptions.maxSeries;
     const maxRows = cardOptions.maxRows;
     let previewData = maxSeries ? { ...data, series: data.series.slice(0, maxSeries) } : data;
-
-    const lttbTarget = maxRows ?? LTTB_THRESHOLD;
-    if (previewData.series.some((frame) => frame.length > lttbTarget)) {
-      previewData = lttbPreviewData(previewData, lttbTarget);
-    }
 
     if (maxRows && previewData.series.some((frame) => frame.length > maxRows)) {
       previewData = {

--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -1,9 +1,9 @@
-import { createTheme, FieldType, createDataFrame, toDataFrame, type PanelData } from '@grafana/data';
+import { createTheme, FieldType, createDataFrame, toDataFrame } from '@grafana/data';
 import { LineInterpolation } from '@grafana/ui';
 
 import { type AdHocFilterItem } from '../../../../../packages/grafana-ui/src/components/Table/TableNG/types';
 
-import { getGroupedFilters, LTTB_THRESHOLD, lttbPreviewData, prepareGraphableFields } from './utils';
+import { getGroupedFilters, prepareGraphableFields } from './utils';
 
 describe('prepare timeseries graph', () => {
   it('errors with no time fields', () => {
@@ -274,126 +274,5 @@ describe('prepare timeseries graph', () => {
         },
       ]);
     });
-  });
-});
-
-describe('lttbPreviewData', () => {
-  const range = (n: number) => Array.from({ length: n }, (_, i) => i);
-
-  const makeFrame = (length: number, extraFields?: Array<{ name: string; type: FieldType; values: unknown[] }>) => {
-    return createDataFrame({
-      fields: [
-        { name: 'time', type: FieldType.time, values: range(length) },
-        { name: 'value', type: FieldType.number, values: range(length) },
-        ...(extraFields ?? []),
-      ],
-    });
-  };
-
-  it('returns frames unchanged when below the threshold', () => {
-    const result = lttbPreviewData({ series: [makeFrame(3)] } as PanelData);
-
-    expect(result.series[0].length).toBe(3);
-    expect(result.series[0].fields[0].values).toEqual([0, 1, 2]);
-  });
-
-  it('returns frames unchanged when there is no time field', () => {
-    const frame = createDataFrame({
-      fields: [
-        { name: 'a', type: FieldType.number, values: [1, 2, 3] },
-        { name: 'b', type: FieldType.number, values: [4, 5, 6] },
-      ],
-    });
-    const result = lttbPreviewData({ series: [frame] } as PanelData);
-
-    expect(result.series[0].length).toBe(3);
-  });
-
-  it('returns frames unchanged when there is no numeric field', () => {
-    const frame = createDataFrame({
-      fields: [
-        { name: 'time', type: FieldType.time, values: [1, 2, 3] },
-        { name: 'label', type: FieldType.string, values: ['a', 'b', 'c'] },
-      ],
-    });
-    const result = lttbPreviewData({ series: [frame] } as PanelData);
-
-    expect(result.series[0].length).toBe(3);
-  });
-
-  it('downsamples frames exceeding the threshold to LTTB_THRESHOLD points', () => {
-    const result = lttbPreviewData({ series: [makeFrame(1000)] } as PanelData);
-
-    expect(result.series[0].length).toBe(LTTB_THRESHOLD);
-    expect(result.series[0].fields[0].values).toHaveLength(LTTB_THRESHOLD);
-    expect(result.series[0].fields[1].values).toHaveLength(LTTB_THRESHOLD);
-  });
-
-  it('always preserves the first and last data points', () => {
-    const result = lttbPreviewData({ series: [makeFrame(1000)] } as PanelData);
-
-    const outTimes = result.series[0].fields[0].values;
-    expect(outTimes[0]).toBe(0);
-    expect(outTimes[outTimes.length - 1]).toBe(999);
-  });
-
-  it('processes each frame independently', () => {
-    const result = lttbPreviewData({ series: [makeFrame(3), makeFrame(500)] } as PanelData);
-
-    expect(result.series[0].length).toBe(3);
-    expect(result.series[1].length).toBe(LTTB_THRESHOLD);
-  });
-
-  it('does not mutate the original data', () => {
-    const frame = makeFrame(500);
-    const data = { series: [frame] } as PanelData;
-    lttbPreviewData(data);
-
-    expect(data.series[0].fields[0].values).toHaveLength(500);
-    expect(data.series[0].length).toBe(500);
-  });
-
-  it('downsamples to a custom threshold when provided', () => {
-    const result = lttbPreviewData({ series: [makeFrame(100)] } as PanelData, 30);
-
-    expect(result.series[0].length).toBe(30);
-    expect(result.series[0].fields[0].values).toHaveLength(30);
-    expect(result.series[0].fields[1].values).toHaveLength(30);
-
-    const outTimes = result.series[0].fields[0].values;
-    expect(outTimes[0]).toBe(0);
-    expect(outTimes[outTimes.length - 1]).toBe(99);
-  });
-
-  it('skips frames at or below the custom threshold', () => {
-    const result = lttbPreviewData({ series: [makeFrame(30)] } as PanelData, 30);
-
-    expect(result.series[0].length).toBe(30);
-    expect(result.series[0].fields[0].values).toEqual(range(30));
-  });
-
-  it('clears interval on the time field to prevent gaps', () => {
-    const frame = createDataFrame({
-      fields: [
-        { name: 'time', type: FieldType.time, values: range(500), config: { interval: 10000 } },
-        { name: 'value', type: FieldType.number, values: range(500) },
-      ],
-    });
-    const result = lttbPreviewData({ series: [frame] } as PanelData);
-
-    const timeField = result.series[0].fields[0];
-    expect(timeField.config.interval).toBeUndefined();
-  });
-
-  it('does not modify config on frames below the threshold', () => {
-    const frame = createDataFrame({
-      fields: [
-        { name: 'time', type: FieldType.time, values: range(3), config: { interval: 10000 } },
-        { name: 'value', type: FieldType.number, values: range(3) },
-      ],
-    });
-    const result = lttbPreviewData({ series: [frame] } as PanelData);
-
-    expect(result.series[0].fields[0].config.interval).toBe(10000);
   });
 });


### PR DESCRIPTION
Skip using the lttb algorithm for now. 
Fallow up in https://github.com/grafana/grafana/issues/121606

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
