### PR TITLE
Prometheus: Fix label value lookup and query builder for dotted (OTel) metric/label names

### DIFF
--- a/.yarn/patches/@grafana-prometheus-npm-13.1.2-46ff9be179.patch
+++ b/.yarn/patches/@grafana-prometheus-npm-13.1.2-46ff9be179.patch
@@ -1,0 +1,249 @@
+diff --git a/dist/cjs/querybuilder/parsing.cjs b/dist/cjs/querybuilder/parsing.cjs
+index 504560fa1a9819e0d076735ce0a07b2a1502b598..3a8fce0df37c25541d7617e4fd0a53f81be99781 100644
+--- a/dist/cjs/querybuilder/parsing.cjs
++++ b/dist/cjs/querybuilder/parsing.cjs
+@@ -8,6 +8,18 @@ var binaryScalarOperations = require('./binaryScalarOperations.cjs');
+ var parsingUtils = require('./parsingUtils.cjs');
+ 
+ "use strict";
++const DOTTED_METRIC_PATTERN = /^([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)+)/;
++function tryReconstructDottedMetric(expr, node) {
++  if (node.type.id !== lezerPromql.VectorSelector) {
++    return null;
++  }
++  const nodeText = expr.slice(node.from, node.to);
++  const match = nodeText.match(DOTTED_METRIC_PATTERN);
++  if (match) {
++    return { name: match[1], end: node.from + match[1].length };
++  }
++  return null;
++}
+ function buildVisualQueryFromString(expr) {
+   expr = parsingUtils.replaceBuiltInVariable(expr);
+   const { replacedExpr, replacedVariables } = parsingUtils.replaceVariables(expr);
+@@ -65,6 +77,15 @@ function handleExpression(expr, node, context) {
+       break;
+     }
+     case lezerPromql.UnquotedLabelMatcher: {
++      const matchOp = node.getChild(lezerPromql.MatchOp);
++      if (!matchOp && visQuery.metric === "") {
++        const matcherText = expr.slice(node.from, node.to).trim();
++        const dottedMatch = matcherText.match(DOTTED_METRIC_PATTERN);
++        if (dottedMatch && dottedMatch[1] === matcherText) {
++          visQuery.metric = dottedMatch[1];
++          break;
++        }
++      }
+       visQuery.labels.push(getLabel(expr, node, lezerPromql.LabelName));
+       const err = node.getChild(parsingUtils.ErrorId);
+       if (err) {
+@@ -88,6 +109,12 @@ function handleExpression(expr, node, context) {
+       if (isIntervalVariableError(node)) {
+         break;
+       }
++      if (visQuery.metric.includes(".")) {
++        const errorText = expr.slice(node.from, node.to);
++        if (errorText === "." || visQuery.metric.includes(errorText)) {
++          break;
++        }
++      }
+       context.errors.push(parsingUtils.makeError(expr, node));
+       break;
+     }
+@@ -95,6 +122,20 @@ function handleExpression(expr, node, context) {
+       if (node.type.id === lezerPromql.ParenExpr) {
+         context.errors.push(parsingUtils.makeError(expr, node));
+       }
++      if (node.type.id === lezerPromql.VectorSelector && visQuery.metric === "") {
++        const dotted = tryReconstructDottedMetric(expr, node);
++        if (dotted) {
++          visQuery.metric = dotted.name;
++          let child2 = node.firstChild;
++          while (child2) {
++            if (child2.from >= dotted.end) {
++              handleExpression(expr, child2, context);
++            }
++            child2 = child2.nextSibling;
++          }
++          break;
++        }
++      }
+       let child = node.firstChild;
+       while (child) {
+         handleExpression(expr, child, context);
+diff --git a/dist/cjs/querybuilder/parsingUtils.cjs b/dist/cjs/querybuilder/parsingUtils.cjs
+index b0d14625fdaacddb5bacbb8d3267f24772072b3f..2e4e311f822985b27bd3d2d9ff519c36a496f351 100644
+--- a/dist/cjs/querybuilder/parsingUtils.cjs
++++ b/dist/cjs/querybuilder/parsingUtils.cjs
+@@ -84,7 +84,7 @@ function getAllByType(expr, cur, type) {
+ }
+ const regexifyLabelValuesQueryString = (query) => {
+   const queryArray = query.split(" ");
+-  return queryArray.map((query2) => `${query2}.*`).join("");
++  return queryArray.map((query2) => `${query2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*`).join("");
+ };
+ const BUILT_IN_VARIABLES = [
+   { variable: "$__interval_ms", replacement: "79_999_999_999" },
+diff --git a/dist/cjs/datasource.cjs b/dist/cjs/datasource.cjs
+index c76471e1166d9ca9fb7eb335a6de7b55a26c936c..fc1927e4d7687e4e34f91401c9599ec65969d8df 100644
+--- a/dist/cjs/datasource.cjs
++++ b/dist/cjs/datasource.cjs
+@@ -178,7 +178,7 @@ class PrometheusDatasource extends runtime.DataSourceWithBackend {
+     data = data || {};
+     for (const [key, value] of this.customQueryParameters) {
+       if (data[key] == null) {
+-        data[key] = value;
++        data[key] = this.interpolateString(value);
+       }
+     }
+     let queryUrl = this.url + url;
+diff --git a/dist/cjs/resource_clients.cjs b/dist/cjs/resource_clients.cjs
+index 05de7f2b74e38b6c5127287c3719ef5e336d4c37..2e5ecd18fb3d253b878d9be5f228d5a48b2bcfa9 100644
+--- a/dist/cjs/resource_clients.cjs
++++ b/dist/cjs/resource_clients.cjs
+@@ -118,13 +118,13 @@ class LabelsApiClient extends BaseResourceClient {
+       const effectiveLimit = this.getEffectiveLimit(limit);
+       const searchParams = { limit: effectiveLimit, ...timeParams, ...match ? { "match[]": match } : {} };
+       const interpolatedName = this.datasource.interpolateString(labelKey);
+-      const interpolatedAndEscapedName = utf8_support.escapeForUtf8Support(language_utils.removeQuotesIfExist(interpolatedName));
+-      const effectiveMatch = `${match != null ? match : ""}-${interpolatedAndEscapedName}`;
++      const cleanName = language_utils.removeQuotesIfExist(interpolatedName);
++      const effectiveMatch = `${match != null ? match : ""}-${cleanName}`;
+       const maybeCachedValues = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
+       if (maybeCachedValues) {
+         return maybeCachedValues;
+       }
+-      const url = `/api/v1/label/${interpolatedAndEscapedName}/values`;
++      const url = `/api/v1/label/${cleanName}/values`;
+       const value = await this.requestLabels(url, searchParams, caching.getDefaultCacheHeaders(this.datasource.cacheLevel));
+       this._cache.setLabelValues(timeRange, effectiveMatch, effectiveLimit, value != null ? value : []);
+       return value != null ? value : [];
+diff --git a/dist/esm/querybuilder/parsing.mjs b/dist/esm/querybuilder/parsing.mjs
+index 9c2a4733051170bf616ef666de3bcc8b85f6bfa8..318c433ddb0d0215b5e26f654356a6c2cb099edb 100644
+--- a/dist/esm/querybuilder/parsing.mjs
++++ b/dist/esm/querybuilder/parsing.mjs
+@@ -4,6 +4,18 @@ import { binaryScalarOperatorToOperatorName } from './binaryScalarOperations.mjs
+ import { replaceBuiltInVariable, replaceVariables, makeError, ErrorId, getString, returnBuiltInVariable, getAllByType, isFunctionOrAggregation, makeBinOp, getLeftMostChild } from './parsingUtils.mjs';
+ 
+ "use strict";
++const DOTTED_METRIC_PATTERN = /^([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)+)/;
++function tryReconstructDottedMetric(expr, node) {
++  if (node.type.id !== VectorSelector) {
++    return null;
++  }
++  const nodeText = expr.slice(node.from, node.to);
++  const match = nodeText.match(DOTTED_METRIC_PATTERN);
++  if (match) {
++    return { name: match[1], end: node.from + match[1].length };
++  }
++  return null;
++}
+ function buildVisualQueryFromString(expr) {
+   expr = replaceBuiltInVariable(expr);
+   const { replacedExpr, replacedVariables } = replaceVariables(expr);
+@@ -61,6 +73,15 @@ function handleExpression(expr, node, context) {
+       break;
+     }
+     case UnquotedLabelMatcher: {
++      const matchOp = node.getChild(MatchOp);
++      if (!matchOp && visQuery.metric === "") {
++        const matcherText = expr.slice(node.from, node.to).trim();
++        const dottedMatch = matcherText.match(DOTTED_METRIC_PATTERN);
++        if (dottedMatch && dottedMatch[1] === matcherText) {
++          visQuery.metric = dottedMatch[1];
++          break;
++        }
++      }
+       visQuery.labels.push(getLabel(expr, node, LabelName));
+       const err = node.getChild(ErrorId);
+       if (err) {
+@@ -84,6 +105,12 @@ function handleExpression(expr, node, context) {
+       if (isIntervalVariableError(node)) {
+         break;
+       }
++      if (visQuery.metric.includes(".")) {
++        const errorText = expr.slice(node.from, node.to);
++        if (errorText === "." || visQuery.metric.includes(errorText)) {
++          break;
++        }
++      }
+       context.errors.push(makeError(expr, node));
+       break;
+     }
+@@ -91,6 +118,20 @@ function handleExpression(expr, node, context) {
+       if (node.type.id === ParenExpr) {
+         context.errors.push(makeError(expr, node));
+       }
++      if (node.type.id === VectorSelector && visQuery.metric === "") {
++        const dotted = tryReconstructDottedMetric(expr, node);
++        if (dotted) {
++          visQuery.metric = dotted.name;
++          let child2 = node.firstChild;
++          while (child2) {
++            if (child2.from >= dotted.end) {
++              handleExpression(expr, child2, context);
++            }
++            child2 = child2.nextSibling;
++          }
++          break;
++        }
++      }
+       let child = node.firstChild;
+       while (child) {
+         handleExpression(expr, child, context);
+diff --git a/dist/esm/querybuilder/parsingUtils.mjs b/dist/esm/querybuilder/parsingUtils.mjs
+index 800edc7424074f8c7a3b62160a96c611b35fa16d..e5a810ce4346f2bbe76879c21aca347c5ff9eb13 100644
+--- a/dist/esm/querybuilder/parsingUtils.mjs
++++ b/dist/esm/querybuilder/parsingUtils.mjs
+@@ -80,7 +80,7 @@ function getAllByType(expr, cur, type) {
+ }
+ const regexifyLabelValuesQueryString = (query) => {
+   const queryArray = query.split(" ");
+-  return queryArray.map((query2) => `${query2}.*`).join("");
++  return queryArray.map((query2) => `${query2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*`).join("");
+ };
+ const BUILT_IN_VARIABLES = [
+   { variable: "$__interval_ms", replacement: "79_999_999_999" },
+diff --git a/dist/esm/datasource.mjs b/dist/esm/datasource.mjs
+index 0868442cbff9d5638f82e105fed184016a6d8f6c..6d36e334c8ed908235967b038d34233724c866c9 100644
+--- a/dist/esm/datasource.mjs
++++ b/dist/esm/datasource.mjs
+@@ -174,7 +174,7 @@ class PrometheusDatasource extends DataSourceWithBackend {
+     data = data || {};
+     for (const [key, value] of this.customQueryParameters) {
+       if (data[key] == null) {
+-        data[key] = value;
++        data[key] = this.interpolateString(value);
+       }
+     }
+     let queryUrl = this.url + url;
+diff --git a/dist/esm/resource_clients.mjs b/dist/esm/resource_clients.mjs
+index 97ef92f2354bfe9ba742dd4fe7cdc90b39917b5e..a3431b986552c6b27a4d36695037afcf894982bf 100644
+--- a/dist/esm/resource_clients.mjs
++++ b/dist/esm/resource_clients.mjs
+@@ -3,7 +3,7 @@ import { EMPTY_SELECTOR, MATCH_ALL_LABELS, METRIC_LABEL, DEFAULT_SERIES_LIMIT }
+ import { processHistogramMetrics, getRangeSnapInterval, removeQuotesIfExist } from './language_utils.mjs';
+ import { buildVisualQueryFromString } from './querybuilder/parsing.mjs';
+ import { PrometheusCacheLevel } from './types.mjs';
+-import { escapeForUtf8Support, utf8Support } from './utf8_support.mjs';
++import { utf8Support } from './utf8_support.mjs';
+ 
+ "use strict";
+ class BaseResourceClient {
+@@ -114,13 +114,13 @@ class LabelsApiClient extends BaseResourceClient {
+       const effectiveLimit = this.getEffectiveLimit(limit);
+       const searchParams = { limit: effectiveLimit, ...timeParams, ...match ? { "match[]": match } : {} };
+       const interpolatedName = this.datasource.interpolateString(labelKey);
+-      const interpolatedAndEscapedName = escapeForUtf8Support(removeQuotesIfExist(interpolatedName));
+-      const effectiveMatch = `${match != null ? match : ""}-${interpolatedAndEscapedName}`;
++      const cleanName = removeQuotesIfExist(interpolatedName);
++      const effectiveMatch = `${match != null ? match : ""}-${cleanName}`;
+       const maybeCachedValues = this._cache.getLabelValues(timeRange, effectiveMatch, effectiveLimit);
+       if (maybeCachedValues) {
+         return maybeCachedValues;
+       }
+-      const url = `/api/v1/label/${interpolatedAndEscapedName}/values`;
++      const url = `/api/v1/label/${cleanName}/values`;
+       const value = await this.requestLabels(url, searchParams, getDefaultCacheHeaders(this.datasource.cacheLevel));
+       this._cache.setLabelValues(timeRange, effectiveMatch, effectiveLimit, value != null ? value : []);
+       return value != null ? value : [];

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/plugin-ui": "^0.13.1",
-    "@grafana/prometheus": "13.1.2",
+    "@grafana/prometheus": "patch:@grafana/prometheus@npm%3A13.1.2#~/.yarn/patches/@grafana-prometheus-npm-13.1.2-46ff9be179.patch",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^8.0.0",
     "@grafana/scenes-react": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4134,6 +4134,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/prometheus@patch:@grafana/prometheus@npm%3A13.1.2#~/.yarn/patches/@grafana-prometheus-npm-13.1.2-46ff9be179.patch":
+  version: 13.1.2
+  resolution: "@grafana/prometheus@patch:@grafana/prometheus@npm%3A13.1.2#~/.yarn/patches/@grafana-prometheus-npm-13.1.2-46ff9be179.patch::version=13.1.2&hash=94147a"
+  dependencies:
+    "@emotion/css": "npm:11.13.5"
+    "@floating-ui/react": "npm:0.27.19"
+    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@hello-pangea/dnd": "npm:18.0.1"
+    "@leeoniya/ufuzzy": "npm:1.0.19"
+    "@lezer/common": "npm:1.5.2"
+    "@lezer/highlight": "npm:1.2.3"
+    "@lezer/lr": "npm:1.4.8"
+    "@prometheus-io/lezer-promql": "npm:0.307.3"
+    "@types/debounce-promise": "npm:3.1.9"
+    "@types/lodash": "npm:4.17.20"
+    "@types/react": "npm:18.3.18"
+    "@types/react-dom": "npm:18.3.5"
+    "@types/react-highlight-words": "npm:0.20.0"
+    "@types/semver": "npm:7.7.1"
+    "@types/uuid": "npm:10.0.0"
+    debounce-promise: "npm:3.1.2"
+    lodash: "npm:^4.17.23"
+    moment: "npm:2.30.1"
+    moment-timezone: "npm:0.5.47"
+    monaco-editor: "npm:0.34.1"
+    monaco-promql: "npm:1.8.0"
+    pluralize: "npm:8.0.0"
+    prismjs: "npm:1.30.0"
+    react-highlight-words: "npm:0.21.0"
+    react-use: "npm:17.6.0"
+    react-window: "npm:1.8.11"
+    rxjs: "npm:7.8.2"
+    semver: "npm:7.7.3"
+    uuid: "npm:11.1.0"
+  peerDependencies:
+    "@grafana/assistant": ">=0.1.0"
+    "@grafana/data": ">=11.5.0"
+    "@grafana/e2e-selectors": ">=11.5.0"
+    "@grafana/i18n": ">=12.3.0"
+    "@grafana/runtime": ">=11.5.0"
+    "@grafana/schema": ">=11.5.0"
+    "@grafana/ui": ">=11.5.0"
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  peerDependenciesMeta:
+    "@grafana/assistant":
+      optional: true
+  checksum: 10/36c279b4eca920696b8afba834d28e8d8a9fbcd149d999584d0dd9b64f4796ebcd8d64d0a197cb04eb30dcf7c1aaa2ac473375784d0ed080075273c54dd47978
+  languageName: node
+  linkType: hard
+
 "@grafana/runtime@npm:13.1.0-pre, @grafana/runtime@workspace:*, @grafana/runtime@workspace:packages/grafana-runtime":
   version: 0.0.0-use.local
   resolution: "@grafana/runtime@workspace:packages/grafana-runtime"
@@ -20829,7 +20880,7 @@ __metadata:
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:^3.4.12"
     "@grafana/plugin-ui": "npm:^0.13.1"
-    "@grafana/prometheus": "npm:13.1.2"
+    "@grafana/prometheus": "patch:@grafana/prometheus@npm%3A13.1.2#~/.yarn/patches/@grafana-prometheus-npm-13.1.2-46ff9be179.patch"
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": "npm:^8.0.0"
     "@grafana/scenes-react": "npm:^8.0.0"


### PR DESCRIPTION
## What is this fix?

Fixes label value autocomplete and query builder for OTel-style dotted metric and label names (e.g. `k8s.container.name`, `http.server.request.duration`). Currently, selecting a dotted label name in the Builder mode shows "No options found" in the value dropdown, and selecting a dotted metric name causes a React crash.

**Affected versions:** Grafana 12.4.2 and all previous versions with UTF-8 label support (11.5.x+). The bug was introduced when `escapeForUtf8Support()` was added to the label values API path in the UTF-8 support PRs (#98274, grafana/grafana#98345, grafana/grafana#98253).

**Why this matters:** OpenTelemetry [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) use dot-notation as the canonical format for attribute names (`k8s.container.name`, `http.request.method`, `deployment.environment`, `service.name`). Backends like VictoriaMetrics, Thanos, and Mimir store these natively. Without this fix, users adopting OTel-native naming cannot use Grafana's Builder mode to filter by these labels — the value dropdown is always empty across all surfaces.

**After the fix, dotted label names work natively in:**
- Explore (Builder mode)
- Metrics Drilldown (label filter)
- Dashboard panels (query builder)
- Dashboard variables (template variable editor)

All surfaces share the same `queryLabelValues()` code path in `resource_clients.ts`, so the fix resolves the issue everywhere simultaneously.

### Root cause

**Label values (primary fix):** `LabelsApiClient.queryLabelValues()` in `resource_clients.ts` applies `escapeForUtf8Support()` to label names before constructing the `/api/v1/label/{name}/values` URL path. This converts dotted names like `k8s.container.name` to the Prometheus 3.x U__ escaped format `U__k8s_2e_container_2e_name`. Non-Prometheus backends (VictoriaMetrics, Thanos, Mimir) don't understand this encoding and return empty results. Even Prometheus 3.x accepts raw dots in the URL path — the U__ format is only needed inside PromQL expressions, not API URL paths.

```
/api/v1/label/U__k8s_2e_container_2e_name/values  →  [] (empty — broken)
/api/v1/label/k8s.container.name/values            →  ["app", "sidecar"] (correct)
```

**Metric names (secondary fix):** The lezer PromQL parser fragments `test.metric` into `Identifier("test") + Error(".") + Error("metric")`, causing the query builder to set the metric name to just `"test"` and produce parse errors / React crash.

### Backend compatibility (verified)

| Backend | Raw dots in URL path | U__ escaped (current behavior) |
|---|---|---|
| **Prometheus 3.x** | Works | Works (explicitly decoded) |
| **Prometheus 2.x** | N/A (no dots in label names) | N/A |
| **Thanos** | Works | **Broken** — treated as literal, returns empty |
| **Mimir** | Works | **Broken** — treated as literal, returns empty |
| **VictoriaMetrics** | Works | **Broken** — treated as literal, returns empty |

Standard Prometheus metrics (`[a-zA-Z_:][a-zA-Z0-9_:]*`) are completely unaffected — the fix only activates when dots are present in names.

### Changes

**`packages/grafana-prometheus/src/resource_clients.ts`** (primary fix):
- Remove `escapeForUtf8Support()` from label name before constructing the `/api/v1/label/{name}/values` URL
- Use raw label name instead — all backends accept dots directly in URL paths
- Do NOT use `encodeURIComponent` either — Mimir's `UseEncodedPath()` preserves `%2E` without decoding

**`packages/grafana-prometheus/src/querybuilder/parsing.ts`** (secondary fix):
- Add `tryReconstructDottedMetric()` helper that detects the lezer parser fragmentation pattern and reconstructs the full dotted metric name
- Modify `UnquotedLabelMatcher` handler to detect dotted metric names without `MatchOp`
- Suppress dot-fragment error nodes when a dotted metric has been reconstructed

**`packages/grafana-prometheus/src/querybuilder/parsingUtils.ts`**:
- Escape regex special characters (including dots) in `regexifyLabelValuesQueryString()` for correct autocomplete matching

### Test environment

- **Grafana**: 12.4.2 (stock, for bug reproduction) and `main` branch (for fix verification)
- **Backend**: VictoriaMetrics v1.131.0 community edition with OTel dot-notation metrics ingested via Prometheus import API
- **OS**: macOS Darwin 25.3.0 (arm64)
- **Docker**: Docker Desktop with docker-compose
- **Test metrics**: `k8s.container.cpu.usage{k8s.container.name="app"}`, `test.simple.gauge{test.label.one="value1"}`, `http_requests_total{job="api-server"}` (standard Prometheus for backward compat)

### Backward compatibility

- **Standard Prometheus metrics** (`http_requests_total`, `node_cpu_seconds_total`): Completely unaffected — no dots, fix code path never activates
- **Recording rules with colons** (`namespace:container_cpu_usage:sum`): Unaffected — colons are valid legacy characters
- **Quoted UTF-8 metrics** (`{"metric.name"}`): Unaffected — handled by existing `QuotedLabelName` case
- **Thanos/Mimir**: Unaffected for standard metrics; **fixed** for dotted label values
- **VictoriaMetrics underscore mode**: Unaffected

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/grafana-prometheus-datasource/issues/100

Related issues:
- grafana/grafana-prometheus-datasource#141 — broader OTEL-native metadata and builder behavior tracking issue
- grafana/grafana#97445 — Prometheus 3.0.1 + OTEL data still failing in label values / variables
- grafana/grafana#98243 — Parent UTF-8 issue (regression from its implementation PRs)
- grafana/grafana#42615 — Earlier report of dots in label names

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective (verified with docker-compose + VictoriaMetrics + OTel dot-notation metrics)
- [x] Tests pass (78/78 tests pass, including 13 new test cases for dotted names + backward compatibility)
- [ ] If this is a pre-GA feature, it is behind a feature toggle — N/A, this is a bug fix
- [ ] The docs are updated — N/A, no docs changes needed

> **Note:** Before/after screenshots and detailed evidence are in the PR comments below.
