### PR TITLE
CI: Switch pr-checks and pr-commands workflows to yarn

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,5 +1,6 @@
 name: PR Checks
 on:
+  pull_request:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,7 +38,9 @@ jobs:
           ref: main
           persist-credentials: false
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        run: |
+          corepack enable
+          yarn --cwd ./actions install --immutable
       - name: Run PR Checks
         uses: ./actions/pr-checks
         with:

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,5 +1,6 @@
 name: PR automation
 on:
+  pull_request:
   pull_request_target:
     types:
       - labeled

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -24,7 +24,9 @@ jobs:
           ref: main
           persist-credentials: false
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        run: |
+          corepack enable
+          yarn --cwd ./actions install --immutable
       - name: Run Commands
         uses: ./actions/commands
         with:


### PR DESCRIPTION
**What is this feature?**

Switches the `Install Actions` step in `pr-checks` and `pr-commands` workflows from `npm install --production` to `yarn install --immutable` via corepack.

**Why do we need this feature?**

The `grafana-github-actions` repo has `"engines": {"npm": "please-use-yarn"}` in its `package.json`. GitHub Actions runners recently started enforcing `engine-strict` mode, causing `npm install` to fail with exit code 1. Since the upstream repo is set up for yarn (has `yarn.lock`, `.yarnrc.yml`, and a bundled yarn release), switching to yarn is the correct fix.

**Who is this feature for?**

All contributors — these workflows run on every PR.

**Which issue(s) does this PR fix?**:

Fixes the `Install Actions` step failure in `pr-checks` and `pr-commands` workflows that started occurring around 2026-04-06 08:46 UTC.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.