### PR TITLE
fix: ignore patch workflow

### DIFF
--- a/.github/workflows/policybot.yml
+++ b/.github/workflows/policybot.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - run: make check-policy.yml
+      - run: make .policy.yml
+      - run: git diff --exit-code
       - name: Check valid against API
         run: curl --silent --fail-with-body -XPUT --upload-file .policy.yml https://github-policy-bot.grafana-ops.net/api/validate

--- a/.policy.yml
+++ b/.policy.yml
@@ -14,7 +14,6 @@ policy:
             - Workflow .github/workflows/build-go-matrix.yml succeeded or skipped
             - Workflow .github/workflows/check-frontend-test-coverage.yml succeeded or skipped
             - Workflow .github/workflows/codeowners-validator.yml succeeded or skipped
-            - Workflow .github/workflows/create-security-patch-from-security-mirror.yml succeeded or skipped
             - Workflow .github/workflows/deploy-pr-preview.yml succeeded or skipped
             - Workflow .github/workflows/deploy-storybook-preview.yml succeeded or skipped
             - Workflow .github/workflows/detect-breaking-changes-levitate.yml succeeded or skipped

--- a/Makefile
+++ b/Makefile
@@ -772,27 +772,17 @@ check-licenses:
 	license_finder --decisions-file .github/license_finder.yaml
 
 GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1f3fd9fd9d68eb06f1e7b0393d # v0.2.0
-define generate-policy-yml
+.PHONY: .policy.yml
+.policy.yml:
 	docker run -u "$(shell id -u):$(shell id -g)" \
 	--quiet \
 	--rm \
 	--volume "$(shell git rev-parse --show-toplevel)":/work \
 	--workdir /work \
 	ghcr.io/grafana/generate-policy-bot-config@${GENERATE_POLICY_BOT_CONFIG_SHA} \
-		--output $(1) \
+		--output .policy.yml \
 		--log-level=debug \
 		--merge-with=.policy.yml.tmpl \
 		.
-endef
-
-.PHONY: .policy.yml
-.policy.yml:
-	@$(call generate-policy-yml,$@)
-
-check-policy.yml:
-	# We redirect stderr to stdout because the tool logs to stderr using proper
-	# Actions log levels (to avoid interfering with `diff`), but those log
-	# commands only work on stdout.
-	@bash -c 'diff -u .policy.yml <($(call generate-policy-yml,-))' 2>&1 && \
-		( echo "No drift detected: .policy.yml is up-to-date." >&2; exit 0 ) || \
-		( echo "Drift detected: .policy.yml is out-of-date. Run \`make .policy.yml\` to update it, and then commit the result." >&2; exit 1 )
+# We don't want the patch workflow to be run. This is exclusively useful for the security-mirror. It won't work in OSS.
+	sed -i '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml

--- a/Makefile
+++ b/Makefile
@@ -785,4 +785,4 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 		--merge-with=.policy.yml.tmpl \
 		.
 # We don't want the patch workflow to be run. This is exclusively useful for the security-mirror. It won't work in OSS.
-	sed -i '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml
+	sed -i.bak '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml; rm -f .policy.yml.bak


### PR DESCRIPTION
The patch workflow is invalid in OSS, as we use a public repository. It is only useful for the security mirror repository.