### PR TITLE
OTel logs formatting: Added support for dot-separated label names

### DIFF
--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -144,6 +144,22 @@ describe('getOtelAttributesField', () => {
 
     expect(getOtelAttributesField(log, true)).toEqual('custom_attr=keep');
   });
+
+  test('Excludes dot-notation OTel log record fields the same as underscore keys', () => {
+    const log = createLogLine({
+      labels: {
+        'observed.timestamp': 'nope',
+        'severity.number': 'nope',
+        'severity.text': 'nope',
+        'span.id': 'nope',
+        'trace.id': 'nope',
+        user_dimension: 'keep',
+      },
+      entry: 'msg',
+    });
+
+    expect(getOtelAttributesField(log, true)).toEqual('user_dimension=keep');
+  });
 });
 
 describe('identifyOTelLanguage', () => {

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -69,9 +69,12 @@ describe('getOtelAttributesField', () => {
       labels: {
         aws_something: 'nope',
         k8s_something: 'nope',
+        'k8s.pod.name': 'nope',
         cluster: 'nope',
         namespace: 'nope',
         pod: 'nope',
+        'service.name': 'nope',
+        'host.name': 'nope',
         vcs_ref_head_name: 'main',
         field: 'value',
       },
@@ -89,6 +92,7 @@ describe('getOtelAttributesField', () => {
         cluster: 'nope',
         namespace: 'nope',
         pod: 'nope',
+        'telemetry.sdk.language': 'nope',
         cluster_1: 'yes',
         namespace_2: 'yes',
         pod_3: 'yes',
@@ -118,6 +122,27 @@ describe('getOtelAttributesField', () => {
     });
 
     expect(getOtelAttributesField(log, false)).toEqual('vcs_ref_head_name=main field=value');
+  });
+
+  test('Excludes dot-notation resource attributes the same as underscore-prefixed keys', () => {
+    const log = createLogLine({
+      labels: {
+        'cloud.provider': 'nope',
+        'cloud.region': 'nope',
+        'container.id': 'nope',
+        'deployment.environment': 'nope',
+        'faas.name': 'nope',
+        'gcp.project.id': 'nope',
+        'os.type': 'nope',
+        'process.pid': 'nope',
+        'cluster.uid': 'nope',
+        'namespace.uid': 'nope',
+        custom_attr: 'keep',
+      },
+      entry: 'msg',
+    });
+
+    expect(getOtelAttributesField(log, true)).toEqual('custom_attr=keep');
   });
 });
 

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -102,7 +102,7 @@ function getDefaultOTelDisplayFormat() {
 const OTEL_RESOURCE_ATTRS_REGEX =
   /^(aws_|aws\.|cloud_|cloud\.|cloudfoundry_|cloudfoundry\.|container_|container\.|deployment_|deployment\.|faas_|faas\.|gcp_|gcp\.|host_|host\.|k8s_|k8s\.|os_|os\.|process_|process\.|service_|service\.|telemetry_|telemetry\.|cluster$|cluster\.|namespace$|namespace\.|pod$|pod\.)/;
 const OTEL_LOG_FIELDS_REGEX =
-  /^(flags|observed_timestamp|severity_number|severity_text|span_id|trace_id|detected_level)$/;
+  /^(flags|observed_timestamp|observed\.timestamp|severity_number|severity\.number|severity_text|severity\.text|span_id|span\.id|trace_id|trace\.id|detected_level)$/;
 
 export function getOtelAttributesField(log: LogListModel, wrapLogMessage: boolean) {
   const additionalFields = Object.keys(log.labels).filter(

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -100,7 +100,7 @@ function getDefaultOTelDisplayFormat() {
 }
 
 const OTEL_RESOURCE_ATTRS_REGEX =
-  /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_|cluster$|namespace$|pod$)/;
+  /^(aws_|aws\.|cloud_|cloud\.|cloudfoundry_|cloudfoundry\.|container_|container\.|deployment_|deployment\.|faas_|faas\.|gcp_|gcp\.|host_|host\.|k8s_|k8s\.|os_|os\.|process_|process\.|service_|service\.|telemetry_|telemetry\.|cluster$|cluster\.|namespace$|namespace\.|pod$|pod\.)/;
 const OTEL_LOG_FIELDS_REGEX =
   /^(flags|observed_timestamp|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 


### PR DESCRIPTION
Adds support for dot-separated resource attribute fields and OTel log fields, in the same way Loki underscore-separated field names are treated.

Closes https://github.com/grafana/grafana/issues/120069

Part of https://github.com/grafana/grafana/issues/101083