### PR TITLE
A11y: Fix screen reader announcements for checkboxes in notification history page

### DIFF
--- a/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
@@ -3,6 +3,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { type ReactNode } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { Card, Checkbox, useTheme2 } from '@grafana/ui';
 
 export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
@@ -36,7 +37,11 @@ export const StoredNotificationItem = ({
       <Card.Heading>{title}</Card.Heading>
       <Card.Description>{children}</Card.Description>
       <Card.Figure>
-        <Checkbox onChange={onClick} tabIndex={-1} value={isSelected} />
+        <Checkbox
+          onChange={onClick}
+          value={isSelected}
+          aria-label={t('notifications.select-notification', 'Select {{title}}', { title })}
+        />
       </Card.Figure>
       <Card.Tags className={styles.trace}>
         {traceId && <span>{`Trace ID: ${traceId}`}</span>}

--- a/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
@@ -33,7 +33,7 @@ export const StoredNotificationItem = ({
   const styles = getStyles(theme);
 
   return (
-    <Card noMargin className={className} onClick={onClick}>
+    <Card noMargin className={className}>
       <Card.Heading>{title}</Card.Heading>
       <Card.Description>{children}</Card.Description>
       <Card.Figure>

--- a/public/app/features/notifications/StoredNotifications.tsx
+++ b/public/app/features/notifications/StoredNotifications.tsx
@@ -75,6 +75,7 @@ export function StoredNotifications() {
       <div className={styles.topRow}>
         <Checkbox
           value={allNotificationsSelected}
+          aria-label={t('notifications.select-all', 'Select all notifications')}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleAllCheckboxToggle(event.target.checked)}
         />
         <Button disabled={selectedNotificationIds.length === 0} onClick={clearSelectedNotifications}>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12267,6 +12267,8 @@
       "description": "Notifications you have received will appear here",
       "title": "You're all caught up!"
     },
+    "select-all": "Select all notifications",
+    "select-notification": "Select {{title}}",
     "stored-notifications": {
       "dismiss-notifications": "Dismiss notifications",
       "title-alert": "This page displays past errors and warnings. Once dismissed, they cannot be retrieved."


### PR DESCRIPTION
**What is this feature?**

Fixes screen reader accessibility for the notification history page (`/profile/notifications`). Adds aria-labels to checkboxes and removes the duplicate interactive element that caused each notification to be announced twice.

**Who is this feature for?**

Users who rely on screen readers or other assistive technologies.

**Which issue(s) does this PR fix?**:

Fixes #117838

**Special notes for your reviewer:**
Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.