### PR TITLE
Dynamic Dashboards: Fix sidebar delimiter color

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -284,7 +284,7 @@ function getStyles(theme: GrafanaTheme2, isEditing: boolean | undefined) {
       gap: theme.spacing(2),
       paddingTop: theme.spacing(1),
       paddingBottom: theme.spacing(2),
-      borderBottom: `1px solid ${theme.colors.border.medium}`,
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
       borderTopLeftRadius: theme.shape.radius.default,
       borderTopRightRadius: theme.shape.radius.default,
     }),


### PR DESCRIPTION
**What is this feature?**
Fixes the delimiter color so it matches the rest of the border.

<img width="60" height="270" alt="image" src="https://github.com/user-attachments/assets/af1fc739-86aa-422e-86f7-53d597bab486" />
