### PR TITLE
Login: Fix extra auto-login redirects

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -163,6 +163,15 @@
         // For the image-renderer to check support for render binding calls
         window.__grafanaRenderBindingSupported = true;
       [[end]]
+
+      // global config
+      window.grafanaBootData = {
+        _femt: true, // isFrontendService() needs this
+        assets: [[.Assets]],
+        navTree: [],
+        settings: [[.Settings]],
+        user: [[.DefaultUser]],
+      };
     </script>
 
     <script nonce="[[.Nonce]]">
@@ -291,7 +300,8 @@
 
           // Handle SSO auto-login redirection from /bootdata.
           // Only redirect if there's no login error to avoid redirect loops.
-          if (rawBootData.autoLoginRedirectURL && !rawBootData.settings.loginError && !queryParams.has('disableAutoLogin')) {
+          const hasLoginError = rawBootData.settings?.loginError || window.grafanaBootData.settings.loginError;
+          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin')) {
             // Copied from context_srv.setRedirectToUrl
             const redirectPath = window.location.href.substring(window.location.origin.length)
             if (redirectPath !== "/login") {
@@ -348,15 +358,6 @@
         }
 
         async function initGrafana() {
-          // global config
-          window.grafanaBootData = {
-            _femt: true, // isFrontendService() needs this
-            assets: [[.Assets]],
-            navTree: [],
-            settings: [[.Settings]],
-            user: [[.DefaultUser]],
-          }
-
           // Preserve a mix of values from the initial boot data, and from the backend
           // - nav tree and user info come from the backend
           // - merge settings from both. FS settings contains less values

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -163,15 +163,6 @@
         // For the image-renderer to check support for render binding calls
         window.__grafanaRenderBindingSupported = true;
       [[end]]
-
-      // global config
-      window.grafanaBootData = {
-        _femt: true, // isFrontendService() needs this
-        assets: [[.Assets]],
-        navTree: [],
-        settings: [[.Settings]],
-        user: [[.DefaultUser]],
-      };
     </script>
 
     <script nonce="[[.Nonce]]">
@@ -302,7 +293,8 @@
           // Only redirect if there's no login error to avoid redirect loops.
           // Don't redirect for public dashboards
           const hasLoginError = rawBootData.settings?.loginError || window.grafanaBootData.settings.loginError;
-          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin') && !publicDashboardAccessToken) {
+          const isOnLoginPage = window.location.pathname.matches(/\/login\/?$/);
+          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin') && isOnLoginPage) {
             // Copied from context_srv.setRedirectToUrl
             const redirectPath = window.location.href.substring(window.location.origin.length)
             if (redirectPath !== "/login") {
@@ -359,6 +351,15 @@
         }
 
         async function initGrafana() {
+          // global config
+          window.grafanaBootData = {
+            _femt: true, // isFrontendService() needs this
+            assets: [[.Assets]],
+            navTree: [],
+            settings: [[.Settings]],
+            user: [[.DefaultUser]],
+          }
+
           // Preserve a mix of values from the initial boot data, and from the backend
           // - nav tree and user info come from the backend
           // - merge settings from both. FS settings contains less values

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -300,8 +300,9 @@
 
           // Handle SSO auto-login redirection from /bootdata.
           // Only redirect if there's no login error to avoid redirect loops.
+          // Don't redirect for public dashboards
           const hasLoginError = rawBootData.settings?.loginError || window.grafanaBootData.settings.loginError;
-          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin')) {
+          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin') && !publicDashboardAccessToken) {
             // Copied from context_srv.setRedirectToUrl
             const redirectPath = window.location.href.substring(window.location.origin.length)
             if (redirectPath !== "/login") {

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -291,10 +291,17 @@
 
           // Handle SSO auto-login redirection from /bootdata.
           // Only redirect if there's no login error to avoid redirect loops.
-          // Don't redirect for public dashboards
           const hasLoginError = rawBootData.settings?.loginError || window.grafanaBootData.settings.loginError;
-          const isOnLoginPage = window.location.pathname.matches(/\/login\/?$/);
-          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin') && isOnLoginPage) {
+          const annonAccessPages = [
+            /\/dashboard\/snapshot\/.*$/,
+            /\/invite$/,
+            /\/signup$/,
+            /\/user\/password\/send-reset-email$/,
+            /\/user\/password\/reset$/,
+            /\/public-dashboards\/.*$/,
+          ]
+          const isAllowedAnonPage = annonAccessPages.some((regex) => regex.test(window.location.pathname));
+          if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin') && !isAllowedAnonPage) {
             // Copied from context_srv.setRedirectToUrl
             const redirectPath = window.location.href.substring(window.location.origin.length)
             if (redirectPath !== "/login") {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/121005 where we fixed auto-login redirects for frontend service, there's two edge cases that weren't handled properly:
- If your auth provider rejected the login for whatever reason and returns an error, we weren't correctly suppressing the error. This was taken into account, but we were checking for the login error on the `/bootdata` response, but this login error comes down from the embedded bootdata
- When viewing a public dashboard you were still being redirected to SSO
   - I think the preferred fix for this is in the backend, but its quicker to do this in the frontend for now

This PR fixes both of them.

Tested by:
- visiting `/login?disableAutoLogin` and running `window.cookieStore.set('login_error', "true")` in my JS console to simulate a login error
- using browser 'set network override' feature to mock the bootdata response with one that contains `autoLoginRedirectURL`