### PR TITLE
Dashboard: Fix issue with getVariableCompatability

### DIFF
--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
@@ -61,60 +61,6 @@ describe('getVariablesCompatibility', () => {
     });
   });
 
-  describe('edit pane selection', () => {
-    it('scopes to the selected object ancestry', () => {
-      const dashVar = makeVar('dashVar');
-      const sectionVar = makeVar('sectionVar');
-      const otherSectionVar = makeVar('otherVar');
-
-      const row1 = new RowItem({
-        title: 'Row 1',
-        $variables: new SceneVariableSet({ variables: [sectionVar] }),
-      });
-
-      const row2 = new RowItem({
-        title: 'Row 2',
-        $variables: new SceneVariableSet({ variables: [otherSectionVar] }),
-      });
-
-      const dashboard = new DashboardScene({
-        $variables: new SceneVariableSet({ variables: [dashVar] }),
-        body: new RowsLayoutManager({ rows: [row1, row2] }),
-      });
-
-      const selection = new ElementSelection([[sectionVar.state.key!, sectionVar.getRef()]]);
-      dashboard.state.editPane.setState({ selection });
-
-      const result = getVariablesCompatibility(dashboard);
-      const names = result.map((v) => v.name);
-
-      expect(names).toContain('sectionVar');
-      expect(names).toContain('dashVar');
-      expect(names).not.toContain('otherVar');
-    });
-
-    it('falls back to all variables when nothing is selected', () => {
-      const dashVar = makeVar('dashVar');
-      const sectionVar = makeVar('sectionVar');
-
-      const row = new RowItem({
-        title: 'Row 1',
-        $variables: new SceneVariableSet({ variables: [sectionVar] }),
-      });
-
-      const dashboard = new DashboardScene({
-        $variables: new SceneVariableSet({ variables: [dashVar] }),
-        body: new RowsLayoutManager({ rows: [row] }),
-      });
-
-      const result = getVariablesCompatibility(dashboard);
-      const names = result.map((v) => v.name);
-
-      expect(names).toContain('dashVar');
-      expect(names).toContain('sectionVar');
-    });
-  });
-
   describe('dashboard view mode (no editPanel, no selection)', () => {
     it('returns all variables from dashboard and all sections', () => {
       const dashVar = makeVar('dashVar');

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
@@ -14,17 +14,6 @@ export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariab
     return collectAncestorVariables(panel);
   }
 
-  // When a scene object is selected in the edit pane (e.g., editing a section variable),
-  // scope to that object's ancestry so datasource pickers only show variables from
-  // the same section + dashboard globals.
-  if (sceneObject instanceof DashboardScene) {
-    const selectedObject = sceneObject.state.editPane.state.selection?.getFirstObject();
-    if (selectedObject && selectedObject !== sceneObject) {
-      // @ts-expect-error
-      return collectAncestorVariables(selectedObject);
-    }
-  }
-
   // If called with a non-root scene object, walk up its ancestry
   if (!(sceneObject instanceof DashboardScene)) {
     // @ts-expect-error


### PR DESCRIPTION
I am not sure we should make changes like this to getVariableCompatability , that function should only be used to support legacy usage that does not need to support nested variables, and if we have code that calls getVariableCompatability and does need to support nested usage we need a different approach to get variables that does not rely on the old global access of templateSrv.getVariables 

The issue with a global function like getVariableCompatability take into account edit pane selection state is that that function could be called for all panels, used by some plugin panels that shows/lists variabls and those panels would then start showing panels from other rows. 

the point is if I can getVariableCompatability and pass in the top level scene object (DashboardScene), only top level variables should be returned. And element selection should not not impact what this function returns (that would be a breaking change)

Also a bit unsure on collectChildVariableSets and why we would ever want to collect child variables, but leaving that for now 