### PR TITLE
perf(unified-storage): batch sqlkv bulk import writes

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -58,6 +58,10 @@ type dataStore struct {
 	legacyDialect sqltemplate.Dialect // TODO: remove when backwards compatibility is no longer needed.
 }
 
+type dataImportBatchWriter interface {
+	InsertDataImportBatch(ctx context.Context, rows []kvpkg.DataImportRow) error
+}
+
 func newDataStore(kv KV) *dataStore {
 	ds := &dataStore{
 		kv:    kv,
@@ -545,6 +549,15 @@ func (d *dataStore) Save(ctx context.Context, key DataKey, value io.Reader) erro
 	}
 
 	return writer.Close()
+}
+
+func (d *dataStore) insertDataImportBatch(ctx context.Context, rows []kvpkg.DataImportRow) (bool, error) {
+	writer, ok := d.kv.(dataImportBatchWriter)
+	if !ok {
+		return false, nil
+	}
+
+	return true, writer.InsertDataImportBatch(ctx, rows)
 }
 
 func (d *dataStore) Delete(ctx context.Context, key DataKey) error {

--- a/pkg/storage/unified/resource/kv/go.mod
+++ b/pkg/storage/unified/resource/kv/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/grafana/pkg/storage/unified/resource/kv
 go 1.25.8
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/dgraph-io/badger/v4 v4.9.1
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1

--- a/pkg/storage/unified/resource/kv/go.sum
+++ b/pkg/storage/unified/resource/kv/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -21,6 +23,7 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -180,6 +180,51 @@ func (qb *queryBuilder) buildInsertDatastoreQuery(keyPath string, value []byte, 
 	return query, []interface{}{guid, keyPath, value, "", "", "", "", 0, ""}
 }
 
+// buildInsertDatastoreBatchQuery generates a multi-row INSERT for datastore import rows.
+func (qb *queryBuilder) buildInsertDatastoreBatchQuery(rows []DataImportRow) (string, []interface{}) {
+	if len(rows) == 0 {
+		return "", nil
+	}
+
+	valueRows := make([]string, 0, len(rows))
+	args := make([]interface{}, 0, len(rows)*9)
+	argIdx := 1
+
+	for _, row := range rows {
+		valueRows = append(valueRows, fmt.Sprintf(
+			"(%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+			qb.dialect.Placeholder(argIdx),
+			qb.dialect.Placeholder(argIdx+1),
+			qb.dialect.Placeholder(argIdx+2),
+			qb.dialect.Placeholder(argIdx+3),
+			qb.dialect.Placeholder(argIdx+4),
+			qb.dialect.Placeholder(argIdx+5),
+			qb.dialect.Placeholder(argIdx+6),
+			qb.dialect.Placeholder(argIdx+7),
+			qb.dialect.Placeholder(argIdx+8),
+		))
+		args = append(args, row.GUID, row.KeyPath, row.Value, "", "", "", "", 0, "")
+		argIdx += 9
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s, %s, %s) VALUES %s",
+		qb.dialect.QuoteIdent(qb.tableName),
+		qb.dialect.QuoteIdent("guid"),
+		qb.dialect.QuoteIdent("key_path"),
+		qb.dialect.QuoteIdent("value"),
+		qb.dialect.QuoteIdent("group"),
+		qb.dialect.QuoteIdent("resource"),
+		qb.dialect.QuoteIdent("namespace"),
+		qb.dialect.QuoteIdent("name"),
+		qb.dialect.QuoteIdent("action"),
+		qb.dialect.QuoteIdent("folder"),
+		strings.Join(valueRows, ", "),
+	)
+
+	return query, args
+}
+
 // buildInsertDatastoreBackwardCompatQuery generates INSERT for backward-compatible mode
 // Inserts guid, value, and placeholder values for NOT NULL columns - these will be updated by applyBackwardsCompatibleChanges()
 func (qb *queryBuilder) buildInsertDatastoreBackwardCompatQuery(value []byte, guid, group, resource, namespace, name, folder string, action int64) (string, []interface{}) {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -23,11 +23,23 @@ const (
 
 var _ KV = &SqlKV{}
 
+// DataImportRow represents a single append-only resource_history row written during bulk import.
+type DataImportRow struct {
+	GUID    string
+	KeyPath string
+	Value   []byte
+}
+
 type SqlKV struct {
 	db         *sql.DB
 	dialect    Dialect
 	DriverName string // TODO: remove when backwards compatibility is no longer needed.
 }
+
+const (
+	dataImportBatchSQLiteMaxRows  = 8
+	dataImportBatchDefaultMaxRows = 1000
+)
 
 func NewSQLKV(db *sql.DB, driverName string) (KV, error) {
 	if db == nil {
@@ -88,6 +100,14 @@ func (k *SqlKV) Ping(ctx context.Context) error {
 	return k.db.PingContext(ctx)
 }
 
+func dataImportBatchRowLimit(dialectName string) int {
+	if dialectName == "sqlite" {
+		return dataImportBatchSQLiteMaxRows
+	}
+
+	return dataImportBatchDefaultMaxRows
+}
+
 // conn returns the dbtx from the context (set during bulk import on SQLite)
 // or falls back to the default *sql.DB connection pool.
 func (k *SqlKV) conn(ctx context.Context) dbtx {
@@ -95,6 +115,54 @@ func (k *SqlKV) conn(ctx context.Context) dbtx {
 		return db
 	}
 	return k.db
+}
+
+// InsertDataImportBatch writes a batch of append-only resource_history rows for the bulk import path.
+func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow) (err error) {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	qb, err := k.getQueryBuilder(DataSection)
+	if err != nil {
+		return err
+	}
+
+	conn := k.conn(ctx)
+	var tx *sql.Tx
+	if _, ok := dbtxFromCtx(ctx); !ok {
+		tx, err = k.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin data import transaction: %w", err)
+		}
+		conn = tx
+		defer func() {
+			if err != nil {
+				err = errors.Join(err, tx.Rollback())
+			}
+		}()
+	}
+
+	maxRows := dataImportBatchRowLimit(k.dialect.Name())
+	for start := 0; start < len(rows); start += maxRows {
+		end := start + maxRows
+		if end > len(rows) {
+			end = len(rows)
+		}
+
+		query, args := qb.buildInsertDatastoreBatchQuery(rows[start:end])
+		if _, err = conn.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to insert data import batch: %w", err)
+		}
+	}
+
+	if tx != nil {
+		if err = tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit data import batch: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (k *SqlKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -37,6 +37,7 @@ type SqlKV struct {
 }
 
 const (
+	// Match the existing SQL backend sqlite cap so both bulk import paths chunk the same way.
 	dataImportBatchSQLiteMaxRows  = 8
 	dataImportBatchDefaultMaxRows = 1000
 )

--- a/pkg/storage/unified/resource/kv/sqlkv_test.go
+++ b/pkg/storage/unified/resource/kv/sqlkv_test.go
@@ -1,0 +1,154 @@
+package kv
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSQLKVMock(t *testing.T, driverName string) (*SqlKV, *sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	store, err := NewSQLKV(db, driverName)
+	require.NoError(t, err)
+
+	sqlKV, ok := store.(*SqlKV)
+	require.True(t, ok)
+
+	return sqlKV, db, mock
+}
+
+func buildDataImportRows(count int) []DataImportRow {
+	rows := make([]DataImportRow, count)
+	for i := 0; i < count; i++ {
+		rows[i] = DataImportRow{
+			GUID:    fmt.Sprintf("guid-%d", i),
+			KeyPath: fmt.Sprintf("unified/data/group/resource/ns/name-%04d/1~created~", i),
+			Value:   []byte(fmt.Sprintf(`{"name":"item-%04d"}`, i)),
+		}
+	}
+
+	return rows
+}
+
+func TestSQLKVInsertDataImportBatchTransactionSelection(t *testing.T) {
+	tests := []struct {
+		name           string
+		useExternalTx  bool
+		expectedRows   int
+		expectedResult int64
+	}{
+		{
+			name:           "local transaction",
+			expectedRows:   2,
+			expectedResult: 2,
+		},
+		{
+			name:           "external transaction",
+			useExternalTx:  true,
+			expectedRows:   2,
+			expectedResult: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlKV, db, mock := setupSQLKVMock(t, "sqlite")
+			ctx := context.Background()
+
+			var tx *sql.Tx
+			var err error
+			if tc.useExternalTx {
+				mock.ExpectBegin()
+				tx, err = db.Begin()
+				require.NoError(t, err)
+				ctx = ContextWithDBTX(ctx, tx)
+			} else {
+				mock.ExpectBegin()
+			}
+
+			mock.ExpectExec("(?i)insert into .*resource_history").
+				WillReturnResult(sqlmock.NewResult(0, tc.expectedResult))
+			mock.ExpectCommit()
+
+			err = sqlKV.InsertDataImportBatch(ctx, buildDataImportRows(tc.expectedRows))
+			require.NoError(t, err)
+
+			if tc.useExternalTx {
+				require.NoError(t, tx.Commit())
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSQLKVInsertDataImportBatchChunking(t *testing.T) {
+	tests := []struct {
+		name         string
+		driverName   string
+		rowCount     int
+		expectedExec int
+	}{
+		{
+			name:         "sqlite chunking",
+			driverName:   "sqlite",
+			rowCount:     dataImportBatchSQLiteMaxRows + 1,
+			expectedExec: 2,
+		},
+		{
+			name:         "mysql chunking",
+			driverName:   "mysql",
+			rowCount:     dataImportBatchDefaultMaxRows + 1,
+			expectedExec: 2,
+		},
+		{
+			name:         "postgres chunking",
+			driverName:   "postgres",
+			rowCount:     dataImportBatchDefaultMaxRows + 1,
+			expectedExec: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlKV, _, mock := setupSQLKVMock(t, tc.driverName)
+
+			mock.ExpectBegin()
+			for i := 0; i < tc.expectedExec; i++ {
+				mock.ExpectExec("(?i)insert into .*resource_history").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			}
+			mock.ExpectCommit()
+
+			err := sqlKV.InsertDataImportBatch(context.Background(), buildDataImportRows(tc.rowCount))
+			require.NoError(t, err)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSQLKVInsertDataImportBatchRollsBackOnExecError(t *testing.T) {
+	sqlKV, _, mock := setupSQLKVMock(t, "sqlite")
+	expectedErr := errors.New("insert failed")
+
+	mock.ExpectBegin()
+	mock.ExpectExec("(?i)insert into .*resource_history").
+		WillReturnError(expectedErr)
+	mock.ExpectRollback()
+
+	err := sqlKV.InsertDataImportBatch(context.Background(), buildDataImportRows(2))
+	require.ErrorIs(t, err, expectedErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2031,6 +2031,15 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 				Folder:          req.Folder,
 			}
 
+			if err := validateDataKey(dataKey); err != nil {
+				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+					Key:    req.Key,
+					Action: req.Action,
+					Error:  fmt.Sprintf("failed to save resource: invalid data key: %s", err),
+				})
+				continue
+			}
+
 			item := kvBulkImportItem{
 				req:     req,
 				dataKey: dataKey,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1997,28 +1997,6 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			switch resourcepb.WatchEvent_Type(req.Action) {
 			case resourcepb.WatchEvent_ADDED:
 				action = DataActionCreated
-				_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
-					Group:     req.Key.Group,
-					Resource:  req.Key.Resource,
-					Namespace: req.Key.Namespace,
-					Name:      req.Key.Name,
-				})
-				if err == nil {
-					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-						Key:    req.Key,
-						Action: req.Action,
-						Error:  "resource already exists",
-					})
-					continue
-				}
-				if !errors.Is(err, ErrNotFound) {
-					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-						Key:    req.Key,
-						Action: req.Action,
-						Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
-					})
-					continue
-				}
 			case resourcepb.WatchEvent_MODIFIED:
 				action = DataActionUpdated
 			case resourcepb.WatchEvent_DELETED:

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1971,7 +1971,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		if len(batch) == 0 {
 			rollback()
 			rsp.Error = AsErrorResult(fmt.Errorf("missing request batch"))
-			break
+			return rsp
 		}
 
 		batchItems := make([]kvBulkImportItem, 0, len(batch))

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1793,6 +1793,43 @@ func (k *kvStorageBackend) GetResourceLastImportTimes(ctx context.Context) iter.
 	}
 }
 
+type kvBulkImportItem struct {
+	req        *resourcepb.BulkRequest
+	dataKey    DataKey
+	nameKey    string
+	microRV    int64
+	previousRV int64
+	generation int64
+}
+
+type singleBulkRequestBatchIterator struct {
+	iter  BulkRequestIterator
+	batch []*resourcepb.BulkRequest
+}
+
+func (s *singleBulkRequestBatchIterator) NextBatch() bool {
+	if !s.iter.Next() {
+		return false
+	}
+
+	req := s.iter.Request()
+	if req == nil {
+		s.batch = nil
+		return true
+	}
+
+	s.batch = []*resourcepb.BulkRequest{req}
+	return true
+}
+
+func (s *singleBulkRequestBatchIterator) Batch() []*resourcepb.BulkRequest {
+	return s.batch
+}
+
+func (s *singleBulkRequestBatchIterator) RollbackRequested() bool {
+	return s.iter.RollbackRequested()
+}
+
 //nolint:gocyclo
 func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings, iter BulkRequestIterator) *resourcepb.BulkResponse {
 	// rvManagerDB is the database handle for rvManager and legacy compat operations.
@@ -1900,115 +1937,188 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 	updatedResources := make(map[NamespacedResource]bool)
 	// Track the last micro RV per resource name for computing previous_resource_version in compat mode.
 	lastMicroRV := make(map[string]int64)
+	recordSavedItem := func(item kvBulkImportItem) error {
+		saved = append(saved, item.dataKey)
+		updatedResources[NamespacedResource{
+			Namespace: item.dataKey.Namespace,
+			Group:     item.dataKey.Group,
+			Resource:  item.dataKey.Resource,
+		}] = true
 
-	for iter.Next() {
-		if iter.RollbackRequested() {
+		if rvManagerDB == nil {
+			return nil
+		}
+
+		if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, rvManagerDB, item.dataKey, item.microRV, item.previousRV, item.generation); err != nil {
+			return fmt.Errorf("failed to update legacy resource_history for bulk: %w", err)
+		}
+
+		return nil
+	}
+
+	batchIter, ok := iter.(BulkRequestBatchIterator)
+	if !ok {
+		batchIter = &singleBulkRequestBatchIterator{iter: iter}
+	}
+
+	for batchIter.NextBatch() {
+		if batchIter.RollbackRequested() {
 			rollback()
 			break
 		}
 
-		req := iter.Request()
-		if req == nil {
+		batch := batchIter.Batch()
+		if len(batch) == 0 {
 			rollback()
-			rsp.Error = AsErrorResult(fmt.Errorf("missing request"))
+			rsp.Error = AsErrorResult(fmt.Errorf("missing request batch"))
 			break
 		}
 
-		rsp.Processed++
-
-		var action kv.DataAction
-		switch resourcepb.WatchEvent_Type(req.Action) {
-		case resourcepb.WatchEvent_ADDED:
-			action = DataActionCreated
-			// Check if resource already exists for create operations
-			_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
-				Group:     req.Key.Group,
-				Resource:  req.Key.Resource,
-				Namespace: req.Key.Namespace,
-				Name:      req.Key.Name,
-			})
-			if err == nil {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  "resource already exists",
-				})
-				continue
-			}
-			if !errors.Is(err, ErrNotFound) {
-				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-					Key:    req.Key,
-					Action: req.Action,
-					Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
-				})
-				continue
-			}
-		case resourcepb.WatchEvent_MODIFIED:
-			action = DataActionUpdated
-		case resourcepb.WatchEvent_DELETED:
-			action = DataActionDeleted
-		default:
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  "invalid event type",
-			})
-			continue
-		}
-
-		obj := &unstructured.Unstructured{}
-		err := obj.UnmarshalJSON(req.Value)
-		if err != nil {
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  "unable to unmarshal json",
-			})
-			continue
-		}
-
-		dataKey := DataKey{
-			Group:           req.Key.Group,
-			Resource:        req.Key.Resource,
-			Namespace:       req.Key.Namespace,
-			Name:            req.Key.Name,
-			ResourceVersion: bulkRvGenerator.next(obj),
-			Action:          action,
-			Folder:          req.Folder,
-		}
-		err = b.dataStore.Save(ctx, dataKey, bytes.NewReader(req.Value))
-		if err != nil {
-			rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
-				Key:    req.Key,
-				Action: req.Action,
-				Error:  fmt.Sprintf("failed to save resource: %s", err),
-			})
-			continue
-		}
-
-		saved = append(saved, dataKey)
-		updatedResources[NamespacedResource{Namespace: dataKey.Namespace, Group: dataKey.Group, Resource: dataKey.Resource}] = true
-
-		// Fill in legacy columns on the resource_history row that was just inserted with only key_path and value.
+		batchItems := make([]kvBulkImportItem, 0, len(batch))
+		batchRows := make([]kv.DataImportRow, 0, len(batch))
+		batchLastMicroRV := lastMicroRV
 		if rvManagerDB != nil {
-			microRV := rvmanager.RVFromSnowflake(dataKey.ResourceVersion)
-			generation := obj.GetGeneration()
-			if action == DataActionDeleted {
-				generation = 0
+			batchLastMicroRV = make(map[string]int64, len(lastMicroRV)+len(batch))
+			for key, value := range lastMicroRV {
+				batchLastMicroRV[key] = value
+			}
+		}
+
+		for _, req := range batch {
+			if req == nil {
+				rollback()
+				rsp.Error = AsErrorResult(fmt.Errorf("missing request"))
+				return rsp
 			}
 
-			// For creates, previous RV is 0. For updates/deletes, it's the RV of the previous event for this resource.
-			nameKey := dataKey.Group + "/" + dataKey.Resource + "/" + dataKey.Namespace + "/" + dataKey.Name
-			var previousRV int64
-			if action != DataActionCreated {
-				previousRV = lastMicroRV[nameKey]
+			rsp.Processed++
+
+			var action kv.DataAction
+			switch resourcepb.WatchEvent_Type(req.Action) {
+			case resourcepb.WatchEvent_ADDED:
+				action = DataActionCreated
+				_, err := b.dataStore.GetLatestResourceKey(ctx, GetRequestKey{
+					Group:     req.Key.Group,
+					Resource:  req.Key.Resource,
+					Namespace: req.Key.Namespace,
+					Name:      req.Key.Name,
+				})
+				if err == nil {
+					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+						Key:    req.Key,
+						Action: req.Action,
+						Error:  "resource already exists",
+					})
+					continue
+				}
+				if !errors.Is(err, ErrNotFound) {
+					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+						Key:    req.Key,
+						Action: req.Action,
+						Error:  fmt.Sprintf("failed to check if resource exists: %s", err),
+					})
+					continue
+				}
+			case resourcepb.WatchEvent_MODIFIED:
+				action = DataActionUpdated
+			case resourcepb.WatchEvent_DELETED:
+				action = DataActionDeleted
+			default:
+				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+					Key:    req.Key,
+					Action: req.Action,
+					Error:  "invalid event type",
+				})
+				continue
 			}
 
