### PR TITLE
Auditing: Log subresource if present and rename kind to resource

### DIFF
--- a/pkg/apiserver/auditing/event.go
+++ b/pkg/apiserver/auditing/event.go
@@ -22,9 +22,10 @@ type Event struct {
 	Object string `json:"object,omitempty"`
 
 	// API information.
-	APIGroup   string `json:"apiGroup,omitempty"`
-	APIVersion string `json:"apiVersion,omitempty"`
-	Kind       string `json:"kind,omitempty"`
+	APIGroup    string `json:"apiGroup,omitempty"`
+	APIVersion  string `json:"apiVersion,omitempty"`
+	Resource    string `json:"resource,omitempty"`
+	SubResource string `json:"subResource,omitempty"`
 
 	// Outcome of the action.
 	Outcome EventOutcome `json:"outcome"`
@@ -58,7 +59,8 @@ func (e Event) KVPairs() []any {
 		"object", e.Object,
 		"apiGroup", e.APIGroup,
 		"apiVersion", e.APIVersion,
-		"kind", e.Kind,
+		"resource", e.Resource,
+		"subResource", e.SubResource,
 		"outcome", e.Outcome,
 	}
 


### PR DESCRIPTION
**What is this feature?**

Now we log `subResource` if present, i.e. for Folders API when doing a `GET /parents`:

```
logger=auditing.console
audit=true
namespace=default
observedAt=2026-04-07T08:49:56.04138Z
subjectUID=user:bfhs3oxcotgcge
verb=get
object=general
apiGroup=folder.grafana.app
apiVersion=v1
resource=folders
subResource=parents <----- NEW!
outcome=success
extra_userAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
extra_sourceIPs=::1
```

Alongside that, update `kind` field to `resource` to better reflect the name as it comes from the `resource` object in k8s-land.

**Why do we need this feature?**

Properly distinguish between purely resource requests and ones with subresources.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
