### PR TITLE
chore: bump DBMaxConns to TestIntegrationDashboardQuota

### DIFF
--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -352,6 +352,7 @@ func TestIntegrationDashboardQuota(t *testing.T) {
 		DisableAnonymous:  true,
 		EnableQuota:       true,
 		DashboardOrgQuota: &dashboardQuota,
+		DBMaxConns:        10,
 	})
 
 	grafanaListedAddr, _ := testinfra.StartGrafanaEnv(t, dir, path)


### PR DESCRIPTION
This pull request makes a minor configuration change to the test setup for dashboard quota integration tests. The maximum number of database connections is now explicitly set to 10 in the test environment configuration.

Raising `max_open_conn` hopefully can help mitigating [test flaykeness](https://github.com/grafana/grafana/actions/runs/23911568282/job/69734681332) by reducing queuing on the connection pool so startup work can overlap reads and stagger writes a bit more smoothly and avoid SQLITE_BUSY failures

