### PR TITLE
test: Prevent incorrect assertion when a dashboard is saved several times in the same E2E test

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -127,7 +127,11 @@ export async function saveDashboard(
     await page.getByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput).fill(title);
   }
   await dashboardPage.getByGrafanaSelector(selectors.components.Drawer.DashboardSaveDrawer.saveButton).click();
+
+  // wait for the toast
   await expect(page.getByText('Dashboard saved')).toBeVisible();
+  // close toast, we do this to prevent any incorrect assertion when several saves occur fast. i.e. the 1st toast is still visible but the 2nd save has not occurred yet
+  await page.getByRole('button', { name: 'Close alert' }).click();
 }
 
 export async function checkRepeatedPanelTitles(


### PR DESCRIPTION
See https://raintank-corp.slack.com/archives/C01BKPAV1EZ/p1774962010496989 for context

**TL;DR**: https://github.com/grafana/grafana/blob/main/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts#L163 fails in main because 2 saves happen "very fast" and the test does not wait properly for the confirmation of the 2nd save before moving on.