### PR TITLE
Zanzana: Add folder contextual tuples for render service

### DIFF
--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -18,6 +18,7 @@ import (
 
 	dashboardV2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	dashboardV2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/clientauth"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -263,6 +264,19 @@ func (s *Server) getContextuals(subject string) (*openfgav1.ContextualTupleKeys,
 				Object: common.NewGroupResourceIdent(
 					dashboardV2beta1.DashboardResourceInfo.GroupResource().Group,
 					dashboardV2beta1.DashboardResourceInfo.GroupResource().Resource,
+					"",
+				),
+			},
+		)
+
+		contextuals = append(
+			contextuals,
+			&openfgav1.TupleKey{
+				User:     subject,
+				Relation: common.RelationSetView,
+				Object: common.NewGroupResourceIdent(
+					folders.FolderResourceInfo.GroupResource().Group,
+					folders.FolderResourceInfo.GroupResource().Resource,
 					"",
 				),
 			},

--- a/pkg/services/authz/zanzana/server/server_contextuals_test.go
+++ b/pkg/services/authz/zanzana/server/server_contextuals_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dashboardV2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
+	dashboardV2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
+)
+
+func TestGetContextuals(t *testing.T) {
+	srv := &Server{}
+
+	t.Run("render service gets dashboard and folder contextual tuples", func(t *testing.T) {
+		contextuals, err := srv.getContextuals("render:0")
+		require.NoError(t, err)
+		require.NotNil(t, contextuals)
+		require.Len(t, contextuals.TupleKeys, 3)
+
+		expectedObjects := []string{
+			common.NewGroupResourceIdent(
+				dashboardV2alpha1.DashboardResourceInfo.GroupResource().Group,
+				dashboardV2alpha1.DashboardResourceInfo.GroupResource().Resource,
+				"",
+			),
+			common.NewGroupResourceIdent(
+				dashboardV2beta1.DashboardResourceInfo.GroupResource().Group,
+				dashboardV2beta1.DashboardResourceInfo.GroupResource().Resource,
+				"",
+			),
+			common.NewGroupResourceIdent(
+				folders.FolderResourceInfo.GroupResource().Group,
+				folders.FolderResourceInfo.GroupResource().Resource,
+				"",
+			),
+		}
+
+		for i, tuple := range contextuals.TupleKeys {
+			assert.Equal(t, "render:0", tuple.User)
+			assert.Equal(t, common.RelationSetView, tuple.Relation)
+			assert.Equal(t, expectedObjects[i], tuple.Object)
+		}
+	})
+
+	t.Run("non-render subject returns nil contextuals", func(t *testing.T) {
+		contextuals, err := srv.getContextuals("user:123")
+		require.NoError(t, err)
+		assert.Nil(t, contextuals)
+	})
+}


### PR DESCRIPTION
## Summary
- The render service (`render:0`) was missing folder view permissions in Zanzana's contextual tuples, causing shadow client "evaluated differently" warnings
- Legacy RBAC grants `render:0` read access to dashboards, folders, datasources, and datasource queries. Zanzana's `getContextuals()` only injected tuples for dashboards — folders were missing
- Adds a `view` contextual tuple on `group_resource:folder.grafana.app/folders` for the render service, matching the existing dashboard tuple pattern

## Test plan
- [x] Unit test added for `getContextuals()` verifying all 3 tuples (dashboard v2alpha1, v2beta1, folders) are returned for render subjects
- [x] Unit test verifying non-render subjects get nil contextuals
- [ ] Verify shadow client mismatch warnings for `render:0` on `folders:read` are resolved in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)