### PR TITLE
annotations: fix sql adapter type filtering

### DIFF
--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -49,7 +49,7 @@ func (a *sqlAdapter) Get(ctx context.Context, namespace, name string) (*annotati
 		SignedInUser: user,
 		OrgID:        orgID,
 		Limit:        1000,
-		AlertID:      -1,
+		Type:         "annotation",
 	}
 
 	items, err := a.repo.Find(ctx, query)
@@ -99,7 +99,7 @@ func (a *sqlAdapter) List(ctx context.Context, namespace string, opts ListOption
 		To:           opts.To,
 		Limit:        queryLimit,
 		Offset:       offset,
-		AlertID:      -1,
+		Type:         "annotation",
 		// CreatedBy holds the uid of the user to filter by. The SQL layer resolves
 		// this to a numeric user_id via subquery.
 		UserUID:  opts.CreatedBy,

--- a/pkg/registry/apps/annotation/sql_adapter_test.go
+++ b/pkg/registry/apps/annotation/sql_adapter_test.go
@@ -31,7 +31,8 @@ func TestMain(m *testing.M) {
 
 // fakeRepo implements annotations.Repository for testing.
 type fakeRepo struct {
-	items []*annotations.ItemDTO
+	items     []*annotations.ItemDTO
+	lastQuery *annotations.ItemQuery
 }
 
 func newFakeRepo() *fakeRepo {
@@ -45,6 +46,7 @@ func (f *fakeRepo) addItem(item *annotations.ItemDTO) {
 }
 
 func (f *fakeRepo) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+	f.lastQuery = query
 	start := int(query.Offset)
 	end := start + int(query.Limit)
 
@@ -81,6 +83,31 @@ func (f *fakeRepo) Delete(ctx context.Context, params *annotations.DeleteParams)
 
 func (f *fakeRepo) FindTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	return annotations.FindTagsResult{}, nil
+}
+
+func TestSQLAdapter_QueriesExcludeAlertAnnotations(t *testing.T) {
+	repo := newFakeRepo()
+	repo.addItem(&annotations.ItemDTO{ID: 1, Text: "test"})
+	adapter := NewSQLAdapter(repo, nil, annotations.CleanupSettings{})
+
+	ctx := identity.WithRequester(t.Context(), &identity.StaticRequester{
+		OrgID: 1,
+	})
+
+	t.Run("List sets Type to annotation", func(t *testing.T) {
+		_, err := adapter.List(ctx, "default", ListOptions{Limit: 10})
+		require.NoError(t, err)
+		require.NotNil(t, repo.lastQuery)
+		assert.Equal(t, "annotation", repo.lastQuery.Type)
+		assert.Zero(t, repo.lastQuery.AlertID)
+	})
+
+	t.Run("Get sets Type to annotation", func(t *testing.T) {
+		_, _ = adapter.Get(ctx, "default", "a-1")
+		require.NotNil(t, repo.lastQuery)
+		assert.Equal(t, "annotation", repo.lastQuery.Type)
+		assert.Zero(t, repo.lastQuery.AlertID)
+	})
 }
 
 func TestSQLAdapter_ListPagination(t *testing.T) {


### PR DESCRIPTION
The sql adapter implementation of the annotation store (which sits atop existing sql storage) currently uses `AlertID: -1` to exclude alert annotations. This works for the xorm store because it will filter out alerting annotations [here](https://github.com/grafana/grafana/blob/b6015acfb098192bdadfd43bd84b4ebf059e99eb/pkg/services/annotations/annotationsimpl/xorm_store.go#L328-L329), but does not work when using the CompositeStore because the loki historian will try to lookup any non-zero alert IDs [here](https://github.com/grafana/grafana/blob/6f3c0959ed8ae878f0a169d77a1b898c9c45bfc5/pkg/services/annotations/annotationsimpl/loki/historian_store.go#L98-L107) and will return a "not found" error.

This PR modifies the sql adapter approach for filtering out alert annotations to instead use `Type: "annotation"`, which both store implementations support for filtering based on annotation type:

xorm store (adds SQL to filter out alerting annotations):
https://github.com/grafana/grafana/blob/965726050ca83aaef9346480589d047f2603289b/pkg/services/annotations/annotationsimpl/xorm_store.go#L370-L371

loki historian (returns empty array since it only stores alerting annotations):
https://github.com/grafana/grafana/blob/965726050ca83aaef9346480589d047f2603289b/pkg/services/annotations/annotationsimpl/loki/historian_store.go#L84-L86