-			if err := b.dataStore.updateLegacyResourceHistoryBulk(ctx, rvManagerDB, dataKey, microRV, previousRV, generation); err != nil {
+			obj := &unstructured.Unstructured{}
+			err := obj.UnmarshalJSON(req.Value)
+			if err != nil {
+				rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+					Key:    req.Key,
+					Action: req.Action,
+					Error:  "unable to unmarshal json",
+				})
+				continue
+			}
+
+			dataKey := DataKey{
+				Group:           req.Key.Group,
+				Resource:        req.Key.Resource,
+				Namespace:       req.Key.Namespace,
+				Name:            req.Key.Name,
+				ResourceVersion: bulkRvGenerator.next(obj),
+				Action:          action,
+				Folder:          req.Folder,
+			}
+
+			item := kvBulkImportItem{
+				req:     req,
+				dataKey: dataKey,
+			}
+
+			if rvManagerDB != nil {
+				item.microRV = rvmanager.RVFromSnowflake(dataKey.ResourceVersion)
+				item.generation = obj.GetGeneration()
+				if action == DataActionDeleted {
+					item.generation = 0
+				}
+
+				nameKey := dataKey.Group + "/" + dataKey.Resource + "/" + dataKey.Namespace + "/" + dataKey.Name
+				item.nameKey = nameKey
+				if action != DataActionCreated {
+					item.previousRV = batchLastMicroRV[nameKey]
+				}
+				batchLastMicroRV[nameKey] = item.microRV
+			}
+
+			batchItems = append(batchItems, item)
+			batchRows = append(batchRows, kv.DataImportRow{
+				GUID:    uuid.New().String(),
+				KeyPath: kv.DataSection + "/" + dataKey.String(),
+				Value:   req.Value,
+			})
+		}
+
+		usedBatchWriter, err := b.dataStore.insertDataImportBatch(ctx, batchRows)
+		if err != nil {
+			rollback()
+			rsp.Error = AsErrorResult(fmt.Errorf("failed to save resource batch: %w", err))
+			return rsp
+		}
+
+		if !usedBatchWriter {
+			for _, item := range batchItems {
+				err := b.dataStore.Save(ctx, item.dataKey, bytes.NewReader(item.req.Value))
+				if err != nil {
+					rsp.Rejected = append(rsp.Rejected, &resourcepb.BulkResponse_Rejected{
+						Key:    item.req.Key,
+						Action: item.req.Action,
+						Error:  fmt.Sprintf("failed to save resource: %s", err),
+					})
+					continue
+				}
+
+				if err := recordSavedItem(item); err != nil {
+					b.log.Error("failed to update legacy resource_history for bulk", "error", err)
+					return rsp
+				}
+				if item.nameKey != "" {
+					lastMicroRV[item.nameKey] = item.microRV
+				}
+			}
+			continue
+		}
+
+		for _, item := range batchItems {
+			if err := recordSavedItem(item); err != nil {
 				b.log.Error("failed to update legacy resource_history for bulk", "error", err)
 				return rsp
 			}
-			lastMicroRV[nameKey] = microRV
+			if item.nameKey != "" {
+				lastMicroRV[item.nameKey] = item.microRV
+			}
 		}
 	}
 

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -198,7 +198,7 @@ func newBulkImportRequest(namespace, name string, action resourcepb.BulkRequest_
 func collectBulkImportNames(t *testing.T, backend *kvStorageBackend, namespace string) []string {
 	t.Helper()
 
-	names := make([]string, 0)
+	names := make([]string, 0, 2)
 	for key, err := range backend.dataStore.Keys(context.Background(), ListRequestKey{
 		Namespace: namespace,
 		Group:     testBulkImportGroup,

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -148,6 +148,29 @@ func TestKVStorageBackendProcessBulkImportBatching(t *testing.T) {
 	}
 }
 
+func TestKVStorageBackendProcessBulkPreservesImportedHistory(t *testing.T) {
+	backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+
+	const namespace = "sqlkv-history"
+	resp := backend.ProcessBulk(context.Background(), BulkSettings{
+		Collection: []*resourcepb.ResourceKey{{
+			Namespace: namespace,
+			Group:     testBulkImportGroup,
+			Resource:  testBulkImportResource,
+		}},
+	}, newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{
+		newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+		newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+		newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_DELETED),
+	}))
+
+	require.Nil(t, resp.Error)
+	require.Empty(t, resp.Rejected)
+	require.Equal(t, int64(3), resp.Processed)
+	require.Equal(t, []string{"item-1", "item-1", "item-1"}, collectBulkImportNames(t, backend, namespace))
+	require.Empty(t, collectLatestBulkImportNames(t, backend, namespace))
+}
+
 func TestKVStorageBackendProcessBulkRollsBackOnImportBatchError(t *testing.T) {
 	sqlKV := setupSqlKV(t)
 	writer, ok := sqlKV.(importBatchWriter)
@@ -204,6 +227,23 @@ func collectBulkImportNames(t *testing.T, backend *kvStorageBackend, namespace s
 		Group:     testBulkImportGroup,
 		Resource:  testBulkImportResource,
 	}, SortOrderAsc) {
+		require.NoError(t, err)
+		names = append(names, key.Name)
+	}
+
+	slices.Sort(names)
+	return names
+}
+
+func collectLatestBulkImportNames(t *testing.T, backend *kvStorageBackend, namespace string) []string {
+	t.Helper()
+
+	names := make([]string, 0, 2)
+	for key, err := range backend.dataStore.ListLatestResourceKeys(context.Background(), ListRequestKey{
+		Namespace: namespace,
+		Group:     testBulkImportGroup,
+		Resource:  testBulkImportResource,
+	}) {
 		require.NoError(t, err)
 		names = append(names, key.Name)
 	}

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -171,6 +171,29 @@ func TestKVStorageBackendProcessBulkPreservesImportedHistory(t *testing.T) {
 	require.Empty(t, collectLatestBulkImportNames(t, backend, namespace))
 }
 
+func TestKVStorageBackendProcessBulkRejectsInvalidDataKeysBeforeBatchInsert(t *testing.T) {
+	backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+
+	const namespace = "sqlkv-invalid-key"
+	req := newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED)
+	req.Folder = "bad/folder"
+
+	resp := backend.ProcessBulk(context.Background(), BulkSettings{
+		Collection: []*resourcepb.ResourceKey{{
+			Namespace: namespace,
+			Group:     testBulkImportGroup,
+			Resource:  testBulkImportResource,
+		}},
+	}, newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{req}))
+
+	require.Nil(t, resp.Error)
+	require.Len(t, resp.Rejected, 1)
+	require.Contains(t, resp.Rejected[0].Error, "invalid data key")
+	require.Equal(t, int64(1), resp.Processed)
+	require.Empty(t, collectBulkImportNames(t, backend, namespace))
+	require.Empty(t, collectLatestBulkImportNames(t, backend, namespace))
+}
+
 func TestKVStorageBackendProcessBulkRollsBackOnImportBatchError(t *testing.T) {
 	sqlKV := setupSqlKV(t)
 	writer, ok := sqlKV.(importBatchWriter)

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -70,13 +70,9 @@ func (i *sliceBulkIterator) RollbackRequested() bool {
 	return false
 }
 
-type importBatchWriter interface {
-	InsertDataImportBatch(ctx context.Context, rows []kvpkg.DataImportRow) error
-}
-
 type failAfterImportKV struct {
 	KV
-	writer    importBatchWriter
+	writer    dataImportBatchWriter
 	failAfter int
 	calls     int
 	err       error
@@ -148,6 +144,28 @@ func TestKVStorageBackendProcessBulkImportBatching(t *testing.T) {
 	}
 }
 
+func TestKVStorageBackendProcessBulkUsesSaveFallbackWhenBatchWriterUnavailable(t *testing.T) {
+	backend := setupTestStorageBackend(t)
+
+	const namespace = "badger-save-fallback"
+	resp := backend.ProcessBulk(context.Background(), BulkSettings{
+		Collection: []*resourcepb.ResourceKey{{
+			Namespace: namespace,
+			Group:     testBulkImportGroup,
+			Resource:  testBulkImportResource,
+		}},
+	}, newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{
+		newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+		newBulkImportRequest(namespace, "item-2", resourcepb.BulkRequest_ADDED),
+	}))
+
+	require.Nil(t, resp.Error)
+	require.Empty(t, resp.Rejected)
+	require.Equal(t, int64(2), resp.Processed)
+	require.Equal(t, []string{"item-1", "item-2"}, collectBulkImportNames(t, backend, namespace))
+	require.Equal(t, []string{"item-1", "item-2"}, collectLatestBulkImportNames(t, backend, namespace))
+}
+
 func TestKVStorageBackendProcessBulkPreservesImportedHistory(t *testing.T) {
 	backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)))
 
