### PR TITLE
Logging: add minimal logging registry and framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -668,6 +668,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/components/QueryEditorWithMigration* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /packages/grafana-runtime/src/config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/services/ @grafana/grafana-frontend-platform
+/packages/grafana-runtime/src/services/logging @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/services/pluginExtensions @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/services/CorrelationsService.ts @grafana/datapro
 /packages/grafana-runtime/src/services/LocationService.test.tsx @grafana/grafana-frontend-navigation

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4,16 +4,6 @@
       "count": 1
     }
   },
-  "e2e/old-arch/utils/support/localStorage.ts": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 2
-    }
-  },
-  "e2e/old-arch/utils/support/types.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
   "e2e/utils/support/localStorage.ts": {
     "@grafana/no-direct-local-storage-access": {
       "count": 2

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -40,7 +40,7 @@ export {
   usePanelPluginMetasMap,
 } from '../services/pluginMeta/hooks';
 export type { AppPluginMetas, PanelPluginMetas } from '../services/pluginMeta/types';
-export { getCachedPromise, invalidateCache, setLogger } from '../utils/getCachedPromise';
+export { getCachedPromise, invalidateCache } from '../utils/getCachedPromise';
 export { defineFeatureEvents } from './analyticsFramework/main';
 export type { EventProperty, Event } from './analyticsFramework/types';
 export {
@@ -53,4 +53,4 @@ export {
   refetchPanelPluginMetas,
 } from '../services/pluginMeta/panels';
 export { installPluginMeta, uninstallPluginMeta } from '../services/pluginMeta/plugins';
-export { logPluginMetaError, setPluginMetaLogger } from '../services/pluginMeta/logging';
+export { logPluginMetaError } from '../services/pluginMeta/logging';

--- a/packages/grafana-runtime/src/services/logging/README.md
+++ b/packages/grafana-runtime/src/services/logging/README.md
@@ -94,17 +94,20 @@ Empties the entire registry. **Test-only** — throws if `NODE_ENV` is not `test
 Use `mockLogger` from `@grafana/test-utils/unstable` to replace a logger with `jest.fn()` stubs. This prevents tests from hitting the real Faro SDK and lets you assert on log calls.
 
 ````ts
+import { type MonitoringLogger } from '@grafana/runtime';
 import { mockLogger } from '@grafana/test-utils/unstable';
-import { getLogger } from '@grafana/runtime/unstable';
+
+let logger: MonitoringLogger;
 
 beforeEach(() => {
-  mockLogger('grafana/runtime.plugins.meta');
+  logger = mockLogger('grafana/runtime.plugins.meta');
 });
+
 it('should log a warning when something unexpected happens', () => {
   doSomethingThatWarns();
 
-  expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
-    'unexpected thin happened',
+  expect(logger.logWarning).toHaveBeenCalledWith(
+    'unexpected thing happened',
     expect.objectContaining({ type: 'panel' })
   );
 });
@@ -112,8 +115,8 @@ it('should log a warning when something unexpected happens', () => {
 it('should log an error on failure', () => {
   doSomethingThatFails();
 
-  expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledTimes(1);
-  expect(getLogger('rafana/runtime.plugins.meta').logError).toHaveBeenCalledWith(expect.any(Error));
+  expect(logger.logError).toHaveBeenCalledTimes(1);
+  expect(logger.logError).toHaveBeenCalledWith(expect.any(Error));
 });```
 
 > **Note:** `mockLogger` calls `setLogger` under the hood, which throws if called outside of `NODE_ENV=test`.

--- a/packages/grafana-runtime/src/services/logging/README.md
+++ b/packages/grafana-runtime/src/services/logging/README.md
@@ -1,0 +1,120 @@
+# Logging Framework
+
+A centralized logger registry built on top of [Grafana Faro Web SDK](https://github.com/grafana/faro-web-sdk). It provides type-safe, source-scoped loggers that forward to the Faro collector, with optional console output for local debugging.
+
+## Key concepts
+
+- **`Loggers`** — a `satisfies Record<string, LoggerDefaults>` object in `loggers.ts` that defines every valid logger source and its defaults (context, console output). Adding an entry here is all that's needed to register a new logger.
+- **`LoggerSource`** — `keyof typeof Loggers`, automatically derived from the keys of the `Loggers` object.
+- **Logger registry** — singleton record that stores one `MonitoringLogger` per source. Initialized once at app boot via `initializeLoggersRegistry()`, which iterates over `Loggers` automatically.
+- **`MonitoringLogger`** — object with five methods: `logDebug`, `logInfo`, `logWarning`, `logError`, `logMeasurement`.
+
+## How to add a new logger
+
+1. **Add an entry to the `Loggers` object** in `loggers.ts`. Follow the naming convention `grafana.<area>.<feature>`:
+
+   ```ts
+   export const Loggers = {
+     'grafana/runtime.plugins.meta': { logToConsole: true },
+     'grafana/runtime.utils.getCachedPromise': {},
+     'grafana.dashboard.panels': { context: { team: 'dashboards' }, logToConsole: true }, // ← add your source
+   } satisfies Record<string, LoggerDefaults>;
+   ```
+
+   That's it — `LoggerSource` updates automatically and `initializeLoggersRegistry()` will pick it up.
+
+2. **Use it** anywhere in the codebase:
+
+   ```ts
+   import { getLogger } from '@grafana/runtime/unstable';
+
+   const logger = getLogger('grafana.dashboard.panels');
+   logger.logInfo('something happened', { extra: 'context' });
+   ```
+
+## Usage examples
+
+### Basic logging
+
+```ts
+import { getLogger } from '@grafana/runtime/unstable';
+
+const logger = getLogger('grafana/runtime.plugins.meta');
+logger.logDebug('cache miss for plugin metadata');
+logger.logInfo('plugin loaded successfully', { pluginId: 'grafana-clock-panel' });
+logger.logWarning('deprecated API used', { type: 'panel' });
+logger.logError(new Error('plugin failed to load'), { pluginId: 'my-plugin' });
+```
+
+### Measurements
+
+```ts
+logger.logMeasurement('page_load', { duration: 1234, ttfb: 200 }, { route: '/dashboards' });
+```
+
+### Console output
+
+Set `logToConsole: true` in the `Loggers` entry to also write to the browser console (useful during development). This wraps each log method so it calls both Faro and the corresponding `console.*` method.
+
+```ts
+'grafana.area.myFeature': { logToConsole: true },
+```
+
+### Default context
+
+You can attach context that will be merged into every log call for that logger:
+
+```ts
+'grafana.area.myFeature': { context: { team: 'platform' } },
+```
+
+## API
+
+### `initializeLoggersRegistry()`
+
+Creates a logger for every entry in the `Loggers` object and stores it in the registry. Called once at app boot (in `app.ts`).
+
+### `getLogger(source: LoggerSource): MonitoringLogger`
+
+Returns the logger for the given source. If the registry hasn't been initialized yet, it logs a warning to the console and:
+
+- In **development** (`NODE_ENV=development`): throws an error.
+- In **production / test**: returns a fallback logger (not stored in the registry) so the caller doesn't crash.
+
+### `setLogger(source: LoggerSource, logger: MonitoringLogger): void`
+
+Replaces a logger's entry in the registry. **Test-only** — throws if `NODE_ENV` is not `test`. Prefer using `mockLogger` from `@grafana/test-utils/unstable` instead of calling this directly.
+
+### `clearLoggerRegistry()`
+
+Empties the entire registry. **Test-only** — throws if `NODE_ENV` is not `test`.
+
+## Mocking loggers in tests
+
+Use `mockLogger` from `@grafana/test-utils/unstable` to replace a logger with `jest.fn()` stubs. This prevents tests from hitting the real Faro SDK and lets you assert on log calls.
+
+````ts
+import { mockLogger } from '@grafana/test-utils/unstable';
+import { getLogger } from '@grafana/runtime/unstable';
+
+beforeEach(() => {
+  mockLogger('grafana/runtime.plugins.meta');
+});
+it('should log a warning when something unexpected happens', () => {
+  doSomethingThatWarns();
+
+  expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
+    'unexpected thin happened',
+    expect.objectContaining({ type: 'panel' })
+  );
+});
+
+it('should log an error on failure', () => {
+  doSomethingThatFails();
+
+  expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledTimes(1);
+  expect(getLogger('rafana/runtime.plugins.meta').logError).toHaveBeenCalledWith(expect.any(Error));
+});```
+
+> **Note:** `mockLogger` calls `setLogger` under the hood, which throws if called outside of `NODE_ENV=test`.
+````

--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -1,0 +1,10 @@
+import { type LogContext } from '@grafana/faro-web-sdk';
+
+export type LoggerDefaults = { context?: Omit<LogContext, 'source'>; logToConsole?: boolean };
+
+export const Loggers = {
+  'grafana/runtime.plugins.meta': { logToConsole: true },
+  'grafana/runtime.utils.getCachedPromise': {},
+} satisfies Record<string, LoggerDefaults>;
+
+export type LoggerSource = keyof typeof Loggers;

--- a/packages/grafana-runtime/src/services/logging/registry.test.ts
+++ b/packages/grafana-runtime/src/services/logging/registry.test.ts
@@ -172,6 +172,7 @@ describe('logging registry', () => {
 
   describe('setLogger', () => {
     it('should replace the registry entry with mocks', () => {
+      // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
       setLogger('grafana/runtime.plugins.meta', {
         logDebug: jest.fn(),
         logError: jest.fn(),
@@ -188,6 +189,7 @@ describe('logging registry', () => {
     });
 
     it('should provide mock functions for all log methods', () => {
+      // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
       setLogger('grafana/runtime.plugins.meta', {
         logDebug: jest.fn(),
         logError: jest.fn(),

--- a/packages/grafana-runtime/src/services/logging/registry.test.ts
+++ b/packages/grafana-runtime/src/services/logging/registry.test.ts
@@ -1,0 +1,279 @@
+import { type MonitoringLogger } from 'src/utils/logging';
+
+import { LogLevel } from '@grafana/faro-web-sdk';
+
+import { type LoggerDefaults } from './loggers';
+import { addLogger, clearLoggerRegistry, getLogger, initializeLoggersRegistry, setLogger } from './registry';
+
+const mockPushLog = jest.fn();
+const mockPushError = jest.fn();
+const mockPushMeasurement = jest.fn();
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+  ...jest.requireActual('@grafana/faro-web-sdk'),
+  faro: {
+    api: {
+      pushLog: (...args: unknown[]) => mockPushLog(...args),
+      pushError: (...args: unknown[]) => mockPushError(...args),
+      pushMeasurement: (...args: unknown[]) => mockPushMeasurement(...args),
+    },
+  },
+}));
+
+jest.mock('../../config', () => ({
+  config: {
+    grafanaJavascriptAgent: { enabled: true },
+  },
+}));
+
+describe('logging registry', () => {
+  let debugSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    clearLoggerRegistry();
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation();
+    logSpy = jest.spyOn(console, 'log').mockImplementation();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  describe('initializeLoggersRegistry', () => {
+    it('should populate the registry with loggers for all configured sources', () => {
+      initializeLoggersRegistry();
+
+      const pluginMetaLogger = getLogger('grafana/runtime.plugins.meta');
+      const cachedPromiseLogger = getLogger('grafana/runtime.utils.getCachedPromise');
+
+      expect(pluginMetaLogger).toBeDefined();
+      expect(cachedPromiseLogger).toBeDefined();
+    });
+  });
+
+  describe('addLogger', () => {
+    it('should add a functional logger', () => {
+      const defaults = { context: { env: 'dev' }, logToConsole: true };
+      addLogger('grafana/runtime.plugins.meta', defaults);
+
+      const logger = getLogger('grafana/runtime.plugins.meta');
+      useLoggerFunctions(logger);
+
+      expectLoggerFunctions({ debugSpy, errorSpy, logSpy, warnSpy }, defaults);
+    });
+
+    it('should warn when adding the same logger twice', () => {
+      addLogger('grafana/runtime.plugins.meta');
+      addLogger('grafana/runtime.plugins.meta', { context: { env: 'dev' }, logToConsole: true });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'LoggerRegistry: a logger with the source:grafana/runtime.plugins.meta already exists, keeping existing entry.'
+      );
+    });
+
+    it('should not overwrite existing logger when adding the same logger twice', () => {
+      addLogger('grafana/runtime.plugins.meta');
+      addLogger('grafana/runtime.plugins.meta', { context: { env: 'dev' }, logToConsole: true });
+
+      warnSpy.mockClear(); // addLogger warns once when trying to add the same logger twice
+
+      const logger = getLogger('grafana/runtime.plugins.meta');
+      useLoggerFunctions(logger);
+
+      expectLoggerFunctions({ debugSpy, errorSpy, logSpy, warnSpy }); // should not contain { env: 'dev' } or any console output
+    });
+  });
+
+  describe('getLogger', () => {
+    const originalEnvironment = process.env.NODE_ENV;
+
+    describe('when called after initializeLoggersRegistry', () => {
+      it('should return a functional logger', () => {
+        initializeLoggersRegistry();
+
+        const logger = getLogger('grafana/runtime.plugins.meta');
+
+        useLoggerFunctions(logger);
+
+        expectLoggerFunctions({ debugSpy, errorSpy, logSpy, warnSpy }, { logToConsole: true });
+      });
+    });
+
+    describe.each([
+      { env: 'test', throws: false },
+      { env: 'development', throws: true },
+      { env: 'production', throws: false },
+    ])('when called for environment:$env before initializeLoggersRegistry', ({ env, throws }) => {
+      beforeEach(() => {
+        process.env.NODE_ENV = env;
+      });
+
+      afterEach(() => {
+        process.env.NODE_ENV = originalEnvironment;
+      });
+
+      it('should warn and only throw in development environment', () => {
+        if (throws) {
+          expect(() => getLogger('grafana/runtime.plugins.meta')).toThrow(
+            `LoggerRegistry: no logger 'grafana/runtime.plugins.meta' exists, are you calling getLogger before initializeLoggersRegistry function was called?`
+          );
+        }
+
+        if (!throws) {
+          getLogger('grafana/runtime.plugins.meta');
+        }
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          `LoggerRegistry: no logger 'grafana/runtime.plugins.meta' exists, are you calling getLogger before initializeLoggersRegistry function was called?`
+        );
+      });
+
+      it('should return a logger without default context and console output', () => {
+        if (throws) {
+          expect(true).toBe(true);
+          return;
+        }
+
+        const logger = getLogger('grafana/runtime.plugins.meta');
+
+        warnSpy.mockClear(); // getLogger warns when logger doesn't exists
+
+        useLoggerFunctions(logger);
+
+        expectLoggerFunctions({ debugSpy, errorSpy, logSpy, warnSpy }); // return a minimal logger
+      });
+
+      it('should not store logger in registry', () => {
+        if (throws) {
+          expect(true).toBe(true);
+          return;
+        }
+
+        getLogger('grafana/runtime.plugins.meta');
+        getLogger('grafana/runtime.plugins.meta');
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith(
+          `LoggerRegistry: no logger 'grafana/runtime.plugins.meta' exists, are you calling getLogger before initializeLoggersRegistry function was called?`
+        );
+      });
+    });
+  });
+
+  describe('setLogger', () => {
+    it('should replace the registry entry with mocks', () => {
+      setLogger('grafana/runtime.plugins.meta', {
+        logDebug: jest.fn(),
+        logError: jest.fn(),
+        logInfo: jest.fn(),
+        logMeasurement: jest.fn(),
+        logWarning: jest.fn(),
+      });
+
+      const logger = getLogger('grafana/runtime.plugins.meta');
+      logger.logInfo('mocked call');
+
+      expect(logger.logInfo).toHaveBeenCalledWith('mocked call');
+      expect(mockPushLog).not.toHaveBeenCalled();
+    });
+
+    it('should provide mock functions for all log methods', () => {
+      setLogger('grafana/runtime.plugins.meta', {
+        logDebug: jest.fn(),
+        logError: jest.fn(),
+        logInfo: jest.fn(),
+        logMeasurement: jest.fn(),
+        logWarning: jest.fn(),
+      });
+
+      const logger = getLogger('grafana/runtime.plugins.meta');
+
+      expect(jest.isMockFunction(logger.logDebug)).toBe(true);
+      expect(jest.isMockFunction(logger.logInfo)).toBe(true);
+      expect(jest.isMockFunction(logger.logWarning)).toBe(true);
+      expect(jest.isMockFunction(logger.logError)).toBe(true);
+      expect(jest.isMockFunction(logger.logMeasurement)).toBe(true);
+    });
+  });
+});
+
+function useLoggerFunctions(logger: MonitoringLogger) {
+  logger.logDebug('registry debug test', { pluginId: 'myorg-test-plugin' });
+  logger.logError(new Error('registry error test'), { pluginId: 'myorg-test-plugin' });
+  logger.logInfo('registry info test', { pluginId: 'myorg-test-plugin' });
+  logger.logWarning('registry warning test', { pluginId: 'myorg-test-plugin' });
+  logger.logMeasurement('some measurement', { render: 10 }, { pluginId: 'myorg-test-plugin' });
+}
+
+function expectLoggerFunctions(
+  spies: {
+    debugSpy: jest.SpyInstance;
+    logSpy: jest.SpyInstance;
+    errorSpy: jest.SpyInstance;
+    warnSpy: jest.SpyInstance;
+  },
+  defaults?: LoggerDefaults
+) {
+  expect(mockPushLog).toHaveBeenNthCalledWith(1, ['registry debug test'], {
+    level: LogLevel.DEBUG,
+    context: { ...defaults?.context, source: 'grafana/runtime.plugins.meta', pluginId: 'myorg-test-plugin' },
+  });
+  expect(mockPushError).toHaveBeenNthCalledWith(1, new Error('registry error test'), {
+    context: { ...defaults?.context, source: 'grafana/runtime.plugins.meta', pluginId: 'myorg-test-plugin' },
+  });
+  expect(mockPushLog).toHaveBeenNthCalledWith(2, ['registry info test'], {
+    level: LogLevel.INFO,
+    context: { ...defaults?.context, source: 'grafana/runtime.plugins.meta', pluginId: 'myorg-test-plugin' },
+  });
+  expect(mockPushLog).toHaveBeenNthCalledWith(3, ['registry warning test'], {
+    level: LogLevel.WARN,
+    context: { ...defaults?.context, source: 'grafana/runtime.plugins.meta', pluginId: 'myorg-test-plugin' },
+  });
+  expect(mockPushMeasurement).toHaveBeenNthCalledWith(
+    1,
+    { type: 'some measurement', values: { render: 10 } },
+    {
+      context: { ...defaults?.context, source: 'grafana/runtime.plugins.meta', pluginId: 'myorg-test-plugin' },
+    }
+  );
+
+  if (!defaults?.logToConsole) {
+    expect(spies.debugSpy).not.toHaveBeenCalled();
+    expect(spies.errorSpy).not.toHaveBeenCalled();
+    expect(spies.logSpy).not.toHaveBeenCalled();
+    expect(spies.warnSpy).not.toHaveBeenCalled();
+  }
+
+  if (defaults?.logToConsole) {
+    expect(spies.debugSpy).toHaveBeenCalledWith('registry debug test', {
+      ...defaults.context,
+      source: 'grafana/runtime.plugins.meta',
+      pluginId: 'myorg-test-plugin',
+    });
+    expect(spies.errorSpy).toHaveBeenCalledWith(
+      'registry error test',
+      { ...defaults.context, source: 'grafana/runtime.plugins.meta', pluginId: 'myorg-test-plugin' },
+      new Error('registry error test')
+    );
+    expect(spies.logSpy).toHaveBeenCalledWith('registry info test', {
+      ...defaults.context,
+      source: 'grafana/runtime.plugins.meta',
+      pluginId: 'myorg-test-plugin',
+    });
+    expect(spies.warnSpy).toHaveBeenCalledWith('registry warning test', {
+      ...defaults.context,
+      source: 'grafana/runtime.plugins.meta',
+      pluginId: 'myorg-test-plugin',
+    });
+  }
+}

--- a/packages/grafana-runtime/src/services/logging/registry.ts
+++ b/packages/grafana-runtime/src/services/logging/registry.ts
@@ -1,0 +1,53 @@
+import { createMonitoringLogger, type MonitoringLogger } from '../../utils/logging';
+
+import { Loggers, type LoggerDefaults, type LoggerSource } from './loggers';
+
+let loggersRegistry: Partial<Record<LoggerSource, MonitoringLogger>> = {};
+
+export function initializeLoggersRegistry() {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const entries = Object.entries(Loggers) as Array<[LoggerSource, LoggerDefaults]>;
+  for (const [source, defaults] of entries) {
+    addLogger(source, defaults);
+  }
+}
+
+export function addLogger(source: LoggerSource, defaults?: LoggerDefaults): void {
+  if (loggersRegistry[source]) {
+    console.warn(`LoggerRegistry: a logger with the source:${source} already exists, keeping existing entry.`);
+    return;
+  }
+
+  loggersRegistry[source] = createMonitoringLogger(source, defaults?.context, defaults?.logToConsole);
+}
+
+export function getLogger(source: LoggerSource): MonitoringLogger {
+  if (!loggersRegistry[source]) {
+    const message = `LoggerRegistry: no logger '${source}' exists, are you calling getLogger before initializeLoggersRegistry function was called?`;
+    console.warn(message);
+
+    if (process.env.NODE_ENV === 'development') {
+      throw new Error(message);
+    }
+
+    return createMonitoringLogger(source);
+  }
+
+  return loggersRegistry[source];
+}
+
+export function setLogger(source: LoggerSource, logger: MonitoringLogger): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('LoggerRegistry: setLogger function can only be called from tests.');
+  }
+
+  loggersRegistry[source] = logger;
+}
+
+export function clearLoggerRegistry() {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('LoggerRegistry: clearLoggerRegistry function can only be called from tests.');
+  }
+
+  loggersRegistry = {};
+}

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -88,6 +88,7 @@ describe('when useMTPlugins flag is enabled', () => {
       beforeEach(() => {
         jest.resetAllMocks();
         initPluginMetasMock.mockResolvedValue({ items: [] });
+        // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
         setLogger('grafana/runtime.plugins.meta', {
           logDebug: jest.fn(),
           logError: jest.fn(),

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -1,6 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
-import { type MonitoringLogger } from '../../utils/logging';
+import { getLogger, setLogger } from '../logging/registry';
 
 import {
   getAppPluginMeta,
@@ -9,7 +9,6 @@ import {
   isAppPluginInstalled,
   setAppPluginMetas,
 } from './apps';
-import { setPluginMetaLogger } from './logging';
 import { initPluginMetas } from './plugins';
 import { app, apps as testApps } from './test-fixtures/config.apps';
 import { v0alpha1Response } from './test-fixtures/v0alpha1Response';
@@ -21,18 +20,8 @@ const getGrafanaExploretracesApp = () =>
   structuredClone(v0alpha1Response.items.find((a) => a.spec.pluginJson.id === 'grafana-exploretraces-app'));
 
 describe('when useMTPlugins flag is enabled', () => {
-  let logger: MonitoringLogger;
-
   beforeAll(() => {
     setTestFlags({ useMTPlugins: true });
-    logger = {
-      logDebug: jest.fn(),
-      logError: jest.fn(),
-      logInfo: jest.fn(),
-      logMeasurement: jest.fn(),
-      logWarning: jest.fn(),
-    };
-    setPluginMetaLogger(logger);
   });
 
   afterAll(() => {
@@ -97,8 +86,15 @@ describe('when useMTPlugins flag is enabled', () => {
 
     describe('and initPluginMetas returns an empty result', () => {
       beforeEach(() => {
+        jest.resetAllMocks();
         initPluginMetasMock.mockResolvedValue({ items: [] });
-        jest.spyOn(console, 'warn').mockImplementation();
+        setLogger('grafana/runtime.plugins.meta', {
+          logDebug: jest.fn(),
+          logError: jest.fn(),
+          logInfo: jest.fn(),
+          logMeasurement: jest.fn(),
+          logWarning: jest.fn(),
+        });
       });
 
       it.each([{ func: getAppPluginMetas }])(
@@ -106,12 +102,8 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func();
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
-          expect(logger.logWarning).toHaveBeenCalledTimes(1);
-          expect(logger.logWarning).toHaveBeenCalledWith(
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
             { type: 'app' }
           );
@@ -123,12 +115,8 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
-          expect(logger.logWarning).toHaveBeenCalledTimes(1);
-          expect(logger.logWarning).toHaveBeenCalledWith(
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
             { type: 'app' }
           );
@@ -191,7 +179,7 @@ describe('when useMTPlugins flag is enabled', () => {
   });
 });
 
-describe('when useMTPlugins flag is enabled', () => {
+describe('when useMTPlugins flag is disabled', () => {
   beforeAll(() => {
     setTestFlags({ useMTPlugins: false });
   });

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -1,31 +1,11 @@
 import { type PluginType } from '@grafana/data';
 
-import { createMonitoringLogger, type MonitoringLogger } from '../../utils/logging';
-
-let logger: MonitoringLogger;
-
-function getLogger() {
-  if (!logger) {
-    logger = createMonitoringLogger('pluginMeta-logs');
-  }
-
-  return logger;
-}
+import { getLogger } from '../logging/registry';
 
 export function logPluginMetaWarning(message: string, type: PluginType): void {
-  getLogger().logWarning(message, { type });
-  console.warn(message);
+  getLogger('grafana/runtime.plugins.meta').logWarning(message, { type });
 }
 
 export function logPluginMetaError(message: string, error: unknown): void {
-  getLogger().logError(new Error(message, { cause: error }));
-  console.error(message, error);
-}
-
-export function setPluginMetaLogger(override: MonitoringLogger) {
-  if (process.env.NODE_ENV !== 'test') {
-    throw new Error('setLogger function can only be called from tests.');
-  }
-
-  logger = override;
+  getLogger('grafana/runtime.plugins.meta').logError(new Error(message, { cause: error }));
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -135,6 +135,7 @@ describe('when useMTPlugins flag is enabled', () => {
     describe('and initPluginMetas or refetchPanelPluginMetas returns an empty result', () => {
       beforeEach(() => {
         jest.resetAllMocks();
+        // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
         setLogger('grafana/runtime.plugins.meta', {
           logDebug: jest.fn(),
           logError: jest.fn(),

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -1,9 +1,8 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
-import { type MonitoringLogger } from '../../utils/logging';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
+import { getLogger, setLogger } from '../logging/registry';
 
-import { setPluginMetaLogger } from './logging';
 import {
   getListedPanelPluginIds,
   getListedPanelPluginMetas,
@@ -30,18 +29,8 @@ const initPluginMetasMock = jest.mocked(initPluginMetas);
 const refetchPluginMetasMock = jest.mocked(refetchPluginMetas);
 
 describe('when useMTPlugins flag is enabled', () => {
-  let logger: MonitoringLogger;
-
   beforeAll(() => {
     setTestFlags({ useMTPlugins: true });
-    logger = {
-      logDebug: jest.fn(),
-      logError: jest.fn(),
-      logInfo: jest.fn(),
-      logMeasurement: jest.fn(),
-      logWarning: jest.fn(),
-    };
-    setPluginMetaLogger(logger);
   });
 
   afterAll(() => {
@@ -145,9 +134,16 @@ describe('when useMTPlugins flag is enabled', () => {
 
     describe('and initPluginMetas or refetchPanelPluginMetas returns an empty result', () => {
       beforeEach(() => {
+        jest.resetAllMocks();
+        setLogger('grafana/runtime.plugins.meta', {
+          logDebug: jest.fn(),
+          logError: jest.fn(),
+          logInfo: jest.fn(),
+          logMeasurement: jest.fn(),
+          logWarning: jest.fn(),
+        });
         initPluginMetasMock.mockResolvedValue({ items: [] });
         refetchPluginMetasMock.mockResolvedValue({ items: [] });
-        jest.spyOn(console, 'warn').mockImplementation();
       });
 
       it.each([
@@ -159,12 +155,8 @@ describe('when useMTPlugins flag is enabled', () => {
       ])(`when func:$func is called then a warning should be logged`, async ({ func }) => {
         await func();
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
-          'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-        );
-        expect(logger.logWarning).toHaveBeenCalledTimes(1);
-        expect(logger.logWarning).toHaveBeenCalledWith(
+        expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+        expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
           'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
           { type: 'panel' }
         );
@@ -175,12 +167,8 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
-          expect(logger.logWarning).toHaveBeenCalledTimes(1);
-          expect(logger.logWarning).toHaveBeenCalledWith(
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
             { type: 'panel' }
           );

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
@@ -1,25 +1,23 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
-import { invalidateCache, setLogger } from '../../utils/getCachedPromise';
-import { type MonitoringLogger } from '../../utils/logging';
+import { invalidateCache } from '../../utils/getCachedPromise';
+import { getLogger, setLogger } from '../logging/registry';
 
 import { initPluginMetas, installPluginMeta, refetchPluginMetas, uninstallPluginMeta } from './plugins';
 import { v0alpha1Meta } from './test-fixtures/v0alpha1Response';
 
 const originalFetch = global.fetch;
-let loggerMock: MonitoringLogger;
 
 beforeEach(() => {
   jest.clearAllMocks();
   invalidateCache();
-  loggerMock = {
+  setLogger('grafana/runtime.utils.getCachedPromise', {
     logDebug: jest.fn(),
     logError: jest.fn(),
     logInfo: jest.fn(),
     logMeasurement: jest.fn(),
     logWarning: jest.fn(),
-  };
-  setLogger(loggerMock);
+  });
 });
 
 afterEach(() => {
@@ -105,12 +103,15 @@ describe('when useMTPlugins flag is enabled', () => {
 
       expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
-      expect(loggerMock.logError).toHaveBeenCalledTimes(1);
-      expect(loggerMock.logError).toHaveBeenCalledWith(new Error(`Something failed while resolving a cached promise`), {
-        message: 'Failed to load plugin metas 500:Internal Server Error',
-        stack: expect.any(String),
-        key: 'loadPluginMetas',
-      });
+      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
+      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
+        new Error(`Something failed while resolving a cached promise`),
+        {
+          message: 'Failed to load plugin metas 500:Internal Server Error',
+          stack: expect.any(String),
+          key: 'loadPluginMetas',
+        }
+      );
     });
 
     it('initPluginMetas should log when fetch rejects', async () => {
@@ -129,12 +130,15 @@ describe('when useMTPlugins flag is enabled', () => {
 
       expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
-      expect(loggerMock.logError).toHaveBeenCalledTimes(1);
-      expect(loggerMock.logError).toHaveBeenCalledWith(new Error(`Something failed while resolving a cached promise`), {
-        message: 'Network Error',
-        stack: expect.any(String),
-        key: 'loadPluginMetas',
-      });
+      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
+      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
+        new Error(`Something failed while resolving a cached promise`),
+        {
+          message: 'Network Error',
+          stack: expect.any(String),
+          key: 'loadPluginMetas',
+        }
+      );
     });
   });
 

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
@@ -11,6 +11,7 @@ const originalFetch = global.fetch;
 beforeEach(() => {
   jest.clearAllMocks();
   invalidateCache();
+  // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
   setLogger('grafana/runtime.utils.getCachedPromise', {
     logDebug: jest.fn(),
     logError: jest.fn(),

--- a/packages/grafana-runtime/src/unstable.ts
+++ b/packages/grafana-runtime/src/unstable.ts
@@ -9,5 +9,5 @@
  * and be subject to the standard policies
  */
 
-// This is a dummy export so typescript doesn't error importing an "empty module"
-export const unstable = {};
+export { clearLoggerRegistry, getLogger, initializeLoggersRegistry, setLogger } from './services/logging/registry';
+export { type LoggerSource } from './services/logging/loggers';

--- a/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
@@ -1,5 +1,6 @@
-import { getCachedPromise, invalidateCache, MAX_CACHE_SIZE, setLogger } from './getCachedPromise';
-import { type MonitoringLogger } from './logging';
+import { getLogger, setLogger } from '../services/logging/registry';
+
+import { getCachedPromise, invalidateCache, MAX_CACHE_SIZE } from './getCachedPromise';
 
 const TEST_ASYNC_DELAY = 10;
 
@@ -15,19 +16,16 @@ function simulateErrorRequest(): Promise<{ ok: boolean; status: number; statusTe
   });
 }
 
-let logger: MonitoringLogger;
-
 beforeEach(() => {
   jest.clearAllMocks();
   invalidateCache();
-  logger = {
+  setLogger('grafana/runtime.utils.getCachedPromise', {
     logDebug: jest.fn(),
     logError: jest.fn(),
     logInfo: jest.fn(),
     logMeasurement: jest.fn(),
     logWarning: jest.fn(),
-  };
-  setLogger(logger);
+  });
 });
 
 // heads up that all jest.fn(any function) will get the name 'mockConstructor'
@@ -223,12 +221,15 @@ describe('getCachedPromise', () => {
 
       expect(actual).toStrictEqual({ ok: false, status: 500, statusText: 'Internal Server Error' });
       expect(promise).toHaveBeenCalledTimes(1);
-      expect(logger.logError).toHaveBeenCalledTimes(1);
-      expect(logger.logError).toHaveBeenCalledWith(new Error(`Something failed while resolving a cached promise`), {
-        stack: expect.any(String),
-        message: 'Network Error',
-        key: 'mockConstructor',
-      });
+      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
+      expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
+        new Error(`Something failed while resolving a cached promise`),
+        {
+          stack: expect.any(String),
+          message: 'Network Error',
+          key: 'mockConstructor',
+        }
+      );
     });
 
     test('should invalidate cache when something errors', async () => {

--- a/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
@@ -19,6 +19,7 @@ function simulateErrorRequest(): Promise<{ ok: boolean; status: number; statusTe
 beforeEach(() => {
   jest.clearAllMocks();
   invalidateCache();
+  // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
   setLogger('grafana/runtime.utils.getCachedPromise', {
     logDebug: jest.fn(),
     logError: jest.fn(),

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -1,6 +1,6 @@
 import { type LogContext } from '@grafana/faro-web-sdk';
 
-import { createMonitoringLogger, type MonitoringLogger } from './logging';
+import { getLogger } from '../services/logging/registry';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const cache: Map<string, Promise<any>> = new Map();
@@ -42,24 +42,6 @@ interface LogErrorArgs {
   key: string;
 }
 
-let logger: MonitoringLogger;
-
-function getLogger() {
-  if (!logger) {
-    logger = createMonitoringLogger('get-cached-promise-logs');
-  }
-
-  return logger;
-}
-
-export function setLogger(override: MonitoringLogger) {
-  if (process.env.NODE_ENV !== 'test') {
-    throw new Error('setLogger function can only be called from tests.');
-  }
-
-  logger = override;
-}
-
 function logError({ error, key }: LogErrorArgs): void {
   const err = error instanceof Error ? error : new Error(String(error));
 
@@ -68,7 +50,10 @@ function logError({ error, key }: LogErrorArgs): void {
     context.stack = err.stack;
   }
 
-  getLogger().logError(new Error(`Something failed while resolving a cached promise`), context);
+  getLogger('grafana/runtime.utils.getCachedPromise').logError(
+    new Error(`Something failed while resolving a cached promise`),
+    context
+  );
 }
 
 function checkCacheSize() {

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -83,22 +83,28 @@ export interface MonitoringLogger {
   logError: (error: Error, contexts?: LogContext) => void;
   logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) => void;
 }
+
 /**
  * Creates a monitoring logger with five levels of logging methods: `logDebug`, `logInfo`, `logWarning`, `logError`, and `logMeasurement`.
  * These methods use `faro.api.pushX` web SDK methods to report these logs or errors to the Faro collector.
  *
  * @param {string} source - Identifier for the source of the log messages.
  * @param {LogContext} [defaultContext] - Context to be included in every log message.
+ * @param {boolean} [logToConsole] - Message and context to be output to console too.
  *
  * @returns {MonitoringLogger} Logger object with five methods:
  * - `logDebug(message: string, contexts?: LogContext)`: Logs a debug message.
  * - `logInfo(message: string, contexts?: LogContext)`: Logs an informational message.
  * - `logWarning(message: string, contexts?: LogContext)`: Logs a warning message.
  * - `logError(error: Error, contexts?: LogContext)`: Logs an error message.
- * - `logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, contexts?: LogContext)`: Logs a measurement.
+ * - `logMeasurement(type: string, measurement: MeasurementValues, contexts?: LogContext)`: Logs a measurement.
  * Each method combines the `defaultContext` (if provided), the `source`, and an optional `LogContext` parameter into a full context that is included with the log message.
  */
-export function createMonitoringLogger(source: string, defaultContext?: LogContext): MonitoringLogger {
+export function createMonitoringLogger(
+  source: string,
+  defaultContext?: LogContext,
+  logToConsole = false
+): MonitoringLogger {
   const createFullContext = (contexts?: LogContext) => ({
     source: source,
     ...defaultContext,
@@ -111,35 +117,61 @@ export function createMonitoringLogger(source: string, defaultContext?: LogConte
      * @param {string} message - The debug message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logDebug: (message: string, contexts?: LogContext) => logDebug(message, createFullContext(contexts)),
+    logDebug: (message: string, contexts?: LogContext) => {
+      logDebug(message, createFullContext(contexts));
+      if (logToConsole) {
+        // eslint-disable-next-line no-console
+        console.debug(message, createFullContext(contexts));
+      }
+    },
 
     /**
      * Logs an informational message with optional additional context.
      * @param {string} message - The informational message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logInfo: (message: string, contexts?: LogContext) => logInfo(message, createFullContext(contexts)),
+    logInfo: (message: string, contexts?: LogContext) => {
+      logInfo(message, createFullContext(contexts));
+      if (logToConsole) {
+        console.log(message, createFullContext(contexts));
+      }
+    },
 
     /**
      * Logs a warning message with optional additional context.
      * @param {string} message - The warning message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logWarning: (message: string, contexts?: LogContext) => logWarning(message, createFullContext(contexts)),
+    logWarning: (message: string, contexts?: LogContext) => {
+      logWarning(message, createFullContext(contexts));
+      if (logToConsole) {
+        console.warn(message, createFullContext(contexts));
+      }
+    },
 
     /**
      * Logs an error with optional additional context.
      * @param {Error} error - The error object to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logError: (error: Error, contexts?: LogContext) => logError(error, createFullContext(contexts)),
+    logError: (error: Error, contexts?: LogContext) => {
+      logError(error, createFullContext(contexts));
+      if (logToConsole) {
+        console.error(error.message, createFullContext(contexts), error);
+      }
+    },
 
     /**
-     * Logs an measurement with optional additional context.
-     * @param {MeasurementEvent} measurement - The measurement object to be recorded.
+     * Logs a measurement with optional additional context.
+     * @param {string} type - The type to be recorded.
+     * @param {MeasurementValues} measurement - The measurement object to be recorded.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) =>
-      logMeasurement(type, measurement, createFullContext(contexts)),
+    logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) => {
+      logMeasurement(type, measurement, createFullContext(contexts));
+      if (logToConsole) {
+        console.log(type, measurement, createFullContext(contexts));
+      }
+    },
   };
 }

--- a/packages/grafana-test-utils/src/unstable.ts
+++ b/packages/grafana-test-utils/src/unstable.ts
@@ -17,3 +17,4 @@ export { customCreateFolderHandler } from './handlers/api/folders/handlers';
 export { customCreateFolderHandler as customCreateFolderHandlerAppPlatform } from './handlers/apis/folder.grafana.app/v1beta1/handlers';
 
 export { setTestFlags, getTestFeatureFlagClient } from './utilities/featureFlags';
+export { mockLogger } from './utilities/mockLogger';

--- a/packages/grafana-test-utils/src/utilities/mockLogger.ts
+++ b/packages/grafana-test-utils/src/utilities/mockLogger.ts
@@ -1,6 +1,7 @@
-import { type LoggerSource, setLogger } from '@grafana/runtime/unstable';
+import { type MonitoringLogger } from '@grafana/runtime';
+import { getLogger, type LoggerSource, setLogger } from '@grafana/runtime/unstable';
 
-export function mockLogger(source: LoggerSource) {
+export function mockLogger(source: LoggerSource): MonitoringLogger {
   setLogger(source, {
     logDebug: jest.fn(),
     logError: jest.fn(),
@@ -8,4 +9,5 @@ export function mockLogger(source: LoggerSource) {
     logWarning: jest.fn(),
     logMeasurement: jest.fn(),
   });
+  return getLogger(source);
 }

--- a/packages/grafana-test-utils/src/utilities/mockLogger.ts
+++ b/packages/grafana-test-utils/src/utilities/mockLogger.ts
@@ -1,0 +1,11 @@
+import { type LoggerSource, setLogger } from '@grafana/runtime/unstable';
+
+export function mockLogger(source: LoggerSource) {
+  setLogger(source, {
+    logDebug: jest.fn(),
+    logError: jest.fn(),
+    logInfo: jest.fn(),
+    logWarning: jest.fn(),
+    logMeasurement: jest.fn(),
+  });
+}

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -51,6 +51,7 @@ import {
   setPanelRenderer,
   setPluginPage,
 } from '@grafana/runtime/internal';
+import { initializeLoggersRegistry } from '@grafana/runtime/unstable';
 import { loadResources as loadScenesResources, sceneUtils } from '@grafana/scenes';
 import config, { updateConfig } from 'app/core/config';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
@@ -139,6 +140,7 @@ export class GrafanaApp {
       window.parent.postMessage('GrafanaAppInit', '*');
 
       initSystemJSHooks();
+      initializeLoggersRegistry();
 
       // Currently the OpenFeature API requires a signed in user. This means feature flags cannot be used
       // on the login page.

--- a/public/app/features/plugins/admin/api.test.ts
+++ b/public/app/features/plugins/admin/api.test.ts
@@ -1,6 +1,7 @@
-import { getBackendSrv, type MonitoringLogger, setBackendSrv } from '@grafana/runtime';
-import { installPluginMeta, setPluginMetaLogger, uninstallPluginMeta } from '@grafana/runtime/internal';
-import { setTestFlags } from '@grafana/test-utils/unstable';
+import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
+import { installPluginMeta, uninstallPluginMeta } from '@grafana/runtime/internal';
+import { getLogger } from '@grafana/runtime/unstable';
+import { mockLogger, setTestFlags } from '@grafana/test-utils/unstable';
 
 import { installPlugin, uninstallPlugin } from './api';
 
@@ -18,8 +19,6 @@ const uninstallPluginMetaMock = jest.mocked(uninstallPluginMeta);
 const originalFetch = global.fetch;
 
 describe('api', () => {
-  let logger: MonitoringLogger;
-
   beforeEach(() => {
     jest.clearAllMocks();
     setBackendSrv({
@@ -33,15 +32,7 @@ describe('api', () => {
       request: jest.fn(),
       datasourceRequest: jest.fn(),
     });
-    logger = {
-      logDebug: jest.fn(),
-      logError: jest.fn(),
-      logInfo: jest.fn(),
-      logMeasurement: jest.fn(),
-      logWarning: jest.fn(),
-    };
-    setPluginMetaLogger(logger);
-    jest.spyOn(console, 'error').mockImplementation();
+    mockLogger('grafana/runtime.plugins.meta');
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -106,13 +97,8 @@ describe('api', () => {
           { version: '1.5.0' },
           { showErrorAlert: false }
         );
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith(
-          'PluginMeta: Failed to install plugin with id myorg-test-panel and version 1.5.0',
-          new Error('Network Error')
-        );
-        expect(logger.logError).toHaveBeenCalledTimes(1);
-        expect(logger.logError).toHaveBeenCalledWith(
+        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledTimes(1);
+        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledWith(
           expect.objectContaining({
             message: 'PluginMeta: Failed to install plugin with id myorg-test-panel and version 1.5.0',
             cause: expect.objectContaining({
@@ -146,13 +132,8 @@ describe('api', () => {
         expect(uninstallPluginMetaMock).toHaveBeenCalledTimes(1);
         expect(uninstallPluginMetaMock).toHaveBeenCalledWith('myorg-test-panel');
         expect(getBackendSrv().post).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith(
-          'PluginMeta: Failed to uninstall plugin with id myorg-test-panel',
-          new Error('Network Error')
-        );
-        expect(logger.logError).toHaveBeenCalledTimes(1);
-        expect(logger.logError).toHaveBeenCalledWith(
+        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledTimes(1);
+        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledWith(
           expect.objectContaining({
             message: 'PluginMeta: Failed to uninstall plugin with id myorg-test-panel',
             cause: expect.objectContaining({

--- a/public/app/features/plugins/admin/api.test.ts
+++ b/public/app/features/plugins/admin/api.test.ts
@@ -1,6 +1,5 @@
-import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, type MonitoringLogger, setBackendSrv } from '@grafana/runtime';
 import { installPluginMeta, uninstallPluginMeta } from '@grafana/runtime/internal';
-import { getLogger } from '@grafana/runtime/unstable';
 import { mockLogger, setTestFlags } from '@grafana/test-utils/unstable';
 
 import { installPlugin, uninstallPlugin } from './api';
@@ -19,6 +18,7 @@ const uninstallPluginMetaMock = jest.mocked(uninstallPluginMeta);
 const originalFetch = global.fetch;
 
 describe('api', () => {
+  let logger: MonitoringLogger;
   beforeEach(() => {
     jest.clearAllMocks();
     setBackendSrv({
@@ -32,7 +32,7 @@ describe('api', () => {
       request: jest.fn(),
       datasourceRequest: jest.fn(),
     });
-    mockLogger('grafana/runtime.plugins.meta');
+    logger = mockLogger('grafana/runtime.plugins.meta');
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -97,8 +97,8 @@ describe('api', () => {
           { version: '1.5.0' },
           { showErrorAlert: false }
         );
-        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledTimes(1);
-        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledWith(
+        expect(logger.logError).toHaveBeenCalledTimes(1);
+        expect(logger.logError).toHaveBeenCalledWith(
           expect.objectContaining({
             message: 'PluginMeta: Failed to install plugin with id myorg-test-panel and version 1.5.0',
             cause: expect.objectContaining({
@@ -132,8 +132,8 @@ describe('api', () => {
         expect(uninstallPluginMetaMock).toHaveBeenCalledTimes(1);
         expect(uninstallPluginMetaMock).toHaveBeenCalledWith('myorg-test-panel');
         expect(getBackendSrv().post).toHaveBeenCalledTimes(1);
-        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledTimes(1);
-        expect(getLogger('grafana/runtime.plugins.meta').logError).toHaveBeenCalledWith(
+        expect(logger.logError).toHaveBeenCalledTimes(1);
+        expect(logger.logError).toHaveBeenCalledWith(
           expect.objectContaining({
             message: 'PluginMeta: Failed to uninstall plugin with id myorg-test-panel',
             cause: expect.objectContaining({

--- a/public/app/features/plugins/extensions/registry/setup.test.ts
+++ b/public/app/features/plugins/extensions/registry/setup.test.ts
@@ -1,5 +1,6 @@
-import { type MonitoringLogger } from '@grafana/runtime';
-import { getAppPluginMetas, invalidateCache, setLogger } from '@grafana/runtime/internal';
+import { getAppPluginMetas, invalidateCache } from '@grafana/runtime/internal';
+import { getLogger } from '@grafana/runtime/unstable';
+import { mockLogger } from '@grafana/test-utils/unstable';
 
 import { getPluginExtensionRegistries } from './setup';
 
@@ -9,21 +10,13 @@ jest.mock('@grafana/runtime/internal', () => ({
 }));
 
 const getAppPluginMetasMock = jest.mocked(getAppPluginMetas);
-let logger: MonitoringLogger;
 
 describe('getPluginExtensionRegistries', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     invalidateCache();
     getAppPluginMetasMock.mockResolvedValue([]);
-    logger = {
-      logDebug: jest.fn(),
-      logError: jest.fn(),
-      logInfo: jest.fn(),
-      logMeasurement: jest.fn(),
-      logWarning: jest.fn(),
-    };
-    setLogger(logger);
+    mockLogger('grafana/runtime.utils.getCachedPromise');
   });
 
   test('should only call getAppPluginMetas once', async () => {
@@ -62,11 +55,14 @@ describe('getPluginExtensionRegistries', () => {
     expect(first).not.toBe(second);
     expect(first).not.toBe(third);
     expect(second).toBe(third);
-    expect(logger.logError).toHaveBeenCalledTimes(1);
-    expect(logger.logError).toHaveBeenCalledWith(new Error('Something failed while resolving a cached promise'), {
-      message: 'Some error',
-      stack: expect.any(String),
-      key: 'initPluginExtensionRegistries',
-    });
+    expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
+    expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
+      new Error('Something failed while resolving a cached promise'),
+      {
+        message: 'Some error',
+        stack: expect.any(String),
+        key: 'initPluginExtensionRegistries',
+      }
+    );
   });
 });

--- a/public/app/features/plugins/extensions/registry/setup.test.ts
+++ b/public/app/features/plugins/extensions/registry/setup.test.ts
@@ -1,5 +1,5 @@
+import { type MonitoringLogger } from '@grafana/runtime';
 import { getAppPluginMetas, invalidateCache } from '@grafana/runtime/internal';
-import { getLogger } from '@grafana/runtime/unstable';
 import { mockLogger } from '@grafana/test-utils/unstable';
 
 import { getPluginExtensionRegistries } from './setup';
@@ -12,11 +12,12 @@ jest.mock('@grafana/runtime/internal', () => ({
 const getAppPluginMetasMock = jest.mocked(getAppPluginMetas);
 
 describe('getPluginExtensionRegistries', () => {
+  let logger: MonitoringLogger;
   beforeEach(() => {
     jest.resetAllMocks();
     invalidateCache();
     getAppPluginMetasMock.mockResolvedValue([]);
-    mockLogger('grafana/runtime.utils.getCachedPromise');
+    logger = mockLogger('grafana/runtime.utils.getCachedPromise');
   });
 
   test('should only call getAppPluginMetas once', async () => {
@@ -55,14 +56,11 @@ describe('getPluginExtensionRegistries', () => {
     expect(first).not.toBe(second);
     expect(first).not.toBe(third);
     expect(second).toBe(third);
-    expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
-    expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
-      new Error('Something failed while resolving a cached promise'),
-      {
-        message: 'Some error',
-        stack: expect.any(String),
-        key: 'initPluginExtensionRegistries',
-      }
-    );
+    expect(logger.logError).toHaveBeenCalledTimes(1);
+    expect(logger.logError).toHaveBeenCalledWith(new Error('Something failed while resolving a cached promise'), {
+      message: 'Some error',
+      stack: expect.any(String),
+      key: 'initPluginExtensionRegistries',
+    });
   });
 });


### PR DESCRIPTION
**What is this feature?**                                                                                                                                                
                                                                                                                                                                           
A centralized logger registry for frontend logging, built on top of Grafana Faro Web SDK. It replaces ad-hoc per-module logger creation with a single registry that is initialized once at app boot. Each logger is scoped by a type-safe source name (e.g. `grafana.plugins.meta`), supports optional console output for local debugging, and provides a `mockLogger` helper for clean test mocking.                                                                                                                   
                                                                                                                                                                           
**Why do we need this feature?**                                                                                                                                         
                                                                                                                                                                           
Frontend modules that needed logging were each creating their own `MonitoringLogger` instances with duplicated setup code, separate `setLogger` test overrides, and inconsistent console output patterns. This made it hard to add new loggers, led to boilerplate in tests (manually constructing mock logger objects), and meant there was no single place to see which loggers exist. The registry centralizes all of this: one initialization point, one `getLogger()` call to retrieve any logger, and one `mockLogger()` call to stub it in tests. 

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #121639

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
