### PR TITLE
K8s Search: Paginate through everything

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1889,7 +1889,7 @@ func (dr *DashboardServiceImpl) listDashboardsThroughK8s(ctx context.Context, or
 	return dashes, nil
 }
 
-func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) (dashboardv0.SearchResults, error) {
+func (dr *DashboardServiceImpl) buildDashboardSearchRequest(query *dashboards.FindPersistedDashboardsQuery) (*resourcepb.ResourceSearchRequest, error) {
 	request := &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{
 			Fields: []*resourcepb.Requirement{},
@@ -2032,7 +2032,7 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	}
 
 	if err != nil {
-		return dashboardv0.SearchResults{}, err
+		return nil, err
 	}
 
 	if federate != nil {
@@ -2042,13 +2042,42 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	if query.Sort.Name != "" {
 		sortName, isDesc, err := sort.ParseSortName(query.Sort.Name)
 		if err != nil {
-			return dashboardv0.SearchResults{}, err
+			return nil, err
 		}
 		request.SortBy = append(request.SortBy, &resourcepb.ResourceSearchRequest_Sort{Field: sortName, Desc: isDesc})
 		// include the sort field in the response so we can populate SortMeta
 		if !slices.Contains(request.Fields, sortName) {
 			request.Fields = append(request.Fields, sortName)
 		}
+	}
+
+	return request, nil
+}
+
+// searchDashboardsThroughK8sRaw returns a single page of search results,
+// respecting the Page/Limit from the query. Used by FindDashboards (the
+// /api/search endpoint) where the caller controls pagination.
+func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) (dashboardv0.SearchResults, error) {
+	request, err := dr.buildDashboardSearchRequest(query)
+	if err != nil {
+		return dashboardv0.SearchResults{}, err
+	}
+
+	res, err := dr.k8sclient.Search(ctx, query.OrgId, request)
+	if err != nil {
+		return dashboardv0.SearchResults{}, err
+	}
+
+	return dashboardsearch.ParseResults(res, 0)
+}
+
+// searchAllDashboardsThroughK8sRaw paginates through all search results,
+// returning every hit. Used by internal callers that need a complete list
+// (e.g. CountInFolders, DeleteInFolders, provisioning).
+func (dr *DashboardServiceImpl) searchAllDashboardsThroughK8sRaw(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) (dashboardv0.SearchResults, error) {
+	request, err := dr.buildDashboardSearchRequest(query)
+	if err != nil {
+		return dashboardv0.SearchResults{}, err
 	}
 
 	return dashboardsearch.SearchAll(ctx, query.OrgId, request, dr.k8sclient.Search)
@@ -2071,7 +2100,7 @@ func (dr *DashboardServiceImpl) searchProvisionedDashboardsThroughK8s(ctx contex
 
 	query.Type = searchstore.TypeDashboard
 
-	searchResults, err := dr.searchDashboardsThroughK8sRaw(ctx, query)
+	searchResults, err := dr.searchAllDashboardsThroughK8sRaw(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -2106,7 +2135,7 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8s(ctx context.Context, 
 	}
 	query.Type = searchstore.TypeDashboard
 
-	response, err := dr.searchDashboardsThroughK8sRaw(ctx, query)
+	response, err := dr.searchAllDashboardsThroughK8sRaw(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -501,7 +501,7 @@ func (dr *DashboardServiceImpl) Count(ctx context.Context, scopeParams *quota.Sc
 }
 
 func (dr *DashboardServiceImpl) GetDashboardsByLibraryPanelUID(ctx context.Context, libraryPanelUID string, orgID int64) ([]*dashboards.DashboardRef, error) {
-	res, err := dr.k8sclient.Search(ctx, orgID, &resourcepb.ResourceSearchRequest{
+	request := &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{
 			Fields: []*resourcepb.Requirement{
 				{
@@ -512,12 +512,9 @@ func (dr *DashboardServiceImpl) GetDashboardsByLibraryPanelUID(ctx context.Conte
 			},
 		},
 		Limit: listAllDashboardsLimit,
-	})
-	if err != nil {
-		return nil, err
 	}
 
-	results, err := dashboardsearch.ParseResults(res, 0)
+	results, err := dashboardsearch.SearchAll(ctx, orgID, request, dr.k8sclient.Search)
 	if err != nil {
 		return nil, err
 	}
@@ -2054,12 +2051,7 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 		}
 	}
 
-	res, err := dr.k8sclient.Search(ctx, query.OrgId, request)
-	if err != nil {
-		return dashboardv0.SearchResults{}, err
-	}
-
-	return dashboardsearch.ParseResults(res, 0)
+	return dashboardsearch.SearchAll(ctx, query.OrgId, request, dr.k8sclient.Search)
 }
 
 type dashboardProvisioningWithUID struct {

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -1,6 +1,7 @@
 package dashboardsearch
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -47,6 +48,51 @@ var (
 		resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID,
 	}
 )
+
+type SearchFunc func(ctx context.Context, orgID int64, request *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error)
+
+// SearchAll executes a search request and paginates through all results by incrementing the offset until the offset is greater than total hits
+// or it hits an empty page.
+func SearchAll(ctx context.Context, orgID int64, request *resourcepb.ResourceSearchRequest, searchFn SearchFunc) (v0alpha1.SearchResults, error) {
+	if request.Limit == 0 {
+		request.Limit = 100000
+	}
+	request.Page = int64(1)
+	request.Offset = int64(0)
+
+	res, err := searchFn(ctx, orgID, request)
+	if err != nil {
+		return v0alpha1.SearchResults{}, err
+	}
+	results, err := ParseResults(res, 0)
+	if err != nil {
+		return v0alpha1.SearchResults{}, err
+	}
+
+	request.Offset += int64(len(results.Hits))
+	request.Page++
+	for request.Offset < res.TotalHits {
+		res, err = searchFn(ctx, orgID, request)
+		if err != nil {
+			return v0alpha1.SearchResults{}, err
+		}
+
+		page, err := ParseResults(res, 0)
+		if err != nil {
+			return v0alpha1.SearchResults{}, err
+		}
+
+		if len(page.Hits) == 0 {
+			break
+		}
+
+		results.Hits = append(results.Hits, page.Hits...)
+		request.Offset += int64(len(page.Hits))
+		request.Page++
+	}
+
+	return results, nil
+}
 
 // nolint:gocyclo
 func ParseResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0alpha1.SearchResults, error) {

--- a/pkg/services/dashboards/service/search/search_test.go
+++ b/pkg/services/dashboards/service/search/search_test.go
@@ -1,8 +1,11 @@
 package dashboardsearch
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -107,5 +110,198 @@ func TestParseResults(t *testing.T) {
 
 		_, err := ParseResults(resSearchResp, 0)
 		require.Error(t, err)
+	})
+}
+
+func makeRow(name string) *resourcepb.ResourceTableRow {
+	return &resourcepb.ResourceTableRow{
+		Key: &resourcepb.ResourceKey{
+			Name:     name,
+			Resource: "dashboards",
+		},
+		Cells: [][]byte{[]byte(name)},
+	}
+}
+
+func makeResponse(names []string, totalHits int64) *resourcepb.ResourceSearchResponse {
+	rows := make([]*resourcepb.ResourceTableRow, len(names))
+	for i, n := range names {
+		rows[i] = makeRow(n)
+	}
+	return &resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: []*resourcepb.ResourceTableColumnDefinition{
+				{Name: "title", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+			},
+			Rows: rows,
+		},
+		TotalHits: totalHits,
+	}
+}
+
+func TestSearchAll(t *testing.T) {
+	t.Run("single page - all results fit in one request", func(t *testing.T) {
+		callCount := 0
+		searchFn := func(_ context.Context, _ int64, _ *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			callCount++
+			return makeResponse([]string{"a", "b", "c"}, 3), nil
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 10}
+		results, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Len(t, results.Hits, 3)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("multiple pages - paginates until all results fetched", func(t *testing.T) {
+		callCount := 0
+		searchFn := func(_ context.Context, _ int64, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			callCount++
+			switch req.Offset {
+			case 0:
+				return makeResponse([]string{"a", "b"}, 5), nil
+			case 2:
+				return makeResponse([]string{"c", "d"}, 5), nil
+			case 4:
+				return makeResponse([]string{"e"}, 5), nil
+			default:
+				return makeResponse([]string{}, 5), nil
+			}
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 2}
+		results, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Len(t, results.Hits, 5)
+		assert.Equal(t, "a", results.Hits[0].Title)
+		assert.Equal(t, "e", results.Hits[4].Title)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("sets default limit when zero", func(t *testing.T) {
+		var capturedLimit int64
+		searchFn := func(_ context.Context, _ int64, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			capturedLimit = req.Limit
+			return makeResponse([]string{"a"}, 1), nil
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 0}
+		_, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100000), capturedLimit)
+	})
+
+	t.Run("resets page and offset before first call", func(t *testing.T) {
+		var capturedPage, capturedOffset int64
+		searchFn := func(_ context.Context, _ int64, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			capturedPage = req.Page
+			capturedOffset = req.Offset
+			return makeResponse([]string{"a"}, 1), nil
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 10, Page: 5, Offset: 999}
+		_, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), capturedPage)
+		assert.Equal(t, int64(0), capturedOffset)
+	})
+
+	t.Run("increments page on each request", func(t *testing.T) {
+		var pages []int64
+		searchFn := func(_ context.Context, _ int64, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			pages = append(pages, req.Page)
+			switch req.Offset {
+			case 0:
+				return makeResponse([]string{"a"}, 3), nil
+			case 1:
+				return makeResponse([]string{"b"}, 3), nil
+			case 2:
+				return makeResponse([]string{"c"}, 3), nil
+			default:
+				return makeResponse([]string{}, 3), nil
+			}
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 1}
+		_, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{1, 2, 3}, pages)
+	})
+
+	t.Run("returns empty results when no hits", func(t *testing.T) {
+		searchFn := func(_ context.Context, _ int64, _ *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			return makeResponse(nil, 0), nil
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 10}
+		results, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Empty(t, results.Hits)
+	})
+
+	t.Run("breaks on empty page to prevent infinite loop", func(t *testing.T) {
+		callCount := 0
+		searchFn := func(_ context.Context, _ int64, _ *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return makeResponse([]string{"a"}, 100), nil
+			}
+			return makeResponse([]string{}, 100), nil
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 10}
+		results, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Len(t, results.Hits, 1)
+		assert.Equal(t, 2, callCount, "should stop after one empty page")
+	})
+
+	t.Run("propagates search error on first call", func(t *testing.T) {
+		searchFn := func(_ context.Context, _ int64, _ *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 10}
+		_, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.ErrorContains(t, err, "connection refused")
+	})
+
+	t.Run("propagates search error on subsequent page", func(t *testing.T) {
+		callCount := 0
+		searchFn := func(_ context.Context, _ int64, _ *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return makeResponse([]string{"a", "b"}, 10), nil
+			}
+			return nil, fmt.Errorf("timeout")
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 2}
+		_, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.ErrorContains(t, err, "timeout")
+	})
+
+	t.Run("advances offset by actual hits received", func(t *testing.T) {
+		var offsets []int64
+		searchFn := func(_ context.Context, _ int64, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+			offsets = append(offsets, req.Offset)
+			switch req.Offset {
+			case 0:
+				return makeResponse([]string{"a", "b", "c"}, 7), nil
+			case 3:
+				return makeResponse([]string{"d", "e"}, 7), nil
+			case 5:
+				return makeResponse([]string{"f", "g"}, 7), nil
+			default:
+				return makeResponse([]string{}, 7), nil
+			}
+		}
+
+		req := &resourcepb.ResourceSearchRequest{Limit: 3}
+		results, err := SearchAll(context.Background(), 1, req, searchFn)
+		require.NoError(t, err)
+		assert.Len(t, results.Hits, 7)
+		assert.Equal(t, []int64{0, 3, 5}, offsets)
 	})
 }

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -215,12 +215,7 @@ func (s *Service) searchFoldersFromApiServer(ctx context.Context, query folder.S
 		request.Limit = query.Limit
 	}
 
