### PR TITLE
[release-12.4.3] Settings: Allow env vars to override unified config options not in ini files

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -895,12 +895,22 @@ type AnnotationCleanupSettings struct {
 	MaxCount int64
 }
 
+// envNameFromIniName converts an ini-style name (section or key) to the
+// uppercased, underscore-separated form used in GF_ environment variables.
+// Dots and dashes become underscores; everything is uppercased.
+func envNameFromIniName(name string) string {
+	s := strings.ToUpper(strings.ReplaceAll(name, ".", "_"))
+	return strings.ReplaceAll(s, "-", "_")
+}
+
+// EnvSectionPrefix returns the GF_ environment variable prefix for a given
+// ini section name, e.g. "auth.google" → "GF_AUTH_GOOGLE_".
+func EnvSectionPrefix(sectionName string) string {
+	return "GF_" + envNameFromIniName(sectionName) + "_"
+}
+
 func EnvKey(sectionName string, keyName string) string {
-	sN := strings.ToUpper(strings.ReplaceAll(sectionName, ".", "_"))
-	sN = strings.ReplaceAll(sN, "-", "_")
-	kN := strings.ToUpper(strings.ReplaceAll(keyName, ".", "_"))
-	envKey := fmt.Sprintf("GF_%s_%s", sN, kN)
-	return envKey
+	return "GF_" + envNameFromIniName(sectionName) + "_" + envNameFromIniName(keyName)
 }
 
 func (cfg *Cfg) applyCommandLineDefaultProperties(props map[string]string, file *ini.File) {

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -1,6 +1,8 @@
 package setting
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -11,6 +13,14 @@ import (
 // DefaultAutoMigrationThreshold is the default threshold for auto migration switching.
 // If a resource has entries at or below this count, it will be migrated.
 const DefaultAutoMigrationThreshold = 10
+
+// knownUnifiedStorageKeys maps uppercased env-var-style key suffixes to their
+// actual camelCase ini key names used in [unified_storage.*] sections.
+var knownUnifiedStorageKeys = map[string]string{
+	"DUALWRITERMODE":         "dualWriterMode",
+	"ENABLEMIGRATION":        "enableMigration",
+	"AUTOMIGRATIONTHRESHOLD": "autoMigrationThreshold",
+}
 
 const (
 	PlaylistResource  = "playlists.playlist.grafana.app"
@@ -34,13 +44,73 @@ var AutoMigratedUnifiedResources = map[string]bool{
 	DashboardResource: true,
 }
 
-// read storage configs from ini file. They look like:
-// [unified_storage.<group>.<resource>]
-// <field> = <value>
-// e.g.
-// [unified_storage.playlists.playlist.grafana.app]
-// dualWriterMode = 2
+// applyUnifiedStorageEnvOverrides scans environment variables matching
+// GF_UNIFIED_STORAGE_<resource>_<key> and creates the corresponding ini
+// sections and keys. This allows users to configure unified_storage resource
+// sections purely via environment variables without pre-defining them in an
+// ini file.
+//
+// Storage configs in the ini file look like:
+//
+//	[unified_storage.<group>.<resource>]
+//	<field> = <value>
+//
+// For example:
+//
+//	[unified_storage.playlists.playlist.grafana.app]
+//	dualWriterMode = 2
+//
+// Kubernetes resource names (e.g., "dashboards.dashboard.grafana.app") never
+// contain underscores — only dots and lowercase alphanumerics — so every
+// underscore in the resource portion of the env var name maps unambiguously
+// back to a dot. The key names are matched from a known list
+// ([knownUnifiedStorageKeys]) to preserve their original camelCase.
+func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
+	envPrefix := EnvSectionPrefix("unified_storage")
+
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, envPrefix) {
+			continue
+		}
+		eqIdx := strings.IndexByte(env, '=')
+		if eqIdx < 0 {
+			continue
+		}
+		envKey := env[:eqIdx]
+		envValue := env[eqIdx+1:]
+		if envValue == "" {
+			continue
+		}
+
+		remainder := envKey[len(envPrefix):]
+
+		// Try to match a known key suffix. The key is always the last component
+		// after the final underscore that matches a known key name.
+		for envKeySuffix, iniKeyName := range knownUnifiedStorageKeys {
+			suffix := "_" + envKeySuffix
+			if !strings.HasSuffix(remainder, suffix) {
+				continue
+			}
+			resourceEnv := remainder[:len(remainder)-len(suffix)]
+			if resourceEnv == "" {
+				continue
+			}
+			// Reconstruct the resource name: lowercase with underscores → dots.
+			resourceName := strings.ToLower(strings.ReplaceAll(resourceEnv, "_", "."))
+			sectionName := "unified_storage." + resourceName
+			cfg.Raw.Section(sectionName).Key(iniKeyName).SetValue(envValue)
+			cfg.appliedEnvOverrides = append(cfg.appliedEnvOverrides,
+				fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
+			break
+		}
+	}
+}
+
 func (cfg *Cfg) setUnifiedStorageConfig() {
+	// Pre-create sections from GF_UNIFIED_STORAGE_* env vars so that
+	// resource sections can be configured purely via environment variables.
+	cfg.applyUnifiedStorageEnvOverrides()
+
 	storageConfig := make(map[string]UnifiedStorageConfig)
 	sections := cfg.Raw.Sections()
 	for _, section := range sections {

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -84,6 +84,41 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 5, cfg.IndexMinCount)
 	})
 
