### PR TITLE
IAM: skip flaky TestIntegrationTeamBindings dual_writer_mode_1

### DIFF
--- a/pkg/tests/apis/iam/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/team_binding_integration_test.go
@@ -21,16 +21,13 @@ import (
 )
 
 func TestIntegrationTeamBindings(t *testing.T) {
+	t.Skip("flaky: context cancelled on basic roles fetch during Delete authz check")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	// TODO: Add rest.Mode5 when it's supported
 	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1}
 	for _, mode := range modes {
 		t.Run(fmt.Sprintf("Team binding CRUD operations with dual writer mode %d", mode), func(t *testing.T) {
-			if mode == rest.Mode1 {
-				t.Skip("flaky: context cancelled on basic roles fetch during Delete authz check")
-			}
-
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				AppModeProduction:      false,
 				DisableAnonymous:       true,

--- a/pkg/tests/apis/iam/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/team_binding_integration_test.go
@@ -27,6 +27,10 @@ func TestIntegrationTeamBindings(t *testing.T) {
 	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1}
 	for _, mode := range modes {
 		t.Run(fmt.Sprintf("Team binding CRUD operations with dual writer mode %d", mode), func(t *testing.T) {
+			if mode == rest.Mode1 {
+				t.Skip("flaky: context cancelled on basic roles fetch during Delete authz check")
+			}
+
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				AppModeProduction:      false,
 				DisableAnonymous:       true,


### PR DESCRIPTION
## Why
`TestIntegrationTeamBindings/Team_binding_CRUD_operations_with_dual_writer_mode_1` has been failing intermittently on both MySQL and Postgres CI shards. The root cause is a context cancellation on the basic roles fetch during the Delete authorization check, which then cascades into all subsequent subtests failing with "user is already added to this team" (the binding was never cleaned up).

Seen across multiple workflow runs: #23746191915, #23760749751, #23767989534 — shard 13/16, both backends.

## What
Skip the `mode_1` subtest until the root cause is investigated and fixed.

`mode_0` is unaffected and continues to run.

## How to test
Run the test locally and confirm `mode_1` is skipped while `mode_0` passes:
```
go test -v -run TestIntegrationTeamBindings ./pkg/tests/apis/iam/
```

## Risks / notes
This is a temporary skip. Follow-up: investigate why the context is being cancelled during `GetBasicRoles` in the delete authz path under DualWriter mode 1.
