### PR TITLE
Folders: Remove unused types and fake store dead code

### DIFF
--- a/pkg/services/folder/foldertest/foldertest.go
+++ b/pkg/services/folder/foldertest/foldertest.go
@@ -14,7 +14,6 @@ type FakeService struct {
 	ExpectedHitList          model.HitList
 	ExpectedError            error
 	ExpectedDescendantCounts map[string]int64
-	LastQuery                folder.GetFoldersQuery
 	foldersByUID             map[string]*folder.Folder
 }
 

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -260,14 +260,6 @@ type GetChildrenQuery struct {
 	FolderUIDs []string `json:"-"`
 }
 
-type HasEditPermissionInFoldersQuery struct {
-	SignedInUser identity.Requester
-}
-
-type HasAdminPermissionInDashboardsOrFoldersQuery struct {
-	SignedInUser identity.Requester
-}
-
 // GetDescendantCountsQuery captures the information required by the folder service
 // to return the count of descendants (direct and indirect) in a folder.
 type GetDescendantCountsQuery struct {

--- a/pkg/services/folder/store_fake.go
+++ b/pkg/services/folder/store_fake.go
@@ -35,10 +35,6 @@ func (f *fakeStore) Update(ctx context.Context, cmd UpdateFolderCommand) (*Folde
 	return f.ExpectedFolder, f.ExpectedError
 }
 
-func (f *fakeStore) Move(ctx context.Context, cmd MoveFolderCommand) error {
-	return f.ExpectedError
-}
-
 func (f *fakeStore) Get(ctx context.Context, cmd GetFolderQuery) (*Folder, error) {
 	return f.ExpectedFolder, f.ExpectedError
 }


### PR DESCRIPTION
- Drops orphaned permission query structs from pkg/services/folder, 
- Removes the unused LastQuery field on foldertest.FakeService
- Deletes the non-interface Move method on the folder fake store. No behavior change for callers.