### PR TITLE
CI: Set splashcreen feature toggle off in release smoke test

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -100,7 +100,7 @@ jobs:
               workflow = 'release-build-pro.yml';
             }
 
-            if (REF == 'main' && SOURCE_EVENT == 'schedule') {
+            if (SOURCE_EVENT == 'schedule') {
               workflow = 'release-build-nightly.yml';
             }
 

--- a/.github/workflows/release-verify-packages.yml
+++ b/.github/workflows/release-verify-packages.yml
@@ -273,7 +273,7 @@ jobs:
           echo "IMAGE_UNDER_TEST=$IMAGE" >> "$GITHUB_ENV"
 
       - name: Run Docker image under test
-        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_SPLASHSCREEN=false "${IMAGE_UNDER_TEST}"
+        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_splashScreen=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps
@@ -360,7 +360,7 @@ jobs:
           echo "IMAGE_UNDER_TEST=$IMAGE" >> "$GITHUB_ENV"
 
       - name: Run Docker Ubuntu image under test
-        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_SPLASHSCREEN=false "${IMAGE_UNDER_TEST}"
+        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_splashScreen=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps

--- a/.github/workflows/release-verify-packages.yml
+++ b/.github/workflows/release-verify-packages.yml
@@ -84,6 +84,7 @@ jobs:
           "$GRAFANA_HOME/bin/grafana" server \
             --homepath="$GRAFANA_HOME" \
             cfg:server.http_port=3001 \
+            cfg:feature_toggles.splashScreen=false \
             > /tmp/release-verify-deb.log 2>&1 &
           echo "$!" > /tmp/release-verify-deb.pid
 
@@ -184,6 +185,7 @@ jobs:
           "$GRAFANA_HOME/bin/grafana" server \
             --homepath="$GRAFANA_HOME" \
             cfg:server.http_port=3001 \
+            cfg:feature_toggles.splashScreen=false \
             > /tmp/release-verify-rpm.log 2>&1 &
           echo "$!" > /tmp/release-verify-rpm.pid
 
@@ -271,7 +273,7 @@ jobs:
           echo "IMAGE_UNDER_TEST=$IMAGE" >> "$GITHUB_ENV"
 
       - name: Run Docker image under test
-        run: docker run -d --name grafana-verify -p 3000:3000 "${IMAGE_UNDER_TEST}"
+        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_SPLASHSCREEN=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps
@@ -358,7 +360,7 @@ jobs:
           echo "IMAGE_UNDER_TEST=$IMAGE" >> "$GITHUB_ENV"
 
       - name: Run Docker Ubuntu image under test
-        run: docker run -d --name grafana-verify -p 3000:3000 "${IMAGE_UNDER_TEST}"
+        run: docker run -d --name grafana-verify -p 3000:3000 -e GF_FEATURE_TOGGLES_SPLASHSCREEN=false "${IMAGE_UNDER_TEST}"
 
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps


### PR DESCRIPTION
Broken by this commit: https://github.com/grafana/grafana/commit/f887733a0349aab9761994d31f9bbaeb23bbc3a7 which enabled a feature toggle on by default. However, to get around the failing e2e tests, the splash screen feature toggle is was disabled, but wasn't done for the release smoke tests.