### PR TITLE
Dashboard: Fix panels being lost when dropped between tab headers

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
@@ -84,6 +84,94 @@ describe('DashboardLayoutOrchestrator', () => {
       });
     });
 
+    it('should cancel drop when panel is released between tab headers (not detached)', () => {
+      const { orchestrator, tab1Manager, gridItem, tabsManager, tab1 } = setupWithTwoTabs();
+
+      orchestrator.setState({
+        draggingGridItem: gridItem.getRef(),
+        sourceTabKey: tab1.state.key,
+      });
+
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._sourceDropTarget = tab1Manager;
+      // Cursor moved between tab headers so _lastDropTarget is the TabsLayoutManager
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._lastDropTarget = tabsManager;
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._itemDetachedFromSource = false;
+
+      expect(tab1Manager.state.layout.state.children).toHaveLength(1);
+
+      // @ts-expect-error - accessing private method for testing
+      const originalGetDropTargetUnderMouse = orchestrator._getDropTargetUnderMouse;
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = jest.fn().mockReturnValue(tabsManager);
+
+      const mockEvent = { clientX: 100, clientY: 100 } as PointerEvent;
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._stopDraggingSync(mockEvent);
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = originalGetDropTargetUnderMouse;
+
+      // Panel should still be in Tab 1 (drop was cancelled)
+      expect(tab1Manager.state.layout.state.children).toHaveLength(1);
+      expect(tab1Manager.state.layout.state.children[0]).toBe(gridItem);
+    });
+
+    it('should return panel to source when dropped between tab headers after detach', () => {
+      const { orchestrator, tab1Manager, tab2Manager, gridItem, tabsManager, tab1 } = setupWithTwoTabs();
+
+      orchestrator.setState({
+        draggingGridItem: gridItem.getRef(),
+        sourceTabKey: tab1.state.key,
+      });
+
+      const tab2 = tabsManager.state.tabs[1];
+
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._sourceDropTarget = tab1Manager;
+      // Cursor moved between tab headers so _lastDropTarget is the TabsLayoutManager
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._lastDropTarget = tabsManager;
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._itemDetachedFromSource = true;
+
+      // Simulate the item being removed from source (as happens during tab switch)
+      tab1Manager.draggedGridItemOutside(gridItem);
+      tabsManager.switchToTab(tab2);
+
+      expect(tab1Manager.state.layout.state.children).toHaveLength(0);
+      expect(tab2Manager.state.layout.state.children).toHaveLength(0);
+
+      // @ts-expect-error - accessing private method for testing
+      const originalGetDropTargetUnderMouse = orchestrator._getDropTargetUnderMouse;
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = jest.fn().mockReturnValue(tabsManager);
+
+      const mockEvent = { clientX: 100, clientY: 100 } as PointerEvent;
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._stopDraggingSync(mockEvent);
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = originalGetDropTargetUnderMouse;
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          // Panel should be returned to source (Tab 1)
+          expect(tab1Manager.state.layout.state.children).toHaveLength(1);
+          expect(tab1Manager.state.layout.state.children[0]).toBe(gridItem);
+
+          // Tab 2 should remain empty
+          expect(tab2Manager.state.layout.state.children).toHaveLength(0);
+
+          resolve();
+        }, 0);
+      });
+    });
+
     it('should complete normal drop when valid drop target exists', () => {
       const { orchestrator, tab1Manager, tab2Manager, gridItem, tab1 } = setupWithTwoTabs();
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
@@ -172,6 +172,68 @@ describe('DashboardLayoutOrchestrator', () => {
       });
     });
 
