### PR TITLE
chore: rm new icon for advisor

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -406,7 +406,6 @@ func (s *ServiceImpl) readNavigationSettings() {
 			SectionID: navtree.NavIDCfg,
 			Text:      "Advisor",
 			SubTitle:  "Run checks and get suggestions to fix issues",
-			IsNew:     true,
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

Removes the new icon as Grafana Advisor was first introduced in v12 and we are GA in v13

**Why do we need this feature?**

Good stewardship of the menu

**Who is this feature for?**

People who don't like rockets

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
