### PR TITLE
Expressions: Add memory limit for math expression binary operations

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2204,10 +2204,10 @@ default_timezone = browser
 # Enable or disable the expressions functionality.
 enabled = true
 
-# Maximum estimated memory (in bytes) that a single math expression binary
-# operation is allowed to allocate. Protects against cartesian explosions when
-# label sets on both sides of a binary operation are incompatible. Set to 0 to
-# disable the limit. Default: 1073741824 (1 GiB).
+# Maximum estimated memory (in bytes) for a single math expression binary
+# operation. Memory usage is estimated before the expression runs. Protects
+# against cartesian explosions when label sets on both sides of a binary
+# operation are incompatible. Set to 0 to disable. Default: 1073741824 (1 GiB).
 math_expression_memory_limit = 1073741824
 
 [geomap]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2204,6 +2204,12 @@ default_timezone = browser
 # Enable or disable the expressions functionality.
 enabled = true
 
+# Maximum estimated memory (in bytes) that a single math expression binary
+# operation is allowed to allocate. Protects against cartesian explosions when
+# label sets on both sides of a binary operation are incompatible. Set to 0 to
+# disable the limit. Default: 1073741824 (1 GiB).
+math_expression_memory_limit = 1073741824
+
 [geomap]
 # Set the JSON configuration for the default basemap
 default_baselayer_config =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -2103,6 +2103,12 @@ default_datasource_uid =
 # Enable or disable the expressions functionality.
 ;enabled = true
 
