### PR TITLE
Dashboards / Playlists: Fix aliased types

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_client.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_client.go
@@ -1,0 +1,102 @@
+package v1beta1
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DashboardClient is the app-sdk typed client for dashboard.grafana.app/v1beta1. It is
+// not an alias of v1.DashboardClient: v1's client wires resource.Client to v1's
+// Kind and overwrites apiVersion on Create/UpdateStatus with v1, which would
+// regress callers that intentionally use v1beta1 paths and metadata.
+type DashboardClient struct {
+	client *resource.TypedClient[*Dashboard, *DashboardList]
+}
+
+func NewDashboardClient(client resource.Client) *DashboardClient {
+	return &DashboardClient{
+		client: resource.NewTypedClient[*Dashboard, *DashboardList](client, DashboardKind()),
+	}
+}
+
+func NewDashboardClientFromGenerator(generator resource.ClientGenerator) (*DashboardClient, error) {
+	c, err := generator.ClientFor(DashboardKind())
+	if err != nil {
+		return nil, err
+	}
+	return NewDashboardClient(c), nil
+}
+
+func (c *DashboardClient) Get(ctx context.Context, identifier resource.Identifier) (*Dashboard, error) {
+	return c.client.Get(ctx, identifier)
+}
+
+func (c *DashboardClient) List(ctx context.Context, namespace string, opts resource.ListOptions) (*DashboardList, error) {
+	return c.client.List(ctx, namespace, opts)
+}
+
+func (c *DashboardClient) ListAll(ctx context.Context, namespace string, opts resource.ListOptions) (*DashboardList, error) {
+	resp, err := c.client.List(ctx, namespace, resource.ListOptions{
+		ResourceVersion: opts.ResourceVersion,
+		Limit:           opts.Limit,
+		LabelFilters:    opts.LabelFilters,
+		FieldSelectors:  opts.FieldSelectors,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for resp.GetContinue() != "" {
+		page, err := c.client.List(ctx, namespace, resource.ListOptions{
+			Continue:        resp.GetContinue(),
+			ResourceVersion: opts.ResourceVersion,
+			Limit:           opts.Limit,
+			LabelFilters:    opts.LabelFilters,
+			FieldSelectors:  opts.FieldSelectors,
+		})
+		if err != nil {
+			return nil, err
+		}
+		resp.SetContinue(page.GetContinue())
+		resp.SetResourceVersion(page.GetResourceVersion())
+		resp.SetItems(append(resp.GetItems(), page.GetItems()...))
+	}
+	return resp, nil
+}
+
+func (c *DashboardClient) Create(ctx context.Context, obj *Dashboard, opts resource.CreateOptions) (*Dashboard, error) {
+	obj.APIVersion = GroupVersion.Identifier()
+	obj.Kind = DashboardKind().Kind()
+	return c.client.Create(ctx, obj, opts)
+}
+
+func (c *DashboardClient) Update(ctx context.Context, obj *Dashboard, opts resource.UpdateOptions) (*Dashboard, error) {
+	return c.client.Update(ctx, obj, opts)
+}
+
+func (c *DashboardClient) Patch(ctx context.Context, identifier resource.Identifier, req resource.PatchRequest, opts resource.PatchOptions) (*Dashboard, error) {
+	return c.client.Patch(ctx, identifier, req, opts)
+}
+
+func (c *DashboardClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus DashboardStatus, opts resource.UpdateOptions) (*Dashboard, error) {
+	return c.client.Update(ctx, &Dashboard{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       DashboardKind().Kind(),
+			APIVersion: GroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
+		},
+		Status: newStatus,
+	}, resource.UpdateOptions{
+		Subresource:     "status",
+		ResourceVersion: opts.ResourceVersion,
+	})
+}
+
+func (c *DashboardClient) Delete(ctx context.Context, identifier resource.Identifier, opts resource.DeleteOptions) error {
+	return c.client.Delete(ctx, identifier, opts)
+}

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/register.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/register.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/grafana/grafana-app-sdk/resource"
 	v1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
@@ -36,22 +37,25 @@ type (
 	DashboardAccess           = v1.DashboardAccess
 	AnnotationPermission      = v1.AnnotationPermission
 	AnnotationActions         = v1.AnnotationActions
-	DashboardClient           = v1.DashboardClient
 	DashboardJSONCodec        = v1.DashboardJSONCodec
 )
 
 var (
-	NewDashboard                    = v1.NewDashboard
-	NewDashboardSpec                = v1.NewDashboardSpec
-	NewDashboardStatus              = v1.NewDashboardStatus
-	NewDashboardClient              = v1.NewDashboardClient
-	NewDashboardClientFromGenerator = v1.NewDashboardClientFromGenerator
+	NewDashboard       = v1.NewDashboard
+	NewDashboardSpec   = v1.NewDashboardSpec
+	NewDashboardStatus = v1.NewDashboardStatus
 
-	DashboardKind         = v1.DashboardKind
-	DashboardSchema       = v1.DashboardSchema
 	GetOpenAPIDefinitions = v1.GetOpenAPIDefinitions
 	ValidateDashboardSpec = v1.ValidateDashboardSpec
 )
+
+var (
+	schemaDashboard *resource.SimpleSchema
+	kindDashboard   resource.Kind
+)
+
+func DashboardKind() resource.Kind            { return kindDashboard }
+func DashboardSchema() *resource.SimpleSchema { return schemaDashboard }
 
 var DashboardResourceInfo = utils.NewResourceInfo(GROUP, VERSION,
 	"dashboards", "dashboard", "Dashboard",
@@ -87,6 +91,10 @@ var (
 )
 
 func init() {
+	k := v1.DashboardKind()
+	schemaDashboard = resource.NewSimpleSchema(GROUP, VERSION, k.ZeroValue(), k.ZeroListValue(),
+		resource.WithKind(k.Kind()), resource.WithPlural(k.Plural()), resource.WithScope(k.Scope()))
+	kindDashboard = resource.Kind{Codecs: k.Codecs, Schema: schemaDashboard}
 	localSchemeBuilder.Register(addKnownTypes)
 }
 

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/playlist.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/playlist.go
@@ -18,7 +18,6 @@ type (
 	PlaylistPlaylistItemType         = v1.PlaylistPlaylistItemType
 	PlayliststatusOperatorState      = v1.PlayliststatusOperatorState
 	PlaylistStatusOperatorStateState = v1.PlaylistStatusOperatorStateState
-	PlaylistClient                   = v1.PlaylistClient
 	PlaylistJSONCodec                = v1.PlaylistJSONCodec
 )
 
@@ -35,8 +34,6 @@ var (
 	NewPlaylistItem                = v1.NewPlaylistItem
 	NewPlaylistPlaylistItem        = v1.NewPlaylistPlaylistItem
 	NewPlayliststatusOperatorState = v1.NewPlayliststatusOperatorState
-	NewPlaylistClient              = v1.NewPlaylistClient
-	NewPlaylistClientFromGenerator = v1.NewPlaylistClientFromGenerator
 )
 
 var (

--- a/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_client.go
+++ b/apps/playlist/pkg/apis/playlist/v0alpha1/playlist_client.go
@@ -1,0 +1,102 @@
+package v0alpha1
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PlaylistClient is the app-sdk typed client for playlist.grafana.app/v0alpha1. It is
+// not an alias of v1.PlaylistClient: v1's client wires resource.Client to v1's
+// Kind and overwrites apiVersion on Create/UpdateStatus with v1, which would
+// regress callers that intentionally use v0alpha1 paths and metadata.
+type PlaylistClient struct {
+	client *resource.TypedClient[*Playlist, *PlaylistList]
+}
+
+func NewPlaylistClient(client resource.Client) *PlaylistClient {
+	return &PlaylistClient{
+		client: resource.NewTypedClient[*Playlist, *PlaylistList](client, PlaylistKind()),
+	}
+}
+
+func NewPlaylistClientFromGenerator(generator resource.ClientGenerator) (*PlaylistClient, error) {
+	c, err := generator.ClientFor(PlaylistKind())
+	if err != nil {
+		return nil, err
+	}
+	return NewPlaylistClient(c), nil
+}
+
+func (c *PlaylistClient) Get(ctx context.Context, identifier resource.Identifier) (*Playlist, error) {
+	return c.client.Get(ctx, identifier)
+}
+
+func (c *PlaylistClient) List(ctx context.Context, namespace string, opts resource.ListOptions) (*PlaylistList, error) {
+	return c.client.List(ctx, namespace, opts)
+}
+
+func (c *PlaylistClient) ListAll(ctx context.Context, namespace string, opts resource.ListOptions) (*PlaylistList, error) {
+	resp, err := c.client.List(ctx, namespace, resource.ListOptions{
+		ResourceVersion: opts.ResourceVersion,
+		Limit:           opts.Limit,
+		LabelFilters:    opts.LabelFilters,
+		FieldSelectors:  opts.FieldSelectors,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for resp.GetContinue() != "" {
+		page, err := c.client.List(ctx, namespace, resource.ListOptions{
+			Continue:        resp.GetContinue(),
+			ResourceVersion: opts.ResourceVersion,
+			Limit:           opts.Limit,
+			LabelFilters:    opts.LabelFilters,
+			FieldSelectors:  opts.FieldSelectors,
+		})
+		if err != nil {
+			return nil, err
+		}
+		resp.SetContinue(page.GetContinue())
+		resp.SetResourceVersion(page.GetResourceVersion())
+		resp.SetItems(append(resp.GetItems(), page.GetItems()...))
+	}
+	return resp, nil
+}
+
+func (c *PlaylistClient) Create(ctx context.Context, obj *Playlist, opts resource.CreateOptions) (*Playlist, error) {
+	obj.APIVersion = GroupVersion.Identifier()
+	obj.Kind = PlaylistKind().Kind()
+	return c.client.Create(ctx, obj, opts)
+}
+
+func (c *PlaylistClient) Update(ctx context.Context, obj *Playlist, opts resource.UpdateOptions) (*Playlist, error) {
+	return c.client.Update(ctx, obj, opts)
+}
+
+func (c *PlaylistClient) Patch(ctx context.Context, identifier resource.Identifier, req resource.PatchRequest, opts resource.PatchOptions) (*Playlist, error) {
+	return c.client.Patch(ctx, identifier, req, opts)
+}
+
+func (c *PlaylistClient) UpdateStatus(ctx context.Context, identifier resource.Identifier, newStatus PlaylistStatus, opts resource.UpdateOptions) (*Playlist, error) {
+	return c.client.Update(ctx, &Playlist{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       PlaylistKind().Kind(),
+			APIVersion: GroupVersion.Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: opts.ResourceVersion,
+			Namespace:       identifier.Namespace,
+			Name:            identifier.Name,
+		},
+		Status: newStatus,
+	}, resource.UpdateOptions{
+		Subresource:     "status",
+		ResourceVersion: opts.ResourceVersion,
+	})
+}
+
+func (c *PlaylistClient) Delete(ctx context.Context, identifier resource.Identifier, opts resource.DeleteOptions) error {
+	return c.client.Delete(ctx, identifier, opts)
+}


### PR DESCRIPTION
This PR fixes the aliases of v1beta1 in dashboards and v0alpha1 in playlists. The clients were incorrect for both of them (would point to the stable v1 api), and for dashboards the kind & schema would also point to v1.

Fixes a hack added in terraform: https://github.com/grafana/terraform-provider-grafana/pull/2648