### PR TITLE
Stats: Remove dashboard version metric

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -192,9 +192,6 @@ var (
 	// StatsTotalRuleGroups is a metric of total number of alert rule groups stored in Grafana.
 	StatsTotalRuleGroups prometheus.Gauge
 
-	// StatsTotalDashboardVersions is a metric of total number of dashboard versions stored in Grafana.
-	StatsTotalDashboardVersions prometheus.Gauge
-
 	grafanaPluginBuildInfoDesc *prometheus.GaugeVec
 
 	grafanaPluginTargetInfoDesc *prometheus.GaugeVec
@@ -589,12 +586,6 @@ func init() {
 		Namespace: ExporterName,
 	}, []string{"plugin_id", "provisioning_method"})
 
-	StatsTotalDashboardVersions = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name:      "stat_totals_dashboard_versions",
-		Help:      "total amount of dashboard versions in the database",
-		Namespace: ExporterName,
-	})
-
 	StatsTotalAnnotations = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_totals_annotations",
 		Help:      "total amount of annotations in the database",
@@ -819,7 +810,6 @@ func initMetricVars(reg prometheus.Registerer) {
 		grafanaPluginFileSystemInfoDesc,
 		grafanaPluginAssetInfoDesc,
 		grafanaPluginProvisioningInfoDesc,
-		StatsTotalDashboardVersions,
 		StatsTotalAnnotations,
 		StatsTotalAlertRules,
 		StatsTotalRuleGroups,

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -175,7 +175,6 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]any, error
 	m["stats.snapshots.count"] = statsResult.Snapshots
 	m["stats.teams.count"] = statsResult.Teams
 	m["stats.total_auth_token.count"] = statsResult.AuthTokens
-	m["stats.dashboard_versions.count"] = statsResult.DashboardVersions
 	m["stats.annotations.count"] = statsResult.Annotations
 	m["stats.alert_rules.count"] = statsResult.AlertRules
 	m["stats.rule_groups.count"] = statsResult.RuleGroups
@@ -339,7 +338,6 @@ func (s *Service) updateTotalStats(ctx context.Context) bool {
 	metrics.StatsTotalActiveEditors.Set(float64(statsResult.ActiveEditors))
 	metrics.StatsTotalAdmins.Set(float64(statsResult.Admins))
 	metrics.StatsTotalActiveAdmins.Set(float64(statsResult.ActiveAdmins))
-	metrics.StatsTotalDashboardVersions.Set(float64(statsResult.DashboardVersions))
 	metrics.StatsTotalAnnotations.Set(float64(statsResult.Annotations))
 	metrics.StatsTotalAlertRules.Set(float64(statsResult.AlertRules))
 	metrics.StatsTotalRuleGroups.Set(float64(statsResult.RuleGroups))

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -166,7 +166,6 @@ func TestCollectingUsageStats(t *testing.T) {
 	assert.EqualValues(t, 15, metrics["stats.total_auth_token.count"])
 	assert.EqualValues(t, 2, metrics["stats.api_keys.count"])
 	assert.EqualValues(t, 5, metrics["stats.avg_auth_token_per_user.count"])
-	assert.EqualValues(t, 16, metrics["stats.dashboard_versions.count"])
 	assert.EqualValues(t, 17, metrics["stats.annotations.count"])
 	assert.EqualValues(t, 18, metrics["stats.alert_rules.count"])
 	assert.EqualValues(t, 19, metrics["stats.library_panels.count"])
@@ -327,7 +326,6 @@ func mockSystemStats(statsService *statstest.FakeService) {
 		Snapshots:                 13,
 		Teams:                     14,
 		AuthTokens:                15,
-		DashboardVersions:         16,
 		Annotations:               17,
 		AlertRules:                18,
 		LibraryPanels:             19,

--- a/pkg/services/stats/models.go
+++ b/pkg/services/stats/models.go
@@ -23,7 +23,6 @@ type SystemStats struct {
 	ProvisionedDashboards     int64
 	AuthTokens                int64
 	APIKeys                   int64 `xorm:"api_keys"`
-	DashboardVersions         int64
 	Annotations               int64
 	AlertRules                int64
 	RuleGroups                int64

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -184,7 +184,6 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 			notServiceAccount(dialect)+` AND last_seen_at > ?) AS monthly_active_users,`, monthlyActiveUserDeadlineDate)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_provisioning") + `) AS provisioned_dashboards,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_snapshot") + `) AS snapshots,`)
-		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_version") + `) AS dashboard_versions,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("annotation") + `) AS annotations,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("team") + `) AS teams,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("user_auth_token") + `) AS auth_tokens,`)


### PR DESCRIPTION
This PR removes the dashboard version metric (`grafana_stat_totals_dashboard_versions`) and removes it from usage reporting.

When it was originally implemented, it was a count against the dashboard_version table. However, now that dashboards are store in unistore, calculating the count on this is expensive when backed by the KV store because we would need to scan all revision keys under each namespaces dashboard prefix.