### PR TITLE
CI: Fix docker tag when publishing

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -817,7 +817,6 @@ jobs:
       runs-on: ubuntu-x64-small
 
   publish-dockerhub:
-    if: github.ref_name == 'main'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -817,6 +817,7 @@ jobs:
       runs-on: ubuntu-x64-small
 
   publish-dockerhub:
+    if: github.ref_name == 'main'
     permissions:
       contents: read
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ $(DOCKER_UBUNTU_FILE): $(TARGZ_FILE)
 	--build-arg GO_SRC=tgz-builder \
 	--build-arg JS_SRC=tgz-builder \
 	--target=final-ubuntu \
-	--tag $(DOCKER_TAG)-ubuntu \
+	--tag $(DOCKER_TAG) \
 	--output type=docker,dest=$@ \
 	.
 


### PR DESCRIPTION
The dockerhub publish on main is failing because of the tag double appending -ubuntu.

https://github.com/grafana/grafana/actions/runs/23939773742/job/69824663838

```
Run cat artifacts-*.txt > artifacts.txt
grafana/grafana-image-tags:13.0.0-23939773742-amd64
grafana/grafana-image-tags:13.0.0-23939773742-arm64
grafana/grafana-image-tags:13.0.0-23939773742-armv7
grafana/grafana-image-tags:13.0.0-23939773742-ubuntu-amd64-ubuntu
grafana/grafana-image-tags:13.0.0-23939773742-ubuntu-arm64-ubuntu
grafana/grafana-image-tags:13.0.0-23939773742-ubuntu-armv7-ubuntu
```

Succeeded: https://github.com/grafana/grafana/actions/runs/23942554442