### PR TITLE
Dashboards: Store proper version in unistore

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -614,6 +614,7 @@ func validateDashboardTags(obj runtime.Object) error {
 
 func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	storageOpts := apistore.StorageOptions{
+		Scheme:                      opts.Scheme,
 		EnableFolderSupport:         true,
 		RequireDeprecatedInternalID: true,
 	}


### PR DESCRIPTION
This PR fixes an issue where dashboards v1beta1 were being stored in unistore as v1.

It does that by setting the scheme, which is used [here](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/apistore/prepare.go#L379). Prior to that, it would [use the standard encoder](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/apistore/prepare.go#L380), which uses the [LegacyCodec](https://github.com/grafana/grafana/blob/main/pkg/services/apiserver/service.go#L292), which then re-encoded it to the preferred version.

Now it will use the [json encoder](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/apistore/prepare.go#L389), which will keep the gvk that the client sent in.