### PR TITLE
Alerting: Mark notification provisioning endpoints deprecated

### DIFF
--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -12,6 +12,10 @@ For more information on the differences between Grafana-managed and data source-
 
 > If you are running Grafana Enterprise, you need to add specific permissions for some endpoints. For more information, refer to [Role-based access control permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/).
 
+{{< admonition type="warning" >}}
+The contact points, notification policies, notification template groups, and mute timings endpoints in this API are deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead.
+{{< /admonition >}}
+
 ## Grafana-managed endpoints
 
 {{< admonition type="note" >}}
@@ -707,7 +711,7 @@ DELETE /api/v1/provisioning/contact-points/:uid
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{name}` for receivers.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{name}` for receivers.
 {{< /admonition >}}
 
 #### Parameters
@@ -737,7 +741,7 @@ DELETE /api/v1/provisioning/mute-timings/:name
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
 {{< /admonition >}}
 
 #### Parameters
@@ -777,7 +781,7 @@ DELETE /api/v1/provisioning/templates/:name
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
 {{< /admonition >}}
 
 #### Parameters
@@ -1039,7 +1043,7 @@ GET /api/v1/provisioning/contact-points
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers` for receivers.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers` for receivers.
 {{< /admonition >}}
 
 #### Parameters
@@ -1281,7 +1285,7 @@ GET /api/v1/provisioning/mute-timings/:name
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
 {{< /admonition >}}
 
 #### Parameters
@@ -1320,7 +1324,7 @@ GET /api/v1/provisioning/mute-timings
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals` for mute timings.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals` for mute timings.
 {{< /admonition >}}
 
 #### All responses
@@ -1427,7 +1431,7 @@ GET /api/v1/provisioning/policies
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
 {{< /admonition >}}
 
 #### All responses
@@ -1493,7 +1497,7 @@ GET /api/v1/provisioning/templates/:name
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
 {{< /admonition >}}
 
 #### Parameters
@@ -1532,7 +1536,7 @@ GET /api/v1/provisioning/templates
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups` for notification template groups.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups` for notification template groups.
 {{< /admonition >}}
 
 #### All responses
@@ -1608,7 +1612,7 @@ POST /api/v1/provisioning/contact-points
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers` for receivers.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers` for receivers.
 {{< /admonition >}}
 
 When creating a contact point, the `EmbeddedContactPoint.name` property determines if the new contact point is added to an existing one. In the UI, contact points with the same name are grouped together under a single contact point.
@@ -1656,7 +1660,7 @@ POST /api/v1/provisioning/mute-timings
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals` for mute timings.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals` for mute timings.
 {{< /admonition >}}
 
 #### Parameters
@@ -1799,7 +1803,7 @@ PUT /api/v1/provisioning/contact-points/:uid
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{name}` for receivers.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{name}` for receivers.
 {{< /admonition >}}
 
 #### Parameters
@@ -1846,7 +1850,7 @@ PUT /api/v1/provisioning/mute-timings/:name
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
 {{< /admonition >}}
 
 #### Parameters
@@ -1904,7 +1908,7 @@ PUT /api/v1/provisioning/policies
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
 {{< /admonition >}}
 
 #### Parameters
@@ -1950,7 +1954,7 @@ PUT /api/v1/provisioning/templates/:name
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
 {{< /admonition >}}
 
 {{% responsive-table %}}
@@ -2006,7 +2010,7 @@ DELETE /api/v1/provisioning/policies
 ```
 
 {{< admonition type="warning" >}}
-This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
+This API is deprecated and will be removed in a future release. Use the [Grafana App Platform alerting APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/packages/grafana-openapi/src/apis/notifications.alerting.grafana.app-v1beta1.json) instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
 {{< /admonition >}}
 
 #### All responses

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -706,6 +706,10 @@ Status: Not Found
 DELETE /api/v1/provisioning/contact-points/:uid
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{name}` for receivers.
+{{< /admonition >}}
+
 #### Parameters
 
 | Name  | Source | Type   | Go type | Required | Default | Description                                |
@@ -731,6 +735,10 @@ Status: No Content
 ```
 DELETE /api/v1/provisioning/mute-timings/:name
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
+{{< /admonition >}}
 
 #### Parameters
 
@@ -767,6 +775,10 @@ Status: Conflict
 ```
 DELETE /api/v1/provisioning/templates/:name
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
+{{< /admonition >}}
 
 #### Parameters
 
@@ -1026,6 +1038,10 @@ Status: Not Found
 GET /api/v1/provisioning/contact-points
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers` for receivers.
+{{< /admonition >}}
+
 #### Parameters
 
 | Name   | Source | Type   | Go type | Required | Default | Description    |
@@ -1264,6 +1280,10 @@ Status: Forbidden
 GET /api/v1/provisioning/mute-timings/:name
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
+{{< /admonition >}}
+
 #### Parameters
 
 | Name   | Source | Type   | Go type | Required | Default | Description      |
@@ -1298,6 +1318,10 @@ Status: Not Found
 ```
 GET /api/v1/provisioning/mute-timings
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals` for mute timings.
+{{< /admonition >}}
 
 #### All responses
 
@@ -1402,6 +1426,10 @@ Status: Forbidden
 GET /api/v1/provisioning/policies
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
+{{< /admonition >}}
+
 #### All responses
 
 | Code                              | Status | Description | Has headers | Schema                                      |
@@ -1464,6 +1492,10 @@ Status: Not Found
 GET /api/v1/provisioning/templates/:name
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
+{{< /admonition >}}
+
 #### Parameters
 
 | Name   | Source | Type   | Go type | Required | Default | Description                |
@@ -1498,6 +1530,10 @@ Status: OK
 ```
 GET /api/v1/provisioning/templates
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups` for notification template groups.
+{{< /admonition >}}
 
 #### All responses
 
@@ -1571,6 +1607,10 @@ Status: Bad Request
 POST /api/v1/provisioning/contact-points
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers` for receivers.
+{{< /admonition >}}
+
 When creating a contact point, the `EmbeddedContactPoint.name` property determines if the new contact point is added to an existing one. In the UI, contact points with the same name are grouped together under a single contact point.
 
 #### Parameters
@@ -1614,6 +1654,10 @@ Status: Bad Request
 ```
 POST /api/v1/provisioning/mute-timings
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals` for mute timings.
+{{< /admonition >}}
 
 #### Parameters
 
