### PR TITLE
Scopes: Fix defaultPath not loading on initial page load

### DIFF
--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -185,6 +185,78 @@ describe('ScopesService', () => {
       expect(selectorService.resolvePathToRoot).not.toHaveBeenCalled();
     });
 
+    it('should derive scope_node from defaultPath when scope_node is absent from URL', async () => {
+      let changeScopesResolve: () => void;
+      const changeScopesPromise = new Promise<void>((resolve) => {
+        changeScopesResolve = resolve;
+      });
+
+      selectorService.changeScopes = jest.fn().mockImplementation(() => {
+        selectorService.state.appliedScopes = [{ scopeId: 'scope1' }];
+        selectorService.state.scopes = {
+          scope1: {
+            metadata: { name: 'scope1' },
+            spec: {
+              title: 'Scope 1',
+              defaultPath: ['', 'automon-team', 'washington', 'washington-nav-test'],
+              filters: [],
+            },
+          },
+        };
+        changeScopesResolve();
+        return changeScopesPromise;
+      });
+
+      locationService.getLocation = jest.fn().mockReturnValue({
+        pathname: '/test',
+        search: '?scopes=scope1',
+      });
+
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+
+      // Await the actual promise that the constructor chains .then() on
+      await changeScopesPromise;
+
+      expect(selectorService.resolvePathToRoot).toHaveBeenCalledWith(
+        'washington-nav-test',
+        expect.anything(),
+        'scope1'
+      );
+    });
+
+    it('should not call resolvePathToRoot when scope_node is absent and no defaultPath exists', async () => {
+      let changeScopesResolve: () => void;
+      const changeScopesPromise = new Promise<void>((resolve) => {
+        changeScopesResolve = resolve;
+      });
+
+      selectorService.changeScopes = jest.fn().mockImplementation(() => {
+        selectorService.state.appliedScopes = [{ scopeId: 'scope1' }];
+        selectorService.state.scopes = {
+          scope1: {
+            metadata: { name: 'scope1' },
+            spec: {
+              title: 'Scope 1',
+              filters: [],
+            },
+          },
+        };
+        changeScopesResolve();
+        return changeScopesPromise;
+      });
+
+      locationService.getLocation = jest.fn().mockReturnValue({
+        pathname: '/test',
+        search: '?scopes=scope1',
+      });
+
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+
+      await changeScopesPromise;
+
+      expect(selectorService.resolvePathToRoot).not.toHaveBeenCalled();
+    });
+
     it('should handle multiple scopes from URL', () => {
       locationService.getLocation = jest.fn().mockReturnValue({
         pathname: '/test',

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -172,6 +172,65 @@ describe('ScopesService', () => {
       expect(selectorService.resolvePathToRoot).toHaveBeenCalledWith('node1', expect.anything());
     });
 
+    it('should catch and log errors when scope_node preload fails', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      selectorService.resolvePathToRoot = jest.fn().mockRejectedValue(new Error('fetch failed'));
+
+      locationService.getLocation = jest.fn().mockReturnValue({
+        pathname: '/test',
+        search: '?scopes=scope1&scope_node=node1',
+      });
+
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+
+      await Promise.resolve();
+
+      expect(consoleError).toHaveBeenCalledWith('Failed to pre-load node path', expect.any(Error));
+      consoleError.mockRestore();
+    });
+
+    it('should catch and log errors when defaultPath preload fails', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      let changeScopesResolve: () => void;
+      const changeScopesPromise = new Promise<void>((resolve) => {
+        changeScopesResolve = resolve;
+      });
+
+      let rejectPathToRoot: (err: Error) => void;
+      selectorService.changeScopes = jest.fn().mockImplementation(() => {
+        selectorService.state.appliedScopes = [{ scopeId: 'scope1' }];
+        selectorService.state.scopes = {
+          scope1: {
+            metadata: { name: 'scope1' },
+            spec: { title: 'Scope 1', defaultPath: ['', 'parent', 'node1'], filters: [] },
+          },
+        };
+        changeScopesResolve();
+        return changeScopesPromise;
+      });
+      selectorService.resolvePathToRoot = jest
+        .fn()
+        .mockImplementation(() => new Promise<void>((_, reject) => (rejectPathToRoot = reject)));
+
+      locationService.getLocation = jest.fn().mockReturnValue({
+        pathname: '/test',
+        search: '?scopes=scope1',
+      });
+
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+
+      // Wait for changeScopes to complete and resolvePathToRoot to be called
+      await changeScopesPromise;
+
+      // Trigger the rejection now that .catch() is attached, then drain it
+      rejectPathToRoot(new Error('fetch failed'));
+      await Promise.resolve();
+
+      expect(consoleError).toHaveBeenCalledWith('Failed to pre-load node path from defaultPath', expect.any(Error));
+      consoleError.mockRestore();
+    });
+
     // TODO: remove when parentNodeId is removed
     it('should not preload when only scope_parent is in URL', () => {
       locationService.getLocation = jest.fn().mockReturnValue({

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -197,7 +197,7 @@ describe('ScopesService', () => {
         changeScopesResolve = resolve;
       });
 
-      let rejectPathToRoot: (err: Error) => void;
+      let rejectPathToRoot: (err: Error) => void = () => {};
       selectorService.changeScopes = jest.fn().mockImplementation(() => {
         selectorService.state.appliedScopes = [{ scopeId: 'scope1' }];
         selectorService.state.scopes = {

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -87,12 +87,28 @@ export class ScopesService implements ScopesContextValue {
       if (navScopePath && !navigationScope) {
         this.dashboardsService.setNavScopePath(deserializeFolderPath(navScopePath));
       }
+
+      // If scope_node wasn't in the URL, derive it from defaultPath and preload the path
+      // so the badge and tree display correctly on initial load.
+      if (!scopeNodeId) {
+        const firstApplied = this.selectorService.state.appliedScopes[0];
+        const scope = firstApplied ? this.selectorService.state.scopes[firstApplied.scopeId] : undefined;
+        const defaultPath = scope?.spec.defaultPath || [];
+        if (defaultPath.length > 0) {
+          const derivedNodeId = defaultPath[defaultPath.length - 1];
+          const tree = this.selectorService.state.tree;
+          if (derivedNodeId && tree) {
+            this.selectorService.resolvePathToRoot(derivedNodeId, tree, firstApplied.scopeId).catch((error) => {
+              console.error('Failed to pre-load node path from defaultPath', error);
+            });
+          }
+        }
+      }
     });
 
-    // Pre-load scope node (which loads parent too)
-    const nodeToPreload = scopeNodeId;
-    if (nodeToPreload) {
-      this.selectorService.resolvePathToRoot(nodeToPreload, this.selectorService.state.tree!).catch((error) => {
+    // Preload scope node (which loads parent too)
+    if (scopeNodeId) {
+      this.selectorService.resolvePathToRoot(scopeNodeId, this.selectorService.state.tree!).catch((error) => {
         console.error('Failed to pre-load node path', error);
       });
     }

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -1679,6 +1679,33 @@ describe('ScopesSelectorService', () => {
 
       expect(apiClient.fetchMultipleScopeNodes).not.toHaveBeenCalled();
     });
+
+    it('should backfill scopeNodeId into appliedScopes from defaultPath when initially absent', async () => {
+      apiClient.fetchMultipleScopes = jest.fn().mockResolvedValue([scopeWithDefaultPath]);
+      apiClient.fetchMultipleScopeNodes = jest
+        .fn()
+        .mockResolvedValue([regionNode, countryNode, cityNode, datacenterNode]);
+
+      // Call without scopeNodeId (simulates URL load without scope_node)
+      await service.changeScopes(['scope-sea-1']);
+
+      // scopeNodeId should be backfilled from defaultPath's last element
+      expect(service.state.appliedScopes[0].scopeNodeId).toBe('datacenter-sea-1');
+      expect(service.state.selectedScopes[0].scopeNodeId).toBe('datacenter-sea-1');
+    });
+
+    it('should not overwrite existing scopeNodeId when defaultPath is present', async () => {
+      apiClient.fetchMultipleScopes = jest.fn().mockResolvedValue([scopeWithDefaultPath]);
+      apiClient.fetchMultipleScopeNodes = jest
+        .fn()
+        .mockResolvedValue([regionNode, countryNode, cityNode, datacenterNode]);
+
+      // Call with an explicit scopeNodeId
+      await service.changeScopes(['scope-sea-1'], undefined, 'explicit-node');
+
+      // Should keep the explicit value, not overwrite from defaultPath
+      expect(service.state.appliedScopes[0].scopeNodeId).toBe('explicit-node');
+    });
   });
 
   describe('open selector with defaultPath expansion', () => {

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -475,14 +475,14 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       // Get scopeNode and parentNode, preferring defaultPath as the source of truth
       let parentNode: ScopeNode | undefined;
       let scopeNodeId: string | undefined;
+      const defaultPath = firstScope?.spec.defaultPath || [];
 
-      if (firstScope?.spec.defaultPath && firstScope.spec.defaultPath.length > 1) {
+      if (defaultPath.length > 1) {
         // Extract from defaultPath (most reliable source)
         // defaultPath format: ['', 'parent-id', 'scope-node-id', ...]
-        scopeNodeId = firstScope.spec.defaultPath[firstScope.spec.defaultPath.length - 1];
-        const parentNodeId = firstScope.spec.defaultPath[firstScope.spec.defaultPath.length - 2];
+        scopeNodeId = defaultPath[defaultPath.length - 1];
+        const parentNodeId = defaultPath[defaultPath.length - 2];
 
-        scopeNode = scopeNodeId ? this.state.nodes[scopeNodeId] : undefined;
         parentNode = parentNodeId && parentNodeId !== '' ? this.state.nodes[parentNodeId] : undefined;
       } else {
         // Fallback to next in priority order
@@ -493,8 +493,13 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         parentNode = parentNodeId ? this.state.nodes[parentNodeId] : undefined;
       }
 
+      // Backfill scopeNodeId from defaultPath so open() can expand the tree.
+      if (scopeNodeId && scopes[0] && !scopes[0].scopeNodeId) {
+        scopes[0] = { ...scopes[0], scopeNodeId };
+      }
+
       this.addRecentScopes(fetchedScopes, parentNode, scopeNodeId);
-      this.updateState({ scopes: newScopesState, loading: false });
+      this.updateState({ appliedScopes: scopes, selectedScopes: scopes, scopes: newScopesState, loading: false });
     }
   };
 


### PR DESCRIPTION
## Summary

- Fix scope selector badge and tree not showing correct path when page loads with `scopes` but without `scope_node` in URL
- Derive `scopeNodeId` from `defaultPath` after scope metadata is fetched, then call `resolvePathToRoot` to populate node cache and tree
- Backfill `scopeNodeId` into `appliedScopes`/`selectedScopes` so `open()` can expand the tree to the correct node

Fixes grafana/hyperion-planning#542

## Screenshots
<img width="1679" height="528" alt="Screenshot 2026-03-31 210424" src="https://github.com/user-attachments/assets/77cdb116-3817-431b-8cbe-39e2356e8abf" />
Results when directly loading the URL http://localhost:3000/d/5SdHCadmz/panel-tests-graph?orgId=1&from=now-6h&to=now&timezone=browser&scopes=gdev-shared-service (no scope_node). &scope_node=gdev-gdev-scopes-production-shared-service-prod is appended on page load, allowing the badge and side nav to render properly.

## Test plan

- [x] Load `?scopes=gdev-shared-service` (no `scope_node`) — badge should show "Production → Shared Service" and tree should expand correctly
- [x] Load `?scopes=gdev-shared-service&scope_node=gdev-gdev-scopes-production-shared-service-prod` — same behavior (no regression)
- [x] Select a scope normally from the tree — breadcrumb and tree work as before
- [x] Remove `scope_node` from URL and refresh for any scope with a defaultPath — should work as above
- [x] 421 unit tests pass (`yarn jest --testPathPattern='public/app/features/scopes/'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)