### PR TITLE
Dashboards: remove dashboardAdHocAndGroupByWrapper (be)

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -589,11 +589,6 @@ export interface FeatureToggles {
   */
   newDashboardWithFiltersAndGroupBy?: boolean;
   /**
-  * Wraps the ad hoc and group by variables in a single wrapper, with all other variables below it
-  * @default false
-  */
-  dashboardAdHocAndGroupByWrapper?: boolean;
-  /**
   * Renders ad hoc filters and group by in a single unified control
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -992,15 +992,6 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:         "dashboardAdHocAndGroupByWrapper",
-			Description:  "Wraps the ad hoc and group by variables in a single wrapper, with all other variables below it",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaDashboardsSquad,
-			HideFromDocs: true,
-			Expression:   "false",
-			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:         "dashboardUnifiedDrilldownControls",
 			Description:  "Renders ad hoc filters and group by in a single unified control",
 			Stage:        FeatureStagePrivatePreview,

--- a/pkg/services/featuremgmt/toggles-gitlog.csv
+++ b/pkg/services/featuremgmt/toggles-gitlog.csv
@@ -603,7 +603,6 @@ elasticsearchRawDSLQuery,2025-12-15T19:11:05Z,,956ab0514812531b3623053bbe9253998
 pluginInsights,2025-12-16T10:20:18Z,2025-12-18T17:11:33Z,1f4f2b4d7c6af8fb32fbba448a95d85e8886d632,Yulia Shanyrova
 drilldownRecommendations,2025-12-17T12:52:59Z,,a1a665e26b8200021bdfd12bd1917439cb5456bd,Victor Marin
 fetchRulesInCompactMode,2025-12-18T09:06:39Z,,5e3a1091b351a63d2b4339f621c2f69e4a0f3336,Alexander Akhmetov
-dashboardAdHocAndGroupByWrapper,2025-12-18T18:58:21Z,,05fd304dbd2be526ac96c29349f361d600144d29,Haris Rozajac
 heatmapRowsAxisOptions,2025-12-18T22:45:00Z,,72e1f1e5461cdde23a888aea9d101702bfcb701a,Leon Sorokin
 alertingSavedSearches,2025-12-19T14:32:27Z,,62b2a202de1463cdfd3be0755b2805266d3b046a,Deyan Halachliyski
 auditLoggingAppPlatform,2025-12-29T15:28:29Z,,e088c9aac9884f0820ad261fdb4c670f8829c7ed,Matheus Macabu

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -114,7 +114,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-03-25,oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
 2025-11-19,refreshTokenRequired,experimental,@grafana/identity-access-team,false,false,false
 2024-04-04,newDashboardWithFiltersAndGroupBy,experimental,@grafana/dashboards-squad,false,false,false
-2025-12-18,dashboardAdHocAndGroupByWrapper,experimental,@grafana/dashboards-squad,false,false,false
 2026-03-09,dashboardUnifiedDrilldownControls,privatePreview,@grafana/dashboards-squad,false,false,true
 2026-03-02,adHocFilterDefaultValues,experimental,@grafana/dashboards-squad,false,false,true
 2024-04-05,cloudWatchNewLabelParsing,GA,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -327,10 +327,6 @@ const (
 	// Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.
 	FlagNewDashboardWithFiltersAndGroupBy = "newDashboardWithFiltersAndGroupBy"
 
-	// FlagDashboardAdHocAndGroupByWrapper
-	// Wraps the ad hoc and group by variables in a single wrapper, with all other variables below it
-	FlagDashboardAdHocAndGroupByWrapper = "dashboardAdHocAndGroupByWrapper"
-
 	// FlagCloudWatchNewLabelParsing
 	// Updates CloudWatch label parsing to be more accurate
 	FlagCloudWatchNewLabelParsing = "cloudWatchNewLabelParsing"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1417,20 +1417,6 @@
     },
     {
       "metadata": {
-        "name": "dashboardAdHocAndGroupByWrapper",
-        "resourceVersion": "1771434338561",
-        "creationTimestamp": "2025-12-18T18:58:21Z"
-      },
-      "spec": {
-        "description": "Wraps the ad hoc and group by variables in a single wrapper, with all other variables below it",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromDocs": true,
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
         "name": "dashboardAssistantPopover",
         "resourceVersion": "1773181791824",
         "creationTimestamp": "2026-03-10T22:29:51Z"


### PR DESCRIPTION
What is this feature?

delete `dashboardAdHocAndGroupByWrapper` feature toggle

depends on https://github.com/grafana/grafana/pull/122031