### PR TITLE
Dynamic dashboards: Hide hidden panels from outline in view mode, display eye-slash in edit mode

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
@@ -1,8 +1,20 @@
-import { VizPanel } from '@grafana/scenes';
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneVariableSet, TestVariable, VizPanel } from '@grafana/scenes';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
+
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
 
 import { ConditionalRenderingGroup } from '../conditional-rendering/group/ConditionalRenderingGroup';
+import { DashboardScene } from '../scene/DashboardScene';
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
+import { AutoGridLayout } from '../scene/layout-auto-grid/AutoGridLayout';
+import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { activateFullSceneTree } from '../utils/test-utils';
 
 import { VizPanelEditableElement } from './VizPanelEditableElement';
 
@@ -42,6 +54,62 @@ describe('VizPanelEditableElement', () => {
       new AutoGridItem({ body: panel });
 
       const element = new VizPanelEditableElement(panel);
+      expect(element.getEditableElementInfo().isHidden).toBe(false);
+    });
+
+    it('returns isHidden=true for a repeated panel whose repeatedConditionalRendering result is false', () => {
+      const panel = new VizPanel({ title: 'My Panel' });
+      const repeatedPanel = new VizPanel({ title: 'My Panel (repeat)' });
+      new AutoGridItem({
+        body: panel,
+        repeatedPanels: [repeatedPanel],
+        repeatedConditionalRendering: [
+          new ConditionalRenderingGroup({
+            conditions: [],
+            visibility: 'show',
+            condition: 'and',
+            result: false,
+            renderHidden: false,
+          }),
+        ],
+      });
+
+      const element = new VizPanelEditableElement(repeatedPanel);
+      expect(element.getEditableElementInfo().isHidden).toBe(true);
+    });
+
+    it('returns isHidden=false for a repeated panel when AutoGridItem has no conditional rendering configured', async () => {
+      const panel = new VizPanel({ title: 'My Panel' });
+      const gridItem = new AutoGridItem({ body: panel, variableName: 'env' });
+      const scene = new DashboardScene({
+        $variables: new SceneVariableSet({
+          variables: [
+            new TestVariable({
+              name: 'env',
+              value: ALL_VARIABLE_VALUE,
+              text: ALL_VARIABLE_TEXT,
+              isMulti: true,
+              includeAll: true,
+              delayMs: 0,
+              optionsToReturn: [
+                { label: 'A', value: 'A' },
+                { label: 'B', value: 'B' },
+              ],
+            }),
+          ],
+        }),
+        body: new AutoGridLayoutManager({
+          layout: new AutoGridLayout({ children: [gridItem] }),
+        }),
+      });
+
+      activateFullSceneTree(scene);
+      await new Promise((r) => setTimeout(r, 1));
+
+      const repeatedPanels = gridItem.state.repeatedPanels!;
+      expect(repeatedPanels.length).toBeGreaterThan(0);
+
+      const element = new VizPanelEditableElement(repeatedPanels[0]);
       expect(element.getEditableElementInfo().isHidden).toBe(false);
     });
 

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
@@ -104,12 +104,12 @@ describe('VizPanelEditableElement', () => {
       });
 
       activateFullSceneTree(scene);
-      await new Promise((r) => setTimeout(r, 1));
 
-      const repeatedPanels = gridItem.state.repeatedPanels!;
-      expect(repeatedPanels.length).toBeGreaterThan(0);
+      await waitFor(() => {
+        expect(gridItem.state.repeatedPanels?.length).toBeGreaterThan(0);
+      });
 
-      const element = new VizPanelEditableElement(repeatedPanels[0]);
+      const element = new VizPanelEditableElement(gridItem.state.repeatedPanels![0]);
       expect(element.getEditableElementInfo().isHidden).toBe(false);
     });
 

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
@@ -1,0 +1,56 @@
+import { VizPanel } from '@grafana/scenes';
+
+import { ConditionalRenderingGroup } from '../conditional-rendering/group/ConditionalRenderingGroup';
+import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+
+import { VizPanelEditableElement } from './VizPanelEditableElement';
+
+describe('VizPanelEditableElement', () => {
+  describe('getEditableElementInfo', () => {
+    it('returns isHidden=true when parent AutoGridItem conditionalRendering result is false', () => {
+      const panel = new VizPanel({ title: 'My Panel' });
+      // Constructing AutoGridItem sets panel.parent automatically
+      new AutoGridItem({
+        body: panel,
+        conditionalRendering: new ConditionalRenderingGroup({
+          conditions: [],
+          visibility: 'show',
+          condition: 'and',
+          result: false,
+          renderHidden: false,
+        }),
+      });
+
+      const element = new VizPanelEditableElement(panel);
+      expect(element.getEditableElementInfo().isHidden).toBe(true);
+    });
+
+    it('returns isHidden=false when parent AutoGridItem conditionalRendering result is true', () => {
+      const panel = new VizPanel({ title: 'My Panel' });
+      new AutoGridItem({
+        body: panel,
+        conditionalRendering: ConditionalRenderingGroup.createEmpty(), // result: true
+      });
+
+      const element = new VizPanelEditableElement(panel);
+      expect(element.getEditableElementInfo().isHidden).toBe(false);
+    });
+
+    it('returns isHidden=false when parent AutoGridItem has no conditionalRendering (defaults to empty group with result=true)', () => {
+      const panel = new VizPanel({ title: 'My Panel' });
+      new AutoGridItem({ body: panel });
+
+      const element = new VizPanelEditableElement(panel);
+      expect(element.getEditableElementInfo().isHidden).toBe(false);
+    });
+
+    it('returns isHidden=undefined when parent is a DashboardGridItem', () => {
+      const panel = new VizPanel({ title: 'My Panel' });
+      new DashboardGridItem({ body: panel, x: 0, y: 0, width: 12, height: 6 });
+
+      const element = new VizPanelEditableElement(panel);
+      expect(element.getEditableElementInfo().isHidden).toBeUndefined();
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.test.ts
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/react';
+
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneVariableSet, TestVariable, VizPanel } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -89,10 +89,14 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
   public constructor(public panel: VizPanel) {}
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
+    const parent = this.panel.parent;
+    const isHidden = parent instanceof AutoGridItem ? !parent.state.conditionalRendering?.state.result : undefined;
+
     return {
       typeName: t('dashboard.edit-pane.elements.panel', 'Panel'),
       icon: 'chart-line',
       instanceName: sceneGraph.interpolate(this.panel, this.panel.state.title, undefined, 'text'),
+      isHidden,
     };
   }
 

--- a/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/VizPanelEditableElement.tsx
@@ -90,7 +90,16 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
     const parent = this.panel.parent;
-    const isHidden = parent instanceof AutoGridItem ? !parent.state.conditionalRendering?.state.result : undefined;
+    let isHidden: boolean | undefined;
+
+    if (parent instanceof AutoGridItem) {
+      const repeatIndex = parent.state.repeatedPanels?.indexOf(this.panel) ?? -1;
+      if (repeatIndex >= 0) {
+        isHidden = !parent.state.repeatedConditionalRendering![repeatIndex].state.result;
+      } else {
+        isHidden = !parent.state.conditionalRendering?.state.result;
+      }
+    }
 
     return {
       typeName: t('dashboard.edit-pane.elements.panel', 'Panel'),


### PR DESCRIPTION
**What is this feature?**

Hides hidden panels from the outline in view mode.

Displays eye-slash on hidden panels in view mode.

<img width="303" height="117" alt="image" src="https://github.com/user-attachments/assets/6752ced0-0318-4b5c-8648-77750d2f9279" />


Fixes #120979
