### PR TITLE
test: Follow-up prevent E2E flakiness (ad hoc vars)

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
@@ -41,6 +41,9 @@ test.describe(
         .click();
       await page.keyboard.type(dataSource);
       await page.getByText(dataSource).click();
+      await page
+        .getByRole('alert', { name: /this data source does not support filters/ })
+        .waitFor({ state: 'detached' });
 
       // mock the API call to get the labels
       const labels = ['label1', 'label2'];


### PR DESCRIPTION
Follow-up of https://github.com/grafana/grafana/pull/121853