### PR TITLE
AuthZ-Service: Add support for subresource authorization

### DIFF
--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -188,7 +188,7 @@ func (s *RBACSync) translateK8sPermissions(_ context.Context, k8sPerms []string)
 		case len(groupResource) == 2:
 			// Case group/resource:verb
 			resource := groupResource[1]
-			resourceMappings, ok := s.mapper.Get(group, resource)
+			resourceMappings, ok := s.mapper.Get(group, resource, "")
 			if !ok {
 				s.log.Warn("Unknown K8s resource", "group", group, "resource", resource)
 				continue

--- a/pkg/services/authz/rbac/k8s_native_mapping.go
+++ b/pkg/services/authz/rbac/k8s_native_mapping.go
@@ -25,12 +25,17 @@ var k8sVerbMap = map[string]string{
 // mapper. Actions follow the {group}/{resource}:{verb} format and all values are
 // derived at call time from the group and resource name alone.
 type k8sNativeMapping struct {
-	group    string
-	resource string
+	group       string
+	resource    string
+	subresource string
 }
 
-func newK8sNativeMapping(group, resource string) Mapping {
-	return &k8sNativeMapping{group: group, resource: resource}
+func newK8sNativeMapping(group, resource, subresource string) Mapping {
+	return &k8sNativeMapping{
+		group:       group,
+		resource:    resource,
+		subresource: subresource,
+	}
 }
 
 // Action returns the RBAC action for the given K8s verb in the format
@@ -40,7 +45,11 @@ func (m *k8sNativeMapping) Action(verb string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return m.group + "/" + m.resource + ":" + v, true
+	prefix := m.group + "/" + m.resource
+	if m.subresource != "" {
+		prefix += "/" + m.subresource
+	}
+	return prefix + ":" + v, true
 }
 
 // ActionSets returns nil; K8s-native resources have no legacy RBAC action sets.
@@ -51,6 +60,7 @@ func (m *k8sNativeMapping) ActionSets(_ string) []string {
 
 // Scope returns the RBAC scope for the given resource instance name.
 // Format: {resource}:uid:{name}
+// Note: The subresource is not included in the scope, as the subresource applies to the resource itself.
 func (m *k8sNativeMapping) Scope(name string) string {
 	return m.group + "/" + m.resource + ":uid:" + name
 }
@@ -63,11 +73,15 @@ func (m *k8sNativeMapping) Prefix() string {
 
 // AllActions returns the deduplicated set of RBAC actions for this resource.
 func (m *k8sNativeMapping) AllActions() []string {
-	base := m.group + "/" + m.resource + ":"
+	prefix := m.group + "/" + m.resource
+	if m.subresource != "" {
+		prefix += "/" + m.subresource
+	}
+
 	seen := make(map[string]struct{}, len(k8sVerbMap))
 	actions := make([]string, 0, len(k8sVerbMap))
 	for _, v := range k8sVerbMap {
-		action := base + v
+		action := prefix + ":" + v
 		if _, ok := seen[action]; ok {
 			continue
 		}

--- a/pkg/services/authz/rbac/k8s_native_mapping_test.go
+++ b/pkg/services/authz/rbac/k8s_native_mapping_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestK8sNativeMapping_Action(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 
 	tests := []struct {
 		verb           string
@@ -44,8 +44,42 @@ func TestK8sNativeMapping_Action(t *testing.T) {
 	}
 }
 
+func TestK8sNativeMapping_Action_WithSubresource(t *testing.T) {
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "buttons")
+
+	tests := []struct {
+		verb           string
+		expectedAction string
+		expectOk       bool
+	}{
+		// Direct verbs
+		{utils.VerbGet, "myapp.ext.grafana.app/widgets/buttons:get", true},
+		{utils.VerbCreate, "myapp.ext.grafana.app/widgets/buttons:create", true},
+		{utils.VerbUpdate, "myapp.ext.grafana.app/widgets/buttons:update", true},
+		{utils.VerbDelete, "myapp.ext.grafana.app/widgets/buttons:delete", true},
+		{utils.VerbGetPermissions, "myapp.ext.grafana.app/widgets/buttons:get_permissions", true},
+		{utils.VerbSetPermissions, "myapp.ext.grafana.app/widgets/buttons:set_permissions", true},
+		// Collapsed verbs
+		{utils.VerbList, "myapp.ext.grafana.app/widgets/buttons:get", true},
+		{utils.VerbWatch, "myapp.ext.grafana.app/widgets/buttons:get", true},
+		{utils.VerbPatch, "myapp.ext.grafana.app/widgets/buttons:update", true},
+		{utils.VerbDeleteCollection, "myapp.ext.grafana.app/widgets/buttons:delete", true},
+		// Unknown verb
+		{"unknownverb", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.verb, func(t *testing.T) {
+			action, ok := m.Action(tt.verb)
+			assert.Equal(t, tt.expectOk, ok)
+			assert.Equal(t, tt.expectedAction, action)
+		})
+	}
+}
+
 func TestK8sNativeMapping_ActionSets(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 	// K8s-native resources have no legacy RBAC action sets.
 	for _, verb := range []string{utils.VerbGet, utils.VerbList, utils.VerbCreate, utils.VerbUpdate, utils.VerbDelete} {
 		assert.Nil(t, m.ActionSets(verb), "ActionSets should be nil for verb %q", verb)
@@ -53,38 +87,44 @@ func TestK8sNativeMapping_ActionSets(t *testing.T) {
 }
 
 func TestK8sNativeMapping_Scope(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 
+	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:abc123", m.Scope("abc123"))
+	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:some-uid", m.Scope("some-uid"))
+	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:", m.Scope(""))
+
+	// Scopes should be the same as the parent resource
+	m = newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "buttons")
 	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:abc123", m.Scope("abc123"))
 	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:some-uid", m.Scope("some-uid"))
 	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:", m.Scope(""))
 }
 
 func TestK8sNativeMapping_Prefix(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 	assert.Equal(t, "myapp.ext.grafana.app/widgets:uid:", m.Prefix())
 }
 
 func TestK8sNativeMapping_HasFolderSupport(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 	assert.True(t, m.HasFolderSupport(),
 		"K8s-native mappings always report folder support so that folder-scoped inheritance works correctly")
 }
 
 func TestK8sNativeMapping_SkipScope(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 	for _, verb := range []string{utils.VerbGet, utils.VerbCreate, utils.VerbUpdate, utils.VerbDelete, utils.VerbGetPermissions, utils.VerbSetPermissions} {
 		assert.False(t, m.SkipScope(verb), "SkipScope should be false for verb %q", verb)
 	}
 }
 
 func TestK8sNativeMapping_Resource(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 	assert.Equal(t, "widgets", m.Resource(), "Resource() should return the K8s resource name without the group prefix")
 }
 
 func TestK8sNativeMapping_AllActions(t *testing.T) {
-	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets")
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "")
 	actions := m.AllActions()
 
 	// Must be deduplicated (list/watch collapse to get, patch to update, deletecollection to delete)
@@ -101,10 +141,27 @@ func TestK8sNativeMapping_AllActions(t *testing.T) {
 	assert.Equal(t, expected, actions)
 }
 
+func TestK8sNativeMapping_AllActions_WithSubresource(t *testing.T) {
+	m := newK8sNativeMapping("myapp.ext.grafana.app", "widgets", "buttons")
+	actions := m.AllActions()
+
+	expected := []string{
+		"myapp.ext.grafana.app/widgets/buttons:create",
+		"myapp.ext.grafana.app/widgets/buttons:delete",
+		"myapp.ext.grafana.app/widgets/buttons:get",
+		"myapp.ext.grafana.app/widgets/buttons:get_permissions",
+		"myapp.ext.grafana.app/widgets/buttons:set_permissions",
+		"myapp.ext.grafana.app/widgets/buttons:update",
+	}
+
+	sort.Strings(actions)
+	assert.Equal(t, expected, actions)
+}
+
 func TestK8sNativeMapping_DifferentGroups(t *testing.T) {
 	// Two apps with the same resource name must produce distinct actions.
-	m1 := newK8sNativeMapping("app1.ext.grafana.app", "widgets")
-	m2 := newK8sNativeMapping("app2.ext.grafana.app", "widgets")
+	m1 := newK8sNativeMapping("app1.ext.grafana.app", "widgets", "")
+	m2 := newK8sNativeMapping("app2.ext.grafana.app", "widgets", "")
 
 	action1, ok1 := m1.Action(utils.VerbGet)
 	action2, ok2 := m2.Action(utils.VerbGet)

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -96,7 +96,7 @@ func (t translation) Resource() string {
 type MapperRegistry interface {
 	// Get returns the permission mapper for the given group and resource.
 	// If no translation is found, it returns false.
-	Get(group, resource string) (Mapping, bool)
+	Get(group, resource, subresource string) (Mapping, bool)
 	// GetAPIResourceName returns the API resource name (e.g. "repositories") for the given group and resource.
 	// Use this to send the canonical resource name in Check requests instead of legacy names (e.g. "provisioning.repositories").
 	// Returns ("", false) if no translation is found.
@@ -398,14 +398,19 @@ func (m mapper) findGroupKey(group string) (string, bool) {
 	return "", false
 }
 
-func (m mapper) Get(group, resource string) (Mapping, bool) {
+func (m mapper) Get(group, resource, subresource string) (Mapping, bool) {
 	groupKey, ok := m.findGroupKey(group)
 	if !ok {
 		return nil, false
 	}
 
+	lookupResource := resource
+	if subresource != "" {
+		lookupResource = resource + "/" + subresource
+	}
+
 	resources := m[groupKey]
-	t, ok := resources[resource]
+	t, ok := resources[lookupResource]
 	if !ok {
 		return nil, false
 	}

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -18,7 +18,7 @@ func TestMapperRegistry_DatasourceWildcard(t *testing.T) {
 
 	// Real config: groups matching *.datasource.grafana.app get the datasources mapping
 	for _, group := range []string{"loki.datasource.grafana.app", "mimir.datasource.grafana.app"} {
-		mapping, ok := reg.Get(group, "datasources")
+		mapping, ok := reg.Get(group, "datasources", "")
 		require.True(t, ok, "Get(%q, \"datasources\") should find mapping", group)
 		require.NotNil(t, mapping)
 		assert.Equal(t, "datasources:uid:", mapping.Prefix())
@@ -27,7 +27,7 @@ func TestMapperRegistry_DatasourceWildcard(t *testing.T) {
 	}
 
 	// Security: wildcard-matched group must not resolve to resources from other groups
-	_, ok := reg.Get("loki.datasource.grafana.app", "dashboards")
+	_, ok := reg.Get("loki.datasource.grafana.app", "dashboards", "")
 	assert.False(t, ok, "Get(datasource group, \"dashboards\") must not return a mapping")
 }
 
@@ -86,7 +86,7 @@ func TestMapperRegistry_WildcardGroup(t *testing.T) {
 	// Matching groups get the mapping
 	for _, group := range []string{"foo.test.grafana.app", "bar.test.grafana.app", "baz.test.grafana.app"} {
 		t.Run("matches_"+group, func(t *testing.T) {
-			mapping, ok := reg.Get(group, "testresources")
+			mapping, ok := reg.Get(group, "testresources", "")
 			require.True(t, ok, "Get(%q, \"testresources\") should find mapping", group)
 			require.NotNil(t, mapping)
 			assert.Equal(t, "testresources:uid:", mapping.Prefix())
@@ -108,7 +108,7 @@ func TestMapperRegistry_WildcardGroup(t *testing.T) {
 	}
 	for _, tc := range denyCases {
 		t.Run("deny_"+tc.name, func(t *testing.T) {
-			_, ok := reg.Get(tc.group, "testresources")
+			_, ok := reg.Get(tc.group, "testresources", "")
 			assert.False(t, ok, "Get(%q) must not return a mapping", tc.group)
 			all := reg.GetAll(tc.group)
 			assert.Empty(t, all, "GetAll(%q) must not return any mappings", tc.group)
@@ -120,8 +120,67 @@ func TestMapperRegistry_ExactMatchPreferred(t *testing.T) {
 	reg := NewMapperRegistry()
 
 	// Exact group keys still work
-	mapping, ok := reg.Get("dashboard.grafana.app", "dashboards")
+	mapping, ok := reg.Get("dashboard.grafana.app", "dashboards", "")
 	require.True(t, ok)
 	require.NotNil(t, mapping)
 	assert.Equal(t, "dashboards:uid:", mapping.Prefix())
+}
+
+func TestMapperRegistry_SubresourceLookup(t *testing.T) {
+	parentTr := newResourceTranslation("widgets", "uid", true, nil)
+	subTr := translation{
+		resource:  "widgets",
+		attribute: "uid",
+		verbMapping: map[string]string{
+			"get":    "widgets.status:read",
+			"update": "widgets.status:write",
+		},
+		folderSupport: false,
+	}
+
+	m := mapper{
+		"example.grafana.app": {
+			"widgets":        parentTr,
+			"widgets/status": subTr,
+		},
+	}
+	var reg MapperRegistry = m
+
+	t.Run("empty subresource returns parent resource", func(t *testing.T) {
+		mapping, ok := reg.Get("example.grafana.app", "widgets", "")
+		require.True(t, ok)
+		action, ok := mapping.Action("get")
+		assert.True(t, ok)
+		assert.Equal(t, "widgets:read", action)
+	})
+
+	t.Run("subresource returns subresource mapping", func(t *testing.T) {
+		mapping, ok := reg.Get("example.grafana.app", "widgets", "status")
+		require.True(t, ok)
+		action, ok := mapping.Action("get")
+		assert.True(t, ok)
+		assert.Equal(t, "widgets.status:read", action)
+	})
+
+	t.Run("subresource uses same scope prefix as parent", func(t *testing.T) {
+		mapping, ok := reg.Get("example.grafana.app", "widgets", "status")
+		require.True(t, ok)
+		assert.Equal(t, "widgets:uid:", mapping.Prefix())
+		assert.Equal(t, "widgets:uid:abc", mapping.Scope("abc"))
+	})
+
+	t.Run("unknown subresource returns false", func(t *testing.T) {
+		_, ok := reg.Get("example.grafana.app", "widgets", "nonexistent")
+		assert.False(t, ok)
+	})
+
+	t.Run("unknown group with subresource returns false", func(t *testing.T) {
+		_, ok := reg.Get("unknown.grafana.app", "widgets", "status")
+		assert.False(t, ok)
+	})
+
+	t.Run("subresource name alone is not a valid resource", func(t *testing.T) {
+		_, ok := reg.Get("example.grafana.app", "status", "")
+		assert.False(t, ok)
+	})
 }

--- a/pkg/services/authz/rbac/metrics.go
+++ b/pkg/services/authz/rbac/metrics.go
@@ -24,7 +24,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 				Name:      "invalid_request_count",
 				Help:      "AuthZ service invalid request count",
 			},
-			[]string{"is_error", "valid", "verb", "group", "resource"},
+			[]string{"is_error", "valid", "verb", "group", "resource", "subresource"},
 		),
 		permissionCacheUsage: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{

--- a/pkg/services/authz/rbac/models.go
+++ b/pkg/services/authz/rbac/models.go
@@ -10,6 +10,7 @@ type checkRequest struct {
 	ActionSets   []string
 	Group        string
 	Resource     string
+	Subresource  string
 	Verb         string
 	Name         string
 	ParentFolder string
@@ -21,6 +22,7 @@ type listRequest struct {
 	UserUID      string
 	Group        string
 	Resource     string
+	Subresource  string
 	Verb         string
 	Action       string
 	ActionSets   []string

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -116,6 +116,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		"namespace", req.GetNamespace(),
 		"group", req.GetGroup(),
 		"resource", req.GetResource(),
+		"subresource", req.GetSubresource(),
 		"verb", req.GetVerb(),
 	)
 	defer func(start time.Time) {
@@ -295,7 +296,7 @@ func (s *Service) groupBatchCheckItems(
 	groups := make(map[string]*batchCheckGroup)
 
 	for _, item := range checks {
-		action, actionSets, err := s.validateAction(ctx, item.GetGroup(), item.GetResource(), item.GetVerb())
+		action, actionSets, err := s.validateAction(ctx, item.GetGroup(), item.GetResource(), item.GetSubresource(), item.GetVerb())
 		if err != nil {
 			results[item.GetCorrelationId()] = &authzv1.BatchCheckResult{Allowed: false, Error: err.Error()}
 			continue
@@ -481,7 +482,7 @@ func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRe
 		return nil, err
 	}
 
-	action, actionSets, err := s.validateAction(ctx, req.GetGroup(), req.GetResource(), req.GetVerb())
+	action, actionSets, err := s.validateAction(ctx, req.GetGroup(), req.GetResource(), req.GetSubresource(), req.GetVerb())
 	if err != nil {
 		return nil, err
 	}
@@ -494,6 +495,7 @@ func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRe
 		ActionSets:   actionSets,
 		Group:        req.GetGroup(),
 		Resource:     req.GetResource(),
+		Subresource:  req.GetSubresource(),
 		Verb:         req.GetVerb(),
 		Name:         req.GetName(),
 		ParentFolder: req.GetFolder(),
@@ -515,7 +517,7 @@ func (s *Service) validateListRequest(ctx context.Context, req *authzv1.ListRequ
 		return nil, err
 	}
 
-	action, actionSets, err := s.validateAction(ctx, req.GetGroup(), req.GetResource(), req.GetVerb())
+	action, actionSets, err := s.validateAction(ctx, req.GetGroup(), req.GetResource(), req.GetSubresource(), req.GetVerb())
 	if err != nil {
 		return nil, err
 	}
@@ -536,6 +538,7 @@ func (s *Service) validateListRequest(ctx context.Context, req *authzv1.ListRequ
 		ActionSets:   actionSets,
 		Group:        req.GetGroup(),
 		Resource:     req.GetResource(),
+		Subresource:  req.GetSubresource(),
 		Verb:         req.GetVerb(),
 		Options:      options,
 	}
@@ -582,18 +585,18 @@ func (s *Service) validateSubject(ctx context.Context, subject string) (string, 
 }
 
 // Find the action for a selected verb
-func (s *Service) validateAction(ctx context.Context, group, resource, verb string) (string, []string, error) {
+func (s *Service) validateAction(ctx context.Context, group, resource, subresource, verb string) (string, []string, error) {
 	ctxLogger := s.logger.FromContext(ctx)
 
-	t, ok := s.mapper.Get(group, resource)
+	t, ok := s.mapper.Get(group, resource, subresource)
 	if !ok {
-		ctxLogger.Debug("resource not in mapper, using K8s-native fallback", "group", group, "resource", resource)
-		t = newK8sNativeMapping(group, resource)
+		ctxLogger.Debug("resource not in mapper, using K8s-native fallback", "group", group, "resource", resource, "subresource", subresource)
+		t = newK8sNativeMapping(group, resource, subresource)
 	}
 
 	action, ok := t.Action(verb)
 	if !ok {
-		ctxLogger.Error("unsupported verb", "group", group, "resource", resource, "verb", verb)
+		ctxLogger.Error("unsupported verb", "group", group, "resource", resource, "subresource", subresource, "verb", verb)
 		return "", nil, status.Error(codes.NotFound, "unsupported verb")
 	}
 
@@ -856,10 +859,10 @@ func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool,
 	defer span.End()
 	ctxLogger := s.logger.FromContext(ctx)
 
-	t, ok := s.mapper.Get(req.Group, req.Resource)
+	t, ok := s.mapper.Get(req.Group, req.Resource, req.Subresource)
 	if !ok {
-		ctxLogger.Debug("resource not in mapper, using K8s-native fallback", "group", req.Group, "resource", req.Resource)
-		t = newK8sNativeMapping(req.Group, req.Resource)
+		ctxLogger.Debug("resource not in mapper, using K8s-native fallback", "group", req.Group, "resource", req.Resource, "subresource", req.Subresource)
+		t = newK8sNativeMapping(req.Group, req.Resource, req.Subresource)
 	}
 
 	if req.Name == "" && req.Verb != utils.VerbCreate {
@@ -1017,10 +1020,10 @@ func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, 
 	defer span.End()
 	ctxLogger := s.logger.FromContext(ctx)
 
-	t, ok := s.mapper.Get(req.Group, req.Resource)
+	t, ok := s.mapper.Get(req.Group, req.Resource, req.Subresource)
 	if !ok {
-		ctxLogger.Debug("resource not in mapper, using K8s-native fallback", "group", req.Group, "resource", req.Resource)
-		t = newK8sNativeMapping(req.Group, req.Resource)
+		ctxLogger.Debug("resource not in mapper, using K8s-native fallback", "group", req.Group, "resource", req.Resource, "subresource", req.Subresource)
+		t = newK8sNativeMapping(req.Group, req.Resource, req.Subresource)
 	}
 
 	var tree folderTree

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -129,7 +129,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 	checkReq, err := s.validateCheckRequest(ctx, req)
 	if err != nil {
 		ctxLogger.Error("invalid request", "error", err)
-		s.metrics.requestCount.WithLabelValues("true", "false", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+		s.metrics.requestCount.WithLabelValues("true", "false", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 		return deny, err
 	}
 	ctx = request.WithNamespace(ctx, req.GetNamespace())
@@ -146,7 +146,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 	permDenialKey := userPermDenialCacheKey(checkReq.Namespace.Value, checkReq.UserUID, checkReq.Action, checkReq.Name, checkReq.ParentFolder)
 	if _, ok := s.permDenialCache.Get(ctx, permDenialKey); ok {
 		s.metrics.permissionCacheUsage.WithLabelValues("true", checkReq.Action).Inc()
-		s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+		s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 		return deny, nil
 	}
 
@@ -157,12 +157,12 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		allowed, err := s.checkPermission(ctx, cachedPerms, checkReq, getTree)
 		if err != nil {
 			ctxLogger.Error("could not check permission", "error", err)
-			s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+			s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 			return deny, err
 		}
 		if allowed {
 			s.metrics.permissionCacheUsage.WithLabelValues("true", checkReq.Action).Inc()
-			s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+			s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 			span.SetAttributes(attribute.Bool("allowed", true))
 			return allow, nil
 		}
@@ -172,14 +172,14 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 	permissions, err := s.getIdentityPermissions(ctx, checkReq.Namespace, checkReq.IdentityType, checkReq.UserUID, checkReq.Action, checkReq.ActionSets)
 	if err != nil {
 		ctxLogger.Error("could not get user permissions", "subject", req.GetSubject(), "error", err)
-		s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+		s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 		return deny, err
 	}
 
 	allowed, err := s.checkPermission(ctx, permissions, checkReq, getTree)
 	if err != nil {
 		ctxLogger.Error("could not check permission", "error", err)
-		s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+		s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 		return deny, err
 	}
 
@@ -187,7 +187,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		s.permDenialCache.Set(ctx, permDenialKey, true)
 	}
 
-	s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+	s.metrics.requestCount.WithLabelValues("false", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 	span.SetAttributes(attribute.Bool("allowed", allowed))
 	return &authzv1.CheckResponse{Allowed: allowed}, nil
 }
@@ -310,6 +310,7 @@ func (s *Service) groupBatchCheckItems(
 			ActionSets:   actionSets,
 			Group:        item.GetGroup(),
 			Resource:     item.GetResource(),
+			Subresource:  item.GetSubresource(),
 			Verb:         item.GetVerb(),
 			Name:         item.GetName(),
 			ParentFolder: item.GetFolder(),
@@ -412,6 +413,7 @@ func (s *Service) List(ctx context.Context, req *authzv1.ListRequest) (*authzv1.
 		"namespace", req.GetNamespace(),
 		"group", req.GetGroup(),
 		"resource", req.GetResource(),
+		"subresource", req.GetSubresource(),
 		"verb", req.GetVerb(),
 	)
 	defer func(start time.Time) {
@@ -421,7 +423,7 @@ func (s *Service) List(ctx context.Context, req *authzv1.ListRequest) (*authzv1.
 	listReq, err := s.validateListRequest(ctx, req)
 	if err != nil {
 		ctxLogger.Error("invalid request", "error", err)
-		s.metrics.requestCount.WithLabelValues("true", "false", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+		s.metrics.requestCount.WithLabelValues("true", "false", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 		return &authzv1.ListResponse{}, err
 	}
 	ctx = request.WithNamespace(ctx, req.GetNamespace())
@@ -448,13 +450,13 @@ func (s *Service) List(ctx context.Context, req *authzv1.ListRequest) (*authzv1.
 		permissions, err = s.getIdentityPermissions(ctx, listReq.Namespace, listReq.IdentityType, listReq.UserUID, listReq.Action, listReq.ActionSets)
 		if err != nil {
 			ctxLogger.Error("could not get user permissions", "subject", req.GetSubject(), "error", err)
-			s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+			s.metrics.requestCount.WithLabelValues("true", "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 			return nil, err
 		}
 	}
 
 	resp, err := s.listPermission(ctx, permissions, listReq)
-	s.metrics.requestCount.WithLabelValues(strconv.FormatBool(err != nil), "true", req.GetVerb(), req.GetGroup(), req.GetResource()).Inc()
+	s.metrics.requestCount.WithLabelValues(strconv.FormatBool(err != nil), "true", req.GetVerb(), req.GetGroup(), req.GetResource(), req.GetSubresource()).Inc()
 	if err != nil {
 		return nil, err
 	}
@@ -485,6 +487,10 @@ func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRe
 	action, actionSets, err := s.validateAction(ctx, req.GetGroup(), req.GetResource(), req.GetSubresource(), req.GetVerb())
 	if err != nil {
 		return nil, err
+	}
+
+	if req.GetResource() == "" && req.GetSubresource() != "" {
+		return nil, status.Error(codes.InvalidArgument, "resource is required when subresource is provided")
 	}
 
 	checkReq := &checkRequest{


### PR DESCRIPTION
In this PR we add support for subressource authorization to the AuthZ Service.

**Why:**
Annotations will be a subresource of dashboards. (see https://github.com/grafana/grafana/pull/118377)


**Special note for reviewers:**
Extract from https://github.com/grafana/grafana/pull/118377 the AuthZ Service logic to simplify reviews.
