### PR TITLE
Transformers: Fix organize fields layout on small screens

### DIFF
--- a/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
@@ -366,8 +366,8 @@ const DraggableFieldName = ({
   return (
     <Draggable draggableId={fieldName} index={index} isDragDisabled={isDragDisabled}>
       {(provided) => (
-        <Box display="flex" gap={0} ref={provided.innerRef} {...provided.draggableProps}>
-          <InlineLabel width={60} as="div">
+        <Box display="flex" gap={0} marginBottom={0.5} ref={provided.innerRef} {...provided.draggableProps}>
+          <InlineLabel as="div" className={styles.flexLabel}>
             <Stack gap={0} justifyContent="flex-start" alignItems="center" width="100%">
               {!isDragDisabled && (
                 <span {...provided.dragHandleProps}>
@@ -399,6 +399,7 @@ const DraggableFieldName = ({
             </Stack>
           </InlineLabel>
           <Input
+            className={styles.flexInput}
             defaultValue={renamedFieldName || ''}
             placeholder={t('transformers.draggable-field-name.rename-placeholder', 'Rename {{fieldName}}', {
               fieldName,
@@ -428,7 +429,7 @@ const DraggableUIOrderByItem = ({ index, item, onChangeSort }: DraggableUIOrderB
     <Draggable draggableId={draggableId} index={index} isDragDisabled={item.order === Order.Off}>
       {(provided) => (
         <Box marginBottom={0.5} display="flex" gap={0} ref={provided.innerRef} {...provided.draggableProps}>
-          <InlineLabel width={60} as="div">
+          <InlineLabel as="div" className={styles.flexLabel}>
             <Stack gap={3} justifyContent="flex-start" alignItems="center" width="100%">
               <span {...provided.dragHandleProps}>
                 <Icon
@@ -466,6 +467,15 @@ const DraggableUIOrderByItem = ({ index, item, onChangeSort }: DraggableUIOrderB
 DraggableUIOrderByItem.displayName = 'DraggableUIOrderByItem';
 
 const getFieldNameStyles = (theme: GrafanaTheme2) => ({
+  flexLabel: css({
+    flex: '1 1 0',
+    width: 'auto',
+    overflow: 'hidden',
+  }),
+  flexInput: css({
+    flex: '1 1 0',
+    width: 'auto',
+  }),
   toggle: css({
     margin: theme.spacing(0, 1),
     color: theme.colors.text.secondary,


### PR DESCRIPTION
## Summary
- Replace fixed-width label (480px) with flex-based 50/50 layout in the "Organize fields by name" transformation editor
- Add consistent spacing between field rows

Fixes field name labels taking too much space and pushing rename inputs off-screen on narrow panels.

Before:
<img width="1118" height="724" alt="image" src="https://github.com/user-attachments/assets/a99605f4-6e24-4fa7-a1d7-5f47a48caba8" />

After:
<img width="804" height="330" alt="image" src="https://github.com/user-attachments/assets/8cd54e72-0259-46ea-a620-6d0eda5aa7e0" />