### PR TITLE
OAuth: allow regexp in org mapping

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -165,7 +165,7 @@ func (s *SocialAzureAD) UserInfo(ctx context.Context, client *http.Client, token
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -364,7 +364,7 @@ func (s *SocialGenericOAuth) extractUserGroups(userInfo *social.BasicUserInfo, d
 // postProcessUserInfo handles post-processing of user info (org roles, private email, etc.)
 func (s *SocialGenericOAuth) postProcessUserInfo(ctx context.Context, client *http.Client, userInfo *social.BasicUserInfo, externalOrgs []string) error {
 	if !s.info.SkipOrgRoleSync {
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, userInfo.Role)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, userInfo.Role)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -353,7 +353,7 @@ func (s *SocialGithub) UserInfo(ctx context.Context, client *http.Client, token 
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/gitlab_oauth.go
+++ b/pkg/login/social/connectors/gitlab_oauth.go
@@ -224,7 +224,7 @@ func (s *SocialGitlab) UserInfo(ctx context.Context, client *http.Client, token 
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -178,7 +178,7 @@ func (s *SocialGoogle) UserInfo(ctx context.Context, client *http.Client, token 
 			userInfo.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, userInfo.Groups, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/grafana_com_oauth.go
+++ b/pkg/login/social/connectors/grafana_com_oauth.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	ssoModels "github.com/grafana/grafana/pkg/services/ssosettings/models"
 	"github.com/grafana/grafana/pkg/services/ssosettings/validation"
@@ -163,7 +162,7 @@ func (s *SocialGrafanaCom) UserInfo(ctx context.Context, client *http.Client, _ 
 	}
 
 	if !s.info.SkipOrgRoleSync {
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), nil, identity.RoleType(data.Role))
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, NewMappingConfiguration([]MappingEntry{}, false), nil, identity.RoleType(data.Role))
 	}
 
 	if !s.isOrganizationMember(data.Orgs) {

--- a/pkg/login/social/connectors/okta_oauth.go
+++ b/pkg/login/social/connectors/okta_oauth.go
@@ -194,7 +194,7 @@ func (s *SocialOkta) UserInfo(ctx context.Context, client *http.Client, token *o
 			return nil, err
 		}
 
-		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, directlyMappedRole)
+		userInfo.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, directlyMappedRole)
 		if s.info.RoleAttributeStrict && len(userInfo.OrgRoles) == 0 {
 			return nil, errRoleAttributeStrictViolation.Errorf("could not evaluate any valid roles using IdP provided data")
 		}

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -28,7 +28,7 @@ type OrgRoleMapper struct {
 }
 
 // MappingConfiguration represents the mapping configuration from external orgs to Grafana orgs and roles.
-// orgMapping: mapping from external orgs to Grafana orgs and roles
+// entries: a list of mappings associating a potential external org to a Grafana org and role
 // strictRoleMapping: if true, the mapper ensures that the evaluated role from orgMapping or the directlyMappedRole is a valid role, otherwise it will return nil.
 type MappingConfiguration struct {
 	entries           []MappingEntry
@@ -42,6 +42,15 @@ func NewMappingConfiguration(entries []MappingEntry, strictRoleMapping bool) Map
 	}
 }
 
