### PR TITLE
Dashboard: Fix scroll overflow in Add edit pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
@@ -6,7 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneObject } from '@grafana/scenes';
-import { Sidebar, useStyles2 } from '@grafana/ui';
+import { ScrollContainer, Sidebar, useStyles2 } from '@grafana/ui';
 import addPanelImg from 'img/dashboards/add-panel.png';
 
 import { useClipboardState } from '../../scene/layouts-shared/useClipboardState';
@@ -40,99 +40,110 @@ export function AddNewEditPane({ onAddPanel, onPastePanel, dashboard, selectedEl
   };
 
   return (
-    <>
+    <div className={styles.wrapper}>
       <Sidebar.PaneHeader title={t('dashboard.add.pane-header', 'Add')} />
-      <AddNewSection
-        title={t('dashboard.add.new-panel.title', 'Panel')}
-        description={t('dashboard.add.new-panel.description', 'Drag or click to add a panel')}
-      >
-        <DragDropContext onDragStart={onStartDragging} onDragEnd={() => {}}>
-          <Droppable droppableId="side-drop-id" isDropDisabled>
-            {(dropProvided) => (
-              <div ref={dropProvided.innerRef} {...dropProvided.droppableProps}>
-                <Draggable draggableId="new-panel-drag" index={0}>
-                  {(dragProvided, dragSnapshot) => {
-                    return (
-                      <div
-                        role="button"
-                        data-testid={selectors.components.Sidebar.newPanelButton}
-                        tabIndex={0}
-                        ref={dragProvided.innerRef}
-                        {...dragProvided.draggableProps}
-                        {...dragProvided.dragHandleProps}
-                        className={cx(styles.imageContainer, dragSnapshot.isDragging && styles.dragging)}
-                        onClick={onAddPanel}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            onAddPanel();
-                          }
-                        }}
-                        aria-label={t('dashboard.add.new-panel.title', 'Panel')}
-                      >
-                        <img
-                          alt={t('dashboard.add.new-panel.button', 'Add new panel button')}
-                          src={addPanelImg}
-                          draggable={false}
-                        />
-                      </div>
-                    );
-                  }}
-                </Draggable>
-                {hasCopiedPanel && (
-                  <Draggable
-                    draggableId="paste-panel-drag"
-                    index={1}
-                    isDragDisabled={!hasCopiedPanel}
-                    disableInteractiveElementBlocking={true}
-                  >
-                    {(dragProvided, _) => (
-                      <div
-                        ref={dragProvided.innerRef}
-                        {...dragProvided.draggableProps}
-                        {...dragProvided.dragHandleProps}
-                      >
-                        <AddButton
-                          className={styles.pasteButton}
-                          icon="clipboard-alt"
+      <ScrollContainer showScrollIndicators={true}>
+        <AddNewSection
+          title={t('dashboard.add.new-panel.title', 'Panel')}
+          description={t('dashboard.add.new-panel.description', 'Drag or click to add a panel')}
+        >
+          <DragDropContext onDragStart={onStartDragging} onDragEnd={() => {}}>
+            <Droppable droppableId="side-drop-id" isDropDisabled>
+              {(dropProvided) => (
+                <div ref={dropProvided.innerRef} {...dropProvided.droppableProps}>
+                  <Draggable draggableId="new-panel-drag" index={0}>
+                    {(dragProvided, dragSnapshot) => {
+                      return (
+                        <div
+                          role="button"
+                          data-testid={selectors.components.Sidebar.newPanelButton}
                           tabIndex={0}
-                          onClick={onPastePanel}
+                          ref={dragProvided.innerRef}
+                          {...dragProvided.draggableProps}
+                          {...dragProvided.dragHandleProps}
+                          className={cx(styles.imageContainer, dragSnapshot.isDragging && styles.dragging)}
+                          onClick={onAddPanel}
                           onKeyDown={(e) => {
                             if (e.key === 'Enter' || e.key === ' ') {
                               e.preventDefault();
-                              onPastePanel();
+                              onAddPanel();
                             }
                           }}
-                          aria-label={t('dashboard.canvas-actions.add.paste.title', 'Paste panel')}
-                          label={t('dashboard.canvas-actions.add.paste.title', 'Paste panel')}
-                          tooltip={t('dashboard.canvas-actions.add.paste.description', 'Click or drag to paste panel')}
-                        ></AddButton>
-                      </div>
-                    )}
+                          aria-label={t('dashboard.add.new-panel.title', 'Panel')}
+                        >
+                          <img
+                            alt={t('dashboard.add.new-panel.button', 'Add new panel button')}
+                            src={addPanelImg}
+                            draggable={false}
+                          />
+                        </div>
+                      );
+                    }}
                   </Draggable>
-                )}
-                {dropProvided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
-      </AddNewSection>
-      <AddNewSection title={t('dashboard-scene.add-new-edit-pane.group-layouts', 'Group layouts')}>
-        <AddRow dashboardScene={dashboardScene} selectedElement={selectedElement} />
-        <AddTab dashboardScene={dashboardScene} selectedElement={selectedElement} />
-      </AddNewSection>
-      <AddNewSection title={t('dashboard-scene.dashboard-side-pane-new.dashboard-controls', 'Dashboard controls')}>
-        {config.featureToggles.dashboardUnifiedDrilldownControls && <AddFilters dashboardScene={dashboardScene} />}
-        <AddVariable dashboardScene={dashboardScene} selectedElement={selectedElement} />
-        <AddAnnotationQuery dashboardScene={dashboardScene} />
-        <AddLink dashboardScene={dashboardScene} />
-      </AddNewSection>
-    </>
+                  {hasCopiedPanel && (
+                    <Draggable
+                      draggableId="paste-panel-drag"
+                      index={1}
+                      isDragDisabled={!hasCopiedPanel}
+                      disableInteractiveElementBlocking={true}
+                    >
+                      {(dragProvided, _) => (
+                        <div
+                          ref={dragProvided.innerRef}
+                          {...dragProvided.draggableProps}
+                          {...dragProvided.dragHandleProps}
+                        >
+                          <AddButton
+                            className={styles.pasteButton}
+                            icon="clipboard-alt"
+                            tabIndex={0}
+                            onClick={onPastePanel}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                onPastePanel();
+                              }
+                            }}
+                            aria-label={t('dashboard.canvas-actions.add.paste.title', 'Paste panel')}
+                            label={t('dashboard.canvas-actions.add.paste.title', 'Paste panel')}
+                            tooltip={t(
+                              'dashboard.canvas-actions.add.paste.description',
+                              'Click or drag to paste panel'
+                            )}
+                          ></AddButton>
+                        </div>
+                      )}
+                    </Draggable>
+                  )}
+                  {dropProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        </AddNewSection>
+        <AddNewSection title={t('dashboard-scene.add-new-edit-pane.group-layouts', 'Group layouts')}>
+          <AddRow dashboardScene={dashboardScene} selectedElement={selectedElement} />
+          <AddTab dashboardScene={dashboardScene} selectedElement={selectedElement} />
+        </AddNewSection>
+        <AddNewSection title={t('dashboard-scene.dashboard-side-pane-new.dashboard-controls', 'Dashboard controls')}>
+          {config.featureToggles.dashboardUnifiedDrilldownControls && <AddFilters dashboardScene={dashboardScene} />}
+          <AddVariable dashboardScene={dashboardScene} selectedElement={selectedElement} />
+          <AddAnnotationQuery dashboardScene={dashboardScene} />
+          <AddLink dashboardScene={dashboardScene} />
+        </AddNewSection>
+      </ScrollContainer>
+    </div>
   );
 }
 
 function getStyles(theme: GrafanaTheme2) {
   return {
+    wrapper: css({
+      display: 'flex',
+      flexDirection: 'column',
+      flex: '1 1 0',
+      height: '100%',
+    }),
     dragging: css({
       cursor: 'move',
     }),


### PR DESCRIPTION
**What is this feature?**

Wraps the Add edit pane content in a `ScrollContainer` so all sections (panels, group layouts, dashboard controls) remain accessible when the pane overflows vertically.

**Why do we need this feature?**

When many items are present or the viewport is short, the bottom sections of the Add pane get clipped with no way to scroll to them.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #121729

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
