### PR TITLE
Suggestions: Remove time series smooth suggestion

### DIFF
--- a/public/app/features/panel/suggestions/getAllSuggestions.test.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.test.ts
@@ -159,7 +159,6 @@ scenario('Single frame with time and number field', (ctx) => {
   it('should return correct suggestions', () => {
     expect(ctx.suggestions).toEqual([
       expect.objectContaining({ pluginId: 'timeseries', name: 'Line chart' }),
-      expect.objectContaining({ pluginId: 'timeseries', name: 'Line chart - smooth' }),
       expect.objectContaining({ pluginId: 'timeseries', name: 'Area chart' }),
       expect.objectContaining({ pluginId: 'timeseries', name: 'Bar chart' }),
       expect.objectContaining({ pluginId: 'gauge' }),
@@ -216,7 +215,6 @@ scenario('Single frame with time 2 number fields', (ctx) => {
   it('should return correct suggestions', () => {
     expect(ctx.suggestions).toEqual([
       expect.objectContaining({ pluginId: 'timeseries', name: 'Line chart' }),
-      expect.objectContaining({ pluginId: 'timeseries', name: 'Line chart - smooth' }),
       expect.objectContaining({ pluginId: 'timeseries', name: 'Area chart - stacked' }),
       expect.objectContaining({ pluginId: 'timeseries', name: 'Area chart - stacked by percentage' }),
       expect.objectContaining({ pluginId: 'timeseries', name: 'Bar chart - stacked' }),

--- a/public/app/plugins/panel/timeseries/suggestions.ts
+++ b/public/app/plugins/panel/timeseries/suggestions.ts
@@ -10,20 +10,13 @@ import {
   type VisualizationSuggestionsSupplier,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import {
-  GraphDrawStyle,
-  type GraphFieldConfig,
-  GraphGradientMode,
-  LineInterpolation,
-  StackingMode,
-} from '@grafana/schema';
+import { GraphDrawStyle, type GraphFieldConfig, GraphGradientMode, StackingMode } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { SUGGESTIONS_LEGEND_OPTIONS } from 'app/features/panel/suggestions/utils';
 
 import { type Options } from './panelcfg.gen';
 
 const MAX_BARS = 100;
-const MAX_ROWS_SMOOTH_CHART = 30;
 
 const MAX_PREVIEW_SERIES = 8;
 const MAX_PREVIEW_BAR_ROWS = 30;
@@ -112,20 +105,6 @@ export const timeseriesSuggestionsSupplier: VisualizationSuggestionsSupplier<Opt
       name: t('timeseries.suggestions.line', 'Line chart'),
     },
   ];
-
-  if (dataSummary.rowCountMax < MAX_ROWS_SMOOTH_CHART) {
-    suggestions.push({
-      name: t('timeseries.suggestions.line-smooth', 'Line chart - smooth'),
-      fieldConfig: {
-        defaults: {
-          custom: {
-            lineInterpolation: LineInterpolation.Smooth,
-          },
-        },
-        overrides: [],
-      },
-    });
-  }
 
   // Single-series suggestions
   if (dataSummary.fieldCountByType(FieldType.number) === 1) {

--- a/public/app/plugins/panel/timeseries/suggestions.ts
+++ b/public/app/plugins/panel/timeseries/suggestions.ts
@@ -23,7 +23,7 @@ import { SUGGESTIONS_LEGEND_OPTIONS } from 'app/features/panel/suggestions/utils
 import { type Options } from './panelcfg.gen';
 
 const MAX_BARS = 100;
-const MAX_ROWS_SMOOTH_CHART = 200;
+const MAX_ROWS_SMOOTH_CHART = 30;
 
 const MAX_PREVIEW_SERIES = 8;
 const MAX_PREVIEW_BAR_ROWS = 30;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15395,8 +15395,7 @@
       "bar": "Bar chart",
       "bar-stacked": "Bar chart - stacked",
       "bar-stacked-percent": "Bar chart - stacked by percentage",
-      "line": "Line chart",
-      "line-smooth": "Line chart - smooth"
+      "line": "Line chart"
     },
     "timezones-editor": {
       "tooltip-add-timezone": "Add timezone",


### PR DESCRIPTION
This PR removes the smooth suggestion for Time series as we now have that option in presets.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
