### PR TITLE
CI: Check for drift caused by Enterprise imports not declared properly

### DIFF
--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -31,8 +31,10 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     name: Go Workspace Check
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
+      id-token: write
 
     steps:
     - name: Checkout repository
@@ -40,6 +42,12 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Setup Enterprise
+      if: github.event.pull_request.head.repo.fork == false
+      uses: ./.github/actions/setup-enterprise
+
+    # Enterprise must be cloned before setup-go so that enterprise
+    # modules are visible when the Go cache key is computed.
     - name: Setup Go
       uses: ./.github/actions/setup-go
       with:
@@ -48,13 +56,19 @@ jobs:
     - name: Update workspace
       run: make update-workspace
 
-    - name: Check for go mod & workspace changes 
+    - name: Check for go mod & workspace changes
       run: |
-        if ! git diff --exit-code --quiet; then
+        if ! git diff --exit-code --quiet -- go.mod go.sum '**/go.mod' '**/go.sum' go.work go.work.sum; then
           echo "Changes detected:"
-          git diff
+          git diff -- go.mod go.sum '**/go.mod' '**/go.sum' go.work go.work.sum
+          echo ""
           echo "Please run 'make update-workspace' and commit the changes."
-          echo "If there is a change in enterprise dependencies, please update pkg/extensions/main.go."
+          echo ""
+          echo "If you are adding or removing a dependency used **only** by Enterprise code,"
+          echo "please update pkg/extensions/enterprise_imports.go or pkg/extensions/enterprise_imports_test.go"
+          echo ""
+          echo "You should add blank imports for dependencies that are used in enterprise code but isn't in OSS."
+          echo "If this is a test-only dependency, add it to enterprise_imports_test.go instead"
           exit 1
         fi
 


### PR DESCRIPTION
Previously, the `Go Workspace Check` would only run in OSS code, and check for drifts in dependencies by running `make update-workspace`.

Now, we optionally bring in Enterprise, and only check for drifts in *.mod/*.sum + work files, so that we can also check for drifts in dependencies being added to Enterprise but not properly declared in the `go.mod` here and vice-versa.

tl;dr: hopefully improve drift detection from Enterprise dependencies!