@@ -1754,6 +1798,10 @@ Status: Bad Request
 PUT /api/v1/provisioning/contact-points/:uid
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/receivers/{name}` for receivers.
+{{< /admonition >}}
+
 #### Parameters
 
 {{% responsive-table %}}
@@ -1796,6 +1844,10 @@ Status: Bad Request
 ```
 PUT /api/v1/provisioning/mute-timings/:name
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/timeintervals/{name}` for mute timings.
+{{< /admonition >}}
 
 #### Parameters
 
@@ -1851,6 +1903,10 @@ Status: Conflict
 PUT /api/v1/provisioning/policies
 ```
 
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
+{{< /admonition >}}
+
 #### Parameters
 
 {{% responsive-table %}}
@@ -1892,6 +1948,10 @@ Status: Bad Request
 ```
 PUT /api/v1/provisioning/templates/:name
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/templategroups/{name}` for notification template groups.
+{{< /admonition >}}
 
 {{% responsive-table %}}
 
@@ -1944,6 +2004,10 @@ Status: Conflict
 ```
 DELETE /api/v1/provisioning/policies
 ```
+
+{{< admonition type="warning" >}}
+This API is deprecated and will be removed in a future release. Use the Grafana App Platform alerting APIs instead: `/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}/routingtrees` for notification policies.
+{{< /admonition >}}
 
 #### All responses
 

--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -1698,26 +1698,6 @@ const injectedRtkApi = api
         }),
         providesTags: ['provisioning'],
       }),
-      routeGetContactpoints: build.query<RouteGetContactpointsApiResponse, RouteGetContactpointsApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/contact-points`,
-          params: {
-            name: queryArg.name,
-          },
-        }),
-        providesTags: ['provisioning'],
-      }),
-      routePostContactpoints: build.mutation<RoutePostContactpointsApiResponse, RoutePostContactpointsApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/contact-points`,
-          method: 'POST',
-          body: queryArg.embeddedContactPoint,
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-        }),
-        invalidatesTags: ['provisioning'],
-      }),
       routeGetContactpointsExport: build.query<
         RouteGetContactpointsExportApiResponse,
         RouteGetContactpointsExportApiArg
@@ -1733,21 +1713,6 @@ const injectedRtkApi = api
         }),
         providesTags: ['provisioning'],
       }),
-      routeDeleteContactpoints: build.mutation<RouteDeleteContactpointsApiResponse, RouteDeleteContactpointsApiArg>({
-        query: (queryArg) => ({ url: `/v1/provisioning/contact-points/${queryArg.uid}`, method: 'DELETE' }),
-        invalidatesTags: ['provisioning'],
-      }),
-      routePutContactpoint: build.mutation<RoutePutContactpointApiResponse, RoutePutContactpointApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/contact-points/${queryArg.uid}`,
-          method: 'PUT',
-          body: queryArg.embeddedContactPoint,
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-        }),
-        invalidatesTags: ['provisioning'],
-      }),
       routeGetAlertRuleGroupExport: build.query<
         RouteGetAlertRuleGroupExportApiResponse,
         RouteGetAlertRuleGroupExportApiArg
@@ -1761,21 +1726,6 @@ const injectedRtkApi = api
         }),
         providesTags: ['provisioning'],
       }),
-      routeGetMuteTimings: build.query<RouteGetMuteTimingsApiResponse, RouteGetMuteTimingsApiArg>({
-        query: () => ({ url: `/v1/provisioning/mute-timings` }),
-        providesTags: ['provisioning'],
-      }),
-      routePostMuteTiming: build.mutation<RoutePostMuteTimingApiResponse, RoutePostMuteTimingApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/mute-timings`,
-          method: 'POST',
-          body: queryArg.muteTimeInterval,
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-        }),
-        invalidatesTags: ['provisioning'],
-      }),
       routeExportMuteTimings: build.query<RouteExportMuteTimingsApiResponse, RouteExportMuteTimingsApiArg>({
         query: (queryArg) => ({
           url: `/v1/provisioning/mute-timings/export`,
@@ -1785,34 +1735,6 @@ const injectedRtkApi = api
           },
         }),
         providesTags: ['provisioning'],
-      }),
-      routeDeleteMuteTiming: build.mutation<RouteDeleteMuteTimingApiResponse, RouteDeleteMuteTimingApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/mute-timings/${queryArg.name}`,
-          method: 'DELETE',
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-          params: {
-            version: queryArg.version,
-          },
-        }),
-        invalidatesTags: ['provisioning'],
-      }),
-      routeGetMuteTiming: build.query<RouteGetMuteTimingApiResponse, RouteGetMuteTimingApiArg>({
-        query: (queryArg) => ({ url: `/v1/provisioning/mute-timings/${queryArg.name}` }),
-        providesTags: ['provisioning'],
-      }),
-      routePutMuteTiming: build.mutation<RoutePutMuteTimingApiResponse, RoutePutMuteTimingApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/mute-timings/${queryArg.name}`,
-          method: 'PUT',
-          body: queryArg.muteTimeInterval,
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-        }),
-        invalidatesTags: ['provisioning'],
       }),
       routeExportMuteTiming: build.query<RouteExportMuteTimingApiResponse, RouteExportMuteTimingApiArg>({
         query: (queryArg) => ({
@@ -1824,57 +1746,9 @@ const injectedRtkApi = api
         }),
         providesTags: ['provisioning'],
       }),
