### PR TITLE
Unified storage: replace InlineSecureValueSupport testify mock with fake in secure_test

### DIFF
--- a/apps/quotas/go.sum
+++ b/apps/quotas/go.sum
@@ -548,8 +548,6 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.26.1 h1:iPbVVEdkhTX++hpe3lzSk7D3G3QSYqLGoHOcEio+UXQ=
-github.com/google/cel-go v0.26.1/go.mod h1:A9O8OU9rdvrK5MQyrqfIxo1a0u4g3sF8KB6PUIaryMM=
 github.com/google/flatbuffers v25.12.19+incompatible h1:haMV2JRRJCe1998HeW/p0X9UaMTK6SDo0ffLn2+DbLs=
 github.com/google/flatbuffers v25.12.19+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
@@ -740,8 +738,6 @@ github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
-github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
@@ -1079,8 +1075,6 @@ github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfA
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
-github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
-github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
@@ -1088,8 +1082,6 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
-github.com/stoewer/go-strcase v1.3.1 h1:iS0MdW+kVTxgMoE1LAZyMiYJFKlOzLooE4MxjirtkAs=
-github.com/stoewer/go-strcase v1.3.1/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/storage/unified/resource/secure_test.go
+++ b/pkg/storage/unified/resource/secure_test.go
@@ -6,14 +6,28 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/registry/apis/secret"
 )
+
+type fakeSecureValueSupport struct {
+	canReferenceErr error
+}
+
+func (f *fakeSecureValueSupport) CanReference(_ context.Context, _ common.ObjectReference, _ ...string) error {
+	return f.canReferenceErr
+}
+
+func (f *fakeSecureValueSupport) CreateInline(_ context.Context, _ common.ObjectReference, _ common.RawSecureValue, _ *string) (string, error) {
+	return "", fmt.Errorf("not expected")
+}
+
+func (f *fakeSecureValueSupport) DeleteWhenOwnedByResource(_ context.Context, _ common.ObjectReference, _ ...string) error {
+	return fmt.Errorf("not expected")
+}
 
 func TestSecureValues(t *testing.T) {
 	raw := &unstructured.Unstructured{
@@ -32,7 +46,6 @@ func TestSecureValues(t *testing.T) {
 	}
 	obj, err := utils.MetaAccessor(raw)
 	require.NoError(t, err)
-	owner := utils.ToObjectReference(obj)
 
 	t.Run("Invalid input", func(t *testing.T) {
 		raw.Object["secure"] = map[string]any{
@@ -40,7 +53,7 @@ func TestSecureValues(t *testing.T) {
 				Create: common.NewSecretValue("XXX"),
 			},
 		}
-		secureMock := secret.NewMockInlineSecureValueSupport(t)
+		fake := &fakeSecureValueSupport{}
 		pberr := canReferenceSecureValues(context.Background(), obj, nil, nil)
 		require.Equal(t, http.StatusServiceUnavailable, int(pberr.Code), "missing store")
 
@@ -50,7 +63,7 @@ func TestSecureValues(t *testing.T) {
 					Create: common.NewSecretValue("XXX"),
 				},
 			}
-			pberr = canReferenceSecureValues(context.Background(), obj, nil, secureMock)
+			pberr = canReferenceSecureValues(context.Background(), obj, nil, fake)
 			require.Equal(t, http.StatusUnprocessableEntity, int(pberr.Code))
 			require.Equal(t, "secure.A.create", pberr.Details.Causes[0].Field)
 		})
@@ -61,7 +74,7 @@ func TestSecureValues(t *testing.T) {
 					Remove: true,
 				},
 			}
-			pberr = canReferenceSecureValues(context.Background(), obj, nil, secureMock)
+			pberr = canReferenceSecureValues(context.Background(), obj, nil, fake)
 			require.Equal(t, http.StatusUnprocessableEntity, int(pberr.Code))
 			require.Equal(t, "secure.A.remove", pberr.Details.Causes[0].Field)
 		})
@@ -72,12 +85,10 @@ func TestSecureValues(t *testing.T) {
 					Name: "", // EMPTY
 				},
 			}
-			pberr = canReferenceSecureValues(context.Background(), obj, nil, secureMock)
+			pberr = canReferenceSecureValues(context.Background(), obj, nil, fake)
 			require.Equal(t, http.StatusUnprocessableEntity, int(pberr.Code))
 			require.Equal(t, "secure.A.name", pberr.Details.Causes[0].Field)
 		})