+	t.Run("env vars create unified_storage resource sections without ini file", func(t *testing.T) {
+		// Set env vars for a resource that has NO ini section defined.
+		t.Setenv("GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_DUALWRITERMODE", "3")
+		t.Setenv("GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION", "false")
+		t.Setenv("GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_AUTOMIGRATIONTHRESHOLD", "5")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		value, exists := cfg.UnifiedStorage[DashboardResource]
+		assert.True(t, exists, "dashboards.dashboard.grafana.app should exist from env var")
+		// Note: enforceMigrationToUnifiedConfigs may override dualWriterMode to 5
+		// for migrated resources. We test the enableMigration was correctly parsed as false.
+		assert.Equal(t, false, value.EnableMigration)
+		assert.Equal(t, 5, value.AutoMigrationThreshold)
+	})
+
+	t.Run("env vars work for unknown resource names", func(t *testing.T) {
+		// A resource not in MigratedUnifiedResources, configured purely via env vars.
+		t.Setenv("GF_UNIFIED_STORAGE_WIDGETS_WIDGET_CUSTOM_IO_DUALWRITERMODE", "2")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		value, exists := cfg.UnifiedStorage["widgets.widget.custom.io"]
+		assert.True(t, exists, "widgets.widget.custom.io should exist from env var")
+		assert.Equal(t, rest.DualWriterMode(2), value.DualWriterMode)
+	})
+
 	t.Run("read unified_storage configs with defaults", func(t *testing.T) {
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})


### PR DESCRIPTION
Minimal version of 5a34b2de6bb989e2287029f2d4e299b1df9aa6b9 from #120162 that fixes: https://github.com/grafana/grafana/issues/120123 in Grafana 12.4.3 patch

---

## Summary

- Adds a `unified_storage`-specific handler (`applyUnifiedStorageEnvOverrides`) that reconstructs resource section names from env vars — safe because K8s resource names never contain underscores — and preserves camelCase key names (`dualWriterMode`, `enableMigration`)
- Extracts shared helpers `envNameFromIniName()` and `EnvSectionPrefix()` to eliminate duplicated ini-name-to-env conversion logic across `EnvKey()`, `applyEnvVariableOverrides`, and `applyUnifiedStorageEnvOverrides`

### Root cause

`applyEnvVariableOverrides` iterated over keys already in the ini file and checked `os.Getenv()` for each. If a key wasn't in any ini file, the corresponding env var was never checked. For dynamic sections like `[unified_storage.dashboards.dashboard.grafana.app]` that don't exist in `defaults.ini`, env vars were completely ignored.

### What works now

| Scenario | Before | After |
|---|---|---|
| `GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION=true` | Ignored | Creates `[unified_storage.dashboards.dashboard.grafana.app]` section with `enableMigration` key |

### Known limitations

- **Dynamic sections**: Only `unified_storage.*` has feature-specific env var handling. Other sections still require ini file pre-definition.

## Test plan

- [x] New test: env var creates `unified_storage` resource section from scratch
- [x] New test: env var works for unknown resource names (`widgets.widget.custom.io`)
- [x] All existing `pkg/setting` tests pass
- [x] Manual: set `GF_UNIFIED_STORAGE_DASHBOARDS_DASHBOARD_GRAFANA_APP_ENABLEMIGRATION=false` without ini entry, verify config is applied
