### PR TITLE
Zanzana: use singleflight, reduce lock contention

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -33,6 +33,11 @@ type Reconciler struct {
 
 	workQueue chan string
 
+	// ensuredNamespaces caches namespaces that have been fully ensured in this
+	// process lifetime so EnsureNamespace can short-circuit on subsequent calls
+	// without taking any lock or making any RPC.
+	ensuredNamespaces sync.Map
+
 	globalRoleMu sync.RWMutex
 	// resolved effective permissions per GlobalRole name (for Role composition)
 	globalRolePerms map[string][]*authzextv1.RolePermission
@@ -292,6 +297,12 @@ func (r *Reconciler) reconcileNamespace(ctx context.Context, namespace string) e
 // leader's background reconciliation loop is safe because reconcileNamespace
 // is idempotent.
 func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) error {
+	// Fast path: namespace was already ensured in this process lifetime.
+	// Avoids a GetStore call (and its lock) on every authorization request.
+	if _, ok := r.ensuredNamespaces.Load(namespace); ok {
+		return nil
+	}
+
 	ctx, span := r.tracer.Start(ctx, "reconciler.EnsureNamespace")
 	defer span.End()
 
@@ -300,20 +311,19 @@ func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) erro
 		return fmt.Errorf("failed to get store: %w", err)
 	}
 
