### PR TITLE
Dashboards: Use correct background color token

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -284,7 +284,7 @@ function getStyles(theme: GrafanaTheme2, isEditing: boolean | undefined) {
       gap: theme.spacing(2),
       paddingTop: theme.spacing(1),
       paddingBottom: theme.spacing(2),
-      background: theme.colors.action.selected,
+      background: theme.colors.background.secondary,
       borderBottom: `1px solid ${theme.colors.border.medium}`,
       borderTopLeftRadius: theme.shape.radius.default,
       borderTopRightRadius: theme.shape.radius.default,


### PR DESCRIPTION
My PR review comment must have been missed https://github.com/grafana/grafana/pull/121633 

The action.selected is not to be used for backgrounds like this, it's a special menu item color token for that is designed to stand out against secondary background. 

Before: 
<img width="448" height="469" alt="Screenshot 2026-04-02 at 07 44 49" src="https://github.com/user-attachments/assets/b3594023-f3dc-4135-acc8-af1d6df29f25" />

After: 
<img width="408" height="470" alt="Screenshot 2026-04-02 at 07 44 55" src="https://github.com/user-attachments/assets/99850923-67c3-4beb-ba63-1aa27bb93080" />


## Problem with light theme

I do not think the original design change considered the light theme, and so I think we have to rollback this change in full (for both light and dark theme) as there are big Issues with light theme no matter if we use action.selected and background.secondary. @Ijin08 

<img width="579" height="572" alt="Screenshot 2026-04-02 at 07 46 06" src="https://github.com/user-attachments/assets/cfb2b514-2250-4425-9035-db59d82ae010" />
<img width="595" height="497" alt="Screenshot 2026-04-02 at 07 46 10" src="https://github.com/user-attachments/assets/27df4e70-101e-451a-ad6d-6305155105f2" />