+// MappingEntry represents a mapping from an external claim to a Grafana org and role
+// The source of the mapping can be a regexp, in which case the Grafana org and role will be expanded with
+// capture groups found by matching the source against the user informatoin during login
+// externalClaim: the external claim to associate. Kept as a string alongside the pattern in case
+// it is a special case or not a valid regexp
+// externalClaimPattern: a compiled regexp from the externalClaim. If not nit, it will be used to expand the associated
+// Grafana org and role
+// mappedOrgTemplate: the Grafana org that should be given in case of a match.
+// mappedRoleTemplate: the Grafana role that should be given in case of a match.
 type MappingEntry struct {
 	externalClaim        string
 	externalClaimPattern *regexp.Regexp
@@ -79,12 +88,12 @@ func (m *OrgRoleMapper) MapOrgRoles(
 	externalOrgs []string,
 	directlyMappedRole org.RoleType,
 ) map[int64]org.RoleType {
-	if len(mappingCfg.entries) == 0 {
+	orgMapping := m.resolveOrgMappings(ctx, externalOrgs, mappingCfg)
+	if len(orgMapping) == 0 {
 		// Org mapping is not configured
 		return m.getDefaultOrgMapping(mappingCfg.strictRoleMapping, directlyMappedRole)
 	}
 
-	orgMapping := m.resolveOrgMappings(ctx, externalOrgs, mappingCfg)
 	userOrgRoles := getMappedOrgRoles(externalOrgs, orgMapping)
 
 	if err := m.handleGlobalOrgMapping(userOrgRoles); err != nil {
@@ -116,26 +125,24 @@ func (m *OrgRoleMapper) resolveOrgMappings(ctx context.Context, externalOrgs []s
 	for _, input := range externalOrgs {
 		for _, entry := range mappingConfiguration.entries {
 			source := entry.externalClaim
-			var mappedOrg string
-			var mappedRole string
+			mappedOrg := entry.mappedOrgTemplate
+			mappedRole := entry.mappedRoleTemplate
 
 			if entry.externalClaimPattern != nil {
 				match := entry.externalClaimPattern.FindStringSubmatchIndex(input)
-				mappedOrg = string(entry.externalClaimPattern.ExpandString(nil, entry.mappedOrgTemplate, input, match))
-				mappedRole = string(entry.externalClaimPattern.ExpandString(nil, entry.mappedRoleTemplate, input, match))
-				source = input
-			} else {
-				mappedOrg = entry.mappedOrgTemplate
-				mappedRole = entry.mappedRoleTemplate
+				if match != nil {
+					mappedOrg = string(entry.externalClaimPattern.ExpandString(nil, entry.mappedOrgTemplate, input, match))
+					mappedRole = string(entry.externalClaimPattern.ExpandString(nil, entry.mappedRoleTemplate, input, match))
+					source = input
+				}
 			}
-			fmt.Printf("mappedOrg: %s\n", mappedOrg)
-			fmt.Printf("mappedRole: %s\n", mappedRole)
 
 			orgId, err := m.getOrgIDForInternalMapping(ctx, mappedOrg)
 			if err != nil {
 				m.logger.Warn("Could not fetch OrgID. Skipping.", "err", err, "mapping", fmt.Sprintf("%v", entry), "org", mappedOrg)
 				if mappingConfiguration.strictRoleMapping {
 					// Return empty mapping if at least one org name cannot be resolved when roleStrict is enabled
+					m.logger.Warn("Skipping org mapping due to missing org role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", entry), "org", mappedOrg)
 					return map[string]map[int64]org.RoleType{}
 				}
 				continue
@@ -159,7 +166,6 @@ func (m *OrgRoleMapper) resolveOrgMappings(ctx context.Context, externalOrgs []s
 		}
 	}
 
-	fmt.Printf("%+v\n", res)
 	return res
 }
 
@@ -234,6 +240,7 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 
 		if len(kv) < 3 {
 			if roleStrict {
+				m.logger.Warn("Skipping org mapping due to missing role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", v))
 				return NewMappingConfiguration([]MappingEntry{}, roleStrict)
 			}
 			roleTemplate = string(org.RoleViewer)

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,14 +31,30 @@ type OrgRoleMapper struct {
 // orgMapping: mapping from external orgs to Grafana orgs and roles
 // strictRoleMapping: if true, the mapper ensures that the evaluated role from orgMapping or the directlyMappedRole is a valid role, otherwise it will return nil.
 type MappingConfiguration struct {
-	orgMapping        map[string]map[int64]org.RoleType
+	entries           []MappingEntry
 	strictRoleMapping bool
 }
 
-func NewMappingConfiguration(orgMapping map[string]map[int64]org.RoleType, strictRoleMapping bool) MappingConfiguration {
+func NewMappingConfiguration(entries []MappingEntry, strictRoleMapping bool) MappingConfiguration {
 	return MappingConfiguration{
-		orgMapping,
+		entries,
 		strictRoleMapping,
+	}
+}
+
+type MappingEntry struct {
+	externalClaim        string
+	externalClaimPattern *regexp.Regexp
+	mappedOrgTemplate    string
+	mappedRoleTemplate   string
+}
+
+func NewMappingEntry(externalClaim string, externalClaimPattern *regexp.Regexp, mappedOrgTemplate string, mappedRoleTemplate string) MappingEntry {
+	return MappingEntry{
+		externalClaim,
+		externalClaimPattern,
+		mappedOrgTemplate,
+		mappedRoleTemplate,
 	}
 }
 
@@ -57,16 +74,18 @@ func ProvideOrgRoleMapper(cfg *setting.Cfg, orgService org.Service) *OrgRoleMapp
 //
 // directlyMappedRole: role that is directly mapped to the user (ex: through `role_attribute_path`)
 func (m *OrgRoleMapper) MapOrgRoles(
+	ctx context.Context,
 	mappingCfg MappingConfiguration,
 	externalOrgs []string,
 	directlyMappedRole org.RoleType,
 ) map[int64]org.RoleType {
-	if len(mappingCfg.orgMapping) == 0 {
+	if len(mappingCfg.entries) == 0 {
 		// Org mapping is not configured
 		return m.getDefaultOrgMapping(mappingCfg.strictRoleMapping, directlyMappedRole)
 	}
 
-	userOrgRoles := getMappedOrgRoles(externalOrgs, mappingCfg.orgMapping)
+	orgMapping := m.resolveOrgMappings(ctx, externalOrgs, mappingCfg)
+	userOrgRoles := getMappedOrgRoles(externalOrgs, orgMapping)
 
 	if err := m.handleGlobalOrgMapping(userOrgRoles); err != nil {
 		// Cannot map global org roles, return nil (prevent resetting asignments)
@@ -90,6 +109,58 @@ func (m *OrgRoleMapper) MapOrgRoles(
 	}
 
 	return userOrgRoles
+}
+
+func (m *OrgRoleMapper) resolveOrgMappings(ctx context.Context, externalOrgs []string, mappingConfiguration MappingConfiguration) map[string]map[int64]org.RoleType {
+	res := map[string]map[int64]org.RoleType{}
+	for _, input := range externalOrgs {
+		for _, entry := range mappingConfiguration.entries {
+			source := entry.externalClaim
+			var mappedOrg string
+			var mappedRole string
+
+			if entry.externalClaimPattern != nil {
+				match := entry.externalClaimPattern.FindStringSubmatchIndex(input)
+				mappedOrg = string(entry.externalClaimPattern.ExpandString(nil, entry.mappedOrgTemplate, input, match))
+				mappedRole = string(entry.externalClaimPattern.ExpandString(nil, entry.mappedRoleTemplate, input, match))
+				source = input
+			} else {
+				mappedOrg = entry.mappedOrgTemplate
+				mappedRole = entry.mappedRoleTemplate
+			}
+			fmt.Printf("mappedOrg: %s\n", mappedOrg)
+			fmt.Printf("mappedRole: %s\n", mappedRole)
+
+			orgId, err := m.getOrgIDForInternalMapping(ctx, mappedOrg)
+			if err != nil {
+				m.logger.Warn("Could not fetch OrgID. Skipping.", "err", err, "mapping", fmt.Sprintf("%v", entry), "org", mappedOrg)
+				if mappingConfiguration.strictRoleMapping {
+					// Return empty mapping if at least one org name cannot be resolved when roleStrict is enabled
+					return map[string]map[int64]org.RoleType{}
+				}
+				continue
+			}
+			if res[source] == nil {
+				res[source] = map[int64]org.RoleType{}
+			}
+			role := org.RoleType(mappedRole)
+			if role.IsValid() {
+				res[source][int64(orgId)] = role
+			} else {
+				if mappingConfiguration.strictRoleMapping {
+					// Return empty mapping if at least one org mapping is invalid
+					m.logger.Warn("Skipping org mapping due to invalid role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", entry), "role", mappedRole)
+					return map[string]map[int64]org.RoleType{}
+				} else {
+					// Default to Viewer otherwise
+					res[source][int64(orgId)] = org.RoleViewer
+				}
+			}
+		}
+	}
+
+	fmt.Printf("%+v\n", res)
+	return res
 }
 
 func (m *OrgRoleMapper) getDefaultOrgMapping(strictRoleMapping bool, directlyMappedRole org.RoleType) map[int64]org.RoleType {
@@ -136,47 +207,48 @@ func (m *OrgRoleMapper) handleGlobalOrgMapping(orgRoles map[int64]org.RoleType) 
 }
 
 // ParseOrgMappingSettings parses the `org_mapping` setting and returns an internal representation of the mapping.
-// If the roleStrict is enabled, the mapping should contain a valid role for each org.
-// FIXME: Consider introducing a struct to represent the org mapping settings
+// If the roleStrict is enabled, the mapping should contain a role for each org, and any parsing failure will cause the
+// entire result to be empty
 func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []string, roleStrict bool) MappingConfiguration {
-	res := map[string]map[int64]org.RoleType{}
+	entries := []MappingEntry{}
 
 	for _, v := range mappings {
 		kv := splitOrgMapping(v)
 		if !isValidOrgMappingFormat(kv) {
 			m.logger.Error("Skipping org mapping due to invalid format.", "mapping", fmt.Sprintf("%v", v))
 			if roleStrict {
-				// Return empty mapping if the mapping format is invalied and roleStrict is enabled
-				return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
+				// Return empty mapping if the mapping format is invalid and roleStrict is enabled
+				return NewMappingConfiguration([]MappingEntry{}, roleStrict)
 			}
 			continue
 		}
+		var externalClaimPattern *regexp.Regexp
+		if kv[0] != "*" {
+			res, err := regexp.Compile(kv[0])
+			if err != nil {
+				m.logger.Info("Could not compile pattern into regexp, no replacement will be made", "mapping", fmt.Sprintf("%v", v))
+			}
+			externalClaimPattern = res
+		}
+		var roleTemplate string
 
-		orgID, err := m.getOrgIDForInternalMapping(ctx, kv[1])
-		if err != nil {
-			m.logger.Warn("Could not fetch OrgID. Skipping.", "err", err, "mapping", fmt.Sprintf("%v", v), "org", kv[1])
+		if len(kv) < 3 {
 			if roleStrict {
-				// Return empty mapping if at least one org name cannot be resolved when roleStrict is enabled
-				return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
+				return NewMappingConfiguration([]MappingEntry{}, roleStrict)
 			}
-			continue
+			roleTemplate = string(org.RoleViewer)
+		} else {
+			roleTemplate = kv[2]
 		}
-
-		if roleStrict && (len(kv) < 3 || !org.RoleType(kv[2]).IsValid()) {
-			// Return empty mapping if at least one org mapping is invalid (missing role, invalid role)
-			m.logger.Warn("Skipping org mapping due to missing or invalid role in mapping when roleStrict is enabled.", "mapping", fmt.Sprintf("%v", v))
-			return NewMappingConfiguration(map[string]map[int64]org.RoleType{}, roleStrict)
-		}
-
-		orga := kv[0]
-		if res[orga] == nil {
-			res[orga] = map[int64]org.RoleType{}
-		}
-
-		res[orga][int64(orgID)] = getRoleForInternalOrgMapping(kv)
+		entries = append(entries, NewMappingEntry(
+			kv[0],
+			externalClaimPattern,
+			kv[1],
+			roleTemplate,
+		))
 	}
 
-	return NewMappingConfiguration(res, roleStrict)
+	return NewMappingConfiguration(entries, roleStrict)
 }
 
 func (m *OrgRoleMapper) getOrgIDForInternalMapping(ctx context.Context, orgIdCfg string) (int, error) {
@@ -240,14 +312,6 @@ func splitOrgMapping(mapping string) []string {
 	return result
 }
 
-func getRoleForInternalOrgMapping(kv []string) org.RoleType {
-	if len(kv) > 2 && org.RoleType(kv[2]).IsValid() {
-		return org.RoleType(kv[2])
-	}
-
-	return org.RoleViewer
-}
-
 func isValidOrgMappingFormat(kv []string) bool {
 	return len(kv) > 1 && len(kv) < 4
 }
@@ -260,9 +324,7 @@ func getMappedOrgRoles(externalOrgs []string, orgMapping map[string]map[int64]or
 	}
 
 	if orgRoles, ok := orgMapping["*"]; ok {
-		for orgID, role := range orgRoles {
-			userOrgRoles[orgID] = role
-		}
+		maps.Copy(userOrgRoles, orgRoles)
 	}
 
 	for _, org := range externalOrgs {

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -212,6 +212,13 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 			directlyMappedRole: "",
 			expected:           map[int64]org.RoleType{1: org.RoleAdmin},
 		},
+		{
+			name:               "should treat invalid regexps as regular strings with no match or expansion",
+			externalOrgs:       []string{"First_Editor"},
+			orgMappingSettings: []string{"*invalid(.*)_(.*):$1:$2"},
+			directlyMappedRole: "",
+			expected:           map[int64]org.RoleType{2: org.RoleViewer},
+		},
 	}
 	orgService := orgtest.NewOrgServiceFake()
 	cfg := setting.NewCfg()

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -2,10 +2,10 @@ package connectors
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
@@ -198,6 +198,20 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 			directlyMappedRole: org.RoleAdmin,
 			expected:           nil,
 		},
+		{
+			name:               "should fill the org and role templates from a regexp match on the external org",
+			externalOrgs:       []string{"First_Editor"},
+			orgMappingSettings: []string{"(.*)_(.*):$1:$2"},
+			directlyMappedRole: "",
+			expected:           map[int64]org.RoleType{1: org.RoleEditor},
+		},
+		{
+			name:               "should not confuse the special case '*' for a regexp pattern",
+			externalOrgs:       []string{"First_Editor"},
+			orgMappingSettings: []string{"(.*)_(.*):$1:$2", "*:1:Admin"},
+			directlyMappedRole: "",
+			expected:           map[int64]org.RoleType{1: org.RoleAdmin},
+		},
 	}
 	orgService := orgtest.NewOrgServiceFake()
 	cfg := setting.NewCfg()
@@ -218,7 +232,7 @@ func TestOrgRoleMapper_MapOrgRoles(t *testing.T) {
 				}
 			}
 			mappingCfg := mapper.ParseOrgMappingSettings(context.Background(), tc.orgMappingSettings, tc.strictRoleMapping)
-			actual := mapper.MapOrgRoles(mappingCfg, tc.externalOrgs, tc.directlyMappedRole)
+			actual := mapper.MapOrgRoles(context.Background(), mappingCfg, tc.externalOrgs, tc.directlyMappedRole)
 
 			assert.EqualValues(t, tc.expected, actual)
 		})
@@ -233,7 +247,7 @@ func TestOrgRoleMapper_MapOrgRoles_ReturnsDefaultOnNilMapping(t *testing.T) {
 	cfg.AutoAssignOrgRole = string(org.RoleViewer)
 	mapper := ProvideOrgRoleMapper(cfg, orgService)
 
-	actual := mapper.MapOrgRoles(NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false), []string{"First"}, org.RoleNone)
+	actual := mapper.MapOrgRoles(context.Background(), NewMappingConfiguration([]MappingEntry{}, false), []string{"First"}, org.RoleNone)
 
 	assert.EqualValues(t, map[int64]org.RoleType{2: org.RoleNone}, actual)
 }
@@ -247,96 +261,90 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 		expected   MappingConfiguration
 	}{
 		{
-			name:       "should return empty mapping when no org mapping settings are provided",
+			name:       "should return an empty configuration when no org mapping settings are provided",
 			rawMapping: []string{},
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false),
+			expected:   NewMappingConfiguration([]MappingEntry{}, false),
 		},
 		{
-			name:       "should return empty mapping when role is invalid and role strict is enabled",
-			rawMapping: []string{"Second:1:SuperEditor"},
-			roleStrict: true,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{}, true),
-		},
-		{
-			name:       "should return correct mapping when org mapping part is missing from a mapping and role strict is disabled",
-			rawMapping: []string{"Second:1", "First:"},
-			roleStrict: false,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{"Second": {1: org.RoleViewer}}, false),
-		},
-		{
-			name:       "should return default mapping when role is invalid and strict role mapping is disabled",
-			rawMapping: []string{"Second:1:SuperEditor"},
-			roleStrict: false,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{"Second": {1: org.RoleViewer}}, false),
-		},
-		{
-			name:       "should return empty mapping when org mapping doesn't contain any role and strict role mapping is enabled",
-			rawMapping: []string{"Second:1"},
-			roleStrict: true,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{}, true),
-		},
-		{
-			name:       "should return default mapping when org mapping doesn't contain any role and strict is disabled",
-			rawMapping: []string{"Second:1"},
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{"Second": {1: org.RoleViewer}}, false),
-		},
-		{
-			name:       "should return correct mapping when the first part contains multiple colons",
-			rawMapping: []string{"Groups\\:IT\\:ops:1:Viewer"},
-			roleStrict: false,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{"Groups:IT:ops": {1: org.RoleViewer}}, false),
-		},
-		{
-			name:       "should return correct mapping when the org name contains multiple colons",
-			rawMapping: []string{`Group1:Org\:1:Viewer`},
-			roleStrict: false,
-			setupMock: func(orgService *orgtest.MockService) {
-				orgService.On("GetByName", mock.Anything, mock.MatchedBy(func(query *org.GetOrgByNameQuery) bool {
-					return query.Name == "Org:1"
-				})).Return(&org.Org{ID: 1}, nil)
-			},
-			expected: NewMappingConfiguration(map[string]map[int64]org.RoleType{"Group1": {1: org.RoleViewer}}, false),
-		},
-		{
-			name:       "should return empty mapping when org mapping is nil",
+			name:       "should return an empty configuration when org mapping is nil",
 			rawMapping: nil,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{}, false),
