### PR TITLE
Secrets: Miscellaneous fixes

### DIFF
--- a/pkg/registry/apis/secret/decrypt/grpc_client.go
+++ b/pkg/registry/apis/secret/decrypt/grpc_client.go
@@ -130,10 +130,10 @@ func (g *GRPCDecryptClient) Decrypt(ctx context.Context, serviceName string, nam
 		return nil, err
 	}
 
-	unique := make(map[string]bool, len(names))
+	unique := make(map[string]struct{}, len(names))
 	for _, v := range names {
 		if v != "" {
-			unique[v] = true
+			unique[v] = struct{}{}
 		}
 	}
 	if len(unique) < 1 {
@@ -175,6 +175,11 @@ func (g *GRPCDecryptClient) Decrypt(ctx context.Context, serviceName string, nam
 	results := make(map[string]decrypt.DecryptResult, len(resp.GetDecryptedValues()))
 
 	for name, result := range resp.GetDecryptedValues() {
+		// Only accept results for names that were actually requested.
+		if _, ok := unique[name]; !ok {
+			continue
+		}
+
 		if result.GetErrorMessage() != "" {
 			results[name] = decrypt.NewDecryptResultErr(errors.New(result.GetErrorMessage()))
 		} else {

--- a/pkg/registry/apis/secret/encryption/cipher/service/service.go
+++ b/pkg/registry/apis/secret/encryption/cipher/service/service.go
@@ -98,6 +98,9 @@ func (s *cipherService) deriveEncryptionAlgorithm(payload []byte) (string, []byt
 
 	payload = payload[1:]
 	algorithmDelimiterIdx := bytes.Index(payload, []byte{encryptionAlgorithmDelimiter})
+	if algorithmDelimiterIdx == -1 {
+		return "", nil, fmt.Errorf("unable to derive encryption algorithm: missing algorithm delimiter")
+	}
 
 	algorithmB64 := payload[:algorithmDelimiterIdx]
 	payload = payload[algorithmDelimiterIdx+1:]

--- a/pkg/registry/apis/secret/encryption/cipher/service/service_test.go
+++ b/pkg/registry/apis/secret/encryption/cipher/service/service_test.go
@@ -46,4 +46,27 @@ func TestService(t *testing.T) {
 		assert.Equal(t, []byte("grafana"), decrypted)
 		// We'll let the provider deal with testing details.
 	})
+
+	t.Run("decrypt payload missing algorithm delimiter should return error not panic", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newGcmService(t)
+
+		// A payload with a leading delimiter byte but no closing delimiter.
+		// Previously this caused a panic via slice bounds out of range
+		// because bytes.Index returned -1 and it was used as a slice bound.
+		malformed := []byte("*no-closing-delimiter")
+		_, err := svc.Decrypt(t.Context(), malformed, "1234")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing algorithm delimiter")
+	})
+
+	t.Run("decrypt single-byte payload should return error not panic", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newGcmService(t)
+		_, err := svc.Decrypt(t.Context(), []byte("x"), "1234")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing algorithm delimiter")
+	})
 }

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -557,7 +557,7 @@ func (s *keeperMetadataStorage) validateSecureValueReferences(ctx context.Contex
 		thirdPartyKeepers = append(thirdPartyKeepers, name)
 	}
 
-	if err := rows.Err(); err != nil {
+	if err := keepersRows.Err(); err != nil {
 		return fmt.Errorf("third party keeper rows error: %w", err)
 	}
 

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -724,7 +724,7 @@ func (s *secureValueMetadataStorage) listByLeaseToken(ctx context.Context, lease
 		}
 
 		if leaseTokenDB != leaseToken {
-			return nil, fmt.Errorf("bug: expected to list secure values with lease token %+v but got a secure value with another lease token %+v", leaseToken, leaseToken)
+			return nil, fmt.Errorf("bug: expected to list secure values with lease token %+v but got a secure value with another lease token %+v", leaseToken, leaseTokenDB)
 		}
 
 		secureValue, err := row.toKubernetes()


### PR DESCRIPTION
Each commit is a tiny fix/improvement, felt it was too much to break it down into 4 PRs:
- Secrets: Use correct lease token variable in error
- Secrets: Use correct row variable when checking errors
- Secrets: Defensive check if algo delimiter is not found
- Secrets: Only return requested secure value names in decrypt request