### PR TITLE
Unified: handle readonlyfs for parquet tmp

### DIFF
--- a/pkg/storage/unified/parquet/reader.go
+++ b/pkg/storage/unified/parquet/reader.go
@@ -51,6 +51,7 @@ func (r *parquetReader) Next() bool {
 		if r.bufferIndex >= r.bufferSize && r.value.reader.HasNext() {
 			r.err = r.readBulk()
 			if r.err != nil {
+				r.close()
 				return false
 			}
 		}
@@ -76,11 +77,13 @@ func (r *parquetReader) Next() bool {
 
 		r.rowGroupIDX++
 		if r.rowGroupIDX >= r.reader.NumRowGroups() {
-			_ = r.reader.Close()
-			r.reader = nil
+			r.close()
 			return false
 		}
 		r.err = r.open(r.reader.RowGroup(r.rowGroupIDX))
+		if r.err != nil {
+			r.close()
+		}
 	}
 
 	return false
@@ -94,6 +97,13 @@ func (r *parquetReader) Request() *resourcepb.BulkRequest {
 // RollbackRequested implements resource.BulkRequestIterator.
 func (r *parquetReader) RollbackRequested() bool {
 	return r.err != nil
+}
+
+func (r *parquetReader) close() {
+	if r.reader != nil {
+		_ = r.reader.Close()
+		r.reader = nil
+	}
 }
 
 func newResourceReader(inputPath string, batchSize int64) (*parquetReader, error) {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"math"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -8,7 +8,6 @@ import (
 	"iter"
 	"math"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -74,6 +73,15 @@ type Backend interface {
 	resourcepb.DiagnosticsServer //nolint:staticcheck
 }
 
+// tmpDir returns a writable temp directory under dataPath for Parquet bulk
+// migration files. Returns "" (OS default) when dataPath is empty.
+func tmpDir(dataPath string) string {
+	if dataPath == "" {
+		return ""
+	}
+	return filepath.Join(dataPath, "tmp")
+}
+
 // NewStorageBackend creates the unified storage backend based on options.StorageType.
 // It supports file-based KV backend using BadgerDB (options.StorageTypeFile).
 // Returns a nil backend if options.StorageTypeUnifiedGrpc, a remote gRPC client is expected to be used instead.
@@ -121,7 +129,7 @@ func NewStorageBackend(
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
-			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"), // only used by the SQL backend path
+			TmpDir:                  tmpDir(cfg.DataPath),
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
 		})
@@ -260,11 +268,6 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		tmpDir:                  opts.TmpDir,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       garbageCollection,
-	}
-	if opts.TmpDir != "" {
-		if err := os.MkdirAll(opts.TmpDir, 0750); err != nil {
-			return nil, fmt.Errorf("create tmp dir: %w", err)
-		}
 	}
 	if err := backend.Init(ctx); err != nil {
 		return nil, err

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -120,7 +120,7 @@ func NewStorageBackend(
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
-			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"),
+			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"), // only used by the SQL backend path
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
 		})
@@ -259,6 +259,11 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		tmpDir:                  opts.TmpDir,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       garbageCollection,
+	}
+	if opts.TmpDir != "" {
+		if err := os.MkdirAll(opts.TmpDir, 0750); err != nil {
+			return nil, fmt.Errorf("create tmp dir: %w", err)
+		}
 	}
 	if err := backend.Init(ctx); err != nil {
 		return nil, err

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -120,6 +120,7 @@ func NewStorageBackend(
 			},
 			SimulatedNetworkLatency: cfg.SimulatedNetworkLatency,
 			MigrationParquetBuffer:  cfg.MigrationParquetBuffer,
+			TmpDir:                  filepath.Join(cfg.DataPath, "tmp"),
 			DisableStorageServices:  disableStorageServices,
 			DisablePruner:           cfg.DisablePruner,
 		})