@@ -169,6 +187,24 @@ func TestKVStorageBackendProcessBulkPreservesImportedHistory(t *testing.T) {
 	require.Equal(t, int64(3), resp.Processed)
 	require.Equal(t, []string{"item-1", "item-1", "item-1"}, collectBulkImportNames(t, backend, namespace))
 	require.Empty(t, collectLatestBulkImportNames(t, backend, namespace))
+}
+
+func TestKVStorageBackendProcessBulkRejectsEmptyBatch(t *testing.T) {
+	backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+
+	const namespace = "sqlkv-empty-batch"
+	resp := backend.ProcessBulk(context.Background(), BulkSettings{
+		Collection: []*resourcepb.ResourceKey{{
+			Namespace: namespace,
+			Group:     testBulkImportGroup,
+			Resource:  testBulkImportResource,
+		}},
+	}, newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{}))
+
+	require.NotNil(t, resp.Error)
+	require.Contains(t, resp.Error.Message, "missing request batch")
+	require.Equal(t, int64(0), resp.Processed)
+	require.Empty(t, collectBulkImportNames(t, backend, namespace))
 }
 
 func TestKVStorageBackendProcessBulkRejectsInvalidDataKeysBeforeBatchInsert(t *testing.T) {
@@ -196,7 +232,7 @@ func TestKVStorageBackendProcessBulkRejectsInvalidDataKeysBeforeBatchInsert(t *t
 
 func TestKVStorageBackendProcessBulkRollsBackOnImportBatchError(t *testing.T) {
 	sqlKV := setupSqlKV(t)
-	writer, ok := sqlKV.(importBatchWriter)
+	writer, ok := sqlKV.(dataImportBatchWriter)
 	require.True(t, ok)
 
 	backend := setupTestStorageBackend(t, withKV(&failAfterImportKV{

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -1,0 +1,213 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kvpkg "github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+const (
+	testBulkImportGroup    = "bulk.grafana.app"
+	testBulkImportResource = "items"
+)
+
+type batchOnlyBulkIterator struct {
+	idx     int
+	batches [][]*resourcepb.BulkRequest
+}
+
+func newBatchOnlyBulkIterator(batches ...[]*resourcepb.BulkRequest) *batchOnlyBulkIterator {
+	return &batchOnlyBulkIterator{idx: -1, batches: batches}
+}
+
+func (i *batchOnlyBulkIterator) Next() bool {
+	panic("Next should not be called when batch iteration is available")
+}
+
+func (i *batchOnlyBulkIterator) Request() *resourcepb.BulkRequest {
+	return nil
+}
+
+func (i *batchOnlyBulkIterator) NextBatch() bool {
+	i.idx++
+	return i.idx < len(i.batches)
+}
+
+func (i *batchOnlyBulkIterator) Batch() []*resourcepb.BulkRequest {
+	return i.batches[i.idx]
+}
+
+func (i *batchOnlyBulkIterator) RollbackRequested() bool {
+	return false
+}
+
+type sliceBulkIterator struct {
+	idx   int
+	items []*resourcepb.BulkRequest
+}
+
+func newSliceBulkIterator(items ...*resourcepb.BulkRequest) *sliceBulkIterator {
+	return &sliceBulkIterator{idx: -1, items: items}
+}
+
+func (i *sliceBulkIterator) Next() bool {
+	i.idx++
+	return i.idx < len(i.items)
+}
+
+func (i *sliceBulkIterator) Request() *resourcepb.BulkRequest {
+	return i.items[i.idx]
+}
+
+func (i *sliceBulkIterator) RollbackRequested() bool {
+	return false
+}
+
+type importBatchWriter interface {
+	InsertDataImportBatch(ctx context.Context, rows []kvpkg.DataImportRow) error
+}
+
+type failAfterImportKV struct {
+	KV
+	writer    importBatchWriter
+	failAfter int
+	calls     int
+	err       error
+}
+
+func (f *failAfterImportKV) InsertDataImportBatch(ctx context.Context, rows []kvpkg.DataImportRow) error {
+	f.calls++
+	if f.calls > f.failAfter {
+		return f.err
+	}
+
+	return f.writer.InsertDataImportBatch(ctx, rows)
+}
+
+func TestKVStorageBackendProcessBulkImportBatching(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		buildIter    func(namespace string) BulkRequestIterator
+		expectedRows []string
+		rejected     int
+		processed    int64
+	}{
+		{
+			name:      "batch iterator",
+			namespace: "sqlkv-batch",
+			buildIter: func(namespace string) BulkRequestIterator {
+				return newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{
+					newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+					newBulkImportRequest(namespace, "item-bad", resourcepb.BulkRequest_UNKNOWN),
+					newBulkImportRequest(namespace, "item-2", resourcepb.BulkRequest_ADDED),
+				})
+			},
+			expectedRows: []string{"item-1", "item-2"},
+			rejected:     1,
+			processed:    3,
+		},
+		{
+			name:      "single iterator fallback",
+			namespace: "sqlkv-single",
+			buildIter: func(namespace string) BulkRequestIterator {
+				return newSliceBulkIterator(
+					newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+					newBulkImportRequest(namespace, "item-2", resourcepb.BulkRequest_ADDED),
+				)
+			},
+			expectedRows: []string{"item-1", "item-2"},
+			rejected:     0,
+			processed:    2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := setupTestStorageBackend(t, withKV(setupSqlKV(t)))
+			resp := backend.ProcessBulk(context.Background(), BulkSettings{
+				Collection: []*resourcepb.ResourceKey{{
+					Namespace: tc.namespace,
+					Group:     testBulkImportGroup,
+					Resource:  testBulkImportResource,
+				}},
+			}, tc.buildIter(tc.namespace))
+
+			require.Nil(t, resp.Error)
+			require.Len(t, resp.Rejected, tc.rejected)
+			require.Equal(t, tc.processed, resp.Processed)
+			require.Equal(t, tc.expectedRows, collectBulkImportNames(t, backend, tc.namespace))
+		})
+	}
+}
+
+func TestKVStorageBackendProcessBulkRollsBackOnImportBatchError(t *testing.T) {
+	sqlKV := setupSqlKV(t)
+	writer, ok := sqlKV.(importBatchWriter)
+	require.True(t, ok)
+
+	backend := setupTestStorageBackend(t, withKV(&failAfterImportKV{
+		KV:        sqlKV,
+		writer:    writer,
+		failAfter: 1,
+		err:       errors.New("batch insert failed"),
+	}))
+
+	const namespace = "sqlkv-rollback"
+	resp := backend.ProcessBulk(context.Background(), BulkSettings{
+		Collection: []*resourcepb.ResourceKey{{
+			Namespace: namespace,
+			Group:     testBulkImportGroup,
+			Resource:  testBulkImportResource,
+		}},
+	}, newBatchOnlyBulkIterator(
+		[]*resourcepb.BulkRequest{newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED)},
+		[]*resourcepb.BulkRequest{newBulkImportRequest(namespace, "item-2", resourcepb.BulkRequest_ADDED)},
+	))
+
+	require.NotNil(t, resp.Error)
+	require.Contains(t, resp.Error.Message, "failed to save resource batch")
+	require.Empty(t, collectBulkImportNames(t, backend, namespace))
+}
+
+func newBulkImportRequest(namespace, name string, action resourcepb.BulkRequest_Action) *resourcepb.BulkRequest {
+	return &resourcepb.BulkRequest{
+		Key: &resourcepb.ResourceKey{
+			Namespace: namespace,
+			Group:     testBulkImportGroup,
+			Resource:  testBulkImportResource,
+			Name:      name,
+		},
+		Action: action,
+		Value: []byte(fmt.Sprintf(
+			`{"apiVersion":"bulk.grafana.app/v1","kind":"Item","metadata":{"name":"%s","namespace":"%s"},"spec":{"name":"%s"}}`,
+			name,
+			namespace,
+			name,
+		)),
+	}
+}
+
+func collectBulkImportNames(t *testing.T, backend *kvStorageBackend, namespace string) []string {
+	t.Helper()
+
+	names := make([]string, 0)
+	for key, err := range backend.dataStore.Keys(context.Background(), ListRequestKey{
+		Namespace: namespace,
+		Group:     testBulkImportGroup,
+		Resource:  testBulkImportResource,
+	}, SortOrderAsc) {
+		require.NoError(t, err)
+		names = append(names, key.Name)
+	}
+
+	slices.Sort(names)
+	return names
+}


### PR DESCRIPTION
PR #120447 batched BulkProcess migration writes for the SQL backend, but the sqlkv-backed import path in `kvStorageBackend.ProcessBulk` still wrote `resource_history` one row at a time and still did one existence lookup per `ADDED` item. This change keeps the existing KV and bulk interfaces intact, adds a narrow optional sqlkv import hook for batched `resource_history` inserts, and removes the per-row create lookup so KV bulk import replays the incoming history stream directly after clearing the target collection. That gives sqlkv imports the same sink-side batching benefit without implementing generic `KV.Batch` semantics or paying N extra read round-trips during import.

## What changed
- add `SqlKV.InsertDataImportBatch` with dialect-specific chunking and transactional execution for append-only bulk import rows
- add a private datastore adapter so the resource package can use the optional sqlkv fast path without changing `KV`
- update `kvStorageBackend.ProcessBulk` to consume `BulkRequestBatchIterator` when available and keep a single-item fallback for non-batched iterators
- remove the per-row `GetLatestResourceKey` check from the `ADDED` import path so repeated entries for the same resource replay as history instead of triggering read-side existence checks
- preserve rollback, legacy compat updates, RV bumping, and last-import-time updates after the new batch write step
- add focused tests for sqlkv batch insert transaction/chunking behavior and KV bulk import batching, rollback, and history replay behavior

## Why
- sqlkv-backed imports were still paying one SQL insert per accepted bulk item even after the server-side batching work landed
- the `ADDED` path was also doing one `GetLatestResourceKey` read per row, which under sqlkv walks the `key_path` range for that resource
- bulk import already clears the target collection and rebuilds current state from imported history, so replaying the stream directly is both smaller and more history-friendly

## Testing
- `go test ./pkg/storage/unified/resource/kv`
- `go test ./pkg/storage/unified/resource`
- `go test ./pkg/storage/unified/resource -run 'TestKVStorageBackendProcessBulk'`
- `go test ./pkg/storage/unified/sql/test -run 'TestIntegrationSQLStorageAndSQLKVCompatibilityTests/IsHA \(polling notifier\)/bulk import large counter CRUD'`
- `go test ./pkg/storage/unified/sql/test -run 'TestIntegrationSQLStorageAndSQLKVCompatibilityTests/IsHA \(polling notifier\)/last import time cross backend'`

Ticket: https://github.com/grafana/search-and-storage-team/issues/693