### PR TITLE
libraryelements: use search to find existing connections when deleting

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
-	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -240,48 +239,14 @@ func (l *LibraryElementService) DeleteLibraryElement(c context.Context, signedIn
 		}
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
 
-		dashboardIDs := []int64{}
-		// get all connections for this element
-		if err := session.SQL("SELECT connection_id FROM library_element_connection where element_id = ?", element.ID).Find(&dashboardIDs); err != nil {
-			return err
-		}
-
-		// then find the dashboards that were supposed to be connected to this element.
-		// A identity may be able to delete a library element but not read all dashboards so we fetch then as the
-		// service user so we can prevent deletion of those connections
-		serviceCtx, serviceIdent := identity.WithServiceIdentity(c, signedInUser.GetOrgID())
-		dashs, err := l.dashboardsService.FindDashboards(serviceCtx, &dashboards.FindPersistedDashboardsQuery{
-			Type:         searchstore.TypeDashboard,
-			OrgId:        serviceIdent.GetOrgID(),
-			DashboardIds: dashboardIDs,
-			SignedInUser: serviceIdent,
-		})
-
+		// Check for connected dashboards via search, using a service identity so we see
+		// all dashboards regardless of the calling user's folder permissions
+		serviceCtx, _ := identity.WithServiceIdentity(c, signedInUser.GetOrgID())
+		connectedDashboards, err := l.dashboardsService.GetDashboardsByLibraryPanelUID(serviceCtx, uid, signedInUser.GetOrgID())
 		if err != nil {
 			return err
 		}
-
-		foundDashes := make([]int64, len(dashs))
-		for i, d := range dashs {
-			foundDashes[i] = d.ID
-		}
-
-		// delete any connections that are orphaned for this element (i.e. the dashboard was deleted)
-		session.Table("library_element_connection")
-		session.Where("element_id = ?", element.ID)
-		session.NotIn("connection_id", foundDashes)
-		if _, err = session.Delete(model.LibraryElementConnectionWithMeta{}); err != nil {
-			return err
-		}
-
-		// now try to delete the element, but fail if it is connected to any dashboards
-		var connectionIDs []struct {
-			ConnectionID int64 `xorm:"connection_id"`
-		}
-		sql := "SELECT connection_id FROM library_element_connection WHERE element_id=?"
-		if err := session.SQL(sql, element.ID).Find(&connectionIDs); err != nil {
-			return err
-		} else if len(connectionIDs) > 0 {
+		if len(connectedDashboards) > 0 {
 			return model.ErrLibraryElementHasConnections
 		}
 

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -80,7 +80,7 @@ func TestIntegration_DeleteLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When a non-admin user cannot see a connected dashboard, deletion should still be blocked",
 		func(t *testing.T, sc scenarioContext) {
 			// Downgrade user to Editor, so they can delete library panels but cannot see all folders/dashboards
-			sc.reqContext.SignedInUser.OrgRole = org.RoleEditor
+			sc.reqContext.OrgRole = org.RoleEditor
 
 			sc.dashboardSvc.On("GetDashboardsByLibraryPanelUID",
 				mock.MatchedBy(func(ctx context.Context) bool {

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -1,12 +1,14 @@
 package libraryelements
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -25,7 +27,7 @@ func TestIntegration_DeleteLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel that exists, it should succeed and return correct ID",
 		func(t *testing.T, sc scenarioContext) {
-			sc.dashboardSvc.On("FindDashboards", mock.Anything, mock.Anything).Return([]dashboards.DashboardSearchProjection{}, nil)
+			sc.dashboardSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, mock.Anything, mock.Anything).Return([]*dashboards.DashboardRef{}, nil)
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
@@ -48,29 +50,49 @@ func TestIntegration_DeleteLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel that is connected, it should fail",
 		func(t *testing.T, sc scenarioContext) {
-			sc.dashboardSvc.On("FindDashboards", mock.Anything, mock.Anything).Return([]dashboards.DashboardSearchProjection{
+			sc.dashboardSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, mock.Anything, mock.Anything).Return([]*dashboards.DashboardRef{
 				{
+					UID: "dash-1",
 					ID:  1,
-					UID: "test",
 				},
 			}, nil)
-			// nolint:staticcheck
-			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, 1)
-			require.NoError(t, err)
 
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 403, resp.Status())
 		})
 
-	scenarioWithPanel(t, "When an admin tries to delete a library panel that is connected to a non-existent dashboard, it should succeed",
+	scenarioWithPanel(t, "When an admin tries to delete a library panel with a stale connection table entry, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
-			sc.dashboardSvc.On("FindDashboards", mock.Anything, mock.Anything).Return([]dashboards.DashboardSearchProjection{}, nil)
+			// Write a stale row to library_element_connection (simulates pre-unified-storage state)
+			// nolint:staticcheck
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, 9999999)
 			require.NoError(t, err)
+
+			// The search service says there are no real connections — deletion should succeed
+			sc.dashboardSvc.On("GetDashboardsByLibraryPanelUID", mock.Anything, mock.Anything, mock.Anything).Return([]*dashboards.DashboardRef{}, nil)
 
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
+		})
+
+	scenarioWithPanel(t, "When a non-admin user cannot see a connected dashboard, deletion should still be blocked",
+		func(t *testing.T, sc scenarioContext) {
+			// Downgrade user to Editor, so they can delete library panels but cannot see all folders/dashboards
+			sc.reqContext.SignedInUser.OrgRole = org.RoleEditor
+
+			sc.dashboardSvc.On("GetDashboardsByLibraryPanelUID",
+				mock.MatchedBy(func(ctx context.Context) bool {
+					return identity.IsServiceIdentity(ctx)
+				}),
+				mock.Anything, mock.Anything,
+			).Return([]*dashboards.DashboardRef{
+				{UID: "hidden-dash", ID: 42},
+			}, nil)
+
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			resp := sc.service.deleteHandler(sc.reqContext)
+			require.Equal(t, 403, resp.Status())
 		})
 }


### PR DESCRIPTION
Previously, we would check the `library_element_connection` table, which was used before the migration to Unified Storage. If the user had a connection before the migration, removed if _after_, and then attempted to delete the library panel, the deletion would fail because of a supposed existing connection (i.e., an entry in `library_element_connection`).

In this PR, deletion uses the dashboard service to check for dashboards that reference the library panel, like the `/connections` endpoint already does at the moment.

Ticket: https://github.com/grafana/support-escalations/issues/21449