### PR TITLE
Folders: Fix double-slash URL for non-Latin folder titles

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -17,6 +17,7 @@ import {
   useDeleteMultipleFoldersMutationFacade,
   useMoveMultipleFoldersMutationFacade,
   getFolderByUidFacade,
+  getFolderUrl,
 } from './hooks';
 import { setupCreateFolder, setupUpdateFolder } from './test-utils';
 
@@ -328,5 +329,51 @@ describe('getFolderByUidFacade', () => {
       .mockResolvedValueOnce({ data: undefined });
 
     await expect(getFolderByUidFacade('some-folder-uid')).rejects.toThrow('One of the folder responses is undefined');
+  });
+});
+
+describe('getFolderUrl', () => {
+  const originalAppSubUrl = String(config.appSubUrl);
+
+  beforeEach(() => {
+    config.appSubUrl = '/grafana';
+  });
+
+  afterEach(() => {
+    config.appSubUrl = originalAppSubUrl;
+  });
+
+  it('returns a slug derived from a Latin title', () => {
+    expect(getFolderUrl('abc123', 'My Folder')).toBe('/grafana/dashboards/f/abc123/my-folder');
+  });
+
+  it('falls back to uid when title is CJK-only', () => {
+    expect(getFolderUrl('abc123', 'テストフォルダ')).toBe('/grafana/dashboards/f/abc123/abc123');
+  });
+
+  it('falls back to uid when title is Cyrillic-only', () => {
+    expect(getFolderUrl('abc123', 'Тест')).toBe('/grafana/dashboards/f/abc123/abc123');
+  });
+
+  it('falls back to uid when title is Arabic-only', () => {
+    expect(getFolderUrl('abc123', 'مجلد')).toBe('/grafana/dashboards/f/abc123/abc123');
+  });
+
+  it('uses the Latin portion of a mixed title', () => {
+    expect(getFolderUrl('abc123', 'テスト Folder')).toBe('/grafana/dashboards/f/abc123/folder');
+  });
+
+  it('falls back to uid when title is empty', () => {
+    expect(getFolderUrl('abc123', '')).toBe('/grafana/dashboards/f/abc123/abc123');
+  });
+
+  it('respects appSubUrl', () => {
+    config.appSubUrl = '/custom';
+    expect(getFolderUrl('uid1', 'Test')).toBe('/custom/dashboards/f/uid1/test');
+  });
+
+  it('works with empty appSubUrl', () => {
+    config.appSubUrl = '';
+    expect(getFolderUrl('uid1', 'Test')).toBe('/dashboards/f/uid1/test');
   });
 });

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -66,11 +66,11 @@ import {
   type OwnerReference,
 } from './index';
 
-function getFolderUrl(uid: string, title: string): string {
-  // mimics https://github.com/grafana/grafana/blob/79fe8a9902335c7a28af30e467b904a4ccfac503/pkg/services/dashboards/models.go#L188
-  // Not the same slugify as on the backend https://github.com/grafana/grafana/blob/aac66e91198004bc044754105e18bfff8fbfd383/pkg/infra/slugify/slugify.go#L86
-  // Probably does not matter as it seems to be only for better human readability.
-  const slug = kbn.slugifyForUrl(title);
+export function getFolderUrl(uid: string, title: string): string {
+  // slugifyForUrl strips non-ASCII characters, so for titles composed entirely of non-Latin
+  // characters (CJK, Cyrillic, Arabic, etc.) the slug is empty. Fall back to uid to avoid
+  // double-slash URLs that break route matching.
+  const slug = kbn.slugifyForUrl(title).replace(/^-+|-+$/g, '') || uid;
   return `${config.appSubUrl}/dashboards/f/${uid}/${slug}`;
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds a `|| uid` fallback to `getFolderUrl` so that non-Latin folder titles (CJK, Cyrillic, Arabic, etc.) produce valid URLs instead of double-slash paths that break route matching.

**Why do we need this feature?**

`kbn.slugifyForUrl` uses `\w` (ASCII-only), so titles composed entirely of non-Latin characters produce an empty slug. This results in URLs like `/dashboards/f/uid//` which break frontend route matching when `foldersAppPlatformAPI` is enabled.