### PR TITLE
Dashboard: Graduate Dynamic Dashboards to GA

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -38,6 +38,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `cloudWatchBatchQueries`              | Runs CloudWatch metrics queries as separate batches                                                                                                           |                    |
 | `annotationPermissionUpdate`          | Change the way annotation permissions work by scoping them to folders and dashboards.                                                                         | Yes                |
 | `dashboardScene`                      | Enables dashboard rendering using scenes for all roles                                                                                                        | Yes                |
+| `dashboardNewLayouts`                 | Enables new dashboard layouts                                                                                                                                 | Yes                |
 | `dashboardDefaultLayoutSelector`      | Enables default layout selector in dashboard settings                                                                                                         | Yes                |
 | `alertingQueryOptimization`           | Optimizes eligible queries in order to reduce load on datasources                                                                                             |                    |
 | `cloudWatchNewLabelParsing`           | Updates CloudWatch label parsing to be more accurate                                                                                                          | Yes                |
@@ -87,7 +88,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability         |
 | `externalServiceAccounts`         | Automatic service account and token setup for plugins                                                  |
 | `annotationsClustering`           | Enables annotation clustering and switches to refactored annotation code                               |
-| `dashboardNewLayouts`             | Enables new dashboard layouts                                                                          |
 | `dashboardFiltersOverview`        | Enables the dashboard filters overview pane                                                            |
 | `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                              |
 | `pdfTables`                       | Enables generating table data as PDF in reporting                                                      |

--- a/e2e-playwright/alerting-suite/saved-searches.spec.ts
+++ b/e2e-playwright/alerting-suite/saved-searches.spec.ts
@@ -8,6 +8,7 @@ test.use({
     alertingListViewV2: true,
     alertingFilterV2: true,
     alertingSavedSearches: true,
+    dashboardNewLayouts: false,
   },
 });
 

--- a/e2e-playwright/dashboard-cujs/scope-redirect.spec.ts
+++ b/e2e-playwright/dashboard-cujs/scope-redirect.spec.ts
@@ -9,6 +9,7 @@ test.use({
     groupByVariable: true,
     reloadDashboardsOnParamsChange: true,
     useScopesNavigationEndpoint: true,
+    dashboardNewLayouts: false,
   },
 });
 

--- a/e2e-playwright/panels-suite/annotations-clustering.spec.ts
+++ b/e2e-playwright/panels-suite/annotations-clustering.spec.ts
@@ -60,7 +60,10 @@ const ALERT_ANNOTATIONS_COUNTS = {
   },
 };
 
-test.use({ viewport: { width: 1000, height: 1840 }, featureToggles: { annotationsClustering: true } });
+test.use({
+  viewport: { width: 1000, height: 1840 },
+  featureToggles: { annotationsClustering: true, dashboardNewLayouts: false },
+});
 
 test.describe('Panels test: Clustering', { tag: ['@panels', '@annotations'] }, () => {
   test.describe('width: 1000', () => {

--- a/e2e-playwright/panels-suite/canvas-scene.spec.ts
+++ b/e2e-playwright/panels-suite/canvas-scene.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from '@grafana/plugin-e2e';
 test.use({
   featureToggles: {
     canvasPanelPanZoom: true,
+    dashboardNewLayouts: false,
   },
 });
 test.describe('Canvas Panel - Scene Tests', () => {

--- a/e2e-playwright/panels-suite/heatmap.spec.ts
+++ b/e2e-playwright/panels-suite/heatmap.spec.ts
@@ -37,6 +37,7 @@ test.describe('Panels test: Heatmap', { tag: ['@panels', '@heatmap'] }, () => {
 test.use({
   featureToggles: {
     timeRangePan: true,
+    dashboardNewLayouts: false,
   },
 });
 

--- a/e2e-playwright/various-suite/grafana-datasource-random-walk.spec.ts
+++ b/e2e-playwright/various-suite/grafana-datasource-random-walk.spec.ts
@@ -5,6 +5,7 @@ const test = base.extend({});
 test.use({
   featureToggles: {
     dashboardTemplates: true,
+    dashboardNewLayouts: false,
   },
 });
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -410,7 +410,7 @@ export interface FeatureToggles {
   dashboardScene?: boolean;
   /**
   * Enables new dashboard layouts
-  * @default false
+  * @default true
   */
   dashboardNewLayouts?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -627,10 +627,10 @@ var (
 		{
 			Name:         "dashboardNewLayouts",
 			Description:  "Enables new dashboard layouts",
-			Stage:        FeatureStagePublicPreview,
+			Stage:        FeatureStageGeneralAvailability,
 			FrontendOnly: false, // The restore backend feature changes behavior based on this flag
 			Owner:        grafanaDashboardsSquad,
-			Expression:   "false",
+			Expression:   "true",
 		},
 		{
 			Name:         "dashboardDefaultLayoutSelector",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -77,7 +77,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-10-31,annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
 2026-03-12,annotationsClustering,preview,@grafana/dataviz-squad,false,false,true
 2023-11-13,dashboardScene,GA,@grafana/dashboards-squad,false,false,true
-2024-10-23,dashboardNewLayouts,preview,@grafana/dashboards-squad,false,false,false
+2024-10-23,dashboardNewLayouts,GA,@grafana/dashboards-squad,false,false,false
 2026-03-19,dashboardDefaultLayoutSelector,GA,@grafana/dashboards-squad,false,false,true
 2026-03-10,dashboardAssistantPopover,experimental,@grafana/dashboards-squad,false,false,true
 2025-08-29,dashboardUndoRedo,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1481,14 +1481,17 @@
     {
       "metadata": {
         "name": "dashboardNewLayouts",
-        "resourceVersion": "1771434338561",
-        "creationTimestamp": "2024-10-23T08:55:45Z"
+        "resourceVersion": "1775209187023",
+        "creationTimestamp": "2024-10-23T08:55:45Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-04-03 09:39:47.02364 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables new dashboard layouts",
-        "stage": "preview",
+        "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
-        "expression": "false"
+        "expression": "true"
       }
     },
     {

--- a/pkg/tests/apis/provisioning/client_test.go
+++ b/pkg/tests/apis/provisioning/client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	dashboardV2 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
@@ -22,24 +22,24 @@ func TestIntegrationProvisioning_Client(t *testing.T) {
 
 	t.Run("dashboard client support", func(t *testing.T) {
 		_, _, err := clients.ForResource(ctx, schema.GroupVersionResource{
-			Group:    dashboardV1.GROUP,
-			Version:  dashboardV1.VERSION,
+			Group:    dashboardV2.GROUP,
+			Version:  dashboardV2.VERSION,
 			Resource: "dashboards",
 		})
 		require.NoError(t, err)
 
-		// With empty version, we should get the preferred version (v1beta1)
+		// With empty version, we should get the preferred version (v2)
 		_, gvk, err := clients.ForResource(ctx, schema.GroupVersionResource{
-			Group:    dashboardV1.GROUP,
+			Group:    dashboardV2.GROUP,
 			Resource: "dashboards",
 		})
 		require.NoError(t, err)
-		require.Equal(t, dashboardV1.VERSION, gvk.Version)
+		require.Equal(t, dashboardV2.VERSION, gvk.Version)
 		require.Equal(t, "Dashboard", gvk.Kind)
 
 		_, _, err = clients.ForKind(ctx, schema.GroupVersionKind{
-			Group:   dashboardV1.GROUP,
-			Version: dashboardV1.VERSION,
+			Group:   dashboardV2.GROUP,
+			Version: dashboardV2.VERSION,
 			Kind:    "Dashboard",
 		})
 		require.NoError(t, err)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,6 +43,11 @@ export const baseConfig: PlaywrightTestConfig<PluginOptions, {}> = {
     screenshot: 'only-on-failure',
     permissions: ['clipboard-read', 'clipboard-write'],
     provisioningRootDir: path.join(process.cwd(), process.env.PROV_DIR ?? 'conf/provisioning'),
+    // Preserve legacy dashboard layout behavior in E2E unless a test overrides this (shallow merge on
+    // `featureToggles` would otherwise drop toggles when a spec sets only a subset).
+    featureToggles: {
+      dashboardNewLayouts: false,
+    },
   },
 };
 


### PR DESCRIPTION
**What is this feature?**

This change graduates Dynamic Dashboards (the new dashboard layouts experience, gated by `dashboardNewLayouts`) from public preview to generally available (GA). The toggle stays in place for opt-out, but its default is now enabled (true), and the feature is documented in the GA section of the feature toggles reference.

**Why do we need this feature?**

The new layouts work has reached a level of stability and adoption where it should be the default for Grafana users, instead of requiring admins to turn the flag on. Shipping it as GA makes the behavior predictable and supported while still allowing instances to disable `dashboardNewLayouts` if needed.

**Who is this feature for?**

Anyone who builds or views dashboards.

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
