### PR TITLE
CI: Update pr-checks to use action from main

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Run PR Checks
-        uses: grafana/grafana-github-actions/pr-checks@jh/pr-checks-refactor
+        uses: grafana/grafana-github-actions/pr-checks@main
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-checks


### PR DESCRIPTION
The workflow in grafana-github-actions was merged, so we should pull this from main now.