### PR TITLE
Table: Fix nested field name overrides

### DIFF
--- a/e2e-playwright/panels-suite/table-nested.spec.ts
+++ b/e2e-playwright/panels-suite/table-nested.spec.ts
@@ -262,6 +262,27 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     await expect(page.getByRole('dialog').getByText(loremIpsumText!)).toBeVisible();
   });
 
+  test('renamed field appears as column in nested table', async ({ gotoPanelEditPage, selectors, page }) => {
+    // Regression test: a field renamed via Organize Fields before a Group to Nested Tables
+    // transform must retain its display name as the nested table column header.
+    // The field "A" is renamed to "Gauge" via the organize transform, then grouped into
+    // nested tables. The nested table column header must read "Gauge", not "A".
+    const panelEditPage = await gotoPanelEditPage({
+      dashboard: {
+        uid: NESTED_COMPLEX_DASHBOARD_UID,
+      },
+      id: '1',
+    });
+
+    await panelEditPage
+      .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.RowExpander)
+      .first()
+      .click();
+
+    const firstNestedTable = page.locator('.rdg').nth(1);
+    await expect(firstNestedTable.getByRole('columnheader', { name: 'Gauge' })).toBeVisible();
+  });
+
   test('tooltip from field', async ({ gotoPanelEditPage, page, selectors }) => {
     const panelEditPage = await gotoPanelEditPage({
       dashboard: {

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -56,6 +56,9 @@ export function cacheFieldDisplayNames(frames: DataFrame[]) {
   frames.forEach((frame) => {
     frame.fields.forEach((field) => {
       getFieldDisplayName(field, frame, frames);
+      if (field.type === FieldType.nestedFrames) {
+        field.values.forEach(cacheFieldDisplayNames);
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary

- update the logic to cache field names to recurse through FieldType.nestedFrames's values when encountered.

## Background

This was ironically one of the first field overrides I got working in #117047 _([I left out the field name of the nested field at that point](https://github.com/grafana/grafana/pull/117047/changes#diff-0ff5432d1fdccb771c753c1e8c072f6c1886234b650b198f89f20961c3fd6a83R57-R60), but I don't think that makes sense actually)_. Somehow, this change got lost in the shuffle as the code was reorganized to be landed in a way that was behind a flag, although of course this particular change isn't behind a flag and would be difficult to make work that way given it's in `@grafana/data`.

### To test

- in the nested table gdev dashboard, the last column should have the name "Gauge" from its "Organize field" override (that's what the new e2e enforces)
- you should also try out adding a display name using field overrides