### PR TITLE
Dashboards: Fix 500 on GET non-existent dashboard via v1beta1 API (backport #111571 to 12.2.x)

### DIFF
--- a/pkg/registry/apis/dashboard/authorizer.go
+++ b/pkg/registry/apis/dashboard/authorizer.go
@@ -109,10 +109,11 @@ func authorizeDashboard(ctx context.Context, ac accesscontrol.AccessControl, use
 			return authorizer.DecisionDeny, "can not create any dashboards", err
 		}
 	case "get":
-		ok, err := ac.Evaluate(ctx, user, accesscontrol.EvalPermission(dashboards.ActionDashboardsRead, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(attr.GetName())))
-		if !ok || err != nil {
-			return authorizer.DecisionDeny, "can not view dashboard", err
-		}
+		// Per-resource authorization (including proper 404 for non-existent
+		// dashboards and 403 for unauthorized access) is handled downstream
+		// in the unified storage layer's read() method.
+		// This is all removed in 12.3.x on-wards.
+		return authorizer.DecisionAllow, "", nil
 	case "update", "patch":
 		ok, err := ac.Evaluate(ctx, user, accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(attr.GetName())))
 		if !ok || err != nil {


### PR DESCRIPTION
## Summary

Backport of #111571 to 12.2.x for grafana/support-escalations#21192.

- **Bug**: `GET /apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/<non-existent-uid>` returns **500 Internal Server Error** instead of **404 Not Found** on Grafana 12.2.x
- **Root cause**: The k8s API authorizer (`authorizeDashboard`) resolved RBAC scopes (`dashboards:uid:<uid>`) during the authorization phase. When the dashboard didn't exist, the scope resolver returned `"could not resolve dashboards:uid:<uid>: Dashboard not found"` — an untyped Go error that the k8s API server surfaced as 500.
- **Fix**: Skip per-resource scope resolution for `GET` operations at the authorizer level. Per-resource authorization (404 for not found, 403 for unauthorized) is already handled downstream in the unified storage layer's `read()` method (`pkg/storage/unified/resource/server.go`).
- The legacy API (`/api/dashboards/uid/<uid>`) correctly returns 404 — this bug is specific to the v1beta1 k8s-style API.
- This entire legacy authorizer was removed in 12.3+ via #111571 (replaced by `ServiceAuthorizer`), so **12.3+ is not affected**.

## Validated behavior after fix

| Scenario | Expected | Verified |
|----------|----------|----------|
| Non-existent dashboard (viewer) | 404 | Yes |
| Existing dashboard, no permission (viewer) | 403 | Handled by downstream `server.read()` |
| Existing dashboard (admin) | 200 | Yes |
| Unauthenticated | 401 | Yes |
| Legacy API parity (`/api/dashboards/uid/`) | Same codes | Yes |

## Test plan

Added in support ticket