### PR TITLE
App Platform: export preferred version functions to use in enterprise

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -127,6 +127,7 @@ type DashboardsAPIBuilder struct {
 	dashboardActivityChannel live.DashboardActivityChannel
 	dashboardK8sClient       client.K8sHandler // for provisioning checks during delete validation
 	isStandalone             bool              // skips any handling including anything to do with legacy storage
+	preferredVersion         *schema.GroupVersion
 }
 
 func RegisterAPIService(
@@ -241,9 +242,17 @@ func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles,
 	}
 }
 
+// SetPreferredVersion overrides the default version ordering so that the given
+// GroupVersion is returned first by GetGroupVersions. This makes it the
+// preferred version in API discovery.
+func (b *DashboardsAPIBuilder) SetPreferredVersion(gv schema.GroupVersion) {
+	b.preferredVersion = &gv
+}
+
 func (b *DashboardsAPIBuilder) GetGroupVersions() []schema.GroupVersion {
+	var versions []schema.GroupVersion
 	if featuremgmt.AnyEnabled(b.features, featuremgmt.FlagDashboardNewLayouts) {
-		return []schema.GroupVersion{
+		versions = []schema.GroupVersion{
 			dashv2.DashboardResourceInfo.GroupVersion(),
 			dashv2beta1.DashboardResourceInfo.GroupVersion(),
 			dashv2alpha1.DashboardResourceInfo.GroupVersion(),
@@ -251,16 +260,45 @@ func (b *DashboardsAPIBuilder) GetGroupVersions() []schema.GroupVersion {
 			dashv1.DashboardResourceInfo.GroupVersion(),
 			dashv1beta1.DashboardResourceInfo.GroupVersion(),
 		}
+	} else {
+		versions = []schema.GroupVersion{
+			dashv1.DashboardResourceInfo.GroupVersion(),
+			dashv1beta1.DashboardResourceInfo.GroupVersion(),
+			dashv0.DashboardResourceInfo.GroupVersion(),
+			dashv2.DashboardResourceInfo.GroupVersion(),
+			dashv2beta1.DashboardResourceInfo.GroupVersion(),
+			dashv2alpha1.DashboardResourceInfo.GroupVersion(),
+		}
 	}
 
-	return []schema.GroupVersion{
-		dashv1.DashboardResourceInfo.GroupVersion(),
-		dashv1beta1.DashboardResourceInfo.GroupVersion(),
-		dashv0.DashboardResourceInfo.GroupVersion(),
-		dashv2.DashboardResourceInfo.GroupVersion(),
-		dashv2beta1.DashboardResourceInfo.GroupVersion(),
-		dashv2alpha1.DashboardResourceInfo.GroupVersion(),
+	if b.preferredVersion == nil {
+		return versions
 	}
+
+	// Validate the preferred version is actually registered before reordering.
+	found := false
+	for _, v := range versions {
+		if v == *b.preferredVersion {
+			found = true
+			break
+		}
+	}
+	if !found {
+		logging.DefaultLogger.With("group", b.preferredVersion.Group, "version", b.preferredVersion.Version).
+			Info("preferred API version not registered, skipping")
+		return versions
+	}
+
+	// Reorder so the preferred version comes first, preserving relative order of the rest.
+	reordered := make([]schema.GroupVersion, 0, len(versions))
+	reordered = append(reordered, *b.preferredVersion)
+	for _, v := range versions {
+		if v == *b.preferredVersion {
+			continue
+		}
+		reordered = append(reordered, v)
+	}
+	return reordered
 }
 
 func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -127,7 +127,6 @@ type DashboardsAPIBuilder struct {
 	dashboardActivityChannel live.DashboardActivityChannel
 	dashboardK8sClient       client.K8sHandler // for provisioning checks during delete validation
 	isStandalone             bool              // skips any handling including anything to do with legacy storage
-	preferredVersion         *schema.GroupVersion
 }
 
 func RegisterAPIService(
@@ -242,17 +241,9 @@ func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles,
 	}
 }
 
-// SetPreferredVersion overrides the default version ordering so that the given
-// GroupVersion is returned first by GetGroupVersions. This makes it the
-// preferred version in API discovery.
-func (b *DashboardsAPIBuilder) SetPreferredVersion(gv schema.GroupVersion) {
-	b.preferredVersion = &gv
-}
-
 func (b *DashboardsAPIBuilder) GetGroupVersions() []schema.GroupVersion {
-	var versions []schema.GroupVersion
 	if featuremgmt.AnyEnabled(b.features, featuremgmt.FlagDashboardNewLayouts) {
-		versions = []schema.GroupVersion{
+		return []schema.GroupVersion{
 			dashv2.DashboardResourceInfo.GroupVersion(),
 			dashv2beta1.DashboardResourceInfo.GroupVersion(),
 			dashv2alpha1.DashboardResourceInfo.GroupVersion(),
@@ -260,45 +251,16 @@ func (b *DashboardsAPIBuilder) GetGroupVersions() []schema.GroupVersion {
 			dashv1.DashboardResourceInfo.GroupVersion(),
 			dashv1beta1.DashboardResourceInfo.GroupVersion(),
 		}
-	} else {
-		versions = []schema.GroupVersion{
-			dashv1.DashboardResourceInfo.GroupVersion(),
-			dashv1beta1.DashboardResourceInfo.GroupVersion(),
-			dashv0.DashboardResourceInfo.GroupVersion(),
-			dashv2.DashboardResourceInfo.GroupVersion(),
-			dashv2beta1.DashboardResourceInfo.GroupVersion(),
-			dashv2alpha1.DashboardResourceInfo.GroupVersion(),
-		}
 	}
 
-	if b.preferredVersion == nil {
-		return versions
+	return []schema.GroupVersion{
+		dashv1.DashboardResourceInfo.GroupVersion(),
+		dashv1beta1.DashboardResourceInfo.GroupVersion(),
+		dashv0.DashboardResourceInfo.GroupVersion(),
+		dashv2.DashboardResourceInfo.GroupVersion(),
+		dashv2beta1.DashboardResourceInfo.GroupVersion(),
+		dashv2alpha1.DashboardResourceInfo.GroupVersion(),
 	}
-
-	// Validate the preferred version is actually registered before reordering.
-	found := false
-	for _, v := range versions {
-		if v == *b.preferredVersion {
-			found = true
-			break
-		}
-	}
-	if !found {
-		logging.DefaultLogger.With("group", b.preferredVersion.Group, "version", b.preferredVersion.Version).
-			Info("preferred API version not registered, skipping")
-		return versions
-	}
-
-	// Reorder so the preferred version comes first, preserving relative order of the rest.
-	reordered := make([]schema.GroupVersion, 0, len(versions))
-	reordered = append(reordered, *b.preferredVersion)
-	for _, v := range versions {
-		if v == *b.preferredVersion {
-			continue
-		}
-		reordered = append(reordered, v)
-	}
-	return reordered
 }
 
 func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {

--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -27,18 +27,21 @@ func applyPreferredAPIVersions(logger log.Logger, cfg *setting.Cfg, scheme *runt
 		if part == "" {
 			continue
 		}
-		gv, err := parseGroupVersionSetting(part)
+		gv, err := ParseGroupVersionSetting(part)
 		if err != nil {
 			return err
 		}
-		if err := applyPreferredForGroup(logger, scheme, apiResourceConfig, gv); err != nil {
+		if err := ApplyPreferredForGroup(logger, scheme, apiResourceConfig, gv); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func parseGroupVersionSetting(s string) (schema.GroupVersion, error) {
+// ParseGroupVersionSetting parses a "group/version" string (e.g.
+// "dashboard.grafana.app/v1") into a GroupVersion. It requires both
+// group and version to be present and non-empty.
+func ParseGroupVersionSetting(s string) (schema.GroupVersion, error) {
 	parts := strings.Split(s, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return schema.GroupVersion{}, fmt.Errorf(
@@ -47,7 +50,11 @@ func parseGroupVersionSetting(s string) (schema.GroupVersion, error) {
 	return schema.GroupVersion{Group: parts[0], Version: parts[1]}, nil
 }
 
-func applyPreferredForGroup(logger log.Logger, scheme *runtime.Scheme, apiResourceConfig *serverstorage.ResourceConfig, preferred schema.GroupVersion) error {
+// ApplyPreferredForGroup reorders the scheme's version priority for a single
+// API group so that preferred comes first. It validates that the version is
+// registered in the scheme and (when apiResourceConfig is non-nil) enabled.
+// The function is a no-op when the version is unknown or disabled.
+func ApplyPreferredForGroup(logger log.Logger, scheme *runtime.Scheme, apiResourceConfig *serverstorage.ResourceConfig, preferred schema.GroupVersion) error {
 	group := preferred.Group
 	pvs := scheme.PrioritizedVersionsForGroup(group)
 	if len(pvs) == 0 {

--- a/pkg/services/apiserver/preferred_version_test.go
+++ b/pkg/services/apiserver/preferred_version_test.go
@@ -14,15 +14,15 @@ import (
 )
 
 func TestParseGroupVersionSetting(t *testing.T) {
-	gv, err := parseGroupVersionSetting("dashboard.grafana.app/v1")
+	gv, err := ParseGroupVersionSetting("dashboard.grafana.app/v1")
 	require.NoError(t, err)
 	require.Equal(t, "dashboard.grafana.app", gv.Group)
 	require.Equal(t, "v1", gv.Version)
 
-	_, err = parseGroupVersionSetting("novslash")
+	_, err = ParseGroupVersionSetting("novslash")
 	require.Error(t, err)
 
-	_, err = parseGroupVersionSetting("/v1")
+	_, err = ParseGroupVersionSetting("/v1")
 	require.Error(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestApplyPreferredForGroup_ReordersVersions(t *testing.T) {
 	rc := serverstorage.NewResourceConfig()
 	rc.EnableVersions(gvAlpha, gvStable)
 
-	require.NoError(t, applyPreferredForGroup(log.NewNopLogger(), scheme, rc, gvStable))
+	require.NoError(t, ApplyPreferredForGroup(log.NewNopLogger(), scheme, rc, gvStable))
 
 	pvs := scheme.PrioritizedVersionsForGroup("test.example")
 	require.Len(t, pvs, 2)
@@ -57,7 +57,7 @@ func TestApplyPreferredForGroup_SkipsWhenDisabled(t *testing.T) {
 	rc.EnableVersions(gvAlpha)
 	rc.DisableVersions(gvStable)
 
-	require.NoError(t, applyPreferredForGroup(log.NewNopLogger(), scheme, rc, gvStable))
+	require.NoError(t, ApplyPreferredForGroup(log.NewNopLogger(), scheme, rc, gvStable))
 
 	pvs := scheme.PrioritizedVersionsForGroup("test.example")
 	require.Len(t, pvs, 2)


### PR DESCRIPTION
**What is this feature?**

Exports some functionalities related to the preferred versions so they can be used in enterprise.

**Why do we need this feature?**

We need a mechanism to control the preferred version of given APIs 

Counterpart (using functions here) https://github.com/grafana/grafana-enterprise/pull/11531