### PR TITLE
E2E: Skip flaky ReturnToPrevious test suite

### DIFF
--- a/e2e-playwright/various-suite/return-to-previous.spec.ts
+++ b/e2e-playwright/various-suite/return-to-previous.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
-test.describe(
+test.describe.skip(
   'ReturnToPrevious button',
   {
     tag: ['@various'],


### PR DESCRIPTION
**What is this feature?**

Skips the `ReturnToPrevious button` e2e Playwright test suite (`e2e-playwright/various-suite/return-to-previous.spec.ts`) by changing `test.describe(` to `test.describe.skip(`. 
