### PR TITLE
IAM: Add id to uid scope resolver for k8s apis

### DIFF
--- a/pkg/registry/apis/iam/authorizer/role_permission_validator.go
+++ b/pkg/registry/apis/iam/authorizer/role_permission_validator.go
@@ -203,14 +203,8 @@ func (v *RolePermissionValidator) parsePermission(act, sc string) (*permission, 
 		return &perm, nil
 	}
 
-	scopeResource, attribute, name := accesscontrol.SplitScope(sc)
+	scopeResource, _, name := accesscontrol.SplitScope(sc)
 	perm.scope.name = name
-
-	// k8s roles should only use UID-based scopes for teams, users, and service accounts
-	// reject ID-based scopes (attribute == "id") for these resources
-	if attribute == "id" {
-		return nil, fmt.Errorf("roles no longer support ID-based scopes for %s. Use uid-based scopes instead", scopeResource)
-	}
 
 	if scopeResource == "folders" || scopeResource == "folder.grafana.app" {
 		perm.scope.folder = true

--- a/pkg/registry/apis/iam/authorizer/role_permission_validator_test.go
+++ b/pkg/registry/apis/iam/authorizer/role_permission_validator_test.go
@@ -63,13 +63,6 @@ func TestParsePermission(t *testing.T) {
 			wantVerb:  "get",
 		},
 		{
-			name:        "reject id-based scope",
-			action:      "dashboards:read",
-			scope:       "dashboards:id:123",
-			wantErr:     true,
-			errContains: "ID-based scopes",
-		},
-		{
 			name:       "folder scope wildcard",
 			action:     "dashboards:read",
 			scope:      "folders:*",

--- a/pkg/registry/apis/iam/legacy/scope_resolver.go
+++ b/pkg/registry/apis/iam/legacy/scope_resolver.go
@@ -1,0 +1,223 @@
+package legacy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
+	"github.com/grafana/grafana/pkg/services/team"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+// ScopeResolverStore is the minimal identity-lookup interface needed by the
+// scope resolution helpers. LegacyIdentityStore satisfies it.
+type ScopeResolverStore interface {
+	GetTeamInternalID(ctx context.Context, ns claims.NamespaceInfo, query GetTeamInternalIDQuery) (*GetTeamInternalIDResult, error)
+	GetUserInternalID(ctx context.Context, ns claims.NamespaceInfo, query GetUserInternalIDQuery) (*GetUserInternalIDResult, error)
+	GetServiceAccountInternalID(ctx context.Context, ns claims.NamespaceInfo, query GetServiceAccountInternalIDQuery) (*GetServiceAccountInternalIDResult, error)
+	GetTeamUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetTeamUIDByIDQuery) (*GetTeamUIDByIDResult, error)
+	GetUserUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error)
+	GetServiceAccountUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error)
+}
+
+// ResolveUIDScopeForWrite converts a single uid-based scope (teams:uid:xxx, users:uid:xxx,
+// serviceaccounts:uid:xxx) to its id-based equivalent (teams:id:123, etc.).
+// Wildcard scopes (e.g. teams:uid:*) are rewritten without a lookup.
+// Returns the scope unchanged if it doesn't match a known uid prefix.
+func ResolveUIDScopeForWrite(ctx context.Context, store ScopeResolverStore, ns claims.NamespaceInfo, scope string) (string, error) {
+	switch {
+	case strings.HasPrefix(scope, "teams:uid:"):
+		uid := strings.TrimPrefix(scope, "teams:uid:")
+		if uid == "*" {
+			return "teams:id:*", nil
+		}
+		result, err := store.GetTeamInternalID(ctx, ns, GetTeamInternalIDQuery{UID: uid})
+		if err != nil {
+			return "", fmt.Errorf("resolving team uid %q to internal id: %w", uid, err)
+		}
+		return fmt.Sprintf("teams:id:%d", result.ID), nil
+	case strings.HasPrefix(scope, "users:uid:"):
+		uid := strings.TrimPrefix(scope, "users:uid:")
+		if uid == "*" {
+			return "users:id:*", nil
+		}
+		result, err := store.GetUserInternalID(ctx, ns, GetUserInternalIDQuery{UID: uid})
+		if err != nil {
+			return "", fmt.Errorf("resolving user uid %q to internal id: %w", uid, err)
+		}
+		return fmt.Sprintf("users:id:%d", result.ID), nil
+	case strings.HasPrefix(scope, "serviceaccounts:uid:"):
+		uid := strings.TrimPrefix(scope, "serviceaccounts:uid:")
+		if uid == "*" {
+			return "serviceaccounts:id:*", nil
+		}
+		result, err := store.GetServiceAccountInternalID(ctx, ns, GetServiceAccountInternalIDQuery{UID: uid})
+		if err != nil {
+			return "", fmt.Errorf("resolving service account uid %q to internal id: %w", uid, err)
+		}
+		return fmt.Sprintf("serviceaccounts:id:%d", result.ID), nil
+	default:
+		return scope, nil
+	}
+}
+
+// ResolveUIDScopesForWrite is the batch version of ResolveUIDScopeForWrite.
+// The returned slice is always a copy; the input is never mutated.
+func ResolveUIDScopesForWrite(ctx context.Context, store ScopeResolverStore, ns claims.NamespaceInfo, permissions []accesscontrol.Permission) ([]accesscontrol.Permission, error) {
+	out := make([]accesscontrol.Permission, len(permissions))
+	copy(out, permissions)
+	for i, p := range out {
+		resolved, err := ResolveUIDScopeForWrite(ctx, store, ns, p.Scope)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != p.Scope {
+			out[i].Scope = resolved
+			out[i].Kind, out[i].Attribute, out[i].Identifier = accesscontrol.SplitScope(resolved)
+		}
+	}
+	return out, nil
+}
+
+// ResolveIDScopeToUIDName resolves an id-based scope to just the uid name.
+// e.g. "teams:id:1" → "teamuid1". Returns an error if the entity is not found
+// or the scope doesn't match a known id prefix.
+func ResolveIDScopeToUIDName(ctx context.Context, store ScopeResolverStore, ns claims.NamespaceInfo, scope string) (string, error) {
+	parts := strings.SplitN(scope, ":", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid scope: %s", scope)
+	}
+	id, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid id in scope %s: %w", scope, err)
+	}
+	switch parts[0] {
+	case "teams":
+		result, err := store.GetTeamUIDByID(ctx, ns, GetTeamUIDByIDQuery{ID: id})
+		if err != nil {
+			return "", fmt.Errorf("resolving team id %d to uid: %w", id, err)
+		}
+		return result.UID, nil
+	case "users":
+		result, err := store.GetUserUIDByID(ctx, ns, GetUserUIDByIDQuery{ID: id})
+		if err != nil {
+			return "", fmt.Errorf("resolving user id %d to uid: %w", id, err)
+		}
+		return result.UID, nil
+	case "serviceaccounts":
+		result, err := store.GetServiceAccountUIDByID(ctx, ns, GetUserUIDByIDQuery{ID: id})
+		if err != nil {
+			return "", fmt.Errorf("resolving service account id %d to uid: %w", id, err)
+		}
+		return result.UID, nil
+	default:
+		return "", fmt.Errorf("unknown id-scoped resource: %s", parts[0])
+	}
+}
+
+// ResolveIDScopeToUID resolves a single id-based scope (teams:id:123, users:id:123,
+// serviceaccounts:id:123) to its uid-based equivalent. Wildcard scopes are converted
+// without a lookup. If the entity is not found the permission should be omitted
+// (drop=true) — teams/users/service accounts clean up their permissions on delete,
+// so this is a safety net for stale data. Non-not-found errors are returned so the
+// caller can decide whether to fail.
+func ResolveIDScopeToUID(ctx context.Context, store ScopeResolverStore, ns claims.NamespaceInfo, scope string, logger log.Logger) (resolved string, drop bool, err error) {
+	switch {
+	case strings.HasPrefix(scope, "teams:id:"):
+		idStr := strings.TrimPrefix(scope, "teams:id:")
+		if idStr == "*" {
+			return "teams:uid:*", false, nil
+		}
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			return scope, false, nil
+		}
+		result, err := store.GetTeamUIDByID(ctx, ns, GetTeamUIDByIDQuery{ID: id})
+		if err != nil {
+			if IsNotFoundError(err) {
+				logger.Warn("Omitting permission with orphaned team scope", "scope", scope)
+				return "", true, nil
+			}
+			return "", false, fmt.Errorf("resolving team id %s to uid: %w", idStr, err)
+		}
+		return "teams:uid:" + result.UID, false, nil
+
+	case strings.HasPrefix(scope, "users:id:"):
+		idStr := strings.TrimPrefix(scope, "users:id:")
+		if idStr == "*" {
+			return "users:uid:*", false, nil
+		}
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			return scope, false, nil
+		}
+		result, err := store.GetUserUIDByID(ctx, ns, GetUserUIDByIDQuery{ID: id})
+		if err != nil {
+			if IsNotFoundError(err) {
+				logger.Warn("Omitting permission with orphaned user scope", "scope", scope)
+				return "", true, nil
+			}
+			return "", false, fmt.Errorf("resolving user id %s to uid: %w", idStr, err)
+		}
+		return "users:uid:" + result.UID, false, nil
+
+	case strings.HasPrefix(scope, "serviceaccounts:id:"):
+		idStr := strings.TrimPrefix(scope, "serviceaccounts:id:")
+		if idStr == "*" {
+			return "serviceaccounts:uid:*", false, nil
+		}
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			return scope, false, nil
+		}
+		result, err := store.GetServiceAccountUIDByID(ctx, ns, GetUserUIDByIDQuery{ID: id})
+		if err != nil {
+			if IsNotFoundError(err) {
+				logger.Warn("Omitting permission with orphaned service account scope", "scope", scope)
+				return "", true, nil
+			}
+			return "", false, fmt.Errorf("resolving service account id %s to uid: %w", idStr, err)
+		}
+		return "serviceaccounts:uid:" + result.UID, false, nil
+
+	default:
+		return scope, false, nil
+	}
+}
+
+// ResolveIDScopesToUID converts id-based scopes to uid-based scopes for a slice
+// of permissions. Permissions referencing deleted entities are silently omitted
+// (with a warning log). This should not happen because parents are expected to clean
+// up permissions on delete. The returned slice is always a new allocation.
+func ResolveIDScopesToUID(
+	ctx context.Context,
+	store ScopeResolverStore,
+	ns claims.NamespaceInfo,
+	perms []accesscontrol.Permission,
+	logger log.Logger,
+) ([]accesscontrol.Permission, error) {
+	out := make([]accesscontrol.Permission, 0, len(perms))
+	for _, p := range perms {
+		resolved, drop, err := ResolveIDScopeToUID(ctx, store, ns, p.Scope, logger)
+		if err != nil {
+			return nil, err
+		}
+		if drop {
+			continue
+		}
+		p.Scope = resolved
+		p.Kind, p.Attribute, p.Identifier = accesscontrol.SplitScope(resolved)
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func IsNotFoundError(err error) bool {
+	return errors.Is(err, user.ErrUserNotFound) || errors.Is(err, team.ErrTeamNotFound) || errors.Is(err, serviceaccounts.ErrServiceAccountNotFound)
+}

--- a/pkg/registry/apis/iam/legacy/scope_resolver.go
+++ b/pkg/registry/apis/iam/legacy/scope_resolver.go
@@ -85,6 +85,29 @@ func ResolveUIDScopesForWrite(ctx context.Context, store ScopeResolverStore, ns 
 	return out, nil
 }
 
+// ResolveUIDScopesForRead is the read-path equivalent of ResolveUIDScopesForWrite.
+// Orphaned permissions (referencing deleted entities) are omitted with a warning
+// instead of causing an error, so read responses stay stable.
+func ResolveUIDScopesForRead(ctx context.Context, store ScopeResolverStore, ns claims.NamespaceInfo, permissions []accesscontrol.Permission, logger log.Logger) ([]accesscontrol.Permission, error) {
+	out := make([]accesscontrol.Permission, 0, len(permissions))
+	for _, p := range permissions {
+		resolved, err := ResolveUIDScopeForWrite(ctx, store, ns, p.Scope)
+		if err != nil {
+			if IsNotFoundError(err) {
+				logger.Warn("Omitting permission with orphaned uid scope", "scope", p.Scope)
+				continue
+			}
+			return nil, err
+		}
+		if resolved != p.Scope {
+			p.Scope = resolved
+			p.Kind, p.Attribute, p.Identifier = accesscontrol.SplitScope(resolved)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
 // ResolveIDScopeToUIDName resolves an id-based scope to just the uid name.
 // e.g. "teams:id:1" → "teamuid1". Returns an error if the entity is not found
 // or the scope doesn't match a known id prefix.
@@ -210,6 +233,32 @@ func ResolveIDScopesToUID(
 		}
 		if drop {
 			continue
+		}
+		p.Scope = resolved
+		p.Kind, p.Attribute, p.Identifier = accesscontrol.SplitScope(resolved)
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// ResolveIDScopesToUIDStrict is the write-path variant of ResolveIDScopesToUID.
+// It returns an error when an id-based scope references a deleted entity instead
+// of silently omitting it, so the caller can reject the request.
+func ResolveIDScopesToUIDStrict(
+	ctx context.Context,
+	store ScopeResolverStore,
+	ns claims.NamespaceInfo,
+	perms []accesscontrol.Permission,
+	logger log.Logger,
+) ([]accesscontrol.Permission, error) {
+	out := make([]accesscontrol.Permission, 0, len(perms))
+	for _, p := range perms {
+		resolved, drop, err := ResolveIDScopeToUID(ctx, store, ns, p.Scope, logger)
+		if err != nil {
+			return nil, err
+		}
+		if drop {
+			return nil, fmt.Errorf("scope %q references a deleted entity", p.Scope)
 		}
 		p.Scope = resolved
 		p.Kind, p.Attribute, p.Identifier = accesscontrol.SplitScope(resolved)

--- a/pkg/registry/apis/iam/legacy/service_account.go
+++ b/pkg/registry/apis/iam/legacy/service_account.go
@@ -2,13 +2,13 @@ package legacy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	claims "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
@@ -78,7 +78,7 @@ func (s *legacySQLStore) GetServiceAccountInternalID(
 	}
 
 	if !rows.Next() {
-		return nil, errors.New("service account not found")
+		return nil, serviceaccounts.ErrServiceAccountNotFound.Errorf("service account by uid %q", query.UID)
 	}
 
 	var id int64

--- a/pkg/registry/apis/iam/legacy/sql.go
+++ b/pkg/registry/apis/iam/legacy/sql.go
@@ -20,6 +20,8 @@ type LegacyIdentityStore interface {
 	ListDisplay(ctx context.Context, ns claims.NamespaceInfo, query ListDisplayQuery) (*ListUserResult, error)
 
 	GetUserInternalID(ctx context.Context, ns claims.NamespaceInfo, query GetUserInternalIDQuery) (*GetUserInternalIDResult, error)
+	GetUserUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error)
+	GetServiceAccountUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error)
 	ListUsers(ctx context.Context, ns claims.NamespaceInfo, query ListUserQuery) (*ListUserResult, error)
 	ListUserTeams(ctx context.Context, ns claims.NamespaceInfo, query ListUserTeamsQuery) (*ListUserTeamsResult, error)
 	CreateUser(ctx context.Context, ns claims.NamespaceInfo, cmd CreateUserCommand) (*CreateUserResult, error)
@@ -34,6 +36,7 @@ type LegacyIdentityStore interface {
 	ListServiceAccountTokens(ctx context.Context, ns claims.NamespaceInfo, query ListServiceAccountTokenQuery) (*ListServiceAccountTokenResult, error)
 
 	GetTeamInternalID(ctx context.Context, ns claims.NamespaceInfo, query GetTeamInternalIDQuery) (*GetTeamInternalIDResult, error)
+	GetTeamUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetTeamUIDByIDQuery) (*GetTeamUIDByIDResult, error)
 	CreateTeam(ctx context.Context, ns claims.NamespaceInfo, cmd CreateTeamCommand) (*CreateTeamResult, error)
 	UpdateTeam(ctx context.Context, ns claims.NamespaceInfo, cmd UpdateTeamCommand) (*UpdateTeamResult, error)
 	ListTeams(ctx context.Context, ns claims.NamespaceInfo, query ListTeamQuery) (*ListTeamResult, error)

--- a/pkg/registry/apis/iam/legacy/sql_test.go
+++ b/pkg/registry/apis/iam/legacy/sql_test.go
@@ -144,7 +144,17 @@ func TestIdentityQueries(t *testing.T) {
 		v.SQLTemplate = mocks.NewTestingSQLTemplate()
 		return &v
 	}
+	getTeamUIDByID := func(q *GetTeamUIDByIDQuery) sqltemplate.SQLTemplate {
+		v := newGetTeamUIDByID(nodb, q)
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
 
+	getUserUIDByID := func(q *GetUserUIDByIDQuery) sqltemplate.SQLTemplate {
+		v := newGetUserUIDByID(nodb, q)
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
 		RootDir:        "testdata",
 		SQLTemplatesFS: sqlTemplatesFS,
@@ -643,6 +653,33 @@ func TestIdentityQueries(t *testing.T) {
 						UserID:  123,
 						Role:    "Admin",
 						Updated: legacysql.NewDBTime(time.Date(2023, 1, 1, 14, 0, 0, 0, time.UTC)),
+					}),
+				},
+			},
+			sqlQueryTeamUIDByIDTemplate: {
+				{
+					Name: "team_uid_by_id",
+					Data: getTeamUIDByID(&GetTeamUIDByIDQuery{
+						OrgID: 1,
+						ID:    42,
+					}),
+				},
+			},
+			sqlQueryUserUIDByIDTemplate: {
+				{
+					Name: "user_uid_by_id",
+					Data: getUserUIDByID(&GetUserUIDByIDQuery{
+						OrgID:            1,
+						ID:               99,
+						IsServiceAccount: false,
+					}),
+				},
+				{
+					Name: "service_account_uid_by_id",
+					Data: getUserUIDByID(&GetUserUIDByIDQuery{
+						OrgID:            1,
+						ID:               55,
+						IsServiceAccount: true,
 					}),
 				},
 			},

--- a/pkg/registry/apis/iam/legacy/team.go
+++ b/pkg/registry/apis/iam/legacy/team.go
@@ -3,7 +3,6 @@ package legacy
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +13,76 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
+
+type GetTeamUIDByIDQuery struct {
+	OrgID int64
+	ID    int64
+}
+
+type GetTeamUIDByIDResult struct {
+	UID string
+}
+
+var sqlQueryTeamUIDByIDTemplate = mustTemplate("team_uid_by_id.sql")
+
+func newGetTeamUIDByID(sqlHelper *legacysql.LegacyDatabaseHelper, q *GetTeamUIDByIDQuery) getTeamUIDByIDQuery {
+	return getTeamUIDByIDQuery{
+		SQLTemplate: sqltemplate.New(sqlHelper.DialectForDriver()),
+		TeamTable:   sqlHelper.Table("team"),
+		Query:       q,
+	}
+}
+
+type getTeamUIDByIDQuery struct {
+	sqltemplate.SQLTemplate
+	TeamTable string
+	Query     *GetTeamUIDByIDQuery
+}
+
+func (r getTeamUIDByIDQuery) Validate() error { return nil }
+
+func (s *legacySQLStore) GetTeamUIDByID(
+	ctx context.Context,
+	ns claims.NamespaceInfo,
+	query GetTeamUIDByIDQuery,
+) (*GetTeamUIDByIDResult, error) {
+	query.OrgID = ns.OrgID
+	if query.OrgID == 0 {
+		return nil, fmt.Errorf("expected non zero org id")
+	}
+
+	sqlConn, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	req := newGetTeamUIDByID(sqlConn, &query)
+	q, err := sqltemplate.Execute(sqlQueryTeamUIDByIDTemplate, req)
+	if err != nil {
+		return nil, fmt.Errorf("execute template %q: %w", sqlQueryTeamUIDByIDTemplate.Name(), err)
+	}
+
+	rows, err := sqlConn.DB.GetSqlxSession().Query(ctx, q, req.GetArgs()...)
+	defer func() {
+		if rows != nil {
+			_ = rows.Close()
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	if !rows.Next() {
+		return nil, team.ErrTeamNotFound
+	}
+
+	var uid string
+	if err := rows.Scan(&uid); err != nil {
+		return nil, err
+	}
+
+	return &GetTeamUIDByIDResult{UID: uid}, nil
+}
 
 type GetTeamInternalIDQuery struct {
 	OrgID int64
@@ -75,7 +144,7 @@ func (s *legacySQLStore) GetTeamInternalID(
 	}
 
 	if !rows.Next() {
-		return nil, errors.New("team not found")
+		return nil, fmt.Errorf("team by uid %q: %w", query.UID, team.ErrTeamNotFound)
 	}
 
 	var id int64

--- a/pkg/registry/apis/iam/legacy/team_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/team_uid_by_id.sql
@@ -1,0 +1,5 @@
+SELECT t.uid
+FROM {{ .Ident .TeamTable }} as t
+WHERE t.org_id = {{ .Arg .Query.OrgID }}
+AND t.id = {{ .Arg .Query.ID }}
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--team_uid_by_id-team_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--team_uid_by_id-team_uid_by_id.sql
@@ -1,0 +1,5 @@
+SELECT t.uid
+FROM `grafana`.`team` as t
+WHERE t.org_id = 1
+AND t.id = 42
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--user_uid_by_id-service_account_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--user_uid_by_id-service_account_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM `grafana`.`user` as u
+INNER JOIN `grafana`.`org_user` as ou ON ou.user_id = u.id AND ou.org_id = 1
+WHERE u.id = 55
+AND u.is_service_account = TRUE
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--user_uid_by_id-user_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--user_uid_by_id-user_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM `grafana`.`user` as u
+INNER JOIN `grafana`.`org_user` as ou ON ou.user_id = u.id AND ou.org_id = 1
+WHERE u.id = 99
+AND u.is_service_account = FALSE
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--team_uid_by_id-team_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--team_uid_by_id-team_uid_by_id.sql
@@ -1,0 +1,5 @@
+SELECT t.uid
+FROM "grafana"."team" as t
+WHERE t.org_id = 1
+AND t.id = 42
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--user_uid_by_id-service_account_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--user_uid_by_id-service_account_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as ou ON ou.user_id = u.id AND ou.org_id = 1
+WHERE u.id = 55
+AND u.is_service_account = TRUE
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--user_uid_by_id-user_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--user_uid_by_id-user_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as ou ON ou.user_id = u.id AND ou.org_id = 1
+WHERE u.id = 99
+AND u.is_service_account = FALSE
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--team_uid_by_id-team_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--team_uid_by_id-team_uid_by_id.sql
@@ -1,0 +1,5 @@
+SELECT t.uid
+FROM "grafana"."team" as t
+WHERE t.org_id = 1
+AND t.id = 42
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--user_uid_by_id-service_account_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--user_uid_by_id-service_account_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as ou ON ou.user_id = u.id AND ou.org_id = 1
+WHERE u.id = 55
+AND u.is_service_account = TRUE
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--user_uid_by_id-user_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--user_uid_by_id-user_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM "grafana"."user" as u
+INNER JOIN "grafana"."org_user" as ou ON ou.user_id = u.id AND ou.org_id = 1
+WHERE u.id = 99
+AND u.is_service_account = FALSE
+LIMIT 1;

--- a/pkg/registry/apis/iam/legacy/user.go
+++ b/pkg/registry/apis/iam/legacy/user.go
@@ -3,7 +3,6 @@ package legacy
 import (
 	"context"
 	stdsql "database/sql"
-	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -21,6 +20,85 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+type GetUserUIDByIDQuery struct {
+	OrgID            int64
+	ID               int64
+	IsServiceAccount bool
+}
+
+type GetUserUIDByIDResult struct {
+	UID string
+}
+
+var sqlQueryUserUIDByIDTemplate = mustTemplate("user_uid_by_id.sql")
+
+func newGetUserUIDByID(sqlHelper *legacysql.LegacyDatabaseHelper, q *GetUserUIDByIDQuery) getUserUIDByIDQuery {
+	return getUserUIDByIDQuery{
+		SQLTemplate:  sqltemplate.New(sqlHelper.DialectForDriver()),
+		UserTable:    sqlHelper.Table("user"),
+		OrgUserTable: sqlHelper.Table("org_user"),
+		Query:        q,
+	}
+}
+
+type getUserUIDByIDQuery struct {
+	sqltemplate.SQLTemplate
+	UserTable    string
+	OrgUserTable string
+	Query        *GetUserUIDByIDQuery
+}
+
+func (r getUserUIDByIDQuery) Validate() error { return nil }
+
+func (s *legacySQLStore) getUserUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error) {
+	query.OrgID = ns.OrgID
+	if query.OrgID == 0 {
+		return nil, fmt.Errorf("expected non zero org id")
+	}
+
+	sqlConn, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	req := newGetUserUIDByID(sqlConn, &query)
+	q, err := sqltemplate.Execute(sqlQueryUserUIDByIDTemplate, req)
+	if err != nil {
+		return nil, fmt.Errorf("execute template %q: %w", sqlQueryUserUIDByIDTemplate.Name(), err)
+	}
+
+	rows, err := sqlConn.DB.GetSqlxSession().Query(ctx, q, req.GetArgs()...)
+	defer func() {
+		if rows != nil {
+			_ = rows.Close()
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	if !rows.Next() {
+		return nil, user.ErrUserNotFound
+	}
+
+	var uid string
+	if err := rows.Scan(&uid); err != nil {
+		return nil, err
+	}
+
+	return &GetUserUIDByIDResult{UID: uid}, nil
+}
+
+func (s *legacySQLStore) GetUserUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error) {
+	query.IsServiceAccount = false
+	return s.getUserUIDByID(ctx, ns, query)
+}
+
+func (s *legacySQLStore) GetServiceAccountUIDByID(ctx context.Context, ns claims.NamespaceInfo, query GetUserUIDByIDQuery) (*GetUserUIDByIDResult, error) {
+	query.IsServiceAccount = true
+	return s.getUserUIDByID(ctx, ns, query)
+}
 
 type GetUserInternalIDQuery struct {
 	OrgID int64
@@ -82,7 +160,7 @@ func (s *legacySQLStore) GetUserInternalID(ctx context.Context, ns claims.Namesp
 	}
 
 	if !rows.Next() {
-		return nil, errors.New("user not found")
+		return nil, user.ErrUserNotFound
 	}
 
 	var id int64
@@ -603,8 +681,7 @@ func (s *legacySQLStore) DeleteUser(ctx context.Context, ns claims.NamespaceInfo
 			if err := rows.Err(); err != nil {
 				return fmt.Errorf("failed to read user lookup rows: %w", err)
 			}
-			// User not found, nothing to delete
-			return fmt.Errorf("user not found")
+			return user.ErrUserNotFound
 		}
 		if err := rows.Scan(&userID); err != nil {
 			return fmt.Errorf("failed to scan user ID: %w", err)
@@ -647,7 +724,7 @@ func (s *legacySQLStore) DeleteUser(ctx context.Context, ns claims.NamespaceInfo
 		}
 
 		if rowsAffected == 0 {
-			return fmt.Errorf("user not found")
+			return user.ErrUserNotFound
 		}
 
 		return nil

--- a/pkg/registry/apis/iam/legacy/user_uid_by_id.sql
+++ b/pkg/registry/apis/iam/legacy/user_uid_by_id.sql
@@ -1,0 +1,6 @@
+SELECT u.uid
+FROM {{ .Ident .UserTable }} as u
+INNER JOIN {{ .Ident .OrgUserTable }} as ou ON ou.user_id = u.id AND ou.org_id = {{ .Arg .Query.OrgID }}
+WHERE u.id = {{ .Arg .Query.ID }}
+AND u.is_service_account = {{ .Arg .Query.IsServiceAccount }}
+LIMIT 1;

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -1,10 +1,13 @@
 package resourcepermission
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 
+	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -40,7 +43,7 @@ type mapper struct {
 func NewMapper(resource string, levels []string) Mapper {
 	sets := make([]string, 0, len(levels))
 	for _, level := range levels {
-		sets = append(sets, resource+":"+level)
+		sets = append(sets, resource+":"+strings.ToLower(level))
 	}
 	return mapper{
 		resource:   resource,
@@ -226,4 +229,75 @@ func (m *MappersRegistry) EnabledScopePatterns() []string {
 		out = append(out, e.mapper.ScopePattern())
 	}
 	return out
+}
+
+// NewIDScopedMapper creates a Mapper for resources stored with id-based scopes
+// in the legacy permission table (teams, users, service accounts).
+// Unlike the default uid-scoped mapper, its ScopePattern returns ":id:%".
+// The actual uid↔id resolution is handled by scope_resolver functions via the
+// MappersRegistry's identity store, not by the mapper itself.
+func NewIDScopedMapper(resource string, levels []string) Mapper {
+	sets := make([]string, 0, len(levels))
+	for _, level := range levels {
+		sets = append(sets, resource+":"+strings.ToLower(level))
+	}
+	return idMapper{resource: resource, actionSets: sets}
+}
+
+// idMapper implements Mapper for id-scoped resources. It differs from the default
+// mapper only in ScopePattern (returns ":id:%" for DB queries).
+type idMapper struct {
+	resource   string
+	actionSets []string
+}
+
+func (m idMapper) ActionSets() []string { return m.actionSets }
+
+func (m idMapper) ActionSet(level string) (string, error) {
+	actionSet := m.resource + ":" + strings.ToLower(level)
+	if !slices.Contains(m.actionSets, actionSet) {
+		return "", fmt.Errorf("invalid level (%s): %w", level, errInvalidSpec)
+	}
+	return actionSet, nil
+}
+
+func (m idMapper) Scope(name string) string {
+	return m.resource + ":uid:" + name
+}
+
+func (m idMapper) ScopePattern() string {
+	return m.resource + ":id:%"
+}
+
+// ParseScopeCtx parses an RBAC scope string into a groupResourceName, resolving id to uid for
+// id-scoped resources (teams, users, service accounts) using the provided store and namespace.
+// For uid-scoped resources (folders, dashboards) it behaves identically to ParseScope.
+func (m *MappersRegistry) ParseScopeCtx(ctx context.Context, ns types.NamespaceInfo, store IdentityStore, scope, datasourceType string) (*groupResourceName, error) {
+	parts := strings.SplitN(scope, ":", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("%w: %s", errInvalidScope, scope)
+	}
+	gr, ok := m.reverse[parts[0]]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errUnknownGroupResource, parts[0])
+	}
+
+	entry := m.entries[gr]
+	group := resolveGroup(gr.Group, datasourceType)
+
+	name := parts[2]
+	if isIDScoped(entry.mapper) && store != nil {
+		uid, err := legacy.ResolveIDScopeToUIDName(ctx, store, ns, scope)
+		if err != nil {
+			return nil, err
+		}
+		name = uid
+	}
+
+	return &groupResourceName{Group: group, Resource: gr.Resource, Name: name}, nil
+}
+
+// isIDScoped returns true if the mapper's ScopePattern uses ":id:" (id-scoped resources).
+func isIDScoped(m Mapper) bool {
+	return strings.Contains(m.ScopePattern(), ":id:")
 }

--- a/pkg/registry/apis/iam/resourcepermission/models.go
+++ b/pkg/registry/apis/iam/resourcepermission/models.go
@@ -39,11 +39,9 @@ var (
 	allowedBasicRoles = map[string]bool{"Viewer": true, "Editor": true, "Admin": true}
 )
 
-type IdentityStore interface {
-	GetServiceAccountInternalID(ctx context.Context, ns types.NamespaceInfo, query idStore.GetServiceAccountInternalIDQuery) (*idStore.GetServiceAccountInternalIDResult, error)
-	GetTeamInternalID(ctx context.Context, ns types.NamespaceInfo, query idStore.GetTeamInternalIDQuery) (*idStore.GetTeamInternalIDResult, error)
-	GetUserInternalID(ctx context.Context, ns types.NamespaceInfo, query idStore.GetUserInternalIDQuery) (*idStore.GetUserInternalIDResult, error)
-}
+// IdentityStore is a type alias for legacy.ScopeResolverStore — the minimal
+// identity-lookup interface for resolving uid↔id scopes.
+type IdentityStore = idStore.ScopeResolverStore
 
 type PageQuery struct {
 	ScopePatterns []string
@@ -131,8 +129,8 @@ func newV0ResourcePermission(grn *groupResourceName, specs []v0alpha1.ResourcePe
 }
 
 // toV0ResourcePermissions translates a list of rbacAssignments into a list of v0alpha1.ResourcePermissions.
-// it is assumed that assignments are sorted by scope
-func (s *ResourcePermSqlBackend) toV0ResourcePermissions(assignments []rbacAssignment, namespace string) ([]v0alpha1.ResourcePermission, error) {
+// it is assumed that assignments are sorted by scope. it translates id-scoped permissions back to uid-scoped permissions.
+func (s *ResourcePermSqlBackend) toV0ResourcePermissions(ctx context.Context, ns types.NamespaceInfo, assignments []rbacAssignment) ([]v0alpha1.ResourcePermission, error) {
 	if len(assignments) == 0 {
 		return nil, nil
 	}
@@ -144,25 +142,59 @@ func (s *ResourcePermSqlBackend) toV0ResourcePermissions(assignments []rbacAssig
 
 		resourcePermissions = make([]v0alpha1.ResourcePermission, 0, 8)
 		specs               = make([]v0alpha1.ResourcePermissionspecPermission, 0, 4)
+		// scopeCache avoids repeated DB lookups for the same id-scoped scope within a single list response.
+		scopeCache = make(map[string]*groupResourceName, len(assignments))
 	)
 
-	grn, err := s.ParseScope(assignments[0].Scope, assignments[0].DatasourceType)
+	logger := s.logger.FromContext(ctx)
+
+	// parseScopeCtxCached resolves and caches scope→GRN lookups.
+	// Returns (nil, nil) for orphaned id-scoped rows so callers can skip them.
+	parseScopeCtxCached := func(scope, datasourceType string) (*groupResourceName, error) {
+		key := scope + ":" + datasourceType
+		if grn, ok := scopeCache[key]; ok {
+			return grn, nil
+		}
+		grn, err := s.mappers.ParseScopeCtx(ctx, ns, s.identityStore, scope, datasourceType)
+		if err != nil {
+			if idStore.IsNotFoundError(err) {
+				logger.Warn("Dropping permission with orphaned scope", "scope", scope, "error", err)
+				scopeCache[key] = nil
+				return nil, nil
+			}
+			return nil, err
+		}
+		scopeCache[key] = grn
+		return grn, nil
+	}
+
+	grn, err := parseScopeCtxCached(assignments[0].Scope, assignments[0].DatasourceType)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, assign := range assignments {
 		// Ensure all assignments belong to the same resource
-		parsedGrn, err := s.ParseScope(assign.Scope, assign.DatasourceType)
+		parsedGrn, err := parseScopeCtxCached(assign.Scope, assign.DatasourceType)
 		if err != nil {
 			return nil, err
 		}
+		if parsedGrn == nil {
+			continue
+		}
+		if grn == nil {
+			grn = parsedGrn
+			created = assign.Created
+			updated = assign.Updated
+		}
 		// If it's a new resource, flush the current specs to a ResourcePermission and start a new one
 		if *parsedGrn != *grn {
-			resourcePermissions = append(
-				resourcePermissions,
-				newV0ResourcePermission(grn, specs, created, updated, namespace),
-			)
+			if len(specs) > 0 {
+				resourcePermissions = append(
+					resourcePermissions,
+					newV0ResourcePermission(grn, specs, created, updated, ns.Value),
+				)
+			}
 
 			// Reset for the new resource
 			grn = parsedGrn
@@ -211,11 +243,13 @@ func (s *ResourcePermSqlBackend) toV0ResourcePermissions(assignments []rbacAssig
 		})
 	}
 
-	// Flush the final resource
-	resourcePermissions = append(
-		resourcePermissions,
-		newV0ResourcePermission(grn, specs, created, updated, namespace),
-	)
+	// Flush the final resource (grn may be nil if all assignments were orphaned)
+	if grn != nil && len(specs) > 0 {
+		resourcePermissions = append(
+			resourcePermissions,
+			newV0ResourcePermission(grn, specs, created, updated, ns.Value),
+		)
+	}
 
 	return resourcePermissions, nil
 }

--- a/pkg/registry/apis/iam/resourcepermission/models_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/models_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/authlib/types"
+
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/stretchr/testify/require"
@@ -21,8 +23,10 @@ func setupBackendNoDB(t *testing.T) *ResourcePermSqlBackend {
 func TestToV0ResourcePermissions(t *testing.T) {
 	backend := setupBackendNoDB(t)
 
+	ns := types.NamespaceInfo{Value: "default"}
+
 	t.Run("empty permissions", func(t *testing.T) {
-		result, err := backend.toV0ResourcePermissions([]rbacAssignment{}, "default")
+		result, err := backend.toV0ResourcePermissions(context.Background(), ns, []rbacAssignment{})
 		require.NoError(t, err)
 		require.Nil(t, result)
 	})
@@ -76,7 +80,7 @@ func TestToV0ResourcePermissions(t *testing.T) {
 			},
 		}
 
-		result, err := backend.toV0ResourcePermissions(permissions, "default")
+		result, err := backend.toV0ResourcePermissions(context.Background(), ns, permissions)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Len(t, result, 1)

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -243,7 +243,7 @@ func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql 
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
-	if resourcePermission == nil {
+	if len(resourcePermission) == 0 {
 		return nil, apierrors.NewNotFound(v0alpha1.ResourcePermissionInfo.GroupResource(), name)
 	}
 

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -20,6 +20,16 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
+// resolveScope returns the legacy db scope for the given resource name.
+// For id-scoped resources (teams, users, service accounts), translates uid→id via the identity store.
+func resolveScope(ctx context.Context, ns types.NamespaceInfo, store IdentityStore, mapper Mapper, name string) (string, error) {
+	scope := mapper.Scope(name)
+	if isIDScoped(mapper) && store != nil {
+		return legacy.ResolveUIDScopeForWrite(ctx, store, ns, scope)
+	}
+	return scope, nil
+}
+
 // List
 func (s *ResourcePermSqlBackend) newRoleIterator(ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper, ns types.NamespaceInfo, pagination *common.Pagination) (*listIterator, error) {
 	var (
@@ -83,7 +93,7 @@ func (s *ResourcePermSqlBackend) newRoleIterator(ctx context.Context, dbHelper *
 		return &listIterator{}, nil
 	}
 
-	v0ResourcePermissions, err := s.toV0ResourcePermissions(assignments, ns.Value)
+	v0ResourcePermissions, err := s.toV0ResourcePermissions(ctx, ns, assignments)
 	if err != nil {
 		return nil, err
 	}
@@ -209,8 +219,13 @@ func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql 
 		return nil, apierrors.NewInternalError(err)
 	}
 
+	scope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("resolving scope for %q: %v", grn.Name, err))
+	}
+
 	resourceQuery := &ListResourcePermissionsQuery{
-		Scopes:     []string{mapper.Scope(grn.Name)},
+		Scopes:     []string{scope},
 		OrgID:      ns.OrgID,
 		ActionSets: mapper.ActionSets(),
 	}
@@ -224,7 +239,7 @@ func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql 
 		return nil, apierrors.NewNotFound(v0alpha1.ResourcePermissionInfo.GroupResource(), name)
 	}
 
-	resourcePermission, err := s.toV0ResourcePermissions(assignments, ns.Value)
+	resourcePermission, err := s.toV0ResourcePermissions(ctx, ns, assignments)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
@@ -422,14 +437,19 @@ func (s *ResourcePermSqlBackend) existsResourcePermission(ctx context.Context, t
 func (s *ResourcePermSqlBackend) createResourcePermission(
 	ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper, ns types.NamespaceInfo, mapper Mapper, grn *groupResourceName, v0ResourcePerm *v0alpha1.ResourcePermission,
 ) (int64, error) {
-	assignments, err := s.buildRbacAssignments(ctx, ns, mapper, v0ResourcePerm.Spec.Permissions, mapper.Scope(grn.Name), datasourcek8s.DSTypeFromDatasourceAPIGroup(grn.Group))
+	rbacScope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+	if err != nil {
+		return 0, apierrors.NewBadRequest(fmt.Sprintf("resolving scope for %q: %v", grn.Name, err))
+	}
+
+	assignments, err := s.buildRbacAssignments(ctx, ns, mapper, v0ResourcePerm.Spec.Permissions, rbacScope, datasourcek8s.DSTypeFromDatasourceAPIGroup(grn.Group))
 	if err != nil {
 		return 0, err
 	}
 
 	err = dbHelper.DB.GetSqlxSession().WithTransaction(ctx, func(tx *session.SessionTx) error {
 		// Check if a resource permission for the same resource already exists
-		if err = s.existsResourcePermission(ctx, tx, dbHelper, ns.OrgID, mapper.Scope(grn.Name)); err != nil {
+		if err = s.existsResourcePermission(ctx, tx, dbHelper, ns.OrgID, rbacScope); err != nil {
 			return err
 		}
 
@@ -462,9 +482,13 @@ func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, d
 		}
 
 		permissionsToAdd, permissionsToRemove := diffPermissions(currentPerms.Spec.Permissions, v0ResourcePerm.Spec.Permissions)
+		rbacScope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+		if err != nil {
+			return fmt.Errorf("resolving scope for %q: %w", grn.Name, err)
+		}
 
 		if len(permissionsToRemove) > 0 {
-			permsToRemove, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToRemove, mapper.Scope(grn.Name), datasourcek8s.DSTypeFromDatasourceAPIGroup(grn.Group))
+			permsToRemove, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToRemove, rbacScope, datasourcek8s.DSTypeFromDatasourceAPIGroup(grn.Group))
 			if err != nil {
 				return err
 			}
@@ -489,7 +513,7 @@ func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, d
 		}
 
 		if len(permissionsToAdd) > 0 {
-			permsToAdd, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToAdd, mapper.Scope(grn.Name), datasourcek8s.DSTypeFromDatasourceAPIGroup(grn.Group))
+			permsToAdd, err := s.buildRbacAssignments(ctx, ns, mapper, permissionsToAdd, rbacScope, datasourcek8s.DSTypeFromDatasourceAPIGroup(grn.Group))
 			if err != nil {
 				return err
 			}
@@ -554,8 +578,11 @@ func (s *ResourcePermSqlBackend) deleteResourcePermission(ctx context.Context, s
 	if err != nil {
 		return err
 	}
-	scope := mapper.Scope(grn.Name)
 
+	scope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+	if err != nil {
+		return fmt.Errorf("resolving scope for %q: %w", grn.Name, err)
+	}
 	resourceQuery := &DeleteResourcePermissionsQuery{
 		Scope: scope,
 		OrgID: ns.OrgID,
@@ -588,9 +615,9 @@ func (s *ResourcePermSqlBackend) ListDirectPermissionsForSubject(ctx context.Con
 	if ns.OrgID <= 0 {
 		return nil, errInvalidNamespace
 	}
+	logger := s.logger.FromContext(ctx)
 	dbHelper, err := s.dbProvider(ctx)
 	if err != nil {
-		logger := s.logger.FromContext(ctx)
 		if errors.Is(err, legacysql.ErrNamespaceNotFound) {
 			logger.Warn("Namespace not found", "error", err)
 			return nil, apierrors.NewNotFound(v0alpha1.ResourcePermissionInfo.GroupResource(), namespace)
@@ -611,9 +638,17 @@ func (s *ResourcePermSqlBackend) ListDirectPermissionsForSubject(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	result := make([]v0alpha1.PermissionSpec, len(assignments))
-	for i, a := range assignments {
-		result[i] = v0alpha1.PermissionSpec{Action: a.Action, Scope: a.Scope}
+	result := make([]v0alpha1.PermissionSpec, 0, len(assignments))
+	for _, a := range assignments {
+		grn, err := s.mappers.ParseScopeCtx(ctx, ns, s.identityStore, a.Scope, a.DatasourceType)
+		if err != nil {
+			logger.Warn("Dropping permission with unresolvable scope", "scope", a.Scope, "action", a.Action, "error", err)
+			continue
+		}
+		result = append(result, v0alpha1.PermissionSpec{
+			Action: a.Action,
+			Scope:  grn.Resource + ":uid:" + grn.Name,
+		})
 	}
 	return result, nil
 }

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -634,16 +634,24 @@ type fakeIdentityStore struct {
 	users           map[string]int64
 	serviceAccounts map[string]int64
 	teams           map[string]int64
-	expectedNs      types.NamespaceInfo
+
+	usersByID           map[int64]string
+	serviceAccountsByID map[int64]string
+	teamsByID           map[int64]string
+
+	expectedNs types.NamespaceInfo
 }
 
 func NewFakeIdentityStore(t *testing.T) *fakeIdentityStore {
 	return &fakeIdentityStore{
-		t:               t,
-		users:           map[string]int64{"captain": 101, "user-1": 1, "user-2": 2},
-		serviceAccounts: map[string]int64{"robot": 201, "sa-1": 3},
-		teams:           map[string]int64{"devs": 301},
-		expectedNs:      types.NamespaceInfo{Value: "default"},
+		t:                   t,
+		users:               map[string]int64{"captain": 101, "user-1": 1, "user-2": 2},
+		serviceAccounts:     map[string]int64{"robot": 201, "sa-1": 3},
+		teams:               map[string]int64{"devs": 301},
+		usersByID:           map[int64]string{101: "captain", 1: "user-1", 2: "user-2"},
+		serviceAccountsByID: map[int64]string{201: "robot", 3: "sa-1"},
+		teamsByID:           map[int64]string{301: "devs"},
+		expectedNs:          types.NamespaceInfo{Value: "default"},
 	}
 }
 
@@ -678,6 +686,30 @@ func (f *fakeIdentityStore) GetUserInternalID(ctx context.Context, ns types.Name
 		return nil, errors.New("not found")
 	}
 	return &legacy.GetUserInternalIDResult{ID: id}, nil
+}
+
+func (f *fakeIdentityStore) GetTeamUIDByID(ctx context.Context, ns types.NamespaceInfo, query legacy.GetTeamUIDByIDQuery) (*legacy.GetTeamUIDByIDResult, error) {
+	uid, ok := f.teamsByID[query.ID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &legacy.GetTeamUIDByIDResult{UID: uid}, nil
+}
+
+func (f *fakeIdentityStore) GetUserUIDByID(ctx context.Context, ns types.NamespaceInfo, query legacy.GetUserUIDByIDQuery) (*legacy.GetUserUIDByIDResult, error) {
+	uid, ok := f.usersByID[query.ID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &legacy.GetUserUIDByIDResult{UID: uid}, nil
+}
+
+func (f *fakeIdentityStore) GetServiceAccountUIDByID(ctx context.Context, ns types.NamespaceInfo, query legacy.GetUserUIDByIDQuery) (*legacy.GetUserUIDByIDResult, error) {
+	uid, ok := f.serviceAccountsByID[query.ID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &legacy.GetUserUIDByIDResult{UID: uid}, nil
 }
 
 func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/types"
@@ -39,9 +40,22 @@ type ResourcePermSqlBackend struct {
 }
 
 func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers *MappersRegistry) *ResourcePermSqlBackend {
+	store := idStore.NewLegacySQLStores(dbProvider)
+	mappers.RegisterMapper(
+		schema.GroupResource{Group: "iam.grafana.app", Resource: "teams"},
+		NewIDScopedMapper("teams", []string{"Member", "Admin"}), nil,
+	)
+	mappers.RegisterMapper(
+		schema.GroupResource{Group: "iam.grafana.app", Resource: "users"},
+		NewIDScopedMapper("users", defaultLevels), nil,
+	)
+	mappers.RegisterMapper(
+		schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"},
+		NewIDScopedMapper("serviceaccounts", []string{"Edit", "Admin"}), nil,
+	)
 	return &ResourcePermSqlBackend{
 		dbProvider:    dbProvider,
-		identityStore: idStore.NewLegacySQLStores(dbProvider),
+		identityStore: store,
 		logger:        log.New("resourceperm_storage_backend"),
 		mappers:       mappers,
 		subscribers:   make([]chan *resource.WrittenEvent, 0),

--- a/pkg/registry/apis/iam/teambinding/legacy_search_test.go
+++ b/pkg/registry/apis/iam/teambinding/legacy_search_test.go
@@ -725,3 +725,15 @@ func (m *mockLegacyStore) ListTeamBindings(ctx context.Context, ns claims.Namesp
 func (m *mockLegacyStore) ListTeamMembers(ctx context.Context, ns claims.NamespaceInfo, query legacy.ListTeamMembersQuery) (*legacy.ListTeamMembersResult, error) {
 	return nil, nil
 }
+
+func (m *mockLegacyStore) GetUserUIDByID(ctx context.Context, ns claims.NamespaceInfo, query legacy.GetUserUIDByIDQuery) (*legacy.GetUserUIDByIDResult, error) {
+	return nil, nil
+}
+
+func (m *mockLegacyStore) GetServiceAccountUIDByID(ctx context.Context, ns claims.NamespaceInfo, query legacy.GetUserUIDByIDQuery) (*legacy.GetUserUIDByIDResult, error) {
+	return nil, nil
+}
+
+func (m *mockLegacyStore) GetTeamUIDByID(ctx context.Context, ns claims.NamespaceInfo, query legacy.GetTeamUIDByIDQuery) (*legacy.GetTeamUIDByIDResult, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This PR adds id -> uid translation for id scoped permissions such that the k8s apis only allow uid scoped permissions, but we still translate the id scoped resources (teams, users, service accounts, reports) to id before saving to the legacy db, and return it as an id in legacy redirects.

If we are unable to translate due to the resource not being found, the permission is omitted from the role. This should not happen because the parent resources have cleanup for their permissions when deleted, but regardless, then the whole role doesn't error.

Closes https://github.com/grafana/identity-access-team/issues/1921 