### PR TITLE
Dashboard Import: Move permissions copying

### DIFF
--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -86,6 +86,11 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
     // and the api server will throw an error
     delete obj.metadata.resourceVersion;
 
+    obj.metadata.annotations = {
+      ...obj.metadata.annotations,
+      [AnnoKeyGrantPermissions]: 'default',
+    };
+
     // for v1 in g12, we will ignore the schema version validation from all default clients,
     // as we implement the necessary backend conversions, we will drop this query param
     if (dashboard.uid) {
@@ -94,10 +99,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
 
       return this.client.update(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
     }
-    obj.metadata.annotations = {
-      ...obj.metadata.annotations,
-      [AnnoKeyGrantPermissions]: 'default',
-    };
+
     // non-scene dashboard will have obj.metadata.name when trying to save a dashboard copy
     delete obj.metadata.name;
     // on create, always clear the id to prevent duplicate ids


### PR DESCRIPTION

[The escalation](https://github.com/grafana/support-escalations/issues/21410) concerns incorrect permissions when importing a v1 dashboard - the Editor role cannot access the dashboard after importing
I managed to trace it to [this line](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/api/v1.ts#L99) introduced by [this change](https://github.com/grafana/grafana/pull/102527. It should be adding default permissions, but is never reached because the dashboard has uid (so it gets returned early in the block above). 

I just moved the block above the condition