+    it('should return panel to its original position when drag is cancelled after detach', () => {
+      const { orchestrator, tab1Manager, tab2Manager, gridItem, tabsManager, tab1 } = setupWithTwoTabs();
+
+      // Add more panels to tab1: [itemBefore, gridItem, itemAfter]
+      const panelBefore = new VizPanel({ title: 'Before', key: 'panel-before', pluginId: 'table' });
+      const panelAfter = new VizPanel({ title: 'After', key: 'panel-after', pluginId: 'table' });
+      const itemBefore = new AutoGridItem({ key: 'item-before', body: panelBefore });
+      const itemAfter = new AutoGridItem({ key: 'item-after', body: panelAfter });
+
+      tab1Manager.state.layout.setState({ children: [itemBefore, gridItem, itemAfter] });
+      expect(tab1Manager.state.layout.state.children[1]).toBe(gridItem);
+
+      orchestrator.setState({
+        draggingGridItem: gridItem.getRef(),
+        sourceTabKey: tab1.state.key,
+      });
+
+      const tab2 = tabsManager.state.tabs[1];
+
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._sourceDropTarget = tab1Manager;
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._lastDropTarget = tabsManager;
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._itemDetachedFromSource = true;
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._sourceOriginalIndex = 1;
+
+      tab1Manager.draggedGridItemOutside(gridItem);
+      tabsManager.switchToTab(tab2);
+
+      expect(tab1Manager.state.layout.state.children).toHaveLength(2);
+      expect(tab2Manager.state.layout.state.children).toHaveLength(0);
+
+      // @ts-expect-error - accessing private method for testing
+      const originalGetDropTargetUnderMouse = orchestrator._getDropTargetUnderMouse;
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = jest.fn().mockReturnValue(tabsManager);
+
+      const mockEvent = { clientX: 100, clientY: 100 } as PointerEvent;
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._stopDraggingSync(mockEvent);
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = originalGetDropTargetUnderMouse;
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          const children = tab1Manager.state.layout.state.children;
+          expect(children).toHaveLength(3);
+          expect(children[0]).toBe(itemBefore);
+          expect(children[1]).toBe(gridItem);
+          expect(children[2]).toBe(itemAfter);
+
+          expect(tab2Manager.state.layout.state.children).toHaveLength(0);
+
+          resolve();
+        }, 0);
+      });
+    });
+
     it('should not cancel drop when lastDropTarget is stale TabsLayoutManager but mouse is over valid target', () => {
       const { orchestrator, tab1Manager, tab2Manager, gridItem, tabsManager, tab1 } = setupWithTwoTabs();
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
@@ -94,7 +94,6 @@ describe('DashboardLayoutOrchestrator', () => {
 
       // @ts-expect-error - accessing private property for testing
       orchestrator._sourceDropTarget = tab1Manager;
-      // Cursor moved between tab headers so _lastDropTarget is the TabsLayoutManager
       // @ts-expect-error - accessing private property for testing
       orchestrator._lastDropTarget = tabsManager;
       // @ts-expect-error - accessing private property for testing
@@ -104,8 +103,9 @@ describe('DashboardLayoutOrchestrator', () => {
 
       // @ts-expect-error - accessing private method for testing
       const originalGetDropTargetUnderMouse = orchestrator._getDropTargetUnderMouse;
+      // No valid target under mouse — fallback to lastDropTarget (TabsLayoutManager)
       // @ts-expect-error - accessing private method for testing
-      orchestrator._getDropTargetUnderMouse = jest.fn().mockReturnValue(tabsManager);
+      orchestrator._getDropTargetUnderMouse = jest.fn().mockReturnValue(null);
 
       const mockEvent = { clientX: 100, clientY: 100 } as PointerEvent;
 
@@ -167,6 +167,48 @@ describe('DashboardLayoutOrchestrator', () => {
           // Tab 2 should remain empty
           expect(tab2Manager.state.layout.state.children).toHaveLength(0);
 
+          resolve();
+        }, 0);
+      });
+    });
+
+    it('should not cancel drop when lastDropTarget is stale TabsLayoutManager but mouse is over valid target', () => {
+      const { orchestrator, tab1Manager, tab2Manager, gridItem, tabsManager, tab1 } = setupWithTwoTabs();
+
+      orchestrator.setState({
+        draggingGridItem: gridItem.getRef(),
+        sourceTabKey: tab1.state.key,
+      });
+
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._sourceDropTarget = tab1Manager;
+      // Stale: last pointermove was over the tab bar, but pointerup lands on a valid target
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._lastDropTarget = tabsManager;
+      // @ts-expect-error - accessing private property for testing
+      orchestrator._itemDetachedFromSource = true;
+
+      tab1Manager.draggedGridItemOutside(gridItem);
+      expect(tab1Manager.state.layout.state.children).toHaveLength(0);
+
+      // @ts-expect-error - accessing private method for testing
+      const originalGetDropTargetUnderMouse = orchestrator._getDropTargetUnderMouse;
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = jest.fn().mockReturnValue(tab2Manager);
+
+      const mockEvent = { clientX: 100, clientY: 100 } as PointerEvent;
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._stopDraggingSync(mockEvent);
+
+      // @ts-expect-error - accessing private method for testing
+      orchestrator._getDropTargetUnderMouse = originalGetDropTargetUnderMouse;
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(tab1Manager.state.layout.state.children).toHaveLength(0);
+          expect(tab2Manager.state.layout.state.children).toHaveLength(1);
+          expect(tab2Manager.state.layout.state.children[0]).toBe(gridItem);
           resolve();
         }, 0);
       });

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -180,6 +180,16 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     const validDropTargetUnderMouse = this._getDropTargetUnderMouse(evt);
     const effectiveDropTarget = validDropTargetUnderMouse ?? lastDropTarget;
 
