### PR TITLE
Alerting: Save query options when toggletip closes without blur

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type AlertQueryOptions, MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
+
+describe('MaxDataPointsOption', () => {
+  it('should commit the value on blur', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const options: AlertQueryOptions = { maxDataPoints: undefined, minInterval: undefined };
+
+    render(<MaxDataPointsOption options={options} onChange={onChange} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.click(input);
+    await user.type(input, '1000');
+    await user.tab();
+
+    expect(onChange).toHaveBeenCalledWith({ ...options, maxDataPoints: 1000 });
+  });
+
+  it('should commit the value on unmount when blur has not fired', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const options: AlertQueryOptions = { maxDataPoints: undefined, minInterval: undefined };
+
+    const { unmount } = render(<MaxDataPointsOption options={options} onChange={onChange} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.click(input);
+    await user.type(input, '500');
+
+    // Unmount without blurring — simulates Toggletip closing
+    unmount();
+
+    expect(onChange).toHaveBeenCalledWith({ ...options, maxDataPoints: 500 });
+  });
+
+  it('should not call onChange on unmount if value has not changed', () => {
+    const onChange = jest.fn();
+    const options: AlertQueryOptions = { maxDataPoints: 1000, minInterval: undefined };
+
+    const { unmount } = render(<MaxDataPointsOption options={options} onChange={onChange} />);
+
+    unmount();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('MinIntervalOption', () => {
+  it('should commit the value on blur', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const options: AlertQueryOptions = { maxDataPoints: undefined, minInterval: undefined };
+
+    render(<MinIntervalOption options={options} onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.type(input, '15s');
+    await user.tab();
+
+    expect(onChange).toHaveBeenCalledWith({ ...options, minInterval: '15s' });
+  });
+
+  it('should commit the value on unmount when blur has not fired', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const options: AlertQueryOptions = { maxDataPoints: undefined, minInterval: undefined };
+
+    const { unmount } = render(<MinIntervalOption options={options} onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.type(input, '30s');
+
+    // Unmount without blurring — simulates Toggletip closing
+    unmount();
+
+    expect(onChange).toHaveBeenCalledWith({ ...options, minInterval: '30s' });
+  });
+
+  it('should not call onChange on unmount if value has not changed', () => {
+    const onChange = jest.fn();
+    const options: AlertQueryOptions = { maxDataPoints: undefined, minInterval: '10s' };
+
+    const { unmount } = render(<MinIntervalOption options={options} onChange={onChange} />);
+
+    unmount();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -233,18 +233,44 @@ export function MaxDataPointsOption({
   onChange: (options: AlertQueryOptions) => void;
 }) {
   const value = options.maxDataPoints ?? '';
+  const currentValueRef = React.useRef(String(value));
+  const committedRef = React.useRef(false);
+  const onChangeRef = React.useRef(onChange);
+  const optionsRef = React.useRef(options);
+  onChangeRef.current = onChange;
+  optionsRef.current = options;
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const maxDataPointsNumber = parseInt(event.target.value, 10);
-
+  const commitValue = React.useCallback((rawValue: string) => {
+    if (committedRef.current) {
+      return;
+    }
+    committedRef.current = true;
+    const maxDataPointsNumber = parseInt(rawValue, 10);
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
-
-    if (maxDataPoints !== options.maxDataPoints) {
-      onChange({
-        ...options,
+    if (maxDataPoints !== optionsRef.current.maxDataPoints) {
+      onChangeRef.current({
+        ...optionsRef.current,
         maxDataPoints,
       });
     }
+  }, []);
+
+  // Commit the current input value on unmount (e.g. when the Toggletip closes)
+  React.useEffect(() => {
+    return () => {
+      commitValue(currentValueRef.current);
+    };
+  }, [commitValue]);
+
+  const onMaxDataPointsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    currentValueRef.current = event.target.value;
+    committedRef.current = false;
+  };
+
+  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
+    currentValueRef.current = event.target.value;
+    committedRef.current = false;
+    commitValue(event.target.value);
   };
 
   return (
@@ -261,6 +287,7 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
+        onChange={onMaxDataPointsChange}
         onBlur={onMaxDataPointsBlur}
         defaultValue={value}
       />
@@ -276,15 +303,42 @@ export function MinIntervalOption({
   onChange: (options: AlertQueryOptions) => void;
 }) {
   const value = options.minInterval ?? '';
+  const currentValueRef = React.useRef(value);
+  const committedRef = React.useRef(false);
+  const onChangeRef = React.useRef(onChange);
+  const optionsRef = React.useRef(options);
+  onChangeRef.current = onChange;
+  optionsRef.current = options;
 
-  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const minInterval = event.target.value;
-    if (minInterval !== value) {
-      onChange({
-        ...options,
-        minInterval,
+  const commitValue = React.useCallback((rawValue: string) => {
+    if (committedRef.current) {
+      return;
+    }
+    committedRef.current = true;
+    if (rawValue !== (optionsRef.current.minInterval ?? '')) {
+      onChangeRef.current({
+        ...optionsRef.current,
+        minInterval: rawValue || undefined,
       });
     }
+  }, []);
+
+  // Commit the current input value on unmount (e.g. when the Toggletip closes)
+  React.useEffect(() => {
+    return () => {
+      commitValue(currentValueRef.current);
+    };
+  }, [commitValue]);
+
+  const onMinIntervalChange = (event: ChangeEvent<HTMLInputElement>) => {
+    currentValueRef.current = event.target.value;
+    committedRef.current = false;
+  };
+
+  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
+    currentValueRef.current = event.target.value;
+    committedRef.current = false;
+    commitValue(event.target.value);
   };
 
   return (
@@ -303,6 +357,7 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
+        onChange={onMinIntervalChange}
         onBlur={onMinIntervalBlur}
         defaultValue={value}
       />


### PR DESCRIPTION
## What is this PR about?

Fixes #111664

When editing **Min Interval** or **Max Data Points** in the alert rule query options tooltip, the value is silently discarded if the user clicks outside the tooltip instead of tabbing to another field. This happens because the `Toggletip` unmounts before the input's `onBlur` event fires.

## Changes

**`QueryWrapper.tsx`** — `MaxDataPointsOption` and `MinIntervalOption`:
- Track the current input value via `onChange` in a `useRef`
- Commit the tracked value in a `useEffect` cleanup (fires on unmount)
- A `committedRef` flag prevents double-commits when `onBlur` fires before unmount

**`QueryOptions.test.tsx`** — 6 new tests:
- Value committed on blur (existing behavior preserved)
- Value committed on unmount when blur has not fired (the fix)
- No unnecessary onChange call on unmount if value unchanged

## How to test

1. Open any alert rule editor
2. Click **Options** next to the datasource selector
3. Change the **Interval** value (e.g. type `15s`)
4. Click outside the tooltip (not into another field)
5. Verify the interval value is saved (shown in the static values display)

Same test for **Max data points**.

## Checklist

- [x] Existing behavior preserved (onBlur still works)
- [x] Tests added and passing (`yarn jest --no-watch public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx`)
- [x] No new TypeScript errors