### PR TITLE
Feature Toggles: Add cacheConfigUnifiedStorageMigration feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1771,7 +1771,7 @@ export interface FeatureToggles {
   */
   enableColorblindSafePanelOptions?: boolean;
   /**
-  * Enables cache config data migration to migrate cache configs to unified storage
+  * Enables cache configs data migration to unified storage
   * @default false
   */
   cacheConfigUnifiedStorageMigration?: boolean;

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1770,4 +1770,9 @@ export interface FeatureToggles {
   * @default false
   */
   enableColorblindSafePanelOptions?: boolean;
+  /**
+  * Enables cache config data migration to migrate cache configs to unified storage
+  * @default false
+  */
+  cacheConfigUnifiedStorageMigration?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2811,6 +2811,13 @@ var (
 			FrontendOnly: true,
 			Expression:   "false",
 		},
+		{
+			Name:        "cacheConfigUnifiedStorageMigration",
+			Description: "Enables cache config data migration to migrate cache configs to unified storage",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaBackendServicesSquad,
+			Expression:  "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2815,7 +2815,7 @@ var (
 			Name:        "cacheConfigUnifiedStorageMigration",
 			Description: "Enables cache config data migration to migrate cache configs to unified storage",
 			Stage:       FeatureStageExperimental,
-			Owner:       grafanaBackendServicesSquad,
+			Owner:       grafanaOperatorExperienceSquad,
 			Expression:  "false",
 		},
 	}

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2813,7 +2813,7 @@ var (
 		},
 		{
 			Name:            "cacheConfigUnifiedStorageMigration",
-			Description:     "Enables cache config data migration to migrate cache configs to unified storage",
+			Description:     "Enables cache configs data migration to unified storage",
 			Stage:           FeatureStageExperimental,
 			Owner:           grafanaOperatorExperienceSquad,
 			Expression:      "false",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2812,11 +2812,12 @@ var (
 			Expression:   "false",
 		},
 		{
-			Name:        "cacheConfigUnifiedStorageMigration",
-			Description: "Enables cache config data migration to migrate cache configs to unified storage",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaOperatorExperienceSquad,
-			Expression:  "false",
+			Name:            "cacheConfigUnifiedStorageMigration",
+			Description:     "Enables cache config data migration to migrate cache configs to unified storage",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaOperatorExperienceSquad,
+			Expression:      "false",
+			RequiresRestart: true,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -349,3 +349,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-01,clearPreviousFieldValues,experimental,@grafana/dataviz-squad,false,false,true
 2026-04-01,enableDatasourceMetaApiPluginLoading,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-04-02,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
+2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-backend-services-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -349,4 +349,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-01,clearPreviousFieldValues,experimental,@grafana/dataviz-squad,false,false,true
 2026-04-01,enableDatasourceMetaApiPluginLoading,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-04-02,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
-2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-backend-services-squad,false,false,false
+2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -349,4 +349,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-01,clearPreviousFieldValues,experimental,@grafana/dataviz-squad,false,false,true
 2026-04-01,enableDatasourceMetaApiPluginLoading,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-04-02,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
-2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,false,false
+2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -925,4 +925,8 @@ const (
 	// FlagQueryServiceQueryCaching
 	// Enables the query service to do query caching
 	FlagQueryServiceQueryCaching = "queryServiceQueryCaching"
+
+	// FlagCacheConfigUnifiedStorageMigration
+	// Enables cache config data migration to migrate cache configs to unified storage
+	FlagCacheConfigUnifiedStorageMigration = "cacheConfigUnifiedStorageMigration"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -927,6 +927,6 @@ const (
 	FlagQueryServiceQueryCaching = "queryServiceQueryCaching"
 
 	// FlagCacheConfigUnifiedStorageMigration
-	// Enables cache config data migration to migrate cache configs to unified storage
+	// Enables cache configs data migration to unified storage
 	FlagCacheConfigUnifiedStorageMigration = "cacheConfigUnifiedStorageMigration"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1159,16 +1159,17 @@
     {
       "metadata": {
         "name": "cacheConfigUnifiedStorageMigration",
-        "resourceVersion": "1775236893766",
+        "resourceVersion": "1775237110442",
         "creationTimestamp": "2026-04-03T17:15:03Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-03 17:21:33.766219 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-04-03 17:25:10.442998 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables cache config data migration to migrate cache configs to unified storage",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "requiresRestart": true,
         "expression": "false"
       }
     },

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1144,20 +1144,6 @@
     },
     {
       "metadata": {
-        "name": "cacheConfigDataMigration",
-        "resourceVersion": "1775236415505",
-        "creationTimestamp": "2026-04-03T17:13:35Z",
-        "deletionTimestamp": "2026-04-03T17:15:03Z"
-      },
-      "spec": {
-        "description": "Enables cache config data migration to move cache configuration to a new storage format",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-services-squad",
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
         "name": "cacheConfigUnifiedStorageMigration",
         "resourceVersion": "1775482512500",
         "creationTimestamp": "2026-04-03T17:15:03Z",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1159,14 +1159,14 @@
     {
       "metadata": {
         "name": "cacheConfigUnifiedStorageMigration",
-        "resourceVersion": "1775237110442",
+        "resourceVersion": "1775482512500",
         "creationTimestamp": "2026-04-03T17:15:03Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-03 17:25:10.442998 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-04-06 13:35:12.500052 +0000 UTC"
         }
       },
       "spec": {
-        "description": "Enables cache config data migration to migrate cache configs to unified storage",
+        "description": "Enables cache configs data migration to unified storage",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "requiresRestart": true,

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1144,6 +1144,36 @@
     },
     {
       "metadata": {
+        "name": "cacheConfigDataMigration",
+        "resourceVersion": "1775236415505",
+        "creationTimestamp": "2026-04-03T17:13:35Z",
+        "deletionTimestamp": "2026-04-03T17:15:03Z"
+      },
+      "spec": {
+        "description": "Enables cache config data migration to move cache configuration to a new storage format",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-services-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cacheConfigUnifiedStorageMigration",
+        "resourceVersion": "1775236722763",
+        "creationTimestamp": "2026-04-03T17:15:03Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-04-03 17:18:42.763848 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables cache config data migration to migrate cache configs to unified storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-services-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "cachingOptimizeSerializationMemoryUsage",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2023-10-12T16:56:49Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1159,16 +1159,16 @@
     {
       "metadata": {
         "name": "cacheConfigUnifiedStorageMigration",
-        "resourceVersion": "1775236722763",
+        "resourceVersion": "1775236893766",
         "creationTimestamp": "2026-04-03T17:15:03Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-03 17:18:42.763848 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-04-03 17:21:33.766219 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables cache config data migration to migrate cache configs to unified storage",
         "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-services-squad",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
         "expression": "false"
       }
     },


### PR DESCRIPTION
## Summary
- Add new experimental feature flag `cacheConfigUnifiedStorageMigration` to gate cache config data migration to unified storage for timing purposed to make sure querier switch to MT same time as when the migration happens
- Owner: `@grafana/grafana-operator-experience-squad
- Default: disabled

## Test plan
- [x] `make gen-feature-toggles` passes

Fixes: #https://github.com/grafana/grafana-operator-experience-squad/issues/1785

🤖 Generated with [Claude Code](https://claude.com/claude-code)