### PR TITLE
Splash Screen: Add role-based CTA links with UTM tracking

### DIFF
--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -5,11 +5,26 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, LinkButton, useStyles2 } from '@grafana/ui';
 import { ModalBase } from '@grafana/ui/internal';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { SplashScreenNav } from './SplashScreenNav';
 import { SplashScreenSlide } from './SplashScreenSlide';
-import { getSplashScreenConfig } from './splashContent';
+import { type SplashFeatureCta, getSplashScreenConfig } from './splashContent';
 import { useShouldShowSplash } from './useShouldShowSplash';
+
+function resolveCtaUrl(cta: SplashFeatureCta): string {
+  if (cta.requiresAdmin && !contextSrv.hasRole('Admin')) {
+    return cta.fallbackUrl ?? cta.url;
+  }
+  if (cta.permission && !contextSrv.hasPermission(cta.permission)) {
+    return cta.fallbackUrl ?? cta.url;
+  }
+  return cta.url;
+}
+
+function isExternalUrl(url: string): boolean {
+  return url.startsWith('http');
+}
 
 export function SplashScreenModal() {
   const [activeIndex, setActiveIndex] = useState(0);
@@ -37,6 +52,9 @@ export function SplashScreenModal() {
   }
 
   const activeFeature = config.features[activeIndex];
+  const cta = activeFeature.cta;
+  const ctaUrl = cta ? resolveCtaUrl(cta) : '';
+  const isCtaExternal = isExternalUrl(ctaUrl);
 
   const footer = (
     <>
@@ -47,17 +65,18 @@ export function SplashScreenModal() {
         onNext={goToNext}
         onGoTo={setActiveIndex}
       />
-      {activeFeature.ctaUrl && (
+      {cta && (
         <LinkButton
-          href={activeFeature.ctaUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          icon="external-link-alt"
+          href={ctaUrl}
+          onClick={isCtaExternal ? undefined : dismiss}
+          target={isCtaExternal ? '_blank' : undefined}
+          rel={isCtaExternal ? 'noopener noreferrer' : undefined}
+          icon={isCtaExternal ? 'external-link-alt' : 'arrow-right'}
           variant="secondary"
           fill="outline"
           size="md"
         >
-          {activeFeature.ctaText}
+          {cta.text}
         </LinkButton>
       )}
     </>

--- a/public/app/core/components/SplashScreenModal/SplashScreenSlide.test.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenSlide.test.tsx
@@ -11,8 +11,6 @@ const mockFeature: SplashFeature = {
   title: 'Test Feature Title',
   subtitle: 'Test subtitle text',
   bullets: ['Bullet one', 'Bullet two', 'Bullet three'],
-  ctaText: 'Try it',
-  ctaUrl: '/test',
   heroImageUrl: 'https://placehold.co/400x400',
 };
 

--- a/public/app/core/components/SplashScreenModal/splashContent.ts
+++ b/public/app/core/components/SplashScreenModal/splashContent.ts
@@ -38,7 +38,7 @@ const UTM = 'src=grafana-oss&cnt=whats-new-modal';
 
 export function getSplashScreenConfig(): SplashScreenConfig {
   return {
-    version: '13.0.1',
+    version: '13.0.0',
     features: [
       {
         id: 'assistant',

--- a/public/app/core/components/SplashScreenModal/splashContent.ts
+++ b/public/app/core/components/SplashScreenModal/splashContent.ts
@@ -8,6 +8,14 @@ import libraryOfThingsImage from './images/library-of-things.png';
 
 export type AccentColorKey = 'dark-purple' | 'primary' | 'success' | 'dark-orange';
 
+export interface SplashFeatureCta {
+  text: string;
+  url: string;
+  fallbackUrl?: string;
+  permission?: string;
+  requiresAdmin?: boolean;
+}
+
 export interface SplashFeature {
   id: string;
   icon: IconName;
@@ -17,8 +25,7 @@ export interface SplashFeature {
   title: string;
   subtitle: string;
   bullets: string[];
-  ctaText?: string;
-  ctaUrl?: string;
+  cta?: SplashFeatureCta;
   heroImageUrl: string;
 }
 
@@ -27,9 +34,11 @@ export interface SplashScreenConfig {
   features: SplashFeature[];
 }
 
+const UTM = 'src=grafana-oss&cnt=whats-new-modal';
+
 export function getSplashScreenConfig(): SplashScreenConfig {
   return {
-    version: '13.0.0',
+    version: '13.0.1',
     features: [
       {
         id: 'assistant',
@@ -43,8 +52,10 @@ export function getSplashScreenConfig(): SplashScreenConfig {
           t('splash-screen.assistant.bullet-2', 'Create comprehensive dashboards in minutes'),
           t('splash-screen.assistant.bullet-3', 'Onboard new team members in days, not weeks'),
         ],
-        ctaText: t('splash-screen.assistant.cta', 'Show me'),
-        ctaUrl: 'https://grafana.com/grafana/plugins/grafana-assistant-app/',
+        cta: {
+          text: t('splash-screen.assistant.cta', 'Show me'),
+          url: `https://grafana.com/grafana/plugins/grafana-assistant-app/?${UTM}`,
+        },
         heroImageUrl: assistantHeroImage,
       },
       {
@@ -65,6 +76,12 @@ export function getSplashScreenConfig(): SplashScreenConfig {
           ),
           t('splash-screen.dynamic-dashboards.bullet-3', 'Auto-arrange panels into a grid for an efficient layout'),
         ],
+        cta: {
+          text: t('splash-screen.dynamic-dashboards.cta', 'Show me'),
+          url: '/dashboard/new',
+          fallbackUrl: `https://grafana.com/docs/grafana/next/visualizations/dashboards/build-dashboards/create-dashboard?${UTM}`,
+          permission: 'dashboards:create',
+        },
         heroImageUrl: dynamicDashboardsImage,
       },
       {
@@ -85,6 +102,12 @@ export function getSplashScreenConfig(): SplashScreenConfig {
             'Works with many deployment scenarios like dev-prod, HA, and instances shared by multiple teams'
           ),
         ],
+        cta: {
+          text: t('splash-screen.git-sync.cta', 'Show me'),
+          url: '/admin/provisioning',
+          fallbackUrl: `https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync?${UTM}`,
+          requiresAdmin: true,
+        },
         heroImageUrl: gitSyncImage,
       },
       {
@@ -105,6 +128,12 @@ export function getSplashScreenConfig(): SplashScreenConfig {
             'Explore and use community dashboards tailored to your data source'
           ),
         ],
+        cta: {
+          text: t('splash-screen.library-of-things.cta', 'Show me'),
+          url: '/dashboards?templateDashboards=true&source=whats-new-modal',
+          fallbackUrl: `https://grafana.com/docs/grafana/next/visualizations/dashboards/build-dashboards/create-template-dashboards?${UTM}`,
+          permission: 'dashboards:create',
+        },
         heroImageUrl: libraryOfThingsImage,
       },
     ],

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14786,6 +14786,7 @@
       "bullet-1": "Split content into tabs for quick switching",
       "bullet-2": "Show or hide panels based on template variables and other conditions",
       "bullet-3": "Auto-arrange panels into a grid for an efficient layout",
+      "cta": "Show me",
       "subtitle": "Make your dashboards more impactful and easier to explore",
       "title": "Add tabs and panel conditions to your dashboards"
     },
@@ -14793,6 +14794,7 @@
       "bullet-1": "Store your dashboard configuration safely in any git repository",
       "bullet-2": "keep track of the changes - and who made them",
       "bullet-3": "Works with many deployment scenarios like dev-prod, HA, and instances shared by multiple teams",
+      "cta": "Show me",
       "subtitle": "Bring version control, collaboration, and reliability to your dashboards",
       "title": "Sync your dashboards to Git"
     },
@@ -14800,6 +14802,7 @@
       "bullet-1": "Start from a clean layout instead of building from scratch",
       "bullet-2": "Load a template and customize it to your needs",
       "bullet-3": "Explore and use community dashboards tailored to your data source",
+      "cta": "Show me",
       "subtitle": "Get to a useful dashboard sooner by starting from a proven design",
       "title": "Kickstart dashboards with suggestions and templates"
     },


### PR DESCRIPTION
## Summary

- Add real CTA URLs for all 4 features with UTM params (`src=grafana-oss&cnt=whats-new-modal`)
- Role-based link resolution: users without required permissions get docs fallback URLs
- Internal links dismiss the splash and navigate in same tab; external links open in new tab