### PR TITLE
AuthZ: Move default list limit to LegacyIdentityStore and paginate resolvers

### DIFF
--- a/pkg/registry/apis/iam/common/pagination.go
+++ b/pkg/registry/apis/iam/common/pagination.go
@@ -7,6 +7,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 )
 
+// DefaultListLimit is the default number of items to fetch per page
+// when no explicit limit is provided.
+const DefaultListLimit = 500
+
 type Pagination struct {
 	Limit    int64
 	Continue int64

--- a/pkg/registry/apis/iam/legacy/service_account.go
+++ b/pkg/registry/apis/iam/legacy/service_account.go
@@ -153,6 +153,9 @@ func (r listServiceAccountsQuery) Validate() error {
 }
 
 func (s *legacySQLStore) ListServiceAccounts(ctx context.Context, ns claims.NamespaceInfo, query ListServiceAccountsQuery) (*ListServiceAccountResult, error) {
+	if query.Pagination.Limit < 1 {
+		query.Pagination.Limit = common.DefaultListLimit
+	}
 	// for continue
 	query.Pagination.Limit += 1
 	query.OrgID = ns.OrgID

--- a/pkg/registry/apis/iam/legacy/team.go
+++ b/pkg/registry/apis/iam/legacy/team.go
@@ -123,6 +123,9 @@ func (r listTeamsQuery) Validate() error {
 
 // ListTeams implements LegacyIdentityStore.
 func (s *legacySQLStore) ListTeams(ctx context.Context, ns claims.NamespaceInfo, query ListTeamQuery) (*ListTeamResult, error) {
+	if query.Pagination.Limit < 1 {
+		query.Pagination.Limit = common.DefaultListLimit
+	}
 	// for continue
 	query.Pagination.Limit += 1
 	query.OrgID = ns.OrgID

--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -134,6 +134,9 @@ func (r listUsersQuery) Validate() error {
 
 // ListUsers implements LegacyIdentityStore.
 func (s *legacySQLStore) ListUsers(ctx context.Context, ns claims.NamespaceInfo, query ListUserQuery) (*ListUserResult, error) {
+	if query.Pagination.Limit < 1 {
+		query.Pagination.Limit = common.DefaultListLimit
+	}
 	// for continue
 	limit := int(query.Pagination.Limit)
 	query.Pagination.Limit += 1

--- a/pkg/services/authz/rbac/resolver.go
+++ b/pkg/services/authz/rbac/resolver.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/grafana/authlib/types"
-	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
@@ -15,13 +14,20 @@ import (
 type ScopeResolverFunc func(scope string) (string, error)
 
 func (s *Service) fetchServiceAccounts(ctx context.Context, ns types.NamespaceInfo) (map[int64]string, error) {
-	serviceAccounts, err := s.identityStore.ListServiceAccounts(ctx, ns, legacy.ListServiceAccountsQuery{})
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch service accounts: %w", err)
-	}
-	saIDs := make(map[int64]string, len(serviceAccounts.Items))
-	for _, sa := range serviceAccounts.Items {
-		saIDs[sa.ID] = sa.UID
+	saIDs := make(map[int64]string)
+	query := legacy.ListServiceAccountsQuery{}
+	for {
+		serviceAccounts, err := s.identityStore.ListServiceAccounts(ctx, ns, query)
+		if err != nil {
+			return nil, fmt.Errorf("could not fetch service accounts: %w", err)
+		}
+		for _, sa := range serviceAccounts.Items {
+			saIDs[sa.ID] = sa.UID
+		}
+		if serviceAccounts.Continue == 0 {
+			break
+		}
+		query.Pagination.Continue = serviceAccounts.Continue
 	}
 	return saIDs, nil
 }
@@ -55,13 +61,20 @@ func (s *Service) newServiceAccountNameResolver(ctx context.Context, ns types.Na
 func (s *Service) fetchTeams(ctx context.Context, ns types.NamespaceInfo) (map[int64]string, error) {
 	key := teamIDsCacheKey(ns.Value)
 	res, err, _ := s.sf.Do(key, func() (any, error) {
-		teams, err := s.identityStore.ListTeams(ctx, ns, legacy.ListTeamQuery{Pagination: common.Pagination{Limit: 100}})
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch teams: %w", err)
-		}
-		teamIDs := make(map[int64]string, len(teams.Teams))
-		for _, team := range teams.Teams {
-			teamIDs[team.ID] = team.UID
+		teamIDs := make(map[int64]string)
+		query := legacy.ListTeamQuery{}
+		for {
+			teams, err := s.identityStore.ListTeams(ctx, ns, query)
+			if err != nil {
+				return nil, fmt.Errorf("could not fetch teams: %w", err)
+			}
+			for _, team := range teams.Teams {
+				teamIDs[team.ID] = team.UID
+			}
+			if teams.Continue == 0 {
+				break
+			}
+			query.Pagination.Continue = teams.Continue
 		}
 		return teamIDs, nil
 	})
@@ -121,13 +134,20 @@ func (s *Service) newTeamNameResolver(ctx context.Context, ns types.NamespaceInf
 }
 
 func (s *Service) fetchUsers(ctx context.Context, ns types.NamespaceInfo) (map[int64]string, error) {
-	users, err := s.identityStore.ListUsers(ctx, ns, legacy.ListUserQuery{})
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch users: %w", err)
-	}
-	userIDs := make(map[int64]string, len(users.Items))
-	for _, user := range users.Items {
-		userIDs[user.ID] = user.UID
+	userIDs := make(map[int64]string)
+	query := legacy.ListUserQuery{}
+	for {
+		users, err := s.identityStore.ListUsers(ctx, ns, query)
+		if err != nil {
+			return nil, fmt.Errorf("could not fetch users: %w", err)
+		}
+		for _, user := range users.Items {
+			userIDs[user.ID] = user.UID
+		}
+		if users.Continue == 0 {
+			break
+		}
+		query.Pagination.Continue = users.Continue
 	}
 	return userIDs, nil
 }

--- a/pkg/services/authz/rbac/resolver_test.go
+++ b/pkg/services/authz/rbac/resolver_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/team"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/require"
 )
 
@@ -160,4 +163,50 @@ func TestService_resolveScopeMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test that fetch* functions paginate through all results when the store returns multiple pages.
+// Each test uses pageSize=2 with 5 items, expecting 3 pages (2+2+1).
+func TestService_fetchPagination(t *testing.T) {
+	ns := types.NamespaceInfo{Value: "org-1", OrgID: 1}
+
+	t.Run("teams", func(t *testing.T) {
+		s := setupService()
+		store := &fakeIdentityStore{disableNsCheck: true, pageSize: 2, teams: []team.Team{
+			{ID: 1, UID: "t1"}, {ID: 2, UID: "t2"}, {ID: 3, UID: "t3"}, {ID: 4, UID: "t4"}, {ID: 5, UID: "t5"},
+		}}
+		s.identityStore = store
+
+		got, err := s.fetchTeams(context.Background(), ns)
+		require.NoError(t, err)
+		require.Len(t, got, 5)
+		require.Equal(t, 3, store.calls)
+	})
+
+	t.Run("service accounts", func(t *testing.T) {
+		s := setupService()
+		store := &fakeIdentityStore{disableNsCheck: true, pageSize: 2, serviceAccounts: []legacy.ServiceAccount{
+			{ID: 1, UID: "sa1"}, {ID: 2, UID: "sa2"}, {ID: 3, UID: "sa3"}, {ID: 4, UID: "sa4"}, {ID: 5, UID: "sa5"},
+		}}
+		s.identityStore = store
+
+		got, err := s.fetchServiceAccounts(context.Background(), ns)
+		require.NoError(t, err)
+		require.Len(t, got, 5)
+		require.Equal(t, 3, store.calls)
+	})
+
+	t.Run("users", func(t *testing.T) {
+		s := setupService()
+		store := &fakeIdentityStore{disableNsCheck: true, pageSize: 2, users: []common.UserWithRole{
+			{User: user.User{ID: 1, UID: "u1"}}, {User: user.User{ID: 2, UID: "u2"}}, {User: user.User{ID: 3, UID: "u3"}},
+			{User: user.User{ID: 4, UID: "u4"}}, {User: user.User{ID: 5, UID: "u5"}},
+		}}
+		s.identityStore = store
+
+		got, err := s.fetchUsers(context.Background(), ns)
+		require.NoError(t, err)
+		require.Len(t, got, 5)
+		require.Equal(t, 3, store.calls)
+	})
 }

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/authz/rbac/store"
@@ -2001,11 +2002,14 @@ func (f *fakeStore) ListFolders(ctx context.Context, namespace types.NamespaceIn
 
 type fakeIdentityStore struct {
 	legacy.LegacyIdentityStore
-	userTeams      []int64
-	teams          []team.Team
-	disableNsCheck bool
-	err            bool
-	calls          int
+	userTeams       []int64
+	teams           []team.Team
+	serviceAccounts []legacy.ServiceAccount
+	users           []common.UserWithRole
+	pageSize        int // if > 0, simulates pagination with this page size
+	disableNsCheck  bool
+	err             bool
+	calls           int
 }
 
 func (f *fakeIdentityStore) ListUserTeams(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListUserTeamsQuery) (*legacy.ListUserTeamsResult, error) {
@@ -2034,7 +2038,113 @@ func (f *fakeIdentityStore) ListTeams(ctx context.Context, namespace types.Names
 	if f.err {
 		return nil, fmt.Errorf("identity store error")
 	}
-	return &legacy.ListTeamResult{Teams: f.teams}, nil
+	if query.Pagination.Limit < 1 && f.pageSize > 0 {
+		query.Pagination.Limit = int64(f.pageSize)
+	}
+	return paginateTeams(f.teams, query.Pagination), nil
+}
+
+func (f *fakeIdentityStore) ListServiceAccounts(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListServiceAccountsQuery) (*legacy.ListServiceAccountResult, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("identity store error")
+	}
+	if query.Pagination.Limit < 1 && f.pageSize > 0 {
+		query.Pagination.Limit = int64(f.pageSize)
+	}
+	return paginateServiceAccounts(f.serviceAccounts, query.Pagination), nil
+}
+
+func (f *fakeIdentityStore) ListUsers(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListUserQuery) (*legacy.ListUserResult, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("identity store error")
+	}
+	if query.Pagination.Limit < 1 && f.pageSize > 0 {
+		query.Pagination.Limit = int64(f.pageSize)
+	}
+	return paginateUsers(f.users, query.Pagination), nil
+}
+
+// paginateTeams simulates cursor-based pagination over a slice of teams.
+func paginateTeams(items []team.Team, p common.Pagination) *legacy.ListTeamResult {
+	limit := int(p.Limit)
+	if limit < 1 {
+		limit = len(items) // no limit = return all
+	}
+	start := 0
+	if p.Continue > 0 {
+		for i, t := range items {
+			if t.ID >= p.Continue {
+				start = i
+				break
+			}
+		}
+	}
+	end := start + limit
+	if end >= len(items) {
+		return &legacy.ListTeamResult{Teams: items[start:]}
+	}
+	return &legacy.ListTeamResult{
+		Teams:    items[start:end],
+		Continue: items[end].ID,
+	}
+}
+
+// paginateServiceAccounts simulates cursor-based pagination over a slice of service accounts.
+func paginateServiceAccounts(items []legacy.ServiceAccount, p common.Pagination) *legacy.ListServiceAccountResult {
+	limit := int(p.Limit)
+	if limit < 1 {
+		limit = len(items)
+	}
+	start := 0
+	if p.Continue > 0 {
+		for i, sa := range items {
+			if sa.ID >= p.Continue {
+				start = i
+				break
+			}
+		}
+	}
+	end := start + limit
+	if end >= len(items) {
+		return &legacy.ListServiceAccountResult{Items: items[start:]}
+	}
+	return &legacy.ListServiceAccountResult{
+		Items:    items[start:end],
+		Continue: items[end].ID,
+	}
+}
+
+// paginateUsers simulates cursor-based pagination over a slice of users.
+func paginateUsers(items []common.UserWithRole, p common.Pagination) *legacy.ListUserResult {
+	limit := int(p.Limit)
+	if limit < 1 {
+		limit = len(items)
+	}
+	start := 0
+	if p.Continue > 0 {
+		for i, u := range items {
+			if u.ID >= p.Continue {
+				start = i
+				break
+			}
+		}
+	}
+	end := start + limit
+	if end >= len(items) {
+		return &legacy.ListUserResult{Items: items[start:]}
+	}
+	return &legacy.ListUserResult{
+		Items:    items[start:end],
+		Continue: items[end].ID,
+	}
 }
 
 func TestService_BatchCheck(t *testing.T) {


### PR DESCRIPTION
## Summary
- Moved the default page size (`500`) from the RBAC resolver into the `LegacyIdentityStore` `List*` methods (`ListServiceAccounts`, `ListTeams`, `ListUsers`) via `common.DefaultListLimit`, so all callers benefit from a sensible default when no explicit limit is provided.
- Added pagination loops in the RBAC scope resolvers (`fetchServiceAccounts`, `fetchTeams`, `fetchUsers`) that follow the `Continue` token to retrieve all items, not just the first page.
- Fixes a latent bug where passing `Limit=0` to the `List*` methods would return 0 items.

## Test plan
- [x] `go test ./pkg/services/authz/rbac/` passes
- [x] `go test ./pkg/registry/apis/iam/...` passes
- [ ] Verify with an org that has >500 teams/users/service accounts that scope resolution succeeds for all items