### PR TITLE
Stats: Fix provisioned dashboard stats and cleanup

### DIFF
--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -37,6 +37,7 @@ type DashboardService interface {
 	GetAllDashboardsByOrgId(ctx context.Context, orgID int64) ([]*Dashboard, error)
 	CleanUpDashboard(ctx context.Context, dashboardUID string, dashboardId int64, orgId int64) error
 	CountDashboardsInOrg(ctx context.Context, orgID int64) (int64, error)
+	CountProvisionedDashboardsInOrg(ctx context.Context, orgID int64) (int64, error)
 	SetDefaultPermissions(ctx context.Context, dto *SaveDashboardDTO, dash *Dashboard, provisioned bool)
 	UnstructuredToLegacyDashboard(ctx context.Context, item *unstructured.Unstructured, orgID int64) (*Dashboard, error)
 	ValidateDashboardRefreshInterval(minRefreshInterval string, targetRefreshInterval string) error

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -95,6 +95,34 @@ func (_m *FakeDashboardService) CountDashboardsInOrg(ctx context.Context, orgID 
 	return r0, r1
 }
 
+// CountProvisionedDashboardsInOrg provides a mock function with given fields: ctx, orgID
+func (_m *FakeDashboardService) CountProvisionedDashboardsInOrg(ctx context.Context, orgID int64) (int64, error) {
+	ret := _m.Called(ctx, orgID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountProvisionedDashboardsInOrg")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) (int64, error)); ok {
+		return rf(ctx, orgID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64) int64); ok {
+		r0 = rf(ctx, orgID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, orgID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CountInFolders provides a mock function with given fields: ctx, orgID, folderUIDs, user
 func (_m *FakeDashboardService) CountInFolders(ctx context.Context, orgID int64, folderUIDs []string, user identity.Requester) (int64, error) {
 	ret := _m.Called(ctx, orgID, folderUIDs, user)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -544,6 +544,21 @@ func (dr *DashboardServiceImpl) CountDashboardsInOrg(ctx context.Context, orgID 
 	return resp.Stats[0].Count, nil
 }
 
+func (dr *DashboardServiceImpl) CountProvisionedDashboardsInOrg(ctx context.Context, orgID int64) (int64, error) {
+	ctx, span := tracer.Start(ctx, "dashboards.service.CountProvisionedDashboardsInOrg")
+	defer span.End()
+
+	dashs, err := dr.searchProvisionedDashboardsThroughK8s(ctx, &dashboards.FindPersistedDashboardsQuery{
+		OrgId:     orgID,
+		ManagedBy: utils.ManagerKindClassicFP, // nolint:staticcheck
+	})
+	if err != nil {
+		return 0, err
+	}
+	span.SetAttributes(attribute.Int("provisioned_dashboards", len(dashs)))
+	return int64(len(dashs)), nil
+}
+
 func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	limits := &quota.Map{}
 

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1800,6 +1800,48 @@ func TestSearchProvisionedDashboardsThroughK8sRaw(t *testing.T) {
 	assert.Equal(t, "dash-db", query.Type) // query type should be added as dashboards only
 }
 
+func TestCountProvisionedDashboardsInOrg(t *testing.T) {
+	ctx := context.Background()
+	k8sCliMock := new(client.MockK8sHandler)
+	service := &DashboardServiceImpl{k8sclient: k8sCliMock}
+	k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
+	k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.Anything).Return(&resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: []*resourcepb.ResourceTableColumnDefinition{
+				{Name: "title", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: "folder", Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: resource.SEARCH_FIELD_MANAGER_KIND, Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: resource.SEARCH_FIELD_MANAGER_ID, Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: resource.SEARCH_FIELD_SOURCE_PATH, Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: resource.SEARCH_FIELD_SOURCE_CHECKSUM, Type: resourcepb.ResourceTableColumnDefinition_STRING},
+				{Name: resource.SEARCH_FIELD_SOURCE_TIME, Type: resourcepb.ResourceTableColumnDefinition_INT64},
+			},
+			Rows: []*resourcepb.ResourceTableRow{
+				{
+					Key: &resourcepb.ResourceKey{
+						Name:     "uid",
+						Resource: "dashboard",
+					},
+					Cells: [][]byte{
+						[]byte("Dashboard 1"),
+						[]byte("folder 1"),
+						[]byte(string(utils.ManagerKindClassicFP)), // nolint:staticcheck
+						[]byte("test"),
+						[]byte("path/to/file"),
+						[]byte("hash"),
+						[]byte("1234567"),
+					},
+				},
+			},
+		},
+		TotalHits: 1,
+	}, nil)
+
+	n, err := service.CountProvisionedDashboardsInOrg(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}
+
 func TestLegacySaveCommandToUnstructured(t *testing.T) {
 	namespace := "test-namespace"
 	t.Run("successfully converts save command to unstructured", func(t *testing.T) {

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -11,7 +11,6 @@ import (
 	playlistv1 "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v1"
 	provisioningv1 "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -102,13 +101,6 @@ func (ss *sqlStatsService) getResourceCounts(ctx context.Context, orgs []*org.Or
 		}
 	}
 	return totals, nil
-}
-
-func (ss *sqlStatsService) playlistsSQL() string {
-	if ss.cfg.UnifiedStorageConfig(setting.PlaylistResource).DualWriterMode == rest.Mode5 {
-		return `0 AS playlists,`
-	}
-	return `(SELECT COUNT(*) FROM ` + ss.db.GetDialect().Quote("playlist") + `) AS playlists,`
 }
 
 func (ss *sqlStatsService) GetAlertNotifiersUsageStats(ctx context.Context, query *stats.GetAlertNotifierUsageStatsQuery) (result []*stats.NotifierUsageStats, err error) {

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	dashboardv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	playlistv1 "github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v1"
 	provisioningv1 "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -53,19 +55,6 @@ type sqlStatsService struct {
 	unifiedStorage resource.ResourceClient
 }
 
-func (ss *sqlStatsService) getDashboardCount(ctx context.Context, orgs []*org.OrgDTO) (int64, error) {
-	count := int64(0)
-	for _, org := range orgs {
-		ctx, _ = identity.WithServiceIdentity(ctx, org.ID)
-		dashsCount, err := ss.dashSvc.CountDashboardsInOrg(ctx, org.ID)
-		if err != nil {
-			return 0, err
-		}
-		count += dashsCount
-	}
-	return count, nil
-}
-
 func (ss *sqlStatsService) getTagCount(ctx context.Context, orgs []*org.OrgDTO) (int64, error) {
 	total := 0
 	for _, org := range orgs {
@@ -82,15 +71,15 @@ func (ss *sqlStatsService) getTagCount(ctx context.Context, orgs []*org.OrgDTO) 
 	return int64(total), nil
 }
 
-func (ss *sqlStatsService) getFolderCount(ctx context.Context, orgs []*org.OrgDTO) (int64, error) {
-	total := int64(0)
+func (ss *sqlStatsService) getProvisionedDashboardCount(ctx context.Context, orgs []*org.OrgDTO) (int64, error) {
+	var total int64
 	for _, org := range orgs {
 		ctx, _ = identity.WithServiceIdentity(ctx, org.ID)
-		folderCount, err := ss.folderSvc.CountFoldersInOrg(ctx, org.ID)
+		n, err := ss.dashSvc.CountProvisionedDashboardsInOrg(ctx, org.ID)
 		if err != nil {
 			return 0, err
 		}
-		total += folderCount
+		total += n
 	}
 	return total, nil
 }
@@ -166,7 +155,6 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("user") + ` WHERE ` + notServiceAccount(dialect) + `) AS users,`)
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("data_source") + `) AS datasources,`)
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("star") + `) AS stars,`)
-		sb.Write(ss.playlistsSQL())
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("alert") + `) AS alerts,`)
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("correlation") + `) AS correlations,`)
 
@@ -182,7 +170,6 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 		monthlyActiveUserDeadlineDate := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 		sb.Write(`(SELECT COUNT(*) FROM `+dialect.Quote("user")+` WHERE `+
 			notServiceAccount(dialect)+` AND last_seen_at > ?) AS monthly_active_users,`, monthlyActiveUserDeadlineDate)
-		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_provisioning") + `) AS provisioned_dashboards,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_snapshot") + `) AS snapshots,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_version") + `) AS dashboard_versions,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("annotation") + `) AS annotations,`)
@@ -223,34 +210,26 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 	}
 	result.Orgs = int64(len(orgs))
 
