### PR TITLE
Provisioning: Add polling fallback when WebSocket watch streams are unavailable

### DIFF
--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -52,31 +52,33 @@ export function createOnCacheEntryAdded<Spec, Status>(
       const response = await cacheDataLoaded;
       const resourceVersion = response.data.metadata?.resourceVersion;
 
-      subscription = client.watch({ resourceVersion }).subscribe({
-        next: (event) => {
-          updateCachedData((draft) => {
-            if (!draft.items) {
-              draft.items = [];
-            }
-            // Find the item with the matching name
-            const existingIndex = draft.items.findIndex((item) => item.metadata?.name === event.object.metadata.name);
+      subscription = client
+        .watch({ resourceVersion, fieldSelector: arg?.fieldSelector, labelSelector: arg?.labelSelector })
+        .subscribe({
+          next: (event) => {
+            updateCachedData((draft) => {
+              if (!draft.items) {
+                draft.items = [];
+              }
+              // Find the item with the matching name
+              const existingIndex = draft.items.findIndex((item) => item.metadata?.name === event.object.metadata.name);
 
-            if (event.type === 'ADDED' && existingIndex === -1) {
-              draft.items.push(event.object);
-            } else if (event.type === 'DELETED' && existingIndex !== -1) {
-              // Remove the item if it exists
-              draft.items.splice(existingIndex, 1);
-            } else if (existingIndex !== -1) {
-              // Could be ADDED or MODIFIED
-              // Update the existing item if it exists
-              draft.items[existingIndex] = event.object;
-            }
-          });
-        },
-        error: (error) => {
-          errorCleanup.fn = options.onError?.(error, updateCachedData, dispatch, arg) ?? undefined;
-        },
-      });
+              if (event.type === 'ADDED' && existingIndex === -1) {
+                draft.items.push(event.object);
+              } else if (event.type === 'DELETED' && existingIndex !== -1) {
+                // Remove the item if it exists
+                draft.items.splice(existingIndex, 1);
+              } else if (existingIndex !== -1) {
+                // Could be ADDED or MODIFIED
+                // Update the existing item if it exists
+                draft.items[existingIndex] = event.object;
+              }
+            });
+          },
+          error: (error) => {
+            errorCleanup.fn = options.onError?.(error, updateCachedData, dispatch, arg) ?? undefined;
+          },
+        });
     } catch (error) {
       console.error('Error in onCacheEntryAdded:', error);
       return;

--- a/public/app/features/apiserver/client.test.ts
+++ b/public/app/features/apiserver/client.test.ts
@@ -1,6 +1,6 @@
 import { Subject, throwError } from 'rxjs';
 
-import { type LiveChannelEvent, LiveChannelConnectionState, LiveChannelEventType } from '@grafana/data';
+import { type LiveChannelEvent, LiveChannelEventType } from '@grafana/data';
 import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -15,7 +15,6 @@ jest.mock('@grafana/runtime', () => ({
   getGrafanaLiveSrv: jest.fn(),
   config: {
     buildInfo: { versionString: 'test-version' },
-    liveEnabled: true,
   },
 }));
 
@@ -522,89 +521,5 @@ describe('ScopedResourceClient watch (polling fallback)', () => {
         fieldSelector: 'metadata.name=my-repo',
       })
     );
-  });
-
-  it('goes straight to polling when liveEnabled is false', async () => {
-    const { config } = jest.requireMock('@grafana/runtime');
-    config.liveEnabled = false;
-
-    getMock.mockResolvedValueOnce({
-      items: [{ metadata: { name: 'repo-a', resourceVersion: '1' }, spec: {} }],
-      metadata: {},
-    });
-
-    const events: Array<{ type: string; object: unknown }> = [];
-    client.watch().subscribe({
-      next: (event) => events.push(event),
-      error: () => {},
-    });
-
-    await jest.advanceTimersByTimeAsync(0);
-
-    // Polling started without even attempting the Live channel
-    expect(getStreamMock).not.toHaveBeenCalled();
-    expect(events).toEqual([
-      { type: 'ADDED', object: expect.objectContaining({ metadata: { name: 'repo-a', resourceVersion: '1' } }) },
-    ]);
-
-    config.liveEnabled = true;
-  });
-
-  it('falls back to polling when live channel hangs (proxy-blocked WebSocket)', async () => {
-    // Simulate a proxy-blocked WebSocket: getStream returns an Observable that
-    // emits an initial Pending status (no error) and then hangs forever.
-    const stream = new Subject<LiveChannelEvent>();
-    getStreamMock.mockReturnValue(stream.asObservable());
-
-    // Emit the initial Pending status (no error) — this is what the channel does
-    // synchronously in getStream() before the subscription is established.
-    // The watch pipe filters this out (not a message event), leaving silence.
-
-    const itemA = { metadata: { name: 'repo-a', resourceVersion: '1' }, spec: {} };
-    getMock.mockResolvedValueOnce({ items: [itemA], metadata: {} });
-
-    const events: Array<{ type: string; object: unknown }> = [];
-    client.watch().subscribe({
-      next: (event) => events.push(event),
-      error: () => {},
-    });
-
-    // Nothing happens yet — the stream is hanging
-    await jest.advanceTimersByTimeAsync(5000);
-    expect(events).toHaveLength(0);
-
-    // After the 10s timeout, the fallback kicks in
-    await jest.advanceTimersByTimeAsync(5000);
-    await jest.advanceTimersByTimeAsync(0); // flush poll microtasks
-
-    expect(events).toEqual([{ type: 'ADDED', object: itemA }]);
-  });
-
-  it('does NOT fall back to polling when the channel is connected but idle', async () => {
-    const stream = new Subject<LiveChannelEvent>();
-    getStreamMock.mockReturnValue(stream.asObservable());
-
-    const events: Array<{ type: string; object: unknown }> = [];
-    const subscription = client.watch().subscribe({
-      next: (event) => events.push(event),
-      error: () => {},
-    });
-
-    // Channel emits Connected status — this cancels the connection timeout.
-    stream.next({
-      type: LiveChannelEventType.Status,
-      id: 'test',
-      timestamp: Date.now(),
-      state: LiveChannelConnectionState.Connected,
-    } as LiveChannelEvent);
-
-    // Advance well past the timeout — should NOT trigger polling.
-    await jest.advanceTimersByTimeAsync(30_000);
-
-    // No polling requests were made (list was never called).
-    expect(getMock).not.toHaveBeenCalled();
-    expect(events).toHaveLength(0);
-
-    subscription.unsubscribe();
   });
 });

