### PR TITLE
PanelStyles: Extend to core panels

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -3,6 +3,7 @@ import {
   type GrafanaConfig,
   LiveChannelEventType,
   LoadingState,
+  ThresholdsMode,
   getDefaultTimeRange,
   locationUtil,
   store,
@@ -731,6 +732,292 @@ describe('DashboardScene', () => {
           const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
           expect(stored.panelType).toBe('candlestick');
           expect(stored.styles).toBeDefined();
+        });
+
+        it('Should copy and paste styles for stat panels', () => {
+          const statPanel = new VizPanel({
+            title: 'Stat Panel',
+            key: `panel-stat-${Math.random()}`,
+            pluginId: 'stat',
+            options: {
+              orientation: 'horizontal',
+              textMode: 'value_and_name',
+              colorMode: 'background',
+              graphMode: 'none',
+              justifyMode: 'center',
+              showPercentChange: true,
+              percentChangeColorMode: 'inverted',
+              wideLayout: false,
+              text: { titleSize: 16, valueSize: 24 },
+              reduceOptions: { calcs: ['mean'] }, // should NOT be captured
+            },
+            fieldConfig: {
+              defaults: {
+                color: { mode: 'thresholds' },
+                thresholds: { mode: ThresholdsMode.Absolute, steps: [{ color: 'green', value: 0 }, { color: 'red', value: 80 }] },
+                mappings: [],
+              },
+              overrides: [],
+            },
+          });
+
+          scene.copyPanelStyles(statPanel);
+
+          const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
+          expect(stored.panelType).toBe('stat');
+          expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'thresholds' });
+          expect(stored.styles.fieldConfig.defaults.thresholds).toBeDefined();
+          expect(stored.styles.fieldConfig.defaults.mappings).toEqual([]);
+          expect(stored.styles.options.orientation).toBe('horizontal');
+          expect(stored.styles.options.colorMode).toBe('background');
+          expect(stored.styles.options.showPercentChange).toBe(true);
+          expect(stored.styles.options.text).toEqual({ titleSize: 16, valueSize: 24 });
+          expect(stored.styles.options.reduceOptions).toBeUndefined();
+
+          const target = new VizPanel({
+            title: 'Stat Panel 2',
+            key: `panel-stat2-${Math.random()}`,
+            pluginId: 'stat',
+            fieldConfig: { defaults: {}, overrides: [] },
+          });
+          const mockOnFieldConfigChange = jest.fn();
+          const mockOnOptionsChange = jest.fn();
+          target.onFieldConfigChange = mockOnFieldConfigChange;
+          target.onOptionsChange = mockOnOptionsChange;
+
+          scene.pastePanelStyles(target);
+          expect(mockOnFieldConfigChange).toHaveBeenCalled();
+          expect(mockOnOptionsChange).toHaveBeenCalledWith(
+            expect.objectContaining({ colorMode: 'background', showPercentChange: true, text: { titleSize: 16, valueSize: 24 } })
+          );
+        });
+
+        it('Should copy and paste styles for gauge panels', () => {
+          const gaugePanel = new VizPanel({
+            title: 'Gauge Panel',
+            key: `panel-gauge-${Math.random()}`,
+            pluginId: 'gauge',
+            options: {
+              orientation: 'horizontal',
+              shape: 'circle',
+              barShape: 'rounded',
+              barWidthFactor: 0.8,
+              effects: { barGlow: true, centerGlow: false, gradient: true },
+              segmentCount: 3,
+              showThresholdMarkers: false,
+              showThresholdLabels: true,
+              sparkline: false,
+              textMode: 'value',
+              text: { titleSize: 14, valueSize: 20 },
+              reduceOptions: { calcs: ['mean'] }, // should NOT be captured
+            },
+            fieldConfig: {
+              defaults: {
+                color: { mode: 'thresholds' },
+                thresholds: { mode: ThresholdsMode.Absolute, steps: [{ color: 'green', value: 0 }, { color: 'red', value: 80 }] },
+                mappings: [],
+              },
+              overrides: [],
+            },
+          });
+
+          scene.copyPanelStyles(gaugePanel);
+
+          const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
+          expect(stored.panelType).toBe('gauge');
+          expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'thresholds' });
+          expect(stored.styles.fieldConfig.defaults.thresholds).toBeDefined();
+          expect(stored.styles.options.shape).toBe('circle');
+          expect(stored.styles.options.barWidthFactor).toBe(0.8);
+          expect(stored.styles.options.effects).toEqual({ barGlow: true, centerGlow: false, gradient: true });
+          expect(stored.styles.options.showThresholdMarkers).toBe(false);
+          expect(stored.styles.options.reduceOptions).toBeUndefined();
+
+          const target = new VizPanel({
+            title: 'Gauge Panel 2',
+            key: `panel-gauge2-${Math.random()}`,
+            pluginId: 'gauge',
+            fieldConfig: { defaults: {}, overrides: [] },
+          });
+          const mockOnFieldConfigChange = jest.fn();
+          const mockOnOptionsChange = jest.fn();
+          target.onFieldConfigChange = mockOnFieldConfigChange;
+          target.onOptionsChange = mockOnOptionsChange;
+
+          scene.pastePanelStyles(target);
+          expect(mockOnFieldConfigChange).toHaveBeenCalled();
+          expect(mockOnOptionsChange).toHaveBeenCalledWith(
+            expect.objectContaining({ shape: 'circle', barWidthFactor: 0.8, showThresholdMarkers: false })
+          );
+        });
+
+        it('Should copy and paste styles for bar gauge panels', () => {
+          const barGaugePanel = new VizPanel({
+            title: 'Bar Gauge Panel',
+            key: `panel-bargauge-${Math.random()}`,
+            pluginId: 'bargauge',
+            options: {
+              orientation: 'horizontal',
+              displayMode: 'gradient',
+              valueMode: 'color',
+              namePlacement: 'auto',
+              showUnfilled: false,
+              sizing: 'auto',
+              text: { titleSize: 14, valueSize: 20 },
+              legend: { showLegend: true, placement: 'bottom' },
+              reduceOptions: { calcs: ['mean'] }, // should NOT be captured
+            },
+            fieldConfig: {
+              defaults: {
+                color: { mode: 'thresholds' },
+                thresholds: { mode: ThresholdsMode.Absolute, steps: [{ color: 'green', value: 0 }, { color: 'red', value: 80 }] },
+                mappings: [],
+              },
+              overrides: [],
+            },
+          });
+
+          scene.copyPanelStyles(barGaugePanel);
+
+          const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
+          expect(stored.panelType).toBe('bargauge');
+          expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'thresholds' });
+          expect(stored.styles.fieldConfig.defaults.thresholds).toBeDefined();
+          expect(stored.styles.options.displayMode).toBe('gradient');
+          expect(stored.styles.options.showUnfilled).toBe(false);
+          expect(stored.styles.options.text).toEqual({ titleSize: 14, valueSize: 20 });
+          expect(stored.styles.options.reduceOptions).toBeUndefined();
+
+          const target = new VizPanel({
+            title: 'Bar Gauge Panel 2',
+            key: `panel-bargauge2-${Math.random()}`,
+            pluginId: 'bargauge',
+            fieldConfig: { defaults: {}, overrides: [] },
+          });
+          const mockOnFieldConfigChange = jest.fn();
+          const mockOnOptionsChange = jest.fn();
+          target.onFieldConfigChange = mockOnFieldConfigChange;
+          target.onOptionsChange = mockOnOptionsChange;
+
+          scene.pastePanelStyles(target);
+          expect(mockOnFieldConfigChange).toHaveBeenCalled();
+          expect(mockOnOptionsChange).toHaveBeenCalledWith(
+            expect.objectContaining({ displayMode: 'gradient', showUnfilled: false })
+          );
+        });
+
+        it('Should copy and paste styles for bar chart panels', () => {
+          const barChartPanel = new VizPanel({
+            title: 'Bar Chart Panel',
+            key: `panel-barchart-${Math.random()}`,
+            pluginId: 'barchart',
+            options: {
+              orientation: 'vertical',
+              showValue: 'auto',
+              stacking: 'none',
+              barWidth: 0.97,
+              barRadius: 0.1,
+              xTickLabelRotation: -45,
+              legend: { showLegend: true, placement: 'bottom' },
+              tooltip: { mode: 'single' },
+              reduceOptions: { calcs: ['mean'] }, // should NOT be captured
+            },
+            fieldConfig: {
+              defaults: {
+                color: { mode: 'palette-classic' },
+                custom: {
+                  lineWidth: 1,
+                  fillOpacity: 80,
+                  gradientMode: 'none',
+                  axisPlacement: 'auto',
+                  hideFrom: { tooltip: false, viz: false, legend: false }, // should NOT be captured
+                },
+              },
+              overrides: [],
+            },
+          });
+
+          scene.copyPanelStyles(barChartPanel);
+
+          const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
+          expect(stored.panelType).toBe('barchart');
+          expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'palette-classic' });
+          expect(stored.styles.fieldConfig.defaults.custom.lineWidth).toBe(1);
+          expect(stored.styles.fieldConfig.defaults.custom.fillOpacity).toBe(80);
+          expect(stored.styles.fieldConfig.defaults.custom.axisPlacement).toBe('auto');
+          expect(stored.styles.fieldConfig.defaults.custom.hideFrom).toBeUndefined();
+          expect(stored.styles.options.orientation).toBe('vertical');
+          expect(stored.styles.options.barRadius).toBe(0.1);
+          expect(stored.styles.options.xTickLabelRotation).toBe(-45);
+          expect(stored.styles.options.reduceOptions).toBeUndefined();
+
+          const target = new VizPanel({
+            title: 'Bar Chart Panel 2',
+            key: `panel-barchart2-${Math.random()}`,
+            pluginId: 'barchart',
+            fieldConfig: { defaults: {}, overrides: [] },
+          });
+          const mockOnFieldConfigChange = jest.fn();
+          const mockOnOptionsChange = jest.fn();
+          target.onFieldConfigChange = mockOnFieldConfigChange;
+          target.onOptionsChange = mockOnOptionsChange;
+
+          scene.pastePanelStyles(target);
+          expect(mockOnFieldConfigChange).toHaveBeenCalled();
+          expect(mockOnOptionsChange).toHaveBeenCalledWith(
+            expect.objectContaining({ orientation: 'vertical', barRadius: 0.1 })
+          );
+        });
+
+        it('Should copy and paste styles for pie chart panels', () => {
+          const pieChartPanel = new VizPanel({
+            title: 'Pie Chart Panel',
+            key: `panel-piechart-${Math.random()}`,
+            pluginId: 'piechart',
+            options: {
+              pieType: 'donut',
+              sort: 'desc',
+              displayLabels: ['percent', 'name'],
+              tooltip: { mode: 'single' },
+              legend: { showLegend: true, placement: 'right', values: ['percent'] },
+              reduceOptions: { calcs: ['mean'] }, // should NOT be captured
+            },
+            fieldConfig: {
+              defaults: {
+                color: { mode: 'palette-classic' },
+                custom: { hideFrom: { tooltip: false, viz: false, legend: false } }, // should NOT be captured
+              },
+              overrides: [],
+            },
+          });
+
+          scene.copyPanelStyles(pieChartPanel);
+
+          const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
+          expect(stored.panelType).toBe('piechart');
+          expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'palette-classic' });
+          expect(stored.styles.fieldConfig.defaults.custom?.hideFrom).toBeUndefined();
+          expect(stored.styles.options.pieType).toBe('donut');
+          expect(stored.styles.options.displayLabels).toEqual(['percent', 'name']);
+          expect(stored.styles.options.legend).toEqual({ showLegend: true, placement: 'right', values: ['percent'] });
+          expect(stored.styles.options.reduceOptions).toBeUndefined();
+
+          const target = new VizPanel({
+            title: 'Pie Chart Panel 2',
+            key: `panel-piechart2-${Math.random()}`,
+            pluginId: 'piechart',
+            fieldConfig: { defaults: {}, overrides: [] },
+          });
+          const mockOnFieldConfigChange = jest.fn();
+          const mockOnOptionsChange = jest.fn();
+          target.onFieldConfigChange = mockOnFieldConfigChange;
+          target.onOptionsChange = mockOnOptionsChange;
+
+          scene.pastePanelStyles(target);
+          expect(mockOnFieldConfigChange).toHaveBeenCalled();
+          expect(mockOnOptionsChange).toHaveBeenCalledWith(
+            expect.objectContaining({ pieType: 'donut', displayLabels: ['percent', 'name'] })
+          );
         });
 
         it('Should paste styles from a trend panel into another trend panel', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -754,7 +754,13 @@ describe('DashboardScene', () => {
             fieldConfig: {
               defaults: {
                 color: { mode: 'thresholds' },
-                thresholds: { mode: ThresholdsMode.Absolute, steps: [{ color: 'green', value: 0 }, { color: 'red', value: 80 }] },
+                thresholds: {
+                  mode: ThresholdsMode.Absolute,
+                  steps: [
+                    { color: 'green', value: 0 },
+                    { color: 'red', value: 80 },
+                  ],
+                },
                 mappings: [],
               },
               overrides: [],
@@ -788,7 +794,11 @@ describe('DashboardScene', () => {
           scene.pastePanelStyles(target);
           expect(mockOnFieldConfigChange).toHaveBeenCalled();
           expect(mockOnOptionsChange).toHaveBeenCalledWith(
-            expect.objectContaining({ colorMode: 'background', showPercentChange: true, text: { titleSize: 16, valueSize: 24 } })
+            expect.objectContaining({
+              colorMode: 'background',
+              showPercentChange: true,
+              text: { titleSize: 16, valueSize: 24 },
+            })
           );
         });
 
@@ -814,7 +824,13 @@ describe('DashboardScene', () => {
             fieldConfig: {
               defaults: {
                 color: { mode: 'thresholds' },
-                thresholds: { mode: ThresholdsMode.Absolute, steps: [{ color: 'green', value: 0 }, { color: 'red', value: 80 }] },
+                thresholds: {
+                  mode: ThresholdsMode.Absolute,
+                  steps: [
+                    { color: 'green', value: 0 },
+                    { color: 'red', value: 80 },
+                  ],
+                },
                 mappings: [],
               },
               overrides: [],
@@ -870,7 +886,13 @@ describe('DashboardScene', () => {
             fieldConfig: {
               defaults: {
                 color: { mode: 'thresholds' },
-                thresholds: { mode: ThresholdsMode.Absolute, steps: [{ color: 'green', value: 0 }, { color: 'red', value: 80 }] },
+                thresholds: {
+                  mode: ThresholdsMode.Absolute,
+                  steps: [
+                    { color: 'green', value: 0 },
+                    { color: 'red', value: 80 },
+                  ],
+                },
                 mappings: [],
               },
               overrides: [],

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -3,7 +3,6 @@ import {
   type GrafanaConfig,
   LiveChannelEventType,
   LoadingState,
-  ThresholdsMode,
   getDefaultTimeRange,
   locationUtil,
   store,
@@ -754,14 +753,6 @@ describe('DashboardScene', () => {
             fieldConfig: {
               defaults: {
                 color: { mode: 'thresholds' },
-                thresholds: {
-                  mode: ThresholdsMode.Absolute,
-                  steps: [
-                    { color: 'green', value: 0 },
-                    { color: 'red', value: 80 },
-                  ],
-                },
-                mappings: [],
               },
               overrides: [],
             },
@@ -772,8 +763,6 @@ describe('DashboardScene', () => {
           const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
           expect(stored.panelType).toBe('stat');
           expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'thresholds' });
-          expect(stored.styles.fieldConfig.defaults.thresholds).toBeDefined();
-          expect(stored.styles.fieldConfig.defaults.mappings).toEqual([]);
           expect(stored.styles.options.orientation).toBe('horizontal');
           expect(stored.styles.options.colorMode).toBe('background');
           expect(stored.styles.options.showPercentChange).toBe(true);
@@ -824,14 +813,6 @@ describe('DashboardScene', () => {
             fieldConfig: {
               defaults: {
                 color: { mode: 'thresholds' },
-                thresholds: {
-                  mode: ThresholdsMode.Absolute,
-                  steps: [
-                    { color: 'green', value: 0 },
-                    { color: 'red', value: 80 },
-                  ],
-                },
-                mappings: [],
               },
               overrides: [],
             },
@@ -842,7 +823,6 @@ describe('DashboardScene', () => {
           const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
           expect(stored.panelType).toBe('gauge');
           expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'thresholds' });
-          expect(stored.styles.fieldConfig.defaults.thresholds).toBeDefined();
           expect(stored.styles.options.shape).toBe('circle');
           expect(stored.styles.options.barWidthFactor).toBe(0.8);
           expect(stored.styles.options.effects).toEqual({ barGlow: true, centerGlow: false, gradient: true });
@@ -886,14 +866,6 @@ describe('DashboardScene', () => {
             fieldConfig: {
               defaults: {
                 color: { mode: 'thresholds' },
-                thresholds: {
-                  mode: ThresholdsMode.Absolute,
-                  steps: [
-                    { color: 'green', value: 0 },
-                    { color: 'red', value: 80 },
-                  ],
-                },
-                mappings: [],
               },
               overrides: [],
             },
@@ -904,7 +876,6 @@ describe('DashboardScene', () => {
           const stored = JSON.parse(store.get(LS_STYLES_COPY_KEY) || '{}');
           expect(stored.panelType).toBe('bargauge');
           expect(stored.styles.fieldConfig.defaults.color).toEqual({ mode: 'thresholds' });
-          expect(stored.styles.fieldConfig.defaults.thresholds).toBeDefined();
           expect(stored.styles.options.displayMode).toBe('gradient');
           expect(stored.styles.options.showUnfilled).toBe(false);
           expect(stored.styles.options.text).toEqual({ titleSize: 14, valueSize: 20 });

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -966,7 +966,9 @@ describe('panelMenuBehavior', () => {
       expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeUndefined();
     });
 
-    it.each(['trend', 'candlestick'])('should show styles menu for %s panel', async (pluginId) => {
+    it.each(['trend', 'candlestick', 'stat', 'gauge', 'bargauge', 'barchart', 'piechart'])(
+      'should show styles menu for %s panel',
+      async (pluginId) => {
       const menu = new VizPanelMenu({ $behaviors: [panelMenuBehavior] });
       const panel = new VizPanel({ title: `${pluginId} Panel`, pluginId, key: `panel-${pluginId}`, menu });
       panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
@@ -985,7 +987,7 @@ describe('panelMenuBehavior', () => {
       expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeDefined();
     });
 
-    it.each(['trend', 'candlestick'])(
+    it.each(['trend', 'candlestick', 'stat', 'gauge', 'bargauge', 'barchart', 'piechart'])(
       'should show paste option for %s panel when matching styles are copied',
       async (pluginId) => {
         store.set(LS_STYLES_COPY_KEY, JSON.stringify({ panelType: pluginId, styles: {} }));
@@ -1011,7 +1013,7 @@ describe('panelMenuBehavior', () => {
       }
     );
 
-    it.each(['trend', 'candlestick'])(
+    it.each(['trend', 'candlestick', 'stat', 'gauge', 'bargauge', 'barchart', 'piechart'])(
       'should not show paste option for %s panel when timeseries styles are copied',
       async (pluginId) => {
         store.set(LS_STYLES_COPY_KEY, JSON.stringify({ panelType: 'timeseries', styles: {} }));

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -969,23 +969,24 @@ describe('panelMenuBehavior', () => {
     it.each(['trend', 'candlestick', 'stat', 'gauge', 'bargauge', 'barchart', 'piechart'])(
       'should show styles menu for %s panel',
       async (pluginId) => {
-      const menu = new VizPanelMenu({ $behaviors: [panelMenuBehavior] });
-      const panel = new VizPanel({ title: `${pluginId} Panel`, pluginId, key: `panel-${pluginId}`, menu });
-      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+        const menu = new VizPanelMenu({ $behaviors: [panelMenuBehavior] });
+        const panel = new VizPanel({ title: `${pluginId} Panel`, pluginId, key: `panel-${pluginId}`, menu });
+        panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
 
-      new DashboardScene({
-        title: 'My dashboard',
-        uid: 'dash-1',
-        meta: { canEdit: true },
-        isEditing: true,
-        body: DefaultGridLayoutManager.fromVizPanels([panel]),
-      });
+        new DashboardScene({
+          title: 'My dashboard',
+          uid: 'dash-1',
+          meta: { canEdit: true },
+          isEditing: true,
+          body: DefaultGridLayoutManager.fromVizPanels([panel]),
+        });
 
-      menu.activate();
-      await new Promise((r) => setTimeout(r, 1));
+        menu.activate();
+        await new Promise((r) => setTimeout(r, 1));
 
-      expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeDefined();
-    });
+        expect(menu.state.items?.find((i) => i.text === 'Styles')).toBeDefined();
+      }
+    );
 
     it.each(['trend', 'candlestick', 'stat', 'gauge', 'bargauge', 'barchart', 'piechart'])(
       'should show paste option for %s panel when matching styles are copied',

--- a/public/app/features/dashboard-scene/utils/panelStyleConfigs.ts
+++ b/public/app/features/dashboard-scene/utils/panelStyleConfigs.ts
@@ -67,10 +67,257 @@ const graphPanelStyleConfig: PanelStyleConfig = {
   },
 };
 
+/**
+ * Style config for the stat panel. No custom field config — all styling
+ * comes from standard fieldConfig properties and panel-level options.
+ *
+ * fieldConfig.defaults:
+ *   color      – color scheme
+ *   thresholds – thresholds driving color mode
+ *   mappings   – value-to-display mappings
+ *
+ * options:
+ *   orientation          – panel orientation (auto, horizontal, vertical)
+ *   textMode             – what text to display (auto, value, value_and_name, name, none)
+ *   colorMode            – value, background, background_solid, none
+ *   graphMode            – area, none
+ *   justifyMode          – alignment of the text (auto, center)
+ *   showPercentChange    – show percent change below value
+ *   percentChangeColorMode – standard, inverted, same_as_value
+ *   wideLayout           – use wide layout when panel is wide enough
+ *   text                 – text sizes: { titleSize, valueSize }
+ */
+const statPanelStyleConfig: PanelStyleConfig = {
+  fieldConfig: {
+    defaultsProps: ['color', 'thresholds', 'mappings'],
+    customProps: [],
+  },
+  options: {
+    props: [
+      'orientation',
+      'textMode',
+      'colorMode',
+      'graphMode',
+      'justifyMode',
+      'showPercentChange',
+      'percentChangeColorMode',
+      'wideLayout',
+      'text',
+    ],
+  },
+};
+
+/**
+ * Style config for the gauge panel. No custom field config — styling
+ * comes from standard fieldConfig properties and panel-level options.
+ *
+ * fieldConfig.defaults:
+ *   color      – color scheme
+ *   thresholds – threshold config that drives gauge color bands
+ *   mappings   – value-to-display mappings
+ *
+ * options:
+ *   orientation         – panel orientation
+ *   text                – text sizes: { titleSize, valueSize }
+ *   shape               – circle vs gauge arc style
+ *   barShape            – flat vs rounded bar ends
+ *   barWidthFactor      – width of the gauge bar relative to available space
+ *   effects             – visual effects: { barGlow, centerGlow, gradient }
+ *   endpointMarker      – point, glow, or none at bar tip
+ *   minVizWidth         – minimum width for manual sizing
+ *   minVizHeight        – minimum height for manual sizing
+ *   sizing              – auto vs manual gauge size
+ *   segmentCount        – number of arc segments
+ *   segmentSpacing      – spacing between segments
+ *   showThresholdMarkers – tick marks at threshold boundaries
+ *   showThresholdLabels  – labels at threshold and neutral values
+ *   sparkline           – show sparkline in background
+ *   textMode            – text displayed inside the gauge
+ *   neutral             – neutral value dividing positive/negative coloring
+ */
+const gaugePanelStyleConfig: PanelStyleConfig = {
+  fieldConfig: {
+    defaultsProps: ['color', 'thresholds', 'mappings'],
+    customProps: [],
+  },
+  options: {
+    props: [
+      'orientation',
+      'text',
+      'shape',
+      'barShape',
+      'barWidthFactor',
+      'effects',
+      'endpointMarker',
+      'minVizWidth',
+      'minVizHeight',
+      'sizing',
+      'segmentCount',
+      'segmentSpacing',
+      'showThresholdMarkers',
+      'showThresholdLabels',
+      'sparkline',
+      'textMode',
+      'neutral',
+    ],
+  },
+};
+
+/**
+ * Style config for the bar gauge panel. No custom field config — styling
+ * comes from standard fieldConfig properties and panel-level options.
+ *
+ * fieldConfig.defaults:
+ *   color      – color scheme
+ *   thresholds – threshold config driving bar colors
+ *   mappings   – value-to-display mappings
+ *
+ * options:
+ *   orientation  – panel orientation (auto, horizontal, vertical)
+ *   text         – text sizes: { titleSize, valueSize }
+ *   legend       – legend options
+ *   displayMode  – gradient, retro LCD, or basic fill
+ *   valueMode    – value color, text color, or hidden
+ *   namePlacement – auto, top, left, or hidden
+ *   showUnfilled – render the unfilled region as gray
+ *   sizing       – auto vs manual bar size
+ *   minVizWidth  – minimum bar width for manual sizing
+ *   minVizHeight – minimum bar height for manual sizing
+ *   maxVizHeight – maximum bar height for manual sizing
+ */
+const barGaugePanelStyleConfig: PanelStyleConfig = {
+  fieldConfig: {
+    defaultsProps: ['color', 'thresholds', 'mappings'],
+    customProps: [],
+  },
+  options: {
+    props: [
+      'orientation',
+      'text',
+      'legend',
+      'displayMode',
+      'valueMode',
+      'namePlacement',
+      'showUnfilled',
+      'sizing',
+      'minVizWidth',
+      'minVizHeight',
+      'maxVizHeight',
+    ],
+  },
+};
+
+/**
+ * Style config for the bar chart panel.
+ *
+ * fieldConfig.defaults:
+ *   color      – color scheme
+ *   thresholds – threshold config (used by thresholdsStyle overlay)
+ *
+ * fieldConfig.defaults.custom:
+ *   lineWidth        – bar border width
+ *   fillOpacity      – bar fill opacity
+ *   gradientMode     – gradient fill mode
+ *   thresholdsStyle  – threshold overlay style (lines/dashed/area)
+ *   transform        – constant or negative-Y transform
+ *   axisPlacement    – axis placement (auto, left, right, hidden)
+ *   axisLabel        – axis label
+ *   axisWidth        – axis width
+ *   axisSoftMin      – soft minimum for axis scale
+ *   axisSoftMax      – soft maximum for axis scale
+ *   axisGridShow     – show axis grid lines
+ *   axisBorderShow   – show axis border
+ *   axisCenteredZero – center axis at zero
+ *   axisColorMode    – axis color mode
+ *   scaleDistribution – axis scale (linear, log, symlog)
+ *
+ * options:
+ *   orientation         – vertical or horizontal bars
+ *   xTickLabelRotation  – x-axis tick label rotation
+ *   xTickLabelMaxLength – x-axis tick label truncation length
+ *   xTickLabelSpacing   – x-axis tick label minimum spacing
+ *   showValue           – show value labels on bars (auto, always, never)
+ *   stacking            – stacking mode (none, normal, percent)
+ *   groupWidth          – width of bar groups
+ *   barWidth            – width of individual bars
+ *   barRadius           – corner radius of bars
+ *   fullHighlight       – highlight full bar area on hover
+ *   tooltip             – tooltip options
+ *   legend              – legend options
+ *   text                – text size options
+ */
+const barChartPanelStyleConfig: PanelStyleConfig = {
+  fieldConfig: {
+    defaultsProps: ['color', 'thresholds'],
+    customProps: [
+      'lineWidth',
+      'fillOpacity',
+      'gradientMode',
+      'thresholdsStyle',
+      'transform',
+      'axisPlacement',
+      'axisLabel',
+      'axisWidth',
+      'axisSoftMin',
+      'axisSoftMax',
+      'axisGridShow',
+      'axisBorderShow',
+      'axisCenteredZero',
+      'axisColorMode',
+      'scaleDistribution',
+    ],
+  },
+  options: {
+    props: [
+      'orientation',
+      'xTickLabelRotation',
+      'xTickLabelMaxLength',
+      'xTickLabelSpacing',
+      'showValue',
+      'stacking',
+      'groupWidth',
+      'barWidth',
+      'barRadius',
+      'fullHighlight',
+      'tooltip',
+      'legend',
+      'text',
+    ],
+  },
+};
+
+/**
+ * Style config for the pie chart panel.
+ *
+ * fieldConfig.defaults:
+ *   color – color scheme (thresholds is disabled for this panel type)
+ *
+ * options:
+ *   pieType       – pie or donut
+ *   sort          – slice sort order (descending, ascending, none)
+ *   displayLabels – labels shown on slices (percent, name, value)
+ *   tooltip       – tooltip options
+ *   legend        – legend options including legend.values (percent, value)
+ */
+const pieChartPanelStyleConfig: PanelStyleConfig = {
+  fieldConfig: {
+    defaultsProps: ['color'],
+    customProps: [],
+  },
+  options: {
+    props: ['pieType', 'sort', 'displayLabels', 'tooltip', 'legend'],
+  },
+};
+
 const PANEL_STYLE_CONFIGS: Record<string, PanelStyleConfig> = {
   timeseries: graphPanelStyleConfig,
   trend: graphPanelStyleConfig,
   candlestick: graphPanelStyleConfig,
+  stat: statPanelStyleConfig,
+  gauge: gaugePanelStyleConfig,
+  bargauge: barGaugePanelStyleConfig,
+  barchart: barChartPanelStyleConfig,
+  piechart: pieChartPanelStyleConfig,
 };
 
 /**

--- a/public/app/features/dashboard-scene/utils/panelStyleConfigs.ts
+++ b/public/app/features/dashboard-scene/utils/panelStyleConfigs.ts
@@ -72,9 +72,7 @@ const graphPanelStyleConfig: PanelStyleConfig = {
  * comes from standard fieldConfig properties and panel-level options.
  *
  * fieldConfig.defaults:
- *   color      – color scheme
- *   thresholds – thresholds driving color mode
- *   mappings   – value-to-display mappings
+ *   color – color scheme
  *
  * options:
  *   orientation          – panel orientation (auto, horizontal, vertical)
@@ -89,7 +87,7 @@ const graphPanelStyleConfig: PanelStyleConfig = {
  */
 const statPanelStyleConfig: PanelStyleConfig = {
   fieldConfig: {
-    defaultsProps: ['color', 'thresholds', 'mappings'],
+    defaultsProps: ['color'],
     customProps: [],
   },
   options: {
@@ -112,9 +110,7 @@ const statPanelStyleConfig: PanelStyleConfig = {
  * comes from standard fieldConfig properties and panel-level options.
  *
  * fieldConfig.defaults:
- *   color      – color scheme
- *   thresholds – threshold config that drives gauge color bands
- *   mappings   – value-to-display mappings
+ *   color – color scheme
  *
  * options:
  *   orientation         – panel orientation
@@ -137,7 +133,7 @@ const statPanelStyleConfig: PanelStyleConfig = {
  */
 const gaugePanelStyleConfig: PanelStyleConfig = {
   fieldConfig: {
-    defaultsProps: ['color', 'thresholds', 'mappings'],
+    defaultsProps: ['color'],
     customProps: [],
   },
   options: {
@@ -168,9 +164,7 @@ const gaugePanelStyleConfig: PanelStyleConfig = {
  * comes from standard fieldConfig properties and panel-level options.
  *
  * fieldConfig.defaults:
- *   color      – color scheme
- *   thresholds – threshold config driving bar colors
- *   mappings   – value-to-display mappings
+ *   color – color scheme
  *
  * options:
  *   orientation  – panel orientation (auto, horizontal, vertical)
@@ -187,7 +181,7 @@ const gaugePanelStyleConfig: PanelStyleConfig = {
  */
 const barGaugePanelStyleConfig: PanelStyleConfig = {
   fieldConfig: {
-    defaultsProps: ['color', 'thresholds', 'mappings'],
+    defaultsProps: ['color'],
     customProps: [],
   },
   options: {
@@ -211,8 +205,7 @@ const barGaugePanelStyleConfig: PanelStyleConfig = {
  * Style config for the bar chart panel.
  *
  * fieldConfig.defaults:
- *   color      – color scheme
- *   thresholds – threshold config (used by thresholdsStyle overlay)
+ *   color – color scheme
  *
  * fieldConfig.defaults.custom:
  *   lineWidth        – bar border width
@@ -248,7 +241,7 @@ const barGaugePanelStyleConfig: PanelStyleConfig = {
  */
 const barChartPanelStyleConfig: PanelStyleConfig = {
   fieldConfig: {
-    defaultsProps: ['color', 'thresholds'],
+    defaultsProps: ['color'],
     customProps: [
       'lineWidth',
       'fillOpacity',


### PR DESCRIPTION
Built upon https://github.com/grafana/grafana/pull/121490 this extends `panelStyleActions` to the following panel types:

- Stat
- Gauge
- Bar Gauge
- Bar Chart
- Pie Chart

Fixes https://github.com/grafana/grafana/issues/121492
Fixes https://github.com/grafana/grafana/issues/121493
Fixes https://github.com/grafana/grafana/issues/121494
Fixes https://github.com/grafana/grafana/issues/121495
Fixes https://github.com/grafana/grafana/issues/121496