### PR TITLE
Unified: fix write delay cancelled too early during shutdown

### DIFF
--- a/pkg/storage/unified/resource/eventstore_test.go
+++ b/pkg/storage/unified/resource/eventstore_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),                                   // database/sql background goroutines from test DB setup.
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionCleaner"),
 		goleak.IgnoreTopFunction("github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher.func1"),                                             // MySQL driver connection watcher from test DB setup.
-goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),                                             // expirable LRU cleanup goroutine.
+		goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),                                             // expirable LRU cleanup goroutine.
 		goleak.IgnoreTopFunction("github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager.(*ResourceVersionManager).startBatchProcessor"), // ResourceVersionManager has no shutdown hook; compat tests intentionally exercise it.
 	)
 }

--- a/pkg/storage/unified/resource/eventstore_test.go
+++ b/pkg/storage/unified/resource/eventstore_test.go
@@ -34,8 +34,7 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),                                   // database/sql background goroutines from test DB setup.
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionCleaner"),
 		goleak.IgnoreTopFunction("github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher.func1"),                                             // MySQL driver connection watcher from test DB setup.
-		goleak.IgnoreTopFunction("github.com/grafana/dskit/runtimeconfig.(*Manager).loop"),                                                     // dskit runtime config manager from test infra.
-		goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),                                             // expirable LRU cleanup goroutine.
+goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),                                             // expirable LRU cleanup goroutine.
 		goleak.IgnoreTopFunction("github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager.(*ResourceVersionManager).startBatchProcessor"), // ResourceVersionManager has no shutdown hook; compat tests intentionally exercise it.
 	)
 }

--- a/pkg/storage/unified/resource/quotas_test.go
+++ b/pkg/storage/unified/resource/quotas_test.go
@@ -423,6 +423,9 @@ func TestQuotaService_GetQuota(t *testing.T) {
 			require.NoError(t, err, "failed to create quota service")
 			err = service.init(ctx)
 			require.NoError(t, err, "failed to initialize quota service")
+			t.Cleanup(func() {
+				_ = service.stop(ctx)
+			})
 
 			quota, err := service.GetQuota(ctx, tt.nsr)
 

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -577,7 +577,7 @@ func (s *server) Stop(ctx context.Context) error {
 	s.stopping = true
 	s.stopMu.Unlock()
 
-	// Stops streaming and unblocks artificialSuccessfulWriteDelay.
+	// Stops streaming (broadcaster, watch events).
 	s.cancel()
 
 	// Wait for in-flight write operations to finish, respecting the context deadline.
@@ -925,7 +925,6 @@ func (s *server) sleepAfterSuccessfulWriteOperation(ctx context.Context, operati
 
 	select {
 	case <-time.After(s.artificialSuccessfulWriteDelay):
-	case <-s.ctx.Done():
 	case <-ctx.Done():
 	}
 	return true

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -614,7 +614,6 @@ func TestArtificialDelayAfterSuccessfulOperation(t *testing.T) {
 	s := &server{
 		artificialSuccessfulWriteDelay: 1 * time.Millisecond,
 		log:                            log.NewNopLogger(),
-		ctx:                            ctx,
 	}
 
 	check := func(t *testing.T, expectedSleep bool, res responseWithErrorResult, err error) {


### PR DESCRIPTION
## Summary
- Remove `case <-s.ctx.Done():` from `sleepAfterSuccessfulWriteOperation` — `Stop()` was calling `s.cancel()` before `inflight.Wait()`, cutting in-flight write delays short and breaking search-after-write consistency
- Remove the `goleak.IgnoreTopFunction` for `runtimeconfig.(*Manager).loop` and add missing `service.stop()` cleanup in `quotas_test.go`

## Test plan
- [x] `go test ./pkg/storage/unified/resource/` — all 760 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)