### PR TITLE
SQL: strip comments with quote-aware state machine in PostgreSQL and MSSQL

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -15,17 +15,132 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
-var (
-	reBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
-	reLineComment  = regexp.MustCompile(`--[^\n]*`)
-)
+// isDollarTagChar reports whether b is valid inside a PostgreSQL dollar-quote tag
+// (letters and digits only; underscore is also allowed per identifier rules).
+func isDollarTagChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
 
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
-// from the query string.
+// from the query string. It is quote-aware: comment sequences inside single-quoted
+// string literals, double-quoted identifiers, and dollar-quoted strings are
+// preserved verbatim.
 func stripSQLComments(sql string) string {
-	sql = reBlockComment.ReplaceAllString(sql, "")
-	sql = reLineComment.ReplaceAllString(sql, "")
-	return sql
+	var out strings.Builder
+	out.Grow(len(sql))
+	i := 0
+	n := len(sql)
+	for i < n {
+		switch {
+		case sql[i] == '$':
+			// Try to detect a PostgreSQL dollar-quoted string: $$...$$ or $tag$...$tag$.
+			// Tags follow identifier rules ([A-Za-z_][A-Za-z0-9_]*) or are empty.
+			// Grafana macros ($__name(...)) are distinguished by ending with '(' not '$'.
+			j := i + 1
+			if j < n && sql[j] == '$' {
+				// Empty-tag dollar-quote: $$...$$
+				closing := "$$"
+				out.WriteString(closing)
+				i = j + 1
+				for i < n {
+					if strings.HasPrefix(sql[i:], closing) {
+						out.WriteString(closing)
+						i += len(closing)
+						break
+					}
+					out.WriteByte(sql[i])
+					i++
+				}
+			} else if j < n && (isDollarTagChar(sql[j]) && !(sql[j] >= '0' && sql[j] <= '9')) {
+				// Possible non-empty tag: must start with letter or underscore.
+				k := j + 1
+				for k < n && isDollarTagChar(sql[k]) {
+					k++
+				}
+				if k < n && sql[k] == '$' {
+					// Confirmed dollar-quote with tag, e.g. $tag$...$tag$
+					closing := sql[i : k+1]
+					out.WriteString(closing)
+					i = k + 1
+					for i < n {
+						if strings.HasPrefix(sql[i:], closing) {
+							out.WriteString(closing)
+							i += len(closing)
+							break
+						}
+						out.WriteByte(sql[i])
+						i++
+					}
+				} else {
+					// Not a dollar-quote (e.g. a Grafana macro $__timeFrom()).
+					out.WriteByte(sql[i])
+					i++
+				}
+			} else {
+				// Not a dollar-quote (e.g. $1 positional parameter).
+				out.WriteByte(sql[i])
+				i++
+			}
+		case sql[i] == '\'':
+			// Single-quoted string literal. Pass verbatim; '' is the escape sequence.
+			out.WriteByte(sql[i])
+			i++
+			for i < n {
+				if sql[i] == '\'' {
+					out.WriteByte(sql[i])
+					i++
+					if i < n && sql[i] == '\'' {
+						// Doubled-quote escape: '' inside a string literal.
+						out.WriteByte(sql[i])
+						i++
+					} else {
+						break
+					}
+				} else {
+					out.WriteByte(sql[i])
+					i++
+				}
+			}
+		case sql[i] == '"':
+			// Double-quoted identifier. Pass verbatim; "" is the escape sequence.
+			out.WriteByte(sql[i])
+			i++
+			for i < n {
+				if sql[i] == '"' {
+					out.WriteByte(sql[i])
+					i++
+					if i < n && sql[i] == '"' {
+						out.WriteByte(sql[i])
+						i++
+					} else {
+						break
+					}
+				} else {
+					out.WriteByte(sql[i])
+					i++
+				}
+			}
+		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
+			// Block comment: skip to closing */.
+			i += 2
+			for i+1 < n {
+				if sql[i] == '*' && sql[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
+			// Line comment: skip to end of line (newline is preserved).
+			for i < n && sql[i] != '\n' {
+				i++
+			}
+		default:
+			out.WriteByte(sql[i])
+			i++
+		}
+	}
+	return out.String()
 }
 
 type postgresMacroEngine struct {

--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -21,6 +21,49 @@ func isDollarTagChar(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }
 
+// consumeQuoted copies a single-quoted or double-quoted region (delimited by q)
+// from sql[i:] into out, handling ” (or "") doubled-quote escapes.
+// i must point at the opening quote. Returns the new position after the closing quote.
+func consumeQuoted(sql string, i, n int, q byte, out *strings.Builder) int {
+	out.WriteByte(q)
+	i++
+	for i < n {
+		if sql[i] == q {
+			out.WriteByte(sql[i])
+			i++
+			if i < n && sql[i] == q {
+				out.WriteByte(sql[i])
+				i++
+			} else {
+				break
+			}
+		} else {
+			out.WriteByte(sql[i])
+			i++
+		}
+	}
+	return i
+}
+
+// consumeDollarQuoted copies a dollar-quoted region from sql[i:] into out.
+// i must point at the start of the opening delimiter (e.g. "$$" or "$tag$").
+// closing is the full closing delimiter string. Returns the new position.
+func consumeDollarQuoted(sql string, i int, closing string, out *strings.Builder) int {
+	out.WriteString(closing)
+	i += len(closing)
+	n := len(sql)
+	for i < n {
+		if strings.HasPrefix(sql[i:], closing) {
+			out.WriteString(closing)
+			i += len(closing)
+			break
+		}
+		out.WriteByte(sql[i])
+		i++
+	}
+	return i
+}
+
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
 // from the query string. It is quote-aware: comment sequences inside single-quoted
 // string literals, double-quoted identifiers, and dollar-quoted strings are
@@ -38,39 +81,15 @@ func stripSQLComments(sql string) string {
 			// Grafana macros ($__name(...)) are distinguished by ending with '(' not '$'.
 			j := i + 1
 			if j < n && sql[j] == '$' {
-				// Empty-tag dollar-quote: $$...$$
-				closing := "$$"
-				out.WriteString(closing)
-				i = j + 1
-				for i < n {
-					if strings.HasPrefix(sql[i:], closing) {
-						out.WriteString(closing)
-						i += len(closing)
-						break
-					}
-					out.WriteByte(sql[i])
-					i++
-				}
-			} else if j < n && (isDollarTagChar(sql[j]) && !(sql[j] >= '0' && sql[j] <= '9')) {
+				i = consumeDollarQuoted(sql, i, "$$", &out)
+			} else if j < n && isDollarTagChar(sql[j]) && (sql[j] < '0' || sql[j] > '9') {
 				// Possible non-empty tag: must start with letter or underscore.
 				k := j + 1
 				for k < n && isDollarTagChar(sql[k]) {
 					k++
 				}
 				if k < n && sql[k] == '$' {
-					// Confirmed dollar-quote with tag, e.g. $tag$...$tag$
-					closing := sql[i : k+1]
-					out.WriteString(closing)
-					i = k + 1
-					for i < n {
-						if strings.HasPrefix(sql[i:], closing) {
-							out.WriteString(closing)
-							i += len(closing)
-							break
-						}
-						out.WriteByte(sql[i])
-						i++
-					}
+					i = consumeDollarQuoted(sql, i, sql[i:k+1], &out)
 				} else {
 					// Not a dollar-quote (e.g. a Grafana macro $__timeFrom()).
 					out.WriteByte(sql[i])
@@ -82,44 +101,9 @@ func stripSQLComments(sql string) string {
 				i++
 			}
 		case sql[i] == '\'':
-			// Single-quoted string literal. Pass verbatim; '' is the escape sequence.
-			out.WriteByte(sql[i])
-			i++
-			for i < n {
-				if sql[i] == '\'' {
-					out.WriteByte(sql[i])
-					i++
-					if i < n && sql[i] == '\'' {
-						// Doubled-quote escape: '' inside a string literal.
-						out.WriteByte(sql[i])
-						i++
-					} else {
-						break
-					}
-				} else {
-					out.WriteByte(sql[i])
-					i++
-				}
-			}
+			i = consumeQuoted(sql, i, n, '\'', &out)
 		case sql[i] == '"':
-			// Double-quoted identifier. Pass verbatim; "" is the escape sequence.
-			out.WriteByte(sql[i])
-			i++
-			for i < n {
-				if sql[i] == '"' {
-					out.WriteByte(sql[i])
-					i++
-					if i < n && sql[i] == '"' {
-						out.WriteByte(sql[i])
-						i++
-					} else {
-						break
-					}
-				} else {
-					out.WriteByte(sql[i])
-					i++
-				}
-			}
+			i = consumeQuoted(sql, i, n, '"', &out)
 		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
 			// Block comment: skip to closing */.
 			i += 2

--- a/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros_test.go
@@ -247,3 +247,107 @@ func TestMacroEngineConcurrency(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestStripSQLComments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "line comment stripped",
+			input: "SELECT 1 -- a comment",
+			want:  "SELECT 1 ",
+		},
+		{
+			name:  "block comment stripped",
+			input: "SELECT /* a comment */ 1",
+			want:  "SELECT  1",
+		},
+		{
+			name:  "multiline block comment stripped",
+			input: "SELECT /*\n  multiline\n  comment\n*/ 1",
+			want:  "SELECT  1",
+		},
+		{
+			name:  "line comment inside single-quoted string preserved",
+			input: "SELECT '-- not a comment' AS label",
+			want:  "SELECT '-- not a comment' AS label",
+		},
+		{
+			name:  "block comment inside single-quoted string preserved",
+			input: "SELECT '/* not a comment */' AS label",
+			want:  "SELECT '/* not a comment */' AS label",
+		},
+		{
+			name:  "line comment inside double-quoted identifier preserved",
+			input: `SELECT "col -- name" FROM t`,
+			want:  `SELECT "col -- name" FROM t`,
+		},
+		{
+			name:  "block comment inside double-quoted identifier preserved",
+			input: `SELECT "col /* name */" FROM t`,
+			want:  `SELECT "col /* name */" FROM t`,
+		},
+		{
+			name:  "doubled-quote escape inside single-quoted string",
+			input: "SELECT 'it''s fine -- not a comment' AS v",
+			want:  "SELECT 'it''s fine -- not a comment' AS v",
+		},
+		{
+			name:  "doubled-quote escape inside double-quoted identifier",
+			input: `SELECT "col ""-- name""" FROM t`,
+			want:  `SELECT "col ""-- name""" FROM t`,
+		},
+		{
+			name:  "mixed: -- inside string then real -- comment",
+			input: "SELECT '-- in string' AS a -- real comment",
+			want:  "SELECT '-- in string' AS a ",
+		},
+		{
+			name:  "mixed: block comment inside string then real block comment",
+			input: "SELECT '/* in string */' AS a /* real comment */",
+			want:  "SELECT '/* in string */' AS a ",
+		},
+		{
+			name:  "no-op: query with no comments",
+			input: "SELECT col FROM t WHERE col > 1",
+			want:  "SELECT col FROM t WHERE col > 1",
+		},
+		{
+			name:  "newline after line comment is preserved",
+			input: "SELECT 1 -- comment\nFROM t",
+			want:  "SELECT 1 \nFROM t",
+		},
+		{
+			name:  "line comment inside empty dollar-quoted string preserved",
+			input: "SELECT $$ -- not a comment $$",
+			want:  "SELECT $$ -- not a comment $$",
+		},
+		{
+			name:  "block comment inside empty dollar-quoted string preserved",
+			input: "SELECT $$ /* not a comment */ $$",
+			want:  "SELECT $$ /* not a comment */ $$",
+		},
+		{
+			name:  "line comment inside tagged dollar-quoted string preserved",
+			input: "SELECT $body$ -- not a comment $body$",
+			want:  "SELECT $body$ -- not a comment $body$",
+		},
+		{
+			name:  "grafana macro not confused with dollar-quote",
+			input: "SELECT $__timeFrom() -- comment",
+			want:  "SELECT $__timeFrom() ",
+		},
+		{
+			name:  "positional parameter not confused with dollar-quote",
+			input: "SELECT $1 -- comment",
+			want:  "SELECT $1 ",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, stripSQLComments(tc.input))
+		})
+	}
+}

--- a/pkg/tsdb/mssql/sqleng/macros.go
+++ b/pkg/tsdb/mssql/sqleng/macros.go
@@ -13,17 +13,97 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
-var (
-	reBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
-	reLineComment  = regexp.MustCompile(`--[^\n]*`)
-)
-
 // stripSQLComments removes SQL line comments (--) and block comments (/* */)
-// from the query string.
+// from the query string. It is quote-aware: comment sequences inside single-quoted
+// string literals, double-quoted identifiers, and T-SQL bracket-quoted identifiers
+// are preserved verbatim.
 func stripSQLComments(sql string) string {
-	sql = reBlockComment.ReplaceAllString(sql, "")
-	sql = reLineComment.ReplaceAllString(sql, "")
-	return sql
+	var out strings.Builder
+	out.Grow(len(sql))
+	i := 0
+	n := len(sql)
+	for i < n {
+		switch {
+		case sql[i] == '\'':
+			// Single-quoted string literal. Pass verbatim; '' is the escape sequence.
+			out.WriteByte(sql[i])
+			i++
+			for i < n {
+				if sql[i] == '\'' {
+					out.WriteByte(sql[i])
+					i++
+					if i < n && sql[i] == '\'' {
+						// Doubled-quote escape: '' inside a string literal.
+						out.WriteByte(sql[i])
+						i++
+					} else {
+						break
+					}
+				} else {
+					out.WriteByte(sql[i])
+					i++
+				}
+			}
+		case sql[i] == '"':
+			// Double-quoted identifier. Pass verbatim; "" is the escape sequence.
+			out.WriteByte(sql[i])
+			i++
+			for i < n {
+				if sql[i] == '"' {
+					out.WriteByte(sql[i])
+					i++
+					if i < n && sql[i] == '"' {
+						out.WriteByte(sql[i])
+						i++
+					} else {
+						break
+					}
+				} else {
+					out.WriteByte(sql[i])
+					i++
+				}
+			}
+		case sql[i] == '[':
+			// T-SQL bracket-quoted identifier. Pass verbatim; ]] is the escape sequence.
+			out.WriteByte(sql[i])
+			i++
+			for i < n {
+				if sql[i] == ']' {
+					out.WriteByte(sql[i])
+					i++
+					if i < n && sql[i] == ']' {
+						// Doubled-bracket escape: ]] inside a bracket identifier.
+						out.WriteByte(sql[i])
+						i++
+					} else {
+						break
+					}
+				} else {
+					out.WriteByte(sql[i])
+					i++
+				}
+			}
+		case i+1 < n && sql[i] == '/' && sql[i+1] == '*':
+			// Block comment: skip to closing */.
+			i += 2
+			for i+1 < n {
+				if sql[i] == '*' && sql[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+		case i+1 < n && sql[i] == '-' && sql[i+1] == '-':
+			// Line comment: skip to end of line (newline is preserved).
+			for i < n && sql[i] != '\n' {
+				i++
+			}
+		default:
+			out.WriteByte(sql[i])
+			i++
+		}
+	}
+	return out.String()
 }
 
 type msSQLMacroEngine struct {

--- a/pkg/tsdb/mssql/sqleng/macros_test.go
+++ b/pkg/tsdb/mssql/sqleng/macros_test.go
@@ -256,3 +256,92 @@ func TestMacroEngineConcurrency(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestStripSQLComments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "line comment stripped",
+			input: "SELECT 1 -- a comment",
+			want:  "SELECT 1 ",
+		},
+		{
+			name:  "block comment stripped",
+			input: "SELECT /* a comment */ 1",
+			want:  "SELECT  1",
+		},
+		{
+			name:  "multiline block comment stripped",
+			input: "SELECT /*\n  multiline\n  comment\n*/ 1",
+			want:  "SELECT  1",
+		},
+		{
+			name:  "line comment inside single-quoted string preserved",
+			input: "SELECT '-- not a comment' AS label",
+			want:  "SELECT '-- not a comment' AS label",
+		},
+		{
+			name:  "block comment inside single-quoted string preserved",
+			input: "SELECT '/* not a comment */' AS label",
+			want:  "SELECT '/* not a comment */' AS label",
+		},
+		{
+			name:  "line comment inside double-quoted identifier preserved",
+			input: `SELECT "col -- name" FROM t`,
+			want:  `SELECT "col -- name" FROM t`,
+		},
+		{
+			name:  "block comment inside double-quoted identifier preserved",
+			input: `SELECT "col /* name */" FROM t`,
+			want:  `SELECT "col /* name */" FROM t`,
+		},
+		{
+			name:  "line comment inside bracket-quoted identifier preserved",
+			input: "SELECT [col -- name] FROM t",
+			want:  "SELECT [col -- name] FROM t",
+		},
+		{
+			name:  "block comment inside bracket-quoted identifier preserved",
+			input: "SELECT [col /* name */] FROM t",
+			want:  "SELECT [col /* name */] FROM t",
+		},
+		{
+			name:  "doubled-bracket escape inside bracket identifier",
+			input: "SELECT [col]]name] FROM t",
+			want:  "SELECT [col]]name] FROM t",
+		},
+		{
+			name:  "doubled-quote escape inside single-quoted string",
+			input: "SELECT 'it''s fine -- not a comment' AS v",
+			want:  "SELECT 'it''s fine -- not a comment' AS v",
+		},
+		{
+			name:  "mixed: -- inside string then real -- comment",
+			input: "SELECT '-- in string' AS a -- real comment",
+			want:  "SELECT '-- in string' AS a ",
+		},
+		{
+			name:  "mixed: block comment inside string then real block comment",
+			input: "SELECT '/* in string */' AS a /* real comment */",
+			want:  "SELECT '/* in string */' AS a ",
+		},
+		{
+			name:  "no-op: query with no comments",
+			input: "SELECT col FROM t WHERE col > 1",
+			want:  "SELECT col FROM t WHERE col > 1",
+		},
+		{
+			name:  "newline after line comment is preserved",
+			input: "SELECT 1 -- comment\nFROM t",
+			want:  "SELECT 1 \nFROM t",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, stripSQLComments(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #121732.

Extends the great work by @karthik-idikuda by porting the fix to quote-aware SQL comment stripping introduced for MySQL (#121535) to PostgreSQL and MSSQL. The original  fix used naive regexes (`--[^\n]*`, `(?s)/\*.*?\*/`) that had no awareness of quoted string context, meaning comment-like sequences inside string literals or identifiers would be incorrectly stripped.

For example, in PostgreSQL:

```sql
SELECT '-- not a comment' AS label
-- after naive regex: SELECT ' AS label  ← broken
```

The fix replaces the regexes with a single-pass state machine in each datasource that tracks quoting context and only strips comments outside quoted regions.

### PostgreSQL ([`macros.go`](vscode-webview://0fnvu3q7mk6l214ld37j4s64af642peoigmvuprm3g7sr7d8j112/pkg/tsdb/grafana-postgresql-datasource/macros.go))

Quoted contexts handled:

- `'...'` single-quoted strings — `''` doubled-quote escape (no backslash; correct for `standard_conforming_strings = on`)
- `"..."` double-quoted identifiers — `""` escape
- `$$...$$` and `$tag$...$tag$` dollar-quoted strings
- Grafana macros (`$__timeFrom()`) and positional parameters (`$1`) are correctly distinguished from dollar-quote tags

### MSSQL ([`macros.go`](vscode-webview://0fnvu3q7mk6l214ld37j4s64af642peoigmvuprm3g7sr7d8j112/pkg/tsdb/mssql/sqleng/macros.go))

Quoted contexts handled:

- `'...'` single-quoted strings — `''` doubled-quote escape (no backslash; correct for T-SQL)
- `"..."` double-quoted identifiers — `""` escape
- `[...]` bracket-quoted identifiers — `]]` escape