-
-		secureMock.AssertExpectations(t)
 	})
 
 	t.Run("OnCreate", func(t *testing.T) {
@@ -89,13 +100,9 @@ func TestSecureValues(t *testing.T) {
 				Name: "111", // duplicate reference, but only checked once
 			},
 		}
-		secureMock := secret.NewMockInlineSecureValueSupport(t)
-		secureMock.On("CanReference", mock.Anything, owner, "111").
-			Return(nil).Once()
 
-		pberr := canReferenceSecureValues(context.Background(), obj, nil, secureMock)
+		pberr := canReferenceSecureValues(context.Background(), obj, nil, &fakeSecureValueSupport{})
 		require.Nil(t, pberr)
-		secureMock.AssertExpectations(t)
 	})
 
 	t.Run("OnUpdate", func(t *testing.T) {
@@ -109,13 +116,9 @@ func TestSecureValues(t *testing.T) {
 		}
 
 		old, _ := utils.MetaAccessor(&unstructured.Unstructured{})
-		secureMock := secret.NewMockInlineSecureValueSupport(t)
-		secureMock.On("CanReference", mock.Anything, owner, "111", "222").
-			Return(nil).Once()
 
-		pberr := canReferenceSecureValues(context.Background(), obj, old, secureMock)
+		pberr := canReferenceSecureValues(context.Background(), obj, old, &fakeSecureValueSupport{})
 		require.Nil(t, pberr)
-		secureMock.AssertExpectations(t)
 	})
 
 	t.Run("OnUpdate with same keys", func(t *testing.T) {
@@ -138,13 +141,9 @@ func TestSecureValues(t *testing.T) {
 						Name: "Not222",
 					},
 				}}})
-		secureMock := secret.NewMockInlineSecureValueSupport(t)
-		secureMock.On("CanReference", mock.Anything, owner, "111", "222").
-			Return(nil).Once()
 
-		pberr := canReferenceSecureValues(context.Background(), obj, old, secureMock)
+		pberr := canReferenceSecureValues(context.Background(), obj, old, &fakeSecureValueSupport{})
 		require.Nil(t, pberr)
-		secureMock.AssertExpectations(t)
 	})
 
 	t.Run("Update without changes should skip CanReference", func(t *testing.T) {
@@ -153,11 +152,12 @@ func TestSecureValues(t *testing.T) {
 				Name: "111",
 			},
 		}
-		secureMock := secret.NewMockInlineSecureValueSupport(t)
 
-		pberr := canReferenceSecureValues(context.Background(), obj, obj, secureMock)
+		// CanReference should not be called; if it were, the error would surface.
+		pberr := canReferenceSecureValues(context.Background(), obj, obj, &fakeSecureValueSupport{
+			canReferenceErr: fmt.Errorf("should not be called"),
+		})
 		require.Nil(t, pberr)
-		secureMock.AssertExpectations(t) // CanReference should not be called
 	})
 
 	t.Run("upstream errors", func(t *testing.T) {
@@ -166,23 +166,17 @@ func TestSecureValues(t *testing.T) {
 				Name: "111",
 			},
 		}
-		secureMock := secret.NewMockInlineSecureValueSupport(t)
-		secureMock.On("CanReference", mock.Anything, owner, "111").
-			Return(fmt.Errorf("nope")).Once() // <<< error in CanReference
 
-		pberr := canReferenceSecureValues(context.Background(), obj, nil, secureMock)
+		pberr := canReferenceSecureValues(context.Background(), obj, nil, &fakeSecureValueSupport{
+			canReferenceErr: fmt.Errorf("nope"),
+		})
 		require.NotNil(t, pberr)
-		secureMock.AssertExpectations(t)
 
 		// Check CanReference when the old value is invalid
 		old, _ := utils.MetaAccessor(&unstructured.Unstructured{
 			Object: map[string]any{"secure": t}})
 
-		secureMock = secret.NewMockInlineSecureValueSupport(t)
-		secureMock.On("CanReference", mock.Anything, owner, "111").
-			Return(nil).Once()
-		pberr = canReferenceSecureValues(context.Background(), obj, old, secureMock)
+		pberr = canReferenceSecureValues(context.Background(), obj, old, &fakeSecureValueSupport{})
 		require.Nil(t, pberr)
-		secureMock.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## Summary
- Replace the mockery-generated `MockInlineSecureValueSupport` with a hand-written `fakeSecureValueSupport` struct in `pkg/storage/unified/resource/secure_test.go`
- Remove dependency on `testify/mock` and the `secret` mock package import
- Eliminate mock-specific string matching patterns (`.On`/`.Return`/`.Once`/`.AssertExpectations`)

## Test plan
- [x] `go test ./pkg/storage/unified/resource/ -run TestSecure -count=1` passes (10 tests)