### PR TITLE
Zanzana: deduplicate folder batch checks and fix ensuredNamespaces cache

### DIFF
--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -249,8 +249,94 @@ func (s *Server) runGroupResourcePhase(
 	return len(checks), nil
 }
 
-// runFolderPermissionPhase checks folder permission inheritance.
-// This applies to generic resources that support folder-based permissions (like dashboards).
+// --- Dedup batcher: groups identical OpenFGA folder checks so each unique
+// (relation, folder, context) tuple is only checked once. ---
+
+type folderDedupKey struct {
+	relation      string
+	folderIdent   string
+	groupResource string
+}
+
+type dedupGroup struct {
+	check          *openfgav1.BatchCheckItem
+	correlationIDs []string
+}
+
+type dedupBatcher struct {
+	groups []dedupGroup
+	seen   map[folderDedupKey]int // key → index into groups
+}
+
+func newDedupBatcher() *dedupBatcher {
+	return &dedupBatcher{seen: make(map[folderDedupKey]int)}
+}
+
+// add registers a correlation ID for a folder check identified by key.
+// If the key has been seen before, the correlation ID is appended to the
+// existing group and the check is discarded. Otherwise the check is stored
+// and assigned a unique internal correlation ID.
+func (b *dedupBatcher) add(key folderDedupKey, correlationID string, check *openfgav1.BatchCheckItem) {
+	if idx, ok := b.seen[key]; ok {
+		b.groups[idx].correlationIDs = append(b.groups[idx].correlationIDs, correlationID)
+		return
+	}
+	check.CorrelationId = fmt.Sprintf("dedup_%d", len(b.groups))
+	b.seen[key] = len(b.groups)
+	b.groups = append(b.groups, dedupGroup{
+		check:          check,
+		correlationIDs: []string{correlationID},
+	})
+}
+
+func (b *dedupBatcher) checks() []*openfgav1.BatchCheckItem {
+	out := make([]*openfgav1.BatchCheckItem, len(b.groups))
+	for i := range b.groups {
+		out[i] = b.groups[i].check
+	}
+	return out
+}
+
+// resolve fans out OpenFGA results to all batch items that share each check.
+// A correlation ID may appear in multiple groups (e.g. subresource expansion);
+// if ANY group returns allowed the item is allowed. Items that only received
+// errors are resolved with the first error.
+func (b *dedupBatcher) resolve(results map[string]*openfgav1.BatchCheckSingleResult, items map[string]*batchCheckItem) {
+	for i := range b.groups {
+		g := &b.groups[i]
+		result, ok := results[g.check.CorrelationId]
+		if !ok {
+			continue
+		}
+		for _, cid := range g.correlationIDs {
+			item := items[cid]
+			if item.allowed {
+				continue
+			}
+			if result.GetAllowed() {
+				item.allowed = true
+				item.resolved = true
+				item.err = ""
+			} else if err := result.GetError(); err != nil && item.err == "" {
+				item.err = err.GetMessage()
+			}
+		}
+	}
+
+	for i := range b.groups {
+		for _, cid := range b.groups[i].correlationIDs {
+			item := items[cid]
+			if !item.resolved && item.err != "" {
+				item.resolved = true
+			}
+		}
+	}
+}
+
+// --- Phase implementations using dedupBatcher ---
+
+// runFolderPermissionPhase checks folder permission inheritance (e.g. can_get on a folder
+// grants access to all dashboards in that folder). Identical folder checks are deduplicated.
 func (s *Server) runFolderPermissionPhase(
 	ctx context.Context,
 	store *zanzana.StoreInfo,
@@ -258,44 +344,34 @@ func (s *Server) runFolderPermissionPhase(
 	items map[string]*batchCheckItem,
 	contextuals *openfgav1.ContextualTupleKeys,
 ) (int, error) {
-	checks := make([]*openfgav1.BatchCheckItem, 0, len(items))
-	checkIDToCorrelation := make(map[string]string, len(items))
+	batcher := newDedupBatcher()
 
 	for _, item := range items {
-		if item.resolved {
+		if item.resolved || !item.resource.IsGeneric() {
 			continue
 		}
-
-		// Only applies to generic resources with folder support
-		if !item.resource.IsGeneric() {
-			continue
-		}
-
 		folderIdent := item.resource.FolderIdent()
 		if folderIdent == "" {
 			continue
 		}
-
-		// Only check folder permission for resources that inherit folder permissions
 		if !isFolderPermissionBasedResource(item.resource.GroupResource()) {
 			continue
 		}
 
-		folderCheckRelation := common.FolderPermissionRelation(item.relation)
-		checkID := fmt.Sprintf("%s_fp", item.correlationID)
-		checkIDToCorrelation[checkID] = item.correlationID
-		checks = append(checks, &openfgav1.BatchCheckItem{
+		relation := common.FolderPermissionRelation(item.relation)
+		key := folderDedupKey{relation: relation, folderIdent: folderIdent, groupResource: item.resource.GroupResource()}
+		batcher.add(key, item.correlationID, &openfgav1.BatchCheckItem{
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     subject,
-				Relation: folderCheckRelation,
+				Relation: relation,
 				Object:   folderIdent,
 			},
 			ContextualTuples: contextuals,
 			Context:          item.resource.Context(),
-			CorrelationId:    checkID,
 		})
 	}
 
+	checks := batcher.checks()
 	if len(checks) == 0 {
 		return 0, nil
 	}
@@ -305,25 +381,13 @@ func (s *Server) runFolderPermissionPhase(
 		return len(checks), err
 	}
 
-	// Process results
-	for checkID, result := range results {
-		correlationID := checkIDToCorrelation[checkID]
-		item := items[correlationID]
-
-		if err := result.GetError(); err != nil {
-			item.err = err.GetMessage()
-			item.resolved = true
-		} else if result.GetAllowed() {
-			item.allowed = true
-			item.resolved = true
-		}
-	}
-
+	batcher.resolve(results, items)
 	return len(checks), nil
 }
 
-// runFolderSubresourcePhase checks folder subresource access.
-// This handles cases where access is granted via folder subresource relations.
+// runFolderSubresourcePhase checks folder subresource access (e.g. folder_get, folder_set_edit).
+// Each item may expand into multiple relations; identical checks are deduplicated, and an item
+// is allowed if ANY of its expanded checks returns allowed.
 func (s *Server) runFolderSubresourcePhase(
 	ctx context.Context,
 	store *zanzana.StoreInfo,
@@ -331,33 +395,24 @@ func (s *Server) runFolderSubresourcePhase(
 	items map[string]*batchCheckItem,
 	contextuals *openfgav1.ContextualTupleKeys,
 ) (int, error) {
-	checks := make([]*openfgav1.BatchCheckItem, 0, len(items))
-	checkIDToCorrelation := make(map[string]string, len(items))
+	batcher := newDedupBatcher()
 
 	for _, item := range items {
-		if item.resolved {
+		if item.resolved || !item.resource.IsGeneric() {
 			continue
 		}
-
-		// Only applies to generic resources
-		if !item.resource.IsGeneric() {
-			continue
-		}
-
 		folderIdent := item.resource.FolderIdent()
 		if folderIdent == "" {
 			continue
 		}
-
 		folderRelation := common.SubresourceRelation(item.relation)
 		if !common.IsSubresourceRelation(folderRelation) {
 			continue
 		}
 
-		for idx, relation := range expandedSubresourcePermissionRelations(folderRelation) {
-			checkID := fmt.Sprintf("%s_fs_%d", item.correlationID, idx)
-			checkIDToCorrelation[checkID] = item.correlationID
-			checks = append(checks, &openfgav1.BatchCheckItem{
+		for _, relation := range expandedSubresourcePermissionRelations(folderRelation) {
+			key := folderDedupKey{relation: relation, folderIdent: folderIdent, groupResource: item.resource.GroupResource()}
+			batcher.add(key, item.correlationID, &openfgav1.BatchCheckItem{
 				TupleKey: &openfgav1.CheckRequestTupleKey{
 					User:     subject,
 					Relation: relation,
@@ -365,11 +420,11 @@ func (s *Server) runFolderSubresourcePhase(
 				},
 				ContextualTuples: contextuals,
 				Context:          item.resource.Context(),
-				CorrelationId:    checkID,
 			})
 		}
 	}
 
+	checks := batcher.checks()
 	if len(checks) == 0 {
 		return 0, nil
 	}
@@ -379,42 +434,7 @@ func (s *Server) runFolderSubresourcePhase(
 		return len(checks), err
 	}
 
-	// Aggregate results per original correlation ID. A single allowed relation
-	// should allow the item; otherwise first OpenFGA error (if any) is surfaced.
-	type relationResult struct {
-		allowed bool
-		err     string
-	}
-	agg := make(map[string]relationResult, len(items))
-
-	for checkID, result := range results {
-		correlationID := checkIDToCorrelation[checkID]
-		cur := agg[correlationID]
-		if cur.allowed {
-			continue
-		}
-		if err := result.GetError(); err != nil {
-			if cur.err == "" {
-				cur.err = err.GetMessage()
-			}
-		} else if result.GetAllowed() {
-			cur.allowed = true
-			cur.err = ""
-		}
-		agg[correlationID] = cur
-	}
-
-	for correlationID, res := range agg {
-		item := items[correlationID]
-		if res.allowed {
-			item.allowed = true
-			item.resolved = true
-		} else if res.err != "" {
-			item.err = res.err
-			item.resolved = true
-		}
-	}
-
+	batcher.resolve(results, items)
 	return len(checks), nil
 }
 

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -299,6 +299,147 @@ func TestIntegrationServerBatchCheck(t *testing.T) {
 	})
 }
 
+func TestIntegrationServerBatchCheck_FolderDeduplication(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	server := setupOpenFGAServer(t)
+	setup(t, server)
+
+	newBatchReq := func(subject string, items []*authzv1.BatchCheckItem) *authzv1.BatchCheckRequest {
+		return &authzv1.BatchCheckRequest{
+			Namespace: namespace,
+			Subject:   subject,
+			Checks:    items,
+		}
+	}
+
+	newItem := func(correlationID, verb, group, resource, subresource, folder, name string) *authzv1.BatchCheckItem {
+		return &authzv1.BatchCheckItem{
+			CorrelationId: correlationID,
+			Verb:          verb,
+			Group:         group,
+			Resource:      resource,
+			Subresource:   subresource,
+			Name:          name,
+			Folder:        folder,
+		}
+	}
+
+	t.Run("phase 2: many dashboards in the same allowed folder", func(t *testing.T) {
+		// user:4 has get on folder 1 via folder permission.
+		// All dashboards in folder 1 should be allowed regardless of name.
+		items := make([]*authzv1.BatchCheckItem, 20)
+		for i := range items {
+			items[i] = newItem(
+				fmt.Sprintf("d-%d", i),
+				utils.VerbGet, dashboardGroup, dashboardResource, "", "1", fmt.Sprintf("dash-%d", i),
+			)
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:4", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 20)
+		for i := range items {
+			assert.True(t, res.GetResults()[fmt.Sprintf("d-%d", i)].GetAllowed(),
+				"d-%d in allowed folder 1 should be allowed", i)
+		}
+	})
+
+	t.Run("phase 2: many dashboards in the same denied folder", func(t *testing.T) {
+		// user:4 does NOT have access to folder 2.
+		items := make([]*authzv1.BatchCheckItem, 10)
+		for i := range items {
+			items[i] = newItem(
+				fmt.Sprintf("d-%d", i),
+				utils.VerbGet, dashboardGroup, dashboardResource, "", "2", fmt.Sprintf("dash-%d", i),
+			)
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:4", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 10)
+		for i := range items {
+			assert.False(t, res.GetResults()[fmt.Sprintf("d-%d", i)].GetAllowed(),
+				"d-%d in denied folder 2 should be denied", i)
+		}
+	})
+
+	t.Run("phase 2: mixed folders with many items each", func(t *testing.T) {
+		// user:4 has access to folders 1 and 3 but not folder 2.
+		var items []*authzv1.BatchCheckItem
+		for i := 0; i < 5; i++ {
+			items = append(items, newItem(fmt.Sprintf("f1-%d", i), utils.VerbGet, dashboardGroup, dashboardResource, "", "1", fmt.Sprintf("a%d", i)))
+			items = append(items, newItem(fmt.Sprintf("f2-%d", i), utils.VerbGet, dashboardGroup, dashboardResource, "", "2", fmt.Sprintf("b%d", i)))
+			items = append(items, newItem(fmt.Sprintf("f3-%d", i), utils.VerbGet, dashboardGroup, dashboardResource, "", "3", fmt.Sprintf("c%d", i)))
+		}
+
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:4", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 15)
+		for i := 0; i < 5; i++ {
+			assert.True(t, res.GetResults()[fmt.Sprintf("f1-%d", i)].GetAllowed(), "folder 1 item %d should be allowed", i)
+			assert.False(t, res.GetResults()[fmt.Sprintf("f2-%d", i)].GetAllowed(), "folder 2 item %d should be denied", i)
+			assert.True(t, res.GetResults()[fmt.Sprintf("f3-%d", i)].GetAllowed(), "folder 3 item %d should be allowed", i)
+		}
+	})
+
+	t.Run("phase 3: many dashboards via folder subresource set_edit", func(t *testing.T) {
+		// user:5 has set_edit on dashboards in folder 1 (subresource phase).
+		items := make([]*authzv1.BatchCheckItem, 15)
+		for i := range items {
+			items[i] = newItem(
+				fmt.Sprintf("d-%d", i),
+				utils.VerbGet, dashboardGroup, dashboardResource, "", "1", fmt.Sprintf("dash-%d", i),
+			)
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:5", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 15)
+		for i := range items {
+			assert.True(t, res.GetResults()[fmt.Sprintf("d-%d", i)].GetAllowed(),
+				"d-%d should be allowed via set_edit on folder 1", i)
+		}
+	})
+
+	t.Run("phase 3: mixed verbs in same folder via set_edit", func(t *testing.T) {
+		// user:5 has set_edit on dashboards in folder 1, which grants get/update/create/delete.
+		var items []*authzv1.BatchCheckItem
+		verbs := []string{utils.VerbGet, utils.VerbUpdate, utils.VerbCreate, utils.VerbDelete}
+		for i, verb := range verbs {
+			for j := 0; j < 3; j++ {
+				items = append(items, newItem(
+					fmt.Sprintf("%s-%d", verb, j),
+					verb, dashboardGroup, dashboardResource, "", "1", fmt.Sprintf("dash-%d-%d", i, j),
+				))
+			}
+		}
+
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:5", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), len(items))
+		for _, item := range items {
+			assert.True(t, res.GetResults()[item.CorrelationId].GetAllowed(),
+				"%s should be allowed via set_edit on folder 1", item.CorrelationId)
+		}
+	})
+
+	t.Run("phase 2: inherited folder access with many items", func(t *testing.T) {
+		// user:8 has set_edit on folder 5. folder-4 -> folder-5 -> folder-6.
+		// Dashboards in folder 5 and 6 should be allowed, folder 4 should not.
+		var items []*authzv1.BatchCheckItem
+		for i := 0; i < 4; i++ {
+			items = append(items, newItem(fmt.Sprintf("f5-%d", i), utils.VerbGet, dashboardGroup, dashboardResource, "", "5", fmt.Sprintf("x%d", i)))
+			items = append(items, newItem(fmt.Sprintf("f6-%d", i), utils.VerbGet, dashboardGroup, dashboardResource, "", "6", fmt.Sprintf("y%d", i)))
+		}
+
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:8", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 8)
+		for i := 0; i < 4; i++ {
+			assert.True(t, res.GetResults()[fmt.Sprintf("f5-%d", i)].GetAllowed(), "folder 5 item %d should be allowed", i)
+			assert.True(t, res.GetResults()[fmt.Sprintf("f6-%d", i)].GetAllowed(), "folder 6 item %d should be allowed", i)
+		}
+	})
+}
+
 func TestIntegrationServerBatchCheck_SubBatching(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 


### PR DESCRIPTION
## Summary

- **Deduplicate folder checks in BatchCheck**: Phases 2 (folder permission) and 3 (folder subresource) were sending one OpenFGA check per batch item even when many items shared the same folder + relation. For example, 20 dashboards in the same folder would produce 20 identical `(user, can_get, folder:1)` checks. A new `dedupBatcher` type groups identical checks so only one round-trip is issued per unique `(relation, folderIdent, groupResource)` tuple, with results fanned out to all matching correlation IDs.

- **Fix ensuredNamespaces cache poisoning**: Two bugs could leave the `ensuredNamespaces` cache permanently stale, causing an all-deny authorization state:
  1. `EnsureNamespace` unconditionally cached a namespace even when `reconcileNamespace` silently deleted its store (namespace gone → NotFound → DeleteStore → return nil). Now it verifies the store still exists post-reconciliation.
  2. The background reconciler could delete a previously-ensured namespace's store without evicting the cache. `reconcileNamespace` now calls `ensuredNamespaces.Delete()` on NotFound.

## Test plan

- [x] All 27 existing `BatchCheck` integration tests pass (including sub-batching)
- [x] 6 new `TestIntegrationServerBatchCheck_FolderDeduplication` tests cover phase 2/3 dedup with allowed/denied/mixed folders, multiple verbs, and inherited folder access
- [x] 5 new `TestEnsureNamespace_*` / `TestReconcileNamespace_*` unit tests cover:
  - Cache not populated when store is deleted during reconciliation
  - Cache populated on successful ensure
  - Fast-path short-circuit for cached namespaces
  - Existing stores cached without reconciliation
  - Cache eviction when background reconciler deletes a store
- [x] All existing reconciler tests still pass