### PR TITLE
Zanzana: Fix inverted folder parent tuples in reconciler

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/translators.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators.go
@@ -37,8 +37,8 @@ func TranslateFolderToTuples(obj *unstructured.Unstructured) ([]*openfgav1.Tuple
 		return nil, nil
 	}
 
-	// Create parent relationship tuple: folder:parent -> parent -> folder:child
-	tuple := common.NewFolderParentTuple(parentFolder, folder.Name)
+	// Create parent relationship tuple: folder:child has parent folder:parent
+	tuple := common.NewFolderParentTuple(folder.Name, parentFolder)
 	return []*openfgav1.TupleKey{tuple}, nil
 }
 

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -333,9 +333,9 @@ func TestTranslateFolderToTuples(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, tuples, 1)
 
-		assert.Equal(t, "folder:child-folder", tuples[0].GetUser())
+		assert.Equal(t, "folder:parent-folder", tuples[0].GetUser())
 		assert.Equal(t, common.RelationParent, tuples[0].GetRelation())
-		assert.Equal(t, "folder:parent-folder", tuples[0].GetObject())
+		assert.Equal(t, "folder:child-folder", tuples[0].GetObject())
 	})
 
 	t.Run("root folder without parent", func(t *testing.T) {
@@ -347,6 +347,31 @@ func TestTranslateFolderToTuples(t *testing.T) {
 		tuples, err := TranslateFolderToTuples(toUnstructured(t, folder))
 		require.NoError(t, err)
 		assert.Nil(t, tuples)
+	})
+
+	t.Run("reconciler tuples match mutation path convention", func(t *testing.T) {
+		// Verify the reconciler produces the same tuple as the mutation path
+		// (common.NewFolderParentTuple(child, parent)) to prevent argument swap regression.
+		folder := &folderv1.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "grandchild",
+				Annotations: map[string]string{
+					"grafana.app/folder": "child",
+				},
+			},
+			Spec: folderv1.FolderSpec{Title: "Grandchild"},
+		}
+
+		tuples, err := TranslateFolderToTuples(toUnstructured(t, folder))
+		require.NoError(t, err)
+		require.Len(t, tuples, 1)
+
+		// The mutation path creates: NewFolderParentTuple(folderUID, parentUID)
+		// where folderUID is the child and parentUID is the parent.
+		expected := common.NewFolderParentTuple("grandchild", "child")
+		assert.Equal(t, expected.GetObject(), tuples[0].GetObject(), "Object should be the child folder")
+		assert.Equal(t, expected.GetRelation(), tuples[0].GetRelation())
+		assert.Equal(t, expected.GetUser(), tuples[0].GetUser(), "User should be the parent folder")
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix swapped arguments to `NewFolderParentTuple` in the reconciler's `TranslateFolderToTuples`, which inverted the entire folder hierarchy in Zanzana's tuple store
- The reconciler passed `(parent, child)` but the function expects `(child, parent)`, causing children to not inherit permissions from parents
- This is the root cause of widespread shadow check mismatches (`expected=true, actual=false`) for folder and dashboard access checks that rely on folder inheritance

After deploying, the next reconciler run will automatically correct all folder parent tuples via its diff+sync mechanism. No manual migration needed.

## Test plan

- [x] Fixed existing `TestTranslateFolderToTuples` assertions to match correct tuple direction
- [x] Added regression test comparing reconciler output to mutation path convention (`NewFolderParentTuple(child, parent)`)
- [x] All reconciler tests pass (`go test ./pkg/services/authz/zanzana/server/reconciler/`)
- [x] Schema validation tests pass (`TestTranslatedTuplesAreSchemaValid`)
- [x] Shadow client tests pass (`go test ./pkg/services/authz/zanzana/client/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)