### PR TITLE
Tempo: Unify dynamic int/double span attributes as float64

### DIFF
--- a/pkg/tsdb/tempo/search.go
+++ b/pkg/tsdb/tempo/search.go
@@ -539,8 +539,10 @@ func transformSpanToTraceData(span *tempopb.Span, spanSet *tempopb.SpanSet, trac
 			val := attribute.Value.GetStringValue()
 			attributes[attribute.Key] = &val
 		case *v1.AnyValue_IntValue:
-			val := attribute.Value.GetIntValue()
-			attributes[attribute.Key] = &val
+			// Use float64 for int tags so dynamic columns stay consistent when the same key
+			// appears as IntValue on some spans and DoubleValue on others (see getTypeForAttribute).
+			v := float64(attribute.Value.GetIntValue())
+			attributes[attribute.Key] = &v
 		case *v1.AnyValue_DoubleValue:
 			val := attribute.Value.GetDoubleValue()
 			attributes[attribute.Key] = &val
@@ -571,7 +573,9 @@ func getTypeForAttribute(attribute *v1.KeyValue) interface{} {
 	case *v1.AnyValue_StringValue:
 		return []*string{}
 	case *v1.AnyValue_IntValue:
-		return []*int64{}
+		// Match transformSpanToTraceData: ints are stored as *float64 so one column can
+		// hold both OTLP integer and double values for the same attribute key.
+		return []*float64{}
 	case *v1.AnyValue_DoubleValue:
 		return []*float64{}
 	case *v1.AnyValue_BoolValue:

--- a/pkg/tsdb/tempo/search_test.go
+++ b/pkg/tsdb/tempo/search_test.go
@@ -256,6 +256,54 @@ func TestTransformSpanSearchResponse_MissingDynamicAttributeUsesNil(t *testing.T
 	assert.True(t, frames[0].Fields[6].NilAt(1))
 }
 
+func TestTransformTraceSearchResponseSubFrame_SameNumericKeyIntAndDouble(t *testing.T) {
+	pCtx := backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "u", Name: "n"}}
+	trace := &tempopb.TraceSearchMetadata{
+		TraceID:           "t1",
+		RootServiceName:   "svc",
+		RootTraceName:     "op",
+		StartTimeUnixNano: 1000000,
+		DurationMs:        10,
+	}
+	// Last attribute seen for "count" during schema scan is int; first span row has double — must not panic on Append.
+	spanSet := &tempopb.SpanSet{
+		Spans: []*tempopb.Span{
+			{
+				SpanID:            "s1",
+				Name:              "a",
+				StartTimeUnixNano: 1000000,
+				DurationNanos:     1000,
+				Attributes: []*v1.KeyValue{
+					{Key: "count", Value: &v1.AnyValue{Value: &v1.AnyValue_DoubleValue{DoubleValue: 1.5}}},
+				},
+			},
+			{
+				SpanID:            "s2",
+				Name:              "b",
+				StartTimeUnixNano: 1001000,
+				DurationNanos:     1000,
+				Attributes: []*v1.KeyValue{
+					{Key: "count", Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: 2}}},
+				},
+			},
+		},
+	}
+
+	frame := transformTraceSearchResponseSubFrame(trace, spanSet, pCtx)
+	require.NotNil(t, frame)
+	require.Equal(t, 2, frame.Rows())
+	idx := -1
+	for i, f := range frame.Fields {
+		if f.Name == "count" {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, idx, 0, "expected dynamic field count")
+	assert.Equal(t, 1.5, *(frame.Fields[idx].At(0).(*float64)))
+	assert.Equal(t, 2.0, *(frame.Fields[idx].At(1).(*float64)))
+}
+
 func TestTransformSpanSearchResponse_NoSpanAttributes(t *testing.T) {
 	pCtx := backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "u", Name: "n"}}
 	resp := &tempopb.SearchResponse{Traces: []*tempopb.TraceSearchMetadata{{


### PR DESCRIPTION
Prevents panic when the same attribute key uses OTLP IntValue on some
spans and DoubleValue on others within one span set (schema picked int64
but a row appended *float64).

Fixes #121642
