### PR TITLE
Provisioning: metric registration should happen once

### DIFF
--- a/apps/provisioning/pkg/connection/metrics.go
+++ b/apps/provisioning/pkg/connection/metrics.go
@@ -1,6 +1,8 @@
 package connection
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -10,40 +12,48 @@ type DecryptMetrics struct {
 	decryptedDuration     *prometheus.HistogramVec
 }
 
+var (
+	decryptMetricsOnce sync.Once
+	decryptMetrics     *DecryptMetrics
+)
+
 func RegisterDecryptMetrics(reg prometheus.Registerer) *DecryptMetrics {
-	secretsDecryptedTotal := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "grafana_provisioning_connection_secret_decrypted_total",
-			Help: "Total number of connection secrets decrypted successfully",
-		},
-		[]string{"secret_type"},
-	)
-	reg.MustRegister(secretsDecryptedTotal)
+	decryptMetricsOnce.Do(func() {
+		secretsDecryptedTotal := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_connection_secret_decrypted_total",
+				Help: "Total number of connection secrets decrypted successfully",
+			},
+			[]string{"secret_type"},
+		)
+		reg.MustRegister(secretsDecryptedTotal)
 
-	decryptErrorsTotal := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "grafana_provisioning_connection_secret_decrypt_errors_total",
-			Help: "Total number of connection secret decrypt errors",
-		},
-		[]string{"secret_type"},
-	)
-	reg.MustRegister(decryptErrorsTotal)
+		decryptErrorsTotal := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_connection_secret_decrypt_errors_total",
+				Help: "Total number of connection secret decrypt errors",
+			},
+			[]string{"secret_type"},
+		)
+		reg.MustRegister(decryptErrorsTotal)
 
-	decryptedDuration := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "grafana_provisioning_connection_secret_decrypted_duration_seconds",
-			Help:    "Duration of connection secret decrypt operations",
-			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0},
-		},
-		[]string{"secret_type"},
-	)
-	reg.MustRegister(decryptedDuration)
+		decryptedDuration := prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "grafana_provisioning_connection_secret_decrypted_duration_seconds",
+				Help:    "Duration of connection secret decrypt operations",
+				Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0},
+			},
+			[]string{"secret_type"},
+		)
+		reg.MustRegister(decryptedDuration)
 
-	return &DecryptMetrics{
-		secretsDecryptedTotal: secretsDecryptedTotal,
-		decryptErrorsTotal:    decryptErrorsTotal,
-		decryptedDuration:     decryptedDuration,
-	}
+		decryptMetrics = &DecryptMetrics{
+			secretsDecryptedTotal: secretsDecryptedTotal,
+			decryptErrorsTotal:    decryptErrorsTotal,
+			decryptedDuration:     decryptedDuration,
+		}
+	})
+	return decryptMetrics
 }
 
 func (m *DecryptMetrics) recordSuccess(st secretTypeLabel, seconds float64) {

--- a/apps/provisioning/pkg/connection/metrics_test.go
+++ b/apps/provisioning/pkg/connection/metrics_test.go
@@ -1,0 +1,55 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Shared registry for all tests to work with sync.Once singleton pattern
+var testRegistry = prometheus.NewRegistry()
+var testDecryptMetrics = RegisterDecryptMetrics(testRegistry)
+
+func TestRegisterDecryptMetrics(t *testing.T) {
+	t.Run("does not panic on pedantic registry", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			RegisterDecryptMetrics(prometheus.NewPedanticRegistry())
+		})
+	})
+
+	t.Run("double registration is safe with sync.Once", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			RegisterDecryptMetrics(testRegistry)
+		})
+	})
+
+	t.Run("returns same instance on repeated calls", func(t *testing.T) {
+		first := RegisterDecryptMetrics(testRegistry)
+		second := RegisterDecryptMetrics(testRegistry)
+		assert.Same(t, first, second, "repeated calls should return the same singleton")
+	})
+
+	t.Run("metrics are functional after registration", func(t *testing.T) {
+		m := testDecryptMetrics
+		require.NotNil(t, m)
+
+		m.recordSuccess(secretTypeToken, 0.5)
+		m.recordError(secretTypeToken)
+
+		families, err := testRegistry.Gather()
+		require.NoError(t, err)
+
+		var found int
+		for _, f := range families {
+			switch f.GetName() {
+			case "grafana_provisioning_connection_secret_decrypted_total",
+				"grafana_provisioning_connection_secret_decrypt_errors_total",
+				"grafana_provisioning_connection_secret_decrypted_duration_seconds":
+				found++
+			}
+		}
+		assert.Equal(t, 3, found, "all three connection decrypt metrics should be registered")
+	})
+}

