### PR TITLE
Chore: Add Graphite to externalized DS reminders

### DIFF
--- a/.github/workflows/externalized-datasources-reminder.yml
+++ b/.github/workflows/externalized-datasources-reminder.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - "public/app/plugins/datasource/cloudwatch/**"
       - "public/app/plugins/datasource/cloud-monitoring/**"
+      - "public/app/plugins/datasource/graphite/**"
       - "public/app/plugins/datasource/zipkin/**"
       - "public/app/plugins/datasource/opentsdb/**"
       - "pkg/tsdb/cloudwatch/**"
       - "pkg/tsdb/cloud-monitoring/**"
+      - "pkg/tsdb/graphite/**"
       - "pkg/tsdb/zipkin/**"
       - "pkg/tsdb/opentsdb/**"
 


### PR DESCRIPTION
Added Graphite paths to the externalized datasources reminder workflow