### PR TITLE
fix(metrics): use datasource UID instead of name for HTTP client metrics labels

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -71,15 +71,8 @@ func DataSourceMetricsMiddleware() sdkhttpclient.Middleware {
 			return next
 		}
 
-		datasourceName, exists := opts.Labels["datasource_name"]
+		datasourceUID, exists := opts.Labels["datasource_uid"]
 		if !exists {
-			return next
-		}
-
-		datasourceLabelName, err := metricutil.SanitizeLabelName(datasourceName)
-		// if the datasource named cannot be turned into a prometheus
-		// label we will skip instrumenting these metrics.
-		if err != nil {
 			return next
 		}
 
@@ -95,7 +88,7 @@ func DataSourceMetricsMiddleware() sdkhttpclient.Middleware {
 		}
 
 		labels := prometheus.Labels{
-			"datasource":                    datasourceLabelName,
+			"datasource":                    datasourceUID,
 			"datasource_type":               datasourceLabelType,
 			"secure_socks_ds_proxy_enabled": strconv.FormatBool(opts.ProxyOptions != nil && opts.ProxyOptions.Enabled),
 		}

--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware_test.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware_test.go
@@ -49,7 +49,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		require.False(t, middlewareCalled)
 	})
 
-	t.Run("Without data source name label options set should return next http.RoundTripper", func(t *testing.T) {
+	t.Run("Without data source UID label options set should return next http.RoundTripper", func(t *testing.T) {
 		origExecuteMiddlewareFunc := executeMiddlewareFunc
 		executeMiddlewareCalled := false
 		middlewareCalled := false
@@ -87,7 +87,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		require.False(t, middlewareCalled)
 	})
 
-	t.Run("With datasource name label options set should execute middleware", func(t *testing.T) {
+	t.Run("With datasource UID label options set should execute middleware", func(t *testing.T) {
 		origExecuteMiddlewareFunc := executeMiddlewareFunc
 		executeMiddlewareCalled := false
 		labels := prometheus.Labels{}
@@ -112,14 +112,14 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 			{
 				description: "secure socks ds proxy is disabled",
 				httpClientOptions: httpclient.Options{
-					Labels: map[string]string{"datasource_name": "My Data Source 123", "datasource_type": "prometheus"},
+					Labels: map[string]string{"datasource_uid": "abc123uid", "datasource_type": "prometheus"},
 				},
 				expectedSecureSocksDSProxyEnabled: "false",
 			},
 			{
 				description: "secure socks ds proxy is enabled",
 				httpClientOptions: httpclient.Options{
-					Labels:       map[string]string{"datasource_name": "My Data Source 123", "datasource_type": "prometheus"},
+					Labels:       map[string]string{"datasource_uid": "abc123uid", "datasource_type": "prometheus"},
 					ProxyOptions: &proxy.Options{Enabled: true},
 				},
 				expectedSecureSocksDSProxyEnabled: "true",
@@ -149,7 +149,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 				require.ElementsMatch(t, []string{"finalrt"}, ctx.callChain)
 				require.True(t, executeMiddlewareCalled)
 				require.Len(t, labels, 3)
-				require.Equal(t, "My_Data_Source_123", labels["datasource"])
+				require.Equal(t, "abc123uid", labels["datasource"])
 				require.Equal(t, "prometheus", labels["datasource_type"])
 				require.Equal(t, tt.expectedSecureSocksDSProxyEnabled, labels["secure_socks_ds_proxy_enabled"])
 				require.True(t, middlewareCalled)


### PR DESCRIPTION

**What is this feature?**

Datasource names are not unique across Grafana organisations, causing metric collisions when multiple orgs have datasources with identical names. This results in metrics from one datasource silently overwriting or being attributed to another.

Switch the `datasource` label in the HTTP client metrics middleware from `datasource_name` to `datasource_uid`, which is globally unique. This also removes the now-unnecessary label sanitization step that converted names into valid Prometheus label values, since UIDs are already Prometheus-compatible.

**Why do we need this feature?**

Datasource names are scoped to an organisation and are not globally unique, two different orgs can each have a datasource named "prometheus". When HTTP client metrics are labelled by datasource name, these collide in the metrics backend: scrapes, latency histograms, and error counters from one org's datasource overwrite or get merged with those from another org's identically-named datasource. This makes per-datasource observability unreliable in multi-org Grafana deployments. Switching to the datasource UID is globally unique across all orgs; eliminates the collision and ensures each datasource's metrics are correctly isolated.


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
