### PR TITLE
EmbeddedDashboard: add hideControls and timeRange props

### DIFF
--- a/packages/grafana-runtime/src/components/EmbeddedDashboard.tsx
+++ b/packages/grafana-runtime/src/components/EmbeddedDashboard.tsx
@@ -13,6 +13,21 @@ export interface EmbeddedDashboardProps {
    * preserve some of the state when moving to other embedded dashboards.
    */
   onStateChange?: (state: string) => void;
+  /**
+   * When true, hides the dashboard controls bar (time picker, refresh picker,
+   * variable selectors, links, and sidebar toggle). Useful when the host
+   * application already provides its own controls.
+   * @alpha
+   */
+  hideControls?: boolean;
+  /**
+   * Reactive external time range. When provided, the embedded dashboard's
+   * time range is kept in sync with these values. Changes to `from` or `to`
+   * update the dashboard immediately. Use together with `hideControls` to
+   * let the host application own the time picker.
+   * @alpha
+   */
+  timeRange?: { from: string; to: string };
 }
 
 /**

--- a/public/app/features/dashboard-scene/embedding/EmbeddedDashboard.tsx
+++ b/public/app/features/dashboard-scene/embedding/EmbeddedDashboard.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { type GrafanaTheme2, urlUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type EmbeddedDashboardProps } from '@grafana/runtime';
-import { SceneObjectStateChangedEvent, sceneUtils } from '@grafana/scenes';
+import { SceneObjectStateChangedEvent, sceneGraph, sceneUtils } from '@grafana/scenes';
 import { Spinner, Alert, useStyles2 } from '@grafana/ui';
 import { getMessageFromError } from 'app/core/utils/errors';
 import { DashboardRoutes } from 'app/types/dashboard';
@@ -42,7 +42,7 @@ interface RendererProps extends EmbeddedDashboardProps {
   model: DashboardScene;
 }
 
-function EmbeddedDashboardRenderer({ model, initialState, onStateChange }: RendererProps) {
+function EmbeddedDashboardRenderer({ model, initialState, onStateChange, hideControls, timeRange }: RendererProps) {
   const [isActive, setIsActive] = useState(false);
   const { controls, body } = model.useState();
   const styles = useStyles2(getStyles);
@@ -59,15 +59,18 @@ function EmbeddedDashboardRenderer({ model, initialState, onStateChange }: Rende
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model]);
 
+  useSyncExternalTimeRange(model, timeRange);
   useSubscribeToEmbeddedUrlState(onStateChange, model);
 
   if (!isActive) {
     return null;
   }
 
+  const showControls = !hideControls && controls;
+
   return (
-    <div className={cx(styles.canvas, controls && styles.canvasWithControls)}>
-      {controls && (
+    <div className={cx(styles.canvas, showControls && styles.canvasWithControls)}>
+      {showControls && (
         <div className={styles.controlsWrapper}>
           <controls.Component model={controls} />
         </div>
@@ -77,6 +80,24 @@ function EmbeddedDashboardRenderer({ model, initialState, onStateChange }: Rende
       </div>
     </div>
   );
+}
+
+function useSyncExternalTimeRange(
+  model: DashboardScene,
+  timeRange: EmbeddedDashboardProps['timeRange']
+) {
+  useEffect(() => {
+    if (!timeRange) {
+      return;
+    }
+
+    const sceneTimeRange = sceneGraph.getTimeRange(model);
+    const { from: currentFrom, to: currentTo } = sceneTimeRange.state;
+
+    if (currentFrom !== timeRange.from || currentTo !== timeRange.to) {
+      sceneTimeRange.setState({ from: timeRange.from, to: timeRange.to });
+    }
+  }, [model, timeRange?.from, timeRange?.to]); // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 function useSubscribeToEmbeddedUrlState(onStateChange: ((state: string) => void) | undefined, model: DashboardScene) {


### PR DESCRIPTION
## Summary
- Adds `hideControls` prop to completely remove the embedded dashboard's controls bar (time picker, refresh picker, variables, links, sidebar toggle)
- Adds `timeRange` prop for reactive external time range syncing into the embedded dashboard's SceneTimeRange
- Both props are marked `@alpha`, matching the existing `EmbeddedDashboard` stability level

## Motivation
Host applications (e.g. Application Observability custom tabs) that embed dashboards via `<EmbeddedDashboard>` already have their own time picker and controls. This creates a duplicate controls bar with unsynchronized time ranges. These props let the host hide the inner controls and own the time range.

## Test plan
- [ ] Verify `<EmbeddedDashboard uid="..." />` (no new props) still renders controls as before
- [ ] Verify `<EmbeddedDashboard uid="..." hideControls />` renders no controls bar at all
- [ ] Verify `<EmbeddedDashboard uid="..." timeRange={{ from: "now-1h", to: "now" }} />` syncs time range on mount
- [ ] Verify changing `timeRange` prop updates the embedded dashboard reactively
- [ ] Verify `hideControls` + `timeRange` together work correctly (no controls, synced time)