### PR TITLE
Federated stats: Remove dashboards and folders

### DIFF
--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -6,7 +6,6 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
-	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
@@ -17,20 +16,6 @@ import (
 type LegacyStatsGetter struct {
 	SQL legacysql.LegacyDatabaseProvider
 	Cfg *setting.Cfg
-}
-
-func (s *LegacyStatsGetter) isDashboardsFallbackDisabled() bool {
-	if s.Cfg == nil {
-		return false
-	}
-	return s.Cfg.UnifiedStorage["dashboards.dashboard.grafana.app"].DualWriterMode == grafanarest.Mode5
-}
-
-func (s *LegacyStatsGetter) isFoldersFallbackDisabled() bool {
-	if s.Cfg == nil {
-		return false
-	}
-	return s.Cfg.UnifiedStorage["folders.folder.grafana.app"].DualWriterMode == grafanarest.Mode5
 }
 
 func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
@@ -78,22 +63,6 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		err = fn("alert_rule", "org_id=? AND namespace_uid=?", group, "alertrules", false)
 		if err != nil {
 			return err
-		}
-
-		// Legacy dashboard table
-		if !s.isDashboardsFallbackDisabled() {
-			err = fn("dashboard", "org_id=? AND folder_uid=? AND is_folder=false", group, "dashboards", true)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Legacy folder table
-		if !s.isFoldersFallbackDisabled() {
-			err = fn("folder", "org_id=? AND parent_uid=?", group, "folders", true)
-			if err != nil {
-				return err
-			}
 		}
 
 		// Legacy library_elements table

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
-	rest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -17,7 +16,6 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -78,16 +76,6 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 		SQL: legacysql.NewDatabaseProvider(db),
 	}
 
-	// Helper to create a cfg with specific dual-writer modes
-	cfgWithModes := func(dashboardsMode, foldersMode int) *setting.Cfg {
-		return &setting.Cfg{
-			UnifiedStorage: map[string]setting.UnifiedStorageConfig{
-				"dashboards.dashboard.grafana.app": {DualWriterMode: rest.DualWriterMode(dashboardsMode)},
-				"folders.folder.grafana.app":       {DualWriterMode: rest.DualWriterMode(foldersMode)},
-			},
-		}
-	}
-
 	t.Run("GetStatsForFolder1", func(t *testing.T) {
 		ctx := context.Background()
 		ctx = request.WithNamespace(ctx, "default")
@@ -106,110 +94,9 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 			},
 			{
 				"group": "sql-fallback",
-				"resource": "dashboards"
-			},
-			{
-				"group": "sql-fallback",
-				"resource": "folders",
-				"count": 1
-			},
-			{
-				"group": "sql-fallback",
 				"resource": "library_elements"
 			}
 		]`, string(jj))
-	})
-
-	// New tests to verify per-resource fallback disabling
-	t.Run("GetStatsForFolder1_DisableDashboardsFallback", func(t *testing.T) {
-		ctx := context.Background()
-		ctx = request.WithNamespace(ctx, "default")
-
-		store := &LegacyStatsGetter{
-			SQL: legacysql.NewDatabaseProvider(db),
-			Cfg: cfgWithModes(5, 0), // dashboards Mode5, folders Mode0
-		}
-
-		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
-			Namespace: "default",
-			Folder:    folder1UID,
-		})
-		require.NoError(t, err)
-
-		var hasDashboards, hasFolders bool
-		for _, s := range stats.Stats {
-			if s.Resource == "dashboards" {
-				hasDashboards = true
-			}
-			if s.Resource == "folders" {
-				hasFolders = true
-				require.EqualValues(t, 1, s.Count)
-			}
-		}
-		require.False(t, hasDashboards, "dashboards stats should be disabled")
-		require.True(t, hasFolders, "folders stats should be present")
-	})
-
-	t.Run("GetStatsForFolder1_DisableFoldersFallback", func(t *testing.T) {
-		ctx := context.Background()
-		ctx = request.WithNamespace(ctx, "default")
-
-		store := &LegacyStatsGetter{
-			SQL: legacysql.NewDatabaseProvider(db),
-			Cfg: cfgWithModes(0, 5), // dashboards Mode0, folders Mode5
-		}
-
-		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
-			Namespace: "default",
-			Folder:    folder1UID,
-		})
-		require.NoError(t, err)
-
-		var hasDashboards, hasFolders bool
-		for _, s := range stats.Stats {
-			if s.Resource == "folders" {
-				hasFolders = true
-			}
-		}
-		require.False(t, hasDashboards, "dashboards stats should be present")
-		require.False(t, hasFolders, "folders stats should be disabled")
-	})
-
-	t.Run("GetStatsForFolder1_DisableBothFallbacks", func(t *testing.T) {
-		ctx := context.Background()
-		ctx = request.WithNamespace(ctx, "default")
-
-		store := &LegacyStatsGetter{
-			SQL: legacysql.NewDatabaseProvider(db),
-			Cfg: cfgWithModes(5, 5), // both Mode5
-		}
-
-		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
-			Namespace: "default",
-			Folder:    folder1UID,
-		})
-		require.NoError(t, err)
-
-		var hasDashboards, hasFolders bool
-		var hasAlertRules, hasLibrary bool
-		for _, s := range stats.Stats {
-			if s.Resource == "dashboards" {
-				hasDashboards = true
-			}
-			if s.Resource == "folders" {
-				hasFolders = true
-			}
-			if s.Resource == "alertrules" {
-				hasAlertRules = true
-			}
-			if s.Resource == "library_elements" {
-				hasLibrary = true
-			}
-		}
-		require.False(t, hasDashboards, "dashboards stats should be disabled")
-		require.False(t, hasFolders, "folders stats should be disabled")
-		require.True(t, hasAlertRules, "alertrules should still be present")
-		require.True(t, hasLibrary, "library_elements should still be present")
 	})
 
 	t.Run("GetStatsForFolder2", func(t *testing.T) {
@@ -231,63 +118,8 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 			},
 			{
 				"group": "sql-fallback",
-				"resource": "dashboards"
-			},
-			{
-				"group": "sql-fallback",
-				"resource": "folders"
-			},
-			{
-				"group": "sql-fallback",
 				"resource": "library_elements"
 			}
 		]`, string(jj))