+    // When effectiveDropTarget differs from lastDropTarget (e.g. due to coalesced
+    // pointermove), clear stale visual drop state on the previous target so it
+    // doesn't keep showing a placeholder/highlight after the drop.
+    if (effectiveDropTarget !== lastDropTarget && lastDropTarget) {
+      lastDropTarget.setDropPosition?.(null);
+      lastDropTarget.setIsDropTarget?.(false);
+      this._currentDropPosition = null;
+      this._lastHoveredAutoGridItemKey = null;
+    }
+
     // TabsLayoutManager is not a valid panel drop target — it represents the
     // tab bar area between tab headers. Cancel the drop so the panel either
     // stays in place or returns to its source layout.

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -98,6 +98,8 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
   private _currentDropPosition: number | null = null;
   /** Last hovered AutoGrid item key (to prevent flickering) */
   private _lastHoveredAutoGridItemKey: string | null = null;
+  /** Original child index of the dragged item before it was detached from its source layout */
+  private _sourceOriginalIndex: number | null = null;
   private _tabDragState: TabDragState | undefined;
   /** Stored pointerup handler for new-panel drag so we can remove it */
   private _dropNewItemPointerUpHandler: ((evt: PointerEvent) => void) | null = null;
@@ -171,6 +173,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     const sourceDropTarget = this._sourceDropTarget;
     const lastDropTarget = this._lastDropTarget;
     const dropPosition = this._currentDropPosition;
+    const sourceOriginalIndex = this._sourceOriginalIndex;
 
     // Fresh target under the pointer at drop time takes priority over
     // lastDropTarget which may be stale if pointermove events were coalesced.
@@ -186,7 +189,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
 
       if (wasDetached && gridItem) {
         setTimeout(() => {
-          sourceDropTarget?.draggedGridItemInside?.(gridItem);
+          sourceDropTarget?.draggedGridItemInside?.(gridItem, sourceOriginalIndex ?? undefined);
           if (sourceDropTarget instanceof AutoGridLayoutManager) {
             sourceDropTarget.state.layout.endExternalDrag();
           }
@@ -250,6 +253,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     this._lastDropTarget = null;
     this._sourceDropTarget = null;
     this._itemDetachedFromSource = false;
+    this._sourceOriginalIndex = null;
     this.setState({ draggingGridItem: undefined, sourceTabKey: undefined, hoverTabKey: undefined });
   }
 
@@ -772,6 +776,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           this._previewType = 'panel';
           this._captureItemDimensions(gridItem);
 
+          this._sourceOriginalIndex = this._getGridItemIndex(gridItem);
           this._sourceDropTarget.draggedGridItemOutside?.(gridItem);
           this._itemDetachedFromSource = true;
 
@@ -803,6 +808,15 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         }
       }
     }
