### PR TITLE
Provisioning: Fix panic on type assertion in fileformat parsing

### DIFF
--- a/pkg/registry/apis/provisioning/resources/fileformat.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat.go
@@ -45,7 +45,11 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 			return nil, nil, "", err
 		}
 		// Strip BOMs from all string values in the parsed JSON
-		value = util.StripBOMFromInterface(value).(map[string]any)
+		stripped, ok := util.StripBOMFromInterface(value).(map[string]any)
+		if !ok {
+			return nil, nil, "", fmt.Errorf("unexpected type after BOM stripping")
+		}
+		value = stripped
 	} else {
 		return nil, nil, "", fmt.Errorf("unable to read file")
 	}
@@ -60,11 +64,19 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 		logging.FromContext(ctx).Debug("TODO... likely a provisioning",
 			"apiVersion", value["apiVersion"],
 			"kind", value["Kind"])
-		gv, err := schema.ParseGroupVersion(value["apiVersion"].(string))
+		apiVersion, ok := value["apiVersion"].(string)
+		if !ok {
+			return nil, nil, "", fmt.Errorf("invalid apiVersion: not a string")
+		}
+		gv, err := schema.ParseGroupVersion(apiVersion)
 		if err != nil {
 			return nil, nil, "", fmt.Errorf("invalid apiVersion")
 		}
-		gvk := gv.WithKind(value["Kind"].(string))
+		kind, ok := value["Kind"].(string)
+		if !ok {
+			return nil, nil, "", fmt.Errorf("invalid Kind: not a string")
+		}
+		gvk := gv.WithKind(kind)
 		return &unstructured.Unstructured{Object: value}, &gvk, "", nil
 	}
 
@@ -138,7 +150,11 @@ func DecodeYAMLObject(input io.Reader) (*unstructured.Unstructured, *schema.Grou
 	val, ok := obj.(*unstructured.Unstructured)
 	if ok {
 		// Strip BOMs from all string values in the parsed object
-		val.Object = util.StripBOMFromInterface(val.Object).(map[string]any)
+		strippedObj, ok := util.StripBOMFromInterface(val.Object).(map[string]any)
+		if !ok {
+			return nil, gvk, fmt.Errorf("unexpected type after BOM stripping")
+		}
+		val.Object = strippedObj
 		return val, gvk, err
 	}
 
@@ -147,6 +163,10 @@ func DecodeYAMLObject(input io.Reader) (*unstructured.Unstructured, *schema.Grou
 		return nil, gvk, err
 	}
 	// Strip BOMs from all string values in the converted object
-	unstructuredMap = util.StripBOMFromInterface(unstructuredMap).(map[string]any)
+	strippedMap, ok := util.StripBOMFromInterface(unstructuredMap).(map[string]any)
+	if !ok {
+		return nil, gvk, fmt.Errorf("unexpected type after BOM stripping")
+	}
+	unstructuredMap = strippedMap
 	return &unstructured.Unstructured{Object: unstructuredMap}, gvk, err
 }

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -262,6 +262,32 @@ spec:
 	})
 }
 
+func TestReadClassicResource_TypeAssertions(t *testing.T) {
+	t.Run("numeric apiVersion does not panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`{"apiVersion": 42}`),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a string")
+	})
+
+	t.Run("numeric Kind does not panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`{"apiVersion": "playlist.grafana.app/v0alpha1", "Kind": 99}`),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a string")
+	})
+
+	t.Run("float64 apiVersion does not panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`{"apiVersion": 1.5}`),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not a string")
+	})
+}
+
 func TestParseFileResource(t *testing.T) {
 	t.Run("k8s resource parsed directly", func(t *testing.T) {
 		info := &repository.FileInfo{


### PR DESCRIPTION
**What is this PR?**

Fixes unsafe type assertions in `pkg/registry/apis/provisioning/resources/fileformat.go` that caused runtime panics of the form `interface conversion: interface {} is float64, not string`.

**Why?**

When JSON is decoded into `map[string]interface{}`, numeric values are decoded as `float64`. Direct type assertions like `value["apiVersion"].(string)` panic at runtime when the value is not a string. This was triggered in production and caused `KubePodCrashLooping` for `grafana-apps`.

Related incident: https://ops.grafana-ops.net/a/grafana-irm-app/alert-groups/IUE8AI1NMAFUF
Related logs: https://ops.grafana-ops.net/goto/dfi06q619yygwe?orgId=stacks-27821

**Changes**

- Added `ok` checks for all unsafe type assertions in `fileformat.go` (`apiVersion`, `Kind`, and `StripBOMFromInterface` return value)
- Added tests covering the panic scenarios (numeric/float64 `apiVersion` and `Kind`)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---
*PR description generated by Claude Code*