### PR TITLE
CI: Use docker build without dagger in release-build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ bin
 !bin/grafana-linux-k8s-debug
 data*
 dist
+!dist/*.tar.gz
 docker
 Dockerfile
 docs

--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -57,6 +57,7 @@ jobs:
           environment: ${{ inputs.environment }}
           service_account: ${{ inputs.service-account }}
       - name: Coalesce artifacts
+        id: coalesce
         run: |
           mkdir -p out
           shopt -s nullglob
@@ -69,10 +70,13 @@ jobs:
           done
           ls -al out
           if [ -z "$(ls -A out)" ]; then
-            echo "No artifacts were downloaded to ./artifact"
-            exit 1
+            echo "No artifacts were downloaded to ./artifact (skipping upload)"
+            echo "has-artifacts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-artifacts=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Upload artifacts
+        if: steps.coalesce.outputs.has-artifacts == 'true'
         uses: grafana/shared-workflows/actions/push-to-gcs@main
         with:
           bucket: ${{ inputs.bucket }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -144,6 +144,7 @@ jobs:
     name: build backend / ${{ matrix.name }}
     runs-on: ubuntu-x64-large
     needs: [setup]
+    continue-on-error: ${{ matrix.allow-failure == true }}
     permissions:
       contents: read
     strategy:
@@ -167,9 +168,11 @@ jobs:
             os: linux
             arch: arm
             arm: '7'
+          # riscv64 is not an officially supported architecture; failures are allowed.
           - name: linux-riscv64
             os: linux
             arch: riscv64
+            allow-failure: true
           - name: windows-amd64
             os: windows
             arch: amd64
@@ -205,6 +208,7 @@ jobs:
   build-targz:
     name: targz / ${{ matrix.name }}
     runs-on: ubuntu-x64-large-io
+    continue-on-error: ${{ matrix.allow-failure == true }}
     needs:
       - setup
       - build-frontend
@@ -232,9 +236,11 @@ jobs:
             os: linux
             arch: arm
             arm: '7'
+          # riscv64 is not an officially supported architecture; failures are allowed.
           - name: linux-riscv64
             os: linux
             arch: riscv64
+            allow-failure: true
           - name: windows-amd64
             os: windows
             arch: amd64
@@ -308,6 +314,7 @@ jobs:
   build-deb-rpm:
     name: deb / rpm / ${{ matrix.name }}
     runs-on: ubuntu-x64-large
+    continue-on-error: ${{ matrix.allow-failure == true }}
     needs:
       - setup
       - build-targz
@@ -337,10 +344,12 @@ jobs:
             os: linux
             arch: arm
             arm: '7'
+          # riscv64 is not an officially supported architecture; failures are allowed.
           - name: linux-riscv64
             os: linux
             arch: riscv64
             rpm: true
+            allow-failure: true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -444,6 +453,8 @@ jobs:
         uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
         with:
           image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
       - name: Build docker image (alpine)
         env:
           GOOS: ${{ matrix.os }}
@@ -538,6 +549,8 @@ jobs:
         uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
         with:
           image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
       - name: Build docker image (ubuntu)
         env:
           GOOS: ${{ matrix.os }}
@@ -671,6 +684,7 @@ jobs:
 
   publish-targz:
     name: Upload targz / ${{ matrix.target }}
+    continue-on-error: ${{ matrix.allow-failure == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -680,7 +694,9 @@ jobs:
           - target: linux-s390x
           - target: linux-armv6
           - target: linux-armv7
+          # riscv64 is not an officially supported architecture; failures are allowed.
           - target: linux-riscv64
+            allow-failure: true
           - target: windows-amd64
           - target: windows-arm64
           - target: darwin-amd64
@@ -693,9 +709,7 @@ jobs:
       - build-targz
     with:
       bucket: grafana-prerelease
-      pattern: |
-        artifacts-packages-${{ matrix.target }}
-        artifacts-list-packages-${{ matrix.target }}
+      pattern: artifacts-*packages-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -703,6 +717,7 @@ jobs:
 
   publish-deb-rpm:
     name: Upload deb/rpm / ${{ matrix.target }}
+    continue-on-error: ${{ matrix.allow-failure == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -712,7 +727,9 @@ jobs:
           - target: linux-s390x
           - target: linux-armv6
           - target: linux-armv7
+          # riscv64 is not an officially supported architecture; failures are allowed.
           - target: linux-riscv64
+            allow-failure: true
     uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
     permissions:
       id-token: write
@@ -721,9 +738,7 @@ jobs:
       - build-deb-rpm
     with:
       bucket: grafana-prerelease
-      pattern: |
-        artifacts-deb-rpm-${{ matrix.target }}
-        artifacts-list-deb-rpm-${{ matrix.target }}
+      pattern: artifacts-*deb-rpm-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -747,9 +762,7 @@ jobs:
       - build-docker-alpine
     with:
       bucket: grafana-prerelease
-      pattern: |
-        artifacts-docker-${{ matrix.target }}
-        artifacts-list-docker-${{ matrix.target }}
+      pattern: artifacts-*docker-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -773,9 +786,7 @@ jobs:
       - build-docker-ubuntu
     with:
       bucket: grafana-prerelease
-      pattern: |
-        artifacts-docker-ubuntu-${{ matrix.target }}
-        artifacts-list-docker-ubuntu-${{ matrix.target }}
+      pattern: artifacts-*docker-ubuntu-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -797,9 +808,7 @@ jobs:
       - build-windows
     with:
       bucket: grafana-prerelease
-      pattern: |
-        artifacts-${{ matrix.target }}
-        artifacts-list-${{ matrix.target }}
+      pattern: artifacts-*${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -307,7 +307,7 @@ jobs:
 
   build-deb-rpm:
     name: deb / rpm / ${{ matrix.name }}
-    runs-on: ubuntu-x64-large-io
+    runs-on: ubuntu-x64-large
     needs:
       - setup
       - build-targz
@@ -359,10 +359,11 @@ jobs:
           BUILD_VERSION: ${{ needs.setup.outputs.version }}
           RPM: ${{ matrix.rpm }}
         run: |
+          for TARGZ in dist/*.tar.gz; do break; done
           if [[ "$RPM" == "true" ]]; then
-            make -j2 build-deb build-rpm BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+            make -j2 build-deb build-rpm -o "$TARGZ" BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
           else
-            make build-deb BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+            make build-deb -o "$TARGZ" BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
           fi
       - name: Generate checksums
         run: |
@@ -404,7 +405,7 @@ jobs:
 
   build-docker-alpine:
     name: docker (alpine) / ${{ matrix.name }}
-    runs-on: ubuntu-x64-large-io
+    runs-on: ubuntu-x64-large
     needs:
       - setup
       - build-targz
@@ -452,7 +453,9 @@ jobs:
           BUILD_VERSION: ${{ needs.setup.outputs.version }}
           ARCH_TAG: ${{ matrix.arch-tag }}
         run: |
+          for TARGZ in dist/*.tar.gz; do break; done
           make build-docker \
+            -o "$TARGZ" \
             BUILD_VERSION="$BUILD_VERSION" \
             BUILD_NUMBER="$BUILD_NUMBER" \
             DOCKER_TAG="grafana/grafana-image-tags:${BUILD_VERSION}-${ARCH_TAG}"
@@ -496,7 +499,7 @@ jobs:
 
   build-docker-ubuntu:
     name: docker (ubuntu) / ${{ matrix.name }}
-    runs-on: ubuntu-x64-large-io
+    runs-on: ubuntu-x64-large
     needs:
       - setup
       - build-targz
@@ -544,7 +547,9 @@ jobs:
           BUILD_VERSION: ${{ needs.setup.outputs.version }}
           ARCH_TAG: ${{ matrix.arch-tag }}
         run: |
+          for TARGZ in dist/*.tar.gz; do break; done
           make build-docker-ubuntu \
+            -o "$TARGZ" \
             BUILD_VERSION="$BUILD_VERSION" \
             BUILD_NUMBER="$BUILD_NUMBER" \
             DOCKER_TAG="grafana/grafana-image-tags:${BUILD_VERSION}-ubuntu-${ARCH_TAG}"
@@ -664,8 +669,8 @@ jobs:
           path: upload/artifacts-${{ matrix.name }}
           retention-days: 1
 
-  publish-targz-artifacts:
-    name: Upload targz artifact / ${{ matrix.target }}
+  publish-targz:
+    name: Upload targz / ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -688,44 +693,16 @@ jobs:
       - build-targz
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-packages-${{ matrix.target }}
+      pattern: |
+        artifacts-packages-${{ matrix.target }}
+        artifacts-list-packages-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
       runs-on: ubuntu-x64-small
 
-  publish-targz-artifact-lists:
-    name: Upload targz artifact list / ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: linux-amd64
-          - target: linux-arm64
-          - target: linux-s390x
-          - target: linux-armv6
-          - target: linux-armv7
-          - target: linux-riscv64
-          - target: windows-amd64
-          - target: windows-arm64
-          - target: darwin-amd64
-          - target: darwin-arm64
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build-targz
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-list-packages-${{ matrix.target }}
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
-      runs-on: ubuntu-x64-small
-
-  publish-deb-rpm-artifacts:
-    name: Upload deb/rpm artifact / ${{ matrix.target }}
+  publish-deb-rpm:
+    name: Upload deb/rpm / ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -744,40 +721,16 @@ jobs:
       - build-deb-rpm
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-deb-rpm-${{ matrix.target }}
+      pattern: |
+        artifacts-deb-rpm-${{ matrix.target }}
+        artifacts-list-deb-rpm-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
       runs-on: ubuntu-x64-small
 
-  publish-deb-rpm-artifact-lists:
-    name: Upload deb/rpm artifact list / ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: linux-amd64
-          - target: linux-arm64
-          - target: linux-s390x
-          - target: linux-armv6
-          - target: linux-armv7
-          - target: linux-riscv64
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build-deb-rpm
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-list-deb-rpm-${{ matrix.target }}
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
-      runs-on: ubuntu-x64-small
-
-  publish-docker-alpine-artifacts:
-    name: Upload docker (alpine) artifact / ${{ matrix.target }}
+  publish-docker-alpine:
+    name: Upload docker (alpine) / ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -794,38 +747,16 @@ jobs:
       - build-docker-alpine
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-docker-${{ matrix.target }}
+      pattern: |
+        artifacts-docker-${{ matrix.target }}
+        artifacts-list-docker-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
       runs-on: ubuntu-x64-small
 
-  publish-docker-alpine-artifact-lists:
-    name: Upload docker (alpine) artifact list / ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: linux-amd64
-          - target: linux-arm64
-          - target: linux-s390x
-          - target: linux-armv7
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build-docker-alpine
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-list-docker-${{ matrix.target }}
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
-      runs-on: ubuntu-x64-small
-
-  publish-docker-ubuntu-artifacts:
-    name: Upload docker (ubuntu) artifact / ${{ matrix.target }}
+  publish-docker-ubuntu:
+    name: Upload docker (ubuntu) / ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -842,38 +773,16 @@ jobs:
       - build-docker-ubuntu
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-docker-ubuntu-${{ matrix.target }}
+      pattern: |
+        artifacts-docker-ubuntu-${{ matrix.target }}
+        artifacts-list-docker-ubuntu-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
       runs-on: ubuntu-x64-small
 
-  publish-docker-ubuntu-artifact-lists:
-    name: Upload docker (ubuntu) artifact list / ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: linux-amd64
-          - target: linux-arm64
-          - target: linux-s390x
-          - target: linux-armv7
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build-docker-ubuntu
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-list-docker-ubuntu-${{ matrix.target }}
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
-      runs-on: ubuntu-x64-small
-
-  publish-windows-artifacts:
-    name: Upload windows artifact / ${{ matrix.target }}
+  publish-windows:
+    name: Upload windows / ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -888,29 +797,9 @@ jobs:
       - build-windows
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-${{ matrix.target }}
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
-      runs-on: ubuntu-x64-small
-
-  publish-windows-artifact-lists:
-    name: Upload windows artifact list / ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: windows-amd64
-          - target: windows-arm64
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build-windows
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-list-${{ matrix.target }}
+      pattern: |
+        artifacts-${{ matrix.target }}
+        artifacts-list-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,8 +21,10 @@ permissions:
 
 # Builds the following artifacts:
 #
-# targz:grafana:* (via make build-targz + pre-seeded dist for Dagger)
-# deb / rpm / docker / zip / msi (Dagger, consuming prebuilt targz from dist when present)
+# targz:grafana:* (via make build-targz)
+# deb / rpm (via make build-deb / build-rpm, from targz)
+# docker alpine / ubuntu (via make build-docker / build-docker-ubuntu, from targz)
+# zip / msi (Dagger, consuming prebuilt targz from dist)
 #
 # One shared frontend artifact is reused for every targz matrix cell (OSS), so assets-manifest.json matches all
 # binaries. For Grafana Cloud / Enterprise / Pro with CDN, do not split frontend and backend across pipelines
@@ -200,8 +202,8 @@ jobs:
           path: bin/${{ matrix.os }}/${{ matrix.arch }}
           retention-days: 1
 
-  build-packages:
-    name: packages / ${{ matrix.name }}
+  build-targz:
+    name: targz / ${{ matrix.name }}
     runs-on: ubuntu-x64-large-io
     needs:
       - setup
@@ -216,33 +218,23 @@ jobs:
           - name: linux-amd64
             os: linux
             arch: amd64
-            deb: true
-            rpm: true
           - name: linux-arm64
             os: linux
             arch: arm64
-            deb: true
-            rpm: true
           - name: linux-s390x
             os: linux
             arch: s390x
-            deb: true
-            rpm: true
           - name: linux-armv6
             os: linux
             arch: arm
             arm: '6'
-            deb: true
           - name: linux-armv7
             os: linux
             arch: arm
             arm: '7'
-            deb: true
           - name: linux-riscv64
             os: linux
             arch: riscv64
-            deb: true
-            rpm: true
           - name: windows-amd64
             os: windows
             arch: amd64
@@ -279,27 +271,10 @@ jobs:
           BUILD_NUMBER: ${{ github.run_id }}
           BUILD_VERSION: ${{ needs.setup.outputs.version }}
         run: make build-targz BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
-      - uses: ./.github/actions/setup-fpm
-        if: matrix.deb || matrix.rpm
-      - name: Build deb and rpm
-        if: matrix.deb
-        env:
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          GOARM: ${{ matrix.arm }}
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-          RPM: ${{ matrix.rpm }}
-        run: |
-          if [[ "$RPM" == "true" ]]; then
-            make -j2 build-deb build-rpm BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
-          else
-            make build-deb BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
-          fi
       - name: Generate checksums
         run: |
           set -euo pipefail
-          for f in dist/*.tar.gz dist/*.deb dist/*.rpm; do
+          for f in dist/*.tar.gz; do
             [ -e "$f" ] || continue
             sha256sum "$f" > "${f}.sha256"
           done
@@ -307,12 +282,12 @@ jobs:
         run: |
           listfile="artifacts-list-packages-${{ matrix.name }}.txt"
           : > "$listfile"
-          for f in dist/*.tar.gz dist/*.deb dist/*.rpm; do
+          for f in dist/*.tar.gz; do
             [ -e "$f" ] || continue
             echo "$f" >> "$listfile"
             echo "${f}.sha256" >> "$listfile"
           done
-      - name: Stage targz artifacts for upload
+      - name: Stage artifacts for upload
         run: |
           set -euo pipefail
           mkdir -p "upload/artifacts-list-packages-${{ matrix.name }}"
@@ -330,10 +305,291 @@ jobs:
           path: upload/artifacts-packages-${{ matrix.name }}
           retention-days: 1
 
+  build-deb-rpm:
+    name: deb / rpm / ${{ matrix.name }}
+    runs-on: ubuntu-x64-large-io
+    needs:
+      - setup
+      - build-targz
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            os: linux
+            arch: amd64
+            rpm: true
+          - name: linux-arm64
+            os: linux
+            arch: arm64
+            rpm: true
+          - name: linux-s390x
+            os: linux
+            arch: s390x
+            rpm: true
+          - name: linux-armv6
+            os: linux
+            arch: arm
+            arm: '6'
+          - name: linux-armv7
+            os: linux
+            arch: arm
+            arm: '7'
+          - name: linux-riscv64
+            os: linux
+            arch: riscv64
+            rpm: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-packages-${{ matrix.name }}
+          path: dist
+      - uses: ./.github/actions/setup-fpm
+      - name: Build deb and rpm
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+          GOARM: ${{ matrix.arm }}
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_VERSION: ${{ needs.setup.outputs.version }}
+          RPM: ${{ matrix.rpm }}
+        run: |
+          if [[ "$RPM" == "true" ]]; then
+            make -j2 build-deb build-rpm BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+          else
+            make build-deb BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+          fi
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          for f in dist/*.deb dist/*.rpm; do
+            [ -e "$f" ] || continue
+            sha256sum "$f" > "${f}.sha256"
+          done
+      - name: Write artifact list
+        run: |
+          listfile="artifacts-list-deb-rpm-${{ matrix.name }}.txt"
+          : > "$listfile"
+          for f in dist/*.deb dist/*.rpm; do
+            [ -e "$f" ] || continue
+            echo "$f" >> "$listfile"
+            echo "${f}.sha256" >> "$listfile"
+          done
+      - name: Stage artifacts for upload
+        run: |
+          set -euo pipefail
+          mkdir -p "upload/artifacts-list-deb-rpm-${{ matrix.name }}"
+          cp "artifacts-list-deb-rpm-${{ matrix.name }}.txt" "upload/artifacts-list-deb-rpm-${{ matrix.name }}/"
+          mkdir -p "upload/artifacts-deb-rpm-${{ matrix.name }}"
+          for f in dist/*.deb dist/*.rpm; do
+            [ -e "$f" ] || continue
+            cp "$f" "upload/artifacts-deb-rpm-${{ matrix.name }}/"
+            cp "${f}.sha256" "upload/artifacts-deb-rpm-${{ matrix.name }}/"
+          done
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: artifacts-list-deb-rpm-${{ matrix.name }}
+          path: upload/artifacts-list-deb-rpm-${{ matrix.name }}
+          retention-days: 1
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: artifacts-deb-rpm-${{ matrix.name }}
+          path: upload/artifacts-deb-rpm-${{ matrix.name }}
+          retention-days: 1
+
+  build-docker-alpine:
+    name: docker (alpine) / ${{ matrix.name }}
+    runs-on: ubuntu-x64-large-io
+    needs:
+      - setup
+      - build-targz
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            os: linux
+            arch: amd64
+            arch-tag: amd64
+          - name: linux-arm64
+            os: linux
+            arch: arm64
+            arch-tag: arm64
+          - name: linux-s390x
+            os: linux
+            arch: s390x
+            arch-tag: s390x
+          - name: linux-armv7
+            os: linux
+            arch: arm
+            arm: '7'
+            arch-tag: armv7
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-packages-${{ matrix.name }}
+          path: dist
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
+      - name: Build docker image (alpine)
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+          GOARM: ${{ matrix.arm }}
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_VERSION: ${{ needs.setup.outputs.version }}
+          ARCH_TAG: ${{ matrix.arch-tag }}
+        run: |
+          make build-docker \
+            BUILD_VERSION="$BUILD_VERSION" \
+            BUILD_NUMBER="$BUILD_NUMBER" \
+            DOCKER_TAG="grafana/grafana-image-tags:${BUILD_VERSION}-${ARCH_TAG}"
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          for f in dist/*.docker.tar.gz; do
+            [ -e "$f" ] || continue
+            sha256sum "$f" > "${f}.sha256"
+          done
+      - name: Write artifact list
+        run: |
+          listfile="artifacts-list-docker-${{ matrix.name }}.txt"
+          : > "$listfile"
+          for f in dist/*.docker.tar.gz; do
+            [ -e "$f" ] || continue
+            echo "$f" >> "$listfile"
+            echo "${f}.sha256" >> "$listfile"
+          done
+      - name: Stage artifacts for upload
+        run: |
+          set -euo pipefail
+          mkdir -p "upload/artifacts-list-docker-${{ matrix.name }}"
+          cp "artifacts-list-docker-${{ matrix.name }}.txt" "upload/artifacts-list-docker-${{ matrix.name }}/"
+          mkdir -p "upload/artifacts-docker-${{ matrix.name }}"
+          for f in dist/*.docker.tar.gz; do
+            [ -e "$f" ] || continue
+            cp "$f" "upload/artifacts-docker-${{ matrix.name }}/"
+            cp "${f}.sha256" "upload/artifacts-docker-${{ matrix.name }}/"
+          done
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: artifacts-list-docker-${{ matrix.name }}
+          path: upload/artifacts-list-docker-${{ matrix.name }}
+          retention-days: 1
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: artifacts-docker-${{ matrix.name }}
+          path: upload/artifacts-docker-${{ matrix.name }}
+          retention-days: 1
+
+  build-docker-ubuntu:
+    name: docker (ubuntu) / ${{ matrix.name }}
+    runs-on: ubuntu-x64-large-io
+    needs:
+      - setup
+      - build-targz
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            os: linux
+            arch: amd64
+            arch-tag: amd64
+          - name: linux-arm64
+            os: linux
+            arch: arm64
+            arch-tag: arm64
+          - name: linux-s390x
+            os: linux
+            arch: s390x
+            arch-tag: s390x
+          - name: linux-armv7
+            os: linux
+            arch: arm
+            arm: '7'
+            arch-tag: armv7
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-packages-${{ matrix.name }}
+          path: dist
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
+      - name: Build docker image (ubuntu)
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+          GOARM: ${{ matrix.arm }}
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_VERSION: ${{ needs.setup.outputs.version }}
+          ARCH_TAG: ${{ matrix.arch-tag }}
+        run: |
+          make build-docker-ubuntu \
+            BUILD_VERSION="$BUILD_VERSION" \
+            BUILD_NUMBER="$BUILD_NUMBER" \
+            DOCKER_TAG="grafana/grafana-image-tags:${BUILD_VERSION}-ubuntu-${ARCH_TAG}"
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          for f in dist/*.ubuntu.docker.tar.gz; do
+            [ -e "$f" ] || continue
+            sha256sum "$f" > "${f}.sha256"
+          done
+      - name: Write artifact list
+        run: |
+          listfile="artifacts-list-docker-ubuntu-${{ matrix.name }}.txt"
+          : > "$listfile"
+          for f in dist/*.ubuntu.docker.tar.gz; do
+            [ -e "$f" ] || continue
+            echo "$f" >> "$listfile"
+            echo "${f}.sha256" >> "$listfile"
+          done
+      - name: Stage artifacts for upload
+        run: |
+          set -euo pipefail
+          mkdir -p "upload/artifacts-list-docker-ubuntu-${{ matrix.name }}"
+          cp "artifacts-list-docker-ubuntu-${{ matrix.name }}.txt" "upload/artifacts-list-docker-ubuntu-${{ matrix.name }}/"
+          mkdir -p "upload/artifacts-docker-ubuntu-${{ matrix.name }}"
+          for f in dist/*.ubuntu.docker.tar.gz; do
+            [ -e "$f" ] || continue
+            cp "$f" "upload/artifacts-docker-ubuntu-${{ matrix.name }}/"
+            cp "${f}.sha256" "upload/artifacts-docker-ubuntu-${{ matrix.name }}/"
+          done
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: artifacts-list-docker-ubuntu-${{ matrix.name }}
+          path: upload/artifacts-list-docker-ubuntu-${{ matrix.name }}
+          retention-days: 1
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: artifacts-docker-ubuntu-${{ matrix.name }}
+          path: upload/artifacts-docker-ubuntu-${{ matrix.name }}
+          retention-days: 1
+
   verify-targz:
     name: verify targz (linux-amd64)
     needs:
-      - build-packages
+      - build-targz
     uses: ./.github/workflows/release-verify.yml
     with:
       run-id: ${{ github.run_id }}
@@ -342,33 +598,25 @@ jobs:
   verify-packages:
     name: verify packages (linux-amd64)
     needs:
-      - build-docker
+      - build-docker-alpine
     uses: ./.github/workflows/release-verify-packages.yml
     with:
       run-id: ${{ github.run_id }}
-      packages-artifact-name: artifacts-linux-amd64
+      packages-artifact-name: artifacts-docker-linux-amd64
 
-  build-docker:
+  build-windows:
     runs-on: ubuntu-x64-large
     needs:
       - setup
-      - build-packages
+      - build-targz
     permissions:
       contents: read
       id-token: write
-    name: ${{ needs.setup.outputs.version }} / docker / ${{ matrix.name }}
+    name: ${{ needs.setup.outputs.version }} / windows / ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: linux-amd64
-            artifacts: docker:grafana:linux/amd64,docker:grafana:linux/amd64:ubuntu
-          - name: linux-arm64
-            artifacts: docker:grafana:linux/arm64,docker:grafana:linux/arm64:ubuntu
-          - name: linux-s390x
-            artifacts: docker:grafana:linux/s390x,docker:grafana:linux/s390x:ubuntu
-          - name: linux-armv7
-            artifacts: docker:grafana:linux/arm/v7,docker:grafana:linux/arm/v7:ubuntu
           - name: windows-amd64
             artifacts: zip:grafana:windows/amd64:nocgo,msi:grafana:windows/amd64:nocgo
           - name: windows-arm64
@@ -383,10 +631,6 @@ jobs:
         with:
           name: artifacts-packages-${{ matrix.name }}
           path: dist
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
-        with:
-          image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
       - uses: ./.github/actions/build-package
         id: build
         with:
@@ -441,38 +685,10 @@ jobs:
       id-token: write
     needs:
       - setup
-      - build-packages
-      - build-docker
+      - build-targz
     with:
       bucket: grafana-prerelease
       pattern: artifacts-packages-${{ matrix.target }}
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
-      runs-on: ubuntu-x64-small
-
-  publish-package-artifacts:
-    name: Upload package artifact / ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: linux-amd64
-          - target: linux-arm64
-          - target: linux-s390x
-          - target: linux-armv7
-          - target: windows-amd64
-          - target: windows-arm64
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build-packages
-      - build-docker
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -499,8 +715,7 @@ jobs:
       id-token: write
     needs:
       - setup
-      - build-packages
-      - build-docker
+      - build-targz
     with:
       bucket: grafana-prerelease
       pattern: artifacts-list-packages-${{ matrix.target }}
@@ -509,8 +724,60 @@ jobs:
       environment: prod
       runs-on: ubuntu-x64-small
 
-  publish-package-artifact-lists:
-    name: Upload package artifact list / ${{ matrix.target }}
+  publish-deb-rpm-artifacts:
+    name: Upload deb/rpm artifact / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv6
+          - target: linux-armv7
+          - target: linux-riscv64
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-deb-rpm
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-deb-rpm-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-deb-rpm-artifact-lists:
+    name: Upload deb/rpm artifact list / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv6
+          - target: linux-armv7
+          - target: linux-riscv64
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-deb-rpm
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-list-deb-rpm-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-alpine-artifacts:
+    name: Upload docker (alpine) artifact / ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -519,6 +786,98 @@ jobs:
           - target: linux-arm64
           - target: linux-s390x
           - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-alpine
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-docker-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-alpine-artifact-lists:
+    name: Upload docker (alpine) artifact list / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-alpine
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-list-docker-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-ubuntu-artifacts:
+    name: Upload docker (ubuntu) artifact / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-ubuntu
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-docker-ubuntu-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-ubuntu-artifact-lists:
+    name: Upload docker (ubuntu) artifact list / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-ubuntu
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-list-docker-ubuntu-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-windows-artifacts:
+    name: Upload windows artifact / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - target: windows-amd64
           - target: windows-arm64
     uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
@@ -526,8 +885,29 @@ jobs:
       id-token: write
     needs:
       - setup
-      - build-packages
-      - build-docker
+      - build-windows
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-windows-artifact-lists:
+    name: Upload windows artifact list / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows-amd64
+          - target: windows-arm64
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-windows
     with:
       bucket: grafana-prerelease
       pattern: artifacts-list-${{ matrix.target }}
@@ -545,40 +925,65 @@ jobs:
     needs:
       - setup
       - verify-targz
-      - build-docker
+      - build-docker-alpine
+      - build-docker-ubuntu
       - verify-packages
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: artifacts-list-linux-amd64
+          name: artifacts-list-docker-linux-amd64
           path: .
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: artifacts-list-linux-arm64
+          name: artifacts-list-docker-linux-arm64
           path: .
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: artifacts-list-linux-armv7
+          name: artifacts-list-docker-linux-armv7
           path: .
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: artifacts-linux-amd64
+          name: artifacts-list-docker-ubuntu-linux-amd64
+          path: .
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-list-docker-ubuntu-linux-arm64
+          path: .
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-list-docker-ubuntu-linux-armv7
+          path: .
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-docker-linux-amd64
           path: dist
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: artifacts-linux-arm64
+          name: artifacts-docker-linux-arm64
           path: dist
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: artifacts-linux-armv7
+          name: artifacts-docker-linux-armv7
+          path: dist
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-docker-ubuntu-linux-amd64
+          path: dist
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-docker-ubuntu-linux-arm64
+          path: dist
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: artifacts-docker-ubuntu-linux-armv7
           path: dist
       - name: Push to Docker Hub
         env:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
           cat artifacts-*.txt > artifacts.txt
-          grep 'grafana_.*docker.tar.gz$' artifacts.txt | xargs -I % docker load -i % | sed 's/Loaded image: //g' | tee docker_images
+          grep 'docker\.tar\.gz$' artifacts.txt | xargs -I % docker load -i % | sed 's/Loaded image: //g' | tee docker_images
           while read -r line; do
             docker push "$line"
           done < docker_images

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -684,7 +684,6 @@ jobs:
 
   publish-targz:
     name: Upload targz / ${{ matrix.target }}
-    continue-on-error: ${{ matrix.allow-failure == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -717,7 +716,6 @@ jobs:
 
   publish-deb-rpm:
     name: Upload deb/rpm / ${{ matrix.target }}
-    continue-on-error: ${{ matrix.allow-failure == true }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -616,11 +616,15 @@ jobs:
   verify-packages:
     name: verify packages (linux-amd64)
     needs:
+      - build-deb-rpm
       - build-docker-alpine
+      - build-docker-ubuntu
     uses: ./.github/workflows/release-verify-packages.yml
     with:
       run-id: ${{ github.run_id }}
-      packages-artifact-name: artifacts-docker-linux-amd64
+      packages-artifact-name: artifacts-deb-rpm-linux-amd64
+      docker-artifact-name: artifacts-docker-linux-amd64
+      docker-ubuntu-artifact-name: artifacts-docker-ubuntu-linux-amd64
 
   build-windows:
     runs-on: ubuntu-x64-large

--- a/.github/workflows/release-verify-packages.yml
+++ b/.github/workflows/release-verify-packages.yml
@@ -8,10 +8,18 @@ on:
         required: true
         type: string
       packages-artifact-name:
-        description: Name of the uploaded package artifact bundle
+        description: Name of the artifact containing deb/rpm packages
         required: false
         type: string
         default: artifacts-linux-amd64
+      docker-artifact-name:
+        description: Name of the artifact containing the alpine docker image. Defaults to packages-artifact-name.
+        required: false
+        type: string
+      docker-ubuntu-artifact-name:
+        description: Name of the artifact containing the ubuntu docker image. Defaults to docker-artifact-name.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -243,7 +251,7 @@ jobs:
 
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: ${{ inputs.packages-artifact-name }}
+          name: ${{ inputs.docker-artifact-name || inputs.packages-artifact-name }}
           run-id: ${{ inputs.run-id }}
           path: dist
 
@@ -330,7 +338,7 @@ jobs:
 
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
-          name: ${{ inputs.packages-artifact-name }}
+          name: ${{ inputs.docker-ubuntu-artifact-name || inputs.docker-artifact-name || inputs.packages-artifact-name }}
           run-id: ${{ inputs.run-id }}
           path: dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 # to maintain formatting of multiline commands in vscode, add the following to settings.json:
 # "docker.languageserver.formatter.ignoreMultilineInstructions": true
 
-ARG BASE_IMAGE=alpine-base
 ARG GO_IMAGE=go-builder-base
 ARG JS_IMAGE=js-builder-base
 ARG JS_PLATFORM=linux/amd64
@@ -111,7 +110,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN mkdir -p data/plugins-bundled
 
 # From-tarball build stage
-FROM ${BASE_IMAGE} AS tgz-builder
+FROM alpine-base AS tgz-builder
 
 WORKDIR /tmp/grafana
 
@@ -128,8 +127,8 @@ RUN mkdir -p data/plugins-bundled
 FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
-# Final stage
-FROM ${BASE_IMAGE}
+# Alpine final stage
+FROM alpine-base AS final-alpine
 
 LABEL maintainer="Grafana Labs <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
@@ -147,25 +146,14 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 
 WORKDIR $GF_PATHS_HOME
 
-# Install dependencies
-RUN if grep -i -q alpine /etc/issue; then \
-  apk add --no-cache ca-certificates bash bubblewrap curl tzdata musl-utils && \
-  apk info -vv | sort; \
-  elif grep -i -q ubuntu /etc/issue; then \
-  DEBIAN_FRONTEND=noninteractive && \
-  apt-get update && \
-  apt-get install -y ca-certificates curl tzdata musl && \
-  apt-get autoremove -y && \
-  rm -rf /var/lib/apt/lists/*; \
-  else \
-  echo 'ERROR: Unsupported base image' && /bin/false; \
-  fi
+RUN apk add --no-cache ca-certificates bash bubblewrap curl tzdata musl-utils && \
+  apk info -vv | sort
 
 # glibc support for alpine x86_64 only
 # docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.40 /usr/glibc-compat > glibc-bin-2.40.tar.gz
 ARG GLIBC_VERSION=2.40
 
-RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
+RUN if [ "$(arch)" = "x86_64" ]; then \
   wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
   usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
   usr/glibc-compat/lib/libc.so.6 \
@@ -180,20 +168,75 @@ RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
 
 COPY --from=go-src /tmp/grafana/conf ./conf
 
-RUN if [ ! $(getent group "$GF_GID") ]; then \
-  if grep -i -q alpine /etc/issue; then \
+RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   addgroup -S -g $GF_GID grafana; \
-  else \
-  groupadd --system --gid $GF_GID grafana; \
-  fi; \
   fi && \
   GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
   mkdir -p "$GF_PATHS_HOME/.aws" && \
-  if grep -i -q alpine /etc/issue; then \
-  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana; \
-  else \
-  useradd --system --uid $GF_UID --gid "$GF_GID_NAME" --no-create-home grafana; \
+  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana && \
+  mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
+  "$GF_PATHS_PROVISIONING/dashboards" \
+  "$GF_PATHS_PROVISIONING/notifiers" \
+  "$GF_PATHS_PROVISIONING/plugins" \
+  "$GF_PATHS_PROVISIONING/access-control" \
+  "$GF_PATHS_PROVISIONING/alerting" \
+  "$GF_PATHS_LOGS" \
+  "$GF_PATHS_PLUGINS" \
+  "$GF_PATHS_DATA" && \
+  cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+  cp conf/ldap.toml /etc/grafana/ldap.toml && \
+  chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
+  chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+
+COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --from=js-src /tmp/grafana/public ./public
+COPY --from=js-src /tmp/grafana/LICENSE ./
+COPY --from=go-src /tmp/grafana/data/plugins-bundled ./data/plugins-bundled
+
+RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
+RUN chmod 644 /.grafana-version
+
+EXPOSE 3000
+
+ARG RUN_SH=./packaging/docker/run.sh
+
+COPY ${RUN_SH} /run.sh
+
+USER "$GF_UID"
+ENTRYPOINT [ "/run.sh" ]
+
+# Ubuntu final stage
+FROM ubuntu-base AS final-ubuntu
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+
+ARG GF_UID="472"
+ARG GF_GID="0"
+
+ENV PATH="/usr/share/grafana/bin:$PATH" \
+  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+  GF_PATHS_DATA="/var/lib/grafana" \
+  GF_PATHS_HOME="/usr/share/grafana" \
+  GF_PATHS_LOGS="/var/log/grafana" \
+  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+
+WORKDIR $GF_PATHS_HOME
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+  apt-get install -y ca-certificates curl tzdata musl && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=go-src /tmp/grafana/conf ./conf
+
+RUN if [ ! "$(getent group "$GF_GID")" ]; then \
+  groupadd --system --gid $GF_GID grafana; \
   fi && \
+  GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+  mkdir -p "$GF_PATHS_HOME/.aws" && \
+  useradd --system --uid $GF_UID --gid "$GF_GID_NAME" --no-create-home grafana && \
   mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
   "$GF_PATHS_PROVISIONING/dashboards" \
   "$GF_PATHS_PROVISIONING/notifiers" \

--- a/Makefile
+++ b/Makefile
@@ -379,8 +379,10 @@ build: build-go build-js ## Build backend and frontend.
 TARGZ_PACKAGE_NAME ?= grafana
 FPM_LICENSE        ?= AGPLv3
 ARCH_LABEL         := $(if $(ARM),$(ARCH)-$(ARM),$(ARCH))
+# armv6 debs use a -rpi suffix to match daggerbuild behavior (grafana-rpi, grafana-enterprise-rpi).
+DEB_PACKAGE_NAME   := $(if $(filter 6,$(ARM)),$(TARGZ_PACKAGE_NAME)-rpi,$(TARGZ_PACKAGE_NAME))
 TARGZ_FILE         := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).tar.gz
-DEB_FILE           := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).deb
+DEB_FILE           := dist/$(DEB_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).deb
 RPM_FILE           := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).rpm
 DOCKER_FILE        := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).docker.tar.gz
 DOCKER_UBUNTU_FILE := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).ubuntu.docker.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -382,6 +382,9 @@ ARCH_LABEL         := $(if $(ARM),$(ARCH)-$(ARM),$(ARCH))
 TARGZ_FILE         := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).tar.gz
 DEB_FILE           := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).deb
 RPM_FILE           := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).rpm
+DOCKER_FILE        := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).docker.tar.gz
+DOCKER_UBUNTU_FILE := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).ubuntu.docker.tar.gz
+DOCKER_TAG         ?= $(TARGZ_PACKAGE_NAME):$(BUILD_VERSION)
 
 # Default catalog plugins under data/plugins-bundled. Stamp encodes OS/ARCH so cross-builds refresh.
 DATA_PLUGINS_BUNDLED_STAMP := data/plugins-bundled/.platform-$(OS)-$(ARCH).stamp
@@ -446,6 +449,36 @@ $(RPM_FILE): $(TARGZ_FILE)
 	FPM_LICENSE="$(FPM_LICENSE)" \
 	$(if $(ARM),GOARM="$(ARM)") \
 	bash scripts/build-rpm.sh
+
+.PHONY: build-docker
+build-docker: $(DOCKER_FILE) ## Build a Docker image (alpine) from a tar.gz
+
+$(DOCKER_FILE): $(TARGZ_FILE)
+	@echo "building docker image (alpine)"
+	docker buildx build \
+	--platform $(OS)/$(ARCH) \
+	--build-arg GRAFANA_TGZ=$(TARGZ_FILE) \
+	--build-arg GO_SRC=tgz-builder \
+	--build-arg JS_SRC=tgz-builder \
+	--target=final-alpine \
+	--tag $(DOCKER_TAG) \
+	--output type=docker,dest=$@ \
+	.
+
+.PHONY: build-docker-ubuntu
+build-docker-ubuntu: $(DOCKER_UBUNTU_FILE) ## Build a Docker image (ubuntu) from a tar.gz
+
+$(DOCKER_UBUNTU_FILE): $(TARGZ_FILE)
+	@echo "building docker image (ubuntu)"
+	docker buildx build \
+	--platform $(OS)/$(ARCH) \
+	--build-arg GRAFANA_TGZ=$(TARGZ_FILE) \
+	--build-arg GO_SRC=tgz-builder \
+	--build-arg JS_SRC=tgz-builder \
+	--target=final-ubuntu \
+	--tag $(DOCKER_TAG)-ubuntu \
+	--output type=docker,dest=$@ \
+	.
 
 .PHONY: run
 run: ## Build and run backend, and watch for changes. See .air.toml for configuration.
@@ -613,6 +646,7 @@ build-docker-full: ## Build Docker image for development.
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
 	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
+	--target=final-alpine \
 	--tag grafana/grafana$(TAG_SUFFIX):dev \
 	$(DOCKER_BUILD_ARGS) \
 	.
@@ -630,8 +664,8 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
 	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
-	--build-arg BASE_IMAGE=ubuntu:24.04 \
 	--build-arg GO_IMAGE=golang:$(GO_VERSION) \
+	--target=final-ubuntu \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
 	$(DOCKER_BUILD_ARGS) \
 	.

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,10 +59,10 @@ docker_build () {
   esac
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
-    base_image="${base_arch}alpine:3.23.3"
+    target="final-alpine"
   else
     libc=""
-    base_image="${base_arch}ubuntu:24.04"
+    target="final-ubuntu"
   fi
 
   grafana_tgz=${GRAFANA_TGZ:-"grafana-latest.linux-${arch}${libc}.tar.gz"}
@@ -70,11 +70,11 @@ docker_build () {
 
   DOCKER_BUILDKIT=1 \
   docker build \
-    --build-arg BASE_IMAGE=${base_image} \
     --build-arg GRAFANA_TGZ=${grafana_tgz} \
     --build-arg GO_SRC=tgz-builder \
     --build-arg JS_SRC=tgz-builder \
     --build-arg RUN_SH=./run.sh \
+    --target ${target} \
     --tag "${tag}" \
     --no-cache=true \
     --file ../../Dockerfile \

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -25,6 +25,12 @@ if [ -n "${GOARM:-}" ]; then
   ARCH_LABEL="${ARCH}-${GOARM}"
 fi
 
+# Match daggerbuild RPI flag: armv6 packages use a -rpi suffix (grafana-rpi, grafana-enterprise-rpi).
+DEB_PACKAGE_NAME="${TARGZ_PACKAGE_NAME}"
+if [ "${GOARM:-}" = "6" ]; then
+  DEB_PACKAGE_NAME="${TARGZ_PACKAGE_NAME}-rpi"
+fi
+
 # Match pkg/build/daggerbuild/backend.PackageArch: arm -> armhf.
 PKG_ARCH="${ARCH}"
 if [ "${ARCH}" = "arm" ]; then
@@ -51,7 +57,7 @@ PKG="${STAGING}/pkg"
 
 mkdir -p "${SRC}"
 
-echo "build deb: ${TARGZ_PACKAGE_NAME}_${BUILD_VERSION}_${BUILD_NUMBER}_${OS}_${ARCH_LABEL}.deb"
+echo "build deb: ${DEB_PACKAGE_NAME}_${BUILD_VERSION}_${BUILD_NUMBER}_${OS}_${ARCH_LABEL}.deb"
 
 tar --exclude=storybook --strip-components=1 -xf "${TARGZ}" -C "${SRC}"
 
@@ -79,7 +85,7 @@ cp "${SRC}/packaging/deb/default/grafana-server"              "${PKG}/etc/defaul
 cp "${SRC}/packaging/deb/init.d/grafana-server"               "${PKG}/etc/init.d/grafana-server"
 cp "${SRC}/packaging/deb/systemd/grafana-server.service"      "${PKG}/usr/lib/systemd/system/grafana-server.service"
 
-FILENAME="${TARGZ_PACKAGE_NAME}_${BUILD_VERSION}_${BUILD_NUMBER}_${OS}_${ARCH_LABEL}.deb"
+FILENAME="${DEB_PACKAGE_NAME}_${BUILD_VERSION}_${BUILD_NUMBER}_${OS}_${ARCH_LABEL}.deb"
 
 mkdir -p dist
 
@@ -101,7 +107,7 @@ fpm \
   --architecture="${PKG_ARCH}" \
   --description=Grafana \
   --license="${FPM_LICENSE:-AGPLv3}" \
-  --name="${TARGZ_PACKAGE_NAME}" \
+  --name="${DEB_PACKAGE_NAME}" \
   --deb-no-default-config-files \
   --deb-compression zst \
   .


### PR DESCRIPTION
- Split Dockerfile into multiple targets (Ubuntu, Alpine). This will make it easier to expand to use scratch or distroless (now possible because we aren't building with CGO)
- Build Grafana release candidates with `make` instead of dagger.
- Fix bug with grafana-rpi artifacts not naming correctly.


Successful run:
- https://github.com/grafana/grafana/actions/runs/23916989982
- https://github.com/grafana/grafana-enterprise/actions/runs/23917009460

After all this is done, the Grafana builds in both repos:
- Are easier to trace and read the logs
- Run faster since we're able to split the process across more runners
- Run the e2e verify suite and actually upload the results