### PR TITLE
Docker: Ensure alpine is the default if no --target is specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,10 @@ COPY ${RUN_SH} /run.sh
 USER "$GF_UID"
 ENTRYPOINT [ "/run.sh" ]
 
-# Ubuntu final stage
+# Default stage — alpine. Builds without --target produce an alpine image.
+# Use --target=final-ubuntu to build the ubuntu variant instead.
+FROM final-alpine
+# Ubuntu final stage — use --target=final-ubuntu to select this variant
 FROM ubuntu-base AS final-ubuntu
 
 LABEL maintainer="Grafana Labs <hello@grafana.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,9 +205,6 @@ COPY ${RUN_SH} /run.sh
 USER "$GF_UID"
 ENTRYPOINT [ "/run.sh" ]
 
-# Default stage — alpine. Builds without --target produce an alpine image.
-# Use --target=final-ubuntu to build the ubuntu variant instead.
-FROM final-alpine
 # Ubuntu final stage — use --target=final-ubuntu to select this variant
 FROM ubuntu-base AS final-ubuntu
 
@@ -270,3 +267,7 @@ COPY ${RUN_SH} /run.sh
 
 USER "$GF_UID"
 ENTRYPOINT [ "/run.sh" ]
+
+# Default stage — alpine. Builds without --target produce an alpine image.
+# Use --target=final-ubuntu to build the ubuntu variant instead.
+FROM final-alpine


### PR DESCRIPTION
If no --target was specified after the recent update, then the ubuntu base would be used, however that is not the behavior that existed before.