### PR TITLE
chore: Update CODEOWNERS to assign /pkg/tests/api/admin/encryption to grafana-operator-experience-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,6 +206,7 @@
 /pkg/tests/apis/iam @grafana/identity-access-team
 /pkg/tests/apis/shorturl @grafana/sharing-squad
 /pkg/tests/api/correlations/ @grafana/datapro
+/pkg/tests/api/admin/encryption/ @grafana/grafana-operator-experience-squad
 /pkg/tsdb/grafanads/ @grafana/grafana-backend-group
 /pkg/tsdb/opentsdb/ @grafana/data-sources-plguins
 /pkg/util/ @grafana/grafana-backend-group


### PR DESCRIPTION
This pull request makes a minor update to the `.github/CODEOWNERS` file, assigning ownership of the `/pkg/tests/api/admin/encryption/` directory to the `@grafana/grafana-operator-experience-squad` team.