### PR TITLE
CI: Disable splashScreen toggle in verify-packages workflow

### DIFF
--- a/.github/workflows/release-verify-packages.yml
+++ b/.github/workflows/release-verify-packages.yml
@@ -84,6 +84,7 @@ jobs:
           "$GRAFANA_HOME/bin/grafana" server \
             --homepath="$GRAFANA_HOME" \
             cfg:server.http_port=3001 \
+            cfg:feature_toggles.splashScreen=false \
             > /tmp/release-verify-deb.log 2>&1 &
           echo "$!" > /tmp/release-verify-deb.pid
 
@@ -184,6 +185,7 @@ jobs:
           "$GRAFANA_HOME/bin/grafana" server \
             --homepath="$GRAFANA_HOME" \
             cfg:server.http_port=3001 \
+            cfg:feature_toggles.splashScreen=false \
             > /tmp/release-verify-rpm.log 2>&1 &
           echo "$!" > /tmp/release-verify-rpm.pid
 
@@ -271,7 +273,7 @@ jobs:
           echo "IMAGE_UNDER_TEST=$IMAGE" >> "$GITHUB_ENV"
 
       - name: Run Docker image under test
-        run: docker run -d --name grafana-verify -p 3000:3000 "${IMAGE_UNDER_TEST}"
+        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_splashScreen=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps
@@ -358,7 +360,7 @@ jobs:
           echo "IMAGE_UNDER_TEST=$IMAGE" >> "$GITHUB_ENV"
 
       - name: Run Docker Ubuntu image under test
-        run: docker run -d --name grafana-verify -p 3000:3000 "${IMAGE_UNDER_TEST}"
+        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_splashScreen=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps


### PR DESCRIPTION
## Summary
- PR #121647 defaulted the `splashScreen` feature toggle to `true` but only added the `false` override to `scripts/grafana-server/custom.ini` (used by pre-merge e2e tests)
- The verify-packages workflow starts Grafana from built deb/rpm/docker packages without that custom.ini, so the splash modal appears and blocks playwright acceptance tests
- Adds `splashScreen=false` override to all 4 server start locations (deb, rpm, docker, docker-ubuntu) in the verify-packages workflow

## Test plan
- [ ] Verify the `verify packages (linux-amd64)` workflow passes with this change
- [ ] Confirm splash screen modal no longer blocks playwright acceptance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)