### PR TITLE
Add polling fallback for Git repository status updates

### DIFF
--- a/public/app/features/provisioning/Wizard/hooks/useRepositoryStatus.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useRepositoryStatus.ts
@@ -4,6 +4,10 @@ import { useListRepositoryQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { isResourceReconciled } from '../../utils/repositoryStatus';
 
+// Fallback polling interval in case the Grafana Live watch stream
+// fails to deliver status updates (e.g. WebSocket blocked by proxy).
+const RECONCILIATION_POLL_MS = 5000;
+
 export function useRepositoryStatus(repoName?: string) {
   const query = useListRepositoryQuery(
     repoName
@@ -11,7 +15,8 @@ export function useRepositoryStatus(repoName?: string) {
           fieldSelector: `metadata.name=${repoName}`,
           watch: true,
         }
-      : skipToken
+      : skipToken,
+    { pollingInterval: RECONCILIATION_POLL_MS }
   );
 
   const repository = query.data?.items?.[0];


### PR DESCRIPTION
**What is this feature?**
This is a bug fix to prevent the Git sync wizard from remaining stuck if web sockets are not working.

**Why do we need this feature?**
The wizard's useRepositoryStatus hook fetches the repository once via HTTP, then relies entirely on a Grafana Live WebSocket stream to receive status updates from the backend controller. When a reverse proxy blocks the WebSocket connection, the frontend never learns that the controller has finished reconciling the repository, and the loading spinner runs forever.

**Who is this feature for?**
Git sync users

**Details of the fix**
Add a 5-second polling fallback to useRepositoryStatus so the frontend periodically refetches the repository status via HTTP. When the WebSocket works, the poll is redundant but harmless.