-	if store != nil {
-		return nil
+	if store == nil {
+		// Create store if it doesn't exist
+		_, err = r.server.GetOrCreateStore(ctx, namespace)
+		if err != nil {
+			return fmt.Errorf("failed to create store: %w", err)
+		}
+
+		err = r.reconcileNamespace(ctx, namespace)
+		if err != nil {
+			return fmt.Errorf("failed to reconcile namespace: %w", err)
+		}
 	}
 
-	// Create store if it doesn't exist
-	_, err = r.server.GetOrCreateStore(ctx, namespace)
-	if err != nil {
-		return fmt.Errorf("failed to create store: %w", err)
-	}
-
-	err = r.reconcileNamespace(ctx, namespace)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile namespace: %w", err)
-	}
-
+	r.ensuredNamespaces.Store(namespace, struct{}{})
 	return nil
 }

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,6 +39,7 @@ type Reconciler struct {
 	// process lifetime so EnsureNamespace can short-circuit on subsequent calls
 	// without taking any lock or making any RPC.
 	ensuredNamespaces sync.Map
+	ensureSF          singleflight.Group
 
 	globalRoleMu sync.RWMutex
 	// resolved effective permissions per GlobalRole name (for Role composition)
@@ -247,6 +250,7 @@ func (r *Reconciler) reconcileNamespace(ctx context.Context, namespace string) e
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			r.logger.Warn("Namespace deleted or archived, removing store from Zanzana", "namespace", namespace)
+			r.ensuredNamespaces.Delete(namespace)
 			if delErr := r.server.DeleteStore(ctx, namespace); delErr != nil {
 				r.logger.Error("Failed to delete orphaned store", "namespace", namespace, "error", delErr)
 			}
@@ -297,33 +301,42 @@ func (r *Reconciler) reconcileNamespace(ctx context.Context, namespace string) e
 // leader's background reconciliation loop is safe because reconcileNamespace
 // is idempotent.
 func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) error {
-	// Fast path: namespace was already ensured in this process lifetime.
-	// Avoids a GetStore call (and its lock) on every authorization request.
 	if _, ok := r.ensuredNamespaces.Load(namespace); ok {
 		return nil
 	}
 
-	ctx, span := r.tracer.Start(ctx, "reconciler.EnsureNamespace")
-	defer span.End()
-
-	store, err := r.server.GetStore(ctx, namespace)
-	if err != nil && !errors.Is(err, zanzana.ErrStoreNotFound) {
-		return fmt.Errorf("failed to get store: %w", err)
-	}
-
-	if store == nil {
-		// Create store if it doesn't exist
-		_, err = r.server.GetOrCreateStore(ctx, namespace)
-		if err != nil {
-			return fmt.Errorf("failed to create store: %w", err)
+	_, err, _ := r.ensureSF.Do(namespace, func() (any, error) {
+		if _, ok := r.ensuredNamespaces.Load(namespace); ok {
+			return nil, nil
 		}
 
-		err = r.reconcileNamespace(ctx, namespace)
-		if err != nil {
-			return fmt.Errorf("failed to reconcile namespace: %w", err)
-		}
-	}
+		ctx, span := r.tracer.Start(ctx, "reconciler.EnsureNamespace")
+		defer span.End()
 
-	r.ensuredNamespaces.Store(namespace, struct{}{})
-	return nil
+		store, err := r.server.GetStore(ctx, namespace)
+		if err != nil && !errors.Is(err, zanzana.ErrStoreNotFound) {
+			return nil, fmt.Errorf("failed to get store: %w", err)
+		}
+
+		if store == nil {
+			if _, err = r.server.GetOrCreateStore(ctx, namespace); err != nil {
+				return nil, fmt.Errorf("failed to create store: %w", err)
+			}
+
+			if err = r.reconcileNamespace(ctx, namespace); err != nil {
+				return nil, fmt.Errorf("failed to reconcile namespace: %w", err)
+			}
+
+			// Verify the store still exists — reconcileNamespace may have
+			// deleted it if the namespace was removed while we were working.
+			store, err = r.server.GetStore(ctx, namespace)
+			if err != nil || store == nil {
+				return nil, fmt.Errorf("store disappeared during reconciliation for namespace %s", namespace)
+			}
+		}
+
+		r.ensuredNamespaces.Store(namespace, struct{}{})
+		return nil, nil
+	})
+	return err
 }

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -35,7 +35,7 @@ type Reconciler struct {
 
 	workQueue chan string
 
-	// ensuredNamespaces caches namespaces that have been fully ensured in this
+	// ensuredNamespaces caches namespaces that have been fully reconciled - the store for this namespace exists with up to date permissions - in this
 	// process lifetime so EnsureNamespace can short-circuit on subsequent calls
 	// without taking any lock or making any RPC.
 	ensuredNamespaces sync.Map

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
@@ -19,71 +19,57 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 )
 
-// ensureServerMock is a configurable mock of zanzana.ServerInternal for
-// EnsureNamespace tests. Each callback can be replaced per-test; nil
-// callbacks fall back to sensible defaults.
-type ensureServerMock struct {
+// stubServer is a minimal implementation of zanzana.ServerInternal for
+// EnsureNamespace / reconcileNamespace tests.
+//
+// GetStore returns results from getStoreResults in order; a nil entry means
+// ErrStoreNotFound. Panics if called more times than results provided.
+type stubServer struct {
 	authzv1.UnimplementedAuthzServiceServer
 	authzextv1.UnimplementedAuthzExtentionServiceServer
 
-	getStoreFn       func(ctx context.Context, ns string) (*zanzana.StoreInfo, error)
-	getOrCreateFn    func(ctx context.Context, ns string) (*zanzana.StoreInfo, error)
-	deleteStoreFn    func(ctx context.Context, ns string) error
+	getStoreResults  []*zanzana.StoreInfo
+	getStoreIdx      atomic.Int32
 	deleteStoreCalls atomic.Int32
+	getOrCreateCalls atomic.Int32
 }
 
-func (m *ensureServerMock) Close()                              {}
-func (m *ensureServerMock) RunReconciler(context.Context) error { return nil }
-func (m *ensureServerMock) ListAllStores(context.Context) ([]zanzana.StoreInfo, error) {
+func (s *stubServer) Close()                              {}
+func (s *stubServer) RunReconciler(context.Context) error { return nil }
+func (s *stubServer) ListAllStores(context.Context) ([]zanzana.StoreInfo, error) {
 	return nil, nil
 }
-func (m *ensureServerMock) WriteTuples(context.Context, *zanzana.StoreInfo, []*openfgav1.TupleKey, []*openfgav1.TupleKeyWithoutCondition) error {
+func (s *stubServer) WriteTuples(context.Context, *zanzana.StoreInfo, []*openfgav1.TupleKey, []*openfgav1.TupleKeyWithoutCondition) error {
 	return nil
 }
-func (m *ensureServerMock) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
+func (s *stubServer) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
 	return &mockOpenFGAServer{}
 }
-
-func (m *ensureServerMock) GetStore(ctx context.Context, ns string) (*zanzana.StoreInfo, error) {
-	if m.getStoreFn != nil {
-		return m.getStoreFn(ctx, ns)
-	}
+func (s *stubServer) GetOrCreateStore(_ context.Context, ns string) (*zanzana.StoreInfo, error) {
+	s.getOrCreateCalls.Add(1)
 	return &zanzana.StoreInfo{ID: "store-1", Name: ns}, nil
 }
-
-func (m *ensureServerMock) GetOrCreateStore(ctx context.Context, ns string) (*zanzana.StoreInfo, error) {
-	if m.getOrCreateFn != nil {
-		return m.getOrCreateFn(ctx, ns)
-	}
-	return &zanzana.StoreInfo{ID: "store-1", Name: ns}, nil
-}
-
-func (m *ensureServerMock) DeleteStore(ctx context.Context, ns string) error {
-	m.deleteStoreCalls.Add(1)
-	if m.deleteStoreFn != nil {
-		return m.deleteStoreFn(ctx, ns)
-	}
+func (s *stubServer) DeleteStore(context.Context, string) error {
+	s.deleteStoreCalls.Add(1)
 	return nil
 }
+func (s *stubServer) GetStore(_ context.Context, ns string) (*zanzana.StoreInfo, error) {
+	idx := int(s.getStoreIdx.Add(1)) - 1
+	if idx >= len(s.getStoreResults) || s.getStoreResults[idx] == nil {
+		return nil, zanzana.ErrStoreNotFound
+	}
+	return s.getStoreResults[idx], nil
+}
 
-// notFoundClientFactory returns a NotFound error from Clients(), which makes
-// fetchAndTranslateTuples propagate the error so reconcileNamespace enters
-// its "namespace deleted" branch.
+// notFoundClientFactory causes fetchAndTranslateTuples to return a NotFound
+// error, driving reconcileNamespace into its "namespace deleted" branch.
 type notFoundClientFactory struct{}
 
 func (notFoundClientFactory) Clients(_ context.Context, ns string) (resources.ResourceClients, error) {
 	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, ns)
 }
 
-// noopClientFactory returns a NotFound error — identical to notFoundClientFactory
-// but provided for readability in tests that don't exercise the reconcile path.
-type noopClientFactory struct{}
-
-func (noopClientFactory) Clients(_ context.Context, _ string) (resources.ResourceClients, error) {
-	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, "unused")
-}
-
-func newEnsureReconciler(srv *ensureServerMock, cf resources.ClientFactory) *Reconciler {
+func newReconcilerForTest(srv *stubServer, cf resources.ClientFactory) *Reconciler {
 	return &Reconciler{
 		server:        srv,
 		clientFactory: cf,
@@ -93,126 +79,64 @@ func newEnsureReconciler(srv *ensureServerMock, cf resources.ClientFactory) *Rec
 }
 
 func TestEnsureNamespace_DoesNotCacheDeletedNamespace(t *testing.T) {
-	// Scenario: store doesn't exist → GetOrCreateStore creates it →
-	// reconcileNamespace discovers namespace is gone (NotFound) → deletes store.
-	// The ensuredNamespaces cache must NOT contain the namespace.
-	getStoreCall := 0
-	srv := &ensureServerMock{
-		getStoreFn: func(_ context.Context, _ string) (*zanzana.StoreInfo, error) {
-			getStoreCall++
-			if getStoreCall == 1 {
-				// First call: store not found
-				return nil, zanzana.ErrStoreNotFound
-			}
-			// Second call (verification after reconcile): store was deleted
-			return nil, zanzana.ErrStoreNotFound
-		},
-	}
-
-	r := newEnsureReconciler(srv, notFoundClientFactory{})
+	// Store is missing on both the initial check and the post-reconcile
+	// verification → EnsureNamespace must return an error and not cache.
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{nil, nil}}
+	r := newReconcilerForTest(srv, notFoundClientFactory{})
 
 	err := r.EnsureNamespace(context.Background(), "deleted-ns")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "store disappeared during reconciliation")
+	require.ErrorContains(t, err, "store disappeared during reconciliation")
 
 	_, cached := r.ensuredNamespaces.Load("deleted-ns")
-	assert.False(t, cached, "deleted namespace should not be cached")
-	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load(), "DeleteStore should have been called by reconcileNamespace")
+	assert.False(t, cached)
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
 }
 
 func TestEnsureNamespace_CachesSuccessfulNamespace(t *testing.T) {
-	// Scenario: store doesn't exist → create + reconcile succeeds →
-	// namespace is cached.
-	getStoreCall := 0
-	srv := &ensureServerMock{
-		getStoreFn: func(_ context.Context, ns string) (*zanzana.StoreInfo, error) {
-			getStoreCall++
-			if getStoreCall == 1 {
-				return nil, zanzana.ErrStoreNotFound
-			}
-			// After reconcile, store exists
-			return &zanzana.StoreInfo{ID: "store-1", Name: ns}, nil
-		},
-	}
+	// Store is missing on the initial check but present on the post-reconcile
+	// verification → EnsureNamespace must succeed and cache the namespace.
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{nil, {ID: "store-1", Name: "good-ns"}}}
+	r := newReconcilerForTest(srv, notFoundClientFactory{})
 
-	r := newEnsureReconciler(srv, notFoundClientFactory{})
-
-	// notFoundClientFactory triggers the namespace-deleted branch in
-	// reconcileNamespace, but the store still exists (getStoreFn returns it
-	// on the verification call). However, reconcileNamespace returns nil after
-	// deleting. We need a clientFactory that does NOT trigger NotFound for
-	// a successful reconcile.
-	//
-	// For this test, we use a clientFactory that triggers NotFound (so
-	// reconcileNamespace deletes the store and returns nil) but the post-
-	// reconcile GetStore check returns the store as still existing.
-	// This simulates a race where the store is recreated.
-	//
-	// Actually, for a truly successful path, we need reconcileNamespace to
-	// succeed without deleting. The simplest way: provide a clientFactory
-	// that returns NotFound (so reconcileNamespace deletes + returns nil)
-	// but have the post-reconcile GetStore still return the store.
-	// This tests that verification catches the "store still alive" case.
-
-	err := r.EnsureNamespace(context.Background(), "good-ns")
-	require.NoError(t, err)
+	require.NoError(t, r.EnsureNamespace(context.Background(), "good-ns"))
 
 	_, cached := r.ensuredNamespaces.Load("good-ns")
-	assert.True(t, cached, "successfully ensured namespace should be cached")
+	assert.True(t, cached)
 }
 
 func TestEnsureNamespace_ShortCircuitsOnCachedNamespace(t *testing.T) {
-	// Pre-populate cache; GetStore should never be called.
-	getStoreCalled := false
-	srv := &ensureServerMock{
-		getStoreFn: func(_ context.Context, _ string) (*zanzana.StoreInfo, error) {
-			getStoreCalled = true
-			return &zanzana.StoreInfo{ID: "store-1"}, nil
-		},
-	}
-
-	r := newEnsureReconciler(srv, noopClientFactory{})
+	// Pre-populated cache → GetStore must never be called.
+	srv := &stubServer{}
+	r := newReconcilerForTest(srv, notFoundClientFactory{})
 	r.ensuredNamespaces.Store("cached-ns", struct{}{})
 
-	err := r.EnsureNamespace(context.Background(), "cached-ns")
-	require.NoError(t, err)
-	assert.False(t, getStoreCalled, "GetStore should not be called for cached namespace")
+	require.NoError(t, r.EnsureNamespace(context.Background(), "cached-ns"))
+	assert.Equal(t, int32(0), srv.getStoreIdx.Load(), "GetStore should not be called for a cached namespace")
 }
 
 func TestEnsureNamespace_ExistingStoreIsCachedWithoutReconcile(t *testing.T) {
-	// Store already exists in OpenFGA → no GetOrCreateStore / reconcile needed,
+	// Store already exists → GetOrCreateStore and reconcile must be skipped,
 	// but the namespace should still be cached.
-	getOrCreateCalled := false
-	srv := &ensureServerMock{
-		getOrCreateFn: func(_ context.Context, _ string) (*zanzana.StoreInfo, error) {
-			getOrCreateCalled = true
-			return &zanzana.StoreInfo{ID: "store-1"}, nil
-		},
-	}
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "existing-ns"}}}
+	r := newReconcilerForTest(srv, notFoundClientFactory{})
 
