### PR TITLE
sqlstore: use '%w' instead of '%s' for create admin user error

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -213,7 +213,7 @@ func (ss *SQLStore) ensureMainOrgAndAdminUser(test bool) error {
 				Password: user.Password(ss.cfg.AdminPassword),
 				IsAdmin:  true,
 			}); err != nil {
-				return fmt.Errorf("failed to create admin user: %s", err)
+				return fmt.Errorf("failed to create admin user: %w", err)
 			}
 
 			ss.log.Info("Created default admin", "user", ss.cfg.AdminUser)


### PR DESCRIPTION
This was causing errors creating the admin user to not be retried because the retry logic is using `errors.Is(...)`.