### PR TITLE
chore: Fix flaky TestServer_Run_Error

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -23,17 +23,26 @@ type testService struct {
 	started    chan struct{}
 	runErr     error
 	isDisabled bool
+	dependsOn  *boomService
 }
 
-func newTestService(runErr error, disabled bool) *testService {
+func newTestService(runErr error, disabled bool, dependsOn *boomService) *testService {
 	return &testService{
 		started:    make(chan struct{}),
 		runErr:     runErr,
 		isDisabled: disabled,
+		dependsOn:  dependsOn,
 	}
 }
 
 func (s *testService) Run(ctx context.Context) error {
+	if s.dependsOn != nil {
+		select {
+		case <-s.dependsOn.started:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	if s.isDisabled {
 		return fmt.Errorf("Shouldn't run disabled service")
 	}
@@ -48,6 +57,34 @@ func (s *testService) Run(ctx context.Context) error {
 
 func (s *testService) IsDisabled() bool {
 	return s.isDisabled
+}
+
+type boomService struct {
+	started chan struct{}
+	runErr  error
+}
+
+func newBoomService(runErr error) *boomService {
+	return &boomService{
+		started: make(chan struct{}),
+		runErr:  runErr,
+	}
+}
+
+func (s *boomService) Run(ctx context.Context) error {
+	if s.runErr != nil {
+		// Unblock testService (and any other waiters on started) before failing; otherwise
+		// testService.Run would wait forever on <-dependsOn.started.
+		close(s.started)
+		return s.runErr
+	}
+	close(s.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *boomService) IsDisabled() bool {
+	return false
 }
 
 func testServer(t *testing.T, services ...registry.BackgroundService) *Server {
@@ -65,8 +102,14 @@ func testServer(t *testing.T, services ...registry.BackgroundService) *Server {
 }
 
 func TestServer_Run_Error(t *testing.T) {
+	// Two services use different concrete types (*testService vs *boomService) so dskit gets two
+	// module names; two *testService values would share one name and overwrite each other.
+	//
+	// testService waits on boom.started before running so boom is ordered before the stable
+	// sibling in practice, avoiding flaky lifecycle errors when a peer fails during its startup.
 	testErr := errors.New("boom")
-	s := testServer(t, newTestService(nil, false), newTestService(testErr, false))
+	boom := newBoomService(testErr)
+	s := testServer(t, newTestService(nil, false, boom), boom)
 	err := s.Run()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), testErr.Error())
@@ -75,7 +118,8 @@ func TestServer_Run_Error(t *testing.T) {
 func TestServer_Shutdown(t *testing.T) {
 	t.Run("successful shutdown", func(t *testing.T) {
 		ctx := context.Background()
-		s := testServer(t, newTestService(nil, false), newTestService(nil, true))
+		// boomService and *testService must not share the same reflect type name (dskit module key).
+		s := testServer(t, newBoomService(nil), newTestService(nil, true, nil))
 		ch := make(chan error)
 		go func() {
 			defer close(ch)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -87,6 +87,17 @@ func (s *boomService) IsDisabled() bool {
 	return false
 }
 
+// shutdownDisabledBGTestService is skipped by the adapter (Shutdown test only; distinct dskit module name).
+type shutdownDisabledBGTestService struct{}
+
+func (shutdownDisabledBGTestService) Run(ctx context.Context) error {
+	return fmt.Errorf("Shouldn't run disabled service")
+}
+
+func (shutdownDisabledBGTestService) IsDisabled() bool {
+	return true
+}
+
 func testServer(t *testing.T, services ...registry.BackgroundService) *Server {
 	t.Helper()
 	s, err := newServer(Options{}, setting.NewCfg(), nil, &acimpl.Service{}, nil, backgroundsvcs.NewBackgroundServiceRegistry(services...), tracing.NewNoopTracerService(), featuremgmt.WithFeatures(), prometheus.NewRegistry())
@@ -118,8 +129,8 @@ func TestServer_Run_Error(t *testing.T) {
 func TestServer_Shutdown(t *testing.T) {
 	t.Run("successful shutdown", func(t *testing.T) {
 		ctx := context.Background()
-		// boomService and *testService must not share the same reflect type name (dskit module key).
-		s := testServer(t, newBoomService(nil), newTestService(nil, true, nil))
+		// Dedicated types so dskit module names differ (*testService vs shutdownDisabledBGTestService).
+		s := testServer(t, newTestService(nil, false, nil), shutdownDisabledBGTestService{})
 		ch := make(chan error)
 		go func() {
 			defer close(ch)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This pull request improves the reliability of the `TestServer_Run_Error` test by introducing a mechanism to coordinate the timing of service failures, preventing race conditions during test execution. The main changes involve adding a new test helper to delay a service's failure until its peer is fully running, and updating the test to use this helper.

**Why do we need this feature?**

Fixes the flakiness; this test registers two services: one that blocks on ctx and one that immediately returns "boom". The module manager used to start them in parallel. Depending on order, the fast failure can tear down the graph while the other service is still Starting / Running, so dskit reports lifecycle errors (invalid service state: Stopping, expected: Running, etc.) instead of the expected boom error.

these test was introduced before introducing dskit usage that changed how services are starting