-	res, err := s.k8sclient.Search(ctx, query.OrgID, request)
-	if err != nil {
-		return nil, err
-	}
-
-	parsedResults, err := dashboardsearch.ParseResults(res, 0)
+	parsedResults, err := dashboardsearch.SearchAll(ctx, query.OrgID, request, s.k8sclient.Search)
 	if err != nil {
 		return nil, err
 	}
@@ -675,15 +670,11 @@ func (s *Service) deleteFromApiServer(ctx context.Context, cmd *folder.DeleteFol
 			},
 			Limit: folderSearchLimit}
 
-		res, err := s.dashboardK8sClient.Search(ctx, cmd.OrgID, request)
+		hits, err := dashboardsearch.SearchAll(ctx, cmd.OrgID, request, s.dashboardK8sClient.Search)
 		if err != nil {
 			return folder.ErrInternal.Errorf("failed to fetch dashboards: %w", err)
 		}
 
-		hits, err := dashboardsearch.ParseResults(res, 0)
-		if err != nil {
-			return folder.ErrInternal.Errorf("failed to fetch dashboards: %w", err)
-		}
 		dashboardUIDs := make([]string, len(hits.Hits))
 		for i, dashboard := range hits.Hits {
 			dashboardUIDs[i] = dashboard.Name

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -614,6 +614,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 				},
 				Labels: []*resourcepb.Requirement{},
 			},