-	})
-
-	// Verify that changing the cfg mode dynamically affects the stats query.
-	// This is the key behavior for the fix: auto-migration sets Mode5 after the
-	// LegacyStatsGetter is created, and the getter must pick up the change.
-	t.Run("DynamicModeChange", func(t *testing.T) {
-		ctx := context.Background()
-		ctx = request.WithNamespace(ctx, "default")
-
-		cfg := cfgWithModes(0, 0) // start with Mode0 for both
-		store := &LegacyStatsGetter{
-			SQL: legacysql.NewDatabaseProvider(db),
-			Cfg: cfg,
-		}
-
-		// With Mode0, legacy dashboard stats should be returned
-		stats, err := store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
-			Namespace: "default",
-			Folder:    folder1UID,
-		})
-		require.NoError(t, err)
-		var hasDashboards bool
-		for _, s := range stats.Stats {
-			if s.Resource == "dashboards" {
-				hasDashboards = true
-			}
-		}
-		require.True(t, hasDashboards, "dashboards stats should be present in Mode0")
-
-		// Simulate auto-migration setting Mode5 after client creation
-		cfg.UnifiedStorage["dashboards.dashboard.grafana.app"] = setting.UnifiedStorageConfig{
-			DualWriterMode: rest.Mode5,
-		}
-
-		// Now legacy dashboard stats should be skipped
-		stats, err = store.GetStats(ctx, &resourcepb.ResourceStatsRequest{
-			Namespace: "default",
-			Folder:    folder1UID,
-		})
-		require.NoError(t, err)
-		hasDashboards = false
-		for _, s := range stats.Stats {
-			if s.Resource == "dashboards" {
-				hasDashboards = true
-			}
-		}
-		require.False(t, hasDashboards, "dashboards stats should be disabled after Mode5 is set")
 	})
 }


### PR DESCRIPTION
Folders & dashboards can no longer be in the legacy tables as the source of truth, so we can remove the legacy federated stats check here