### PR TITLE
Lint: Use custom no-restricted-syntax rules

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,11 +1,11 @@
 {
   "e2e/cypress/support/commands.js": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 1
     }
   },
   "e2e/old-arch/utils/support/localStorage.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 2
     }
   },
@@ -15,7 +15,7 @@
     }
   },
   "e2e/utils/support/localStorage.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 2
     }
   },
@@ -123,7 +123,7 @@
     }
   },
   "packages/grafana-data/src/themes/registry.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
@@ -317,7 +317,7 @@
     }
   },
   "packages/grafana-data/src/utils/store.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 6
     }
   },
@@ -353,27 +353,27 @@
     }
   },
   "packages/grafana-prometheus/src/components/PromExploreExtraField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 4
     }
   },
   "packages/grafana-prometheus/src/components/PromQueryField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
   "packages/grafana-prometheus/src/components/metrics-browser/useMetricsLabelsValues.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 6
     }
   },
   "packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 5
     }
   },
   "packages/grafana-prometheus/src/configuration/ExemplarSetting.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -446,11 +446,11 @@
     }
   },
   "packages/grafana-runtime/src/config.ts": {
+    "@grafana/no-direct-local-storage-access": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 5
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/grafana-runtime/src/services/EchoSrv.ts": {
@@ -510,7 +510,7 @@
     }
   },
   "packages/grafana-sql/src/components/visual-query-builder/Preview.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -540,7 +540,7 @@
     }
   },
   "packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
@@ -565,12 +565,12 @@
     }
   },
   "packages/grafana-ui/src/components/FormField/FormField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "packages/grafana-ui/src/components/FormLabel/FormLabel.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     }
   },
@@ -585,40 +585,40 @@
     }
   },
   "packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx": {
+    "@grafana/no-gf-form": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/grafana-ui/src/components/Forms/Legacy/Select/NoOptionsMessage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
   "packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 6
     }
   },
   "packages/grafana-ui/src/components/Forms/Legacy/Select/SelectOption.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 4
     }
   },
   "packages/grafana-ui/src/components/Forms/Legacy/Switch/Switch.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     }
   },
   "packages/grafana-ui/src/components/Icon/Icon.story.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
   "packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.story.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 2
     }
   },
@@ -642,6 +642,11 @@
       "count": 1
     }
   },
+  "packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx": {
+    "@grafana/no-plain-links": {
+      "count": 1
+    }
+  },
   "packages/grafana-ui/src/components/PanelChrome/PanelContext.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
@@ -658,27 +663,27 @@
     }
   },
   "packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
   "packages/grafana-ui/src/components/Segment/Segment.story.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
   "packages/grafana-ui/src/components/Segment/SegmentAsync.story.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
   "packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "packages/grafana-ui/src/components/Segment/SegmentInput.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -771,11 +776,11 @@
     }
   },
   "packages/grafana-ui/src/components/Table/utils.ts": {
+    "@grafana/no-locale-compare": {
+      "count": 1
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 6
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/grafana-ui/src/components/TableInputCSV/TableInputCSV.tsx": {
@@ -884,12 +889,12 @@
     }
   },
   "packages/grafana-ui/src/themes/GlobalStyles/forms.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 25
     }
   },
   "packages/grafana-ui/src/themes/GlobalStyles/legacySelect.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 28
     }
   },
@@ -929,7 +934,7 @@
     }
   },
   "packages/grafana-ui/src/utils/logger.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 1
     }
   },
@@ -949,7 +954,7 @@
     }
   },
   "public/app/core/components/AccessControl/PermissionList.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -959,12 +964,12 @@
     }
   },
   "public/app/core/components/ForgottenPassword/ChangePassword.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/core/components/ForgottenPassword/ForgottenPassword.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -980,17 +985,17 @@
     }
   },
   "public/app/core/components/Login/LoginForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/core/components/OptionsUI/NumberInput.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/core/components/OptionsUI/fieldColor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -1005,27 +1010,27 @@
     }
   },
   "public/app/core/components/Page/EditableTitle.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/core/components/PanelTypeFilter/PanelTypeFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
   "public/app/core/components/RolePicker/RolePickerMenu.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 4
     }
   },
   "public/app/core/components/RolePickerDrawer/RolePickerDrawer.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 6
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -1036,12 +1041,12 @@
     }
   },
   "public/app/core/components/Signup/SignupPage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 6
     }
   },
   "public/app/core/components/Signup/VerifyEmail.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -1064,7 +1069,7 @@
     }
   },
   "public/app/core/config.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-config-panels": {
       "count": 1
     }
   },
@@ -1074,12 +1079,12 @@
     }
   },
   "public/app/core/reducers/appNotification.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 3
     }
   },
   "public/app/core/reducers/navBarTree.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 2
     }
   },
@@ -1159,60 +1164,60 @@
     }
   },
   "public/app/features/actions/ActionEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 7
     }
   },
   "public/app/features/actions/ActionVariablesEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
   "public/app/features/actions/ParamsEditor.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
+    "@grafana/no-locale-compare": {
       "count": 1
     },
-    "no-restricted-syntax": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
   },
   "public/app/features/admin/AdminEditOrgPage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/admin/UserCreatePage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
   "public/app/features/admin/UserLdapSyncInfo.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     }
   },
   "public/app/features/admin/UserOrgs.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/admin/ldap/LdapDrawer.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 23
     }
   },
   "public/app/features/admin/ldap/LdapGroupMapping.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
   "public/app/features/admin/ldap/LdapPage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/admin/ldap/LdapSettingsPage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 5
     }
   },
@@ -1270,37 +1275,42 @@
     }
   },
   "public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/contact-points/components/ContactPointsFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx": {
+    "@grafana/no-plain-links": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/import-to-gma/NamespaceAndGroupFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeInterval.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 5
     }
   },
   "public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeRange.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 13
     }
   },
@@ -1310,24 +1320,24 @@
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/CloudCommonChannelSettings.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/GrafanaCommonChannelSettings.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/fields/SubformArrayField.tsx": {
@@ -1341,7 +1351,7 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/AlertRuleNameInput.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -1351,7 +1361,7 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -1361,12 +1371,12 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -1389,65 +1399,65 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 8
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/ActiveTimingFields.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteTimings.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/CloudDataSourceSelector.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
   "public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 2
     }
   },
   "public/app/features/alerting/unified/components/rules/RuleListStateView.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rules/state-history/StateHistory.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/silences/MatchersField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 5
     }
   },
   "public/app/features/alerting/unified/components/silences/SilencePeriod.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/silences/SilencesEditor.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 3
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 3
     }
   },
   "public/app/features/alerting/unified/group-details/GroupEditPage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 5
     }
   },
