### PR TITLE
Loki: escape \\r and \\t in label values for Windows Event log compatibility

### DIFF
--- a/public/app/plugins/datasource/loki/languageUtils.ts
+++ b/public/app/plugins/datasource/loki/languageUtils.ts
@@ -37,16 +37,39 @@ function escapeLokiRegexp(value: string): string {
   return value.replace(RE2_METACHARACTERS, '\\$&');
 }
 
-// based on the openmetrics-documentation, the 3 symbols we have to handle are:
+// based on the openmetrics-documentation, the primary symbols we have to handle are:
 // - \n ... the newline character
 // - \  ... the backslash character
 // - "  ... the double-quote character
+// Additionally, for LogQL compatibility with Windows logs, we also handle:
+// - \r ... the carriage return character
+// - \t ... the tab character
 export function escapeLabelValueInExactSelector(labelValue: string): string {
-  return labelValue.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
+  return labelValue
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/"/g, '\\"');
 }
 
 export function unescapeLabelValue(labelValue: string): string {
-  return labelValue.replace(/\\n/g, '\n').replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  return labelValue.replace(/\\(n|r|t|\\|")/g, (_, c) => {
+    switch (c) {
+      case 'n':
+        return '\n';
+      case 'r':
+        return '\r';
+      case 't':
+        return '\t';
+      case '\\':
+        return '\\';
+      case '"':
+        return '"';
+      default:
+        return _;
+    }
+  });
 }
 
 export function escapeLabelValueInRegexSelector(labelValue: string): string {

--- a/public/app/plugins/datasource/loki/language_utils.test.ts
+++ b/public/app/plugins/datasource/loki/language_utils.test.ts
@@ -1,4 +1,8 @@
-import { escapeLabelValueInExactSelector, escapeLabelValueInRegexSelector } from './languageUtils';
+import {
+  escapeLabelValueInExactSelector,
+  escapeLabelValueInRegexSelector,
+  unescapeLabelValue,
+} from './languageUtils';
 
 describe('escapeLabelValueInExactSelector()', () => {
   it('handles newline characters', () => {
@@ -13,8 +17,52 @@ describe('escapeLabelValueInExactSelector()', () => {
     expect(escapeLabelValueInExactSelector('t"es"t')).toBe('t\\"es\\"t');
   });
 
+  it('handles carriage return characters', () => {
+    expect(escapeLabelValueInExactSelector('t\res\rt')).toBe('t\\res\\rt');
+  });
+
+  it('handles tab characters', () => {
+    expect(escapeLabelValueInExactSelector('t\tes\tt')).toBe('t\\tes\\tt');
+  });
+
   it('handles all together', () => {
     expect(escapeLabelValueInExactSelector('t\\e"st\nl\nab"e\\l')).toBe('t\\\\e\\"st\\nl\\nab\\"e\\\\l');
+  });
+
+  it('handles Windows CRLF and tab (common in Windows Event logs)', () => {
+    expect(escapeLabelValueInExactSelector('line1\r\nline2\tcolumn')).toBe('line1\\r\\nline2\\tcolumn');
+  });
+});
+
+describe('unescapeLabelValue()', () => {
+  it('unescapes newline sequences', () => {
+    expect(unescapeLabelValue('t\\nes\\nt')).toBe('t\nes\nt');
+  });
+
+  it('unescapes backslash sequences', () => {
+    expect(unescapeLabelValue('t\\\\es\\\\t')).toBe('t\\es\\t');
+  });
+
+  it('unescapes double-quote sequences', () => {
+    expect(unescapeLabelValue('t\\"es\\"t')).toBe('t"es"t');
+  });
+
+  it('unescapes carriage return sequences', () => {
+    expect(unescapeLabelValue('t\\res\\rt')).toBe('t\res\rt');
+  });
+
+  it('unescapes tab sequences', () => {
+    expect(unescapeLabelValue('t\\tes\\tt')).toBe('t\tes\tt');
+  });
+
+  it('correctly round-trips a label value with backslash followed by n (not a newline)', () => {
+    const original = 'path\\nfile';
+    expect(unescapeLabelValue(escapeLabelValueInExactSelector(original))).toBe(original);
+  });
+
+  it('correctly round-trips a label value with Windows CRLF and tab', () => {
+    const original = 'message:\r\n\tdetail';
+    expect(unescapeLabelValue(escapeLabelValueInExactSelector(original))).toBe(original);
   });
 });
 


### PR DESCRIPTION
**What is this feature?**

This fixes incorrect escaping of carriage return (`\r`) and tab (`\t`) characters in Loki label values and line filter expressions, which are common in Windows Event logs ingested via Alloy.

**Why do we need this feature?**

Windows Event log messages typically contain CRLF (`\r\n`) and tab (`\t`) field separators. When users build Loki queries through the query builder using values that include these characters (e.g. `{eventID="4724"} |~ ".*帳戶名稱:\t\thope"`), the escaping functions would pass `\r` and `\t` through unescaped into double-quoted LogQL strings, producing malformed queries or zero results.

Additionally, `unescapeLabelValue` had a sequential-replacement ordering bug: a label value containing a literal backslash followed by `n` (e.g. `path\nfile`, a Windows path) would incorrectly decode `\\n` → `\n` → newline in two steps, instead of correctly producing `\n` (backslash + n).

**Who is this feature for?**

Users querying Windows Event logs (or any logs with CRLF/tab content) through the Loki datasource in Grafana's query builder.

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana-loki-datasource#167

**Changes:**

- `escapeLabelValueInExactSelector`: added `.replace(/\r/g, '\\r')` and `.replace(/\t/g, '\\t')` so these characters are properly encoded in double-quoted LogQL strings
- `unescapeLabelValue`: replaced three sequential `String.replace()` calls with a single-pass regex and switch — fixes the ordering bug and adds `\r`/`\t` decoding
- `language_utils.test.ts`: added tests for `\r`, `\t`, Windows CRLF+tab combinations, and a full `unescapeLabelValue` test suite including round-trip tests

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.