--- a/apps/provisioning/pkg/repository/metrics.go
+++ b/apps/provisioning/pkg/repository/metrics.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -10,40 +12,48 @@ type DecryptMetrics struct {
 	decryptedDuration     *prometheus.HistogramVec
 }
 
+var (
+	decryptMetricsOnce sync.Once
+	decryptMetrics     *DecryptMetrics
+)
+
 func RegisterDecryptMetrics(reg prometheus.Registerer) *DecryptMetrics {
-	secretsDecryptedTotal := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "grafana_provisioning_repository_secret_decrypted_total",
-			Help: "Total number of repository secrets decrypted successfully",
-		},
-		[]string{"secret_type"},
-	)
-	reg.MustRegister(secretsDecryptedTotal)
+	decryptMetricsOnce.Do(func() {
+		secretsDecryptedTotal := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_repository_secret_decrypted_total",
+				Help: "Total number of repository secrets decrypted successfully",
+			},
+			[]string{"secret_type"},
+		)
+		reg.MustRegister(secretsDecryptedTotal)
 
-	decryptErrorsTotal := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "grafana_provisioning_repository_secret_decrypt_errors_total",
-			Help: "Total number of repository secret decrypt errors",
-		},
-		[]string{"secret_type"},
-	)
-	reg.MustRegister(decryptErrorsTotal)
+		decryptErrorsTotal := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_repository_secret_decrypt_errors_total",
+				Help: "Total number of repository secret decrypt errors",
+			},
+			[]string{"secret_type"},
+		)
+		reg.MustRegister(decryptErrorsTotal)
 
-	decryptedDuration := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "grafana_provisioning_repository_secret_decrypted_duration_seconds",
-			Help:    "Duration of repository secret decrypt operations",
-			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0},
-		},
-		[]string{"secret_type"},
-	)
-	reg.MustRegister(decryptedDuration)
+		decryptedDuration := prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "grafana_provisioning_repository_secret_decrypted_duration_seconds",
+				Help:    "Duration of repository secret decrypt operations",
+				Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0},
+			},
+			[]string{"secret_type"},
+		)
+		reg.MustRegister(decryptedDuration)
 
-	return &DecryptMetrics{
-		secretsDecryptedTotal: secretsDecryptedTotal,
-		decryptErrorsTotal:    decryptErrorsTotal,
-		decryptedDuration:     decryptedDuration,
-	}
+		decryptMetrics = &DecryptMetrics{
+			secretsDecryptedTotal: secretsDecryptedTotal,
+			decryptErrorsTotal:    decryptErrorsTotal,
+			decryptedDuration:     decryptedDuration,
+		}
+	})
+	return decryptMetrics
 }
 
 func (m *DecryptMetrics) recordSuccess(st secretTypeLabel, seconds float64) {

--- a/apps/provisioning/pkg/repository/metrics_test.go
+++ b/apps/provisioning/pkg/repository/metrics_test.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Shared registry for all tests to work with sync.Once singleton pattern
+var testRegistry = prometheus.NewRegistry()
+var testDecryptMetrics = RegisterDecryptMetrics(testRegistry)
+
+func TestRegisterDecryptMetrics(t *testing.T) {
+	t.Run("does not panic on pedantic registry", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			RegisterDecryptMetrics(prometheus.NewPedanticRegistry())
+		})
+	})
+
+	t.Run("double registration is safe with sync.Once", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			RegisterDecryptMetrics(testRegistry)
+		})
+	})
+
+	t.Run("returns same instance on repeated calls", func(t *testing.T) {
+		first := RegisterDecryptMetrics(testRegistry)
+		second := RegisterDecryptMetrics(testRegistry)
+		assert.Same(t, first, second, "repeated calls should return the same singleton")
+	})
+
+	t.Run("metrics are functional after registration", func(t *testing.T) {
+		m := testDecryptMetrics
+		require.NotNil(t, m)
+
+		m.recordSuccess(secretTypeToken, 0.5)
+		m.recordError(secretTypeToken)
+
+		families, err := testRegistry.Gather()
+		require.NoError(t, err)
+
+		var found int
+		for _, f := range families {
+			switch f.GetName() {
+			case "grafana_provisioning_repository_secret_decrypted_total",
+				"grafana_provisioning_repository_secret_decrypt_errors_total",
+				"grafana_provisioning_repository_secret_decrypted_duration_seconds":
+				found++
+			}
+		}
+		assert.Equal(t, 3, found, "all three repository decrypt metrics should be registered")
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ensure metric registration happens only once. Registering the same metric several times result in a panic.

**Why do we need this feature?**

As we deploy several provisioning API versions in HG, the init process will run and try to register the same metric twice, causing a panic that would prevent the API server to start. By ensuring the registration happens only once, we protect against this scenario.

**Who is this feature for?**

Provisioning feature.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/1034

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