+  }
+
+  private _getGridItemIndex(gridItem: SceneGridItemLike): number | null {
+    if (this._sourceDropTarget instanceof AutoGridLayoutManager) {
+      const children = this._sourceDropTarget.state.layout.state.children;
+      const idx = children.findIndex((child) => child === gridItem);
+      return idx >= 0 ? idx : null;
+    }
+    return null;
   }
 
   private _getItemLabel(gridItem: SceneGridItemLike): string {

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -172,16 +172,18 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     const lastDropTarget = this._lastDropTarget;
     const dropPosition = this._currentDropPosition;
 
-    // Check if there's a valid drop target under the mouse
-    // (tab headers and other non-drop areas return null)
+    // Fresh target under the pointer at drop time takes priority over
+    // lastDropTarget which may be stale if pointermove events were coalesced.
     const validDropTargetUnderMouse = this._getDropTargetUnderMouse(evt);
+    const effectiveDropTarget = validDropTargetUnderMouse ?? lastDropTarget;
 
     // TabsLayoutManager is not a valid panel drop target — it represents the
     // tab bar area between tab headers. Cancel the drop so the panel either
     // stays in place or returns to its source layout.
-    const droppedOnTabBar =
-      lastDropTarget instanceof TabsLayoutManager || validDropTargetUnderMouse instanceof TabsLayoutManager;
-    if (droppedOnTabBar) {
+    if (effectiveDropTarget instanceof TabsLayoutManager) {
+      this._clearDropPosition();
+      this._lastDropTarget?.setIsDropTarget?.(false);
+
       if (wasDetached && gridItem) {
         setTimeout(() => {
           sourceDropTarget?.draggedGridItemInside?.(gridItem);
@@ -189,25 +191,18 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             sourceDropTarget.state.layout.endExternalDrag();
           }
         });
-      } else {
-        this._clearDropPosition();
-        this._lastDropTarget?.setIsDropTarget?.(false);
       }
-    } else if (wasDetached && !validDropTargetUnderMouse && gridItem && lastDropTarget instanceof TabItem) {
-      // noTargetUnderMouse = wasDetached && !validDropTargetUnderMouse && gridItem;
-      // canDropIntoCurrentTab = noTargetUnderMouse && lastDropTarget instanceof TabItem;
+    } else if (wasDetached && !validDropTargetUnderMouse && gridItem && effectiveDropTarget instanceof TabItem) {
       // If item was detached (cross-tab drag started) but there's no valid drop target under mouse,
       // drop into the current tab if lastDropTarget is a TabItem (e.g., dropped on tab header)
-      // Drop into the current tab's layout
       setTimeout(() => {
-        lastDropTarget.draggedGridItemInside?.(gridItem);
-        // Clean up source grid state
+        effectiveDropTarget.draggedGridItemInside?.(gridItem);
         if (sourceDropTarget instanceof AutoGridLayoutManager) {
           sourceDropTarget.state.layout.endExternalDrag();
         }
       });
     } else {
-      const isCrossLayoutDrop = sourceDropTarget !== lastDropTarget || wasDetached;
+      const isCrossLayoutDrop = sourceDropTarget !== effectiveDropTarget || wasDetached;
 
       // Handle cross-layout or cross-tab drop
       if (isCrossLayoutDrop) {
@@ -221,7 +216,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
             // Pass drop position for precise placement (AutoGrid uses this)
             // Note: draggedGridItemInside also clears isDropTarget and dropPosition
-            lastDropTarget?.draggedGridItemInside?.(gridItem, dropPosition ?? undefined);
+            effectiveDropTarget?.draggedGridItemInside?.(gridItem, dropPosition ?? undefined);
 
             // Clean up source grid's drag state (CSS variables and draggingKey) after item is moved.
             // This is done here (after movement) to prevent flickering where the item

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -147,6 +147,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
 
     this._sourceDropTarget = dropTarget;
     this._lastDropTarget = dropTarget;
+    this._sourceOriginalIndex = this._getGridItemIndex(gridItem);
 
     // Capture the offset from cursor to item's top-left corner
     this._captureDragOffset(evt.clientX, evt.clientY, gridItem);
@@ -786,7 +787,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           this._previewType = 'panel';
           this._captureItemDimensions(gridItem);
 
-          this._sourceOriginalIndex = this._getGridItemIndex(gridItem);
           this._sourceDropTarget.draggedGridItemOutside?.(gridItem);
           this._itemDetachedFromSource = true;
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -176,12 +176,28 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     // (tab headers and other non-drop areas return null)
     const validDropTargetUnderMouse = this._getDropTargetUnderMouse(evt);
 
-    // If item was detached (cross-tab drag started) but there's no valid drop target under mouse,
-    // drop into the current tab if lastDropTarget is a TabItem (e.g., dropped on tab header)
-    const noTargetUnderMouse = wasDetached && !validDropTargetUnderMouse && gridItem;
-    const canDropIntoCurrentTab = noTargetUnderMouse && lastDropTarget instanceof TabItem;
-
-    if (canDropIntoCurrentTab) {
+    // TabsLayoutManager is not a valid panel drop target — it represents the
+    // tab bar area between tab headers. Cancel the drop so the panel either
+    // stays in place or returns to its source layout.
+    const droppedOnTabBar =
+      lastDropTarget instanceof TabsLayoutManager || validDropTargetUnderMouse instanceof TabsLayoutManager;
+    if (droppedOnTabBar) {
+      if (wasDetached && gridItem) {
+        setTimeout(() => {
+          sourceDropTarget?.draggedGridItemInside?.(gridItem);
+          if (sourceDropTarget instanceof AutoGridLayoutManager) {
+            sourceDropTarget.state.layout.endExternalDrag();
+          }
+        });
+      } else {
+        this._clearDropPosition();
+        this._lastDropTarget?.setIsDropTarget?.(false);
+      }
+    } else if (wasDetached && !validDropTargetUnderMouse && gridItem && lastDropTarget instanceof TabItem) {
+      // noTargetUnderMouse = wasDetached && !validDropTargetUnderMouse && gridItem;
+      // canDropIntoCurrentTab = noTargetUnderMouse && lastDropTarget instanceof TabItem;
+      // If item was detached (cross-tab drag started) but there's no valid drop target under mouse,
+      // drop into the current tab if lastDropTarget is a TabItem (e.g., dropped on tab header)
       // Drop into the current tab's layout
       setTimeout(() => {
         lastDropTarget.draggedGridItemInside?.(gridItem);


### PR DESCRIPTION
**What is this feature?**

When dragging a panel and releasing it over the tab bar area (between tab
headers), the panel could disappear because TabsLayoutManager was not
handled as an invalid drop target. Now the orchestrator detects drops on
the tab bar and either cancels the drop (if not detached) or returns the
panel to its source layout (if detached during a cross-tab drag).

**Why do we need this feature?**

Prepare for GA!

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #121538

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