@@ -212,6 +213,11 @@ type BackendOptions struct {
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	MigrationParquetBuffer bool
 
+	// Directory for temporary Parquet files during bulk migration.
+	// Defaults to the OS temp dir when empty. Set to cfg.DataPath/tmp to
+	// support containers with readonlyRootFilesystem enabled.
+	TmpDir string
+
 	// testing
 	SimulatedNetworkLatency time.Duration // slows down the create transactions by a fixed amount
 
@@ -250,6 +256,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		bulkLock:                &bulkLock{running: make(map[string]bool)},
 		simulatedNetworkLatency: opts.SimulatedNetworkLatency,
 		migrationParquetBuffer:  opts.MigrationParquetBuffer,
+		tmpDir:                  opts.TmpDir,
 		lastImportTimeMaxAge:    opts.LastImportTimeMaxAge,
 		garbageCollection:       garbageCollection,
 	}
@@ -308,6 +315,9 @@ type backend struct {
 
 	// When true, bulk migrations buffer data through a temporary Parquet file
 	migrationParquetBuffer bool
+
+	// tmpDir is the directory for temporary Parquet files; empty means OS default.
+	tmpDir string
 
 	// Fields to control the cleanup of "lastImportTime" rows (used to find indexes to rebuild)
 	lastImportTimeMaxAge       time.Duration

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -168,12 +168,20 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		useParquet = resource.ParquetBufferFromContext(clientCtx)
 	}
 	if useParquet && b.dialect.DialectName() == "sqlite" {
-		file, err := os.CreateTemp("", "grafana-bulk-export-*.parquet")
+		if b.tmpDir != "" {
+			if err := os.MkdirAll(b.tmpDir, 0750); err != nil {
+				return &resourcepb.BulkResponse{
+					Error: resource.AsErrorResult(fmt.Errorf("create tmp dir: %w", err)),
+				}
+			}
+		}
+		file, err := os.CreateTemp(b.tmpDir, "grafana-bulk-export-*.parquet")
 		if err != nil {
 			return &resourcepb.BulkResponse{
 				Error: resource.AsErrorResult(err),
 			}
 		}
+		defer os.Remove(file.Name())
 
 		writer, err := parquet.NewParquetWriter(file)
 		if err != nil {

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -168,13 +168,26 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		useParquet = resource.ParquetBufferFromContext(clientCtx)
 	}
 	if useParquet && b.dialect.DialectName() == "sqlite" {
+		if b.tmpDir != "" {
+			if err := os.MkdirAll(b.tmpDir, 0750); err != nil {
+				return &resourcepb.BulkResponse{
+					Error: resource.AsErrorResult(fmt.Errorf("create tmp dir: %w", err)),
+				}
+			}
+		}
 		file, err := os.CreateTemp(b.tmpDir, "grafana-bulk-export-*.parquet")
 		if err != nil {
 			return &resourcepb.BulkResponse{
 				Error: resource.AsErrorResult(err),
 			}
 		}
-		defer os.Remove(file.Name())
+		defer func() {
+			// Close is best-effort; the parquet writer may have already closed the file.
+			_ = file.Close()
+			if err := os.Remove(file.Name()); err != nil && !os.IsNotExist(err) {
+				b.log.Warn("failed to remove parquet tmp file", "path", file.Name(), "err", err)
+			}
+		}()
 
 		writer, err := parquet.NewParquetWriter(file)
 		if err != nil {
@@ -183,17 +196,10 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 			}
 		}
 
-		// write bulk to parquet
+		// write bulk to parquet (ProcessBulk closes the file via writer.Close)
 		rsp := writer.ProcessBulk(ctx, setting, iter)
 		if rsp.Error != nil {
 			return rsp
-		}
-
-		// Ensure the parquet file is flushed before the reader opens it
-		if err := file.Close(); err != nil {
-			return &resourcepb.BulkResponse{
-				Error: resource.AsErrorResult(err),
-			}
 		}
 
 		b.log.Info("using parquet buffer", "path", file.Name(), "processed", rsp.Processed)

--- a/pkg/storage/unified/sql/backend_bulk.go
+++ b/pkg/storage/unified/sql/backend_bulk.go
@@ -168,13 +168,6 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		useParquet = resource.ParquetBufferFromContext(clientCtx)
 	}
 	if useParquet && b.dialect.DialectName() == "sqlite" {
-		if b.tmpDir != "" {
-			if err := os.MkdirAll(b.tmpDir, 0750); err != nil {
-				return &resourcepb.BulkResponse{
-					Error: resource.AsErrorResult(fmt.Errorf("create tmp dir: %w", err)),
-				}
-			}
-		}
 		file, err := os.CreateTemp(b.tmpDir, "grafana-bulk-export-*.parquet")
 		if err != nil {
 			return &resourcepb.BulkResponse{
@@ -194,6 +187,13 @@ func (b *backend) ProcessBulk(ctx context.Context, setting resource.BulkSettings
 		rsp := writer.ProcessBulk(ctx, setting, iter)
 		if rsp.Error != nil {
 			return rsp
+		}
+
+		// Ensure the parquet file is flushed before the reader opens it
+		if err := file.Close(); err != nil {
+			return &resourcepb.BulkResponse{
+				Error: resource.AsErrorResult(err),
+			}
 		}
 
 		b.log.Info("using parquet buffer", "path", file.Name(), "processed", rsp.Processed)

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -124,6 +126,29 @@ func TestNewBackend(t *testing.T) {
 		require.NotNil(t, b)
 	})
 
+	t.Run("with TmpDir does not create directory eagerly", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir() + "/not-yet-created"
+		dbp := test.NewDBProviderNopSQL(t)
+		b, err := NewBackend(BackendOptions{DBProvider: dbp, TmpDir: tmpDir})
+		require.NoError(t, err)
+		require.NotNil(t, b)
+
+		// The directory should NOT have been created at construction time.
+		_, statErr := os.Stat(tmpDir)
+		require.True(t, os.IsNotExist(statErr), "TmpDir should not be created eagerly by NewBackend")
+	})
+
+	t.Run("with empty TmpDir", func(t *testing.T) {
+		t.Parallel()
+
+		dbp := test.NewDBProviderNopSQL(t)
+		b, err := NewBackend(BackendOptions{DBProvider: dbp, TmpDir: ""})
+		require.NoError(t, err)
+		require.NotNil(t, b)
+	})
+
 	t.Run("no db provider", func(t *testing.T) {
 		t.Parallel()
 
@@ -131,6 +156,18 @@ func TestNewBackend(t *testing.T) {
 		require.Nil(t, b)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "no db provider")
+	})
+}
+
+func TestTmpDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty string for empty dataPath", func(t *testing.T) {
+		require.Equal(t, "", tmpDir(""))
+	})
+
+	t.Run("returns dataPath/tmp for non-empty dataPath", func(t *testing.T) {
+		require.Equal(t, filepath.Join("/var/lib/grafana", "tmp"), tmpDir("/var/lib/grafana"))
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Bulk migration now writes temporary Parquet files to `cfg.DataPath/tmp` instead of the OS default `/tmp/` directory. Also adds cleanup (`os.Remove`) and explicit `file.Close()` before the reader opens the file.

**Why do we need this feature?**

Grafana fails to start on containers with a read-only root filesystem when only `/var/lib/grafana` is writable. The startup migration tries to write a temp Parquet file to `/tmp/`, which is not available in that setup.

**Who is this feature for?**

Users running Grafana in containers with a read-only root filesystem and SQLite as the database backend.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #121283 

**Special notes for your reviewer:**

`TmpDir` is only set on the SQL backend code-path, since the Parquet buffer is only used there.

`backend.go`:
- New `TmpDir` field on `BackendOptions` and `backend` struct, set to `filepath.Join(cfg.DataPath, "tmp")` in `NewStorageBackend`
- Directory is created via `os.MkdirAll` in `NewBackend`
- When `TmpDir` is empty, `os.CreateTemp` falls back to the OS default = no behavior change for existing setups

`backend_bulk.go`:
- `os.CreateTemp(b.tmpDir, ...)` instead of `os.CreateTemp("", ...)` so the temp file lands in the configured data directory
- `defer os.Remove(file.Name())` to clean up the temp file after use (I think this was missing in the original code)
- Explicit `file.Close()` before the Parquet reader opens the file to ensure all data is flushed to disk

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.