### PR TITLE
Dashboards: Reduce Rudderstack event frequency and payload size for large URL dashboards

### DIFF
--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -22,7 +22,7 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
   });
 };
 
-const MAX_PAGE_URL_LENGTH = 2048;
+export const MAX_PAGE_URL_LENGTH = 2048;
 
 /**
  * Helper function to report pageview events to the {@link EchoSrv}.

--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -22,6 +22,8 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
   });
 };
 
+const MAX_PAGE_URL_LENGTH = 2048;
+
 /**
  * Helper function to report pageview events to the {@link EchoSrv}.
  *
@@ -29,7 +31,8 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
  */
 export const reportPageview = () => {
   const location = locationService.getLocation();
-  const page = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
+  const fullPage = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
+  const page = fullPage.length > MAX_PAGE_URL_LENGTH ? fullPage.substring(0, MAX_PAGE_URL_LENGTH) : fullPage;
   getEchoSrv().addEvent<PageviewEchoEvent>({
     type: EchoEventType.Pageview,
     payload: {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -7,7 +7,7 @@ export * from './services';
 export * from './config';
 export * from './analytics/types';
 export { loadPluginCss, type PluginCssOptions, setPluginImportUtils, getPluginImportUtils } from './utils/plugin';
-export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView, MAX_PAGE_URL_LENGTH } from './analytics/utils';
+export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView } from './analytics/utils';
 export { featureEnabled } from './utils/licensing';
 export {
   logInfo,

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -7,7 +7,7 @@ export * from './services';
 export * from './config';
 export * from './analytics/types';
 export { loadPluginCss, type PluginCssOptions, setPluginImportUtils, getPluginImportUtils } from './utils/plugin';
-export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView } from './analytics/utils';
+export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView, MAX_PAGE_URL_LENGTH } from './analytics/utils';
 export { featureEnabled } from './utils/licensing';
 export {
   logInfo,

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useLayoutEffect, useRef } from 'react';
+import { Suspense, useEffect, useLayoutEffect } from 'react';
 import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { config, locationSearchToObject, navigationLogger, reportPageview } from '@grafana/runtime';
@@ -36,19 +36,12 @@ export function GrafanaRoute(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const lastReportedPage = useRef<string>('');
-
   useEffect(() => {
     cleanupDOM();
-    // Only report a pageview when the URL actually changes to avoid firing on every re-render.
-    // Dashboards can re-render frequently (variable loading, data fetching) while the URL stays the same.
-    const currentPage = props.location.pathname + props.location.search + props.location.hash;
-    if (currentPage !== lastReportedPage.current) {
-      lastReportedPage.current = currentPage;
-      reportPageview();
-    }
+    reportPageview();
     navigationLogger('GrafanaRoute', false, 'Updated', props);
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.location.pathname, props.location.search, props.location.hash]);
 
   navigationLogger('GrafanaRoute', false, 'Rendered', props.route);
 

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useLayoutEffect } from 'react';
+import { Suspense, useEffect, useLayoutEffect, useRef } from 'react';
 import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { config, locationSearchToObject, navigationLogger, reportPageview } from '@grafana/runtime';
@@ -36,9 +36,17 @@ export function GrafanaRoute(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const lastReportedPage = useRef<string>('');
+
   useEffect(() => {
     cleanupDOM();
-    reportPageview();
+    // Only report a pageview when the URL actually changes to avoid firing on every re-render.
+    // Dashboards can re-render frequently (variable loading, data fetching) while the URL stays the same.
+    const currentPage = props.location.pathname + props.location.search + props.location.hash;
+    if (currentPage !== lastReportedPage.current) {
+      lastReportedPage.current = currentPage;
+      reportPageview();
+    }
     navigationLogger('GrafanaRoute', false, 'Updated', props);
   });
 

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -1,8 +1,10 @@
-import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv, MAX_PAGE_URL_LENGTH } from '@grafana/runtime';
+import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv } from '@grafana/runtime';
 
 import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
+
+const MAX_PAGE_URL_LENGTH = 2048;
 
 interface EchoConfig {
   // How often should metrics be reported

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -1,4 +1,4 @@
-import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv } from '@grafana/runtime';
+import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv, MAX_PAGE_URL_LENGTH } from '@grafana/runtime';
 
 import { contextSrv } from '../context_srv';
 
@@ -10,8 +10,6 @@ interface EchoConfig {
   // Enables debug mode
   debug: boolean;
 }