@@ -1457,7 +1467,7 @@
     }
   },
   "public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
@@ -1482,7 +1492,7 @@
     }
   },
   "public/app/features/alerting/unified/rule-editor/formDefaults.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 6
     }
   },
@@ -1497,7 +1507,7 @@
     }
   },
   "public/app/features/alerting/unified/utils/datasource.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 2
     }
   },
@@ -1523,7 +1533,7 @@
     }
   },
   "public/app/features/alerting/unified/utils/rule-id.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
@@ -1554,17 +1564,17 @@
     }
   },
   "public/app/features/auth-config/FieldRenderer.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 5
     }
   },
   "public/app/features/auth-config/ProviderConfigForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/auth-config/components/ServerDiscoveryModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -1574,36 +1584,36 @@
     }
   },
   "public/app/features/connections/tabs/ConnectData/ConnectData.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 4
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 4
     },
     "react/no-unescaped-entities": {
       "count": 2
     }
   },
   "public/app/features/correlations/Forms/ConfigureCorrelationBasicInfoForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/correlations/Forms/ConfigureCorrelationTargetForm.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 3
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 3
     }
   },
   "public/app/features/correlations/Forms/QueryEditorField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/correlations/Forms/TransformationEditorRow.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -1613,7 +1623,7 @@
     }
   },
   "public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -1623,7 +1633,7 @@
     }
   },
   "public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -1641,7 +1651,7 @@
     }
   },
   "public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -1669,7 +1679,7 @@
     }
   },
   "public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManagerEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -1679,12 +1689,12 @@
     }
   },
   "public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     },
     "react-hooks/rules-of-hooks": {
@@ -1692,7 +1702,7 @@
     }
   },
   "public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     },
     "react-hooks/rules-of-hooks": {
@@ -1728,45 +1738,48 @@
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/VariableSelectField.tsx": {
-    "@typescript-eslint/no-explicit-any": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     },
-    "no-restricted-syntax": {
+    "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/VariableTextField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/ConfigEmailSharing.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/EmailListConfiguration.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx": {
-    "no-restricted-syntax": {
-      "count": 4
+    "@grafana/no-gf-form": {
+      "count": 1
+    },
+    "@grafana/require-no-margin-on-field": {
+      "count": 3
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -1786,8 +1799,11 @@
     }
   },
   "public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx": {
-    "no-restricted-syntax": {
-      "count": 7
+    "@grafana/no-locale-compare": {
+      "count": 1
+    },
+    "@grafana/require-no-margin-on-field": {
+      "count": 6
     }
   },
   "public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts": {
@@ -1827,17 +1843,17 @@
     }
   },
   "public/app/features/dashboard/components/DashboardSettings/AutoRefreshIntervals.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 6
     }
   },
   "public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 5
     }
   },
@@ -1847,7 +1863,7 @@
     }
   },
   "public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -1857,7 +1873,7 @@
     }
   },
   "public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -1865,10 +1881,10 @@
     "@grafana/no-aria-label-selectors": {
       "count": 1
     },
-    "@typescript-eslint/no-explicit-any": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     },
-    "no-restricted-syntax": {
+    "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
@@ -1889,7 +1905,7 @@
     "@grafana/no-aria-label-selectors": {
       "count": 1
     },
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -1907,7 +1923,7 @@
     }
   },
   "public/app/features/dashboard/components/RowOptions/RowOptionsForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -1917,7 +1933,7 @@
     }
   },
   "public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -1932,35 +1948,35 @@
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareExport.tsx": {
-    "@typescript-eslint/no-explicit-any": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     },
-    "no-restricted-syntax": {
+    "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareLink.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/ConfigPublicDashboard.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/EmailSharingConfiguration.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -1968,7 +1984,7 @@
     }
   },
   "public/app/features/dashboard/components/SubMenu/AnnotationPicker.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -1986,12 +2002,12 @@
     }
   },
   "public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/features/dashboard/components/TransformationsEditor/TransformationFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -2033,6 +2049,11 @@
   "public/app/features/dashboard/dashgrid/DashboardGrid.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
+    }
+  },
+  "public/app/features/dashboard/dashgrid/DashboardLibrary/CompatibilityBadge.tsx": {
+    "@grafana/no-plain-links": {
+      "count": 2
     }
   },
   "public/app/features/dashboard/dashgrid/DashboardPanel.tsx": {
@@ -2128,22 +2149,27 @@
     }
   },
   "public/app/features/datasources/components/ButtonRow.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/features/datasources/components/DataSourcePluginState.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     }
   },
   "public/app/features/datasources/components/DataSourceTestingStatus.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/features/datasources/components/DataSourceTypeCard.tsx": {
     "@grafana/no-aria-label-selectors": {
+      "count": 1
+    }
+  },
+  "public/app/features/datasources/components/EditDataSourceActions.test.tsx": {
+    "@grafana/no-plain-links": {
       "count": 1
     }
   },
@@ -2174,24 +2200,24 @@
     }
   },
   "public/app/features/datasources/state/selectors.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
+    "@grafana/no-locale-compare": {
       "count": 2
     },
-    "no-restricted-syntax": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 2
     }
   },
   "public/app/features/dimensions/editors/FileUploader.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/dimensions/editors/FolderPickerTab.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 2
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "public/app/features/dimensions/editors/ResourceDimensionEditor.tsx": {
@@ -2210,7 +2236,7 @@
     }
   },
   "public/app/features/dimensions/editors/URLPickerTab.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -2230,12 +2256,12 @@
     }
   },
   "public/app/features/explore/CorrelationHelper.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/features/explore/CorrelationTransformationAddModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -2250,7 +2276,7 @@
     }
   },
   "public/app/features/explore/Logs/LogsColumnSearch.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -2260,7 +2286,7 @@
     }
   },
   "public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -2338,7 +2364,7 @@
     }
   },
   "public/app/features/explore/TraceView/components/utils/sort.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