+			Page:  1,
 			Limit: folderSearchLimit}).Return(&resourcepb.ResourceSearchResponse{
 			Results: &resourcepb.ResourceTable{
 				Columns: []*resourcepb.ResourceTableColumnDefinition{
@@ -704,6 +705,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 					},
 				},
 			},
+			Page:  1,
 			Limit: folderSearchLimit}).Return(&resourcepb.ResourceSearchResponse{
 			Results: &resourcepb.ResourceTable{
 				Columns: []*resourcepb.ResourceTableColumnDefinition{
@@ -769,6 +771,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 			},
 			Query:  "*test*",
 			Fields: dashboardsearch.IncludeFields,
+			Page:   1,
 			Limit:  folderSearchLimit}).Return(&resourcepb.ResourceSearchResponse{
 			Results: &resourcepb.ResourceTable{
 				Columns: []*resourcepb.ResourceTableColumnDefinition{
@@ -1034,6 +1037,7 @@ func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
 					},
 				},
 			},
+			Page:  1,
 			Limit: folderSearchLimit}).Return(&resourcepb.ResourceSearchResponse{
 			Results: &resourcepb.ResourceTable{
 				Columns: []*resourcepb.ResourceTableColumnDefinition{


### PR DESCRIPTION
This PR fixes a bug where the folder & dashboard service would not loop through additional pages returned by search.

[See background here](https://raintank-corp.slack.com/archives/C04RVCAG9B5/p1775053086400969)