### PR TITLE
Auth: URL-encode redirectTo cookie value in OAuth login flow

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/url"
+
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
@@ -40,7 +42,7 @@ func (hs *HTTPServer) OAuthLogin(reqCtx *contextmodel.ReqContext) {
 
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if hs.Features.IsEnabledGlobally(featuremgmt.FlagUseSessionStorageForRedirection) {
-			cookies.WriteCookie(reqCtx.Resp, "redirectTo", redirectTo, hs.Cfg.OAuthCookieMaxAge, hs.CookieOptionsFromCfg)
+			cookies.WriteCookie(reqCtx.Resp, "redirectTo", url.QueryEscape(redirectTo), hs.Cfg.OAuthCookieMaxAge, hs.CookieOptionsFromCfg)
 		}
 		if pkce := redirect.Extra[authn.KeyOAuthPKCE]; pkce != "" {
 			cookies.WriteCookie(reqCtx.Resp, OauthPKCECookieName, pkce, hs.Cfg.OAuthCookieMaxAge, hs.CookieOptionsFromCfg)

--- a/pkg/api/login_oauth_test.go
+++ b/pkg/api/login_oauth_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -202,4 +204,63 @@ func TestOAuthLogin_Error(t *testing.T) {
 	errCookie := res.Cookies()[0]
 	assert.Equal(t, loginErrorCookieName, errCookie.Name)
 	require.NoError(t, res.Body.Close())
+}
+
+func TestOAuthLogin_RedirectToCookiePreservesEncodedCharacters(t *testing.T) {
+	// Go's net/http silently strips characters like " from cookie values
+	// because they are not valid per RFC 6265. OAuthLogin must URL-encode
+	// the redirectTo value before writing it to the cookie so that characters
+	// like " survive as %22, matching the url.QueryUnescape on the read side
+	// in handleLogin.
+
+	redirectTos := []string{
+		"/some/path",
+		"/some/path?flag=true&id=abc123",
+		`/some/path?query=metric{label="value"}`,
+		`/some/path?flag=true&query=up{instance="localhost:9090"}&dashboard=d402d94e`,
+	}
+
+	for _, redirectTo := range redirectTos {
+		t.Run(redirectTo, func(t *testing.T) {
+			server := SetupAPITestServer(t, func(hs *HTTPServer) {
+				hs.Cfg = setting.NewCfg()
+				hs.SecretsService = fakes.NewFakeSecretsService()
+				hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagUseSessionStorageForRedirection)
+				hs.authnService = &authntest.FakeService{
+					ExpectedRedirect: &authn.Redirect{
+						URL: "https://oauth-provider.example.com/authorize",
+						Extra: map[string]string{
+							authn.KeyOAuthState: "test-state",
+						},
+					},
+				}
+			})
+
+			server.HttpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+
+			res, err := server.Send(server.NewGetRequest(
+				"/login/generic_oauth?redirectTo=" + url.QueryEscape(redirectTo),
+			))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, res.Body.Close()) }()
+
+			assert.Equal(t, http.StatusFound, res.StatusCode)
+
+			var redirectToCookie *http.Cookie
+			for _, c := range res.Cookies() {
+				if c.Name == "redirectTo" {
+					redirectToCookie = c
+					break
+				}
+			}
+			require.NotNil(t, redirectToCookie, "OAuthLogin should write a redirectTo cookie")
+
+			decoded, err := url.QueryUnescape(redirectToCookie.Value)
+			require.NoError(t, err)
+			assert.Equal(t, redirectTo, decoded,
+				"redirectTo cookie should round-trip through QueryUnescape to the original value")
+		})
+	}
 }


### PR DESCRIPTION
**What is this feature?**

URL-encode the `redirectTo` query parameter value before writing it to a cookie during the OAuth login flow. This pairs with the existing `url.QueryUnescape` on the read side in `handleLogin`.

**Why do we need this feature?**

Go's `net/http` silently strips double-quote characters (`"`) from cookie values because they are not valid per RFC 6265. When a `redirectTo` URL contains quotes — for example, a deep link with a PromQL query like `metric{label="value"}` — the quotes are lost during the cookie round-trip, corrupting the redirect destination after OAuth login completes.

**Who is this feature for?**

Any user or integration that deep links into a Grafana instance via `/login/<provider>?redirectTo=...` where the redirect path contains URL-encoded double quotes (`%22`). This is particularly relevant for deep links that include PromQL expressions in query parameters.

**Which issue(s) does this PR fix?**:

<!--
Fixes #
-->

**Special notes for your reviewer:**

The fix is a one-line change in `login_oauth.go` — wrapping the `redirectTo` value with `url.QueryEscape` before writing it to the cookie. The read side (`authn.go:299`) already calls `url.QueryUnescape`, so this completes the encode/decode pair.

The test exercises the full `OAuthLogin` handler and verifies the cookie value round-trips correctly through `url.QueryUnescape`. Without the fix, the two test cases with `"` in the redirect path fail — the quotes are silently stripped.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
