### PR TITLE
Alerting: Fix flaky TestValidateRuleNodeIntervalFailures

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -37,7 +37,7 @@ var allExecError = []apimodels.ExecutionErrorState{
 
 func config(t *testing.T) *setting.UnifiedAlertingSettings {
 	t.Helper()
-	baseInterval := time.Duration(rand.IntN(99)+1) * time.Second
+	baseInterval := time.Duration(rand.IntN(97)+3) * time.Second // Possible intervals: [3, 99].
 	result := &setting.UnifiedAlertingSettings{
 		BaseInterval:                  baseInterval,
 		DefaultRuleEvaluationInterval: baseInterval * time.Duration(rand.IntN(9)+1),


### PR DESCRIPTION
This PR fixes a flaky test.
```bash
go test -count=100 -run TestValidateRuleNodeIntervalFailures      
--- FAIL: TestValidateRuleNodeIntervalFailures (0.00s)
    api_ruler_validation_test.go:950: Config Base interval is [2s]
panic: invalid argument to Int64N [recovered, repanicked]

goroutine 203 [running]:
testing.tRunner.func1.2({0x4e13b60, 0x69fdd20})
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1875 +0x35b
panic({0x4e13b60?, 0x69fdd20?})
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/runtime/panic.go:783 +0x132
math/rand/v2.(*Rand).Int64N(...)
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/math/rand/v2/rand.go:66
math/rand/v2.Int64N(...)
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/math/rand/v2/rand.go:303
github.com/grafana/grafana/pkg/services/ngalert/api.TestValidateRuleNodeIntervalFailures(0xc0016781c0)
        /home/santiago-grafana/Desktop/grafana/grafana/pkg/services/ngalert/api/api_ruler_validation_test.go:967 +0x24e
testing.tRunner(0xc0016781c0, 0x6248000)
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
        /home/santiago-grafana/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1997 +0x465
exit status 2
FAIL    github.com/grafana/grafana/pkg/services/ngalert/api     0.050s
```

The `config()` helper generates intervals in the $[1, 99]$ range. If values are 1 or 2, then subtracting [here](https://github.com/grafana/grafana/blob/a0c37795221001e207f12447a7760954bc0025cf/pkg/services/ngalert/api/api_ruler_validation_test.go#L967) will result in a number $n \le 0$ passed into `rand.Int64N()`, making the test panic.

The test also fails if the random interval is 1 (all other intervals are multiples).

Ensuring that `config()` assigns intervals in the range $[3, 99]$ fixes the potential panics and errors.