### PR TITLE
Community: capture Enhancement issue types as feature requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1280,6 +1280,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/feature-toggles-ci.yml @grafana/docs-tooling
 /.github/workflows/github-release.yml @grafana/grafana-developer-enablement-squad
 /.github/workflows/external-fr-notify.yml @grafana/grafana-community-support
+/.github/workflows/external-fr-type-labeler.yml @grafana/grafana-community-support
 /.github/workflows/external-fr-weekly-digest.yml @grafana/grafana-community-support
 /.github/workflows/external-pr-notify-handler.yml @grafana/grafana-community-support
 /.github/workflows/external-pr-notify-trigger.yml @grafana/grafana-community-support

--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -2,7 +2,7 @@ name: External FR Notify
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, typed]
 
 permissions:
   contents: read
@@ -18,8 +18,11 @@ jobs:
     name: Notify team about new FR
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.issue.labels.*.name, 'type/feature-request') &&
-      !contains(github.event.issue.labels.*.name, 'fr/auto-triaged')
+      !contains(github.event.issue.labels.*.name, 'fr/auto-triaged') &&
+      (
+        (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'type/feature-request'))
+        || github.event.action == 'typed'
+      )
 
     steps:
       - name: Checkout repository
@@ -50,6 +53,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: node --experimental-strip-types .github/workflows/scripts/fr-notify.mts metadata
 
       - name: Match teams and send notifications

--- a/.github/workflows/external-fr-type-labeler.yml
+++ b/.github/workflows/external-fr-type-labeler.yml
@@ -1,0 +1,40 @@
+name: Label Enhancement issues
+
+on:
+  issues:
+    types: [typed, opened]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Add feature-request label
+    if: >-
+      github.event.action == 'typed' ||
+      (github.event.action == 'opened' && github.event.issue.type != null)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check issue type and add label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          ISSUE_TYPE=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.type.name // empty')
+          echo "Issue type: ${ISSUE_TYPE:-none}"
+
+          if [ "$ISSUE_TYPE" != "Enhancement" ]; then
+            echo "Not an Enhancement issue, skipping"
+            exit 0
+          fi
+
+          LABELS=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '[.labels[].name] | join(",")')
+          if echo "$LABELS" | grep -q "type/feature-request"; then
+            echo "Already has type/feature-request label, skipping"
+            exit 0
+          fi
+
+          echo "Adding type/feature-request label"
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "type/feature-request"

--- a/.github/workflows/scripts/fr-digest.mts
+++ b/.github/workflows/scripts/fr-digest.mts
@@ -364,7 +364,7 @@ async function main(): Promise<void> {
     console.log(`Found ${staleFrs.length} stale feature requests`);
 
     const engagedFrs = frs
-      .filter((fr) => fr.thumbs_up >= 1 || fr.comments >= 1)
+      .filter((fr) => fr.thumbs_up >= 5 || fr.comments >= 5)
       .sort((a, b) => (b.thumbs_up + b.comments) - (a.thumbs_up + a.comments))
       .slice(0, 10);
     console.log(`Found ${engagedFrs.length} engaged feature requests`);

--- a/.github/workflows/scripts/fr-notify.mts
+++ b/.github/workflows/scripts/fr-notify.mts
@@ -13,14 +13,32 @@ import {
 function getIssueMetadata(): void {
   const issueNumber = requireEnv('ISSUE_NUMBER');
   const repo = requireEnv('REPO');
+  const eventAction = process.env.EVENT_ACTION ?? '';
 
-  const issueData = JSON.parse(
-    execFileSync('gh', ['issue', 'view', issueNumber, '--repo', repo, '--json', 'title,author,labels,createdAt'], {
-      encoding: 'utf-8', timeout: 30_000,
-    }),
+  const issueJson = execFileSync(
+    'gh', ['api', `repos/${repo}/issues/${issueNumber}`, '--jq',
+      '{title: .title, author: .user.login, labels: [.labels[].name], createdAt: .created_at, type: (.type.name // "")}'],
+    { encoding: 'utf-8', timeout: 30_000 },
   );
+  const issueData = JSON.parse(issueJson);
 
-  const labels: string[] = (issueData.labels ?? []).map((l: { name: string }) => l.name);
+  const labels: string[] = issueData.labels ?? [];
+  const issueType: string = issueData.type ?? '';
+
+  if (eventAction === 'typed' && issueType !== 'Enhancement') {
+    log.notice(`Issue #${issueNumber} type is "${issueType || 'none'}", not Enhancement — skipping`);
+    setOutput('skip_processing', 'true');
+    process.exit(0);
+  }
+
+  if (eventAction === 'typed' && !labels.includes('type/feature-request')) {
+    log.notice(`Adding type/feature-request label to Enhancement issue #${issueNumber}`);
+    execFileSync('gh', ['issue', 'edit', issueNumber, '--repo', repo, '--add-label', 'type/feature-request'], {
+      encoding: 'utf-8', timeout: 30_000,
+    });
+    labels.push('type/feature-request');
+  }
+
   if (labels.includes('fr/auto-triaged')) {
     log.notice(`Issue #${issueNumber} already has fr/auto-triaged label - skipping to prevent duplicate processing`);
     setOutput('skip_processing', 'true');
@@ -31,7 +49,7 @@ function getIssueMetadata(): void {
   setOutput('created_date', (issueData.createdAt as string).split('T')[0]);
 
   const title = (issueData.title as string ?? 'No title').replace(/[\x00-\x1F]/g, '').slice(0, 150);
-  let author = issueData.author?.login ?? 'unknown';
+  let author = (issueData.author as string) ?? 'unknown';
   if (!isValidGitHubUsername(author)) {
     log.warning('Invalid author format detected, using "unknown"');
     author = 'unknown';


### PR DESCRIPTION
## Summary
- Adds a bridge workflow that automatically labels GitHub "Enhancement" issue types with `type/feature-request`, so existing FR notification and digest workflows pick them up
- Updates FR notify to handle `typed` events directly, checking the issue type via REST API and adding the label when needed
- Raise community interest threshold for FR digests


Made with [Cursor](https://cursor.com)