@@ -2389,11 +2415,11 @@
     }
   },
   "public/app/features/inspector/InspectDataOptions.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 4
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 4
     }
   },
   "public/app/features/inspector/InspectDataTab.tsx": {
@@ -2421,12 +2447,12 @@
     }
   },
   "public/app/features/invites/SignupInvited.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
   "public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -2451,7 +2477,7 @@
     }
   },
   "public/app/features/migrate-to-cloud/cloud/MigrationTokenPane/CreateTokenModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -2461,7 +2487,7 @@
     }
   },
   "public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/ConnectModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -2476,17 +2502,17 @@
     }
   },
   "public/app/features/org/NewOrgPage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/org/OrgProfile.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/features/org/UserInviteForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -2504,12 +2530,12 @@
     "@grafana/no-aria-label-selectors": {
       "count": 2
     },
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
   "public/app/features/playlist/ShareModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -2524,16 +2550,16 @@
     }
   },
   "public/app/features/plugins/admin/helpers.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 2
     }
   },
   "public/app/features/plugins/admin/pages/Browse.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 4
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 4
     }
   },
   "public/app/features/plugins/admin/state/actions.ts": {
@@ -2575,12 +2601,12 @@
     }
   },
   "public/app/features/profile/ChangePasswordForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/features/profile/UserProfileEditForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -2598,11 +2624,11 @@
     "@grafana/no-aria-label-selectors": {
       "count": 1
     },
+    "@grafana/no-gf-form": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 1
     },
     "react-hooks/rules-of-hooks": {
       "count": 1
@@ -2670,25 +2696,25 @@
     }
   },
   "public/app/features/search/state/SearchStateManager.ts": {
+    "@grafana/no-direct-local-storage-access": {
+      "count": 16
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 16
     }
   },
   "public/app/features/search/utils.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 3
     }
   },
   "public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
   "public/app/features/serviceaccounts/components/CreateTokenModal.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -2698,8 +2724,11 @@
     }
   },
   "public/app/features/support-bundles/SupportBundlesCreate.tsx": {
-    "no-restricted-syntax": {
-      "count": 2
+    "@grafana/no-locale-compare": {
+      "count": 1
+    },
+    "@grafana/require-no-margin-on-field": {
+      "count": 1
     }
   },
   "public/app/features/templating/fieldAccessorCache.ts": {
@@ -2835,27 +2864,27 @@
     }
   },
   "public/app/features/variables/adhoc/picker/AdHocFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/features/variables/adhoc/picker/AdHocFilterKey.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     }
   },
   "public/app/features/variables/adhoc/picker/AdHocFilterRenderer.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/features/variables/adhoc/picker/AdHocFilterValue.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/features/variables/adhoc/picker/ConditionSegment.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
@@ -2921,7 +2950,7 @@
     }
   },
   "public/app/features/variables/pickers/PickerRenderer.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     },
     "react/no-unescaped-entities": {
@@ -2929,7 +2958,7 @@
     }
   },
   "public/app/features/variables/pickers/shared/VariableInput.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -2947,7 +2976,7 @@
     }
   },
   "public/app/features/variables/query/QueryVariableRefreshSelect.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -2980,11 +3009,11 @@
     }
   },
   "public/app/features/variables/query/reducer.ts": {
+    "@grafana/no-locale-compare": {
+      "count": 1
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "public/app/features/variables/shared/formatVariable.ts": {
@@ -3052,7 +3081,7 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/BasicLogsToggle.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -3062,17 +3091,17 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/DefaultSubscription.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/AzureCheatSheet.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -3082,12 +3111,12 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filters.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 7
     }
   },
@@ -3120,7 +3149,7 @@
     }
   },
   "public/app/plugins/datasource/cloud-monitoring/components/Fields.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -3151,22 +3180,25 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/SecureSocksProxySettingsNewStyling.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/XrayLinkConfig.tsx": {
-    "no-restricted-syntax": {
-      "count": 2
+    "@grafana/no-gf-form": {
+      "count": 1
+    },
+    "@grafana/require-no-margin-on-field": {
+      "count": 1
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LegacyLogGroupNamesSelection.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -3191,7 +3223,7 @@
     }
   },
   "public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 4
     }
   },
@@ -3201,7 +3233,7 @@
     }
   },
   "public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/EditorField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -3211,14 +3243,14 @@
     }
   },
   "public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx": {
+    "@grafana/no-locale-compare": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "public/app/plugins/datasource/grafana-testdata-datasource/components/RandomWalkEditor.tsx": {
@@ -3245,11 +3277,11 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 5
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 5
     }
   },
   "public/app/plugins/datasource/grafana/components/QueryEditor.tsx": {
@@ -3261,7 +3293,7 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 6
     }
   },
@@ -3279,7 +3311,7 @@
     }
   },
   "public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -3351,15 +3383,15 @@
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/annotation/AnnotationEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     },
-    "no-restricted-syntax": {
+    "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -3367,17 +3399,17 @@
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/config/InfluxSQLConfig.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/query/QueryEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -3390,12 +3422,12 @@
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
@@ -3438,7 +3470,7 @@
     }
   },
   "public/app/plugins/datasource/loki/components/LokiContextUi.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 7
     }
   },
@@ -3448,12 +3480,12 @@
     }
   },
   "public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/loki/components/LokiQueryField.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -3461,8 +3493,11 @@
     }
   },
   "public/app/plugins/datasource/loki/configuration/DerivedField.tsx": {
-    "no-restricted-syntax": {
-      "count": 13
+    "@grafana/no-gf-form": {
+      "count": 4
+    },
+    "@grafana/require-no-margin-on-field": {
+      "count": 9
     }
   },
   "public/app/plugins/datasource/loki/datasource.ts": {
@@ -3476,32 +3511,32 @@
     }
   },
   "public/app/plugins/datasource/loki/querybuilder/state.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/loki/shardQuerySplitting.ts": {
-    "no-restricted-syntax": {
+    "@grafana/no-direct-local-storage-access": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 10
     }
   },
   "public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 11
     }
   },
   "public/app/plugins/datasource/mssql/configuration/Kerberos.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 8
     }
   },
   "public/app/plugins/datasource/opentsdb/components/OpenTsdbDetails.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 3
     }
   },
@@ -3516,17 +3551,17 @@
     }
   },
   "public/app/plugins/datasource/parca/QueryEditor/QueryOptions.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 15
     }
   },
@@ -3541,7 +3576,7 @@
     }
   },
   "public/app/plugins/datasource/tempo/_importedDependencies/components/AdHocFilter/AdHocFilter.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -3549,22 +3584,22 @@
     }
   },
   "public/app/plugins/datasource/tempo/_importedDependencies/components/AdHocFilter/AdHocFilterKey.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 3
     }
   },
   "public/app/plugins/datasource/tempo/_importedDependencies/components/AdHocFilter/AdHocFilterRenderer.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/tempo/_importedDependencies/components/AdHocFilter/AdHocFilterValue.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/tempo/_importedDependencies/components/AdHocFilter/ConditionSegment.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-gf-form": {
       "count": 2
     }
   },
