### PR TITLE
PanelChrome: Add pulsating animation to streaming indicator

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx, keyframes } from '@emotion/css';
 import { type CSSProperties, type ReactElement, type ReactNode, useId, useState } from 'react';
 import * as React from 'react';
 import { useMeasure, useToggle } from 'react-use';
@@ -619,6 +619,16 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'panel-streaming',
       marginRight: 0,
       color: theme.colors.success.text,
+      [theme.transitions.handleMotion('no-preference')]: {
+        animationName: keyframes({
+          '0%': { opacity: 0 },
+          '50%': { opacity: 1 },
+          '100%': { opacity: 0 },
+        }),
+        animationDuration: '4s',
+        animationIterationCount: 'infinite',
+        animationDelay: '0.5s',
+      },
 
       '&:hover': {
         color: theme.colors.success.text,


### PR DESCRIPTION
Fixes #89415

## Summary

Adds a CSS pulse animation to the streaming loading indicator (green circle icon) in PanelChrome. The static indicator was easy to miss; the pulsating effect makes it clear the panel is actively receiving streamed data.

## Changes

Single file change in `packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx`:

- Import `keyframes` from `@emotion/css`
- Add a fade-in/fade-out pulse animation to the `streaming` style
- Animation respects `prefers-reduced-motion` via `theme.transitions.handleMotion('no-preference')`

## Details

- Animation: opacity fades from 0 to 1 and back over 4 seconds, with a 0.5s initial delay
- No animation when user has `prefers-reduced-motion: reduce` set
- No new components or test changes needed (purely visual enhancement)