+			expected:   NewMappingConfiguration([]MappingEntry{}, false),
 		},
 		{
-			name:       "should return empty mapping when one of the org mappings are not in the correct format and strict role mapping is enabled",
-			rawMapping: []string{"Second:Group:1:SuperEditor", "Second:1:Viewer"},
+			name:       "should return an entry for each valid mapping",
+			rawMapping: []string{"First:1:Editor", "(.*)_(.*):$1:$2"},
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("First", regexp.MustCompile("First"), "1", "Editor"),
+				NewMappingEntry("(.*)_(.*)", regexp.MustCompile("(.*)_(.*)"), "$1", "$2"),
+			}, false),
+		},
+		{
+			name:       "should filter out malformed mappings",
+			rawMapping: []string{"First:1:Editor", "Second:2:Viewer", "Third", "F:o:u:r:t:h"},
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("First", regexp.MustCompile("First"), "1", "Editor"),
+				NewMappingEntry("Second", regexp.MustCompile("Second"), "2", "Viewer"),
+			}, false),
+		},
+		{
+			name:       "should return an empty configuration if one mapping was malformed and role strict is enabled",
+			rawMapping: []string{"First:1:Editor", "Second:2:Viewer", "Third", "Fourth:Group:3:Viewer"},
 			roleStrict: true,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{}, true),
