### PR TITLE
test: Prevent tests to fail when multiple toasts are displayed after saving a dashboard

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -129,9 +129,10 @@ export async function saveDashboard(
   await dashboardPage.getByGrafanaSelector(selectors.components.Drawer.DashboardSaveDrawer.saveButton).click();
 
   // wait for the toast
-  await expect(page.getByText('Dashboard saved')).toBeVisible();
+  const toast = page.getByRole('status', { name: 'Dashboard saved' });
+  await expect(toast).toBeVisible();
   // close toast, we do this to prevent any incorrect assertion when several saves occur fast. i.e. the 1st toast is still visible but the 2nd save has not occurred yet
-  await page.getByRole('button', { name: 'Close alert' }).click();
+  await toast.getByRole('button', { name: 'Close alert' }).click();
 }
 
 export async function checkRepeatedPanelTitles(


### PR DESCRIPTION
Follow-up of https://github.com/grafana/grafana/pull/121676

Slack context: https://raintank-corp.slack.com/archives/C01BKPAV1EZ/p1775221218642629