### PR TITLE
Packaging: Remove /sbin/service dependency

### DIFF
--- a/pkg/build/daggerbuild/artifacts/package_rpm.go
+++ b/pkg/build/daggerbuild/artifacts/package_rpm.go
@@ -95,9 +95,6 @@ func (d *RPM) BuildFile(ctx context.Context, builder *dagger.Container, opts *pi
 			{"/src/packaging/rpm/systemd/grafana-server.service", "/pkg/usr/lib/systemd/system/grafana-server.service"},
 		},
 		AfterInstall: "/src/packaging/rpm/control/postinst",
-		Depends: []string{
-			"/sbin/service",
-		},
 		ExtraArgs: []string{
 			"--rpm-posttrans=/src/packaging/rpm/control/posttrans",
 			"--rpm-digest=sha256",

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -93,7 +93,6 @@ fpm \
   --config-files=/etc/sysconfig/grafana-server \
   --config-files=/usr/lib/systemd/system/grafana-server.service \
   --after-install="${SRC}/packaging/rpm/control/postinst" \
-  --depends=/sbin/service \
   --architecture="${PKG_ARCH}" \
   --description=Grafana \
   --license="${FPM_LICENSE:-AGPLv3}" \


### PR DESCRIPTION
I think /sbin/service dependency for legacy support is not necessary anymore, since sysvinit support has been removed quite some time ago. We don't use init.d scripts anymore, right? This change should remove the dependency from rpm packaging.