### PR TITLE
Alerting: Fix empty GUID in alert rule tables

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig.go
@@ -36,6 +36,13 @@ func AddAlertRuleGuidMigration(mg *migrator.Migrator) {
 
 	mg.AddMigration("populate rule guid in alert rule table", &setRuleGuidMigration{})
 
+	// Fix for https://github.com/grafana/grafana/issues/103076
+	// Versions 10.4.x through 11.5.x did not generate GUIDs when inserting new alert rules
+	// (InsertAlertRules did not set the guid field), causing the column default '' to be used.
+	// This migration assigns unique GUIDs to any rows that still have empty guid/rule_guid,
+	// which would otherwise cause unique constraint violations during index creation.
+	mg.AddMigration("fix empty guid in alert_rule and alert_rule_version tables", &fixEmptyGuidMigration{})
+
 	mg.AddMigration("drop index in alert_rule_version table on rule_org_id, rule_uid and version columns", migrator.NewDropIndexMigration(alertRuleVersion, alertRuleVersionUDX_OrgIdRuleUIDVersion))
 
 	mg.AddMigration("add index in alert_rule_version table on rule_org_id, rule_uid, rule_guid and version columns",
@@ -198,5 +205,96 @@ func (c cleanUpRuleVersionsMigration) Exec(sess *xorm.Session, mg *migrator.Migr
 
 		mg.Logger.Debug(fmt.Sprintf("Batch %d of %d processed", i+1, batches))
 	}
+	return nil
+}
+
+// fixEmptyGuidMigration fixes alert_rule and alert_rule_version rows that have empty guid/rule_guid.
+// This can happen when alert rules were created by Grafana versions that did not generate GUIDs
+// on insert (10.4.x through 11.5.x). See https://github.com/grafana/grafana/issues/103076
+type fixEmptyGuidMigration struct {
+	migrator.MigrationBase
+}
+
+var _ migrator.CodeMigration = (*fixEmptyGuidMigration)(nil)
+
+func (c fixEmptyGuidMigration) SQL(migrator.Dialect) string {
+	return codeMigration
+}
+
+func (c fixEmptyGuidMigration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	// Step 1: Fix empty guids in alert_rule table
+	var lastId *int64
+	totalFixed := 0
+	for {
+		var results []int64
+		qq := sess.Table(`alert_rule`).Select("id").Where("guid = ''").OrderBy("id").Limit(500)
+		if lastId != nil {
+			qq = qq.Where("id > ?", lastId)
+		}
+		if err := qq.Find(&results); err != nil {
+			return err
+		}
+		if len(results) == 0 {
+			break
+		}
+
+		bd := strings.Builder{}
+		for idx, id := range results {
+			u := uuid.NewString()
+			if idx == 0 {
+				bd.WriteString(fmt.Sprintf("SELECT %d as id, '%s' as guid", id, u))
+				continue
+			}
+			bd.WriteString(fmt.Sprintf(" UNION ALL SELECT %d, '%s' ", id, u))
+		}
+
+		var q string
+		if mg.Dialect.DriverName() == migrator.MySQL {
+			q = fmt.Sprintf(`UPDATE alert_rule AS ar
+			INNER JOIN (%s) AS t ON ar.id = t.id
+			SET ar.guid = t.guid;`, bd.String())
+		} else {
+			q = fmt.Sprintf(`UPDATE alert_rule SET guid = t.guid FROM (%s) AS t WHERE alert_rule.id = t.id`, bd.String())
+		}
+
+		_, err := sess.Exec(q)
+		if err != nil {
+			mg.Logger.Error("Failed to fix empty guids in alert_rule table", "error", err)
+			return err
+		}
+
+		totalFixed += len(results)
+		lastId = util.Pointer(results[len(results)-1])
+	}
+
+	if totalFixed > 0 {
+		mg.Logger.Info("Fixed empty guids in alert_rule table", "count", totalFixed)
+	}
+
+	// Step 2: Fix empty rule_guids in alert_rule_version table by copying from alert_rule
+	q := `UPDATE alert_rule_version
+		SET rule_guid = alert_rule.guid
+		FROM alert_rule
+		WHERE alert_rule.uid = alert_rule_version.rule_uid
+		  AND alert_rule.org_id = alert_rule_version.rule_org_id
+		  AND alert_rule_version.rule_guid = '';`
+
+	if mg.Dialect.DriverName() == migrator.MySQL {
+		q = `UPDATE alert_rule_version AS arv
+			INNER JOIN alert_rule AS ar ON arv.rule_uid = ar.uid AND arv.rule_org_id = ar.org_id
+			SET arv.rule_guid = ar.guid
+			WHERE arv.rule_guid = '';`
+	}
+
+	result, err := sess.Exec(q)
+	if err != nil {
+		mg.Logger.Error("Failed to fix empty rule_guids in alert_rule_version table", "error", err)
+		return err
+	}
+
+	if rowsAffected, _ := result.RowsAffected(); rowsAffected > 0 {
+		mg.Logger.Info("Fixed empty rule_guids in alert_rule_version table", "count", rowsAffected)
+	}
+
 	return nil
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_version_guid_mig_test.go
@@ -1,0 +1,162 @@
+package ualert
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+func setupTestDB(t *testing.T) (*xorm.Engine, *migrator.Migrator) {
+	t.Helper()
+	dbType := sqlutil.GetTestDBType()
+	testDB, err := sqlutil.GetTestDB(dbType)
+	require.NoError(t, err)
+	t.Cleanup(testDB.Cleanup)
+
+	x, err := xorm.NewEngine(testDB.DriverName, testDB.ConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := x.Close(); err != nil {
+			t.Logf("failed to close xorm engine: %v", err)
+		}
+	})
+
+	err = migrator.NewDialect(x.DriverName()).CleanDB(x)
+	require.NoError(t, err)
+
+	mg := migrator.NewMigrator(x, &setting.Cfg{
+		Logger: log.New("guid-migration.test"),
+		Raw:    ini.Empty(),
+	})
+	ossMigrations := &migrations.OSSMigrations{}
+	ossMigrations.AddMigration(mg)
+
+	err = mg.Start(false, 0)
+	require.NoError(t, err)
+
+	return x, mg
+}
+
+func TestFixEmptyGuidMigration(t *testing.T) {
+	x, mg := setupTestDB(t)
+
+	sess := x.NewSession()
+	defer sess.Close()
+
+	// First, remove the unique index on guid so we can insert empty GUIDs
+	// (the migration already created the index during setupTestDB)
+	_, err := sess.Exec(`DROP INDEX IF EXISTS UQE_alert_rule_guid`)
+	require.NoError(t, err)
+
+	// Insert alert rules with empty GUIDs to simulate the bug
+	_, err = sess.Exec(`INSERT INTO alert_rule (org_id, uid, title, condition, data, namespace_uid, rule_group, no_data_state, exec_err_state, "for", interval_seconds, version, updated, guid)
+		VALUES (1, 'uid1', 'rule1', 'A', '[]', 'ns1', 'group1', 'NoData', 'Error', 0, 60, 1, '2026-01-01 00:00:00', '')`)
+	require.NoError(t, err)
+
+	_, err = sess.Exec(`INSERT INTO alert_rule (org_id, uid, title, condition, data, namespace_uid, rule_group, no_data_state, exec_err_state, "for", interval_seconds, version, updated, guid)
+		VALUES (1, 'uid2', 'rule2', 'A', '[]', 'ns1', 'group1', 'NoData', 'Error', 0, 60, 1, '2026-01-01 00:00:00', '')`)
+	require.NoError(t, err)
+
+	// Insert alert_rule_version rows with empty rule_guid
+	_, err = sess.Exec(`INSERT INTO alert_rule_version (rule_org_id, rule_uid, rule_namespace_uid, rule_group, title, condition, data, no_data_state, exec_err_state, "for", interval_seconds, version, created, rule_guid)
+		VALUES (1, 'uid1', 'ns1', 'group1', 'rule1', 'A', '[]', 'NoData', 'Error', 0, 60, 1, '2026-01-01 00:00:00', '')`)
+	require.NoError(t, err)
+
+	_, err = sess.Exec(`INSERT INTO alert_rule_version (rule_org_id, rule_uid, rule_namespace_uid, rule_group, title, condition, data, no_data_state, exec_err_state, "for", interval_seconds, version, created, rule_guid)
+		VALUES (1, 'uid2', 'ns1', 'group1', 'rule2', 'A', '[]', 'NoData', 'Error', 0, 60, 1, '2026-01-01 00:00:00', '')`)
+	require.NoError(t, err)
+
+	// Verify we have empty GUIDs
+	var emptyCount int64
+	_, err = sess.SQL("SELECT COUNT(*) FROM alert_rule WHERE guid = ''").Get(&emptyCount)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), emptyCount, "should have 2 alert rules with empty guid")
+
+	var emptyVersionCount int64
+	_, err = sess.SQL("SELECT COUNT(*) FROM alert_rule_version WHERE rule_guid = ''").Get(&emptyVersionCount)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), emptyVersionCount, "should have 2 alert rule versions with empty rule_guid")
+
+	// Run the fixup migration
+	mig := fixEmptyGuidMigration{}
+	err = mig.Exec(sess, mg)
+	require.NoError(t, err)
+
+	// Verify no empty GUIDs remain in alert_rule
+	_, err = sess.SQL("SELECT COUNT(*) FROM alert_rule WHERE guid = ''").Get(&emptyCount)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), emptyCount, "should have 0 alert rules with empty guid after fix")
+
+	// Verify no empty rule_guids remain in alert_rule_version
+	_, err = sess.SQL("SELECT COUNT(*) FROM alert_rule_version WHERE rule_guid = ''").Get(&emptyVersionCount)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), emptyVersionCount, "should have 0 alert rule versions with empty rule_guid after fix")
+
+	// Verify all GUIDs are valid UUIDs
+	var guids []string
+	err = sess.SQL("SELECT guid FROM alert_rule").Find(&guids)
+	require.NoError(t, err)
+	require.Len(t, guids, 2)
+	for _, g := range guids {
+		_, err := uuid.Parse(g)
+		require.NoError(t, err, "guid should be a valid UUID: %s", g)
+	}
+
+	// Verify all GUIDs are unique
+	require.NotEqual(t, guids[0], guids[1], "GUIDs should be unique")
+
+	// Verify alert_rule_version.rule_guid matches alert_rule.guid
+	type ruleGuidPair struct {
+		Guid     string `xorm:"guid"`
+		RuleGuid string `xorm:"rule_guid"`
+	}
+	var pairs []ruleGuidPair
+	err = sess.SQL(`SELECT ar.guid, arv.rule_guid
+		FROM alert_rule ar
+		JOIN alert_rule_version arv ON ar.uid = arv.rule_uid AND ar.org_id = arv.rule_org_id`).Find(&pairs)
+	require.NoError(t, err)
+	require.Len(t, pairs, 2)
+	for _, p := range pairs {
+		require.Equal(t, p.Guid, p.RuleGuid, "alert_rule.guid should match alert_rule_version.rule_guid")
+	}
+}
+
+func TestFixEmptyGuidMigration_NoEmptyGuids(t *testing.T) {
+	x, mg := setupTestDB(t)
+
+	sess := x.NewSession()
+	defer sess.Close()
+
+	// Insert alert rules WITH valid GUIDs — no fix needed
+	guid1 := uuid.NewString()
+	guid2 := uuid.NewString()
+
+	_, err := sess.Exec(`INSERT INTO alert_rule (org_id, uid, title, condition, data, namespace_uid, rule_group, no_data_state, exec_err_state, "for", interval_seconds, version, updated, guid)
+		VALUES (1, 'uid1', 'rule1', 'A', '[]', 'ns1', 'group1', 'NoData', 'Error', 0, 60, 1, '2026-01-01 00:00:00', ?)`, guid1)
+	require.NoError(t, err)
+
+	_, err = sess.Exec(`INSERT INTO alert_rule (org_id, uid, title, condition, data, namespace_uid, rule_group, no_data_state, exec_err_state, "for", interval_seconds, version, updated, guid)
+		VALUES (1, 'uid2', 'rule2', 'A', '[]', 'ns1', 'group1', 'NoData', 'Error', 0, 60, 1, '2026-01-01 00:00:00', ?)`, guid2)
+	require.NoError(t, err)
+
+	// Run the fixup migration — should be a no-op
+	mig := fixEmptyGuidMigration{}
+	err = mig.Exec(sess, mg)
+	require.NoError(t, err)
+
+	// Verify GUIDs are unchanged
+	var guids []string
+	err = sess.SQL("SELECT guid FROM alert_rule ORDER BY uid").Find(&guids)
+	require.NoError(t, err)
+	require.Equal(t, guid1, guids[0])
+	require.Equal(t, guid2, guids[1])
+}