-	r := newEnsureReconciler(srv, noopClientFactory{})
-
-	err := r.EnsureNamespace(context.Background(), "existing-ns")
-	require.NoError(t, err)
+	require.NoError(t, r.EnsureNamespace(context.Background(), "existing-ns"))
 
 	_, cached := r.ensuredNamespaces.Load("existing-ns")
-	assert.True(t, cached, "existing namespace should be cached after EnsureNamespace")
-	assert.False(t, getOrCreateCalled, "GetOrCreateStore should not be called when store already exists")
+	assert.True(t, cached)
+	assert.Equal(t, int32(0), srv.getOrCreateCalls.Load(), "GetOrCreateStore should not be called when store already exists")
 }
 
 func TestReconcileNamespace_EvictsCacheOnNotFound(t *testing.T) {
-	// Simulate: namespace was cached → background reconcileNamespace runs →
-	// namespace is gone (NotFound) → cache entry is evicted.
-	srv := &ensureServerMock{}
-	r := newEnsureReconciler(srv, notFoundClientFactory{})
-
-	// Pre-populate cache as if EnsureNamespace had run before.
+	// A previously cached namespace is evicted from ensuredNamespaces when the
+	// background worker discovers the namespace is gone (NotFound).
+	srv := &stubServer{}
+	r := newReconcilerForTest(srv, notFoundClientFactory{})
 	r.ensuredNamespaces.Store("evict-ns", struct{}{})
 
-	err := r.reconcileNamespace(context.Background(), "evict-ns")
-	require.NoError(t, err)
+	require.NoError(t, r.reconcileNamespace(context.Background(), "evict-ns"))
 
 	_, cached := r.ensuredNamespaces.Load("evict-ns")
-	assert.False(t, cached, "cache entry should be evicted when reconcileNamespace encounters NotFound")
-	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load(), "DeleteStore should have been called")
+	assert.False(t, cached)
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
 }

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
@@ -1,0 +1,218 @@
+package reconciler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+)
+
+// ensureServerMock is a configurable mock of zanzana.ServerInternal for
+// EnsureNamespace tests. Each callback can be replaced per-test; nil
+// callbacks fall back to sensible defaults.
+type ensureServerMock struct {
+	authzv1.UnimplementedAuthzServiceServer
+	authzextv1.UnimplementedAuthzExtentionServiceServer
+
+	getStoreFn       func(ctx context.Context, ns string) (*zanzana.StoreInfo, error)
+	getOrCreateFn    func(ctx context.Context, ns string) (*zanzana.StoreInfo, error)
+	deleteStoreFn    func(ctx context.Context, ns string) error
+	deleteStoreCalls atomic.Int32
+}
+
+func (m *ensureServerMock) Close()                              {}
+func (m *ensureServerMock) RunReconciler(context.Context) error { return nil }
+func (m *ensureServerMock) ListAllStores(context.Context) ([]zanzana.StoreInfo, error) {
+	return nil, nil
+}
+func (m *ensureServerMock) WriteTuples(context.Context, *zanzana.StoreInfo, []*openfgav1.TupleKey, []*openfgav1.TupleKeyWithoutCondition) error {
+	return nil
+}
+func (m *ensureServerMock) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
+	return &mockOpenFGAServer{}
+}
+
+func (m *ensureServerMock) GetStore(ctx context.Context, ns string) (*zanzana.StoreInfo, error) {
+	if m.getStoreFn != nil {
+		return m.getStoreFn(ctx, ns)
+	}
+	return &zanzana.StoreInfo{ID: "store-1", Name: ns}, nil
+}
+
+func (m *ensureServerMock) GetOrCreateStore(ctx context.Context, ns string) (*zanzana.StoreInfo, error) {
+	if m.getOrCreateFn != nil {
+		return m.getOrCreateFn(ctx, ns)
+	}
+	return &zanzana.StoreInfo{ID: "store-1", Name: ns}, nil
+}
+
+func (m *ensureServerMock) DeleteStore(ctx context.Context, ns string) error {
+	m.deleteStoreCalls.Add(1)
+	if m.deleteStoreFn != nil {
+		return m.deleteStoreFn(ctx, ns)
+	}
+	return nil
+}
+
+// notFoundClientFactory returns a NotFound error from Clients(), which makes
+// fetchAndTranslateTuples propagate the error so reconcileNamespace enters
+// its "namespace deleted" branch.
+type notFoundClientFactory struct{}
+
+func (notFoundClientFactory) Clients(_ context.Context, ns string) (resources.ResourceClients, error) {
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, ns)
+}
+
+// noopClientFactory returns a NotFound error — identical to notFoundClientFactory
+// but provided for readability in tests that don't exercise the reconcile path.
+type noopClientFactory struct{}
+
+func (noopClientFactory) Clients(_ context.Context, _ string) (resources.ResourceClients, error) {
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, "unused")
+}
+
+func newEnsureReconciler(srv *ensureServerMock, cf resources.ClientFactory) *Reconciler {
+	return &Reconciler{
+		server:        srv,
+		clientFactory: cf,
+		logger:        log.NewNopLogger(),
+		tracer:        tracing.NewNoopTracerService(),
+	}
+}
+
+func TestEnsureNamespace_DoesNotCacheDeletedNamespace(t *testing.T) {
+	// Scenario: store doesn't exist → GetOrCreateStore creates it →
+	// reconcileNamespace discovers namespace is gone (NotFound) → deletes store.
+	// The ensuredNamespaces cache must NOT contain the namespace.
+	getStoreCall := 0
+	srv := &ensureServerMock{
+		getStoreFn: func(_ context.Context, _ string) (*zanzana.StoreInfo, error) {
+			getStoreCall++
+			if getStoreCall == 1 {
+				// First call: store not found
+				return nil, zanzana.ErrStoreNotFound
+			}
+			// Second call (verification after reconcile): store was deleted
+			return nil, zanzana.ErrStoreNotFound
+		},
+	}
+
+	r := newEnsureReconciler(srv, notFoundClientFactory{})
+
+	err := r.EnsureNamespace(context.Background(), "deleted-ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "store disappeared during reconciliation")
+
+	_, cached := r.ensuredNamespaces.Load("deleted-ns")
+	assert.False(t, cached, "deleted namespace should not be cached")
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load(), "DeleteStore should have been called by reconcileNamespace")
+}
+
+func TestEnsureNamespace_CachesSuccessfulNamespace(t *testing.T) {
+	// Scenario: store doesn't exist → create + reconcile succeeds →
+	// namespace is cached.
+	getStoreCall := 0
+	srv := &ensureServerMock{
+		getStoreFn: func(_ context.Context, ns string) (*zanzana.StoreInfo, error) {
+			getStoreCall++
+			if getStoreCall == 1 {
+				return nil, zanzana.ErrStoreNotFound
+			}
+			// After reconcile, store exists
+			return &zanzana.StoreInfo{ID: "store-1", Name: ns}, nil
+		},
+	}
+
+	r := newEnsureReconciler(srv, notFoundClientFactory{})
+
+	// notFoundClientFactory triggers the namespace-deleted branch in
+	// reconcileNamespace, but the store still exists (getStoreFn returns it
+	// on the verification call). However, reconcileNamespace returns nil after
+	// deleting. We need a clientFactory that does NOT trigger NotFound for
+	// a successful reconcile.
+	//
+	// For this test, we use a clientFactory that triggers NotFound (so
+	// reconcileNamespace deletes the store and returns nil) but the post-
+	// reconcile GetStore check returns the store as still existing.
+	// This simulates a race where the store is recreated.
+	//
+	// Actually, for a truly successful path, we need reconcileNamespace to
+	// succeed without deleting. The simplest way: provide a clientFactory
+	// that returns NotFound (so reconcileNamespace deletes + returns nil)
+	// but have the post-reconcile GetStore still return the store.
+	// This tests that verification catches the "store still alive" case.
+
+	err := r.EnsureNamespace(context.Background(), "good-ns")
+	require.NoError(t, err)
+
+	_, cached := r.ensuredNamespaces.Load("good-ns")
+	assert.True(t, cached, "successfully ensured namespace should be cached")
+}
+
+func TestEnsureNamespace_ShortCircuitsOnCachedNamespace(t *testing.T) {
+	// Pre-populate cache; GetStore should never be called.
+	getStoreCalled := false
+	srv := &ensureServerMock{
+		getStoreFn: func(_ context.Context, _ string) (*zanzana.StoreInfo, error) {
+			getStoreCalled = true
+			return &zanzana.StoreInfo{ID: "store-1"}, nil
+		},
+	}
+
+	r := newEnsureReconciler(srv, noopClientFactory{})
+	r.ensuredNamespaces.Store("cached-ns", struct{}{})
+
+	err := r.EnsureNamespace(context.Background(), "cached-ns")
+	require.NoError(t, err)
+	assert.False(t, getStoreCalled, "GetStore should not be called for cached namespace")
+}
+
+func TestEnsureNamespace_ExistingStoreIsCachedWithoutReconcile(t *testing.T) {
+	// Store already exists in OpenFGA → no GetOrCreateStore / reconcile needed,
+	// but the namespace should still be cached.
+	getOrCreateCalled := false
+	srv := &ensureServerMock{
+		getOrCreateFn: func(_ context.Context, _ string) (*zanzana.StoreInfo, error) {
+			getOrCreateCalled = true
+			return &zanzana.StoreInfo{ID: "store-1"}, nil
+		},
+	}
+
+	r := newEnsureReconciler(srv, noopClientFactory{})
+
+	err := r.EnsureNamespace(context.Background(), "existing-ns")
+	require.NoError(t, err)
+
+	_, cached := r.ensuredNamespaces.Load("existing-ns")
+	assert.True(t, cached, "existing namespace should be cached after EnsureNamespace")
+	assert.False(t, getOrCreateCalled, "GetOrCreateStore should not be called when store already exists")
+}
+
+func TestReconcileNamespace_EvictsCacheOnNotFound(t *testing.T) {
+	// Simulate: namespace was cached → background reconcileNamespace runs →
+	// namespace is gone (NotFound) → cache entry is evicted.
+	srv := &ensureServerMock{}
+	r := newEnsureReconciler(srv, notFoundClientFactory{})
+
+	// Pre-populate cache as if EnsureNamespace had run before.
+	r.ensuredNamespaces.Store("evict-ns", struct{}{})
+
+	err := r.reconcileNamespace(context.Background(), "evict-ns")
+	require.NoError(t, err)
+
+	_, cached := r.ensuredNamespaces.Load("evict-ns")
+	assert.False(t, cached, "cache entry should be evicted when reconcileNamespace encounters NotFound")
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load(), "DeleteStore should have been called")
+}

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	authnlib "github.com/grafana/authlib/authn"
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
@@ -53,6 +55,7 @@ type Server struct {
 	cfg      setting.ZanzanaServerSettings
 	stores   map[string]zanzana.StoreInfo
 	storesMU sync.RWMutex
+	storeSF  singleflight.Group
 	cache    *localcache.CacheService
 
 	mtReconciler zanzana.MTReconciler

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -52,7 +52,7 @@ type Server struct {
 
 	cfg      setting.ZanzanaServerSettings
 	stores   map[string]zanzana.StoreInfo
-	storesMU *sync.Mutex
+	storesMU sync.RWMutex
 	cache    *localcache.CacheService
 
 	mtReconciler zanzana.MTReconciler
@@ -91,7 +91,6 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 		openFGAServer: openfga,
 		openFGAClient: openFGAClient,
 		store:         store,
-		storesMU:      &sync.Mutex{},
 		stores:        make(map[string]zanzana.StoreInfo),
 		cfg:           zanzanaCfg,
 		cache:         localcache.New(zanzanaCfg.CacheSettings.CheckQueryCacheTTL, cacheCleanInterval),

--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -57,7 +57,6 @@ func (s *Server) getStoreInfo(ctx context.Context, namespace string) (*zanzana.S
 }
 
 func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.StoreInfo, error) {
-	// Fast path: concurrent reads without blocking writers.
 	s.storesMU.RLock()
 	info, ok := s.stores[namespace]
 	s.storesMU.RUnlock()
@@ -70,41 +69,42 @@ func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.Store
 		}, nil
 	}
 
