### PR TITLE
Notifications: Fix flaky SMTP test

### DIFF
--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -185,9 +185,8 @@ func TestSmtpSend(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
-		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
-		time.Sleep(1 * time.Millisecond)
-		messages := srv.MessagesAndPurge()
+		messages, err := srv.WaitForMessagesAndPurge(1, 5*time.Second)
+		require.NoError(t, err)
 		require.Len(t, messages, 1)
 		sentMsg := messages[0]
 
@@ -237,9 +236,8 @@ func TestSmtpSend(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
-		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
-		time.Sleep(1 * time.Millisecond)
-		messages := srv.MessagesAndPurge()
+		messages, err := srv.WaitForMessagesAndPurge(1, 5*time.Second)
+		require.NoError(t, err)
 		require.Len(t, messages, 1)
 		sentMsg := messages[0]
 
@@ -298,9 +296,8 @@ func TestSmtpSend(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 3, count)
 
-		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
-		time.Sleep(1 * time.Millisecond)
-		messages := srv.MessagesAndPurge()
+		messages, err := srv.WaitForMessagesAndPurge(3, 5*time.Second)
+		require.NoError(t, err)
 		assert.Len(t, messages, 3)
 
 		// sort for test consistency


### PR DESCRIPTION
By Claude:
> The smtpmock library already has WaitForMessagesAndPurge(count, timeout) — exactly what's needed. The 1ms sleep is simply not enough; messages are processed asynchronously and the test races.
>
>  Root cause (~95% confident): The time.Sleep(1 * time.Millisecond) workaround is insufficient. When the mock server is slow to register a message:
>  - single_message_sends gets 0 messages (not yet registered)
>  - multiple_recipients, single_message gets 2 messages (its own + the leaked one from the >previous subtest)
>
>  Fix: Replace time.Sleep + MessagesAndPurge() with WaitForMessagesAndPurge(count, timeout).