### PR TITLE
Dashboard: Add margin between datasource and query editor

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
@@ -124,10 +124,11 @@ export function QueryVariableEditorForm({
       <VariableLegend>
         <Trans i18nKey="dashboard-scene.query-variable-editor-form.query-options">Query options</Trans>
       </VariableLegend>
+
+      {/* eslint-disable-next-line @grafana/require-no-margin */}
       <Field
         label={t('dashboard-scene.query-variable-editor-form.label-data-source', 'Data source')}
         htmlFor="data-source-picker"
-        noMargin
       >
         <DataSourcePicker current={datasourceRef} onChange={datasourceChangeHandler} variables={true} width={30} />
       </Field>

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -268,10 +268,10 @@ export function Editor({ variable }: { variable: QueryVariable }) {
 
   return (
     <div data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.editor}>
+      {/* eslint-disable-next-line @grafana/require-no-margin */}
       <Field
         label={t('dashboard-scene.query-variable-editor-form.label-target-data-source', 'Target data source')}
         htmlFor="data-source-picker"
-        noMargin
       >
         <DataSourcePicker current={datasourceRef} onChange={onDataSourceChange} variables={true} width={30} />
       </Field>


### PR DESCRIPTION
**What is this feature?**

Add margin between datasource and query editor.

**Why do we need this feature?**

Adjust UX.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

This needs to be properly fixed. However, introducing a Stack-based approach can cause bugs right before the cutoff. So just removing "noMargin" should be enough.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
