### PR TITLE
Dashboard: sidebar height

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -213,6 +213,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       width: '280px',
       flexGrow: 1,
       paddingBottom: theme.spacing(2),
+      overflowY: 'auto',
     }),
     openPaneRight: css({
       borderRight: `1px solid ${theme.colors.border.weak}`,


### PR DESCRIPTION
**What is this feature?**

before:

<img width="558" height="636" alt="image" src="https://github.com/user-attachments/assets/f390b433-5721-43c2-9fc0-394feee16664" />


after:

https://github.com/user-attachments/assets/27e39790-cc2b-4912-9134-8b0c00985bc2



Fixes: https://github.com/grafana/grafana/issues/121250