-      routeResetPolicyTree: build.mutation<RouteResetPolicyTreeApiResponse, RouteResetPolicyTreeApiArg>({
-        query: () => ({ url: `/v1/provisioning/policies`, method: 'DELETE' }),
-        invalidatesTags: ['provisioning'],
-      }),
-      routeGetPolicyTree: build.query<RouteGetPolicyTreeApiResponse, RouteGetPolicyTreeApiArg>({
-        query: () => ({ url: `/v1/provisioning/policies` }),
-        providesTags: ['provisioning'],
-      }),
-      routePutPolicyTree: build.mutation<RoutePutPolicyTreeApiResponse, RoutePutPolicyTreeApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/policies`,
-          method: 'PUT',
-          body: queryArg.route,
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-        }),
-        invalidatesTags: ['provisioning'],
-      }),
       routeGetPolicyTreeExport: build.query<RouteGetPolicyTreeExportApiResponse, RouteGetPolicyTreeExportApiArg>({
         query: () => ({ url: `/v1/provisioning/policies/export` }),
         providesTags: ['provisioning'],
-      }),
-      routeGetTemplates: build.query<RouteGetTemplatesApiResponse, RouteGetTemplatesApiArg>({
-        query: () => ({ url: `/v1/provisioning/templates` }),
-        providesTags: ['provisioning'],
-      }),
-      routeDeleteTemplate: build.mutation<RouteDeleteTemplateApiResponse, RouteDeleteTemplateApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/templates/${queryArg.name}`,
-          method: 'DELETE',
-          params: {
-            version: queryArg.version,
-          },
-        }),
-        invalidatesTags: ['provisioning'],
-      }),
-      routeGetTemplate: build.query<RouteGetTemplateApiResponse, RouteGetTemplateApiArg>({
-        query: (queryArg) => ({ url: `/v1/provisioning/templates/${queryArg.name}` }),
-        providesTags: ['provisioning'],
-      }),
-      routePutTemplate: build.mutation<RoutePutTemplateApiResponse, RoutePutTemplateApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/provisioning/templates/${queryArg.name}`,
-          method: 'PUT',
-          body: queryArg.notificationTemplateContent,
-          headers: {
-            'X-Disable-Provenance': queryArg['X-Disable-Provenance'],
-          },
-        }),
-        invalidatesTags: ['provisioning'],
       }),
       listAllProvidersSettings: build.query<ListAllProvidersSettingsApiResponse, ListAllProvidersSettingsApiArg>({
         query: () => ({ url: `/v1/sso-settings` }),
@@ -3288,16 +3162,6 @@ export type RouteGetAlertRuleExportApiArg = {
   /** Alert rule UID */
   uid: string;
 };
-export type RouteGetContactpointsApiResponse = /** status 200 ContactPoints */ ContactPointsRead;
-export type RouteGetContactpointsApiArg = {
-  /** Filter by name */
-  name?: string;
-};
-export type RoutePostContactpointsApiResponse = /** status 202 EmbeddedContactPoint */ EmbeddedContactPointRead;
-export type RoutePostContactpointsApiArg = {
-  'X-Disable-Provenance'?: string;
-  embeddedContactPoint: EmbeddedContactPoint;
-};
 export type RouteGetContactpointsExportApiResponse =
   /** status 200 AlertingFileExport */ AlertingFileExportIsTheFullProvisionedFileExport;
 export type RouteGetContactpointsExportApiArg = {
@@ -3310,18 +3174,6 @@ export type RouteGetContactpointsExportApiArg = {
   /** Filter by name */
   name?: string;
 };
-export type RouteDeleteContactpointsApiResponse = unknown;
-export type RouteDeleteContactpointsApiArg = {
-  /** UID is the contact point unique identifier */
-  uid: string;
-};
-export type RoutePutContactpointApiResponse = /** status 202 Ack */ Ack;
-export type RoutePutContactpointApiArg = {
-  /** UID is the contact point unique identifier */
-  uid: string;
-  'X-Disable-Provenance'?: string;
-  embeddedContactPoint: EmbeddedContactPoint;
-};
 export type RouteGetAlertRuleGroupExportApiResponse =
   /** status 200 AlertingFileExport */ AlertingFileExportIsTheFullProvisionedFileExport;
 export type RouteGetAlertRuleGroupExportApiArg = {
@@ -3332,14 +3184,6 @@ export type RouteGetAlertRuleGroupExportApiArg = {
   folderUid: string;
   group: string;
 };
-export type RouteGetMuteTimingsApiResponse = /** status 200 MuteTimings */ MuteTimings;
-export type RouteGetMuteTimingsApiArg = void;
-export type RoutePostMuteTimingApiResponse =
-  /** status 201 MuteTimeInterval */ MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted;
-export type RoutePostMuteTimingApiArg = {
-  'X-Disable-Provenance'?: string;
-  muteTimeInterval: MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted;
-};
 export type RouteExportMuteTimingsApiResponse =
   /** status 200 AlertingFileExport */ AlertingFileExportIsTheFullProvisionedFileExport;
 export type RouteExportMuteTimingsApiArg = {
@@ -3347,28 +3191,6 @@ export type RouteExportMuteTimingsApiArg = {
   download?: boolean;
   /** Format of the downloaded file. Supported yaml, json or hcl. Accept header can also be used, but the query parameter will take precedence. */
   format?: 'yaml' | 'json' | 'hcl';
-};
-export type RouteDeleteMuteTimingApiResponse = unknown;
-export type RouteDeleteMuteTimingApiArg = {
-  /** Mute timing name */
-  name: string;
-  /** Version of mute timing to use for optimistic concurrency. Leave empty to disable validation */
-  version?: string;
-  'X-Disable-Provenance'?: string;
-};
-export type RouteGetMuteTimingApiResponse =
-  /** status 200 MuteTimeInterval */ MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted;
-export type RouteGetMuteTimingApiArg = {
-  /** Mute timing name */
-  name: string;
-};
-export type RoutePutMuteTimingApiResponse =
-  /** status 202 MuteTimeInterval */ MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted;
-export type RoutePutMuteTimingApiArg = {
-  /** Mute timing name */
-  name: string;
-  'X-Disable-Provenance'?: string;
-  muteTimeInterval: MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted;
 };
 export type RouteExportMuteTimingApiResponse =
   /** status 200 AlertingFileExport */ AlertingFileExportIsTheFullProvisionedFileExport;
@@ -3380,40 +3202,9 @@ export type RouteExportMuteTimingApiArg = {
   /** Mute timing name */
   name: string;
 };
-export type RouteResetPolicyTreeApiResponse = /** status 202 Ack */ Ack;
-export type RouteResetPolicyTreeApiArg = void;
-export type RouteGetPolicyTreeApiResponse = /** status 200 Route */ Route;
-export type RouteGetPolicyTreeApiArg = void;
-export type RoutePutPolicyTreeApiResponse = /** status 202 Ack */ Ack;
-export type RoutePutPolicyTreeApiArg = {
-  'X-Disable-Provenance'?: string;
-  /** The new notification routing tree to use */
-  route: Route;
-};
 export type RouteGetPolicyTreeExportApiResponse =
   /** status 200 AlertingFileExport */ AlertingFileExportIsTheFullProvisionedFileExport;
 export type RouteGetPolicyTreeExportApiArg = void;
-export type RouteGetTemplatesApiResponse = /** status 200 NotificationTemplates */ NotificationTemplates;
-export type RouteGetTemplatesApiArg = void;
-export type RouteDeleteTemplateApiResponse = unknown;
-export type RouteDeleteTemplateApiArg = {
-  /** Template group name */
-  name: string;
-  /** Version of template to use for optimistic concurrency. Leave empty to disable validation */
-  version?: string;
-};
-export type RouteGetTemplateApiResponse = /** status 200 NotificationTemplate */ NotificationTemplate;
-export type RouteGetTemplateApiArg = {
-  /** Template group name */
-  name: string;
-};
-export type RoutePutTemplateApiResponse = /** status 202 NotificationTemplate */ NotificationTemplate;
-export type RoutePutTemplateApiArg = {
-  /** Template group name */
-  name: string;
-  'X-Disable-Provenance'?: string;
-  notificationTemplateContent: NotificationTemplateContent;
-};
 export type ListAllProvidersSettingsApiResponse = /** status 200 (empty) */ {
   id?: string;
   provider?: string;
@@ -5691,109 +5482,8 @@ export type AlertingFileExportIsTheFullProvisionedFileExport = {
   muteTimes?: MuteTimeIntervalExport[];
   policies?: NotificationPolicyExportIsTheProvisionedFileExportOfAlertingNotificiationPolicyV1[];
 };
-export type EmbeddedContactPoint = {
-  disableResolveMessage?: boolean;
-  /** Name is used as grouping key in the UI. Contact points with the
-    same name will be grouped in the UI. */
-  name?: string;
-  settings: Json;
-  type:
-    | 'alertmanager'
-    | 'dingding'
-    | 'discord'
-    | 'email'
-    | 'googlechat'
-    | 'kafka'
-    | 'line'
-    | 'opsgenie'
-    | 'pagerduty'
-    | 'pushover'
-    | 'sensugo'
-    | 'slack'
-    | 'teams'
-    | 'telegram'
-    | 'threema'
-    | 'victorops'
-    | 'webhook'
-    | 'wecom';
-  /** UID is the unique identifier of the contact point. The UID can be
-    set by the user. */
-  uid?: string;
-};
-export type EmbeddedContactPointRead = {
-  disableResolveMessage?: boolean;
-  /** Name is used as grouping key in the UI. Contact points with the
-    same name will be grouped in the UI. */
-  name?: string;
-  provenance?: string;
-  settings: Json;
-  type:
-    | 'alertmanager'
-    | 'dingding'
-    | 'discord'
-    | 'email'
-    | 'googlechat'
-    | 'kafka'
-    | 'line'
-    | 'opsgenie'
-    | 'pagerduty'
-    | 'pushover'
-    | 'sensugo'
-    | 'slack'
-    | 'teams'
-    | 'telegram'
-    | 'threema'
-    | 'victorops'
-    | 'webhook'
-    | 'wecom';
-  /** UID is the unique identifier of the contact point. The UID can be
-    set by the user. */
-  uid?: string;
-};
-export type ContactPoints = EmbeddedContactPoint[];
-export type ContactPointsRead = EmbeddedContactPointRead[];
-export type ValidationError = {
-  message?: string;
-};
 export type PermissionDenied = object;
-export type Ack = object;
-export type MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted = {
-  name?: string;
-  time_intervals?: TimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted[];
-};
-export type MuteTimings = MuteTimeIntervalRepresentsANamedSetOfTimeIntervalsForWhichARouteShouldBeMuted[];
-export type Provenance = string;
-export type Route = {
-  active_time_intervals?: string[];
-  continue?: boolean;
-  group_by?: string[];
-  group_interval?: string;
-  group_wait?: string;
-  /** Deprecated. Remove before v1.0 release. */
-  match?: {
-    [key: string]: string;
-  };
-  match_re?: MatchRegexpsRepresentsAMapOfRegexp;
-  matchers?: Matchers;
-  mute_time_intervals?: string[];
-  object_matchers?: ObjectMatchersIsAListOfMatchersThatCanBeUsedToFilterAlerts;
-  provenance?: Provenance;
-  receiver?: string;
-  repeat_interval?: string;
-  routes?: Route[];
-};
 export type NotFound = object;
-export type NotificationTemplate = {
-  name?: string;
-  provenance?: Provenance;
-  template?: string;
-  version?: string;
-};
-export type NotificationTemplates = NotificationTemplate[];
-export type NotificationTemplateContent = {
-  template?: string;
-  version?: string;
-};
 export const {
   useListRolesQuery,
   useLazyListRolesQuery,
@@ -6163,38 +5853,16 @@ export const {
   useLazyRouteGetAlertRulesExportQuery,
   useRouteGetAlertRuleExportQuery,
   useLazyRouteGetAlertRuleExportQuery,
-  useRouteGetContactpointsQuery,
-  useLazyRouteGetContactpointsQuery,
-  useRoutePostContactpointsMutation,
   useRouteGetContactpointsExportQuery,
   useLazyRouteGetContactpointsExportQuery,
-  useRouteDeleteContactpointsMutation,
-  useRoutePutContactpointMutation,
   useRouteGetAlertRuleGroupExportQuery,
   useLazyRouteGetAlertRuleGroupExportQuery,
-  useRouteGetMuteTimingsQuery,
-  useLazyRouteGetMuteTimingsQuery,
-  useRoutePostMuteTimingMutation,
   useRouteExportMuteTimingsQuery,
   useLazyRouteExportMuteTimingsQuery,
-  useRouteDeleteMuteTimingMutation,
-  useRouteGetMuteTimingQuery,
-  useLazyRouteGetMuteTimingQuery,
-  useRoutePutMuteTimingMutation,
   useRouteExportMuteTimingQuery,
   useLazyRouteExportMuteTimingQuery,
-  useRouteResetPolicyTreeMutation,
-  useRouteGetPolicyTreeQuery,
-  useLazyRouteGetPolicyTreeQuery,
-  useRoutePutPolicyTreeMutation,
   useRouteGetPolicyTreeExportQuery,
   useLazyRouteGetPolicyTreeExportQuery,
-  useRouteGetTemplatesQuery,
-  useLazyRouteGetTemplatesQuery,
-  useRouteDeleteTemplateMutation,
-  useRouteGetTemplateQuery,
-  useLazyRouteGetTemplateQuery,
-  useRoutePutTemplateMutation,
   useListAllProvidersSettingsQuery,
   useLazyListAllProvidersSettingsQuery,
   useRemoveProviderSettingsMutation,

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -24925,6 +24925,7 @@
     },
     "/v1/provisioning/contact-points": {
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetContactpoints",
         "parameters": [
           {
@@ -24962,6 +24963,7 @@
         "tags": ["provisioning"]
       },
       "post": {
+        "deprecated": true,
         "operationId": "RoutePostContactpoints",
         "parameters": [
           {
@@ -25127,6 +25129,7 @@
     },
     "/v1/provisioning/contact-points/{UID}": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteDeleteContactpoints",
         "parameters": [
           {
@@ -25158,6 +25161,7 @@
         "tags": ["provisioning"]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutContactpoint",
         "parameters": [
           {
@@ -25507,6 +25511,7 @@
     },
     "/v1/provisioning/mute-timings": {
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetMuteTimings",
         "responses": {
           "200": {
@@ -25534,6 +25539,7 @@
         "tags": ["provisioning"]
       },
       "post": {
+        "deprecated": true,
         "operationId": "RoutePostMuteTiming",
         "parameters": [
           {
@@ -25682,6 +25688,7 @@
     },
     "/v1/provisioning/mute-timings/{name}": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteDeleteMuteTiming",
         "parameters": [
           {
@@ -25738,6 +25745,7 @@
         "tags": ["provisioning"]
       },
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetMuteTiming",
         "parameters": [
           {
@@ -25779,6 +25787,7 @@
         "tags": ["provisioning"]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutMuteTiming",
         "parameters": [
           {
@@ -25955,6 +25964,7 @@
     },
     "/v1/provisioning/policies": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteResetPolicyTree",
         "responses": {
           "202": {
@@ -25982,6 +25992,7 @@
         "tags": ["provisioning"]
       },
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetPolicyTree",
         "responses": {
           "200": {
@@ -26009,6 +26020,7 @@
         "tags": ["provisioning"]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutPolicyTree",
         "parameters": [
           {
@@ -26167,6 +26179,7 @@
     },
     "/v1/provisioning/templates": {
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetTemplates",
         "responses": {
           "200": {
@@ -26196,6 +26209,7 @@
     },
     "/v1/provisioning/templates/{name}": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteDeleteTemplate",
         "parameters": [
           {
@@ -26245,6 +26259,7 @@
         "tags": ["provisioning"]
       },
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetTemplate",
         "parameters": [
           {
@@ -26293,6 +26308,7 @@
         "tags": ["provisioning"]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutTemplate",
         "parameters": [
           {

--- a/pkg/services/ngalert/api/provisioning.go
+++ b/pkg/services/ngalert/api/provisioning.go
@@ -37,7 +37,31 @@ const (
 	// endpoints.
 	// TODO: update when the API moves to beta.
 	replacementAlertRuleByUID = appPlatformBase + "/alertrules/{name}, " + appPlatformBase + "/recordingrules/{name}"
+
+	notificationAppPlatformBase = "/apis/notifications.alerting.grafana.app/v1beta1/namespaces/{namespace}"
+
+	replacementReceivers        = notificationAppPlatformBase + "/receivers"
+	replacementReceiverByUID    = notificationAppPlatformBase + "/receivers/{name}"
+	replacementRoutingTree      = notificationAppPlatformBase + "/routingtrees"
+	replacementTemplates        = notificationAppPlatformBase + "/templategroups"
+	replacementTemplateByName   = notificationAppPlatformBase + "/templategroups/{name}"
+	replacementMuteTimings      = notificationAppPlatformBase + "/timeintervals"
+	replacementMuteTimingByName = notificationAppPlatformBase + "/timeintervals/{name}"
 )
+
+// deprecatedNotificationProvisioningResponse sets deprecation notice headers on
+// the response for notification provisioning endpoints superseded by the
+// notifications.alerting.grafana.app/v1beta1 app-platform APIs.
+func deprecatedNotificationProvisioningResponse(resp response.Response, replacement string) response.Response {
+	if nr, ok := resp.(*response.NormalResponse); ok {
+		nr.SetHeader("Warning", `299 - "Deprecated API: use the Grafana App Platform alerting API instead."`)
+		nr.SetHeader("X-API-Deprecation-Date", "2026-04-07")
+		if replacement != "" {
+			nr.SetHeader("X-API-Replacement", replacement)
+		}
+	}
+	return resp
+}
 
 type ProvisioningApiHandler struct {
 	svc *ProvisioningSrv
@@ -50,7 +74,7 @@ func NewProvisioningApi(svc *ProvisioningSrv) *ProvisioningApiHandler {
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetPolicyTree(ctx *contextmodel.ReqContext) response.Response {
-	return f.svc.RouteGetPolicyTree(ctx)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteGetPolicyTree(ctx), replacementRoutingTree)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetPolicyTreeExport(ctx *contextmodel.ReqContext) response.Response {
@@ -58,11 +82,11 @@ func (f *ProvisioningApiHandler) handleRouteGetPolicyTreeExport(ctx *contextmode
 }
 
 func (f *ProvisioningApiHandler) handleRoutePutPolicyTree(ctx *contextmodel.ReqContext, route apimodels.Route) response.Response {
-	return f.svc.RoutePutPolicyTree(ctx, route)
+	return deprecatedNotificationProvisioningResponse(f.svc.RoutePutPolicyTree(ctx, route), replacementRoutingTree)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetContactpoints(ctx *contextmodel.ReqContext) response.Response {
-	return f.svc.RouteGetContactPoints(ctx)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteGetContactPoints(ctx), replacementReceivers)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetContactpointsExport(ctx *contextmodel.ReqContext) response.Response {
@@ -70,51 +94,51 @@ func (f *ProvisioningApiHandler) handleRouteGetContactpointsExport(ctx *contextm
 }
 
 func (f *ProvisioningApiHandler) handleRoutePostContactpoints(ctx *contextmodel.ReqContext, cp apimodels.EmbeddedContactPoint) response.Response {
-	return f.svc.RoutePostContactPoint(ctx, cp)
+	return deprecatedNotificationProvisioningResponse(f.svc.RoutePostContactPoint(ctx, cp), replacementReceivers)
 }
 
 func (f *ProvisioningApiHandler) handleRoutePutContactpoint(ctx *contextmodel.ReqContext, cp apimodels.EmbeddedContactPoint, UID string) response.Response {
-	return f.svc.RoutePutContactPoint(ctx, cp, UID)
+	return deprecatedNotificationProvisioningResponse(f.svc.RoutePutContactPoint(ctx, cp, UID), replacementReceiverByUID)
 }
 
 func (f *ProvisioningApiHandler) handleRouteDeleteContactpoints(ctx *contextmodel.ReqContext, UID string) response.Response {
-	return f.svc.RouteDeleteContactPoint(ctx, UID)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteDeleteContactPoint(ctx, UID), replacementReceiverByUID)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetTemplates(ctx *contextmodel.ReqContext) response.Response {
-	return f.svc.RouteGetTemplates(ctx)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteGetTemplates(ctx), replacementTemplates)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetTemplate(ctx *contextmodel.ReqContext, name string) response.Response {
-	return f.svc.RouteGetTemplate(ctx, name)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteGetTemplate(ctx, name), replacementTemplateByName)
 }
 
 func (f *ProvisioningApiHandler) handleRoutePutTemplate(ctx *contextmodel.ReqContext, body apimodels.NotificationTemplateContent, name string) response.Response {
-	return f.svc.RoutePutTemplate(ctx, body, name)
+	return deprecatedNotificationProvisioningResponse(f.svc.RoutePutTemplate(ctx, body, name), replacementTemplateByName)
 }
 
 func (f *ProvisioningApiHandler) handleRouteDeleteTemplate(ctx *contextmodel.ReqContext, name string) response.Response {
-	return f.svc.RouteDeleteTemplate(ctx, name)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteDeleteTemplate(ctx, name), replacementTemplateByName)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetMuteTiming(ctx *contextmodel.ReqContext, name string) response.Response {
-	return f.svc.RouteGetMuteTiming(ctx, name)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteGetMuteTiming(ctx, name), replacementMuteTimingByName)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetMuteTimings(ctx *contextmodel.ReqContext) response.Response {
-	return f.svc.RouteGetMuteTimings(ctx)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteGetMuteTimings(ctx), replacementMuteTimings)
 }
 
 func (f *ProvisioningApiHandler) handleRoutePostMuteTiming(ctx *contextmodel.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
-	return f.svc.RoutePostMuteTiming(ctx, mt)
+	return deprecatedNotificationProvisioningResponse(f.svc.RoutePostMuteTiming(ctx, mt), replacementMuteTimings)
 }
 
 func (f *ProvisioningApiHandler) handleRoutePutMuteTiming(ctx *contextmodel.ReqContext, mt apimodels.MuteTimeInterval, name string) response.Response {
-	return f.svc.RoutePutMuteTiming(ctx, mt, name)
+	return deprecatedNotificationProvisioningResponse(f.svc.RoutePutMuteTiming(ctx, mt, name), replacementMuteTimingByName)
 }
 
 func (f *ProvisioningApiHandler) handleRouteDeleteMuteTiming(ctx *contextmodel.ReqContext, name string) response.Response {
-	return f.svc.RouteDeleteMuteTiming(ctx, name)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteDeleteMuteTiming(ctx, name), replacementMuteTimingByName)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetAlertRules(ctx *contextmodel.ReqContext) response.Response {
@@ -146,7 +170,7 @@ func (f *ProvisioningApiHandler) handleRouteDeleteAlertRule(ctx *contextmodel.Re
 }
 
 func (f *ProvisioningApiHandler) handleRouteResetPolicyTree(ctx *contextmodel.ReqContext) response.Response {
-	return f.svc.RouteResetPolicyTree(ctx)
+	return deprecatedNotificationProvisioningResponse(f.svc.RouteResetPolicyTree(ctx), replacementRoutingTree)
 }
 
 func (f *ProvisioningApiHandler) handleRouteGetAlertRuleGroup(ctx *contextmodel.ReqContext, folder, group string) response.Response {

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -6598,7 +6598,8 @@
     "summary": "Get all the contact points.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "post": {
     "consumes": [
@@ -6642,7 +6643,8 @@
     "summary": "Create a contact point.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/contact-points/export": {
@@ -6738,7 +6740,8 @@
     "summary": "Delete a contact point.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -6789,7 +6792,8 @@
     "summary": "Update an existing contact point.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
@@ -7015,7 +7019,8 @@
     "summary": "Get all the mute timings.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "post": {
     "consumes": [
@@ -7059,7 +7064,8 @@
     "summary": "Create a new mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/mute-timings/export": {
@@ -7156,7 +7162,8 @@
     "summary": "Delete a mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "get": {
     "operationId": "RouteGetMuteTiming",
@@ -7189,7 +7196,8 @@
     "summary": "Get a mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -7246,7 +7254,8 @@
     "summary": "Replace an existing mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/mute-timings/{name}/export": {
@@ -7330,7 +7339,8 @@
     "summary": "Clears the notification policy tree.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "get": {
     "operationId": "RouteGetPolicyTree",
@@ -7351,7 +7361,8 @@
     "summary": "Get the notification policy tree.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -7396,7 +7407,8 @@
     "summary": "Sets the notification policy tree.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/policies/export": {
@@ -7455,7 +7467,8 @@
     "summary": "Get all notification template groups.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/templates/{name}": {
@@ -7496,7 +7509,8 @@
     "summary": "Delete a notification template group.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "get": {
     "operationId": "RouteGetTemplate",
@@ -7532,7 +7546,8 @@
     "summary": "Get a notification template group.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -7589,7 +7604,8 @@
     "summary": "Updates an existing notification template group.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   }
  },

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -8,6 +8,8 @@ import (
 //
 // Get all the contact points.
 //
+// Deprecated: true
+//
 //     Responses:
 //       200: ContactPoints
 //       403: ForbiddenError
@@ -31,6 +33,8 @@ import (
 //
 // Create a contact point.
 //
+// Deprecated: true
+//
 //     Consumes:
 //     - application/json
 //
@@ -43,6 +47,8 @@ import (
 //
 // Update an existing contact point.
 //
+// Deprecated: true
+//
 //     Consumes:
 //     - application/json
 //
@@ -54,6 +60,8 @@ import (
 // swagger:route DELETE /v1/provisioning/contact-points/{UID} provisioning stable RouteDeleteContactpoints
 //
 // Delete a contact point.
+//
+// Deprecated: true
 //
 //     Consumes:
 //     - application/json

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -8,6 +8,8 @@ import (
 //
 // Get all the mute timings.
 //
+// Deprecated: true
+//
 //     Responses:
 //       200: MuteTimings
 //       403: ForbiddenError
@@ -30,6 +32,8 @@ import (
 // swagger:route GET /v1/provisioning/mute-timings/{name} provisioning stable RouteGetMuteTiming
 //
 // Get a mute timing.
+//
+// Deprecated: true
 //
 //     Responses:
 //       200: MuteTimeInterval
@@ -55,6 +59,8 @@ import (
 //
 // Create a new mute timing.
 //
+// Deprecated: true
+//
 //     Consumes:
 //     - application/json
 //
@@ -66,6 +72,8 @@ import (
 // swagger:route PUT /v1/provisioning/mute-timings/{name} provisioning stable RoutePutMuteTiming
 //
 // Replace an existing mute timing.
+//
+// Deprecated: true
 //
 //     Consumes:
 //     - application/json
@@ -79,6 +87,8 @@ import (
 // swagger:route DELETE /v1/provisioning/mute-timings/{name} provisioning stable RouteDeleteMuteTiming
 //
 // Delete a mute timing.
+//
+// Deprecated: true
 //
 //     Responses:
 //       204: description: The mute timing was deleted successfully.

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -8,6 +8,8 @@ import (
 //
 // Get the notification policy tree.
 //
+// Deprecated: true
+//
 //     Responses:
 //       200: Route
 //         description: The currently active notification routing tree
@@ -16,6 +18,8 @@ import (
 // swagger:route PUT /v1/provisioning/policies provisioning stable RoutePutPolicyTree
 //
 // Sets the notification policy tree.
+//
+// Deprecated: true
 //
 //     Consumes:
 //     - application/json
@@ -28,6 +32,8 @@ import (
 // swagger:route DELETE /v1/provisioning/policies provisioning stable RouteResetPolicyTree
 //
 // Clears the notification policy tree.
+//
+// Deprecated: true
 //
 //     Consumes:
 //     - application/json

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -6,6 +6,8 @@ import "github.com/grafana/alerting/definition"
 //
 // Get all notification template groups.
 //
+// Deprecated: true
+//
 //     Responses:
 //       200: NotificationTemplates
 //       403: ForbiddenError
@@ -13,6 +15,8 @@ import "github.com/grafana/alerting/definition"
 // swagger:route GET /v1/provisioning/templates/{name} provisioning stable RouteGetTemplate
 //
 // Get a notification template group.
+//
+// Deprecated: true
 //
 //     Responses:
 //       200: NotificationTemplate
@@ -22,6 +26,8 @@ import "github.com/grafana/alerting/definition"
 // swagger:route PUT /v1/provisioning/templates/{name} provisioning stable RoutePutTemplate
 //
 // Updates an existing notification template group.
+//
+// Deprecated: true
 //
 //     Consumes:
 //     - application/json
@@ -35,6 +41,8 @@ import "github.com/grafana/alerting/definition"
 // swagger:route DELETE /v1/provisioning/templates/{name} provisioning stable RouteDeleteTemplate
 //
 // Delete a notification template group.
+//
+// Deprecated: true
 //
 //     Responses:
 //       204: description: The template was deleted successfully.

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -8894,7 +8894,8 @@
     "summary": "Get all the contact points.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "post": {
     "consumes": [
@@ -8932,7 +8933,8 @@
     "summary": "Create a contact point.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/contact-points/export": {
@@ -9022,7 +9024,8 @@
     "summary": "Delete a contact point.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -9067,7 +9070,8 @@
     "summary": "Update an existing contact point.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
@@ -9269,7 +9273,8 @@
     "summary": "Get all the mute timings.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "post": {
     "consumes": [
@@ -9307,7 +9312,8 @@
     "summary": "Create a new mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/mute-timings/export": {
@@ -9398,7 +9404,8 @@
     "summary": "Delete a mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "get": {
     "operationId": "RouteGetMuteTiming",
@@ -9425,7 +9432,8 @@
     "summary": "Get a mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -9476,7 +9484,8 @@
     "summary": "Replace an existing mute timing.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/mute-timings/{name}/export": {
@@ -9554,7 +9563,8 @@
     "summary": "Clears the notification policy tree.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "get": {
     "operationId": "RouteGetPolicyTree",
@@ -9569,7 +9579,8 @@
     "summary": "Get the notification policy tree.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -9608,7 +9619,8 @@
     "summary": "Sets the notification policy tree.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/policies/export": {
@@ -9655,7 +9667,8 @@
     "summary": "Get all notification template groups.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/provisioning/templates/{name}": {
@@ -9690,7 +9703,8 @@
     "summary": "Delete a notification template group.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "get": {
     "operationId": "RouteGetTemplate",
@@ -9720,7 +9734,8 @@
     "summary": "Get a notification template group.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    },
    "put": {
     "consumes": [
@@ -9771,7 +9786,8 @@
     "summary": "Updates an existing notification template group.",
     "tags": [
      "provisioning"
-    ]
+    ],
+    "deprecated": true
    }
   },
   "/v1/rule/backtest": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3293,6 +3293,7 @@
         ],
         "summary": "Get all the contact points.",
         "operationId": "RouteGetContactpoints",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -3326,6 +3327,7 @@
         ],
         "summary": "Create a contact point.",
         "operationId": "RoutePostContactpoints",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -3438,6 +3440,7 @@
         ],
         "summary": "Update an existing contact point.",
         "operationId": "RoutePutContactpoint",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -3490,6 +3493,7 @@
         ],
         "summary": "Delete a contact point.",
         "operationId": "RouteDeleteContactpoints",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -3727,6 +3731,7 @@
         ],
         "summary": "Get all the mute timings.",
         "operationId": "RouteGetMuteTimings",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "MuteTimings",
@@ -3752,6 +3757,7 @@
         ],
         "summary": "Create a new mute timing.",
         "operationId": "RoutePostMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -3848,6 +3854,7 @@
         ],
         "summary": "Get a mute timing.",
         "operationId": "RouteGetMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -3885,6 +3892,7 @@
         ],
         "summary": "Replace an existing mute timing.",
         "operationId": "RoutePutMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -3940,6 +3948,7 @@
         ],
         "summary": "Delete a mute timing.",
         "operationId": "RouteDeleteMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -4046,6 +4055,7 @@
         ],
         "summary": "Get the notification policy tree.",
         "operationId": "RouteGetPolicyTree",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "Route",
@@ -4071,6 +4081,7 @@
         ],
         "summary": "Sets the notification policy tree.",
         "operationId": "RoutePutPolicyTree",
+        "deprecated": true,
         "parameters": [
           {
             "description": "The new notification routing tree to use",
@@ -4117,6 +4128,7 @@
         ],
         "summary": "Clears the notification policy tree.",
         "operationId": "RouteResetPolicyTree",
+        "deprecated": true,
         "responses": {
           "202": {
             "description": "Ack",
@@ -4178,6 +4190,7 @@
         ],
         "summary": "Get all notification template groups.",
         "operationId": "RouteGetTemplates",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "NotificationTemplates",
@@ -4202,6 +4215,7 @@
         ],
         "summary": "Get a notification template group.",
         "operationId": "RouteGetTemplate",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -4242,6 +4256,7 @@
         ],
         "summary": "Updates an existing notification template group.",
         "operationId": "RoutePutTemplate",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -4297,6 +4312,7 @@
         ],
         "summary": "Delete a notification template group.",
         "operationId": "RouteDeleteTemplate",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11108,6 +11108,7 @@
         ],
         "summary": "Get all the contact points.",
         "operationId": "RouteGetContactpoints",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -11140,6 +11141,7 @@
         ],
         "summary": "Create a contact point.",
         "operationId": "RoutePostContactpoints",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -11250,6 +11252,7 @@
         ],
         "summary": "Update an existing contact point.",
         "operationId": "RoutePutContactpoint",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -11301,6 +11304,7 @@
         ],
         "summary": "Delete a contact point.",
         "operationId": "RouteDeleteContactpoints",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -11533,6 +11537,7 @@
         ],
         "summary": "Get all the mute timings.",
         "operationId": "RouteGetMuteTimings",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "MuteTimings",
@@ -11557,6 +11562,7 @@
         ],
         "summary": "Create a new mute timing.",
         "operationId": "RoutePostMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -11651,6 +11657,7 @@
         ],
         "summary": "Get a mute timing.",
         "operationId": "RouteGetMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -11687,6 +11694,7 @@
         ],
         "summary": "Replace an existing mute timing.",
         "operationId": "RoutePutMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -11741,6 +11749,7 @@
         ],
         "summary": "Delete a mute timing.",
         "operationId": "RouteDeleteMuteTiming",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -11845,6 +11854,7 @@
         ],
         "summary": "Get the notification policy tree.",
         "operationId": "RouteGetPolicyTree",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "Route",
@@ -11869,6 +11879,7 @@
         ],
         "summary": "Sets the notification policy tree.",
         "operationId": "RoutePutPolicyTree",
+        "deprecated": true,
         "parameters": [
           {
             "description": "The new notification routing tree to use",
@@ -11914,6 +11925,7 @@
         ],
         "summary": "Clears the notification policy tree.",
         "operationId": "RouteResetPolicyTree",
+        "deprecated": true,
         "responses": {
           "202": {
             "description": "Ack",
@@ -11973,6 +11985,7 @@
         ],
         "summary": "Get all notification template groups.",
         "operationId": "RouteGetTemplates",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "NotificationTemplates",
@@ -11996,6 +12009,7 @@
         ],
         "summary": "Get a notification template group.",
         "operationId": "RouteGetTemplate",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -12035,6 +12049,7 @@
         ],
         "summary": "Updates an existing notification template group.",
         "operationId": "RoutePutTemplate",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",
@@ -12089,6 +12104,7 @@
         ],
         "summary": "Delete a notification template group.",
         "operationId": "RouteDeleteTemplate",
+        "deprecated": true,
         "parameters": [
           {
             "type": "string",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -26004,6 +26004,7 @@
     },
     "/v1/provisioning/contact-points": {
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetContactpoints",
         "parameters": [
           {
@@ -26043,6 +26044,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "operationId": "RoutePostContactpoints",
         "parameters": [
           {
@@ -26216,6 +26218,7 @@
     },
     "/v1/provisioning/contact-points/{UID}": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteDeleteContactpoints",
         "parameters": [
           {
@@ -26249,6 +26252,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutContactpoint",
         "parameters": [
           {
@@ -26612,6 +26616,7 @@
     },
     "/v1/provisioning/mute-timings": {
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetMuteTimings",
         "responses": {
           "200": {
@@ -26641,6 +26646,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "operationId": "RoutePostMuteTiming",
         "parameters": [
           {
@@ -26797,6 +26803,7 @@
     },
     "/v1/provisioning/mute-timings/{name}": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteDeleteMuteTiming",
         "parameters": [
           {
@@ -26855,6 +26862,7 @@
         ]
       },
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetMuteTiming",
         "parameters": [
           {
@@ -26898,6 +26906,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutMuteTiming",
         "parameters": [
           {
@@ -27082,6 +27091,7 @@
     },
     "/v1/provisioning/policies": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteResetPolicyTree",
         "responses": {
           "202": {
@@ -27111,6 +27121,7 @@
         ]
       },
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetPolicyTree",
         "responses": {
           "200": {
@@ -27140,6 +27151,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutPolicyTree",
         "parameters": [
           {
@@ -27302,6 +27314,7 @@
     },
     "/v1/provisioning/templates": {
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetTemplates",
         "responses": {
           "200": {
@@ -27333,6 +27346,7 @@
     },
     "/v1/provisioning/templates/{name}": {
       "delete": {
+        "deprecated": true,
         "operationId": "RouteDeleteTemplate",
         "parameters": [
           {
@@ -27384,6 +27398,7 @@
         ]
       },
       "get": {
+        "deprecated": true,
         "operationId": "RouteGetTemplate",
         "parameters": [
           {
@@ -27434,6 +27449,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "operationId": "RoutePutTemplate",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

Marks notification provisioning API endpoints as deprecated in favor of the Grafana App Platform alerting APIs (`notifications.alerting.grafana.app/v1beta1`). Adds deprecation response headers (`Warning`, `X-API-Deprecation-Date`, `X-API-Replacement`), OpenAPI `deprecated: true` annotations, and markdown doc notices.

Endpoints deprecated (and respective k8s api's replacement):
- `GET/POST /api/v1/provisioning/contact-points` → `/receivers`
- `PUT/DELETE /api/v1/provisioning/contact-points/:uid` → `/receivers/{name}`
- `GET/PUT/DELETE /api/v1/provisioning/templates/:name` → `/templategroups/{name}`
- `GET/POST /api/v1/provisioning/mute-timings` → `/timeintervals`
- `GET/PUT/DELETE /api/v1/provisioning/mute-timings/:name` → `/timeintervals/{name}`
- `GET/PUT /api/v1/provisioning/policies` → `/routingtrees`