### PR TITLE
Chore: Add enableDatasourceMetaApiPluginLoading feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1770,4 +1770,9 @@ export interface FeatureToggles {
   * @default false
   */
   clearPreviousFieldValues?: boolean;
+  /**
+  * Enables loading datasource plugins from the MetaAPI instead of bootData settings
+  * @default false
+  */
+  enableDatasourceMetaApiPluginLoading?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2809,6 +2809,14 @@ var (
 			Expression:   "false",
 			HideFromDocs: true,
 		},
+		{
+			Name:         "enableDatasourceMetaApiPluginLoading",
+			Description:  "Enables loading datasource plugins from the MetaAPI instead of bootData settings",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaFrontendPlatformSquad,
+			FrontendOnly: true,
+			Expression:   "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -349,3 +349,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-28,queryServiceQueryCaching,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-04-01,tracesDrilldownTimeSeeker,experimental,@grafana/observability-traces-and-profiling,false,false,true
 2026-04-01,clearPreviousFieldValues,experimental,@grafana/dataviz-squad,false,false,true
+2026-04-01,enableDatasourceMetaApiPluginLoading,experimental,@grafana/grafana-frontend-platform,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1952,6 +1952,20 @@
     },
     {
       "metadata": {
+        "name": "enableDatasourceMetaApiPluginLoading",
+        "resourceVersion": "1775045310507",
+        "creationTimestamp": "2026-04-01T12:08:30Z"
+      },
+      "spec": {
+        "description": "Enables loading datasource plugins from the MetaAPI instead of bootData settings",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "enableExtensionsAdminPage",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2024-11-05T15:55:10Z"


### PR DESCRIPTION
**What is this feature?**

Adds a new experimental feature toggle `enableDatasourceMetaApiPluginLoading` that will allow loading datasource plugins from the MetaAPI instead of `bootData.settings.datasources`. The toggle is frontend-only and defaults to off.

**Why do we need this feature?**

This prepares for a migration from the legacy `bootData.settings.datasources` approach to the new MetaAPI for loading datasource plugins. The toggle itself is not used yet — actual usage will follow in a subsequent PR.

**Who is this feature for?**

Grafana frontend platform developers working on the datasource plugin loading pipeline.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

This is a preparatory PR — the toggle is defined but not consumed anywhere yet. A follow-up PR will wire it up.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.