### PR TITLE
APIServer: Reorder codec so stored version is preferred version

### DIFF
--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -99,4 +100,40 @@ func ApplyPreferredForGroup(logger log.Logger, scheme *runtime.Scheme, apiResour
 	}
 	logger.Info("set preferred API version for group", "group", group, "preferredVersion", preferred.Version)
 	return nil
+}
+
+// ReorderGroupVersionsForLegacyCodec reorders the slice passed to
+// serializer.CodecFactory.LegacyCodec(...) so that each preferred version is
+// first within its group, which determines what is stored in unified storage.
+func ReorderGroupVersionsForLegacyCodec(logger log.Logger, cfg *setting.Cfg, scheme *runtime.Scheme, groupVersions []schema.GroupVersion) ([]schema.GroupVersion, error) {
+	raw := strings.TrimSpace(cfg.SectionWithEnvOverrides("grafana-apiserver").Key("preferred_api_version").String())
+	if raw == "" {
+		return groupVersions, nil
+	}
+
+	out := slices.Clone(groupVersions)
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		gv, err := ParseGroupVersionSetting(part)
+		if err != nil {
+			return nil, err
+		}
+
+		prefIdx := slices.Index(out, gv)
+		if prefIdx < 0 {
+			logger.Info("preferred_api_version (legacy codec): version not in codec list, skipping",
+				"group", gv.Group, "version", gv.Version)
+			continue
+		}
+		firstIdx := slices.IndexFunc(out, func(v schema.GroupVersion) bool {
+			return v.Group == gv.Group
+		})
+		if firstIdx != prefIdx {
+			out[prefIdx], out[firstIdx] = out[firstIdx], out[prefIdx]
+		}
+	}
+	return out, nil
 }

--- a/pkg/services/apiserver/preferred_version_test.go
+++ b/pkg/services/apiserver/preferred_version_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestParseGroupVersionSetting(t *testing.T) {
@@ -62,4 +63,52 @@ func TestApplyPreferredForGroup_SkipsWhenDisabled(t *testing.T) {
 	pvs := scheme.PrioritizedVersionsForGroup("test.example")
 	require.Len(t, pvs, 2)
 	require.Equal(t, "v1alpha1", pvs[0].Version, "unchanged order when preferred is disabled")
+}
+
+func TestReorderGroupVersionsForLegacyCodec_PutsPreferredFirstInGroup(t *testing.T) {
+	cfg := setting.NewCfg()
+	sec := cfg.Raw.Section("grafana-apiserver")
+	_, err := sec.NewKey("preferred_api_version", "test.example/v1")
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	gvAlpha := schema.GroupVersion{Group: "test.example", Version: "v1alpha1"}
+	gvStable := schema.GroupVersion{Group: "test.example", Version: "v1"}
+	metav1.AddToGroupVersion(scheme, gvAlpha)
+	metav1.AddToGroupVersion(scheme, gvStable)
+	require.NoError(t, scheme.SetVersionPriority(gvAlpha, gvStable))
+
+	other := schema.GroupVersion{Group: "other.example", Version: "v1"}
+	metav1.AddToGroupVersion(scheme, other)
+
+	input := []schema.GroupVersion{
+		other,
+		gvAlpha,
+		gvStable,
+	}
+	out, err := ReorderGroupVersionsForLegacyCodec(log.NewNopLogger(), cfg, scheme, input)
+	require.NoError(t, err)
+	require.Equal(t, []schema.GroupVersion{other, gvStable, gvAlpha}, out)
+}
+
+func TestReorderGroupVersionsForLegacyCodec_EmptySettingNoop(t *testing.T) {
+	cfg := setting.NewCfg()
+	scheme := runtime.NewScheme()
+	gv := schema.GroupVersion{Group: "test.example", Version: "v1"}
+	metav1.AddToGroupVersion(scheme, gv)
+	input := []schema.GroupVersion{gv}
+	out, err := ReorderGroupVersionsForLegacyCodec(log.NewNopLogger(), cfg, scheme, input)
+	require.NoError(t, err)
+	require.Equal(t, input, out)
+}
+
+func TestReorderGroupVersionsForLegacyCodec_InvalidEntry(t *testing.T) {
+	cfg := setting.NewCfg()
+	sec := cfg.Raw.Section("grafana-apiserver")
+	_, err := sec.NewKey("preferred_api_version", "not-a-valid-gv")
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	_, err = ReorderGroupVersionsForLegacyCodec(log.NewNopLogger(), cfg, scheme, nil)
+	require.Error(t, err)
 }

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -289,6 +289,13 @@ func (s *service) start(ctx context.Context) error {
 	}
 	groupVersions = append(groupVersions, additionalGroupVersions...)
 
+	// reorder so the preferred version, if set in the config.ini, is first in the slice.
+	// this will impact what version is stored in unified storage.
+	groupVersions, err = ReorderGroupVersionsForLegacyCodec(s.log, s.cfg, s.scheme, groupVersions)
+	if err != nil {
+		return fmt.Errorf("preferred_api_version: %w", err)
+	}
+
 	o := grafanaapiserveroptions.NewOptions(s.codecs.LegacyCodec(groupVersions...))
 
 	// Register authorizers from app installers


### PR DESCRIPTION
By default, we store in unified storage the preferred version for the group. This is done using the [standard encoder](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/apistore/prepare.go#L380), which uses the [LegacyCodec](https://github.com/grafana/grafana/blob/main/pkg/services/apiserver/service.go#L292), which then re-encoded it to the preferred version.

However, right now, this does not respect the preferred version set in the config.ini. e.g:
```
[grafana-apiserver]
preferred_api_version = dashboard.grafana.app/v1beta1, playlist.grafana.app/v0alpha1
```

This PR fixes that so we store the proper version.