### PR TITLE
DynamicDashboards: Confirm delete variables, annotations queries and links

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-custom-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-custom-variables.spec.ts
@@ -165,6 +165,7 @@ test.describe(
 
       // check that variable deletion works
       await dashboardPage.getByGrafanaSelector(selectors.components.EditPaneHeader.deleteButton).click();
+      await dashboardPage.getByGrafanaSelector(selectors.pages.ConfirmModal.delete).click();
       await expect(variableLabel).toBeHidden();
     });
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -154,11 +154,6 @@ export class RowItem
       return;
     }
 
-    if (this.getParentLayout().shouldUngroup()) {
-      this.onDelete();
-      return;
-    }
-
     appEvents.publish(
       new ShowConfirmModalEvent({
         title: t('dashboard.rows-layout.delete-row-title', 'Delete row?'),

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -159,10 +159,6 @@ export class RowsLayoutManager
     this.addNewRow(row);
   }
 
-  public shouldUngroup(): boolean {
-    return this.state.rows.length === 1;
-  }
-
   public getOutlineChildren() {
     const outlineChildren: SceneObject[] = [];
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -150,13 +150,6 @@ export class TabItem
   }
 
   public onConfirmDelete() {
-    const layout = this.getParentLayout();
-
-    if (layout.shouldUngroup()) {
-      layout.removeTab(this);
-      return;
-    }
-
     if (this.getLayout().getVizPanels().length === 0) {
       this.onDelete();
       return;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -232,10 +232,6 @@ export class TabsLayoutManager
     this.addNewTab(tab);
   }
 
-  public shouldUngroup(): boolean {
-    return this.state.tabs.length === 1;
-  }
-
   public convertAllGridLayouts(gridLayoutType: GridLayoutType) {
     for (const tab of this.state.tabs) {
       switch (gridLayoutType) {

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationEditableElement.tsx
@@ -2,8 +2,10 @@ import { useId, useMemo } from 'react';
 
 import { t } from '@grafana/i18n';
 import { type dataLayers } from '@grafana/scenes';
+import { appEvents } from 'app/core/app_events';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { type DashboardAnnotationsDataLayer } from '../../scene/DashboardAnnotationsDataLayer';
 import { DashboardDataLayerSet } from '../../scene/DashboardDataLayerSet';
@@ -119,6 +121,24 @@ export class AnnotationEditableElement implements EditableDashboardElement {
         name: `${this.layer.state.name} - Copy`,
       }),
     });
+  }
+
+  public onConfirmDelete() {
+    const name = this.layer.state.name;
+    appEvents.publish(
+      new ShowConfirmModalEvent({
+        title: t('dashboard-scene.annotation-editable-element.delete-title', 'Delete annotation query'),
+        text: t(
+          'dashboard-scene.annotation-editable-element.delete-text',
+          'Are you sure you want to delete: {{name}}?',
+          { name }
+        ),
+        yesText: t('dashboard-scene.annotation-editable-element.delete-confirm', 'Delete annotation query'),
+        onConfirm: () => {
+          this.onDelete();
+        },
+      })
+    );
   }
 
   public onDelete() {

--- a/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.tsx
@@ -3,8 +3,10 @@ import { useId, useMemo } from 'react';
 import { t } from '@grafana/i18n';
 import { SceneObjectBase, type SceneObjectRef, type SceneObjectState } from '@grafana/scenes';
 import type { DashboardLink } from '@grafana/schema';
+import { appEvents } from 'app/core/app_events';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
 import {
@@ -217,6 +219,25 @@ export class LinkEditEditableElement implements EditableDashboardElement {
 
     linkEditActions.addLink({ dashboard, link, addedObject: linkEdit });
     openLinkEditPane(dashboard, links.length);
+  }
+
+  public onConfirmDelete(): void {
+    const dashboard = this.linkEdit.state.dashboardRef.resolve();
+    const links = dashboard.state.links ?? [];
+    const link = links[this.linkEdit.state.linkIndex];
+    const name = link?.title ?? t('dashboard-scene.link-editable-element.unnamed', 'Unnamed link');
+    appEvents.publish(
+      new ShowConfirmModalEvent({
+        title: t('dashboard-scene.link-editable-element.delete-title', 'Delete link'),
+        text: t('dashboard-scene.link-editable-element.delete-text', 'Are you sure you want to delete: {{name}}?', {
+          name,
+        }),
+        yesText: t('dashboard-scene.link-editable-element.delete-confirm', 'Delete link'),
+        onConfirm: () => {
+          this.onDelete();
+        },
+      })
+    );
   }
 
   public onDelete(): void {

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -13,8 +13,10 @@ import {
   useSceneObjectState,
 } from '@grafana/scenes';
 import { Input, TextArea, Button, Field, Box, Stack, Alert } from '@grafana/ui';
+import { appEvents } from 'app/core/app_events';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardScene } from '../../scene/DashboardScene';
@@ -142,6 +144,22 @@ export class VariableEditableElement implements EditableDashboardElement, BulkAc
       }),
     });
     DashboardInteractions.variableActionButtonClicked('duplicate', { type: this.variable.state.type });
+  }
+
+  public onConfirmDelete() {
+    const name = this.variable.state.name;
+    appEvents.publish(
+      new ShowConfirmModalEvent({
+        title: t('dashboard-scene.variable-editable-element.delete-title', 'Delete variable'),
+        text: t('dashboard-scene.variable-editable-element.delete-text', 'Are you sure you want to delete: {{name}}?', {
+          name,
+        }),
+        yesText: t('dashboard-scene.variable-editable-element.delete-confirm', 'Delete variable'),
+        onConfirm: () => {
+          this.onDelete();
+        },
+      })
+    );
   }
 
   public onDelete() {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6769,6 +6769,11 @@
         "change-annotation-panel-filter": "Change annotation panel filter"
       }
     },
+    "annotation-editable-element": {
+      "delete-confirm": "Delete annotation query",
+      "delete-text": "Are you sure you want to delete: {{name}}?",
+      "delete-title": "Delete annotation query"
+    },
     "annotation-list": {
       "create-drag-end-handler": {
         "description": {
@@ -7184,6 +7189,12 @@
       "add-link": "Add link",
       "remove-link": "Remove link",
       "update-link": "Update link"
+    },
+    "link-editable-element": {
+      "delete-confirm": "Delete link",
+      "delete-text": "Are you sure you want to delete: {{name}}?",
+      "delete-title": "Delete link",
+      "unnamed": "Unnamed link"
     },
     "link-list": {
       "create-drag-end-handler": {
@@ -7635,6 +7646,11 @@
           "label": "Above dashboard, label hidden"
         }
       }
+    },
+    "variable-editable-element": {
+      "delete-confirm": "Delete variable",
+      "delete-text": "Are you sure you want to delete: {{name}}?",
+      "delete-title": "Delete variable"
     },
     "variable-editor-form": {
       "aria-label-variable-editor-form": "Variable editor form",


### PR DESCRIPTION
**What is this feature?**

Adds confirmations for deleting variables, annotation queries and links using the trashcan icon in the sidebar.

The delete button already prefer `onConfirmDelete` if it's present on the object, so all we need to do is add the function.

Not 100% sure about the colon. It's there because it's there in the confirmation when deleting variables from dashboard settings.

<img width="1124" height="586" alt="image" src="https://github.com/user-attachments/assets/6e115b8a-4949-4b9a-98b7-e5369be4e75b" />


Fixes #121735