-	// for services in unified storage, get the stats through the service rather than the db directly
-	dashCount, err := ss.getDashboardCount(ctx, orgs)
-	if err != nil {
-		return result, err
-	}
-	result.Dashboards = dashCount
-
-	folderCount, err := ss.getFolderCount(ctx, orgs)
-	if err != nil {
-		return result, err
-	}
-	result.Folders = folderCount
-
+	// for resources in unified storage
 	kindRepository := provisioningv1.GROUP + "/" + provisioningv1.RepositoryResourceInfo.GroupResource().Resource
 	kindPlaylist := playlistv1.APIGroup + "/playlists"
-	unifiedKinds := []string{kindRepository}
-	if ss.cfg.UnifiedStorageConfig(setting.PlaylistResource).DualWriterMode >= rest.Mode4 {
-		unifiedKinds = append(unifiedKinds, kindPlaylist)
-	}
-
+	kindFolder := folderv1.APIGroup + "/folders"
+	kindDashboard := dashboardv1.APIGroup + "/dashboards"
+	unifiedKinds := []string{kindRepository, kindPlaylist, kindFolder, kindDashboard}
 	resourceCounts, err := ss.getResourceCounts(ctx, orgs, unifiedKinds)
 	if err != nil {
 		return result, err
 	}
 	result.Repositories = resourceCounts[kindRepository]
