### PR TITLE
CI: Update pr-checks to use the new version

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,20 +1,6 @@
 name: PR Checks
 on:
   pull_request:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-      - labeled
-      - unlabeled
-      - edited
-      - auto_merge_enabled
-  issues:
-    types:
-      - milestoned
-      - demilestoned
 
 concurrency:
   group: pr-checks-${{ github.event.number }}-new

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ on:
       - demilestoned
 
 concurrency:
-  group: pr-checks-${{ github.event.number }}
+  group: pr-checks-${{ github.event.number }}-new
 
 permissions:
   statuses: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,5 +1,6 @@
 name: PR Checks
 on:
+  pull_request:
   pull_request_target:
     types:
       - opened
@@ -30,21 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-
-      - name: Checkout Actions
-        uses: actions/checkout@v5
-        with:
-          repository: "grafana/grafana-github-actions"
-          ref: main
-          persist-credentials: false
-      # Note: this action checks out the grafana/grafana-github-actions repo, not Grafana.
-      # So this `yarn install` is installing dependencies for the actions, not for Grafana.
-      - name: Install Actions
-        run: |
-          corepack enable
-          yarn install --immutable
       - name: Run PR Checks
-        uses: ./pr-checks
+        uses: grafana/grafana-github-actions/pr-checks@jh/pr-checks-refactor
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-checks


### PR DESCRIPTION
Updates pr-checks.yml to use the new pre-compiled version from https://github.com/grafana/grafana-github-actions/pull/269.