@@ -3592,24 +3627,24 @@
     }
   },
   "public/app/plugins/datasource/tempo/resultTransformer.ts": {
+    "@grafana/no-locale-compare": {
+      "count": 2
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    },
-    "no-restricted-syntax": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/zipkin/QueryField.tsx": {
+    "@grafana/no-gf-form": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
       "count": 1
     }
   },
@@ -3652,17 +3687,17 @@
     }
   },
   "public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
   "public/app/plugins/panel/canvas/editor/element/ParamsEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/no-locale-compare": {
       "count": 1
     }
   },
   "public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 2
     }
   },
@@ -3691,7 +3726,7 @@
     }
   },
   "public/app/plugins/panel/debug/StateView.tsx": {
-    "no-restricted-syntax": {
+    "@grafana/require-no-margin-on-field": {
       "count": 1
     }
   },
@@ -3724,11 +3759,11 @@
     }
   },
   "public/app/plugins/panel/geomap/editor/StyleEditor.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 14
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 12
-    },
-    "no-restricted-syntax": {
-      "count": 14
     }
   },
   "public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx": {
@@ -3869,11 +3904,11 @@
     }
   },
   "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 2
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationMarker2.tsx": {
@@ -3887,11 +3922,11 @@
     }
   },
   "public/app/plugins/panel/xychart/SeriesEditor.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 5
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 4
-    },
-    "no-restricted-syntax": {
-      "count": 5
     }
   },
   "public/app/plugins/panel/xychart/migrations.ts": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1737,6 +1737,16 @@
       "count": 4
     }
   },
+  "public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/variables/components/VariableHideSelect.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/settings/variables/components/VariableSelectField.tsx": {
     "@grafana/require-no-margin-on-field": {
       "count": 1
@@ -3901,6 +3911,11 @@
   "public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    }
+  },
+  "public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationEditor2.tsx": {
+    "@grafana/require-no-margin-on-field": {
+      "count": 2
     }
   },
   "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -510,7 +510,7 @@
     }
   },
   "packages/grafana-sql/src/components/visual-query-builder/Preview.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -964,12 +964,12 @@
     }
   },
   "public/app/core/components/ForgottenPassword/ChangePassword.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/core/components/ForgottenPassword/ForgottenPassword.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -985,17 +985,17 @@
     }
   },
   "public/app/core/components/Login/LoginForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/core/components/OptionsUI/NumberInput.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/core/components/OptionsUI/fieldColor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1010,7 +1010,7 @@
     }
   },
   "public/app/core/components/Page/EditableTitle.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1025,12 +1025,12 @@
     }
   },
   "public/app/core/components/RolePickerDrawer/RolePickerDrawer.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 6
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -1041,12 +1041,12 @@
     }
   },
   "public/app/core/components/Signup/SignupPage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 6
     }
   },
   "public/app/core/components/Signup/VerifyEmail.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1164,7 +1164,7 @@
     }
   },
   "public/app/features/actions/ActionEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 7
     }
   },
@@ -1182,12 +1182,12 @@
     }
   },
   "public/app/features/admin/AdminEditOrgPage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/admin/UserCreatePage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -1197,27 +1197,27 @@
     }
   },
   "public/app/features/admin/UserOrgs.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/admin/ldap/LdapDrawer.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 23
     }
   },
   "public/app/features/admin/ldap/LdapGroupMapping.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
   "public/app/features/admin/ldap/LdapPage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/admin/ldap/LdapSettingsPage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     }
   },
@@ -1275,17 +1275,17 @@
     }
   },
   "public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/contact-points/components/ContactPointsFilter.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1295,22 +1295,22 @@
     }
   },
   "public/app/features/alerting/unified/components/import-to-gma/NamespaceAndGroupFilter.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeInterval.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     }
   },
   "public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeRange.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 13
     }
   },
@@ -1320,17 +1320,17 @@
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/CloudCommonChannelSettings.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/GrafanaCommonChannelSettings.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -1351,7 +1351,7 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/AlertRuleNameInput.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -1361,7 +1361,7 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -1371,12 +1371,12 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/FolderSelector.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -1404,22 +1404,22 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/ActiveTimingFields.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteTimings.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/CloudDataSourceSelector.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -1434,22 +1434,22 @@
     }
   },
   "public/app/features/alerting/unified/components/rules/state-history/StateHistory.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/silences/MatchersField.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     }
   },
   "public/app/features/alerting/unified/components/silences/SilencePeriod.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/silences/SilencesEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -1457,7 +1457,7 @@
     }
   },
   "public/app/features/alerting/unified/group-details/GroupEditPage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     }
   },
@@ -1564,17 +1564,17 @@
     }
   },
   "public/app/features/auth-config/FieldRenderer.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     }
   },
   "public/app/features/auth-config/ProviderConfigForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/auth-config/components/ServerDiscoveryModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1584,7 +1584,7 @@
     }
   },
   "public/app/features/connections/tabs/ConnectData/ConnectData.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -1595,12 +1595,12 @@
     }
   },
   "public/app/features/correlations/Forms/ConfigureCorrelationBasicInfoForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/correlations/Forms/ConfigureCorrelationTargetForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -1608,12 +1608,12 @@
     }
   },
   "public/app/features/correlations/Forms/QueryEditorField.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/correlations/Forms/TransformationEditorRow.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -1623,7 +1623,7 @@
     }
   },
   "public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -1633,7 +1633,7 @@
     }
   },
   "public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -1651,7 +1651,7 @@
     }
   },
   "public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1679,7 +1679,7 @@
     }
   },
   "public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManagerEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -1689,12 +1689,12 @@
     }
   },
   "public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "react-hooks/rules-of-hooks": {
@@ -1702,7 +1702,7 @@
     }
   },
   "public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "react-hooks/rules-of-hooks": {
@@ -1738,17 +1738,17 @@
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/VariableHideSelect.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/VariableSelectField.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
@@ -1756,22 +1756,22 @@
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/VariableTextField.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/ConfigEmailSharing.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/EmailListConfiguration.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -1779,17 +1779,17 @@
     "@grafana/no-gf-form": {
       "count": 1
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -1812,7 +1812,7 @@
     "@grafana/no-locale-compare": {
       "count": 1
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 6
     }
   },
@@ -1853,17 +1853,17 @@
     }
   },
   "public/app/features/dashboard/components/DashboardSettings/AutoRefreshIntervals.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 6
     }
   },
   "public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     }
   },
