### PR TITLE
Splash Screen: always open CTA links in new tab

### DIFF
--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -22,10 +22,6 @@ function resolveCtaUrl(cta: SplashFeatureCta): string {
   return cta.url;
 }
 
-function isExternalUrl(url: string): boolean {
-  return url.startsWith('http');
-}
-
 export function SplashScreenModal() {
   const [activeIndex, setActiveIndex] = useState(0);
   const styles = useStyles2(getStyles);
@@ -54,7 +50,6 @@ export function SplashScreenModal() {
   const activeFeature = config.features[activeIndex];
   const cta = activeFeature.cta;
   const ctaUrl = cta ? resolveCtaUrl(cta) : '';
-  const isCtaExternal = isExternalUrl(ctaUrl);
 
   const footer = (
     <>
@@ -68,10 +63,9 @@ export function SplashScreenModal() {
       {cta && (
         <LinkButton
           href={ctaUrl}
-          onClick={isCtaExternal ? undefined : dismiss}
-          target={isCtaExternal ? '_blank' : undefined}
-          rel={isCtaExternal ? 'noopener noreferrer' : undefined}
-          icon={isCtaExternal ? 'external-link-alt' : 'arrow-right'}
+          target="_blank"
+          rel="noopener noreferrer"
+          icon="external-link-alt"
           variant="secondary"
           fill="outline"
           size="md"


### PR DESCRIPTION
## Summary

All CTA "Show me" links now open in a new tab so users can browse all 4 slides before dismissing. Previously, internal links dismissed the modal and navigated in the same tab, causing users to miss remaining slides.