### PR DESCRIPTION
Add migration to generate UUIDs for rows with empty guid fields.

Fixes #103076

**What is this feature?**

Add a fixup migration that generates UUIDs for `alert_rule` rows with empty `guid` and propagates them to `alert_rule_version.rule_guid`.

**Why do we need this feature?**

Grafana versions 10.4.x through 11.5.x did not generate GUIDs when inserting new alert rules (`InsertAlertRules` did not set the `guid` field). The column default `''` was used instead. Since `alert_rule.guid` has a unique index (`UQE_alert_rule_guid`), the second alert rule insertion fails with:

```
UNIQUE constraint failed: alert_rule.guid
```

This blocks all alert rule creation across all orgs once a single empty GUID exists. The insert path was fixed on `main`, but databases already corrupted with empty GUIDs remain broken after upgrading.

**Who is this feature for?**

Users running Grafana 10.4.x through 11.5.x who have existing alert rules with empty GUIDs and cannot create new alerts after upgrading.

**Which issue(s) does this PR fix?**:

Fixes #103076

**Special notes for your reviewer:**

- The migration reuses the exact same SQL patterns as the existing `setRuleGuidMigration` in the same file
- Step 1: Batch-selects `alert_rule` rows where `guid = ''`, generates a UUID for each, updates in batches of 500
- Step 2: Copies fixed GUIDs to matching `alert_rule_version` rows where `rule_guid = ''`
- Supports SQLite, PostgreSQL, and MySQL dialects
- Two tests included: one for the fix case, one for the no-op case

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