@@ -1873,7 +1873,7 @@
     }
   },
   "public/app/features/dashboard/components/HelpWizard/HelpWizard.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -1883,7 +1883,7 @@
     }
   },
   "public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1891,7 +1891,7 @@
     "@grafana/no-aria-label-selectors": {
       "count": 1
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
@@ -1915,7 +1915,7 @@
     "@grafana/no-aria-label-selectors": {
       "count": 1
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -1933,7 +1933,7 @@
     }
   },
   "public/app/features/dashboard/components/RowOptions/RowOptionsForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -1943,7 +1943,7 @@
     }
   },
   "public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -1958,12 +1958,12 @@
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareExport.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
@@ -1971,22 +1971,22 @@
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareLink.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/ConfigPublicDashboard.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/EmailSharingConfiguration.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -2017,7 +2017,7 @@
     }
   },
   "public/app/features/dashboard/components/TransformationsEditor/TransformationFilter.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -2218,12 +2218,12 @@
     }
   },
   "public/app/features/dimensions/editors/FileUploader.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/dimensions/editors/FolderPickerTab.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -2246,7 +2246,7 @@
     }
   },
   "public/app/features/dimensions/editors/URLPickerTab.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -2266,12 +2266,12 @@
     }
   },
   "public/app/features/explore/CorrelationHelper.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/features/explore/CorrelationTransformationAddModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -2286,7 +2286,7 @@
     }
   },
   "public/app/features/explore/Logs/LogsColumnSearch.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -2296,7 +2296,7 @@
     }
   },
   "public/app/features/explore/RichHistory/RichHistorySettingsTab.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -2425,7 +2425,7 @@
     }
   },
   "public/app/features/inspector/InspectDataOptions.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -2457,12 +2457,12 @@
     }
   },
   "public/app/features/invites/SignupInvited.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
   "public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -2487,7 +2487,7 @@
     }
   },
   "public/app/features/migrate-to-cloud/cloud/MigrationTokenPane/CreateTokenModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -2497,7 +2497,7 @@
     }
   },
   "public/app/features/migrate-to-cloud/onprem/EmptyState/CallToAction/ConnectModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -2512,17 +2512,17 @@
     }
   },
   "public/app/features/org/NewOrgPage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/org/OrgProfile.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/features/org/UserInviteForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -2540,12 +2540,12 @@
     "@grafana/no-aria-label-selectors": {
       "count": 2
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
   "public/app/features/playlist/ShareModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -2565,7 +2565,7 @@
     }
   },
   "public/app/features/plugins/admin/pages/Browse.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -2611,12 +2611,12 @@
     }
   },
   "public/app/features/profile/ChangePasswordForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/features/profile/UserProfileEditForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -2719,12 +2719,12 @@
     }
   },
   "public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
   "public/app/features/serviceaccounts/components/CreateTokenModal.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -2737,7 +2737,7 @@
     "@grafana/no-locale-compare": {
       "count": 1
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -2986,7 +2986,7 @@
     }
   },
   "public/app/features/variables/query/QueryVariableRefreshSelect.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3091,7 +3091,7 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/BasicLogsToggle.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3101,17 +3101,17 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/DefaultSubscription.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/AzureCheatSheet.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3121,12 +3121,12 @@
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filters.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 7
     }
   },
@@ -3159,7 +3159,7 @@
     }
   },
   "public/app/plugins/datasource/cloud-monitoring/components/Fields.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3190,12 +3190,12 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
   "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/SecureSocksProxySettingsNewStyling.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3203,7 +3203,7 @@
     "@grafana/no-gf-form": {
       "count": 1
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3233,7 +3233,7 @@
     }
   },
   "public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 4
     }
   },
@@ -3243,7 +3243,7 @@
     }
   },
   "public/app/plugins/datasource/grafana-pyroscope-datasource/QueryEditor/EditorField.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3287,7 +3287,7 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -3303,7 +3303,7 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 6
     }
   },
@@ -3321,7 +3321,7 @@
     }
   },
   "public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     },
     "react-prefer-function-component/react-prefer-function-component": {
@@ -3398,7 +3398,7 @@
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -3409,7 +3409,7 @@
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/config/InfluxSQLConfig.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -3506,7 +3506,7 @@
     "@grafana/no-gf-form": {
       "count": 4
     },
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 9
     }
   },
@@ -3531,22 +3531,22 @@
     }
   },
   "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 10
     }
   },
   "public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 11
     }
   },
   "public/app/plugins/datasource/mssql/configuration/Kerberos.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 8
     }
   },
   "public/app/plugins/datasource/opentsdb/components/OpenTsdbDetails.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 3
     }
   },
@@ -3561,7 +3561,7 @@
     }
   },
   "public/app/plugins/datasource/parca/QueryEditor/QueryOptions.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3697,7 +3697,7 @@
     }
   },
   "public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3707,7 +3707,7 @@
     }
   },
   "public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
@@ -3736,7 +3736,7 @@
     }
   },
   "public/app/plugins/panel/debug/StateView.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 1
     }
   },
