### PR TITLE
Zanzana: Fix mt-reconciler ReadRequest.PageSize exceeding OpenFGA limit

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -44,7 +44,7 @@ type Config struct {
 	Interval            time.Duration
 	WriteBatchSize      int // Number of tuples to write in a single batch (0 = no batching)
 	QueueSize           int // Size of the buffered work queue for namespaces (default 1000)
-	ZanzanaReadPageSize int // Page size when reading tuples from Zanzana (default 1000)
+	ZanzanaReadPageSize int // Page size when reading tuples from Zanzana (default 100, max 100)
 }
 
 func (c Config) queueSize() int {
@@ -56,7 +56,7 @@ func (c Config) queueSize() int {
 
 func (c Config) zanzanaReadPageSize() int32 {
 	if c.ZanzanaReadPageSize <= 0 {
-		return 1000
+		return 100
 	}
 	return int32(c.ZanzanaReadPageSize)
 }

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -197,7 +197,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 				Workers:             cfg.ZanzanaReconciler.Workers,
 				Interval:            cfg.ZanzanaReconciler.Interval,
 				WriteBatchSize:      cfg.ZanzanaReconciler.WriteBatchSize,
-				ZanzanaReadPageSize: cfg.ZanzanaReconciler.ZanzanaReadPageSize,
+				ZanzanaReadPageSize: int(cfg.ZanzanaServer.ReadPageSize),
 				QueueSize:           cfg.ZanzanaReconciler.QueueSize,
 			},
 			reconcilerLogger,

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -75,8 +75,6 @@ type ZanzanaReconcilerSettings struct {
 	Interval time.Duration
 	// Batch size for writing tuples to Zanzana.
 	WriteBatchSize int
-	// Page size when reading tuples from Zanzana during reconciliation.
-	ZanzanaReadPageSize int
 	// Size of the buffered work queue for namespaces.
 	QueueSize int
 
@@ -410,7 +408,6 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zr.Workers = reconcilerSec.Key("workers").MustInt(4)
 	zr.Interval = reconcilerSec.Key("interval").MustDuration(1 * time.Hour)
 	zr.WriteBatchSize = reconcilerSec.Key("write_batch_size").MustInt(100)
-	zr.ZanzanaReadPageSize = reconcilerSec.Key("zanzana_read_page_size").MustInt(1000)
 	zr.QueueSize = reconcilerSec.Key("queue_size").MustInt(1000)
 	zr.LeaderElectionEnabled = reconcilerSec.Key("leader_election_enabled").MustBool(false)
 	zr.LeaderElectionLeaseName = reconcilerSec.Key("leader_election_lease_name").MustString("zanzana-mt-reconciler")


### PR DESCRIPTION
## Summary

- The mt-reconciler had its own `zanzana_read_page_size` config under `[zanzana.reconciler]` defaulting to **1000**, but OpenFGA validates that `ReadRequest.PageSize` must be in **[1, 100]**, causing `invalid ReadRequest.PageSize: value must be inside range [1, 100]` errors
- Removed the reconciler-specific setting and bound it to the existing `[zanzana.server] read_page_size` (default 100) instead
- Updated the fallback default in the reconciler helper from 1000 to 100

## Test plan

- [x] `go build ./pkg/services/authz/zanzana/...` passes
- [x] `go test ./pkg/services/authz/zanzana/server/reconciler/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)