### PR TITLE
SQL: Normalize Wrapped Driver Names In Annotation Migration

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/tag"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -776,6 +778,87 @@ func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
 			}
 			return result.DashboardUID != nil && *result.DashboardUID == "test-run-uid"
 		}, 5*time.Second, 100*time.Millisecond, "dashboard_uid should be populated when migration runs")
+	})
+
+	t.Run("RunDashboardUIDMigrations should normalize wrapped driver names", func(t *testing.T) {
+		driverName := ""
+		expectedUID := ""
+		title := ""
+
+		switch {
+		case db.IsTestDbMySQL():
+			driverName = migrator.MySQL + "WithHooks"
+			expectedUID = "test-wrapped-mysql-uid"
+			title = "Test Wrapped MySQL Driver"
+		case db.IsTestDbPostgres():
+			driverName = migrator.Postgres + "WithHooks"
+			expectedUID = "test-wrapped-postgres-uid"
+			title = "Test Wrapped Postgres Driver"
+		default:
+			t.Skip("wrapped driver regression test requires mysql or postgres")
+		}
+
+		l := log.New("annotation.test")
+
+		dashboard := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+			UserID: 1,
+			OrgID:  1,
+			Dashboard: simplejson.NewFromAny(map[string]any{
+				"title": title,
+				"uid":   expectedUID,
+			}),
+		})
+
+		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), nil)
+		annotation := &annotations.Item{
+			OrgID:        1,
+			UserID:       1,
+			DashboardID:  dashboard.ID,
+			DashboardUID: dashboard.UID,
+			Text:         "test wrapped driver migration",
+			Type:         "alert",
+			Epoch:        100,
+		}
+		err := tempStore.Add(context.Background(), annotation)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			err := tempStore.Delete(context.Background(), &annotations.DeleteParams{ID: annotation.ID, OrgID: 1})
+			assert.NoError(t, err)
+		})
+
+		err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+			_, err := sess.Exec("UPDATE annotation SET dashboard_uid = NULL WHERE id = ?", annotation.ID)
+			return err
+		})
+		require.NoError(t, err)
+
+		sess := sql.GetEngine().NewSession()
+		t.Cleanup(func() {
+			sess.Close()
+		})
+
+		err = migrations.RunDashboardUIDMigrations(sess, driverName, l)
+		require.NoError(t, err)
+
+		var result struct {
+			DashboardUID *string `xorm:"dashboard_uid"`
+		}
+		err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+			has, err := sess.Table("annotation").
+				Where("id = ?", annotation.ID).
+				Get(&result)
+			if err != nil {
+				return err
+			}
+			if !has {
+				return fmt.Errorf("annotation not found")
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result.DashboardUID)
+		assert.Equal(t, expectedUID, *result.DashboardUID)
 	})
 }
 

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -250,6 +250,8 @@ func (m *SetDashboardUIDMigration) Exec(sess *xorm.Session, mg *Migrator) error 
 }
 
 func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log.Logger) error {
+	driverName = NewDialect(driverName).DriverName()
+
 	batchSize := 5000
 	if size := os.Getenv("ANNOTATION_DASHBOARD_UID_MIGRATION_BATCH_SIZE"); size != "" {
 		n, err := strconv.ParseInt(size, 10, 64)


### PR DESCRIPTION
**What is this feature?**

This PR fixes annotation `dashboard_uid` backfill when Grafana runs with instrumented SQL drivers such as `mysqlWithHooks` or `postgresWithHooks`.

`RunDashboardUIDMigrations(...)` now normalizes the incoming driver name before selecting the dialect-specific SQL branch:

- `mysqlWithHooks` -> `mysql`
- `postgresWithHooks` -> `postgres`

This ensures the migration uses the correct existing MySQL/Postgres query instead of falling back to the generic SQL path.

**Why do we need this feature?**

This fixes a bug in the annotation startup migration.

When `[database] instrument_queries = true`, Grafana wraps the configured DB driver name:
- `mysql` becomes `mysqlWithHooks`
- `postgres` becomes `postgresWithHooks`

Before this change, `RunDashboardUIDMigrations(...)` switched on the raw driver name. That meant wrapped driver names did not match the `MySQL` or `Postgres` cases and instead fell through to the default SQL path.

In my MySQL setup this caused the annotation `dashboard_uid` startup migration to fail with:

```text
Error 1235 (42000): This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'
```

**Who is this feature for?**

Grafana operators and developers running:
- MySQL or Postgres as the primary database
- `[database] instrument_queries = true`

**Special notes for your reviewer:**

Test coverage:
- Added an integration regression test in `pkg/services/annotations/annotationsimpl/xorm_store_test.go`.
- The test:
  - creates a dashboard
  - creates an annotation linked to that dashboard
  - sets `annotation.dashboard_uid = NULL`
  - calls `RunDashboardUIDMigrations(...)` with a wrapped driver name
  - verifies `dashboard_uid` is backfilled correctly
- It covers:
  - `mysqlWithHooks` on MySQL test runs
  - `postgresWithHooks` on Postgres test runs
- Other backends already use the default SQL path and skip switch on DriverName so we don't need to test them.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to the What's New doc.
