### PR TITLE
Dynamic dashboards: revert edit sidebar buttons color change

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -284,7 +284,6 @@ function getStyles(theme: GrafanaTheme2, isEditing: boolean | undefined) {
       gap: theme.spacing(2),
       paddingTop: theme.spacing(1),
       paddingBottom: theme.spacing(2),
-      background: theme.colors.action.selected,
       borderBottom: `1px solid ${theme.colors.border.medium}`,
       borderTopLeftRadius: theme.shape.radius.default,
       borderTopRightRadius: theme.shape.radius.default,


### PR DESCRIPTION
**What is this feature?**

The background color change for the edit buttons were made to highlight the edit buttons when in edit mode. Unfortunately when using light theme it had the opposite effect, downplaying the edit buttons. This PR reverts the background color while keeping the delimiter between the edit and view buttons. 