### PR TITLE
Provisioning: fix child folder creation on new branch with folder metadata

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -180,6 +180,12 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 		err = safepath.Walk(ctx, opts.Path, func(ctx context.Context, segPath string) error {
 			folderPath := segPath + "/"
 			existing, _, readErr := ReadFolderMetadata(ctx, r.repo, folderPath, opts.Ref)
+			if errors.Is(readErr, repository.ErrRefNotFound) {
+				// The target branch doesn't exist yet — it will be created from the
+				// configured branch by repo.Create. Check the configured branch so
+				// we know whether the file already exists in the tree we'll inherit.
+				existing, _, readErr = ReadFolderMetadata(ctx, r.repo, folderPath, "")
+			}
 			if readErr == nil {
 				if segPath == leafPath {
 					return apierrors.NewAlreadyExists(
@@ -191,7 +197,7 @@ func (r *DualReadWriter) CreateFolder(ctx context.Context, opts DualWriteOptions
 				stableUID = existing.Name
 				return nil
 			}
-			if !errors.Is(readErr, repository.ErrFileNotFound) && !errors.Is(readErr, repository.ErrRefNotFound) {
+			if !errors.Is(readErr, repository.ErrFileNotFound) {
 				return fmt.Errorf("failed to read folder metadata for %q: %w", folderPath, readErr)
 			}
 			// Not found: write a new folder metadata file

--- a/pkg/registry/apis/provisioning/resources/dualwriter_test.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter_test.go
@@ -456,7 +456,7 @@ func TestCreateFolder(t *testing.T) {
 			errContains: "failed to read folder metadata",
 		},
 		{
-			name: "flag enabled: ref not found is treated as file not found (new branch)",
+			name: "flag enabled: ref not found falls back to configured branch, file not found → creates on new branch",
 			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
 				config := &provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
@@ -468,7 +468,10 @@ func TestCreateFolder(t *testing.T) {
 				}
 				rw := repository.NewMockReaderWriter(t)
 				rw.On("Config").Return(config)
+				// First read targets the new branch → branch doesn't exist
 				rw.On("Read", mock.Anything, "newfolder/_folder.json", "new-branch").Return(nil, repository.ErrRefNotFound)
+				// Fallback read targets the configured branch → file not found either
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").Return(nil, repository.ErrFileNotFound)
 				rw.On("Create", mock.Anything, "newfolder/_folder.json", "new-branch", mock.MatchedBy(func(b []byte) bool {
 					var res folders.Folder
 					if err := json.Unmarshal(b, &res); err != nil {
@@ -488,6 +491,78 @@ func TestCreateFolder(t *testing.T) {
 			check: func(t *testing.T, result *provisioning.ResourceWrapper) {
 				assert.Equal(t, "newfolder/", result.Path)
 				assert.Equal(t, "new-branch", result.Ref)
+			},
+		},
+		{
+			name: "flag enabled: ref not found falls back to configured branch, file exists → reuses UID for ancestor",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				config := &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+					Spec: provisioning.RepositorySpec{
+						Type:      provisioning.GitRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow, provisioning.BranchWorkflow},
+						Sync:      provisioning.SyncOptions{Enabled: false},
+					},
+				}
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(config)
+
+				// Parent: branch doesn't exist → fallback to configured branch → found
+				existingParent := NewFolderManifest("parent-uid-on-main", "parent", FolderKind)
+				existingData, _ := json.Marshal(existingParent)
+				rw.On("Read", mock.Anything, "parent/_folder.json", "new-branch").Return(nil, repository.ErrRefNotFound)
+				rw.On("Read", mock.Anything, "parent/_folder.json", "").
+					Return(&repository.FileInfo{Data: existingData}, nil)
+
+				// Child (leaf): branch doesn't exist → fallback → not found → create
+				rw.On("Read", mock.Anything, "parent/child/_folder.json", "new-branch").Return(nil, repository.ErrRefNotFound)
+				rw.On("Read", mock.Anything, "parent/child/_folder.json", "").Return(nil, repository.ErrFileNotFound)
+				rw.On("Create", mock.Anything, "parent/child/_folder.json", "new-branch", mock.MatchedBy(func(b []byte) bool {
+					var f folders.Folder
+					return json.Unmarshal(b, &f) == nil && f.Name != "" && f.Spec.Title == "child"
+				}), "").Return(nil)
+
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind)
+				dw := &DualReadWriter{repo: rw, authorizer: NewAuthorizer(config, rw, accessMock, false), folderMetadataEnabled: true, folders: fm}
+				return dw, DualWriteOptions{Path: "parent/child/", Ref: "new-branch"}
+			},
+			check: func(t *testing.T, result *provisioning.ResourceWrapper) {
+				assert.Equal(t, "parent/child/", result.Path)
+				assert.Equal(t, "new-branch", result.Ref)
+			},
+		},
+		{
+			name: "flag enabled: ref not found falls back to configured branch, leaf exists → AlreadyExists",
+			setup: func(t *testing.T) (*DualReadWriter, DualWriteOptions) {
+				config := &provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+					Spec: provisioning.RepositorySpec{
+						Type:      provisioning.GitRepositoryType,
+						Workflows: []provisioning.Workflow{provisioning.WriteWorkflow, provisioning.BranchWorkflow},
+						Sync:      provisioning.SyncOptions{Enabled: false},
+					},
+				}
+				rw := repository.NewMockReaderWriter(t)
+				rw.On("Config").Return(config)
+
+				// Leaf: branch doesn't exist → fallback to configured branch → found
+				existingLeaf := NewFolderManifest("leaf-uid-on-main", "newfolder", FolderKind)
+				existingData, _ := json.Marshal(existingLeaf)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "new-branch").Return(nil, repository.ErrRefNotFound)
+				rw.On("Read", mock.Anything, "newfolder/_folder.json", "").
+					Return(&repository.FileInfo{Data: existingData}, nil)
+
+				accessMock := auth.NewMockAccessChecker(t)
+				accessMock.On("Check", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				fm := NewFolderManager(rw, nil, NewEmptyFolderTree(), FolderKind)
+				dw := &DualReadWriter{repo: rw, authorizer: NewAuthorizer(config, rw, accessMock, false), folderMetadataEnabled: true, folders: fm}
+				return dw, DualWriteOptions{Path: "newfolder/", Ref: "new-branch"}
+			},
+			wantErr: true,
+			errCheck: func(t *testing.T, err error) {
+				assert.True(t, apierrors.IsAlreadyExists(err), "expected AlreadyExists, got: %v", err)
 			},
 		},
 		{

--- a/pkg/tests/apis/provisioning/foldermetadata/create_folder_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/create_folder_git_test.go
@@ -90,6 +90,53 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Do(ctx)
 		require.NoError(t, result.Error(), "child _folder.json should exist on the branch")
 	})
+
+	t.Run("create nested folder on new branch reuses ancestor metadata from default branch", func(t *testing.T) {
+		// First, create a parent folder on the default branch so it has _folder.json.
+		resp := postFolderViaFilesAPI(t, helper, repoName, "existing-parent/", "", "Create parent on default branch")
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating parent on default branch should succeed: %s", string(body))
+
+		// Read the parent UID from the default branch.
+		result := helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "existing-parent", "_folder.json").
+			Do(ctx)
+		require.NoError(t, result.Error(), "parent _folder.json should exist on default branch")
+
+		// Now create a child inside that parent on a NEW branch.
+		// This is the scenario that previously failed with "file already exists" because
+		// the code tried to re-create parent/_folder.json on the new branch even though
+		// it already existed on the default branch (which the new branch inherits from).
+		branchName := "branch-with-existing-parent"
+		resp = postFolderViaFilesAPI(t, helper, repoName, "existing-parent/new-child/", branchName, "Create child on new branch")
+		body, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "creating child under existing parent on new branch should succeed: %s", string(body))
+
+		// Verify the child _folder.json was created on the branch.
+		result = helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "existing-parent", "new-child", "_folder.json").
+			Param("ref", branchName).
+			Do(ctx)
+		require.NoError(t, result.Error(), "child _folder.json should exist on the branch")
+
+		// Verify the parent _folder.json is still readable on the branch (inherited from default).
+		result = helper.AdminREST.Get().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("files", "existing-parent", "_folder.json").
+			Param("ref", branchName).
+			Do(ctx)
+		require.NoError(t, result.Error(), "parent _folder.json should be readable on the branch (inherited)")
+	})
 }
 
 // postFolderViaFilesAPI makes a raw HTTP POST to the files endpoint to create a folder.


### PR DESCRIPTION
## What

  Fixes a bug where creating a nested folder on a **new branch** intermittently failed with `"file already exists"` when an ancestor folder already had `_folder.json` on the configured branch.

  ## Why

This issue was introduced in https://github.com/grafana/grafana/pull/121053, which fixed a `"ref not found"` error when creating folders on a new branch by treating `ErrRefNotFound` (branch doesn't exist) the same as `ErrFileNotFound` (file doesn't exist) — both falling through to `WriteFolderMetadata` → `repo.Create`. 
However, this conflated two different semantics:

  - `ErrFileNotFound`: the branch exists but the file isn't there — safe to create.
  - `ErrRefNotFound`: the branch doesn't exist yet — `repo.Create` will create it from the configured branch via `ensureBranchExists`, **inheriting all its files**.

  When the configured branch already contains `_folder.json` for an ancestor folder, the new branch inherits that file. `CreateBlob` then finds it in the tree and fails with `ErrObjectAlreadyExists`.

  ## How

  When `ReadFolderMetadata` returns `ErrRefNotFound`, fall back to reading from the configured branch first. If the file exists there, reuse its UID (for ancestors) or return `AlreadyExists` (for the leaf) — exactly as if the branch already existed. Only proceed to create when the file is absent from both the target ref and the configured branch.

  ## Test plan

  - [x] Updated existing unit test for `ErrRefNotFound` handling to include fallback read
  - [x] Added unit test: ancestor `_folder.json` exists on configured branch → reuses UID on new branch
  - [x] Added unit test: leaf `_folder.json` exists on configured branch → returns `AlreadyExists`
  - [x] Added integration test: create parent on default branch, then create nested child on new branch → succeeds and both `_folder.json` files are readable on the branch
  - [x] Manual: create a folder on default branch, then create a child folder inside it on a new branch — should succeed on first attempt

  Fixes https://github.com/grafana/git-ui-sync-project/issues/1052