--- a/public/app/features/apiserver/client.test.ts
+++ b/public/app/features/apiserver/client.test.ts
@@ -1,4 +1,7 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { Subject, throwError } from 'rxjs';
+
+import { type LiveChannelEvent, LiveChannelConnectionState, LiveChannelEventType } from '@grafana/data';
+import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { DatasourceAPIVersions, ScopedResourceClient } from './client';
@@ -9,8 +12,10 @@ jest.mock('@grafana/runtime', () => ({
     get: jest.fn(),
     post: jest.fn(),
   }),
+  getGrafanaLiveSrv: jest.fn(),
   config: {
     buildInfo: { versionString: 'test-version' },
+    liveEnabled: true,
   },
 }));
 
@@ -251,5 +256,355 @@ describe('ScopedResourceClient', () => {
         { params: undefined }
       );
     });
+  });
+});
+
+describe('ScopedResourceClient watch (polling fallback)', () => {
+  const provisioningGvr: GroupVersionResource = {
+    group: 'provisioning.grafana.app',
+    version: 'v0alpha1',
+    resource: 'repositories',
+  };
+
+  let client: ScopedResourceClient;
+  let getMock: jest.Mock;
+  let getStreamMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    // The polling fallback logs via console.warn; suppress jest-fail-on-console.
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    getMock = jest.fn();
+    getStreamMock = jest.fn();
+
+    (getGrafanaLiveSrv as jest.Mock).mockReturnValue({
+      getStream: getStreamMock,
+    });
+
+    (getBackendSrv as jest.Mock).mockReturnValue({
+      get: getMock,
+    });
+
+    contextSrv.user.uid = 'test-uid';
+    client = new ScopedResourceClient(provisioningGvr);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('forwards events from the Live channel when it works', () => {
+    const stream = new Subject<LiveChannelEvent>();
+    getStreamMock.mockReturnValue(stream.asObservable());
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    const subscription = client.watch().subscribe({
+      next: (event) => events.push(event),
+    });
+
+    const resourceEvent = { type: 'ADDED', object: { metadata: { name: 'repo-1' }, spec: {} } };
+    stream.next({
+      type: LiveChannelEventType.Message,
+      message: resourceEvent,
+    });
+
+    expect(events).toEqual([resourceEvent]);
+    subscription.unsubscribe();
+  });
+
+  it('falls back to polling when live channel errors', async () => {
+    const wsError = new Error('WebSocket failed');
+    getStreamMock.mockReturnValue(throwError(() => wsError));
+
+    const itemA = { metadata: { name: 'repo-a', resourceVersion: '1' }, spec: {} };
+    getMock.mockResolvedValueOnce({ items: [itemA], metadata: {} });
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    client.watch().subscribe({
+      next: (event) => events.push(event),
+      error: () => {},
+    });
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(events).toEqual([{ type: 'ADDED', object: itemA }]);
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces original watch error when first poll also fails', async () => {
+    const wsError = new Error('WebSocket failed');
+    getStreamMock.mockReturnValue(throwError(() => wsError));
+
+    getMock.mockRejectedValueOnce(new Error('HTTP 403'));
+
+    let receivedError: unknown;
+    client.watch().subscribe({
+      next: () => {},
+      error: (err) => {
+        receivedError = err;
+      },
+    });
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    // Original watch error is surfaced, not the poll error
+    expect(receivedError).toBe(wsError);
+  });
+
+  it('emits correct diff events across polling cycles', async () => {
+    getStreamMock.mockReturnValue(throwError(() => new Error('ws')));
+
+    const itemA = { metadata: { name: 'a', resourceVersion: '1' }, spec: {} };
+    const itemB = { metadata: { name: 'b', resourceVersion: '1' }, spec: {} };
+    const itemAv2 = { metadata: { name: 'a', resourceVersion: '2' }, spec: { updated: true } };
+    const itemC = { metadata: { name: 'c', resourceVersion: '1' }, spec: {} };
+
+    // First poll: A, B
+    getMock.mockResolvedValueOnce({ items: [itemA, itemB], metadata: {} });
+    // Second poll: A (changed RV), C (new) — B removed
+    getMock.mockResolvedValueOnce({ items: [itemAv2, itemC], metadata: {} });
+    // Third poll: same as second — no changes
+    getMock.mockResolvedValueOnce({ items: [itemAv2, itemC], metadata: {} });
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    client.watch().subscribe({
+      next: (event) => events.push(event),
+      error: () => {},
+    });
+
+    // First poll
+    await jest.advanceTimersByTimeAsync(0);
+    expect(events).toEqual([
+      { type: 'ADDED', object: itemA },
+      { type: 'ADDED', object: itemB },
+    ]);
+
+    events.length = 0;
+
+    // Second poll (5s later)
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(events).toEqual([
+      { type: 'MODIFIED', object: itemAv2 },
+      { type: 'ADDED', object: itemC },
+      { type: 'DELETED', object: itemB },
+    ]);
+
+    events.length = 0;
+
+    // Third poll (another 5s) — same data, no events
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(events).toEqual([]);
+  });
+
+  it('tolerates subsequent poll errors without terminating', async () => {
+    getStreamMock.mockReturnValue(throwError(() => new Error('ws')));
+
+    const itemA = { metadata: { name: 'a', resourceVersion: '1' }, spec: {} };
+    const itemAv2 = { metadata: { name: 'a', resourceVersion: '2' }, spec: {} };
+
+    getMock.mockResolvedValueOnce({ items: [itemA], metadata: {} });
+    getMock.mockRejectedValueOnce(new Error('timeout'));
+    getMock.mockResolvedValueOnce({ items: [itemAv2], metadata: {} });
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    let error: unknown;
+    client.watch().subscribe({
+      next: (event) => events.push(event),
+      error: (err) => {
+        error = err;
+      },
+    });
+
+    // First poll: success
+    await jest.advanceTimersByTimeAsync(0);
+    expect(events).toHaveLength(1);
+
+    // Second poll: error swallowed
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(error).toBeUndefined();
+
+    // Third poll: recovery
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ type: 'MODIFIED', object: itemAv2 });
+  });
+
+  it('errors after max consecutive poll failures', async () => {
+    getStreamMock.mockReturnValue(throwError(() => new Error('ws')));
+
+    const itemA = { metadata: { name: 'a', resourceVersion: '1' }, spec: {} };
+
+    // First poll succeeds, then 5 consecutive failures
+    getMock.mockResolvedValueOnce({ items: [itemA], metadata: {} });
+    for (let i = 0; i < 5; i++) {
+      getMock.mockRejectedValueOnce(new Error('server down'));
+    }
+
+    let error: unknown;
+    client.watch().subscribe({
+      next: () => {},
+      error: (err) => {
+        error = err;
+      },
+    });
+
+    // First poll: success
+    await jest.advanceTimersByTimeAsync(0);
+    expect(error).toBeUndefined();
+
+    // Failures 1-4: tolerated
+    for (let i = 0; i < 4; i++) {
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(error).toBeUndefined();
+    }
+
+    // Failure 5: circuit breaker trips
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('server down');
+  });
+
+  it('stops polling when unsubscribed', async () => {
+    getStreamMock.mockReturnValue(throwError(() => new Error('ws')));
+
+    const itemA = { metadata: { name: 'a', resourceVersion: '1' }, spec: {} };
+    getMock.mockResolvedValue({ items: [itemA], metadata: {} });
+
+    const subscription = client.watch().subscribe({ next: () => {} });
+
+    // First poll
+    await jest.advanceTimersByTimeAsync(0);
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    subscription.unsubscribe();
+
+    // Should not poll again
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes selectors from watch options to list during polling', async () => {
+    getStreamMock.mockReturnValue(throwError(() => new Error('ws')));
+    getMock.mockResolvedValueOnce({ items: [], metadata: {} });
+
+    client
+      .watch({
+        fieldSelector: 'metadata.name=my-job',
+        labelSelector: 'app=grafana',
+      })
+      .subscribe({ next: () => {} });
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(getMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        fieldSelector: 'metadata.name=my-job',
+        labelSelector: 'app=grafana',
+      })
+    );
+  });
+
+  it('name option overrides fieldSelector for polling', async () => {
+    getStreamMock.mockReturnValue(throwError(() => new Error('ws')));
+    getMock.mockResolvedValueOnce({ items: [], metadata: {} });
+
+    client.watch({ name: 'my-repo' }).subscribe({ next: () => {} });
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(getMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        fieldSelector: 'metadata.name=my-repo',
+      })
+    );
+  });
+
+  it('goes straight to polling when liveEnabled is false', async () => {
+    const { config } = jest.requireMock('@grafana/runtime');
+    config.liveEnabled = false;
+
+    getMock.mockResolvedValueOnce({
+      items: [{ metadata: { name: 'repo-a', resourceVersion: '1' }, spec: {} }],
+      metadata: {},
+    });
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    client.watch().subscribe({
+      next: (event) => events.push(event),
+      error: () => {},
+    });
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    // Polling started without even attempting the Live channel
+    expect(getStreamMock).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      { type: 'ADDED', object: expect.objectContaining({ metadata: { name: 'repo-a', resourceVersion: '1' } }) },
+    ]);
+
+    config.liveEnabled = true;
+  });
+
+  it('falls back to polling when live channel hangs (proxy-blocked WebSocket)', async () => {
+    // Simulate a proxy-blocked WebSocket: getStream returns an Observable that
+    // emits an initial Pending status (no error) and then hangs forever.
+    const stream = new Subject<LiveChannelEvent>();
+    getStreamMock.mockReturnValue(stream.asObservable());
+
+    // Emit the initial Pending status (no error) — this is what the channel does
+    // synchronously in getStream() before the subscription is established.
+    // The watch pipe filters this out (not a message event), leaving silence.
+
+    const itemA = { metadata: { name: 'repo-a', resourceVersion: '1' }, spec: {} };
+    getMock.mockResolvedValueOnce({ items: [itemA], metadata: {} });
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    client.watch().subscribe({
+      next: (event) => events.push(event),
+      error: () => {},
+    });
+
+    // Nothing happens yet — the stream is hanging
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(events).toHaveLength(0);
+
+    // After the 10s timeout, the fallback kicks in
+    await jest.advanceTimersByTimeAsync(5000);
+    await jest.advanceTimersByTimeAsync(0); // flush poll microtasks
+
+    expect(events).toEqual([{ type: 'ADDED', object: itemA }]);
+  });
+
+  it('does NOT fall back to polling when the channel is connected but idle', async () => {
+    const stream = new Subject<LiveChannelEvent>();
+    getStreamMock.mockReturnValue(stream.asObservable());
+
+    const events: Array<{ type: string; object: unknown }> = [];
+    const subscription = client.watch().subscribe({
+      next: (event) => events.push(event),
+      error: () => {},
+    });
+
+    // Channel emits Connected status — this cancels the connection timeout.
+    stream.next({
+      type: LiveChannelEventType.Status,
+      id: 'test',
+      timestamp: Date.now(),
+      state: LiveChannelConnectionState.Connected,
+    } as LiveChannelEvent);
+
+    // Advance well past the timeout — should NOT trigger polling.
+    await jest.advanceTimersByTimeAsync(30_000);
+
+    // No polling requests were made (list was never called).
+    expect(getMock).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+
+    subscription.unsubscribe();
   });
 });

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -193,6 +193,9 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
     const listOpts = this.getWatchSelectors(params);
 
     return new Observable<ResourceEvent<T, S, K>>((subscriber) => {
+      // NOTE: starting empty means the first poll can't detect items deleted between
+      // the initial list() and polling start. Seeding from the RTKQ cache would fix
+      // this but requires threading initial state through watch() → createPollingFallback.
       let previousItems = new Map<string, Resource<T, S, K>>();
       let active = true;
       let firstPoll = true;

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,6 +1,11 @@
-import { type Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
+import { type Subscription, Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
-import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
+import {
+  isLiveChannelMessageEvent,
+  isLiveChannelStatusEvent,
+  LiveChannelConnectionState,
+  LiveChannelScope,
+} from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -39,45 +44,85 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
   }
 
   public watch(params?: WatchOptions): Observable<ResourceEvent<T, S, K>> {
+    const selectors = this.getWatchSelectors(params);
     const requestParams = {
       watch: true,
-      labelSelector: this.parseListOptionsSelector(params?.labelSelector),
-      fieldSelector: this.parseListOptionsSelector(params?.fieldSelector),
+      labelSelector: this.parseListOptionsSelector(selectors.labelSelector),
+      fieldSelector: this.parseListOptionsSelector(selectors.fieldSelector),
     };
-    if (params?.name) {
-      requestParams.fieldSelector = `metadata.name=${params.name}`;
-    }
 
     // For now, watch over live only supports provisioning
     if (this.gvr.group === 'provisioning.grafana.app') {
+      // If Grafana Live is disabled (max_connections=0), skip the WebSocket
+      // path entirely — centrifuge never connects and the stream hangs forever.
+      if (!config.liveEnabled) {
+        return this.createPollingFallback(params, new Error('Grafana Live is disabled'));
+      }
+
       let query = '';
       if (requestParams.fieldSelector?.startsWith('metadata.name=')) {
         query = requestParams.fieldSelector.substring('metadata.name'.length);
       }
-      return getGrafanaLiveSrv()
-        .getStream<ResourceEvent<T, S, K>>({
-          scope: LiveChannelScope.Watch,
-          stream: this.gvr.group,
-          path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid || 'anonymous'}`,
-          data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
-        })
-        .pipe(
-          map((event) => {
-            if (isLiveChannelStatusEvent(event) && event.error) {
-              throw event.error;
-            }
-            return event;
-          }),
-          filter((event) => isLiveChannelMessageEvent(event)),
-          map((event) => event.message),
-          // No RxJS retry here — centrifuge handles transient reconnection
-          // at the protocol level. Non-temporary errors (e.g. permission denied)
-          // should surface immediately rather than being retried.
-          catchError((error) => {
-            console.error('Live channel watch stream error:', error);
-            throw error;
-          })
-        );
+      const liveStream = getGrafanaLiveSrv().getStream<ResourceEvent<T, S, K>>({
+        scope: LiveChannelScope.Watch,
+        stream: this.gvr.group,
+        path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid || 'anonymous'}`,
+        data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
+      });
+
+      // Wrap the live stream with a connection timeout. If the channel
+      // doesn't move past the initial Pending state within the timeout
+      // (e.g. proxy blocking WebSocket upgrade), fall back to polling.
+      // Once connected, the timer is canceled and the stream runs
+      // indefinitely — idle-but-connected channels are NOT timed out.
+      return new Observable<ResourceEvent<T, S, K>>((subscriber) => {
+        let connected = false;
+        let pollSub: Subscription | null = null;
+
+        const connectionTimer = setTimeout(() => {
+          if (!connected) {
+            console.warn('Live channel connection timeout, falling back to polling');
+            liveSub.unsubscribe();
+            pollSub = this.createPollingFallback(params, new Error('Live channel connection timeout')).subscribe(
+              subscriber
+            );
+          }
+        }, ScopedResourceClient.LIVE_CHANNEL_TIMEOUT_MS);
+
+        const liveSub = liveStream
+          .pipe(
+            map((event) => {
+              if (isLiveChannelStatusEvent(event) && event.error) {
+                throw event.error;
+              }
+              // Any event beyond the initial Pending status proves the
+              // channel is alive — cancel the connection timeout.
+              const isPending = isLiveChannelStatusEvent(event) && event.state === LiveChannelConnectionState.Pending;
+              if (!isPending && !connected) {
+                connected = true;
+                clearTimeout(connectionTimer);
+              }
+              return event;
+            }),
+            filter((event) => isLiveChannelMessageEvent(event)),
+            map((event) => event.message)
+          )
+          .subscribe({
+            next: (value) => subscriber.next(value),
+            error: (error) => {
+              clearTimeout(connectionTimer);
+              console.warn('Live channel watch failed, falling back to polling:', error);
+              pollSub = this.createPollingFallback(params, error).subscribe(subscriber);
+            },
+            complete: () => subscriber.complete(),
+          });
+
+        return () => {
+          clearTimeout(connectionTimer);
+          liveSub.unsubscribe();
+          pollSub?.unsubscribe();
+        };
+      });
     }
 
     const decoder = new TextDecoder();
@@ -159,6 +204,123 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
   }
 
   private parseListOptionsSelector = parseListOptionsSelector;
+
+  private static LIVE_CHANNEL_TIMEOUT_MS = 10_000;
+  private static POLLING_INTERVAL_MS = 5000;
+  private static MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
+  /**
+   * Convert WatchOptions into the fieldSelector / labelSelector pair
+   * used by both the live-channel watch request and the polling fallback.
+   */
+  private getWatchSelectors(params?: WatchOptions): Pick<ListOptions, 'fieldSelector' | 'labelSelector'> {
+    const opts: Pick<ListOptions, 'fieldSelector' | 'labelSelector'> = {};
+    if (params?.labelSelector) {
+      opts.labelSelector = params.labelSelector;
+    }
+    if (params?.fieldSelector) {
+      opts.fieldSelector = params.fieldSelector;
+    }
+    // WatchOptions.name overrides fieldSelector
+    if (params?.name) {
+      opts.fieldSelector = `metadata.name=${params.name}`;
+    }
+    return opts;
+  }
+
+  /**
+   * Polling fallback when the Grafana Live WebSocket Observable errors.
+   * Periodically calls list() and diffs against the previous snapshot to emit
+   * ADDED / MODIFIED / DELETED events, providing eventual-state alignment.
+   *
+   * The first poll acts as a gate: if it fails, the original watch error is
+   * surfaced to the subscriber (preventing silent infinite polling for hard
+   * failures like auth errors). Subsequent poll failures are logged and retried.
+   */
+  private createPollingFallback(
+    params: WatchOptions | undefined,
+    originalError: unknown
+  ): Observable<ResourceEvent<T, S, K>> {
+    const listOpts = this.getWatchSelectors(params);
+
+    return new Observable<ResourceEvent<T, S, K>>((subscriber) => {
+      let previousItems = new Map<string, Resource<T, S, K>>();
+      let active = true;
+      let firstPoll = true;
+      let timerId: ReturnType<typeof setTimeout> | null = null;
+      let consecutiveFailures = 0;
+
+      const poll = async () => {
+        if (!active) {
+          return;
+        }
+        try {
+          const result = await this.list(listOpts);
+          if (!active) {
+            return;
+          }
+
+          const currentItems = new Map<string, Resource<T, S, K>>();
+          for (const item of result.items) {
+            currentItems.set(item.metadata.name, item);
+          }
+
+          // Emit ADDED or MODIFIED for items in current result
+          for (const [name, item] of currentItems) {
+            const prev = previousItems.get(name);
+            if (!prev) {
+              subscriber.next({ type: 'ADDED', object: item });
+            } else if (prev.metadata.resourceVersion !== item.metadata.resourceVersion) {
+              subscriber.next({ type: 'MODIFIED', object: item });
+            }
+          }
+
+          // Emit DELETED for items no longer present
+          for (const [name, item] of previousItems) {
+            if (!currentItems.has(name)) {
+              subscriber.next({ type: 'DELETED', object: item });
+            }
+          }
+
+          previousItems = currentItems;
+          firstPoll = false;
+          consecutiveFailures = 0;
+        } catch (pollError) {
+          if (firstPoll) {
+            // First poll failed too — this is likely a hard error (auth, bad endpoint).
+            // Surface the original watch error rather than polling silently forever.
+            subscriber.error(originalError);
+            return;
+          }
+          consecutiveFailures++;
+          if (consecutiveFailures >= ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES) {
+            subscriber.error(pollError);
+            return;
+          }
+          // Transient failure: log and retry next cycle.
+          console.warn(
+            `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
+            pollError
+          );
+        }
+
+        if (active) {
+          timerId = setTimeout(poll, ScopedResourceClient.POLLING_INTERVAL_MS);
+        }
+      };
+
+      // Start first poll immediately
+      poll();
+
+      // Teardown: stop polling when unsubscribed
+      return () => {
+        active = false;
+        if (timerId !== null) {
+          clearTimeout(timerId);
+        }
+      };
+    });
+  }
 }
 
 // add the origin annotations so we know what was set from the UI

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,11 +1,6 @@
-import { type Subscription, Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
+import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
-import {
-  isLiveChannelMessageEvent,
-  isLiveChannelStatusEvent,
-  LiveChannelConnectionState,
-  LiveChannelScope,
-} from '@grafana/data';
+import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -53,76 +48,31 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
 
     // For now, watch over live only supports provisioning
     if (this.gvr.group === 'provisioning.grafana.app') {
-      // If Grafana Live is disabled (max_connections=0), skip the WebSocket
-      // path entirely — centrifuge never connects and the stream hangs forever.
-      if (!config.liveEnabled) {
-        return this.createPollingFallback(params, new Error('Grafana Live is disabled'));
-      }
-
       let query = '';
       if (requestParams.fieldSelector?.startsWith('metadata.name=')) {
         query = requestParams.fieldSelector.substring('metadata.name'.length);
       }
-      const liveStream = getGrafanaLiveSrv().getStream<ResourceEvent<T, S, K>>({
-        scope: LiveChannelScope.Watch,
-        stream: this.gvr.group,
-        path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid || 'anonymous'}`,
-        data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
-      });
-
-      // Wrap the live stream with a connection timeout. If the channel
-      // doesn't move past the initial Pending state within the timeout
-      // (e.g. proxy blocking WebSocket upgrade), fall back to polling.
-      // Once connected, the timer is canceled and the stream runs
-      // indefinitely — idle-but-connected channels are NOT timed out.
-      return new Observable<ResourceEvent<T, S, K>>((subscriber) => {
-        let connected = false;
-        let pollSub: Subscription | null = null;
-
-        const connectionTimer = setTimeout(() => {
-          if (!connected) {
-            console.warn('Live channel connection timeout, falling back to polling');
-            liveSub.unsubscribe();
-            pollSub = this.createPollingFallback(params, new Error('Live channel connection timeout')).subscribe(
-              subscriber
-            );
-          }
-        }, ScopedResourceClient.LIVE_CHANNEL_TIMEOUT_MS);
-
-        const liveSub = liveStream
-          .pipe(
-            map((event) => {
-              if (isLiveChannelStatusEvent(event) && event.error) {
-                throw event.error;
-              }
-              // Any event beyond the initial Pending status proves the
-              // channel is alive — cancel the connection timeout.
-              const isPending = isLiveChannelStatusEvent(event) && event.state === LiveChannelConnectionState.Pending;
-              if (!isPending && !connected) {
-                connected = true;
-                clearTimeout(connectionTimer);
-              }
-              return event;
-            }),
-            filter((event) => isLiveChannelMessageEvent(event)),
-            map((event) => event.message)
-          )
-          .subscribe({
-            next: (value) => subscriber.next(value),
-            error: (error) => {
-              clearTimeout(connectionTimer);
-              console.warn('Live channel watch failed, falling back to polling:', error);
-              pollSub = this.createPollingFallback(params, error).subscribe(subscriber);
-            },
-            complete: () => subscriber.complete(),
-          });
-
-        return () => {
-          clearTimeout(connectionTimer);
-          liveSub.unsubscribe();
-          pollSub?.unsubscribe();
-        };
-      });
+      return getGrafanaLiveSrv()
+        .getStream<ResourceEvent<T, S, K>>({
+          scope: LiveChannelScope.Watch,
+          stream: this.gvr.group,
+          path: `${this.gvr.version}/${this.gvr.resource}${query}/${contextSrv.user.uid || 'anonymous'}`,
+          data: params?.resourceVersion ? { resourceVersion: params.resourceVersion } : undefined,
+        })
+        .pipe(
+          map((event) => {
+            if (isLiveChannelStatusEvent(event) && event.error) {
+              throw event.error;
+            }
+            return event;
+          }),
+          filter((event) => isLiveChannelMessageEvent(event)),
+          map((event) => event.message),
+          catchError((error) => {
+            console.warn('Live channel watch failed, falling back to polling:', error);
+            return this.createPollingFallback(params, error);
+          })
+        );
     }
 
     const decoder = new TextDecoder();
@@ -205,7 +155,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
 
   private parseListOptionsSelector = parseListOptionsSelector;
 
-  private static LIVE_CHANNEL_TIMEOUT_MS = 10_000;
   private static POLLING_INTERVAL_MS = 5000;
   private static MAX_CONSECUTIVE_POLL_FAILURES = 5;
 

--- a/public/app/features/live/centrifuge/service.test.ts
+++ b/public/app/features/live/centrifuge/service.test.ts
@@ -1,0 +1,153 @@
+import { State } from 'centrifuge';
+import { of, lastValueFrom, toArray } from 'rxjs';
+
+import {
+  type LiveChannelEvent,
+  LiveChannelConnectionState,
+  LiveChannelScope,
+  isLiveChannelStatusEvent,
+} from '@grafana/data';
+
+import { CentrifugeService, type CentrifugeSrvDeps } from './service';
+
+// ---------------------------------------------------------------------------
+// Centrifuge mock
+// ---------------------------------------------------------------------------
+
+let mockCentrifugeState = State.Disconnected;
+
+const mockCentrifuge = {
+  get state() {
+    return mockCentrifugeState;
+  },
+  connect: jest.fn(),
+  on: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  newSubscription: jest.fn(() => mockSubscription),
+  getSubscription: jest.fn(() => null),
+  removeSubscription: jest.fn(),
+  rpc: jest.fn(),
+};
+
+const mockSubscription = {
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn(),
+  removeAllListeners: jest.fn(),
+  publish: jest.fn(),
+  presence: jest.fn(),
+  on: jest.fn().mockReturnThis(),
+};
+
+jest.mock('centrifuge', () => ({
+  ...jest.requireActual('centrifuge'),
+  Centrifuge: jest.fn(() => mockCentrifuge),
+}));
+
+// Suppress getBackendSrv usage inside onError handler
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(() => ({ get: jest.fn() })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseAddr = {
+  scope: LiveChannelScope.Grafana,
+  stream: 'teststream',
+  path: 'testpath',
+};
+
+function makeDeps(overrides: Partial<CentrifugeSrvDeps> = {}): CentrifugeSrvDeps {
+  return {
+    grafanaAuthToken: null,
+    appUrl: 'http://localhost:3000',
+    namespace: 'default',
+    orgRole: 'Admin',
+    liveEnabled: true,
+    dataStreamSubscriberReadiness: of(true),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CentrifugeService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    mockCentrifugeState = State.Disconnected;
+    mockCentrifuge.on.mockClear();
+    mockCentrifuge.addListener.mockClear();
+    mockCentrifuge.connect.mockClear();
+    mockCentrifuge.newSubscription.mockClear();
+    mockCentrifuge.removeSubscription.mockClear();
+    mockCentrifuge.getSubscription.mockClear();
+  });
+
+  it('should timeout and shut down channel when centrifuge never connects', async () => {
+    jest.useFakeTimers();
+
+    // centrifuge stays Disconnected — connectionBlocker never resolves
+    const service = new CentrifugeService(makeDeps());
+
+    const stream$ = service.getStream(baseAddr);
+
+    // Collect all emitted events
+    const eventsPromise = lastValueFrom(stream$.pipe(toArray()));
+
+    // Advance past the 10s timeout
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    const events = await eventsPromise;
+
+    // Should have at least 2 status events: initial Pending, then the error
+    expect(events.length).toBeGreaterThanOrEqual(2);
+
+    const errorEvent = events.find((e) => isLiveChannelStatusEvent(e) && e.error === 'Grafana Live connection timeout');
+    expect(errorEvent).toBeDefined();
+
+    // Stream should have completed (lastValueFrom resolved)
+  });
+
+  it('should immediately shut down channel when liveEnabled is false', async () => {
+    const service = new CentrifugeService(makeDeps({ liveEnabled: false }));
+
+    const stream$ = service.getStream(baseAddr);
+    const events = await lastValueFrom(stream$.pipe(toArray()));
+
+    // Should contain the error status
+    const errorEvent = events.find((e) => isLiveChannelStatusEvent(e) && e.error === 'Grafana Live is disabled');
+    expect(errorEvent).toBeDefined();
+
+    // Should NOT have created a subscription
+    expect(mockCentrifuge.newSubscription).not.toHaveBeenCalled();
+  });
+
+  it('should proceed normally when centrifuge is already connected', async () => {
+    // Set connected state BEFORE constructing the service so connectionBlocker resolves immediately
+    mockCentrifugeState = State.Connected;
+
+    const service = new CentrifugeService(makeDeps());
+
+    const stream$ = service.getStream(baseAddr);
+
+    // The stream should emit the initial Pending status and stay open (subscription created)
+    const firstEvent = await new Promise<LiveChannelEvent>((resolve) => {
+      stream$.subscribe({ next: resolve });
+    });
+
+    expect(isLiveChannelStatusEvent(firstEvent)).toBe(true);
+    if (isLiveChannelStatusEvent(firstEvent)) {
+      expect(firstEvent.state).toBe(LiveChannelConnectionState.Pending);
+    }
+
+    // initChannel should have succeeded — subscription was created
+    expect(mockCentrifuge.newSubscription).toHaveBeenCalled();
+    expect(mockSubscription.subscribe).toHaveBeenCalled();
+  });
+});

--- a/public/app/features/live/centrifuge/service.test.ts
+++ b/public/app/features/live/centrifuge/service.test.ts
@@ -10,10 +10,6 @@ import {
 
 import { CentrifugeService, type CentrifugeSrvDeps } from './service';
 
-// ---------------------------------------------------------------------------
-// Centrifuge mock
-// ---------------------------------------------------------------------------
-
 let mockCentrifugeState = State.Disconnected;
 
 const mockCentrifuge = {
@@ -44,15 +40,10 @@ jest.mock('centrifuge', () => ({
   Centrifuge: jest.fn(() => mockCentrifuge),
 }));
 
-// Suppress getBackendSrv usage inside onError handler
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: jest.fn(() => ({ get: jest.fn() })),
 }));
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 const baseAddr = {
   scope: LiveChannelScope.Grafana,
@@ -72,10 +63,6 @@ function makeDeps(overrides: Partial<CentrifugeSrvDeps> = {}): CentrifugeSrvDeps
   };
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe('CentrifugeService', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -92,26 +79,20 @@ describe('CentrifugeService', () => {
   it('should timeout and shut down channel when centrifuge never connects', async () => {
     jest.useFakeTimers();
 
-    // centrifuge stays Disconnected — connectionBlocker never resolves
     const service = new CentrifugeService(makeDeps());
 
     const stream$ = service.getStream(baseAddr);
 
-    // Collect all emitted events
     const eventsPromise = lastValueFrom(stream$.pipe(toArray()));
 
-    // Advance past the 10s timeout
     await jest.advanceTimersByTimeAsync(10_000);
 
     const events = await eventsPromise;
 
-    // Should have at least 2 status events: initial Pending, then the error
     expect(events.length).toBeGreaterThanOrEqual(2);
 
     const errorEvent = events.find((e) => isLiveChannelStatusEvent(e) && e.error === 'Grafana Live connection timeout');
     expect(errorEvent).toBeDefined();
-
-    // Stream should have completed (lastValueFrom resolved)
   });
 
   it('should immediately shut down channel when liveEnabled is false', async () => {
@@ -120,23 +101,19 @@ describe('CentrifugeService', () => {
     const stream$ = service.getStream(baseAddr);
     const events = await lastValueFrom(stream$.pipe(toArray()));
 
-    // Should contain the error status
     const errorEvent = events.find((e) => isLiveChannelStatusEvent(e) && e.error === 'Grafana Live is disabled');
     expect(errorEvent).toBeDefined();
 
-    // Should NOT have created a subscription
     expect(mockCentrifuge.newSubscription).not.toHaveBeenCalled();
   });
 
   it('should proceed normally when centrifuge is already connected', async () => {
-    // Set connected state BEFORE constructing the service so connectionBlocker resolves immediately
     mockCentrifugeState = State.Connected;
 
     const service = new CentrifugeService(makeDeps());
 
     const stream$ = service.getStream(baseAddr);
 
-    // The stream should emit the initial Pending status and stay open (subscription created)
     const firstEvent = await new Promise<LiveChannelEvent>((resolve) => {
       stream$.subscribe({ next: resolve });
     });
@@ -146,7 +123,6 @@ describe('CentrifugeService', () => {
       expect(firstEvent.state).toBe(LiveChannelConnectionState.Pending);
     }
 
-    // initChannel should have succeeded — subscription was created
     expect(mockCentrifuge.newSubscription).toHaveBeenCalled();
     expect(mockSubscription.subscribe).toHaveBeenCalled();
   });

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -74,6 +74,7 @@ export class CentrifugeService implements CentrifugeSrv {
   readonly connectionBlocker: Promise<void>;
   private readonly dataStreamSubscriberReadiness: Observable<boolean>;
   private lastAuthCheck = 0;
+  private static CONNECTION_TIMEOUT_MS = 10_000;
 
   constructor(private deps: CentrifugeSrvDeps) {
     this.dataStreamSubscriberReadiness = deps.dataStreamSubscriberReadiness.pipe(share(), startWith(true));
@@ -164,6 +165,13 @@ export class CentrifugeService implements CentrifugeSrv {
     if (channel.currentStatus.state === LiveChannelConnectionState.Invalid) {
       return channel;
     }
+    // If Live is disabled, fail the channel immediately rather than waiting
+    // for the connection timeout.
+    if (!this.deps.liveEnabled) {
+      channel.shutdownWithError('Grafana Live is disabled');
+      return channel;
+    }
+
     channel.shutdownCallback = () => {
       this.open.delete(id);
 
@@ -187,7 +195,12 @@ export class CentrifugeService implements CentrifugeSrv {
 
   private async initChannel(channel: CentrifugeLiveChannel): Promise<void> {
     if (this.centrifuge.state !== State.Connected) {
-      await this.connectionBlocker;
+      await Promise.race([
+        this.connectionBlocker,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject('Grafana Live connection timeout'), CentrifugeService.CONNECTION_TIMEOUT_MS)
+        ),
+      ]);
     }
     const subscription = this.centrifuge.newSubscription(channel.id, {
       data: channel.addr.data,

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -195,6 +195,8 @@ export class CentrifugeService implements CentrifugeSrv {
 
   private async initChannel(channel: CentrifugeLiveChannel): Promise<void> {
     if (this.centrifuge.state !== State.Connected) {
+      // Wait for centrifuge to connect, but bail out after the timeout
+      // so the channel can fall back to polling instead of hanging forever.
       await Promise.race([
         this.connectionBlocker,
         new Promise<never>((_, reject) =>

--- a/public/app/features/provisioning/Job/JobStatus.test.tsx
+++ b/public/app/features/provisioning/Job/JobStatus.test.tsx
@@ -132,9 +132,9 @@ describe('JobStatus', () => {
     });
   });
 
-  it('handles watch stream errors by marking the cached job as failed', async () => {
+  it('continues showing real job state when watch stream errors (polling fallback)', async () => {
     const onStatusChange = jest.fn();
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
     mockJobList(createJob());
 
@@ -146,18 +146,16 @@ describe('JobStatus', () => {
       getMockLiveSrv().emitWatchError('jobs', new Error('connection lost'));
     });
 
+    // The polling fallback intercepts the watch error and re-fetches real state.
+    // Wait for the poll to complete and re-update the cache.
     await waitFor(() => {
-      expect(onStatusChange).toHaveBeenCalledWith({
-        status: 'error',
-        error: {
-          title: 'Error running job',
-          message: ['Error: connection lost'],
-        },
-        warning: undefined,
-        action: undefined,
-      });
+      expect(onStatusChange.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
 
-    consoleErrorSpy.mockRestore();
+    // No artificial error state — the job continues showing its real server state.
+    expect(onStatusChange).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }));
+    expect(screen.getByText('Pulling...')).toBeInTheDocument();
+
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -593,8 +593,8 @@ describe('ProvisioningWizard', () => {
       expect(finishButton).toBeDisabled();
     });
 
-    it('shows an error alert and keeps the finish button disabled when the jobs watch stream errors', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    it('continues showing job progress when the watch stream errors (polling fallback)', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       try {
         setupWorkingJobHandlers();
 
@@ -605,11 +605,17 @@ describe('ProvisioningWizard', () => {
           getMockLiveSrv().emitWatchError('jobs', new Error('connection lost'));
         });
 
-        expect(await screen.findByText('Error running job')).toBeInTheDocument();
-        expect(screen.getByText('Error: connection lost')).toBeInTheDocument();
+        // The polling fallback intercepts the watch error and re-fetches the job.
+        // The UI continues showing real job progress instead of an error.
+        await waitFor(() => {
+          expect(screen.getByText('Pulling...')).toBeInTheDocument();
+        });
+
+        // No error is displayed — the fallback is transparent to the user.
+        expect(screen.queryByText('Error running job')).not.toBeInTheDocument();
         expect(finishButton).toBeDisabled();
       } finally {
-        consoleErrorSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
       }
     });
 


### PR DESCRIPTION
**What is this feature?**

When Grafana Live WebSocket connections are unavailable, the provisioning UI transparently falls back to HTTP polling. `ScopedResourceClient.watch()` catches Live channel errors with `catchError` and switches to a polling Observable that diffs `list()` snapshots to emit `ADDED`/`MODIFIED`/`DELETED` events. 
**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1053

Can be tested with this config option: 
   ```ini
   [live]
   max_connections = 0
   ```