### PR TITLE
test: Prevent E2E flakiness (ad hoc vars)

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
@@ -39,6 +39,7 @@ test.describe(
       await dashboardPage
         .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.AdHocFiltersVariable.datasourceSelect)
         .click();
+      await page.keyboard.type(dataSource);
       await page.getByText(dataSource).click();
 
       // mock the API call to get the labels


### PR DESCRIPTION
A very small PR to make sure the data source can be selected when testing ad hoc (filter) vars.