### PR TITLE
Unified storage: replace dualwrite storageMock with hand-written fake

### DIFF
--- a/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
@@ -31,7 +31,7 @@ func TestDryRun_Create(t *testing.T) {
 			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.createReturns = append(us.createReturns, returnVal{obj: exampleObj})
+			us.onCreate(exampleObj, nil)
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestDryRun_Delete(t *testing.T) {
 			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.deleteReturns = append(us.deleteReturns, returnVal{obj: exampleObj})
+			us.onDelete(exampleObj, nil)
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestDryRun_Update(t *testing.T) {
 			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
+			us.onUpdate(exampleObj, nil)
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 		ls := &fakeStorage{}
 		us := &fakeStorage{}
 
-		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
+		us.onUpdate(exampleObj, nil)
 
 		dw, err := newStorage(kind, rest.Mode1, ls, us)
 		require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 		ls := &fakeStorage{}
 		us := &fakeStorage{}
 
-		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
+		us.onUpdate(exampleObj, nil)
 
 		dw, err := newStorage(kind, rest.Mode2, ls, us)
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 		ls := &fakeStorage{}
 		us := &fakeStorage{}
 
-		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
+		us.onUpdate(exampleObj, nil)
 
 		dw, err := newStorage(kind, rest.Mode3, ls, us)
 		require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestDryRun_DeleteCollection(t *testing.T) {
 			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.deleteCollectionReturns = append(us.deleteCollectionReturns, returnVal{obj: exampleList})
+			us.onDeleteCollection(exampleList, nil)
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_dryrun_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,14 +27,11 @@ func TestDryRun_Create(t *testing.T) {
 
 	for _, m := range modes {
 		t.Run(m.name+" should not create in legacy storage when dry-run is set", func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, nil)
+			us.createReturns = append(us.createReturns, returnVal{obj: exampleObj})
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -45,9 +41,9 @@ func TestDryRun_Create(t *testing.T) {
 			require.Equal(t, exampleObj, obj)
 
 			// Legacy storage should NOT have been called
-			ls.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.Empty(t, ls.createCalls)
 			// Unified storage should have been called
-			us.AssertCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.NotEmpty(t, us.createCalls)
 		})
 	}
 }
@@ -64,14 +60,11 @@ func TestDryRun_Delete(t *testing.T) {
 
 	for _, m := range modes {
 		t.Run(m.name+" should not delete in legacy storage when dry-run is set", func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+			us.deleteReturns = append(us.deleteReturns, returnVal{obj: exampleObj})
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -81,9 +74,9 @@ func TestDryRun_Delete(t *testing.T) {
 			require.Equal(t, exampleObj, obj)
 
 			// Legacy storage should NOT have been called
-			ls.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.Empty(t, ls.deleteCalls)
 			// Unified storage should have been called
-			us.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.NotEmpty(t, us.deleteCalls)
 		})
 	}
 }
@@ -100,14 +93,11 @@ func TestDryRun_Update(t *testing.T) {
 
 	for _, m := range modes {
 		t.Run(m.name+" should not update in legacy storage when dry-run is set", func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+			us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -120,22 +110,19 @@ func TestDryRun_Update(t *testing.T) {
 			require.Equal(t, exampleObj, obj)
 
 			// Legacy storage should NOT have been called
-			ls.AssertNotCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.Empty(t, ls.updateCalls)
 			// Unified storage should have been called
-			us.AssertCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.NotEmpty(t, us.updateCalls)
 		})
 	}
 }
 
 func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 	t.Run("Mode1 should wrap objInfo and set forceAllowCreate=true", func(t *testing.T) {
-		l := (rest.Storage)(nil)
-		s := (rest.Storage)(nil)
+		ls := &fakeStorage{}
+		us := &fakeStorage{}
 
-		ls := storageMock{&mock.Mock{}, l}
-		us := storageMock{&mock.Mock{}, s}
-
-		us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
 
 		dw, err := newStorage(kind, rest.Mode1, ls, us)
 		require.NoError(t, err)
@@ -147,22 +134,19 @@ func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify unified was called with wrappedUpdateInfo and forceAllowCreate=true
-		require.Len(t, us.Calls, 1)
-		call := us.Calls[0]
-		_, isWrapped := call.Arguments[2].(*wrappedUpdateInfo)
+		require.Len(t, us.updateCalls, 1)
+		call := us.updateCalls[0]
+		_, isWrapped := call.args[2].(*wrappedUpdateInfo)
 		require.True(t, isWrapped, "Mode1 dry-run should wrap objInfo with wrappedUpdateInfo")
-		forceCreate := call.Arguments[5].(bool)
+		forceCreate := call.args[5].(bool)
 		require.True(t, forceCreate, "Mode1 dry-run should set forceAllowCreate=true")
 	})
 
 	t.Run("Mode2 should wrap objInfo and set forceAllowCreate=true", func(t *testing.T) {
-		l := (rest.Storage)(nil)
-		s := (rest.Storage)(nil)
+		ls := &fakeStorage{}
+		us := &fakeStorage{}
 
-		ls := storageMock{&mock.Mock{}, l}
-		us := storageMock{&mock.Mock{}, s}
-
-		us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
 
 		dw, err := newStorage(kind, rest.Mode2, ls, us)
 		require.NoError(t, err)
@@ -174,22 +158,19 @@ func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify unified was called with wrappedUpdateInfo and forceAllowCreate=true
-		require.Len(t, us.Calls, 1)
-		call := us.Calls[0]
-		_, isWrapped := call.Arguments[2].(*wrappedUpdateInfo)
+		require.Len(t, us.updateCalls, 1)
+		call := us.updateCalls[0]
+		_, isWrapped := call.args[2].(*wrappedUpdateInfo)
 		require.True(t, isWrapped, "Mode2 dry-run should wrap objInfo with wrappedUpdateInfo")
-		forceCreate := call.Arguments[5].(bool)
+		forceCreate := call.args[5].(bool)
 		require.True(t, forceCreate, "Mode2 dry-run should set forceAllowCreate=true")
 	})
 
 	t.Run("Mode3 should wrap objInfo and set forceAllowCreate=true (same as Mode1)", func(t *testing.T) {
-		l := (rest.Storage)(nil)
-		s := (rest.Storage)(nil)
+		ls := &fakeStorage{}
+		us := &fakeStorage{}
 
-		ls := storageMock{&mock.Mock{}, l}
-		us := storageMock{&mock.Mock{}, s}
-
-		us.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
 
 		dw, err := newStorage(kind, rest.Mode3, ls, us)
 		require.NoError(t, err)
@@ -201,11 +182,11 @@ func TestDryRun_Update_WrapsObjInfoForLegacyReadModes(t *testing.T) {
 		require.NoError(t, err)
 
 		// Mode3 now maps to DualWrite (same as Mode1), so objInfo should be wrapped
-		require.Len(t, us.Calls, 1)
-		call := us.Calls[0]
-		_, isWrapped := call.Arguments[2].(*wrappedUpdateInfo)
+		require.Len(t, us.updateCalls, 1)
+		call := us.updateCalls[0]
+		_, isWrapped := call.args[2].(*wrappedUpdateInfo)
 		require.True(t, isWrapped, "Mode3 dry-run should wrap objInfo with wrappedUpdateInfo")
-		forceCreate := call.Arguments[5].(bool)
+		forceCreate := call.args[5].(bool)
 		require.True(t, forceCreate, "Mode3 dry-run should set forceAllowCreate=true")
 	})
 }
@@ -222,14 +203,11 @@ func TestDryRun_DeleteCollection(t *testing.T) {
 
 	for _, m := range modes {
 		t.Run(m.name+" should not delete collection in legacy storage when dry-run is set", func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			// Only unified storage should be called
-			us.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+			us.deleteCollectionReturns = append(us.deleteCollectionReturns, returnVal{obj: exampleList})
 
 			dw, err := newStorage(kind, m.mode, ls, us)
 			require.NoError(t, err)
@@ -242,9 +220,9 @@ func TestDryRun_DeleteCollection(t *testing.T) {
 			require.Equal(t, exampleList, obj)
 
 			// Legacy storage should NOT have been called
-			ls.AssertNotCalled(t, "DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.Empty(t, ls.deleteCollectionCalls)
 			// Unified storage should have been called
-			us.AssertCalled(t, "DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.NotEmpty(t, us.deleteCollectionCalls)
 		})
 	}
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter_list_pagination_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_list_pagination_test.go
@@ -40,7 +40,7 @@ func TestDualWriter_List_UnifiedDonePaging(t *testing.T) {
 	ls := &fakeStorage{}
 	us := &fakeStorage{}
 
-	ls.listReturns = append(ls.listReturns, returnVal{obj: exampleList})
+	ls.onList(exampleList, nil)
 
 	dw, err := newStorage(kind, rest.Mode1, ls, us)
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestDualWriter_List_UnifiedTimeoutDoesNotBlock(t *testing.T) {
 	ls := &fakeStorage{}
 	us := &fakeStorage{}
 
-	ls.listReturns = append(ls.listReturns, returnVal{obj: exampleList})
+	ls.onList(exampleList, nil)
 	// unified deliberately blocks until ctx is canceled (simulates slow response)
 	us.blockList = true
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter_list_pagination_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_list_pagination_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 
@@ -16,8 +15,8 @@ import (
 // continue token encodes an empty legacy cursor (legacy finished paging) but unified
 // still has more. The writer should return an empty list without touching either store.
 func TestDualWriter_List_LegacyDonePaging(t *testing.T) {
-	ls := storageMock{&mock.Mock{}, rest.Storage(nil)}
-	us := storageMock{&mock.Mock{}, rest.Storage(nil)}
+	ls := &fakeStorage{}
+	us := &fakeStorage{}
 
 	dw, err := newStorage(kind, rest.Mode1, ls, us)
 	require.NoError(t, err)
@@ -27,20 +26,21 @@ func TestDualWriter_List_LegacyDonePaging(t *testing.T) {
 
 	obj, err := dw.List(context.Background(), &metainternalversion.ListOptions{Continue: continueToken})
 	require.NoError(t, err)
-	require.Nil(t, obj) // storageMock.NewList() returns nil
+	require.Nil(t, obj) // fakeStorage.NewList() returns nil
 
-	ls.AssertNotCalled(t, "List", mock.Anything, mock.Anything)
-	us.AssertNotCalled(t, "List", mock.Anything, mock.Anything)
+	// Neither store should have been called
+	require.Empty(t, ls.listCalls)
+	require.Empty(t, us.listCalls)
 }
 
 // TestDualWriter_List_UnifiedDonePaging covers the case where the combined token
 // encodes an empty unified cursor (unified finished paging) but legacy still has
 // more. The writer should skip the unified request entirely.
 func TestDualWriter_List_UnifiedDonePaging(t *testing.T) {
-	ls := storageMock{&mock.Mock{}, rest.Storage(nil)}
-	us := storageMock{&mock.Mock{}, rest.Storage(nil)}
+	ls := &fakeStorage{}
+	us := &fakeStorage{}
 
-	ls.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+	ls.listReturns = append(ls.listReturns, returnVal{obj: exampleList})
 
 	dw, err := newStorage(kind, rest.Mode1, ls, us)
 	require.NoError(t, err)
@@ -52,20 +52,20 @@ func TestDualWriter_List_UnifiedDonePaging(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, exampleList, obj)
 
-	ls.AssertCalled(t, "List", mock.Anything, mock.Anything)
-	us.AssertNotCalled(t, "List", mock.Anything, mock.Anything)
+	require.NotEmpty(t, ls.listCalls)
+	require.Empty(t, us.listCalls)
 }
 
 // TestDualWriter_List_UnifiedTimeoutDoesNotBlock verifies that when the unified
 // list call takes longer than the 300 ms budget the writer returns the legacy
 // result immediately without blocking.
 func TestDualWriter_List_UnifiedTimeoutDoesNotBlock(t *testing.T) {
-	ls := storageMock{&mock.Mock{}, rest.Storage(nil)}
-	us := storageMock{&mock.Mock{}, rest.Storage(nil)}
+	ls := &fakeStorage{}
+	us := &fakeStorage{}
 
-	ls.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
-	// unified deliberately takes longer than the 300 ms timeout
-	us.On("List", mock.Anything, mock.Anything).WaitUntil(time.After(time.Second)).Return(anotherList, nil)
+	ls.listReturns = append(ls.listReturns, returnVal{obj: exampleList})
+	// unified deliberately blocks until ctx is canceled (simulates slow response)
+	us.blockList = true
 
 	dw, err := newStorage(kind, rest.Mode1, ls, us)
 	require.NoError(t, err)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
@@ -39,17 +39,17 @@ func TestMode1_Create(t *testing.T) {
 				name:  "creating an object only in the legacy store",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObjNoRV})
+					s.onCreate(exampleObjNoRV, nil)
 				},
 			},
 			{
 				name:  "error when creating object in the legacy store fails",
 				input: failingObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
+					s.onCreate(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -57,10 +57,10 @@ func TestMode1_Create(t *testing.T) {
 				name:  "should not error when unified create fails in background",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.createReturns = append(s.createReturns, returnVal{err: errors.New("unified error")})
+					s.onCreate(nil, errors.New("unified error"))
 				},
 			},
 		}
@@ -107,35 +107,35 @@ func TestMode1_Get(t *testing.T) {
 			{
 				name: "should succeed when getting an object from LegacyStorage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: anotherObj})
+					s.onGet(anotherObj, nil)
 				},
 			},
 			{
 				name: "should error when getting an object from LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when getting an object from UnifiedStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 			},
 			{
 				name: "should not block for unified storage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
 					s.blockGet = true
@@ -183,20 +183,20 @@ func TestMode1_List(t *testing.T) {
 			{
 				name: "should error when listing from LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
+					s.onList(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: &example.PodList{}})
+					s.onList(&example.PodList{}, nil)
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when listing from UnifiedStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: &example.PodList{}})
+					s.onList(&example.PodList{}, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
+					s.onList(nil, errors.New("error"))
 				},
 			},
 		}
@@ -238,29 +238,29 @@ func TestMode1_Delete(t *testing.T) {
 			{
 				name: "should succeed when deleting an object from LegacyStorage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 			},
 			{
 				name: "should error when deleting an object from LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
+					s.onDelete(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when deleting an object from UnifiedStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
+					s.onDelete(nil, errors.New("error"))
 				},
 			},
 		}
@@ -307,20 +307,20 @@ func TestMode1_DeleteCollection(t *testing.T) {
 				name:  "should succeed when deleting a collection from LegacyStorage",
 				input: &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}},
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
+					s.onDeleteCollection(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
+					s.onDeleteCollection(exampleObj, nil)
 				},
 			},
 			{
 				name:  "should error when deleting a collection from LegacyStorage fails",
 				input: &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "fail"}},
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
+					s.onDeleteCollection(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
+					s.onDeleteCollection(exampleObj, nil)
 				},
 				wantErr: true,
 			},
@@ -328,10 +328,10 @@ func TestMode1_DeleteCollection(t *testing.T) {
 				name:  "should not error when deleting a collection from UnifiedStorage fails",
 				input: &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}},
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
+					s.onDeleteCollection(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
+					s.onDeleteCollection(nil, errors.New("error"))
 				},
 			},
 		}
@@ -376,29 +376,29 @@ func TestMode1_Update(t *testing.T) {
 			{
 				name: "should succeed when updating an object in LegacyStorage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: anotherObj})
+					s.onUpdate(anotherObj, nil)
 				},
 			},
 			{
 				name: "should error when updating an object in LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
+					s.onUpdate(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: anotherObj})
+					s.onUpdate(anotherObj, nil)
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when updating an object in UnifiedStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
+					s.onUpdate(nil, errors.New("error"))
 				},
 			},
 		}

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -29,8 +28,8 @@ var anotherList = &example.PodList{Items: []example.Pod{*anotherObj}}
 func TestMode1_Create(t *testing.T) {
 	type testCase struct {
 		input          runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input runtime.Object)
-		setupStorageFn func(m *mock.Mock)
+		setupLegacyFn  func(s *fakeStorage, input runtime.Object)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -39,46 +38,43 @@ func TestMode1_Create(t *testing.T) {
 			{
 				name:  "creating an object only in the legacy store",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObjNoRV, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObjNoRV})
 				},
 			},
 			{
 				name:  "error when creating object in the legacy store fails",
 				input: failingObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, failingObj, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
 			{
 				name:  "should not error when unified create fails in background",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("unified error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.createReturns = append(s.createReturns, returnVal{err: errors.New("unified error")})
 				},
 			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode1, ls, us)
@@ -101,8 +97,8 @@ func TestMode1_Create(t *testing.T) {
 
 func TestMode1_Get(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, name string)
-		setupStorageFn func(m *mock.Mock, name string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -110,71 +106,64 @@ func TestMode1_Get(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when getting an object from LegacyStorage",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(anotherObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: anotherObj})
 				},
 			},
 			{
 				name: "should error when getting an object from LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when getting an object from UnifiedStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
 			},
 			{
 				name: "should not block for unified storage",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).WaitUntil(time.After(time.Hour)).Return(anotherObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.blockGet = true
 				},
 			},
 		}
 
