### PR TITLE
CI: Add frontend navigation team to frontend coverage opt-in list

### DIFF
--- a/.github/workflows/report-frontend-coverage-to-bench.yaml
+++ b/.github/workflows/report-frontend-coverage-to-bench.yaml
@@ -15,7 +15,8 @@ jobs:
       opted-in-teams: >-
         [
           "@grafana/datapro",
-          "@grafana/dataviz-squad"
+          "@grafana/dataviz-squad",
+          "@grafana/grafana-frontend-navigation"
         ]
     steps:
       - name: Define opted-in teams


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds `@grafana/grafana-frontend-navigation` to the list of opted-in teams in the `report-frontend-coverage-to-bench` GitHub Actions workflow.



