### PR TITLE
Admin: Retry queries and tx more times in sqlite

### DIFF
--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -94,7 +94,9 @@ func RunAdminApiReencryptTest(
 ) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		APIServerStorageType: options.StorageTypeUnified,
-		EnableLog:            true,
+		EnableLog:            false,
+		QueryRetries:         30, // arbitrary 3x from the default
+		TransactionRetries:   30, // arbitrary 3x from the default
 	})
 
 	grafanaListenAddr, env := testinfra.StartGrafanaEnv(t, dir, path)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -490,7 +490,6 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		return section, err
 	}
 
-	queryRetries := 10
 	if opts.EnableCSP {
 		securitySect, err := cfg.NewSection("security")
 		require.NoError(t, err)
@@ -615,9 +614,15 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = logSection.NewKey("address", opts.GRPCServerAddress)
 		require.NoError(t, err)
 	}
-	// retry queries 3 times by default
+
+	// retry queries 10 times by default
+	queryRetries := 10
 	if opts.QueryRetries != 0 {
-		queryRetries = int(opts.QueryRetries)
+		queryRetries = opts.QueryRetries
+	}
+	transactionRetries := 10
+	if opts.TransactionRetries != 0 {
+		transactionRetries = opts.TransactionRetries
 	}
 
 	if opts.NGAlertSchedulerBaseInterval > 0 {
@@ -802,6 +807,8 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	require.NoError(t, err)
 	_, err = dbSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
 	require.NoError(t, err)
+	_, err = dbSection.NewKey("transaction_retries", fmt.Sprintf("%d", transactionRetries))
+	require.NoError(t, err)
 	maxConns := opts.DBMaxConns
 	if maxConns <= 0 {
 		maxConns = 2
@@ -858,7 +865,8 @@ type GrafanaOpts struct {
 	UnifiedAlertingDisabledOrgs           []int64
 	EnableLog                             bool
 	GRPCServerAddress                     string
-	QueryRetries                          int64
+	QueryRetries                          int
+	TransactionRetries                    int
 	GrafanaComAPIURL                      string
 	UnifiedStorageConfig                  map[string]setting.UnifiedStorageConfig
 	UnifiedStorageDisableSearch           bool


### PR DESCRIPTION
The test fails sometimes due to SQLite locks.
```
2026-04-01T17:40:29.6480082Z
logger=secrets.migrations
t=2026-04-01T17:40:10.414209753Z
level=warn
msg="Could not update alert_configuration secret while re-encrypting it"
id=1
error="[sqlstore.max-retries-reached] retry 10: database is locked (5) (SQLITE_BUSY)"
```

Here I am tripling the retries and also adding a configurable retry for the transactions, since the reencrypt code also uses it, and also setting it to a high value.

Disabling the logs since we figured out why this test was flaky.