+			expected:   NewMappingConfiguration([]MappingEntry{}, true),
 		},
 		{
-			name:       "should skip org mapping when one of the org mappings are not in the correct format and strict role mapping is enabled",
-			rawMapping: []string{"Second:Group:1:SuperEditor", "Second:1:Admin"},
-			roleStrict: false,
-			expected:   NewMappingConfiguration(map[string]map[int64]org.RoleType{"Second": {1: org.RoleAdmin}}, false),
+			name:       "should replace missing roles with Viewer if role strict is disabled",
+			rawMapping: []string{"First:1:Editor", "Second:2:Viewer", "Third:3"},
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("First", regexp.MustCompile("First"), "1", "Editor"),
+				NewMappingEntry("Second", regexp.MustCompile("Second"), "2", "Viewer"),
+				NewMappingEntry("Third", regexp.MustCompile("Third"), "3", "Viewer"),
+			}, false),
 		},
 		{
-			name:       "should return empty mapping if at least one org was not found or the resolution failed and strict role mapping is enabled",
-			rawMapping: []string{"ExternalOrg1:First:Editor", "ExternalOrg1:NonExistent:Viewer"},
+			name:       "should return an empty configuration when a role is missing and role strict is enabled",
+			rawMapping: []string{"First:1:Editor", "Second:2:Viewer", "Third:3"},
 			roleStrict: true,
-			setupMock: func(orgService *orgtest.MockService) {
-				orgService.On("GetByName", mock.Anything, mock.MatchedBy(func(query *org.GetOrgByNameQuery) bool {
-					return query.Name == "First"
-				})).Return(&org.Org{ID: 1}, nil)
-				orgService.On("GetByName", mock.Anything, mock.Anything).Return(nil, assert.AnError)
-			},
-			expected: NewMappingConfiguration(map[string]map[int64]org.RoleType{}, true),
+			expected:   NewMappingConfiguration([]MappingEntry{}, true),
 		},
 		{
-			name:       "should skip org mapping if org was not found or the resolution fails and strict role mapping is disabled",
-			rawMapping: []string{"ExternalOrg1:First:Editor", "ExternalOrg1:NonExistent:Viewer"},
+			name:       "should not set a regexp if its compilation failed",
+			rawMapping: []string{"First:1:Editor", "*invalid:2:Viewer", "Third:3"},
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("First", regexp.MustCompile("First"), "1", "Editor"),
+				NewMappingEntry("*invalid", nil, "2", "Viewer"),
+				NewMappingEntry("Third", regexp.MustCompile("Third"), "3", "Viewer"),
+			}, false),
+		},
+		// Technically just a specific case of the previous test, but made explicit to confirm non-regression
+		{
+			name:       "should not set a regexp if the pattern is a single star",
+			rawMapping: []string{"First:1:Editor", "*:2:Viewer", "Third:3"},
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("First", regexp.MustCompile("First"), "1", "Editor"),
+				NewMappingEntry("*", nil, "2", "Viewer"),
+				NewMappingEntry("Third", regexp.MustCompile("Third"), "3", "Viewer"),
+			}, false),
+		},
+
+		// Since the role is a template that will be filled on login, we can't validate it yet
+		{
+			name:       "should not enforce validity of role",
+			rawMapping: []string{"First:1:Editor", "Second:2:Viewer", "Third:3:SuperEditor"},
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("First", regexp.MustCompile("First"), "1", "Editor"),
+				NewMappingEntry("Second", regexp.MustCompile("Second"), "2", "Viewer"),
+				NewMappingEntry("Third", regexp.MustCompile("Third"), "3", "SuperEditor"),
+			}, false),
+		},
+
+		{
+			name:       "should correctly escape colons",
+			rawMapping: []string{"Groups\\:IT\\:ops:Org\\:1:Viewer"},
 			roleStrict: false,
-			setupMock: func(orgService *orgtest.MockService) {
-				orgService.On("GetByName", mock.Anything, mock.MatchedBy(func(query *org.GetOrgByNameQuery) bool {
-					return query.Name == "First"
-				})).Return(&org.Org{ID: 1}, nil)
-				orgService.On("GetByName", mock.Anything, mock.Anything).Return(nil, assert.AnError)
-			},
-			expected: NewMappingConfiguration(map[string]map[int64]org.RoleType{"ExternalOrg1": {1: org.RoleEditor}}, false),
+			expected: NewMappingConfiguration([]MappingEntry{
+				NewMappingEntry("Groups:IT:ops", regexp.MustCompile("Groups:IT:ops"), "Org:1", "Viewer"),
+			}, false),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -132,7 +132,7 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 			return nil, err
 		}
 
-		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, role)
+		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(ctx, s.orgMappingCfg, externalOrgs, role)
 		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Followup of #120886

This feature introduces the ability to dynamically resolve the entries in the `org_mapping` setting, via regexp matching on the claims found in the jwt.

For example, given the following configuration:

```ini
[auth.generic_oauth]
org_attribute_path = "groups"
org_mapping = "team_(.*)_role_(.*):$1:$2"
```
If a user were to log in with the `groups` claim in their jwt set to `["team_Acme_role_Editor"]`, then the org mapping would be dynamically resolved to `team_Acme_role_Editor:Acme:Editor`, giving them the appropriate permissions.


**Why do we need this feature?**

`org_mapping` currently requires an explicit mapping for each org, meaning that any approach to dynamically provision them (with e.g. the terraform or crossplane provider) also needs to modify the config file and restart grafana.
With this feature, we could have a handful of rules to cover all current and future orgs that match a pattern.

**Who is this feature for?**

Grafana administrators who dynamically provision organizations.


**Which issue(s) does this PR fix?**:

Fixes #106340

**Special notes for your reviewer:**

Similarily to my previous PR, I took the liberty of making this one a draft to get early feedback before changing the docs, and determining whether this feature should be behind a toggle of a configuration setting.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Cheers!