### PR TITLE
Zanzana: Fix token authentication for openfga cli

### DIFF
--- a/pkg/services/authz/zanzana/server/openfga_server.go
+++ b/pkg/services/authz/zanzana/server/openfga_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -233,6 +234,7 @@ func NewOpenFGAHttpServer(cfg setting.ZanzanaServerSettings, grpcSrv grpcserver.
 			return status.Convert(encodedErr)
 		}),
 		runtime.WithHealthzEndpoint(healthv1pb.NewHealthClient(conn)),
+		runtime.WithIncomingHeaderMatcher(openfgaGatewayIncomingHeaderMatcher),
 		runtime.WithOutgoingHeaderMatcher(func(s string) (string, bool) { return s, true }),
 	}
 	mux := runtime.NewServeMux(muxOpts...)
@@ -251,4 +253,19 @@ func NewOpenFGAHttpServer(cfg setting.ZanzanaServerSettings, grpcSrv grpcserver.
 		}).Handler(mux),
 		ReadHeaderTimeout: 30 * time.Second,
 	}, nil
+}
+
+// openfgaGatewayIncomingHeaderMatcher forwards Grafana auth headers into gRPC metadata.
+// grpc-gateway's DefaultHeaderMatcher only allows IANA permanent headers or names prefixed
+// with Grpc-Metadata-, so a plain X-Access-Token HTTP header would otherwise be dropped
+// and the Zanzana authenticator would see no token (ErrMissingRequiredToken).
+func openfgaGatewayIncomingHeaderMatcher(key string) (string, bool) {
+	switch textproto.CanonicalMIMEHeaderKey(key) {
+	case "X-Access-Token":
+		return "X-Access-Token", true
+	case "X-Grafana-Id":
+		// Matches authlib GRPCTokenProvider ID token metadata key.
+		return "X-Id-Token", true
+	}
+	return runtime.DefaultHeaderMatcher(key)
 }


### PR DESCRIPTION
**What is this feature?**

Forward token from HTTP connection to the GRPC, so authentication works correctly when using debug openfga http interface.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