@@ -3769,7 +3769,7 @@
     }
   },
   "public/app/plugins/panel/geomap/editor/StyleEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 14
     },
     "@typescript-eslint/consistent-type-assertions": {
@@ -3914,12 +3914,12 @@
     }
   },
   "public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationEditor2.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     }
   },
   "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 2
     },
     "@typescript-eslint/no-explicit-any": {
@@ -3937,7 +3937,7 @@
     }
   },
   "public/app/plugins/panel/xychart/SeriesEditor.tsx": {
-    "@grafana/require-no-margin-on-field": {
+    "@grafana/require-no-margin": {
       "count": 5
     },
     "@typescript-eslint/consistent-type-assertions": {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -207,14 +207,7 @@ module.exports = [
       ],
       'unicorn/no-empty-file': 'error',
       'no-constant-condition': 'error',
-      'no-restricted-syntax': [
-        'error',
-        {
-          // value regex is to filter out whitespace-only text nodes (e.g. new lines and spaces in the JSX)
-          selector: "JSXElement[openingElement.name.name='a'] > JSXText[value!=/^\\s*$/]",
-          message: 'No bare anchor nodes containing only text. Use `TextLink` instead.',
-        },
-      ],
+      '@grafana/no-plain-links': 'error',
     },
   },
 
@@ -584,50 +577,14 @@ module.exports = [
     ],
     rules: {
       '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'Identifier[name=localStorage]',
-          message: 'Direct usage of localStorage is not allowed. import store from @grafana/data instead',
-        },
-        {
-          selector: 'MemberExpression[object.name=localStorage]',
-          message: 'Direct usage of localStorage is not allowed. import store from @grafana/data instead',
-        },
-        {
-          selector:
-            'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Card"]) JSXOpeningElement[name.name="Card"]:not(:has(JSXAttribute[name.name="noMargin"]))',
-          message:
-            'Add noMargin prop to Card components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
-        },
-        {
-          selector:
-            'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Field"]) JSXOpeningElement[name.name="Field"]:not(:has(JSXAttribute[name.name="noMargin"]))',
-          message:
-            'Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
-        },
-        {
-          selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="localeCompare"]',
-          message:
-            'Using localeCompare() can cause performance issues when sorting large datasets. Consider using Intl.Collator for better performance when sorting arrays, or add an eslint-disable comment if sorting a small, known dataset.',
-        },
-        {
-          // eslint-disable-next-line no-restricted-syntax
-          selector: 'Literal[value=/gf-form/], TemplateElement[value.cooked=/gf-form/]',
-          // eslint-disable-next-line no-restricted-syntax
-          message: 'gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.',
-        },
-        {
-          selector: 'MemberExpression[object.name="config"][property.name="apps"]',
-          message:
-            'Usage of config.apps is not allowed. Use the function getAppPluginMetas or useAppPluginMetas from @grafana/runtime/internal instead',
-        },
-        {
-          selector: 'MemberExpression[object.name="config"][property.name="panels"]',
-          message:
-            'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
-        },
-      ],
+      '@grafana/no-direct-local-storage-access': 'error',
+      '@grafana/require-no-margin-on-card': 'error',
+      '@grafana/require-no-margin-on-field': 'error',
+      '@grafana/no-locale-compare': 'error',
+      // eslint-disable-next-line @grafana/no-gf-form
+      '@grafana/no-gf-form': 'error',
+      '@grafana/no-config-apps': 'error',
+      '@grafana/no-config-panels': 'error',
     },
   },
   {
@@ -638,37 +595,18 @@ module.exports = [
       ...enterpriseIgnores,
     ],
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'MemberExpression[object.name="config"][property.name="apps"]',
-          message:
-            'Usage of config.apps is not allowed. Use the function getAppPluginMetas or useAppPluginMetas from @grafana/runtime/internal instead',
-        },
-        {
-          selector: 'MemberExpression[object.name="config"][property.name="panels"]',
-          message:
-            'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
-        },
-      ],
+      '@grafana/no-config-apps': 'error',
+      '@grafana/no-config-panels': 'error',
+    },
+    plugins: {
+      '@grafana': grafanaPlugin,
     },
   },
   {
     files: [...enterpriseIgnores],
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'MemberExpression[object.name="config"][property.name="apps"]',
-          message:
-            'Usage of config.apps is not allowed. Use the function getAppPluginMetas or useAppPluginMetas from @grafana/runtime/internal instead',
-        },
-        {
-          selector: 'MemberExpression[object.name="config"][property.name="panels"]',
-          message:
-            'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
-        },
-      ],
+      '@grafana/no-config-apps': 'error',
+      '@grafana/no-config-panels': 'error',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -578,8 +578,7 @@ module.exports = [
     rules: {
       '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
       '@grafana/no-direct-local-storage-access': 'error',
-      '@grafana/require-no-margin-on-card': 'error',
-      '@grafana/require-no-margin-on-field': 'error',
+      '@grafana/require-no-margin': 'error',
       '@grafana/no-locale-compare': 'error',
       // eslint-disable-next-line @grafana/no-gf-form
       '@grafana/no-gf-form': 'error',

--- a/packages/grafana-eslint-rules/index.cjs
+++ b/packages/grafana-eslint-rules/index.cjs
@@ -6,7 +6,9 @@ const noRestrictedImgSrcs = require('./rules/no-restricted-img-srcs.cjs');
 const consistentStoryTitles = require('./rules/consistent-story-titles.cjs');
 const noPluginExternalImportPaths = require('./rules/no-plugin-external-import-paths.cjs');
 const noInvalidCssProperties = require('./rules/no-invalid-css-properties.cjs');
+const noRestrictedSyntaxRules = require('./rules/no-restricted-syntax.cjs');
 
+/** @type {import('eslint').Linter.Plugin} */
 module.exports = {
   rules: {
     'no-unreduced-motion': noUnreducedMotion,
@@ -17,5 +19,6 @@ module.exports = {
     'consistent-story-titles': consistentStoryTitles,
     'no-plugin-external-import-paths': noPluginExternalImportPaths,
     'no-invalid-css-properties': noInvalidCssProperties,
+    ...noRestrictedSyntaxRules.rules,
   },
 };

--- a/packages/grafana-eslint-rules/package.json
+++ b/packages/grafana-eslint-rules/package.json
@@ -16,7 +16,8 @@
     "directory": "packages/grafana-eslint-rules"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^8.9.0"
+    "@typescript-eslint/utils": "^8.9.0",
+    "eslint-no-restricted": "^0.1.1"
   },
   "devDependencies": {
     "@typescript-eslint/types": "^8.54.0",

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -1,0 +1,57 @@
+const createNoRestrictedSyntax = require('eslint-no-restricted/syntax');
+
+// This is a bit different - instead of defining a custom rule manually, we use
+// eslint-no-restricted to turn no-restricted-syntax config into actual eslint rules.
+// This gives them individual rule names for suppression and reporting.
+
+/** @type {NonNullable<import('eslint').Linter.Plugin['rules']>} */
+module.exports = createNoRestrictedSyntax(
+  {
+    name: 'no-plain-links',
+    // value regex is to filter out whitespace-only text nodes (e.g. new lines and spaces in the JSX)
+    selector: "JSXElement[openingElement.name.name='a'] > JSXText[value!=/^\\s*$/]",
+    message: 'No bare anchor nodes containing only text. Use `TextLink` instead.',
+  },
+  {
+    name: 'no-direct-local-storage-access',
+    selector: 'Identifier[name=localStorage], MemberExpression[object.name=localStorage]',
+    message: 'Direct usage of localStorage is not allowed. import store from @grafana/data instead',
+  },
+  {
+    name: 'require-no-margin-on-card',
+    selector:
+      'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Card"]) JSXOpeningElement[name.name="Card"]:not(:has(JSXAttribute[name.name="noMargin"]))',
+    message:
+      'Add noMargin prop to Card components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
+  },
+  {
+    name: 'require-no-margin-on-field',
+    selector:
+      'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Field"]) JSXOpeningElement[name.name="Field"]:not(:has(JSXAttribute[name.name="noMargin"]))',
+    message:
+      'Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
+  },
+  {
+    name: 'no-locale-compare',
+    selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="localeCompare"]',
+    message:
+      'Using localeCompare() can cause performance issues when sorting large datasets. Consider using Intl.Collator for better performance when sorting arrays, or add an eslint-disable comment if sorting a small, known dataset.',
+  },
+  {
+    name: 'no-gf-form',
+    selector: 'Literal[value=/gf-form/], TemplateElement[value.cooked=/gf-form/]',
+    message: 'gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.',
+  },
+  {
+    name: 'no-config-apps',
+    selector: 'MemberExpression[object.name="config"][property.name="apps"]',
+    message:
+      'Usage of config.apps is not allowed. Use the function getAppPluginMetas or useAppPluginMetas from @grafana/runtime/internal instead',
+  },
+  {
+    name: 'no-config-panels',
+    selector: 'MemberExpression[object.name="config"][property.name="panels"]',
+    message:
+      'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
+  }
+);

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -18,18 +18,13 @@ module.exports = createNoRestrictedSyntax(
     message: 'Direct usage of localStorage is not allowed. import store from @grafana/data instead',
   },
   {
-    name: 'require-no-margin-on-card',
-    selector:
-      'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Card"]) JSXOpeningElement[name.name="Card"]:not(:has(JSXAttribute[name.name="noMargin"]))',
-    message:
-      'Add noMargin prop to Card components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
-  },
-  {
-    name: 'require-no-margin-on-field',
-    selector:
+    name: 'require-no-margin',
+    selector: [
       'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Field"]) JSXOpeningElement[name.name="Field"]:not(:has(JSXAttribute[name.name="noMargin"]))',
+      'Program:has(ImportDeclaration[source.value="@grafana/ui"] ImportSpecifier[imported.name="Card"]) JSXOpeningElement[name.name="Card"]:not(:has(JSXAttribute[name.name="noMargin"]))',
+    ].join(', '),
     message:
-      'Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
+      'Add noMargin prop this component to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.',
   },
   {
     name: 'no-locale-compare',

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.ts
@@ -23,7 +23,7 @@ function setMetas(metas: PluginMetasResponse) {
   if (!metas.items.length) {
     // something failed while trying to fetch plugin meta
     // fallback to config.panels from bootdata
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-config-apps
     setApps(config.apps);
     logPluginMetaWarning(FALLBACK_TO_BOOTDATA_WARNING, PluginType.app);
     return;
@@ -35,7 +35,7 @@ function setMetas(metas: PluginMetasResponse) {
 
 async function initAppPluginMetas(): Promise<void> {
   if (!getFeatureFlagClient().getBooleanValue('useMTPlugins', false)) {
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-config-apps
     setApps(config.apps);
     return;
   }

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.ts
@@ -48,7 +48,7 @@ function setMetas(metas: PluginMetasResponse) {
   if (!metas.items.length) {
     // something failed while trying to fetch plugin meta
     // fallback to config.panels from bootdata
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-config-panels
     setPanelsAndAliases(config.panels);
     logPluginMetaWarning(FALLBACK_TO_BOOTDATA_WARNING, PluginType.panel);
     return;
@@ -60,7 +60,7 @@ function setMetas(metas: PluginMetasResponse) {
 
 async function initPanelPluginMetas(): Promise<void> {
   if (!getFeatureFlagClient().getBooleanValue('useMTPlugins', false)) {
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-config-panels
     setPanelsAndAliases(config.panels);
     return;
   }

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx
@@ -65,7 +65,6 @@ export function VariableDisplaySelect({
   }
 
   return (
-    // eslint-disable-next-line @grafana/require-no-margin-on-field
     <Field label={t('dashboard-scene.variable-display-select.label', 'Display')}>
       <Combobox
         data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalDisplaySelect}

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx
@@ -65,7 +65,7 @@ export function VariableDisplaySelect({
   }
 
   return (
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/require-no-margin-on-field
     <Field label={t('dashboard-scene.variable-display-select.label', 'Display')}>
       <Combobox
         data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalDisplaySelect}

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableHideSelect.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableHideSelect.tsx
@@ -38,7 +38,6 @@ export function VariableHideSelect({ onChange, hide, type }: PropsWithChildren<P
   }
 
   return (
-    // eslint-disable-next-line @grafana/require-no-margin-on-field
     <Field label={t('dashboard-scene.variable-hide-select.label', 'Hide')}>
       <RadioButtonGroup options={HIDE_OPTIONS} onChange={onChange} value={value} />
     </Field>

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableHideSelect.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableHideSelect.tsx
@@ -38,7 +38,7 @@ export function VariableHideSelect({ onChange, hide, type }: PropsWithChildren<P
   }
 
   return (
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/require-no-margin-on-field
     <Field label={t('dashboard-scene.variable-hide-select.label', 'Hide')}>
       <RadioButtonGroup options={HIDE_OPTIONS} onChange={onChange} value={value} />
     </Field>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
@@ -20,7 +20,7 @@ const renderMenuItems = (
   datasourceType: string
 ) => {
   links.sort((linkA, linkB) => {
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line @grafana/no-locale-compare
     return (linkA.title || 'link').toLowerCase().localeCompare((linkB.title || 'link').toLowerCase());
   });
 

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationEditor2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationEditor2.tsx
@@ -109,7 +109,7 @@ export const AnnotationEditor2 = ({ annoVals, annoIdx, dismiss, timeZone, ...oth
           return (
             <>
               <div className={styles.content}>
-                {/* eslint-disable-next-line no-restricted-syntax */}
+                {/* eslint-disable-next-line @grafana/require-no-margin-on-field */}
                 <Field
                   htmlFor={'annotation-description-textarea'}
                   autoFocus={true}
@@ -126,7 +126,7 @@ export const AnnotationEditor2 = ({ annoVals, annoIdx, dismiss, timeZone, ...oth
                     })}
                   />
                 </Field>
-                {/* eslint-disable-next-line no-restricted-syntax */}
+                {/* eslint-disable-next-line @grafana/require-no-margin-on-field */}
                 <Field htmlFor={'annotation-tags-input'} label={t('timeseries.annotation-editor2.label-tags', 'Tags')}>
                   <Controller
                     control={control}

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationEditor2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/AnnotationEditor2.tsx
@@ -109,7 +109,6 @@ export const AnnotationEditor2 = ({ annoVals, annoIdx, dismiss, timeZone, ...oth
           return (
             <>
               <div className={styles.content}>
-                {/* eslint-disable-next-line @grafana/require-no-margin-on-field */}
                 <Field
                   htmlFor={'annotation-description-textarea'}
                   autoFocus={true}
@@ -126,7 +125,6 @@ export const AnnotationEditor2 = ({ annoVals, annoIdx, dismiss, timeZone, ...oth
                     })}
                   />
                 </Field>
-                {/* eslint-disable-next-line @grafana/require-no-margin-on-field */}
                 <Field htmlFor={'annotation-tags-input'} label={t('timeseries.annotation-editor2.label-tags', 'Tags')}>
                   <Controller
                     control={control}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,6 +3415,7 @@ __metadata:
     "@typescript-eslint/types": "npm:^8.54.0"
     "@typescript-eslint/utils": "npm:^8.9.0"
     eslint: "npm:9.32.0"
+    eslint-no-restricted: "npm:^0.1.1"
     jest: "npm:29.7.0"
     tslib: "npm:2.8.1"
   languageName: unknown
@@ -11880,6 +11881,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.58.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/project-service@npm:8.58.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.58.0"
+    "@typescript-eslint/types": "npm:^8.58.0"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/fab2601f76b2df61b09e3b7ff364d0e17e6d80e65e84e8a8d11f6a0813748bed3912da098659d00f46b1f277d462bd7529157182b72b5e2e0b41ee6176a0edd7
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
@@ -11900,12 +11914,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.58.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.58.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.0"
+    "@typescript-eslint/visitor-keys": "npm:8.58.0"
+  checksum: 10/97293f1215faa785a3c1ee8d630591db9dcd5fb6bdcdd0b2e818c80478d41e59a05003fb33000530780dc466fb8cf662352932080ee7406c4aaac72af4000541
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.56.0, @typescript-eslint/tsconfig-utils@npm:^8.56.0":
   version: 8.56.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.56.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
   checksum: 10/b1834aeffcdc07835eae0bf52aca573cba7e6528b5c1483e9b1f7f4f9e1f6450a8650796be11140e0437caf7eb1b0f9711c22989c8294547534f12614a759760
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.58.0, @typescript-eslint/tsconfig-utils@npm:^8.58.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/4f47212c0e26e6b06e97044ec5e483007d5145ef6b205393a0b43cbc0b385c75c14ba5749d01cf7d1ff100332c2cf1d336f060f7d2191bb67fb892bb4446afaa
   languageName: node
   linkType: hard
 
@@ -11936,6 +11969,13 @@ __metadata:
   version: 8.56.0
   resolution: "@typescript-eslint/types@npm:8.56.0"
   checksum: 10/d7549535c99d9202742bf0191bcc2822c2d18a03e206be9ad5a6f6b0902de7381c93e8c238754fe5d1dfdcc22d7e3bbafa032f63ba165d6dc03e180f84b138f9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.58.0, @typescript-eslint/types@npm:^8.58.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/types@npm:8.58.0"
+  checksum: 10/c68eac0bc25812fdbb2ed4a121e42bfca9f24f3c6be95f6a9c4e7b9af767f1bcfacd6d496e358166143e0a1801dc7d042ce1b5e69946ac2768d9114ff6b8d375
   languageName: node
   linkType: hard
 
@@ -11976,6 +12016,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.58.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.58.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.58.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.58.0"
+    "@typescript-eslint/types": "npm:8.58.0"
+    "@typescript-eslint/visitor-keys": "npm:8.58.0"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/4d6c4175e8a4d5c097393d161016836cc322f090c3f69fd751f5bbc25afce64df9ea0c97cee8b36ac060e06dc2cca2a4de7a0c7e04e19727cc4bd98ab3291fed
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:8.56.0, @typescript-eslint/utils@npm:^8.0.0, @typescript-eslint/utils@npm:^8.13.0, @typescript-eslint/utils@npm:^8.15.0, @typescript-eslint/utils@npm:^8.32.1, @typescript-eslint/utils@npm:^8.33.1, @typescript-eslint/utils@npm:^8.9.0":
   version: 8.56.0
   resolution: "@typescript-eslint/utils@npm:8.56.0"
@@ -12009,6 +12068,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.56.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/utils@npm:8.58.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.58.0"
+    "@typescript-eslint/types": "npm:8.58.0"
+    "@typescript-eslint/typescript-estree": "npm:8.58.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/936433b761a990147612d78bb4afc79244239541b4a4061fbbc2de1810b40ec7f78eb4e9181e5d9c5ab7acbd9bf49fc6195dbb1d823370f717f07ad492ad6c7e
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -12026,6 +12100,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.56.0"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10/1eaa26ffe8a2c83d42d428beef207d793aef73c2e306f94e716d39519eaaa07547da898c7d63a5c406a3662895d735b4b1f33b513a1addb69473c65e7d92a2b5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.58.0":
+  version: 8.58.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.58.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.58.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10/50b0779e19079dedf3723323a4dfa398c639b3da48f2fcf071c22ca69342e03592f1726d68ea59b9b5a51f14ab112eabc5c93fd2579c84b02a3320042ae20066
   languageName: node
   linkType: hard
 
@@ -17914,6 +17998,17 @@ __metadata:
     eslint:
       optional: true
   checksum: 10/bd25d6610ec3abaa50e8f1beb0119541562bbb8dd02c035c7e887976fe1e0c5dd8175f4607ca8d86d1146df24d52a071bd3d1dd329f6902bd58df805a8ca16d3
+  languageName: node
+  linkType: hard
+
+"eslint-no-restricted@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "eslint-no-restricted@npm:0.1.1"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.56.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9 || ^10
+  checksum: 10/27bd70a4461291d9825e505c86fdb4000f31dfc7ff362d711f4f977ae76150ed90e297eaae15d6362cf34530e5366f35c69edb84121878be8389b1f1e22665aa
   languageName: node
   linkType: hard
 
@@ -32948,6 +33043,15 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10/d6b2b3b6caad8d2f4ddc0c3785d22bb1a6041773335a1c71d73a5d67d11d993763fe8e4faefc4a4d03bb42b26c6126bbcf2e34826baed1def5369d0ebad358fa
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "ts-api-utils@npm:2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10/d5f1936f5618c6ab6942a97b78802217540ced00e7501862ae1f578d9a3aa189fc06050e64cb8951d21f7088e5fd35f53d2bf0d0370a883861c7b05e993ebc44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR changes all our no-restricted-rules config to use the [`eslint-no-restricted` package](https://github.com/bradzacher/eslint-no-restricted) instead.

Instead of these lints being applied through config of the `no-restricted-syntax` rule, this package converts them to individual rules, with their own names like `@grafana/no-plain-links`. This makes it easier to suppress them and see in our reporting.

e.g.

<img width="945" height="187" alt="Screenshot 2026-04-01 at 3 55 58 pm" src="https://github.com/user-attachments/assets/ec7b5903-ed57-4c8a-85bf-628bbee14699" />