-	if count, ok := resourceCounts[kindPlaylist]; ok {
-		result.Playlists = count
+	result.Playlists = resourceCounts[kindPlaylist]
+	result.Folders = resourceCounts[kindFolder]
+	result.Dashboards = resourceCounts[kindDashboard]
+
+	provisioned, err := ss.getProvisionedDashboardCount(ctx, orgs)
+	if err != nil {
+		return result, err
 	}
+	result.ProvisionedDashboards = provisioned
 
 	return result, err
 }
@@ -296,7 +275,6 @@ func (ss *sqlStatsService) GetAdminStats(ctx context.Context, query *stats.GetAd
 			SELECT COUNT(*)
 			FROM ` + dialect.Quote("data_source") + `
 		) AS datasources,
-		` + ss.playlistsSQL() + `
 		(
 			SELECT COUNT(*)
 			FROM ` + dialect.Quote("star") + `
@@ -347,27 +325,22 @@ func (ss *sqlStatsService) GetAdminStats(ctx context.Context, query *stats.GetAd
 	}
 	result.Orgs = int64(len(orgs))
 
-	// for services in unified storage, get the stats through the service rather than the db directly
-	dashCount, err := ss.getDashboardCount(ctx, orgs)
-	if err != nil {
-		return result, err
-	}
-	result.Dashboards = dashCount
-
+	// tags are on the dashboard itself, need to search through unified storage to find the stats
 	tagCount, err := ss.getTagCount(ctx, orgs)
 	if err != nil {
 		return result, err
 	}
 	result.Tags = tagCount
 
-	if ss.cfg.UnifiedStorageConfig(setting.PlaylistResource).DualWriterMode == rest.Mode5 {
-		kindPlaylist := playlistv1.APIGroup + "/playlists"
-		resourceCounts, err := ss.getResourceCounts(ctx, orgs, []string{kindPlaylist})
-		if err != nil {
-			return result, err
-		}
-		result.Playlists = resourceCounts[kindPlaylist]
+	// resources in unified storage
+	kindPlaylist := playlistv1.APIGroup + "/playlists"
+	kindDashboard := dashboardv1.APIGroup + "/dashboards"
+	resourceCounts, err := ss.getResourceCounts(ctx, orgs, []string{kindPlaylist, kindDashboard})
+	if err != nil {
+		return result, err
 	}
+	result.Playlists = resourceCounts[kindPlaylist]
+	result.Dashboards = resourceCounts[kindDashboard]
 
 	return result, err
 }

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -43,13 +43,14 @@ func TestIntegrationStatsDataAccess(t *testing.T) {
 
 	db, cfg := db.InitTestDBWithCfg(t)
 	orgSvc := populateDB(t, db, cfg)
+
 	dashSvc := &dashboards.FakeDashboardService{}
-	dashSvc.On("CountDashboardsInOrg", mock.Anything, int64(1)).Return(int64(2), nil)
-	dashSvc.On("CountDashboardsInOrg", mock.Anything, int64(2)).Return(int64(1), nil)
-	dashSvc.On("CountDashboardsInOrg", mock.Anything, int64(3)).Return(int64(0), nil)
 	dashSvc.On("GetDashboardTags", mock.Anything, &dashboards.GetDashboardTagsQuery{OrgID: 1}).Return([]*dashboards.DashboardTagCloudItem{{Term: "test"}}, nil)
 	dashSvc.On("GetDashboardTags", mock.Anything, &dashboards.GetDashboardTagsQuery{OrgID: 2}).Return([]*dashboards.DashboardTagCloudItem{}, nil)
 	dashSvc.On("GetDashboardTags", mock.Anything, &dashboards.GetDashboardTagsQuery{OrgID: 3}).Return([]*dashboards.DashboardTagCloudItem{}, nil)
+	dashSvc.On("CountProvisionedDashboardsInOrg", mock.Anything, int64(1)).Return(int64(0), nil)
+	dashSvc.On("CountProvisionedDashboardsInOrg", mock.Anything, int64(2)).Return(int64(0), nil)
+	dashSvc.On("CountProvisionedDashboardsInOrg", mock.Anything, int64(3)).Return(int64(0), nil)
 
 	folderService := &foldertest.FakeService{}
 	folderService.ExpectedFolders = []*folder.Folder{{ID: 1}, {ID: 2}, {ID: 3}}
@@ -90,8 +91,8 @@ func TestIntegrationStatsDataAccess(t *testing.T) {
 		assert.Equal(t, int64(0), result.APIKeys)
 		assert.Equal(t, int64(2), result.Correlations)
 		assert.Equal(t, int64(3), result.Orgs)
-		assert.Equal(t, int64(3), result.Dashboards)
-		assert.Equal(t, int64(9), result.Folders)       // will return 3 folders for each org
+		assert.Equal(t, int64(15), result.Dashboards)   // 5 per org from mock × 3 orgs
+		assert.Equal(t, int64(15), result.Folders)      // 5 per org from mock × 3 orgs
 		assert.Equal(t, int64(15), result.Playlists)    // 5 per org from mock × 3 orgs
 		assert.Equal(t, int64(15), result.Repositories) // 5 per org from mock × 3 orgs
 		assert.NotNil(t, result.DatabaseCreatedTime)
@@ -127,7 +128,7 @@ func TestIntegrationStatsDataAccess(t *testing.T) {
 		stats, err := statsService.GetAdminStats(context.Background(), &query)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), stats.Tags)
-		assert.Equal(t, int64(3), stats.Dashboards)
+		assert.Equal(t, int64(15), stats.Dashboards) // 5 per org from mock × 3 orgs
 		assert.Equal(t, int64(3), stats.Orgs)
 		assert.Equal(t, int64(15), stats.Playlists) // 5 per org from mock × 3 orgs
 	})


### PR DESCRIPTION
This PR fixes the `dashboard_provisioning` stat (was reading from the legacy table, and now that data is stored in unified storage). 

It also cleans up the dashboard & folder stats to use the generic unified storage stats. And always has playlists use that, since they are now always in unistore too