### PR TITLE
ci: add a comment to the patch job

### DIFF
--- a/.github/workflows/create-security-patch-from-security-mirror.yml
+++ b/.github/workflows/create-security-patch-from-security-mirror.yml
@@ -26,4 +26,5 @@ jobs:
       patch_repo: "grafana/grafana-security-patches"
       patch_prefix: "${{ github.event.pull_request.number }}"
       sender: "${{ github.event.pull_request.user.login }}"
+      comment: "Closes: ${{ github.repository }}#${{ github.event.pull_request.number }}"
     secrets: inherit # zizmor: ignore[secrets-inherit]


### PR DESCRIPTION
When a patch is created, this links them via a `Closes:` comment. This both adds a link in the GitHub UI, and cleans up PRs we merge as patches.