+# Maximum estimated memory (in bytes) that a single math expression binary
+# operation is allowed to allocate. Protects against cartesian explosions when
+# label sets on both sides of a binary operation are incompatible. Set to 0 to
+# disable the limit. Default: 1073741824 (1 GiB).
+;math_expression_memory_limit = 1073741824
+
 [geomap]
 # Set the JSON configuration for the default basemap
 ;default_baselayer_config = `{

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -2103,10 +2103,10 @@ default_datasource_uid =
 # Enable or disable the expressions functionality.
 ;enabled = true
 
-# Maximum estimated memory (in bytes) that a single math expression binary
-# operation is allowed to allocate. Protects against cartesian explosions when
-# label sets on both sides of a binary operation are incompatible. Set to 0 to
-# disable the limit. Default: 1073741824 (1 GiB).
+# Maximum estimated memory (in bytes) for a single math expression binary
+# operation. Memory usage is estimated before the expression runs. Protects
+# against cartesian explosions when label sets on both sides of a binary
+# operation are incompatible. Set to 0 to disable. Default: 1073741824 (1 GiB).
 ;math_expression_memory_limit = 1073741824
 
 [geomap]

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -3018,6 +3018,10 @@ Set the maximum length of a SQL query that can be used in a SQL expression. Defa
 
 The duration a SQL expression will run before being cancelled. The default is `10s`. A setting of `0s` means no limit.
 
+#### `math_expression_memory_limit`
+
+Set the maximum estimated memory in bytes that a single math expression binary operation can allocate. Default is `1073741824` (1 GiB). A setting of `0` means no limit.
+
 ### `[geomap]`
 
 This section controls the defaults settings for **Geomap Plugin**.

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/expr/metrics"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // Command is an interface for all expression commands.
@@ -29,11 +30,12 @@ type MathCommand struct {
 	RawExpression string
 	Expression    *mathexp.Expr
 	refID         string
+	memoryLimit   int64 // maximum estimated output bytes for a binary operation; 0 disables
 }
 
 // NewMathCommand creates a new MathCommand. It will return an error
 // if there is an error parsing expr.
-func NewMathCommand(refID, expr string) (*MathCommand, error) {
+func NewMathCommand(refID, expr string, memoryLimit int64) (*MathCommand, error) {
 	parsedExpr, err := mathexp.New(expr)
 	if err != nil {
 		return nil, err
@@ -42,11 +44,12 @@ func NewMathCommand(refID, expr string) (*MathCommand, error) {
 		RawExpression: expr,
 		Expression:    parsedExpr,
 		refID:         refID,
+		memoryLimit:   memoryLimit,
 	}, nil
 }
 
 // UnmarshalMathCommand creates a MathCommand from Grafana's frontend query.
-func UnmarshalMathCommand(rn *rawNode) (*MathCommand, error) {
+func UnmarshalMathCommand(rn *rawNode, cfg *setting.Cfg) (*MathCommand, error) {
 	rawExpr, ok := rn.Query["expression"]
 	if !ok {
 		return nil, errors.New("command is missing an expression")
@@ -56,7 +59,7 @@ func UnmarshalMathCommand(rn *rawNode) (*MathCommand, error) {
 		return nil, fmt.Errorf("math expression is expected to be a string, got %T", rawExpr)
 	}
 
-	gm, err := NewMathCommand(rn.RefID, exprString)
+	gm, err := NewMathCommand(rn.RefID, exprString, cfg.MathExpressionMemoryLimit)
 	if err != nil {
 		return nil, fmt.Errorf("invalid math command: %w", err)
 	}
@@ -75,7 +78,7 @@ func (gm *MathCommand) Execute(ctx context.Context, _ time.Time, vars mathexp.Va
 	_, span := tracer.Start(ctx, "SSE.ExecuteMath")
 	span.SetAttributes(attribute.String("expression", gm.RawExpression))
 	defer span.End()
-	return gm.Expression.Execute(gm.refID, vars, tracer)
+	return gm.Expression.Execute(gm.refID, vars, tracer, mathexp.WithMemoryLimit(gm.memoryLimit))
 }
 
 func (gm *MathCommand) Type() string {

--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -30,6 +30,11 @@ type State struct {
 	Drops     map[string]map[string][]data.Labels // binary node text -> LH/RH -> Drop Labels
 	DropCount int64
 
+	// MemoryLimit is the maximum estimated output size (in bytes) for a single
+	// binary operation. If the estimated allocation exceeds this, walkBinary
+	// returns an error instead of proceeding. A value of 0 disables the limit.
+	MemoryLimit int64
+
 	tracer tracing.Tracer
 }
 
@@ -49,14 +54,30 @@ func New(expr string, funcs ...map[string]parse.Func) (*Expr, error) {
 	return e, nil
 }
 
+// ExecuteOption is a functional option for configuring expression execution.
+type ExecuteOption func(*State)
+
+// WithMemoryLimit sets the maximum estimated memory (in bytes) that a single
+// binary operation may allocate for its output. When the estimate exceeds
+// this limit, evaluation returns a descriptive error. A value of 0 disables
+// the limit.
+func WithMemoryLimit(limit int64) ExecuteOption {
+	return func(s *State) {
+		s.MemoryLimit = limit
+	}
+}
+
 // Execute applies a parse expression to the context and executes it
-func (e *Expr) Execute(refID string, vars Vars, tracer tracing.Tracer) (r Results, err error) {
+func (e *Expr) Execute(refID string, vars Vars, tracer tracing.Tracer, opts ...ExecuteOption) (r Results, err error) {
 	s := &State{
 		Expr:  e,
 		Vars:  vars,
 		RefID: refID,
 
 		tracer: tracer,
+	}
+	for _, opt := range opts {
+		opt(s)
 	}
 	return e.executeState(s)
 }
@@ -306,6 +327,150 @@ func (e *State) union(aResults, bResults Results, biNode *parse.BinaryNode) []*U
 	return unions
 }
 
+const (
+	// bytesPerDatapoint is the estimated heap cost per datapoint in the output
+	// series: 24 bytes for time.Time (wall, ext, loc) + 16 bytes for *float64
+	// (pointer + value).
+	bytesPerDatapoint = 40
+
+	// bytesPerBPoint is the estimated heap cost per entry in the bPoints map
+	// used by biSeriesSeries: ~30 bytes for the time string key + 8 bytes for
+	// *float64 + ~50 bytes for map bucket overhead.
+	bytesPerBPoint = 88
+
+	// frameOverhead is the estimated fixed cost per output Value for the
+	// data.Frame, data.Field structs, and metadata.
+	frameOverhead = 500
+)
+
+// labelBytes returns the total byte size of all keys and values in a label set.
+func labelBytes(labels data.Labels) int {
+	n := 0
+	for k, v := range labels {
+		n += len(k) + len(v)
+	}
+	return n
+}
+
+// resultStats holds the pre-computed statistics for one side of a binary operation
+// used for memory estimation.
+type resultStats struct {
+	count         int // total number of Values
+	seriesCount   int // number of Values that are Series
+	maxDatapoints int // longest series length
+	maxLabelBytes int // largest label set in bytes
+}
+
+// computeResultStats computes stats for a Results set in O(n) with zero heap allocation.
+func computeResultStats(r Results) resultStats {
+	var s resultStats
+	s.count = len(r.Values)
+	for _, v := range r.Values {
+		if series, ok := v.(Series); ok {
+			s.seriesCount++
+			if l := series.Len(); l > s.maxDatapoints {
+				s.maxDatapoints = l
+			}
+		}
+		if lb := labelBytes(v.GetLabels()); lb > s.maxLabelBytes {
+			s.maxLabelBytes = lb
+		}
+	}
+	return s
+}
+
+// estimateBinaryOutputBytes computes an upper-bound estimate of the memory that
+// walkBinary would allocate for its output, given the stats from both sides.
+//
+// The estimate is deliberately conservative (over-estimates) in several ways:
+//   - It assumes worst-case label matching: every A pairs with every B. In
+//     practice, union() filters by label compatibility, producing far fewer
+//     pairs when labels match. This means the estimate can be orders of
+//     magnitude higher than actual allocation for well-matched label sets.
+//   - It uses the max datapoints from either side for every union, even though
+//     biSeriesSeries only emits points at matching timestamps (an intersection).
+//   - It charges bPoints map cost for all unions whenever any Series exists on
+//     both sides, even if most unions are Number x Number.
+//
+// These over-estimates are acceptable because the limit is a safety mechanism
+// against cartesian explosions (where labels don't match). Operators who hit
+// false rejections on legitimate high-cardinality expressions can raise the
+// configured limit.
+func estimateBinaryOutputBytes(a, b resultStats) int64 {
+	if a.count == 0 || b.count == 0 {
+		return 0
+	}
+
+	worstCaseUnions := int64(a.count) * int64(b.count)
+
+	// Output cost per union depends on the types involved. We use the worst
+	// case: both sides are Series (the most expensive combination).
+	maxDatapoints := a.maxDatapoints
+	if b.maxDatapoints > maxDatapoints {
+		maxDatapoints = b.maxDatapoints
+	}
+
+	maxLabels := a.maxLabelBytes
+	if b.maxLabelBytes > maxLabels {
+		maxLabels = b.maxLabelBytes
+	}
+
+	// For Series x Series, we also pay for the bPoints map.
+	perUnion := int64(maxDatapoints)*bytesPerDatapoint +
+		int64(maxLabels) +
+		frameOverhead
+	if a.seriesCount > 0 && b.seriesCount > 0 {
+		perUnion += int64(maxDatapoints) * bytesPerBPoint
+	}
+
+	return worstCaseUnions * perUnion
+}
+
+// checkBinaryMemoryLimit estimates the output cost of a binary operation and
+// returns a descriptive error if it exceeds the configured memory limit.
+func (e *State) checkBinaryMemoryLimit(ar, br Results, node *parse.BinaryNode) error {
+	aStats := computeResultStats(ar)
+	bStats := computeResultStats(br)
+	estimated := estimateBinaryOutputBytes(aStats, bStats)
+
+	if estimated <= e.MemoryLimit {
+		return nil
+	}
+
+	aVar := node.Args[0].String()
+	bVar := node.Args[1].String()
+
+	return fmt.Errorf(
+		"expression %q attempted to combine %d series from %s with %d series from %s, "+
+			"producing up to %d series pairs (estimated memory: %s, limit: %s). "+
+			"This usually means the label sets returned by your queries are no longer compatible. "+
+			"When labels match, this expression would produce ~%d pairs. "+
+			"Check that the queries for %s and %s return series with the same label names and values",
+		node.String(),
+		aStats.count, aVar,
+		bStats.count, bVar,
+		int64(aStats.count)*int64(bStats.count),
+		formatBytes(estimated),
+		formatBytes(e.MemoryLimit),
+		max(aStats.count, bStats.count),
+		aVar, bVar,
+	)
+}
+
+// formatBytes returns a human-readable byte size string.
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KiB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
 func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 	res := Results{Values: Values{}}
 	ar, err := e.walk(node.Args[0])
@@ -316,6 +481,13 @@ func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 	if err != nil {
 		return res, err
 	}
+
+	if e.MemoryLimit > 0 {
+		if err := e.checkBinaryMemoryLimit(ar, br, node); err != nil {
+			return res, err
+		}
+	}
+
 	unions := e.union(ar, br, node)
 	for _, uni := range unions {
 		var value Value

--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -352,88 +352,104 @@ func labelBytes(labels data.Labels) int {
 	return n
 }
 
-// resultStats holds the pre-computed statistics for one side of a binary operation
-// used for memory estimation.
-type resultStats struct {
-	count         int // total number of Values
-	seriesCount   int // number of Values that are Series
-	maxDatapoints int // longest series length
-	maxLabelBytes int // largest label set in bytes
+// binaryMemoryEstimate holds the result of estimateBinaryMemory.
+type binaryMemoryEstimate struct {
+	unions int   // actual number of unions label matching would produce
+	bytes  int64 // estimated total output allocation in bytes
+	aCount int   // number of Values on the A side
+	bCount int   // number of Values on the B side
 }
 
-// computeResultStats computes stats for a Results set in O(n) with zero heap allocation.
-func computeResultStats(r Results) resultStats {
-	var s resultStats
-	s.count = len(r.Values)
-	for _, v := range r.Values {
-		if series, ok := v.(Series); ok {
-			s.seriesCount++
-			if l := series.Len(); l > s.maxDatapoints {
-				s.maxDatapoints = l
+// seriesLen returns the datapoint count for a Value if it is a Series, or 0.
+func seriesLen(v Value) int {
+	if s, ok := v.(Series); ok {
+		return s.Len()
+	}
+	return 0
+}
+
+// estimateBinaryMemory replays the label matching logic from union() to count
+// the exact number of unions and accumulate a per-pair memory estimate, without
+// allocating Union structs or output frames.
+//
+// For each matching pair, the estimate accounts for the actual types and sizes
+// of both values (Series length, label bytes). The only remaining
+// over-estimation is using max(aLen, bLen) for the output series length instead
+// of the timestamp intersection, which is not knowable without scanning
+// datapoints.
+func estimateBinaryMemory(aResults, bResults Results) binaryMemoryEstimate {
+	est := binaryMemoryEstimate{
+		aCount: len(aResults.Values),
+		bCount: len(bResults.Values),
+	}
+	if est.aCount == 0 || est.bCount == 0 {
+		return est
+	}
+
+	addPair := func(a, b Value) {
+		est.unions++
+
+		aDP := seriesLen(a)
+		bDP := seriesLen(b)
+		outputDP := max(aDP, bDP)
+
+		aLB := labelBytes(a.GetLabels())
+		bLB := labelBytes(b.GetLabels())
+		outputLB := max(aLB, bLB)
+
+		pairCost := int64(outputDP)*bytesPerDatapoint +
+			int64(outputLB) +
+			frameOverhead
+		// biSeriesSeries builds a bPoints map from one side.
+		if aDP > 0 && bDP > 0 {
+			pairCost += int64(outputDP) * bytesPerBPoint
+		}
+
+		est.bytes += pairCost
+	}
+
+	if est.aCount == 1 || est.bCount == 1 {
+		aNoData := aResults.Values[0].Type() == parse.TypeNoData
+		bNoData := bResults.Values[0].Type() == parse.TypeNoData
+		if aNoData || bNoData {
+			addPair(aResults.Values[0], bResults.Values[0])
+			return est
+		}
+	}
+
+	for _, a := range aResults.Values {
+		for _, b := range bResults.Values {
+			aLabels := a.GetLabels()
+			bLabels := b.GetLabels()
+			switch {
+			case aLabels.Equals(bLabels) || len(aLabels) == 0 || len(bLabels) == 0:
+				addPair(a, b)
+			case len(aLabels) == len(bLabels):
+				// skip: invalid union
+			case aLabels.Contains(bLabels):
+				addPair(a, b)
+			case bLabels.Contains(aLabels):
+				addPair(a, b)
 			}
 		}
-		if lb := labelBytes(v.GetLabels()); lb > s.maxLabelBytes {
-			s.maxLabelBytes = lb
-		}
 	}
-	return s
+
+	// Mirror the fallback in union(): if nothing matched and both sides have
+	// exactly one value, they get combined anyway.
+	if est.unions == 0 && est.aCount == 1 && est.bCount == 1 {
+		addPair(aResults.Values[0], bResults.Values[0])
+	}
+
+	return est
 }
 
-// estimateBinaryOutputBytes computes an upper-bound estimate of the memory that
-// walkBinary would allocate for its output, given the stats from both sides.
-//
-// The estimate is deliberately conservative (over-estimates) in several ways:
-//   - It assumes worst-case label matching: every A pairs with every B. In
-//     practice, union() filters by label compatibility, producing far fewer
-//     pairs when labels match. This means the estimate can be orders of
-//     magnitude higher than actual allocation for well-matched label sets.
-//   - It uses the max datapoints from either side for every union, even though
-//     biSeriesSeries only emits points at matching timestamps (an intersection).
-//   - It charges bPoints map cost for all unions whenever any Series exists on
-//     both sides, even if most unions are Number x Number.
-//
-// These over-estimates are acceptable because the limit is a safety mechanism
-// against cartesian explosions (where labels don't match). Operators who hit
-// false rejections on legitimate high-cardinality expressions can raise the
-// configured limit.
-func estimateBinaryOutputBytes(a, b resultStats) int64 {
-	if a.count == 0 || b.count == 0 {
-		return 0
-	}
-
-	worstCaseUnions := int64(a.count) * int64(b.count)
-
-	// Output cost per union depends on the types involved. We use the worst
-	// case: both sides are Series (the most expensive combination).
-	maxDatapoints := a.maxDatapoints
-	if b.maxDatapoints > maxDatapoints {
-		maxDatapoints = b.maxDatapoints
-	}
-
-	maxLabels := a.maxLabelBytes
-	if b.maxLabelBytes > maxLabels {
-		maxLabels = b.maxLabelBytes
-	}
-
-	// For Series x Series, we also pay for the bPoints map.
-	perUnion := int64(maxDatapoints)*bytesPerDatapoint +
-		int64(maxLabels) +
-		frameOverhead
-	if a.seriesCount > 0 && b.seriesCount > 0 {
-		perUnion += int64(maxDatapoints) * bytesPerBPoint
-	}
-
-	return worstCaseUnions * perUnion
-}
-
-// checkBinaryMemoryLimit estimates the output cost of a binary operation and
-// returns a descriptive error if it exceeds the configured memory limit.
+// checkBinaryMemoryLimit estimates the output cost of a binary operation by
+// replaying the label matching logic and computing per-pair costs. Returns a
+// descriptive error if the estimate exceeds the configured memory limit.
 func (e *State) checkBinaryMemoryLimit(ar, br Results, node *parse.BinaryNode) error {
-	aStats := computeResultStats(ar)
-	bStats := computeResultStats(br)
-	estimated := estimateBinaryOutputBytes(aStats, bStats)
+	est := estimateBinaryMemory(ar, br)
 
-	if estimated <= e.MemoryLimit {
+	if est.bytes <= e.MemoryLimit {
 		return nil
 	}
 
@@ -442,17 +458,17 @@ func (e *State) checkBinaryMemoryLimit(ar, br Results, node *parse.BinaryNode) e
 
 	return fmt.Errorf(
 		"expression %q attempted to combine %d series from %s with %d series from %s, "+
-			"producing up to %d series pairs (estimated memory: %s, limit: %s). "+
+			"producing %d series pairs (estimated memory: %s, limit: %s). "+
 			"This usually means the label sets returned by your queries are no longer compatible. "+
 			"When labels match, this expression would produce ~%d pairs. "+
 			"Check that the queries for %s and %s return series with the same label names and values",
 		node.String(),
-		aStats.count, aVar,
-		bStats.count, bVar,
-		int64(aStats.count)*int64(bStats.count),
-		formatBytes(estimated),
+		est.aCount, aVar,
+		est.bCount, bVar,
+		est.unions,
+		formatBytes(est.bytes),
 		formatBytes(e.MemoryLimit),
-		max(aStats.count, bStats.count),
+		max(est.aCount, est.bCount),
 		aVar, bVar,
 	)
 }

--- a/pkg/expr/mathexp/exp_memory_limit_test.go
+++ b/pkg/expr/mathexp/exp_memory_limit_test.go
@@ -1,0 +1,309 @@
+package mathexp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeResultStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  Results
+		expected resultStats
+	}{
+		{
+			name:     "empty results",
+			results:  Results{},
+			expected: resultStats{},
+		},
+		{
+			name: "single number with labels",
+			results: Results{
+				Values: Values{
+					makeNumber("n", data.Labels{"service": "web", "region": "us-east-1"}, float64Pointer(42)),
+				},
+			},
+			expected: resultStats{
+				count:         1,
+				seriesCount:   0,
+				maxDatapoints: 0,
+				maxLabelBytes: len("service") + len("web") + len("region") + len("us-east-1"),
+			},
+		},
+		{
+			name: "two series with different lengths and labels",
+			results: Results{
+				Values: Values{
+					makeSeries("a", data.Labels{"id": "1"},
+						tp{time.Unix(1, 0), float64Pointer(1)},
+						tp{time.Unix(2, 0), float64Pointer(2)},
+					),
+					makeSeries("b", data.Labels{"id": "1", "env": "production"},
+						tp{time.Unix(1, 0), float64Pointer(3)},
+						tp{time.Unix(2, 0), float64Pointer(4)},
+						tp{time.Unix(3, 0), float64Pointer(5)},
+					),
+				},
+			},
+			expected: resultStats{
+				count:         2,
+				seriesCount:   2,
+				maxDatapoints: 3,
+				maxLabelBytes: len("id") + len("1") + len("env") + len("production"),
+			},
+		},
+		{
+			name: "mix of series and numbers",
+			results: Results{
+				Values: Values{
+					makeSeries("s", data.Labels{"x": "y"},
+						tp{time.Unix(1, 0), float64Pointer(1)},
+					),
+					makeNumber("n", data.Labels{"a": "longer-value"}, float64Pointer(10)),
+				},
+			},
+			expected: resultStats{
+				count:         2,
+				seriesCount:   1,
+				maxDatapoints: 1,
+				maxLabelBytes: len("a") + len("longer-value"),
+			},
+		},
+		{
+			name: "NoData values have zero labels and zero datapoints",
+			results: Results{
+				Values: Values{
+					NewNoData(),
+					makeSeries("s", data.Labels{"id": "1"},
+						tp{time.Unix(1, 0), float64Pointer(1)},
+					),
+				},
+			},
+			expected: resultStats{
+				count:         2,
+				seriesCount:   1,
+				maxDatapoints: 1,
+				maxLabelBytes: len("id") + len("1"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeResultStats(tc.results)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestEstimateBinaryOutputBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        resultStats
+		b        resultStats
+		expected int64
+	}{
+		{
+			name:     "empty A returns zero",
+			a:        resultStats{count: 0},
+			b:        resultStats{count: 10, seriesCount: 10, maxDatapoints: 100},
+			expected: 0,
+		},
+		{
+			name:     "empty B returns zero",
+			a:        resultStats{count: 10, seriesCount: 10, maxDatapoints: 100},
+			b:        resultStats{count: 0},
+			expected: 0,
+		},
+		{
+			name: "number x number uses only labels and overhead",
+			a:    resultStats{count: 5, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 100},
+			b:    resultStats{count: 5, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 200},
+			// 25 unions * (0 + 200 + 500) = 17,500
+			expected: 25 * (200 + frameOverhead),
+		},
+		{
+			name: "series x series includes bPoints cost",
+			a:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
+			b:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
+			// 100 unions * (300*bytesPerDatapoint + 200 + frameOverhead + 300*bytesPerBPoint)
+			expected: 100 * (300*bytesPerDatapoint + 200 + frameOverhead + 300*bytesPerBPoint),
+		},
+		{
+			name: "series x number omits bPoints cost",
+			a:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
+			b:    resultStats{count: 1, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 50},
+			// 10 unions * (300*bytesPerDatapoint + 200 + frameOverhead), no bPoints since b has no series
+			expected: 10 * (300*bytesPerDatapoint + 200 + frameOverhead),
+		},
+		{
+			name: "asymmetric series uses max datapoints from either side",
+			a:    resultStats{count: 2, seriesCount: 2, maxDatapoints: 100, maxLabelBytes: 50},
+			b:    resultStats{count: 3, seriesCount: 3, maxDatapoints: 500, maxLabelBytes: 50},
+			// 6 unions * (500*bytesPerDatapoint + 50 + frameOverhead + 500*bytesPerBPoint)
+			expected: 6 * (500*bytesPerDatapoint + 50 + frameOverhead + 500*bytesPerBPoint),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := estimateBinaryOutputBytes(tc.a, tc.b)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestWalkBinary_memory_limit_blocks_cartesian_explosion(t *testing.T) {
+	// Build two sets of 100 series each with non-matching labels.
+	// This creates a worst-case cartesian product of 10,000 unions.
+	aValues := make(Values, 100)
+	bValues := make(Values, 100)
+	for i := 0; i < 100; i++ {
+		aValues[i] = makeSeries("a", data.Labels{"a_id": string(rune('A'+i%26)) + string(rune('0'+i/26))},
+			tp{time.Unix(1, 0), float64Pointer(1)},
+			tp{time.Unix(2, 0), float64Pointer(2)},
+			tp{time.Unix(3, 0), float64Pointer(3)},
+		)
+		bValues[i] = makeSeries("b", data.Labels{"b_id": string(rune('A'+i%26)) + string(rune('0'+i/26))},
+			tp{time.Unix(1, 0), float64Pointer(10)},
+			tp{time.Unix(2, 0), float64Pointer(20)},
+			tp{time.Unix(3, 0), float64Pointer(30)},
+		)
+	}
+
+	vars := Vars{
+		"A": Results{Values: aValues},
+		"B": Results{Values: bValues},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// With a very small limit, the cartesian product should be rejected.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(1024))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "100 series from $A")
+	assert.Contains(t, err.Error(), "100 series from $B")
+	assert.Contains(t, err.Error(), "10000 series pairs")
+}
+
+func TestWalkBinary_memory_limit_allows_matched_labels(t *testing.T) {
+	// Build two sets of 100 series with matching labels.
+	// This produces exactly 100 unions (1:1), which should be well within limits.
+	aValues := make(Values, 100)
+	bValues := make(Values, 100)
+	for i := 0; i < 100; i++ {
+		label := data.Labels{"id": string(rune('A'+i%26)) + string(rune('0'+i/26))}
+		aValues[i] = makeSeries("a", label,
+			tp{time.Unix(1, 0), float64Pointer(float64(i))},
+			tp{time.Unix(2, 0), float64Pointer(float64(i * 2))},
+		)
+		bValues[i] = makeSeries("b", label,
+			tp{time.Unix(1, 0), float64Pointer(1)},
+			tp{time.Unix(2, 0), float64Pointer(2)},
+		)
+	}
+
+	vars := Vars{
+		"A": Results{Values: aValues},
+		"B": Results{Values: bValues},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// The estimate is worst-case (10,000 unions) but the actual matching
+	// produces only 100. Derive the limit from the estimation function
+	// so this test is resilient to constant changes.
+	aStats := computeResultStats(vars["A"])
+	bStats := computeResultStats(vars["B"])
+	estimated := estimateBinaryOutputBytes(aStats, bStats)
+
+	// Set limit exactly at the worst-case estimate: should pass.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(estimated))
+	require.NoError(t, err)
+}
+
+func TestWalkBinary_memory_limit_zero_disables_check(t *testing.T) {
+	// Even a cartesian product should proceed when limit is 0.
+	vars := Vars{
+		"A": Results{Values: Values{
+			makeSeries("a", data.Labels{"a_id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+			makeSeries("a", data.Labels{"a_id": "2"}, tp{time.Unix(1, 0), float64Pointer(2)}),
+		}},
+		"B": Results{Values: Values{
+			makeSeries("b", data.Labels{"b_id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			makeSeries("b", data.Labels{"b_id": "2"}, tp{time.Unix(1, 0), float64Pointer(20)}),
+		}},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// Limit of 0 means no limit.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(0))
+	require.NoError(t, err)
+}
+
+func TestWalkBinary_memory_limit_not_applied_without_option(t *testing.T) {
+	// Without WithMemoryLimit, even small cartesian products should work.
+	vars := Vars{
+		"A": Results{Values: Values{
+			makeSeries("a", data.Labels{"a_id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+		}},
+		"B": Results{Values: Values{
+			makeSeries("b", data.Labels{"b_id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+		}},
+	}
+
+	e, err := New("$A + $B")
+	require.NoError(t, err)
+
+	// No WithMemoryLimit option: MemoryLimit defaults to 0 (disabled).
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest())
+	require.NoError(t, err)
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int64
+		expected string
+	}{
+		{"bytes", 512, "512 B"},
+		{"kibibytes", 1536, "1.5 KiB"},
+		{"mebibytes", 5 << 20, "5.0 MiB"},
+		{"gibibytes", 1 << 30, "1.0 GiB"},
+		{"fractional gibibytes", 3 * (1 << 30) / 2, "1.5 GiB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, formatBytes(tc.input))
+		})
+	}
+}
+
+func TestLabelBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   data.Labels
+		expected int
+	}{
+		{"nil labels", nil, 0},
+		{"empty labels", data.Labels{}, 0},
+		{"single pair", data.Labels{"key": "value"}, 8},
+		{"multiple pairs", data.Labels{"service": "web", "region": "us-east-1"}, 7 + 3 + 6 + 9},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, labelBytes(tc.labels))
+		})
+	}
+}

--- a/pkg/expr/mathexp/exp_memory_limit_test.go
+++ b/pkg/expr/mathexp/exp_memory_limit_test.go
@@ -10,166 +10,156 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestComputeResultStats(t *testing.T) {
+func TestEstimateBinaryMemory(t *testing.T) {
 	tests := []struct {
-		name     string
-		results  Results
-		expected resultStats
+		name          string
+		a             Results
+		b             Results
+		expectUnions  int
+		expectNonZero bool // true if bytes should be > 0
 	}{
 		{
-			name:     "empty results",
-			results:  Results{},
-			expected: resultStats{},
+			name:         "empty A returns zero",
+			a:            Results{},
+			b:            Results{Values: Values{makeSeries("b", data.Labels{"id": "1"})}},
+			expectUnions: 0,
 		},
 		{
-			name: "single number with labels",
-			results: Results{
-				Values: Values{
-					makeNumber("n", data.Labels{"service": "web", "region": "us-east-1"}, float64Pointer(42)),
-				},
-			},
-			expected: resultStats{
-				count:         1,
-				seriesCount:   0,
-				maxDatapoints: 0,
-				maxLabelBytes: len("service") + len("web") + len("region") + len("us-east-1"),
-			},
+			name: "matching labels produce 1:1 unions",
+			a: Results{Values: Values{
+				makeSeries("a", data.Labels{"id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+				makeSeries("a", data.Labels{"id": "2"}, tp{time.Unix(1, 0), float64Pointer(2)}),
+			}},
+			b: Results{Values: Values{
+				makeSeries("b", data.Labels{"id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+				makeSeries("b", data.Labels{"id": "2"}, tp{time.Unix(1, 0), float64Pointer(20)}),
+			}},
+			expectUnions:  2,
+			expectNonZero: true,
 		},
 		{
-			name: "two series with different lengths and labels",
-			results: Results{
-				Values: Values{
-					makeSeries("a", data.Labels{"id": "1"},
-						tp{time.Unix(1, 0), float64Pointer(1)},
-						tp{time.Unix(2, 0), float64Pointer(2)},
-					),
-					makeSeries("b", data.Labels{"id": "1", "env": "production"},
-						tp{time.Unix(1, 0), float64Pointer(3)},
-						tp{time.Unix(2, 0), float64Pointer(4)},
-						tp{time.Unix(3, 0), float64Pointer(5)},
-					),
-				},
-			},
-			expected: resultStats{
-				count:         2,
-				seriesCount:   2,
-				maxDatapoints: 3,
-				maxLabelBytes: len("id") + len("1") + len("env") + len("production"),
-			},
+			name: "non-matching labels of same length produce zero unions",
+			a: Results{Values: Values{
+				makeSeries("a", data.Labels{"a_id": "1"}),
+				makeSeries("a", data.Labels{"a_id": "2"}),
+			}},
+			b: Results{Values: Values{
+				makeSeries("b", data.Labels{"b_id": "1"}),
+				makeSeries("b", data.Labels{"b_id": "2"}),
+			}},
+			expectUnions: 0,
 		},
 		{
-			name: "mix of series and numbers",
-			results: Results{
-				Values: Values{
-					makeSeries("s", data.Labels{"x": "y"},
-						tp{time.Unix(1, 0), float64Pointer(1)},
-					),
-					makeNumber("n", data.Labels{"a": "longer-value"}, float64Pointer(10)),
-				},
-			},
-			expected: resultStats{
-				count:         2,
-				seriesCount:   1,
-				maxDatapoints: 1,
-				maxLabelBytes: len("a") + len("longer-value"),
-			},
+			name: "empty labels on one side produce cartesian product",
+			a: Results{Values: Values{
+				makeSeries("a", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(1)}),
+				makeSeries("a", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(2)}),
+			}},
+			b: Results{Values: Values{
+				makeSeries("b", data.Labels{"id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+				makeSeries("b", data.Labels{"id": "2"}, tp{time.Unix(1, 0), float64Pointer(20)}),
+			}},
+			expectUnions:  4,
+			expectNonZero: true,
 		},
 		{
-			name: "NoData values have zero labels and zero datapoints",
-			results: Results{
-				Values: Values{
-					NewNoData(),
-					makeSeries("s", data.Labels{"id": "1"},
-						tp{time.Unix(1, 0), float64Pointer(1)},
-					),
-				},
-			},
-			expected: resultStats{
-				count:         2,
-				seriesCount:   1,
-				maxDatapoints: 1,
-				maxLabelBytes: len("id") + len("1"),
-			},
+			name: "subset labels produce fan-out",
+			a: Results{Values: Values{
+				makeSeries("a", data.Labels{"service": "web", "endpoint": "/api"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+				makeSeries("a", data.Labels{"service": "web", "endpoint": "/health"}, tp{time.Unix(1, 0), float64Pointer(2)}),
+			}},
+			b: Results{Values: Values{
+				makeSeries("b", data.Labels{"service": "web"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			}},
+			expectUnions:  2,
+			expectNonZero: true,
+		},
+		{
+			name: "single non-matching values fall back to 1 union",
+			a: Results{Values: Values{
+				makeSeries("a", data.Labels{"id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+			}},
+			b: Results{Values: Values{
+				makeSeries("b", data.Labels{"id": "2"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			}},
+			expectUnions:  1,
+			expectNonZero: true,
+		},
+		{
+			name: "NoData on one side produces 1 union",
+			a:    Results{Values: Values{NewNoData()}},
+			b: Results{Values: Values{
+				makeSeries("b", data.Labels{"id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			}},
+			expectUnions:  1,
+			expectNonZero: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := computeResultStats(tc.results)
-			assert.Equal(t, tc.expected, got)
+			est := estimateBinaryMemory(tc.a, tc.b)
+			assert.Equal(t, tc.expectUnions, est.unions)
+			assert.Equal(t, len(tc.a.Values), est.aCount)
+			assert.Equal(t, len(tc.b.Values), est.bCount)
+			if tc.expectNonZero {
+				assert.Greater(t, est.bytes, int64(0))
+			} else {
+				assert.Equal(t, int64(0), est.bytes)
+			}
 		})
 	}
 }
 
-func TestEstimateBinaryOutputBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		a        resultStats
-		b        resultStats
-		expected int64
-	}{
-		{
-			name:     "empty A returns zero",
-			a:        resultStats{count: 0},
-			b:        resultStats{count: 10, seriesCount: 10, maxDatapoints: 100},
-			expected: 0,
-		},
-		{
-			name:     "empty B returns zero",
-			a:        resultStats{count: 10, seriesCount: 10, maxDatapoints: 100},
-			b:        resultStats{count: 0},
-			expected: 0,
-		},
-		{
-			name: "number x number uses only labels and overhead",
-			a:    resultStats{count: 5, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 100},
-			b:    resultStats{count: 5, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 200},
-			// 25 unions * (0 + 200 + 500) = 17,500
-			expected: 25 * (200 + frameOverhead),
-		},
-		{
-			name: "series x series includes bPoints cost",
-			a:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
-			b:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
-			// 100 unions * (300*bytesPerDatapoint + 200 + frameOverhead + 300*bytesPerBPoint)
-			expected: 100 * (300*bytesPerDatapoint + 200 + frameOverhead + 300*bytesPerBPoint),
-		},
-		{
-			name: "series x number omits bPoints cost",
-			a:    resultStats{count: 10, seriesCount: 10, maxDatapoints: 300, maxLabelBytes: 200},
-			b:    resultStats{count: 1, seriesCount: 0, maxDatapoints: 0, maxLabelBytes: 50},
-			// 10 unions * (300*bytesPerDatapoint + 200 + frameOverhead), no bPoints since b has no series
-			expected: 10 * (300*bytesPerDatapoint + 200 + frameOverhead),
-		},
-		{
-			name: "asymmetric series uses max datapoints from either side",
-			a:    resultStats{count: 2, seriesCount: 2, maxDatapoints: 100, maxLabelBytes: 50},
-			b:    resultStats{count: 3, seriesCount: 3, maxDatapoints: 500, maxLabelBytes: 50},
-			// 6 unions * (500*bytesPerDatapoint + 50 + frameOverhead + 500*bytesPerBPoint)
-			expected: 6 * (500*bytesPerDatapoint + 50 + frameOverhead + 500*bytesPerBPoint),
-		},
-	}
+func TestEstimateBinaryMemory_per_pair_cost_reflects_actual_sizes(t *testing.T) {
+	// Two matching series with different lengths. The estimate should use each
+	// pair's actual sizes, not a global max.
+	shortSeries := makeSeries("a", data.Labels{"id": "1"},
+		tp{time.Unix(1, 0), float64Pointer(1)},
+	)
+	longSeries := makeSeries("a", data.Labels{"id": "2"},
+		tp{time.Unix(1, 0), float64Pointer(1)},
+		tp{time.Unix(2, 0), float64Pointer(2)},
+		tp{time.Unix(3, 0), float64Pointer(3)},
+		tp{time.Unix(4, 0), float64Pointer(4)},
+		tp{time.Unix(5, 0), float64Pointer(5)},
+	)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := estimateBinaryOutputBytes(tc.a, tc.b)
-			assert.Equal(t, tc.expected, got)
-		})
-	}
+	a := Results{Values: Values{shortSeries, longSeries}}
+	b := Results{Values: Values{
+		makeSeries("b", data.Labels{"id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+		makeSeries("b", data.Labels{"id": "2"},
+			tp{time.Unix(1, 0), float64Pointer(10)},
+			tp{time.Unix(2, 0), float64Pointer(20)},
+			tp{time.Unix(3, 0), float64Pointer(30)},
+			tp{time.Unix(4, 0), float64Pointer(40)},
+			tp{time.Unix(5, 0), float64Pointer(50)},
+		),
+	}}
+
+	est := estimateBinaryMemory(a, b)
+	assert.Equal(t, 2, est.unions)
+
+	// Compute expected cost per pair:
+	lb := labelBytes(data.Labels{"id": "1"})
+	// Pair 1: short(1 dp) x short(1 dp), Pair 2: long(5 dp) x long(5 dp)
+	pair1 := int64(1)*bytesPerDatapoint + int64(lb) + frameOverhead + int64(1)*bytesPerBPoint
+	pair2 := int64(5)*bytesPerDatapoint + int64(lb) + frameOverhead + int64(5)*bytesPerBPoint
+	assert.Equal(t, pair1+pair2, est.bytes)
 }
 
 func TestWalkBinary_memory_limit_blocks_cartesian_explosion(t *testing.T) {
-	// Build two sets of 100 series each with non-matching labels.
-	// This creates a worst-case cartesian product of 10,000 unions.
+	// Build two sets of 100 series with empty labels on both sides.
+	// Empty labels match everything, producing a true 10,000-pair cartesian product.
 	aValues := make(Values, 100)
 	bValues := make(Values, 100)
 	for i := 0; i < 100; i++ {
-		aValues[i] = makeSeries("a", data.Labels{"a_id": string(rune('A'+i%26)) + string(rune('0'+i/26))},
+		aValues[i] = makeSeries("a", data.Labels{},
 			tp{time.Unix(1, 0), float64Pointer(1)},
 			tp{time.Unix(2, 0), float64Pointer(2)},
 			tp{time.Unix(3, 0), float64Pointer(3)},
 		)
-		bValues[i] = makeSeries("b", data.Labels{"b_id": string(rune('A'+i%26)) + string(rune('0'+i/26))},
+		bValues[i] = makeSeries("b", data.Labels{},
 			tp{time.Unix(1, 0), float64Pointer(10)},
 			tp{time.Unix(2, 0), float64Pointer(20)},
 			tp{time.Unix(3, 0), float64Pointer(30)},
@@ -217,15 +207,14 @@ func TestWalkBinary_memory_limit_allows_matched_labels(t *testing.T) {
 	e, err := New("$A + $B")
 	require.NoError(t, err)
 
-	// The estimate is worst-case (10,000 unions) but the actual matching
-	// produces only 100. Derive the limit from the estimation function
-	// so this test is resilient to constant changes.
-	aStats := computeResultStats(vars["A"])
-	bStats := computeResultStats(vars["B"])
-	estimated := estimateBinaryOutputBytes(aStats, bStats)
+	// Derive the limit from the estimation so this test is resilient to
+	// constant changes. With real union counting, the estimate reflects the
+	// actual 100 pairs, not the worst-case 10,000.
+	est := estimateBinaryMemory(vars["A"], vars["B"])
+	assert.Equal(t, 100, est.unions)
 
-	// Set limit exactly at the worst-case estimate: should pass.
-	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(estimated))
+	// Set limit exactly at the estimate: should pass.
+	_, err = e.Execute("", vars, tracing.InitializeTracerForTest(), WithMemoryLimit(est.bytes))
 	require.NoError(t, err)
 }
 
@@ -233,12 +222,12 @@ func TestWalkBinary_memory_limit_zero_disables_check(t *testing.T) {
 	// Even a cartesian product should proceed when limit is 0.
 	vars := Vars{
 		"A": Results{Values: Values{
-			makeSeries("a", data.Labels{"a_id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
-			makeSeries("a", data.Labels{"a_id": "2"}, tp{time.Unix(1, 0), float64Pointer(2)}),
+			makeSeries("a", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(1)}),
+			makeSeries("a", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(2)}),
 		}},
 		"B": Results{Values: Values{
-			makeSeries("b", data.Labels{"b_id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
-			makeSeries("b", data.Labels{"b_id": "2"}, tp{time.Unix(1, 0), float64Pointer(20)}),
+			makeSeries("b", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			makeSeries("b", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(20)}),
 		}},
 	}
 
@@ -254,10 +243,10 @@ func TestWalkBinary_memory_limit_not_applied_without_option(t *testing.T) {
 	// Without WithMemoryLimit, even small cartesian products should work.
 	vars := Vars{
 		"A": Results{Values: Values{
-			makeSeries("a", data.Labels{"a_id": "1"}, tp{time.Unix(1, 0), float64Pointer(1)}),
+			makeSeries("a", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(1)}),
 		}},
 		"B": Results{Values: Values{
-			makeSeries("b", data.Labels{"b_id": "1"}, tp{time.Unix(1, 0), float64Pointer(10)}),
+			makeSeries("b", data.Labels{}, tp{time.Unix(1, 0), float64Pointer(10)}),
 		}},
 	}
 

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -150,7 +150,7 @@ func buildCMDNode(ctx context.Context, rn *rawNode, toggles featuremgmt.FeatureT
 
 	switch commandType {
 	case TypeMath:
-		node.Command, err = UnmarshalMathCommand(rn)
+		node.Command, err = UnmarshalMathCommand(rn, cfg)
 	case TypeReduce:
 		node.Command, err = UnmarshalReduceCommand(rn)
 	case TypeResample:

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -490,6 +490,12 @@ type Cfg struct {
 	// SQLExpressionTimeoutSeconds is the duration a SQL expression will run before timing out
 	SQLExpressionTimeout time.Duration
 
+	// MathExpressionMemoryLimit is the maximum estimated memory (in bytes) that a
+	// single math expression binary operation is allowed to allocate for its output.
+	// When the estimated cost exceeds this limit, evaluation fails with a descriptive
+	// error. A value of 0 disables the limit. Default: 1 GiB.
+	MathExpressionMemoryLimit int64
+
 	ImageUploadProvider string
 
 	// LiveMaxConnections is a maximum number of WebSocket connections to
@@ -1012,6 +1018,7 @@ func (cfg *Cfg) readExpressionsSettings() {
 	cfg.SQLExpressionOutputCellLimit = expressions.Key("sql_expression_output_cell_limit").MustInt64(DefaultSQLExpressionOutputCellLimit)
 	cfg.SQLExpressionTimeout = expressions.Key("sql_expression_timeout").MustDuration(DefaultSQLExpressionTimeout)
 	cfg.SQLExpressionQueryLengthLimit = expressions.Key("sql_expression_query_length_limit").MustInt64(DefaultSQLExpressionQueryLengthLimit)
+	cfg.MathExpressionMemoryLimit = expressions.Key("math_expression_memory_limit").MustInt64(1 << 30) // 1 GiB
 }
 
 type AnnotationCleanupSettings struct {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -490,10 +490,10 @@ type Cfg struct {
 	// SQLExpressionTimeoutSeconds is the duration a SQL expression will run before timing out
 	SQLExpressionTimeout time.Duration
 
-	// MathExpressionMemoryLimit is the maximum estimated memory (in bytes) that a
-	// single math expression binary operation is allowed to allocate for its output.
-	// When the estimated cost exceeds this limit, evaluation fails with a descriptive
-	// error. A value of 0 disables the limit. Default: 1 GiB.
+	// MathExpressionMemoryLimit is the maximum estimated memory (in bytes) for a
+	// single math expression binary operation. Memory usage is estimated before
+	// the expression runs. When the estimate exceeds this limit, evaluation fails
+	// with a descriptive error. A value of 0 disables the limit. Default: 1 GiB.
 	MathExpressionMemoryLimit int64
 
 	ImageUploadProvider string


### PR DESCRIPTION
**What is this feature?**

A configurable memory limit for math expression binary operations. Before union() or any output allocation runs, walkBinary replays the label matching logic to count actual unions and compute per-pair memory costs from real series lengths and label sizes, without allocating. If the estimate exceeds the limit, evaluation fails with a human-readable error describing which queries have incompatible labels and what the operator should check.

Default: 1 GiB, configurable via [expressions] math_expression_memory_limit. Set to 0 to disable.

**Why do we need this feature?**

When label sets on both sides of a binary operation become incompatible (e.g. an upstream relabel config changes), union() produces len(A) * len(B) pairs instead of the expected 1:1 matching. For 1,000 series on each side this means 1,000,000 unions instead of 1,000, leading to unbounded memory allocation that can OOM-kill the process.

**Who is this feature for?**

Operators running Grafana with alerting rules that use math expressions combining multi-series query results.

**Which issue(s) does this PR fix?**:

Fixes #121943