-	name := "foo"
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode1, ls, us)
 			require.NoError(t, err)
 
-			obj, err := dw.Get(context.Background(), name, &metav1.GetOptions{})
+			obj, err := dw.Get(context.Background(), "foo", &metav1.GetOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
-
-			us.AssertNotCalled(t, "Get", context.Background(), tt.name, &metav1.GetOptions{})
 
 			require.Equal(t, obj, exampleObj)
 			require.NotEqual(t, obj, anotherObj)
@@ -184,8 +173,8 @@ func TestMode1_Get(t *testing.T) {
 
 func TestMode1_List(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock)
-		setupStorageFn func(m *mock.Mock)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -193,38 +182,35 @@ func TestMode1_List(t *testing.T) {
 		[]testCase{
 			{
 				name: "should error when listing from LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(&example.PodList{}, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: &example.PodList{}})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when listing from UnifiedStorage fails",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(&example.PodList{}, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: &example.PodList{}})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode1, ls, us)
@@ -242,8 +228,8 @@ func TestMode1_List(t *testing.T) {
 
 func TestMode1_Delete(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, name string)
-		setupStorageFn func(m *mock.Mock, name string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -251,62 +237,56 @@ func TestMode1_Delete(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when deleting an object from LegacyStorage",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name: "should error when deleting an object from LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when deleting an object from UnifiedStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Delete", mock.Anything, name, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
-	name := "foo"
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode1, ls, us)
 			require.NoError(t, err)
 
-			obj, _, err := dw.Delete(context.Background(), name, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
+			obj, _, err := dw.Delete(context.Background(), "foo", func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 
-			us.AssertNotCalled(t, "Delete", context.Background(), name, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 			require.Equal(t, obj, exampleObj)
 			require.NotEqual(t, obj, anotherObj)
 		})
@@ -316,8 +296,8 @@ func TestMode1_Delete(t *testing.T) {
 func TestMode1_DeleteCollection(t *testing.T) {
 	type testCase struct {
 		input          *metav1.DeleteOptions
-		setupLegacyFn  func(m *mock.Mock, input *metav1.DeleteOptions)
-		setupStorageFn func(m *mock.Mock, input *metav1.DeleteOptions)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -326,49 +306,46 @@ func TestMode1_DeleteCollection(t *testing.T) {
 			{
 				name:  "should succeed when deleting a collection from LegacyStorage",
 				input: &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}},
-				setupLegacyFn: func(m *mock.Mock, input *metav1.DeleteOptions) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input *metav1.DeleteOptions) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name:  "should error when deleting a collection from LegacyStorage fails",
 				input: &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "fail"}},
-				setupLegacyFn: func(m *mock.Mock, input *metav1.DeleteOptions) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, input *metav1.DeleteOptions) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
 			{
 				name:  "should not error when deleting a collection from UnifiedStorage fails",
 				input: &metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{Kind: "foo"}},
-				setupLegacyFn: func(m *mock.Mock, input *metav1.DeleteOptions) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input *metav1.DeleteOptions) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode1, ls, us)
@@ -381,7 +358,6 @@ func TestMode1_DeleteCollection(t *testing.T) {
 				return
 			}
 
-			us.AssertNotCalled(t, "DeleteCollection", context.Background(), tt.input, func(ctx context.Context, obj runtime.Object) error { return nil }, &metav1.DeleteOptions{})
 			require.Equal(t, obj, exampleObj)
 			require.NotEqual(t, obj, anotherObj)
 		})
@@ -390,8 +366,8 @@ func TestMode1_DeleteCollection(t *testing.T) {
 
 func TestMode1_Update(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, input string)
-		setupStorageFn func(m *mock.Mock, input string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -399,55 +375,50 @@ func TestMode1_Update(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when updating an object in LegacyStorage",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(anotherObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: anotherObj})
 				},
 			},
 			{
 				name: "should error when updating an object in LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(anotherObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: anotherObj})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when updating an object in UnifiedStorage fails",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
-	name := "foo"
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode1, ls, us)
 			require.NoError(t, err)
 
-			obj, _, err := dw.Update(context.Background(), name, updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
+			obj, _, err := dw.Update(context.Background(), "foo", updatedObjInfoObj{}, func(ctx context.Context, obj runtime.Object) error { return nil }, func(ctx context.Context, obj, old runtime.Object) error { return nil }, false, &metav1.UpdateOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode2_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode2_test.go
@@ -33,20 +33,20 @@ func TestMode2_Create(t *testing.T) {
 				name:  "should create an object in both the LegacyStorage and Storage",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the LegacyStorage fails",
 				input: failingObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
+					s.onCreate(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				wantErr: true,
 			},
@@ -93,30 +93,30 @@ func TestMode2_Get(t *testing.T) {
 				name:  "should get an object from LegacyStorage with best-effort unified read",
 				input: "foo",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: anotherObj})
+					s.onGet(anotherObj, nil)
 				},
 			},
 			{
 				name:  "should not error when getting an object from the Storage fails (best effort)",
 				input: "foo",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 			},
 			{
 				name:  "should return an error when getting an object from LegacyStorage fails",
 				input: "object-fail",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -164,20 +164,20 @@ func TestMode2_List(t *testing.T) {
 				name:        "should return a list of objects from LegacyStorage with best-effort unified list",
 				inputLegacy: exampleOption,
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
+					s.onList(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: anotherList})
+					s.onList(anotherList, nil)
 				},
 			},
 			{
 				name:        "should return an error when listing objects from the LegacyStorage fails",
 				inputLegacy: exampleOption,
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
+					s.onList(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: anotherList})
+					s.onList(anotherList, nil)
 				},
 				wantErr: true,
 			},
