### PR TITLE
chore(unified-storage): log sqlkv import batch inserts

### DIFF
--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 const (
@@ -22,6 +24,8 @@ const (
 )
 
 var _ KV = &SqlKV{}
+
+var sqlKVLog = log.New("resource-sqlkv")
 
 // DataImportRow represents a single append-only resource_history row written during bulk import.
 type DataImportRow struct {
@@ -109,6 +113,23 @@ func dataImportBatchRowLimit(dialectName string) int {
 	return dataImportBatchDefaultMaxRows
 }
 
+func dataImportBatchStatementCount(rowCount, maxRows int) int {
+	if rowCount == 0 || maxRows <= 0 {
+		return 0
+	}
+
+	return (rowCount + maxRows - 1) / maxRows
+}
+
+func dataImportBatchPayloadBytes(rows []DataImportRow) int {
+	payloadBytes := 0
+	for _, row := range rows {
+		payloadBytes += len(row.Value)
+	}
+
+	return payloadBytes
+}
+
 // conn returns the dbtx from the context (set during bulk import on SQLite)
 // or falls back to the default *sql.DB connection pool.
 func (k *SqlKV) conn(ctx context.Context) dbtx {
@@ -129,8 +150,10 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 		return err
 	}
 
+	insertStart := time.Now()
 	conn := k.conn(ctx)
 	var tx *sql.Tx
+	usingContextTx := false
 	if _, ok := dbtxFromCtx(ctx); !ok {
 		tx, err = k.db.BeginTx(ctx, nil)
 		if err != nil {
@@ -142,9 +165,13 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 				err = errors.Join(err, tx.Rollback())
 			}
 		}()
+	} else {
+		usingContextTx = true
 	}
 
 	maxRows := dataImportBatchRowLimit(k.dialect.Name())
+	statementCount := dataImportBatchStatementCount(len(rows), maxRows)
+	payloadBytes := dataImportBatchPayloadBytes(rows)
 	for start := 0; start < len(rows); start += maxRows {
 		end := start + maxRows
 		if end > len(rows) {
@@ -153,6 +180,15 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 
 		query, args := qb.buildInsertDatastoreBatchQuery(rows[start:end])
 		if _, err = conn.ExecContext(ctx, query, args...); err != nil {
+			sqlKVLog.Error("sqlkv bulk import insert failed",
+				"error", err,
+				"dialect", k.dialect.Name(),
+				"rows", len(rows),
+				"statements", statementCount,
+				"max_rows", maxRows,
+				"payload_bytes", payloadBytes,
+				"using_context_tx", usingContextTx,
+			)
 			return fmt.Errorf("failed to insert data import batch: %w", err)
 		}
 	}
@@ -161,6 +197,29 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 		if err = tx.Commit(); err != nil {
 			return fmt.Errorf("failed to commit data import batch: %w", err)
 		}
+	}
+
+	insertDuration := time.Since(insertStart)
+	if insertDuration > 500*time.Millisecond {
+		sqlKVLog.Warn("slow sqlkv bulk import insert",
+			"dialect", k.dialect.Name(),
+			"rows", len(rows),
+			"statements", statementCount,
+			"max_rows", maxRows,
+			"payload_bytes", payloadBytes,
+			"using_context_tx", usingContextTx,
+			"insert", insertDuration,
+		)
+	} else {
+		sqlKVLog.Debug("sqlkv bulk import insert timing",
+			"dialect", k.dialect.Name(),
+			"rows", len(rows),
+			"statements", statementCount,
+			"max_rows", maxRows,
+			"payload_bytes", payloadBytes,
+			"using_context_tx", usingContextTx,
+			"insert", insertDuration,
+		)
 	}
 
 	return nil

--- a/pkg/storage/unified/resource/kv/sqlkv_test.go
+++ b/pkg/storage/unified/resource/kv/sqlkv_test.go
@@ -42,6 +42,56 @@ func buildDataImportRows(count int) []DataImportRow {
 	return rows
 }
 
+func TestDataImportBatchStatementCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		rowCount int
+		maxRows  int
+		expected int
+	}{
+		{
+			name:     "zero rows",
+			rowCount: 0,
+			maxRows:  dataImportBatchDefaultMaxRows,
+			expected: 0,
+		},
+		{
+			name:     "non positive max rows",
+			rowCount: 3,
+			maxRows:  0,
+			expected: 0,
+		},
+		{
+			name:     "single statement",
+			rowCount: 8,
+			maxRows:  8,
+			expected: 1,
+		},
+		{
+			name:     "multiple statements",
+			rowCount: 9,
+			maxRows:  8,
+			expected: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, dataImportBatchStatementCount(tc.rowCount, tc.maxRows))
+		})
+	}
+}
+
+func TestDataImportBatchPayloadBytes(t *testing.T) {
+	rows := []DataImportRow{
+		{Value: []byte("abc")},
+		{Value: []byte("de")},
+		{Value: nil},
+	}
+
+	require.Equal(t, 5, dataImportBatchPayloadBytes(rows))
+}
+
 func TestSQLKVInsertDataImportBatchTransactionSelection(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
PR #121630 added batched sqlkv import writes, but the sqlkv path still had no batch-level visibility comparable to the SQL backend's bulk insert timing logs. This follow-up adds aggregated logging around `SqlKV.InsertDataImportBatch` so we can see how many rows and statements each sqlkv import batch executes, how much payload it carries, whether it is using a context transaction, and how long the insert takes when debugging imports.

## What changed
- add aggregated sqlkv import batch logging in `InsertDataImportBatch`
- log `rows`, `statements`, `max_rows`, `payload_bytes`, `using_context_tx`, and insert duration
- emit `Warn` for slow batches, `Debug` for normal timing, and `Error` on failed batch inserts
- add focused unit tests for the derived statement-count and payload-byte calculations

## Why
- the SQL backend already logs bulk insert timing, but the sqlkv fast path had no equivalent instrumentation
- without this, it is hard to tell whether sqlkv import batching is grouping rows as expected or how many SQL statements a given import batch actually produces

## Testing
- `go test ./pkg/storage/unified/resource/kv`
- `go test ./pkg/storage/unified/resource -run 'TestKVStorageBackendProcessBulk'`