### PR TITLE
BarGauge: Fix horizontal bar not filling available width

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -313,6 +313,28 @@ describe('BarGauge', () => {
       const styles = getBasicAndGradientStyles(props);
       expect(styles.emptyBar.height).toBe('150px');
     });
+
+    it('should use border-box on value so padding does not inflate width beyond allocated space', () => {
+      const props = getProps({
+        height: 150,
+        value: getValue(100),
+        orientation: VizOrientation.Horizontal,
+      });
+      const styles = getBasicAndGradientStyles(props);
+      expect(styles.value.boxSizing).toBe('border-box');
+    });
+
+    it('bar should fill full available width when value equals max', () => {
+      const props = getProps({
+        width: 500,
+        height: 150,
+        value: getValue(100),
+        orientation: VizOrientation.Horizontal,
+      });
+      const { maxBarWidth } = calculateBarAndValueDimensions(props);
+      const styles = getBasicAndGradientStyles(props);
+      expect(styles.bar.width).toBe(`${maxBarWidth}px`);
+    });
   });
 
   describe('Gradient', () => {

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -361,6 +361,7 @@ export function getTitleStyles(props: Props): { wrapper: CSSProperties; title: C
         titleStyles.width = `${titleDim.width}px`;
         titleStyles.textAlign = 'right';
         titleStyles.paddingRight = '10px';
+        titleStyles.boxSizing = 'border-box';
       }
     }
   }
@@ -702,6 +703,7 @@ function getValueStyles(
     alignItems: 'center',
     textWrap: 'nowrap',
     lineHeight: VALUE_LINE_HEIGHT,
+    boxSizing: 'border-box',
   };
 
   // how many pixels in wide can the text be?


### PR DESCRIPTION
**What is this feature?**

Fixes horizontal bar gauges not filling their full available width when the value reaches or exceeds the configured max. The value text element and left-placed title use CSS padding that wasn't accounted for in the flex layout, causing the bar to be compressed by flex-shrink.

**Why do we need this feature?**

In horizontal bar gauges, `getValueStyles` applies `paddingLeft` and `paddingRight` (10px each) on the value element with the default `content-box` sizing. This means the element's visual width is `valueWidth + 20px`, exceeding the space `calculateBarAndValueDimensions` allocated for it. The flex container responds by shrinking all items, making the colored bar shorter than it should be. A similar issue affects the title element when placed to the left (10px `paddingRight` not included in its computed width).

The fix adds `box-sizing: border-box` to both elements so their padding is included within the allocated width rather than added on top.

**Who is this feature for?**

Anyone using horizontal bar gauge panels.

**Which issue(s) does this PR fix?**:

Fixes #120918

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. N/A — bug fix
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. N/A — bug fix

### Root cause

In `getValueStyles` (horizontal path), the value element receives:
- `width: ${valueWidth}px` (explicitly set)
- `paddingLeft: 10px`, `paddingRight: 10px`

With the default `box-sizing: content-box`, total visual width = `valueWidth + 20`. But `calculateBarAndValueDimensions` computes `maxBarWidth = width - valueWidth - titleWidth`, assuming the value only occupies `valueWidth`. The combined bar + value overflows the flex container by 20px (30px with left-placed title), and `flex-shrink` compresses the bar.

### Fix

Add `boxSizing: 'border-box'` to the value element styles and to the title element styles when placed left. This makes the padding part of the allocated width instead of extra.

### Test plan

- Added unit test verifying `boxSizing: 'border-box'` is set on horizontal value styles
- Added unit test verifying bar width equals `maxBarWidth` when value equals max
- All 34 existing BarGauge tests pass