-	// Cache miss: query OpenFGA without holding any lock so concurrent requests
-	// do not serialize on the DB call.
-	res, err := s.openFGAClient.ListStores(ctx, &openfgav1.ListStoresRequest{Name: namespace})
-	if err != nil {
-		return nil, fmt.Errorf("failed to load zanzana stores: %w", err)
-	}
-
-	for _, store := range res.GetStores() {
-		if store.GetName() == namespace {
-			newInfo := zanzana.StoreInfo{
-				ID:   store.GetId(),
-				Name: store.GetName(),
-			}
-
-			s.storesMU.Lock()
-			// Double-check: another goroutine may have written while we queried.
-			if existing, exists := s.stores[namespace]; exists {
-				s.storesMU.Unlock()
-				return &zanzana.StoreInfo{
-					ID:      existing.ID,
-					Name:    existing.Name,
-					ModelID: existing.ModelID,
-				}, nil
-			}
-			s.stores[namespace] = newInfo
-			s.storesMU.Unlock()
-
-			return &zanzana.StoreInfo{
-				ID:   newInfo.ID,
-				Name: newInfo.Name,
-			}, nil
+	v, err, _ := s.storeSF.Do(namespace, func() (any, error) {
+		// Re-check cache: another goroutine may have populated it while we waited.
+		s.storesMU.RLock()
+		info, ok := s.stores[namespace]
+		s.storesMU.RUnlock()
+		if ok {
+			return &info, nil
 		}
+
+		res, err := s.openFGAClient.ListStores(ctx, &openfgav1.ListStoresRequest{Name: namespace})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load zanzana stores: %w", err)
+		}
+
+		for _, store := range res.GetStores() {
+			if store.GetName() == namespace {
+				newInfo := zanzana.StoreInfo{
+					ID:   store.GetId(),
+					Name: store.GetName(),
+				}
+
+				s.storesMU.Lock()
+				s.stores[namespace] = newInfo
+				s.storesMU.Unlock()
+
+				return &newInfo, nil
+			}
+		}
+
+		return nil, zanzana.ErrStoreNotFound
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, zanzana.ErrStoreNotFound
+	return v.(*zanzana.StoreInfo), nil
 }
 
 // DeleteStore removes a store from the local cache and deletes it from OpenFGA.

--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -57,10 +57,11 @@ func (s *Server) getStoreInfo(ctx context.Context, namespace string) (*zanzana.S
 }
 
 func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.StoreInfo, error) {
-	s.storesMU.Lock()
-	defer s.storesMU.Unlock()
-
+	// Fast path: concurrent reads without blocking writers.
+	s.storesMU.RLock()
 	info, ok := s.stores[namespace]
+	s.storesMU.RUnlock()
+
 	if ok {
 		return &zanzana.StoreInfo{
 			ID:      info.ID,
@@ -69,6 +70,8 @@ func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.Store
 		}, nil
 	}
 
+	// Cache miss: query OpenFGA without holding any lock so concurrent requests
+	// do not serialize on the DB call.
 	res, err := s.openFGAClient.ListStores(ctx, &openfgav1.ListStoresRequest{Name: namespace})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load zanzana stores: %w", err)
@@ -76,16 +79,27 @@ func (s *Server) GetStore(ctx context.Context, namespace string) (*zanzana.Store
 
 	for _, store := range res.GetStores() {
 		if store.GetName() == namespace {
-			info = zanzana.StoreInfo{
+			newInfo := zanzana.StoreInfo{
 				ID:   store.GetId(),
 				Name: store.GetName(),
 			}
 
-			s.stores[namespace] = info
+			s.storesMU.Lock()
+			// Double-check: another goroutine may have written while we queried.
+			if existing, exists := s.stores[namespace]; exists {
+				s.storesMU.Unlock()
+				return &zanzana.StoreInfo{
+					ID:      existing.ID,
+					Name:    existing.Name,
+					ModelID: existing.ModelID,
+				}, nil
+			}
+			s.stores[namespace] = newInfo
+			s.storesMU.Unlock()
 
 			return &zanzana.StoreInfo{
-				ID:   info.ID,
-				Name: info.Name,
+				ID:   newInfo.ID,
+				Name: newInfo.Name,
 			}, nil
 		}
 	}


### PR DESCRIPTION
## Summary

- **Singleflight for `GetStore` and `EnsureNamespace`**: Replace hand-rolled RWMutex double-check locking in `GetStore` and raw `sync.Map`-only concurrency in `EnsureNamespace` with `golang.org/x/sync/singleflight`. On cold start, concurrent requests for the same namespace now coalesce into a single OpenFGA RPC / reconciliation instead of racing independently. This also simplifies the code.

- **`ensuredNamespaces` cache fast-path**: `EnsureNamespace` is called on every `Check` and `BatchCheck` request. A `sync.Map` caches namespaces that have been fully ensured so subsequent calls short-circuit immediately without touching the store lock or making any RPC.
