### PR TITLE
Alerting: add custom API URL support for Telegram contact point

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -261,9 +261,10 @@ type SlackIntegration struct {
 type TelegramIntegration struct {
 	DisableResolveMessage *bool `json:"-" yaml:"-" hcl:"disable_resolve_message"`
 
-	BotToken        Secret `json:"bottoken" yaml:"bottoken" hcl:"token"`
-	ChatID          string `json:"chatid,omitempty" yaml:"chatid,omitempty" hcl:"chat_id"`
-	MessageThreadID string `json:"message_thread_id,omitempty" yaml:"message_thread_id,omitempty" hcl:"message_thread_id"`
+	BotToken        Secret  `json:"bottoken" yaml:"bottoken" hcl:"token"`
+	ChatID          string  `json:"chatid,omitempty" yaml:"chatid,omitempty" hcl:"chat_id"`
+	MessageThreadID string  `json:"message_thread_id,omitempty" yaml:"message_thread_id,omitempty" hcl:"message_thread_id"`
+	APIUrl          *string `json:"api_url,omitempty" yaml:"api_url,omitempty" hcl:"api_url"`
 
 	Message               *string `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
 	ParseMode             *string `json:"parse_mode,omitempty" yaml:"parse_mode,omitempty" hcl:"parse_mode"`


### PR DESCRIPTION
## What is this feature?

Adds an optional `api_url` field to the Telegram contact point integration, allowing users to configure a custom Telegram Bot API endpoint instead of the hardcoded `https://api.telegram.org` default.

## Why do we need this feature?

Telegram offers a [local Bot API server](https://core.telegram.org/bots/api#using-a-local-bot-api-server) deployment for specific use cases such as downloading large files or running bots in airgapped/restricted networks. Users behind corporate proxies or in countries where `api.telegram.org` is blocked also need the ability to route requests through an alternative endpoint.

The Mimir/vanilla Alertmanager Telegram integration (v0mimir1) already supports this via `api_url`, and Prometheus Alertmanager documents it as a [standard configuration option](https://prometheus.io/docs/alerting/latest/configuration/#telegram_config). The Grafana-managed (v1) Telegram notifier does not currently expose this setting.

## Changes

This PR adds the `APIUrl` field to the `TelegramIntegration` struct in the Grafana contact point data model used for provisioning and HCL/Terraform export.

A companion change in [grafana/alerting](https://github.com/grafana/alerting) is needed to:
1. Add the `APIUrl` field to the v1 `Config` struct and `NewConfig` parser (with fallback to the default URL)
2. Add an "API URL" entry to the v1 `Schema` options (so it appears in the contact point UI)
3. Use the configured URL in `telegram.go` instead of the hardcoded `APIURL` package variable

Once the alerting module is updated and the dependency is bumped, the full feature will be end-to-end functional.

## Who is this feature for?

Users who run a local Telegram Bot API deployment, operate behind corporate proxies, or are in networks where `api.telegram.org` is not directly reachable.

Fixes #81534