### PR TITLE
test: Prevent retried E2E tests to fail

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-variables.spec.ts
@@ -122,7 +122,7 @@ test.describe(
     test('can make a hidden variable visible', async ({ dashboardPage, selectors, page }) => {
       const variable = variableWithDefaults({ display: 'Hidden' });
 
-      await saveDashboard(dashboardPage, page, selectors, 'can make a hidden variable visible');
+      await saveDashboard(dashboardPage, page, selectors, `can make a hidden variable visible (${Math.random()})`);
       await flows.addNewTextBoxVariable(dashboardPage, variable);
 
       // check the variable is hidden in the dashboard
@@ -163,7 +163,7 @@ test.describe(
     test('can hide variable under the controls menu', async ({ dashboardPage, selectors, page }) => {
       const variable = variableWithDefaults();
 
-      await saveDashboard(dashboardPage, page, selectors, 'can hide a variable in controls menu');
+      await saveDashboard(dashboardPage, page, selectors, `can hide a variable in controls menu - (${Math.random()})`);
 
       await flows.addNewTextBoxVariable(dashboardPage, variable);
 


### PR DESCRIPTION
Slack context: https://raintank-corp.slack.com/archives/C01BKPAV1EZ/p1775134813084599

**TL;DR:** when saved during E2E testing, some dashboards are not assigned unique names, so retrying a test may fail because the dashboard cannot be saved again ("A dashboard or a folder with the same name already exists").

This PR is a quick fix to unblock the failing tests in `main`. We should adopt a better strategy and/or do a proper cleanup in the future.