### PR TITLE
Splash Screen: Set OpenFeature default to true for OSS

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -39,7 +39,7 @@ export function AppChrome({ children }: Props) {
   } = useExtensionSidebarContext();
   const state = chrome.useState();
   const scopes = useScopes();
-  const isSplashScreenEnabled = useBooleanFlagValue('splashScreen', false);
+  const isSplashScreenEnabled = useBooleanFlagValue('splashScreen', true);
 
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
   const isScopesDashboardsOpen = Boolean(


### PR DESCRIPTION
## Summary

Changes the `useBooleanFlagValue('splashScreen', ...)` default from `false` to `true` so the splash screen renders by default on self-hosted OSS instances where no OpenFeature provider is configured.