@@ -185,10 +185,10 @@ func TestMode2_List(t *testing.T) {
 				name:        "should not error when listing objects from the Storage fails (best effort)",
 				inputLegacy: exampleOption,
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
+					s.onList(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
+					s.onList(nil, errors.New("error"))
 				},
 			},
 		}
@@ -231,29 +231,29 @@ func TestMode2_Delete(t *testing.T) {
 			{
 				name: "should delete an object from both the LegacyStorage and Storage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 			},
 			{
 				name: "should return an error when deleting an object from the LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
+					s.onDelete(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when deleting an object from the Storage fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
+					s.onDelete(nil, errors.New("error"))
 				},
 			},
 		}
@@ -300,25 +300,25 @@ func TestMode2_DeleteCollection(t *testing.T) {
 			{
 				name: "should delete a collection from both the LegacyStorage and Storage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
+					s.onDeleteCollection(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
+					s.onDeleteCollection(exampleList, nil)
 				},
 			},
 			{
 				name: "should not error when deleting a collection from the Storage fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
+					s.onDeleteCollection(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
+					s.onDeleteCollection(nil, errors.New("error"))
 				},
 			},
 			{
 				name: "should return an error when deleting a collection from the LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
+					s.onDeleteCollection(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -365,27 +365,27 @@ func TestMode2_Update(t *testing.T) {
 			{
 				name: "should succeed when updating an object in both the LegacyStorage and Storage is successful",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				expectedObj: exampleObj,
 			},
 			{
 				name: "should return an error when updating the LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
+					s.onUpdate(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when updating the Storage fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
+					s.onUpdate(nil, errors.New("error"))
 				},
 				expectedObj: exampleObj,
 			},

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode2_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode2_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,8 +22,8 @@ var exampleOption = &metainternalversion.ListOptions{}
 func TestMode2_Create(t *testing.T) {
 	type testCase struct {
 		input          runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input runtime.Object)
-		setupStorageFn func(m *mock.Mock, input runtime.Object)
+		setupLegacyFn  func(s *fakeStorage, input runtime.Object)
+		setupStorageFn func(s *fakeStorage, input runtime.Object)
 		name           string
 		wantErr        bool
 	}
@@ -33,22 +32,21 @@ func TestMode2_Create(t *testing.T) {
 			{
 				name:  "should create an object in both the LegacyStorage and Storage",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the LegacyStorage fails",
 				input: failingObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
@@ -56,17 +54,14 @@ func TestMode2_Create(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us, tt.input)
 			}
 
 			dw, err := newStorage(kind, rest.Mode2, ls, us)
@@ -86,8 +81,8 @@ func TestMode2_Create(t *testing.T) {
 
 func TestMode2_Get(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, input string)
-		setupStorageFn func(m *mock.Mock, input string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		input          string
 		wantErr        bool
@@ -97,31 +92,31 @@ func TestMode2_Get(t *testing.T) {
 			{
 				name:  "should get an object from LegacyStorage with best-effort unified read",
 				input: "foo",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(anotherObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: anotherObj})
 				},
 			},
 			{
 				name:  "should not error when getting an object from the Storage fails (best effort)",
 				input: "foo",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
 			},
 			{
 				name:  "should return an error when getting an object from LegacyStorage fails",
 				input: "object-fail",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Get", mock.Anything, input, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
@@ -129,17 +124,14 @@ func TestMode2_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode2, ls, us)
@@ -161,8 +153,8 @@ func TestMode2_Get(t *testing.T) {
 func TestMode2_List(t *testing.T) {
 	type testCase struct {
 		inputLegacy    *metainternalversion.ListOptions
-		setupLegacyFn  func(m *mock.Mock)
-		setupStorageFn func(m *mock.Mock)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -171,49 +163,46 @@ func TestMode2_List(t *testing.T) {
 			{
 				name:        "should return a list of objects from LegacyStorage with best-effort unified list",
 				inputLegacy: exampleOption,
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: anotherList})
 				},
 			},
 			{
 				name:        "should return an error when listing objects from the LegacyStorage fails",
 				inputLegacy: exampleOption,
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: anotherList})
 				},
 				wantErr: true,
 			},
 			{
 				name:        "should not error when listing objects from the Storage fails (best effort)",
 				inputLegacy: exampleOption,
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode2, ls, us)
@@ -232,8 +221,8 @@ func TestMode2_List(t *testing.T) {
 
 func TestMode2_Delete(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, input string)
-		setupStorageFn func(m *mock.Mock, input string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -241,30 +230,30 @@ func TestMode2_Delete(t *testing.T) {
 		[]testCase{
 			{
 				name: "should delete an object from both the LegacyStorage and Storage",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name: "should return an error when deleting an object from the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when deleting an object from the Storage fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
@@ -273,17 +262,14 @@ func TestMode2_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode2, ls, us)
@@ -304,8 +290,8 @@ func TestMode2_Delete(t *testing.T) {
 
 func TestMode2_DeleteCollection(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock)
-		setupStorageFn func(m *mock.Mock)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -313,26 +299,26 @@ func TestMode2_DeleteCollection(t *testing.T) {
 		[]testCase{
 			{
 				name: "should delete a collection from both the LegacyStorage and Storage",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
 				},
 			},
 			{
 				name: "should not error when deleting a collection from the Storage fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
 				},
 			},
 			{
 				name: "should return an error when deleting a collection from the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
@@ -342,17 +328,14 @@ func TestMode2_DeleteCollection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode2, ls, us)
@@ -372,8 +355,8 @@ func TestMode2_DeleteCollection(t *testing.T) {
 func TestMode2_Update(t *testing.T) {
 	type testCase struct {
 		expectedObj    runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input string)
-		setupStorageFn func(m *mock.Mock, input string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -381,28 +364,28 @@ func TestMode2_Update(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when updating an object in both the LegacyStorage and Storage is successful",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
 				expectedObj: exampleObj,
 			},
 			{
 				name: "should return an error when updating the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when updating the Storage fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
 				},
 				expectedObj: exampleObj,
 			},
@@ -412,17 +395,14 @@ func TestMode2_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode2, ls, us)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
@@ -29,17 +29,17 @@ func TestMode3_Create(t *testing.T) {
 				name:  "should succeed when creating an object in both the LegacyStorage and Storage",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the legacy store fails",
 				input: failingObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
+					s.onCreate(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -47,10 +47,10 @@ func TestMode3_Create(t *testing.T) {
 				name:  "should not error when creating in unified store fails (best effort)",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
+					s.onCreate(nil, errors.New("error"))
 				},
 			},
 		}
@@ -94,28 +94,28 @@ func TestMode3_Get(t *testing.T) {
 			{
 				name: "should succeed when getting an object from LegacyStorage",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 			},
 			{
 				name: "should not error when getting an object from unified store fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 			},
 			{
 				name: "should error when getting an object from LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				wantErr: true,
 			},
@@ -163,26 +163,26 @@ func TestMode3_List(t *testing.T) {
 			{
 				name: "should return a list from LegacyStorage with best-effort unified list",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
+					s.onList(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: anotherList})
+					s.onList(anotherList, nil)
 				},
 			},
 			{
 				name: "should error when listing from LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
+					s.onList(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when listing from unified fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
+					s.onList(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
+					s.onList(nil, errors.New("error"))
 				},
 			},
 		}
@@ -226,29 +226,29 @@ func TestMode3_Delete(t *testing.T) {
 			{
 				name: "should succeed when deleting an object in both stores",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 			},
 			{
 				name: "should return an error when deleting from LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
+					s.onDelete(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when deleting from unified fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
+					s.onDelete(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
+					s.onDelete(nil, errors.New("error"))
 				},
 			},
 		}
@@ -295,25 +295,25 @@ func TestMode3_DeleteCollection(t *testing.T) {
 			{
 				name: "should succeed when deleting a collection in both stores",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
+					s.onDeleteCollection(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
+					s.onDeleteCollection(exampleList, nil)
 				},
 			},
 			{
 				name: "should not error when deleting a collection from Storage fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
+					s.onDeleteCollection(exampleList, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
+					s.onDeleteCollection(nil, errors.New("error"))
 				},
 			},
 			{
 				name: "should return an error when deleting a collection from the LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
+					s.onDeleteCollection(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -360,27 +360,27 @@ func TestMode3_Update(t *testing.T) {
 			{
 				name: "should succeed when updating an object in both stores",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				expectedObj: exampleObj,
 			},
 			{
 				name: "should return an error when updating an object in the LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
+					s.onUpdate(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when updating unified fails (best effort)",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
+					s.onUpdate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
+					s.onUpdate(nil, errors.New("error"))
 				},
 				expectedObj: exampleObj,
 			},

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,8 +18,8 @@ import (
 func TestMode3_Create(t *testing.T) {
 	type testCase struct {
 		input          runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input runtime.Object)
-		setupStorageFn func(m *mock.Mock, input runtime.Object)
+		setupLegacyFn  func(s *fakeStorage, input runtime.Object)
+		setupStorageFn func(s *fakeStorage, input runtime.Object)
 		name           string
 		wantErr        bool
 	}
@@ -29,47 +28,43 @@ func TestMode3_Create(t *testing.T) {
 			{
 				name:  "should succeed when creating an object in both the LegacyStorage and Storage",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the legacy store fails",
 				input: failingObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
 			{
 				name:  "should not error when creating in unified store fails (best effort)",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
+				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us, tt.input)
 			}
 
 			dw, err := newStorage(kind, rest.Mode3, ls, us)
@@ -89,8 +84,8 @@ func TestMode3_Create(t *testing.T) {
 
 func TestMode3_Get(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, name string)
-		setupStorageFn func(m *mock.Mock, name string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -98,29 +93,29 @@ func TestMode3_Get(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when getting an object from LegacyStorage",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name: "should not error when getting an object from unified store fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
 			},
 			{
 				name: "should error when getting an object from LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
@@ -130,17 +125,14 @@ func TestMode3_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode3, ls, us)
@@ -161,8 +153,8 @@ func TestMode3_Get(t *testing.T) {
 
 func TestMode3_List(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock)
-		setupStorageFn func(m *mock.Mock)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -170,44 +162,41 @@ func TestMode3_List(t *testing.T) {
 		[]testCase{
 			{
 				name: "should return a list from LegacyStorage with best-effort unified list",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(anotherList, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: anotherList})
 				},
 			},
 			{
 				name: "should error when listing from LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when listing from unified fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("List", mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.listReturns = append(s.listReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode3, ls, us)
@@ -227,8 +216,8 @@ func TestMode3_List(t *testing.T) {
 
 func TestMode3_Delete(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, input string)
-		setupStorageFn func(m *mock.Mock, input string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -236,30 +225,30 @@ func TestMode3_Delete(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when deleting an object in both stores",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name: "should return an error when deleting from LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when deleting from unified fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, false, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Delete", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, false, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteReturns = append(s.deleteReturns, returnVal{err: errors.New("error")})
 				},
 			},
 		}
@@ -268,17 +257,14 @@ func TestMode3_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode3, ls, us)
@@ -299,8 +285,8 @@ func TestMode3_Delete(t *testing.T) {
 
 func TestMode3_DeleteCollection(t *testing.T) {
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock)
-		setupStorageFn func(m *mock.Mock)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -308,26 +294,26 @@ func TestMode3_DeleteCollection(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when deleting a collection in both stores",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
 				},
 			},
 			{
 				name: "should not error when deleting a collection from Storage fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleList, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{obj: exampleList})
 				},
-				setupStorageFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
 				},
 			},
 			{
 				name: "should return an error when deleting a collection from the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock) {
-					m.On("DeleteCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.deleteCollectionReturns = append(s.deleteCollectionReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
@@ -337,17 +323,14 @@ func TestMode3_DeleteCollection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode3, ls, us)
@@ -367,8 +350,8 @@ func TestMode3_DeleteCollection(t *testing.T) {
 func TestMode3_Update(t *testing.T) {
 	type testCase struct {
 		expectedObj    runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input string)
-		setupStorageFn func(m *mock.Mock, input string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -376,28 +359,28 @@ func TestMode3_Update(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when updating an object in both stores",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
 				expectedObj: exampleObj,
 			},
 			{
 				name: "should return an error when updating an object in the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error")).Once()
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should not error when updating unified fails (best effort)",
-				setupLegacyFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
+				setupLegacyFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, input string) {
-					m.On("Update", mock.Anything, input, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, false, errors.New("error")).Once()
+				setupStorageFn: func(s *fakeStorage) {
+					s.updateReturns = append(s.updateReturns, returnVal{err: errors.New("error")})
 				},
 				expectedObj: exampleObj,
 			},
@@ -407,17 +390,14 @@ func TestMode3_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			dw, err := newStorage(kind, rest.Mode3, ls, us)

--- a/pkg/storage/legacysql/dualwrite/dualwriter_validation_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_validation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,8 +16,8 @@ import (
 // dualWriter.Create that fire before any storage is touched.
 func TestDualWriter_Create_ValidationErrors(t *testing.T) {
 	t.Run("should error when object has a UID preset", func(t *testing.T) {
-		ls := storageMock{&mock.Mock{}, rest.Storage(nil)}
-		us := storageMock{&mock.Mock{}, rest.Storage(nil)}
+		ls := &fakeStorage{}
+		us := &fakeStorage{}
 
 		dw, err := newStorage(kind, rest.Mode1, ls, us)
 		require.NoError(t, err)
@@ -33,13 +32,13 @@ func TestDualWriter_Create_ValidationErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "UID should not be")
 
 		// No storage call should have been made
-		ls.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-		us.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		require.Empty(t, ls.createCalls)
+		require.Empty(t, us.createCalls)
 	})
 
 	t.Run("should error when object has neither name nor generateName", func(t *testing.T) {
-		ls := storageMock{&mock.Mock{}, rest.Storage(nil)}
-		us := storageMock{&mock.Mock{}, rest.Storage(nil)}
+		ls := &fakeStorage{}
+		us := &fakeStorage{}
 
 		dw, err := newStorage(kind, rest.Mode1, ls, us)
 		require.NoError(t, err)
@@ -55,7 +54,7 @@ func TestDualWriter_Create_ValidationErrors(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "name or generatename")
 
-		ls.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-		us.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		require.Empty(t, ls.createCalls)
+		require.Empty(t, us.createCalls)
 	})
 }

--- a/pkg/storage/legacysql/dualwrite/runtime_test.go
+++ b/pkg/storage/legacysql/dualwrite/runtime_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/grafana/grafana/pkg/apiserver/rest"
 	unifiedmigrations "github.com/grafana/grafana/pkg/storage/unified/migrations/contract"
 )
 
@@ -21,8 +19,8 @@ var kind = schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"
 func TestRuntime_Create(t *testing.T) {
 	type testCase struct {
 		input          runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input runtime.Object)
-		setupStorageFn func(m *mock.Mock, input runtime.Object)
+		setupLegacyFn  func(s *fakeStorage, input runtime.Object)
+		setupStorageFn func(s *fakeStorage, input runtime.Object)
 		name           string
 		wantErr        bool
 	}
@@ -31,19 +29,18 @@ func TestRuntime_Create(t *testing.T) {
 			{
 				name:  "should succeed when creating an object in both the LegacyStorage and Storage",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the legacy store fails",
 				input: failingObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error")).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
@@ -51,17 +48,14 @@ func TestRuntime_Create(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us, tt.input)
 			}
 
 			m, err := ProvideService(NewFakeConfig(), NewFakeMigrator(), NewFakeMigrationStatusReader(), prometheus.NewRegistry())
@@ -92,8 +86,8 @@ func TestDualWriter_RuntimeModeSwitch(t *testing.T) {
 	svc, err := ProvideService(NewFakeConfig(), NewFakeMigrator(), reader, prometheus.NewRegistry())
 	require.NoError(t, err)
 
-	ls := storageMock{&mock.Mock{}, (rest.Storage)(nil)}
-	us := storageMock{&mock.Mock{}, (rest.Storage)(nil)}
+	ls := &fakeStorage{}
+	us := &fakeStorage{}
 
 	dw, err := svc.NewStorage(gr, ls, us)
 	require.NoError(t, err)
@@ -101,9 +95,9 @@ func TestDualWriter_RuntimeModeSwitch(t *testing.T) {
 	require.True(t, isDual, "DualWrite mode must produce a *dualWriter")
 
 	// DualWrite phase: Get returns the legacy result.
-	// Background unified.Get may also fire; allow it with no call-count restriction.
-	ls.On("Get", mock.Anything, "foo", mock.Anything).Return(exampleObj, nil).Once()
-	us.On("Get", mock.Anything, "foo", mock.Anything).Return(anotherObj, nil)
+	// Background unified.Get may also fire.
+	ls.getReturns = append(ls.getReturns, returnVal{obj: exampleObj})
+	us.getReturns = append(us.getReturns, returnVal{obj: anotherObj})
 
 	obj, err := dw.Get(context.Background(), "foo", &metav1.GetOptions{})
 	require.NoError(t, err)
@@ -113,27 +107,23 @@ func TestDualWriter_RuntimeModeSwitch(t *testing.T) {
 	reader.setMode(unifiedmigrations.StorageModeUnified)
 
 	// Unified phase: Get returns the unified result.
-	// legacy.Get must NOT be called — the mock panics on any unexpected call,
-	// so this is an implicit assertion.
 	obj, err = dw.Get(context.Background(), "foo", &metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, anotherObj, obj, "Unified: result must come from unified")
-
-	ls.AssertExpectations(t)
 }
 
 func TestDualWriter_UnifiedModeSkipsLegacyMutations(t *testing.T) {
 	// Verifies that once StorageModeUnified is active, Create/Update/Delete/DeleteCollection
-	// bypass legacy storage entirely. The storageMock panics on any unexpected call, so
-	// any legacy invocation here would fail the test implicitly.
+	// bypass legacy storage entirely. The fakeStorage returns zero values by default, so
+	// any legacy invocation would return unexpected results and fail assertions.
 	gr := schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"}
 
 	reader := &mutableStatusReader{mode: unifiedmigrations.StorageModeDualWrite}
 	svc, err := ProvideService(NewFakeConfig(), NewFakeMigrator(), reader, prometheus.NewRegistry())
 	require.NoError(t, err)
 
-	ls := storageMock{&mock.Mock{}, (rest.Storage)(nil)}
-	us := storageMock{&mock.Mock{}, (rest.Storage)(nil)}
+	ls := &fakeStorage{}
+	us := &fakeStorage{}
 
 	dw, err := svc.NewStorage(gr, ls, us)
 	require.NoError(t, err)
@@ -144,38 +134,36 @@ func TestDualWriter_UnifiedModeSkipsLegacyMutations(t *testing.T) {
 	reader.setMode(unifiedmigrations.StorageModeUnified)
 
 	t.Run("Create routes only to unified", func(t *testing.T) {
-		us.On("Create", mock.Anything, exampleObj, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+		us.createReturns = append(us.createReturns, returnVal{obj: exampleObj})
 		obj, err := dw.Create(context.Background(), exampleObj, createFn, &metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, exampleObj, obj)
-		us.AssertExpectations(t)
+		require.Empty(t, ls.createCalls, "legacy Create should not have been called")
 	})
 
 	t.Run("Delete routes only to unified", func(t *testing.T) {
-		us.On("Delete", mock.Anything, "foo", mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
+		us.deleteReturns = append(us.deleteReturns, returnVal{obj: exampleObj})
 		obj, _, err := dw.Delete(context.Background(), "foo", nil, &metav1.DeleteOptions{})
 		require.NoError(t, err)
 		require.Equal(t, exampleObj, obj)
-		us.AssertExpectations(t)
+		require.Empty(t, ls.deleteCalls, "legacy Delete should not have been called")
 	})
 
 	t.Run("Update routes only to unified", func(t *testing.T) {
-		us.On("Update", mock.Anything, "foo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(exampleObj, false, nil).Once()
+		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
 		obj, _, err := dw.Update(context.Background(), "foo", updatedObjInfoObj{}, createFn, nil, false, &metav1.UpdateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, exampleObj, obj)
-		us.AssertExpectations(t)
+		require.Empty(t, ls.updateCalls, "legacy Update should not have been called")
 	})
-
-	ls.AssertExpectations(t)
 }
 
 func TestRuntime_Get(t *testing.T) {
 	t.Skip("skip until we use this for a non dashboard/folder resource")
 
 	type testCase struct {
-		setupLegacyFn  func(m *mock.Mock, name string)
-		setupStorageFn func(m *mock.Mock, name string)
+		setupLegacyFn  func(s *fakeStorage)
+		setupStorageFn func(s *fakeStorage)
 		name           string
 		wantErr        bool
 	}
@@ -183,30 +171,30 @@ func TestRuntime_Get(t *testing.T) {
 		[]testCase{
 			{
 				name: "should succeed when getting an object from both stores",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
 			},
 			{
 				name: "should return an error when getting an object in the unified store fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
 				wantErr: true,
 			},
 			{
 				name: "should succeed when getting an object in the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
+				setupLegacyFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
 				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
+				setupStorageFn: func(s *fakeStorage) {
+					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
 				},
 			},
 		}
@@ -215,17 +203,14 @@ func TestRuntime_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, name)
+				tt.setupLegacyFn(ls)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, name)
+				tt.setupStorageFn(us)
 			}
 
 			m, err := ProvideService(NewFakeConfig(), NewFakeMigrator(), NewFakeMigrationStatusReader(), prometheus.NewRegistry())
@@ -257,8 +242,8 @@ func TestRuntime_CreateWhileMigrating(t *testing.T) {
 
 	type testCase struct {
 		input          runtime.Object
-		setupLegacyFn  func(m *mock.Mock, input runtime.Object)
-		setupStorageFn func(m *mock.Mock, input runtime.Object)
+		setupLegacyFn  func(s *fakeStorage, input runtime.Object)
+		setupStorageFn func(s *fakeStorage, input runtime.Object)
 		prepare        func(dual Service) (StorageStatus, error)
 		name           string
 		wantErr        bool
@@ -268,12 +253,11 @@ func TestRuntime_CreateWhileMigrating(t *testing.T) {
 			{
 				name:  "should succeed when not migrated",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
 				prepare: func(dual Service) (StorageStatus, error) {
 					status, err := dual.Status(context.Background(), kind)
@@ -286,12 +270,11 @@ func TestRuntime_CreateWhileMigrating(t *testing.T) {
 			{
 				name:  "should succeed after migration",
 				input: exampleObj,
-				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
-				setupStorageFn: func(m *mock.Mock, _ runtime.Object) {
-					// We don't use the input here, as the input is transformed before being passed to unified storage.
-					m.On("Create", mock.Anything, exampleObjNoRV, mock.Anything, mock.Anything).Return(exampleObj, nil).Once()
+				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
+					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
 				},
 				prepare: func(dual Service) (StorageStatus, error) {
 					status, err := dual.Status(context.Background(), kind)
@@ -310,17 +293,14 @@ func TestRuntime_CreateWhileMigrating(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := (rest.Storage)(nil)
-			s := (rest.Storage)(nil)
-
-			ls := storageMock{&mock.Mock{}, l}
-			us := storageMock{&mock.Mock{}, s}
+			ls := &fakeStorage{}
+			us := &fakeStorage{}
 
 			if tt.setupLegacyFn != nil {
-				tt.setupLegacyFn(ls.Mock, tt.input)
+				tt.setupLegacyFn(ls, tt.input)
 			}
 			if tt.setupStorageFn != nil {
-				tt.setupStorageFn(us.Mock, tt.input)
+				tt.setupStorageFn(us, tt.input)
 			}
 
 			dw, err := dual.NewStorage(kind, ls, us)

--- a/pkg/storage/legacysql/dualwrite/runtime_test.go
+++ b/pkg/storage/legacysql/dualwrite/runtime_test.go
@@ -30,17 +30,17 @@ func TestRuntime_Create(t *testing.T) {
 				name:  "should succeed when creating an object in both the LegacyStorage and Storage",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 			},
 			{
 				name:  "should return an error when creating an object in the legacy store fails",
 				input: failingObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{err: errors.New("error")})
+					s.onCreate(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
@@ -96,8 +96,8 @@ func TestDualWriter_RuntimeModeSwitch(t *testing.T) {
 
 	// DualWrite phase: Get returns the legacy result.
 	// Background unified.Get may also fire.
-	ls.getReturns = append(ls.getReturns, returnVal{obj: exampleObj})
-	us.getReturns = append(us.getReturns, returnVal{obj: anotherObj})
+	ls.onGet(exampleObj, nil)
+	us.onGet(anotherObj, nil)
 
 	obj, err := dw.Get(context.Background(), "foo", &metav1.GetOptions{})
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestDualWriter_UnifiedModeSkipsLegacyMutations(t *testing.T) {
 	reader.setMode(unifiedmigrations.StorageModeUnified)
 
 	t.Run("Create routes only to unified", func(t *testing.T) {
-		us.createReturns = append(us.createReturns, returnVal{obj: exampleObj})
+		us.onCreate(exampleObj, nil)
 		obj, err := dw.Create(context.Background(), exampleObj, createFn, &metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, exampleObj, obj)
@@ -142,7 +142,7 @@ func TestDualWriter_UnifiedModeSkipsLegacyMutations(t *testing.T) {
 	})
 
 	t.Run("Delete routes only to unified", func(t *testing.T) {
-		us.deleteReturns = append(us.deleteReturns, returnVal{obj: exampleObj})
+		us.onDelete(exampleObj, nil)
 		obj, _, err := dw.Delete(context.Background(), "foo", nil, &metav1.DeleteOptions{})
 		require.NoError(t, err)
 		require.Equal(t, exampleObj, obj)
@@ -150,7 +150,7 @@ func TestDualWriter_UnifiedModeSkipsLegacyMutations(t *testing.T) {
 	})
 
 	t.Run("Update routes only to unified", func(t *testing.T) {
-		us.updateReturns = append(us.updateReturns, returnVal{obj: exampleObj})
+		us.onUpdate(exampleObj, nil)
 		obj, _, err := dw.Update(context.Background(), "foo", updatedObjInfoObj{}, createFn, nil, false, &metav1.UpdateOptions{})
 		require.NoError(t, err)
 		require.Equal(t, exampleObj, obj)
@@ -172,29 +172,29 @@ func TestRuntime_Get(t *testing.T) {
 			{
 				name: "should succeed when getting an object from both stores",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 			},
 			{
 				name: "should return an error when getting an object in the unified store fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},
 			{
 				name: "should succeed when getting an object in the LegacyStorage fails",
 				setupLegacyFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{err: errors.New("error")})
+					s.onGet(nil, errors.New("error"))
 				},
 				setupStorageFn: func(s *fakeStorage) {
-					s.getReturns = append(s.getReturns, returnVal{obj: exampleObj})
+					s.onGet(exampleObj, nil)
 				},
 			},
 		}
@@ -254,10 +254,10 @@ func TestRuntime_CreateWhileMigrating(t *testing.T) {
 				name:  "should succeed when not migrated",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				prepare: func(dual Service) (StorageStatus, error) {
 					status, err := dual.Status(context.Background(), kind)
@@ -271,10 +271,10 @@ func TestRuntime_CreateWhileMigrating(t *testing.T) {
 				name:  "should succeed after migration",
 				input: exampleObj,
 				setupLegacyFn: func(s *fakeStorage, input runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				setupStorageFn: func(s *fakeStorage, _ runtime.Object) {
-					s.createReturns = append(s.createReturns, returnVal{obj: exampleObj})
+					s.onCreate(exampleObj, nil)
 				},
 				prepare: func(dual Service) (StorageStatus, error) {
 					status, err := dual.Status(context.Background(), kind)

--- a/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
+++ b/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
@@ -83,6 +83,26 @@ type fakeStorage struct {
 	deleteCollectionCalls   []callRecord
 }
 
+// Helper methods to configure return values. Each pushes onto the method's return queue.
+func (f *fakeStorage) onCreate(obj runtime.Object, err error) {
+	f.createReturns = append(f.createReturns, returnVal{obj: obj, err: err})
+}
+func (f *fakeStorage) onGet(obj runtime.Object, err error) {
+	f.getReturns = append(f.getReturns, returnVal{obj: obj, err: err})
+}
+func (f *fakeStorage) onList(obj runtime.Object, err error) {
+	f.listReturns = append(f.listReturns, returnVal{obj: obj, err: err})
+}
+func (f *fakeStorage) onUpdate(obj runtime.Object, err error) {
+	f.updateReturns = append(f.updateReturns, returnVal{obj: obj, err: err})
+}
+func (f *fakeStorage) onDelete(obj runtime.Object, err error) {
+	f.deleteReturns = append(f.deleteReturns, returnVal{obj: obj, err: err})
+}
+func (f *fakeStorage) onDeleteCollection(obj runtime.Object, err error) {
+	f.deleteCollectionReturns = append(f.deleteCollectionReturns, returnVal{obj: obj, err: err})
+}
+
 // pop removes and returns the first element of the slice if there are more than one;
 // otherwise it returns the single remaining element (keeping it for future calls).
 // It panics if the slice is empty, which signals a test misconfiguration.

--- a/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
+++ b/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/stretchr/testify/mock"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,98 +41,176 @@ func newStorage(gr schema.GroupResource, mode grafanarest.DualWriterMode, legacy
 	return ProvideServiceForTests(cfg).NewStorage(gr, legacy, unified)
 }
 
-type storageMock struct {
-	*mock.Mock
-	grafanarest.Storage
+// returnVal holds a single return value set for a fakeStorage method.
+type returnVal struct {
+	obj  runtime.Object
+	obj2 bool // second return for Delete/Update
+	err  error
 }
 
-// Unified Store
-func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+// callRecord holds the arguments from a single method call.
+type callRecord struct {
+	args []any
+}
+
+// fakeStorage is a hand-written test fake implementing grafanarest.Storage methods.
+// Tests configure it by appending to the *Returns slices. Each method pops the first
+// element from its return queue; if only one element remains it is reused for all
+// subsequent calls (matching the behavior of mock.Return without .Once).
+type fakeStorage struct {
+	grafanarest.Storage // embedded for unimplemented methods
+
+	mu sync.Mutex
+
+	createReturns []returnVal
+	createCalls   []callRecord
+
+	getReturns []returnVal
+	getCalls   []callRecord
+	blockGet   bool // if true, Get blocks until ctx is canceled
+
+	listReturns []returnVal
+	listCalls   []callRecord
+	blockList   bool // if true, List blocks until ctx is canceled
+
+	updateReturns []returnVal
+	updateCalls   []callRecord
+
+	deleteReturns []returnVal
+	deleteCalls   []callRecord
+
+	deleteCollectionReturns []returnVal
+	deleteCollectionCalls   []callRecord
+}
+
+// pop removes and returns the first element of the slice if there are more than one;
+// otherwise it returns the single remaining element (keeping it for future calls).
+// It panics if the slice is empty, which signals a test misconfiguration.
+func pop(returns *[]returnVal) returnVal {
+	if len(*returns) == 0 {
+		panic("fakeStorage: no return values configured")
+	}
+	v := (*returns)[0]
+	if len(*returns) > 1 {
+		*returns = (*returns)[1:]
+	}
+	return v
+}
+
+func (f *fakeStorage) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	select {
 	case <-ctx.Done():
 		return nil, errors.New("context canceled")
 	default:
 	}
 
-	args := m.Called(ctx, name, options)
-	if err := args.Get(1); err != nil {
-		return nil, err.(error)
+	if f.blockGet {
+		<-ctx.Done()
+		return nil, errors.New("context canceled")
 	}
-	return args.Get(0).(runtime.Object), args.Error(1)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getCalls = append(f.getCalls, callRecord{args: []any{ctx, name, options}})
+	r := pop(&f.getReturns)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.obj, nil
 }
 
-func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+func (f *fakeStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	select {
 	case <-ctx.Done():
 		return nil, errors.New("context canceled")
 	default:
 	}
 
-	args := m.Called(ctx, obj, createValidation, options)
-	if err := args.Get(1); err != nil {
-		return nil, err.(error)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createCalls = append(f.createCalls, callRecord{args: []any{ctx, obj, createValidation, options}})
+	r := pop(&f.createReturns)
+	if r.err != nil {
+		return nil, r.err
 	}
-	return args.Get(0).(runtime.Object), args.Error(1)
+	return r.obj, nil
 }
 
-func (m storageMock) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+func (f *fakeStorage) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
 	select {
 	case <-ctx.Done():
 		return nil, errors.New("context canceled")
 	default:
 	}
 
-	args := m.Called(ctx, options)
-	if err := args.Get(1); err != nil {
-		return nil, err.(error)
+	if f.blockList {
+		<-ctx.Done()
+		return nil, errors.New("context canceled")
 	}
-	return args.Get(0).(runtime.Object), args.Error(1)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls = append(f.listCalls, callRecord{args: []any{ctx, options}})
+	r := pop(&f.listReturns)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.obj, nil
 }
 
-func (m storageMock) NewList() runtime.Object {
+func (f *fakeStorage) NewList() runtime.Object {
 	return nil
 }
 
-func (m storageMock) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+func (f *fakeStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	select {
 	case <-ctx.Done():
 		return nil, false, errors.New("context canceled")
 	default:
 	}
 
-	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-	if err := args.Get(2); err != nil {
-		return nil, false, err.(error)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updateCalls = append(f.updateCalls, callRecord{args: []any{ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options}})
+	r := pop(&f.updateReturns)
+	if r.err != nil {
+		return nil, false, r.err
 	}
-	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
+	return r.obj, r.obj2, nil
 }
 
-func (m storageMock) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+func (f *fakeStorage) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	select {
 	case <-ctx.Done():
 		return nil, false, errors.New("context canceled")
 	default:
 	}
 
-	args := m.Called(ctx, name, deleteValidation, options)
-	if err := args.Get(2); err != nil {
-		return nil, false, err.(error)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteCalls = append(f.deleteCalls, callRecord{args: []any{ctx, name, deleteValidation, options}})
+	r := pop(&f.deleteReturns)
+	if r.err != nil {
+		return nil, false, r.err
 	}
-	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
+	return r.obj, r.obj2, nil
 }
 
-func (m storageMock) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+func (f *fakeStorage) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
 	select {
 	case <-ctx.Done():
 		return nil, errors.New("context canceled")
 	default:
 	}
 
-	args := m.Called(ctx, deleteValidation, options, listOptions)
-	if err := args.Get(1); err != nil {
-		return nil, err.(error)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteCollectionCalls = append(f.deleteCollectionCalls, callRecord{args: []any{ctx, deleteValidation, options, listOptions}})
+	r := pop(&f.deleteCollectionReturns)
+	if r.err != nil {
+		return nil, r.err
 	}
-	return args.Get(0).(runtime.Object), args.Error(1)
+	return r.obj, nil
 }
 
 type updatedObjInfoObj struct{}


### PR DESCRIPTION
## Summary
- Replace `testify/mock`-based `storageMock` in dualwrite tests with a hand-written `fakeStorage` struct
- The fake uses per-method return queues (`createReturns`, `getReturns`, etc.) and call records (`createCalls`, `getCalls`, etc.) instead of `mock.On()`/`mock.Called()`
- `blockGet`/`blockList` fields replace `WaitUntil(time.After(time.Hour))` for testing timeout behavior
- `AssertNotCalled`/`AssertCalled` replaced with `require.Empty`/`require.NotEmpty` on call slices
- Direct `.Calls[0].Arguments[N]` access replaced with `.updateCalls[0].args[N]`
- Converted new runtime mode-switch tests from #121987 to use `fakeStorage` as well

## Test plan
- [x] All 144 tests in `pkg/storage/legacysql/dualwrite/` pass (`go test ./pkg/storage/legacysql/dualwrite/ -count=1`)