-
-const MAX_META_URL_LENGTH = 2048;
 
 /**
  * Echo is a service for collecting events from Grafana client-app
@@ -89,8 +87,8 @@ export class Echo implements EchoSrv {
       timeSinceNavigationStart: performance.now(),
       path: window.location.pathname,
       url:
-        window.location.href.length > MAX_META_URL_LENGTH
-          ? window.location.href.substring(0, MAX_META_URL_LENGTH)
+        window.location.href.length > MAX_PAGE_URL_LENGTH
+          ? window.location.href.substring(0, MAX_PAGE_URL_LENGTH)
           : window.location.href,
     };
   };

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -11,6 +11,8 @@ interface EchoConfig {
   debug: boolean;
 }
 
+const MAX_META_URL_LENGTH = 2048;
+
 /**
  * Echo is a service for collecting events from Grafana client-app
  * It collects events, distributes them across registered backend and flushes once per configured interval
@@ -86,7 +88,10 @@ export class Echo implements EchoSrv {
       ts: new Date().getTime(),
       timeSinceNavigationStart: performance.now(),
       path: window.location.pathname,
-      url: window.location.href,
+      url:
+        window.location.href.length > MAX_META_URL_LENGTH
+          ? window.location.href.substring(0, MAX_META_URL_LENGTH)
+          : window.location.href,
     };
   };
 }

--- a/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
@@ -136,7 +136,6 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
       );
     }
 
-    window.rudderanalytics?.page?.();
   }
 
   addEvent = (e: PageviewEchoEvent) => {

--- a/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
@@ -135,7 +135,6 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
         apiOptions
       );
     }
-
   }
 
   addEvent = (e: PageviewEchoEvent) => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -14,6 +14,7 @@ import {
   SceneVariableSet,
   VizPanel,
 } from '@grafana/scenes';
+import { type Dashboard } from '@grafana/schema';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
@@ -25,7 +26,6 @@ import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
-import { type Dashboard } from '@grafana/schema';
 
 import { vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
 import { activateFullSceneTree } from '../utils/test-utils';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -25,6 +25,8 @@ import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { type Dashboard } from '@grafana/schema';
+
 import { vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
 import { activateFullSceneTree } from '../utils/test-utils';
 import { findVizPanelByKey, getQueryRunnerFor } from '../utils/utils';
@@ -213,6 +215,43 @@ describe('PanelEditor', () => {
 
       // Change back to already saved state
       panel.setState({ title: 'changed title' });
+      expect(panelEditor.state.isDirty).toBe(false);
+    });
+  });
+
+  describe('When panel has pre-existing unsaved changes (e.g. styles pasted from dashboard view)', () => {
+    it('Should set isDirty to true immediately when entering panel edit', async () => {
+      const { panelEditor } = await setupWithPreExistingStyleChanges();
+      expect(panelEditor.state.isDirty).toBe(true);
+    });
+
+    it('Should not set isDirty when panel has no pre-existing changes', async () => {
+      const { panelEditor } = await setup({});
+      // No paste, so isDirty should remain undefined (not set)
+      expect(panelEditor.state.isDirty).toBe(undefined);
+    });
+
+    it('Should revert pasted fieldConfig when discarding panel changes', async () => {
+      const originalFieldConfig = { defaults: { color: { mode: 'fixed' } }, overrides: [] };
+      const { panelEditor, panel, dashboard } = await setupWithPreExistingStyleChanges({ originalFieldConfig });
+
+      expect(panelEditor.state.isDirty).toBe(true);
+
+      panelEditor.onDiscard();
+
+      const discardedPanel = findVizPanelByKey(dashboard, panel.state.key!)!;
+      expect(discardedPanel.state.fieldConfig).toEqual(originalFieldConfig);
+    });
+
+    it('Should track further changes relative to the initial (saved) state after entering panel edit', async () => {
+      const originalFieldConfig = { defaults: { color: { mode: 'fixed' } }, overrides: [] };
+      const { panelEditor, panel } = await setupWithPreExistingStyleChanges({ originalFieldConfig });
+
+      expect(panelEditor.state.isDirty).toBe(true);
+
+      // Restoring to the original fieldConfig via setState (same path as how the original was captured)
+      // should make the panel no longer dirty.
+      panel.setState({ fieldConfig: originalFieldConfig });
       expect(panelEditor.state.isDirty).toBe(false);
     });
   });
@@ -501,4 +540,83 @@ async function setup(options: SetupOptions = {}) {
   }
 
   return { dashboard, panel, gridItem, panelEditor, pluginResolve };
+}
+
+interface SetupWithPreExistingStyleChangesOptions {
+  originalFieldConfig?: { defaults: Record<string, unknown>; overrides: unknown[] };
+}
+
+/**
+ * Sets up a panel editor scenario where styles were pasted from dashboard view
+ * before entering panel edit. This simulates the bug where the discard button
+ * is disabled even though the panel has unsaved changes.
+ */
+async function setupWithPreExistingStyleChanges(options: SetupWithPreExistingStyleChangesOptions = {}) {
+  const originalFieldConfig = options.originalFieldConfig ?? { defaults: { color: { mode: 'palette-classic' } }, overrides: [] };
+  const pastedFieldConfig = { defaults: { color: { mode: 'fixed' }, custom: { lineWidth: 3 } }, overrides: [] };
+
+  const pluginToLoad = getPanelPlugin({ id: 'timeseries', skipDataQuery: false });
+  pluginPromise = Promise.resolve(pluginToLoad);
+
+  // Create the panel with original fieldConfig
+  const panel = new VizPanel({
+    key: 'panel-1',
+    pluginId: 'timeseries',
+    title: 'original title',
+    fieldConfig: originalFieldConfig,
+    $data: new SceneDataTransformer({
+      transformations: [],
+      $data: new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        maxDataPoints: 500,
+        datasource: { uid: 'ds1' },
+      }),
+    }),
+  });
+
+  const gridItem = new DashboardGridItem({ body: panel });
+
+  const dashboard = new DashboardScene({
+    isEditing: true,
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [gridItem],
+      }),
+    }),
+  });
+
+  // Set the initial save model to represent what was last saved (with the original fieldConfig)
+  const initialSaveModel: Dashboard = {
+    schemaVersion: 36,
+    title: 'test dashboard',
+    panels: [
+      {
+        id: 1,
+        type: 'timeseries',
+        title: 'original title',
+        fieldConfig: originalFieldConfig as Dashboard['panels'][0]['fieldConfig'],
+        options: {},
+        targets: [{ refId: 'A', datasource: { uid: 'ds1' } }],
+        datasource: { uid: 'ds1' },
+        gridPos: { x: 0, y: 0, h: 8, w: 12 },
+      },
+    ],
+  };
+  dashboard.setInitialSaveModel(initialSaveModel);
+
+  // Simulate paste styles from dashboard view (before entering panel edit).
+  // Use setState directly because onFieldConfigChange requires the panel plugin to be loaded,
+  // which is not the case when pasting from dashboard view (mirrors how DashboardScene.pastePanelStyles works).
+  panel.setState({ fieldConfig: pastedFieldConfig });
+
+  // Now enter panel edit (AFTER the paste — this is the bug scenario)
+  const panelEditor = buildPanelEditScene(panel);
+  dashboard.setState({ editPanel: panelEditor });
+
+  panelEditor.debounceSaveModelDiff = false;
+  deactivate = activateFullSceneTree(dashboard);
+  await new Promise((r) => setTimeout(r, 1));
+
+  return { dashboard, panel, gridItem, panelEditor };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -552,7 +552,10 @@ interface SetupWithPreExistingStyleChangesOptions {
  * is disabled even though the panel has unsaved changes.
  */
 async function setupWithPreExistingStyleChanges(options: SetupWithPreExistingStyleChangesOptions = {}) {
-  const originalFieldConfig = options.originalFieldConfig ?? { defaults: { color: { mode: 'palette-classic' } }, overrides: [] };
+  const originalFieldConfig = options.originalFieldConfig ?? {
+    defaults: { color: { mode: 'palette-classic' } },
+    overrides: [],
+  };
   const pastedFieldConfig = { defaults: { color: { mode: 'fixed' }, custom: { lineWidth: 3 } }, overrides: [] };
 
   const pluginToLoad = getPanelPlugin({ id: 'timeseries', skipDataQuery: false });
@@ -563,7 +566,7 @@ async function setupWithPreExistingStyleChanges(options: SetupWithPreExistingSty
     key: 'panel-1',
     pluginId: 'timeseries',
     title: 'original title',
-    fieldConfig: originalFieldConfig,
+    fieldConfig: originalFieldConfig as any,
     $data: new SceneDataTransformer({
       transformations: [],
       $data: new SceneQueryRunner({
@@ -595,7 +598,7 @@ async function setupWithPreExistingStyleChanges(options: SetupWithPreExistingSty
         id: 1,
         type: 'timeseries',
         title: 'original title',
-        fieldConfig: originalFieldConfig as Dashboard['panels'][0]['fieldConfig'],
+        fieldConfig: originalFieldConfig as any,
         options: {},
         targets: [{ refId: 'A', datasource: { uid: 'ds1' } }],
         datasource: { uid: 'ds1' },

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -218,7 +218,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     const body = (this._layoutItemState as Record<string, unknown>)?.body;
     if (body instanceof Object && 'setState' in body) {
       (body as VizPanel).setState({
-        fieldConfig: initialPanel.fieldConfig ?? { defaults: {}, overrides: [] },
+        fieldConfig: (initialPanel.fieldConfig ?? { defaults: {}, overrides: [] }) as any,
       });
     }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -20,6 +20,7 @@ import {
   type VizPanel,
 } from '@grafana/scenes';
 import { type Panel } from '@grafana/schema';
+import { isDashboardV1Spec } from 'app/features/dashboard/api/utils';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
 import { getLastUsedDatasourceFromStorage } from 'app/features/dashboard/utils/dashboard';
 import { saveLibPanel } from 'app/features/library-panels/state/api';
@@ -188,6 +189,57 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   }
 
   /**
+   * Detects if the panel has unsaved changes that were made before entering panel edit
+   * (e.g., styles pasted from dashboard view). When detected, `isDirty` is set to true
+   * and `_layoutItemState` is updated so discard will correctly revert those changes.
+   */
+  private _detectPreExistingChanges(panel: VizPanel) {
+    const initialPanel = this._getInitialPanelSaveModel();
+    if (!initialPanel) {
+      return;
+    }
+
+    const currentPanelData = vizPanelToPanel(panel);
+    // Only compare fieldConfig — the only field that pastePanelStyles modifies
+    const hasFieldConfigChanges = !deepEqual(currentPanelData.fieldConfig, initialPanel.fieldConfig);
+
+    if (!hasFieldConfigChanges) {
+      return;
+    }
+
+    // Override _originalSaveModel so future dirty checks compare against the pre-paste fieldConfig
+    this._originalSaveModel = {
+      ...currentPanelData,
+      fieldConfig: initialPanel.fieldConfig ?? { defaults: {}, overrides: [] },
+    };
+
+    // Update the captured layout item state so that `onDiscard` correctly reverts the pasted fieldConfig.
+    // _layoutItemState is a shallow clone of the layout item state, so body is the original panel reference.
+    const body = (this._layoutItemState as Record<string, unknown>)?.body;
+    if (body instanceof Object && 'setState' in body) {
+      (body as VizPanel).setState({
+        fieldConfig: initialPanel.fieldConfig ?? { defaults: {}, overrides: [] },
+      });
+    }
+
+    this.setState({ isDirty: true });
+  }
+
+  /**
+   * Returns the panel's save model from before any unsaved edits were made to the dashboard.
+   * Returns undefined for V2 dashboards or when the panel is not found.
+   */
+  private _getInitialPanelSaveModel(): Panel | undefined {
+    const dashboard = getDashboardSceneFor(this);
+    const initialSaveModel = dashboard.getInitialSaveModel();
+    if (!initialSaveModel || !isDashboardV1Spec(initialSaveModel)) {
+      return undefined;
+    }
+    const panelId = getPanelIdForVizPanel(this.getPanel());
+    return initialSaveModel.panels?.find((p) => p.id === panelId);
+  }
+
+  /**
    * Useful for testing to turn on debounce
    */
   public debounceSaveModelDiff = true;
@@ -226,6 +278,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     if (this.state.isInitializing) {
       this.setOriginalState(this.state.panelRef);
       this._setupChangeDetection();
+      this._detectPreExistingChanges(panel);
       this._updateDataPane(plugin);
 
       // Listen for panel plugin changes


### PR DESCRIPTION
Fixes #121808

Found a few issues that were working together to make things worse — pageview events were firing on every React re-render instead of just when the URL actually changed, and the full URL (which can be 800KB+ for dashboards with lots of variable state) was being attached to every analytics event, not just pageviews. Also fixed a double-fire on initial load in the Rudderstack v3 backend where the constructor and the first pageview event both called `page()`.

The fix deduplicates pageview reporting by comparing URLs before firing, and caps URL length at 2KB in both the event payload and the shared event metadata.