### PR TITLE
UserStorage: Create react hook for getting a UserStorage instance

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -26,7 +26,7 @@ export {
   type GetObservablePluginLinks,
 } from '../services/pluginExtensions/getObservablePluginLinks';
 
-export { UserStorage } from '../utils/userStorage';
+export { UserStorage, useUserStorage } from '../utils/userStorage';
 
 export { initOpenFeature, getFeatureFlagClient } from '../internal/openFeature';
 

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -1,10 +1,11 @@
+import { renderHook } from '@testing-library/react';
 import { cloneDeep } from 'lodash';
 import { of } from 'rxjs';
 
 import { config } from '../config';
 import { type BackendSrvRequest, type FetchError, type FetchResponse, type BackendSrv } from '../services';
 
-import { usePluginUserStorage, _clearStorageCache } from './userStorage';
+import { usePluginUserStorage, useUserStorage, _clearStorageCache } from './userStorage';
 
 const request = jest.fn<Promise<FetchResponse | FetchError>, BackendSrvRequest[]>();
 
@@ -388,5 +389,23 @@ describe('userStorage', () => {
       // Should have made 1 GET and 2 PATCH requests
       expect(request).toHaveBeenCalledTimes(3);
     });
+  });
+});
+
+describe('useUserStorage', () => {
+  it('returns the same instance across re-renders', () => {
+    const { result, rerender } = renderHook(() => useUserStorage('my-service'));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('returns a new instance when the service name changes', () => {
+    const { result, rerender } = renderHook(({ service }) => useUserStorage(service), {
+      initialProps: { service: 'service-a' },
+    });
+    const first = result.current;
+    rerender({ service: 'service-b' });
+    expect(result.current).not.toBe(first);
   });
 });

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -1,4 +1,5 @@
 import { get } from 'lodash';
+import { useRef } from 'react';
 import { lastValueFrom } from 'rxjs';
 
 import { usePluginContext, type UserStorage as UserStorageType, store } from '@grafana/data';
@@ -300,4 +301,18 @@ export function usePluginUserStorage(): PluginUserStorage {
     throw new Error(`No PluginContext found. The usePluginUserStorage() hook can only be used from a plugin.`);
   }
   return new UserStorage(context?.meta.id);
+}
+
+/**
+ * Internal Grafana-core only interface for constructing a UserStorage instance in a
+ * react component.
+ */
+export function useUserStorage(service: string): UserStorageType {
+  const ref = useRef<[service: string, UserStorageType]>();
+
+  if (!ref.current || ref.current[0] !== service) {
+    ref.current = [service, new UserStorage(service)];
+  }
+
+  return ref.current[1];
 }


### PR DESCRIPTION
Adds a `useUserStorage` hook for internal use in Grafana core that returns an object that doesn't change on re-renders, avoiding the need to consumers to re-implement this same logic.