### PR TITLE
add a method to skip validating frontend assists for micro servives

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1278,6 +1278,13 @@ func (cfg *Cfg) setHomePath(args CommandLineArgs) {
 
 var skipStaticRootValidation = false
 
+// SetSkipStaticRootValidation prevents the "Failed to detect generated javascript
+// files in public/build" log from being emitted during config loading. Useful for
+// API server deployments that do not serve a frontend.
+func SetSkipStaticRootValidation() {
+	skipStaticRootValidation = true
+}
+
 func NewCfg() *Cfg {
 	return &Cfg{
 		Env:    Dev,


### PR DESCRIPTION
 We are running a bunch of grafana servers as backend only and we are checking constantly for a static build path which produces a lot of errors in our log `Failed to detect generated javascript files in public/build`.
 
 This will be called in the entry point in enterprise to minimize this log. 