### PR TITLE
Replace testify/mock with hand-written fakes in storewrapper tests

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -6,47 +6,48 @@ import (
 
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8srest "k8s.io/apiserver/pkg/registry/rest"
 )
 
 type testSetup struct {
-	mockStore *rest.MockStorage
-	mockAuth  *FakeAuthorizer
-	wrapper   *Wrapper
-	ctx       context.Context
+	store   *fakeStore
+	auth    *fakeAuthorizer
+	wrapper *Wrapper
+	ctx     context.Context
 }
 
 func newTestSetup(t *testing.T) *testSetup {
-	mockStore := rest.NewMockStorage(t)
-	mockAuth := &FakeAuthorizer{}
-	wrapper := New(mockStore, mockAuth)
+	t.Helper()
+	store := &fakeStore{}
+	auth := &fakeAuthorizer{}
+	wrapper := New(store, auth)
 
 	ctx := identity.WithRequester(
 		context.Background(),
 		&identity.StaticRequester{UserUID: "u001", Type: types.TypeUser},
 	)
 
-	return &testSetup{mockStore: mockStore, mockAuth: mockAuth, wrapper: wrapper, ctx: ctx}
+	return &testSetup{store: store, auth: auth, wrapper: wrapper, ctx: ctx}
 }
 
 func newTestSetupWithPreserveIdentity(t *testing.T) *testSetup {
-	mockStore := rest.NewMockStorage(t)
-	mockAuth := &FakeAuthorizer{}
-	wrapper := New(mockStore, mockAuth, WithPreserveIdentity())
+	t.Helper()
+	store := &fakeStore{}
+	auth := &fakeAuthorizer{}
+	wrapper := New(store, auth, WithPreserveIdentity())
 
 	ctx := identity.WithRequester(
 		context.Background(),
 		&identity.StaticRequester{UserUID: "u001", Type: types.TypeUser},
 	)
 
-	return &testSetup{mockStore: mockStore, mockAuth: mockAuth, wrapper: wrapper, ctx: ctx}
+	return &testSetup{store: store, auth: auth, wrapper: wrapper, ctx: ctx}
 }
 
 func matchesOriginalUser() func(context.Context) bool {
@@ -67,42 +68,42 @@ func TestWrapper_Create(t *testing.T) {
 		setup := newTestSetup(t)
 
 		obj := &fakeObject{}
-		createOpts := &metaV1.CreateOptions{}
 		expectedObj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "created"}}
 
-		// Verify original user identity is used for authorization
-		setup.mockAuth.On("BeforeCreate", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
+		setup.store.createObj = expectedObj
 
-		// Verify service identity is used to call the underlying store
-		setup.mockStore.On("Create", mock.MatchedBy(matchesServiceIdentity()), obj, mock.Anything, createOpts).Return(expectedObj, nil)
-
-		result, err := setup.wrapper.Create(setup.ctx, obj, nil, createOpts)
+		result, err := setup.wrapper.Create(setup.ctx, obj, nil, &metaV1.CreateOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedObj, result)
 
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		// Verify original user identity was used for authorization
+		require.True(t, setup.auth.beforeCreateCalled)
+		require.True(t, matchesOriginalUser()(setup.auth.beforeCreateCtx))
+
+		// Verify service identity was used for the underlying store call
+		require.True(t, setup.store.createCalled)
+		require.True(t, matchesServiceIdentity()(setup.store.createCtx))
 	})
 	t.Run("unauthorized", func(t *testing.T) {
 		setup := newTestSetup(t)
 
 		obj := &fakeObject{}
-		createOpts := &metaV1.CreateOptions{}
 
-		// Simulate unauthorized error from authorizer
-		setup.mockAuth.On("BeforeCreate", mock.MatchedBy(matchesOriginalUser()), obj).Return(ErrUnauthorized)
+		setup.auth.beforeCreateErr = ErrUnauthorized
 
-		result, err := setup.wrapper.Create(setup.ctx, obj, nil, createOpts)
+		result, err := setup.wrapper.Create(setup.ctx, obj, nil, &metaV1.CreateOptions{})
 
 		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Equal(t, ErrUnauthorized, err)
 
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertNotCalled(t, "Create")
+		// Verify authorization was called with original user
+		require.True(t, setup.auth.beforeCreateCalled)
+		require.True(t, matchesOriginalUser()(setup.auth.beforeCreateCtx))
+
+		// Verify store was NOT called
+		assert.False(t, setup.store.createCalled)
 	})
 }
 
@@ -114,14 +115,11 @@ func TestWrapper_Delete(t *testing.T) {
 		deleteOpts := &metaV1.DeleteOptions{Preconditions: &metaV1.Preconditions{ResourceVersion: &version}}
 		expectedObj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "deleted"}}
 
-		// Mock Get to fetch the object before deletion
-		setup.mockStore.On("Get", mock.MatchedBy(matchesServiceIdentity()), "to-delete", mock.Anything).Return(obj, nil)
-
-		// Verify original user identity is used for authorization
-		setup.mockAuth.On("BeforeDelete", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
-
-		// Verify service identity is used to call the underlying store
-		setup.mockStore.On("Delete", mock.MatchedBy(matchesServiceIdentity()), "to-delete", mock.Anything, deleteOpts).Return(expectedObj, true, nil)
+		// Get returns the object before deletion
+		setup.store.getObj = obj
+		// Delete returns the expected object
+		setup.store.deleteObj = expectedObj
+		setup.store.deleteDeleted = true
 
 		result, deleted, err := setup.wrapper.Delete(setup.ctx, "to-delete", nil, deleteOpts)
 
@@ -129,9 +127,15 @@ func TestWrapper_Delete(t *testing.T) {
 		assert.Equal(t, expectedObj, result)
 		assert.True(t, deleted)
 
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		// Verify original user identity was used for authorization
+		require.True(t, setup.auth.beforeDeleteCalled)
+		require.True(t, matchesOriginalUser()(setup.auth.beforeDeleteCtx))
+
+		// Verify service identity was used for store calls
+		require.True(t, setup.store.getCalled)
+		require.True(t, matchesServiceIdentity()(setup.store.getCtx))
+		require.True(t, setup.store.deleteCalled)
+		require.True(t, matchesServiceIdentity()(setup.store.deleteCtx))
 	})
 	t.Run("unauthorized", func(t *testing.T) {
 		setup := newTestSetup(t)
@@ -139,11 +143,10 @@ func TestWrapper_Delete(t *testing.T) {
 		obj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "to-delete"}}
 		deleteOpts := &metaV1.DeleteOptions{Preconditions: &metaV1.Preconditions{ResourceVersion: &version}}
 
-		// Mock Get to fetch the object before deletion
-		setup.mockStore.On("Get", mock.MatchedBy(matchesServiceIdentity()), "to-delete", mock.Anything).Return(obj, nil)
-
-		// Simulate unauthorized error from authorizer
-		setup.mockAuth.On("BeforeDelete", mock.MatchedBy(matchesOriginalUser()), obj).Return(ErrUnauthorized)
+		// Get returns the object before deletion
+		setup.store.getObj = obj
+		// Authorizer rejects
+		setup.auth.beforeDeleteErr = ErrUnauthorized
 
 		result, deleted, err := setup.wrapper.Delete(setup.ctx, "to-delete", nil, deleteOpts)
 
@@ -152,10 +155,8 @@ func TestWrapper_Delete(t *testing.T) {
 		assert.False(t, deleted)
 		assert.Equal(t, ErrUnauthorized, err)
 
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
-		setup.mockStore.AssertNotCalled(t, "Delete")
+		// Verify store.Delete was NOT called
+		assert.False(t, setup.store.deleteCalled)
 	})
 }
 
@@ -165,41 +166,34 @@ func TestWrapper_Get(t *testing.T) {
 
 		obj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "fetched"}}
 
-		// Verify service identity is used to call the underlying store
-		setup.mockStore.On("Get", mock.MatchedBy(matchesServiceIdentity()), "fetched", mock.Anything).Return(obj, nil)
-
-		// Verify original user identity is used for after-get authorization
-		setup.mockAuth.On("AfterGet", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
+		setup.store.getObj = obj
 
 		result, err := setup.wrapper.Get(setup.ctx, "fetched", &metaV1.GetOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, obj, result)
 
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		// Verify service identity was used for store call
+		require.True(t, setup.store.getCalled)
+		require.True(t, matchesServiceIdentity()(setup.store.getCtx))
+
+		// Verify original user identity was used for after-get authorization
+		require.True(t, setup.auth.afterGetCalled)
+		require.True(t, matchesOriginalUser()(setup.auth.afterGetCtx))
 	})
 	t.Run("unauthorized", func(t *testing.T) {
 		setup := newTestSetup(t)
 
 		obj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "fetched"}}
 
-		// Verify service identity is used to call the underlying store
-		setup.mockStore.On("Get", mock.MatchedBy(matchesServiceIdentity()), "fetched", mock.Anything).Return(obj, nil)
-
-		// Simulate unauthorized error from after-get authorizer
-		setup.mockAuth.On("AfterGet", mock.MatchedBy(matchesOriginalUser()), obj).Return(ErrUnauthorized)
+		setup.store.getObj = obj
+		setup.auth.afterGetErr = ErrUnauthorized
 
 		result, err := setup.wrapper.Get(setup.ctx, "fetched", &metaV1.GetOptions{})
 
 		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Equal(t, ErrUnauthorized, err)
-
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
 	})
 }
 
@@ -216,20 +210,21 @@ func TestWrapper_List(t *testing.T) {
 			{Object: &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "item1"}}},
 		}}
 
-		// Verify service identity is used to call the underlying store
-		setup.mockStore.On("List", mock.MatchedBy(matchesServiceIdentity()), mock.Anything).Return(listObj, nil)
-
-		// Verify original user identity is used for filtering the list
-		setup.mockAuth.On("FilterList", mock.MatchedBy(matchesOriginalUser()), listObj).Return(filteredListObj, nil)
+		setup.store.listObj = listObj
+		setup.auth.filterListResult = filteredListObj
 
 		result, err := setup.wrapper.List(setup.ctx, &internalversion.ListOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, filteredListObj, result)
 
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		// Verify service identity was used for store call
+		require.True(t, setup.store.listCalled)
+		require.True(t, matchesServiceIdentity()(setup.store.listCtx))
+
+		// Verify original user identity was used for filtering
+		require.True(t, setup.auth.filterListCalled)
+		require.True(t, matchesOriginalUser()(setup.auth.filterListCtx))
 	})
 	t.Run("unauthorized", func(t *testing.T) {
 		setup := newTestSetup(t)
@@ -239,21 +234,14 @@ func TestWrapper_List(t *testing.T) {
 			{Object: &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "item2"}}},
 		}}
 
-		// Verify service identity is used to call the underlying store
-		setup.mockStore.On("List", mock.MatchedBy(matchesServiceIdentity()), mock.Anything).Return(listObj, nil)
-
-		// Simulate unauthorized error from FilterList authorizer
-		setup.mockAuth.On("FilterList", mock.MatchedBy(matchesOriginalUser()), listObj).Return(nil, ErrUnauthorized)
+		setup.store.listObj = listObj
+		setup.auth.filterListErr = ErrUnauthorized
 
 		result, err := setup.wrapper.List(setup.ctx, &internalversion.ListOptions{})
 
 		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Equal(t, ErrUnauthorized, err)
-
-		// Assert expectations
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
 	})
 }
 
@@ -266,36 +254,28 @@ func TestWrapper_Update(t *testing.T) {
 	objInfo := &fakeUpdatedObjectInfo{obj: oldObj}
 	updateOpts := &metaV1.UpdateOptions{}
 
-	var authzInfo *authorizedUpdateInfo
-
-	// Verify service identity is used to call the underlying store
-	setup.mockStore.On("Update",
-		mock.MatchedBy(matchesServiceIdentity()),
-		"to-update",
-		mock.MatchedBy(func(info *authorizedUpdateInfo) bool {
-			// Capture the authorizedUpdateInfo for later verification
-			authzInfo = info
-			return true
-		}),
-		mock.Anything,
-		mock.Anything,
-		false,
-		updateOpts).Return(oldObj, true, nil)
+	setup.store.updateObj = oldObj
+	setup.store.updateCreated = true
 
 	result, updated, err := setup.wrapper.Update(setup.ctx, "to-update", objInfo, nil, nil, false, updateOpts)
 	require.NoError(t, err)
 	assert.Equal(t, oldObj, result)
 	assert.True(t, updated)
 
+	// Verify service identity was used for store call
+	require.True(t, setup.store.updateCalled)
+	require.True(t, matchesServiceIdentity()(setup.store.updateCtx))
+
 	// Now verify that the authorization is performed inside UpdatedObject
-	setup.mockAuth.On("BeforeUpdate", mock.MatchedBy(matchesOriginalUser()), oldObj, oldObj).Return(nil)
-	obj, err := authzInfo.UpdatedObject(context.Background(), oldObj)
+	// by calling UpdatedObject on the captured authorizedUpdateInfo
+	require.NotNil(t, setup.store.updateObjInfo)
+	obj, err := setup.store.updateObjInfo.UpdatedObject(context.Background(), oldObj)
 	require.NoError(t, err)
 	assert.Equal(t, oldObj, obj)
 
-	// Assert expectations
-	setup.mockAuth.AssertExpectations(t)
-	setup.mockStore.AssertExpectations(t)
+	// Verify the authorizer was called with original user identity
+	require.True(t, setup.auth.beforeUpdateCalled)
+	require.True(t, matchesOriginalUser()(setup.auth.beforeUpdateCtx))
 }
 
 func TestWrapper_DeleteCollection(t *testing.T) {
@@ -313,41 +293,39 @@ func TestWrapper_PassthroughMethods(t *testing.T) {
 
 	t.Run("New", func(t *testing.T) {
 		obj := &fakeObject{}
-		setup.mockStore.On("New").Return(obj).Once()
+		setup.store.newObj = obj
 		assert.Equal(t, obj, setup.wrapper.New())
 	})
 
 	t.Run("NewList", func(t *testing.T) {
 		obj := &fakeObject{}
-		setup.mockStore.On("NewList").Return(obj).Once()
+		setup.store.newListObj = obj
 		assert.Equal(t, obj, setup.wrapper.NewList())
 	})
 
 	t.Run("GetSingularName", func(t *testing.T) {
-		setup.mockStore.On("GetSingularName").Return("fake").Once()
+		setup.store.singularName = "fake"
 		assert.Equal(t, "fake", setup.wrapper.GetSingularName())
 	})
 
 	t.Run("NamespaceScoped", func(t *testing.T) {
-		setup.mockStore.On("NamespaceScoped").Return(true).Once()
+		setup.store.namespaceScoped = true
 		assert.True(t, setup.wrapper.NamespaceScoped())
 	})
 
 	t.Run("Destroy", func(t *testing.T) {
-		setup.mockStore.On("Destroy").Once()
 		setup.wrapper.Destroy()
+		assert.True(t, setup.store.destroyCalled)
 	})
 
 	t.Run("ConvertToTable", func(t *testing.T) {
 		obj := &fakeObject{}
 		table := &metaV1.Table{}
-		setup.mockStore.On("ConvertToTable", setup.ctx, obj, mock.Anything).Return(table, nil).Once()
+		setup.store.convertToTableResult = table
 		result, err := setup.wrapper.ConvertToTable(setup.ctx, obj, nil)
 		require.NoError(t, err)
 		assert.Equal(t, table, result)
 	})
-
-	setup.mockStore.AssertExpectations(t)
 }
 
 func TestWrapper_WithPreserveIdentity(t *testing.T) {
@@ -355,70 +333,65 @@ func TestWrapper_WithPreserveIdentity(t *testing.T) {
 		setup := newTestSetupWithPreserveIdentity(t)
 
 		obj := &fakeObject{}
-		createOpts := &metaV1.CreateOptions{}
 		expectedObj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "created"}}
 
-		setup.mockAuth.On("BeforeCreate", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
-		// Inner store must receive original user identity, not service identity.
-		setup.mockStore.On("Create", mock.MatchedBy(matchesOriginalUser()), obj, mock.Anything, createOpts).Return(expectedObj, nil)
+		setup.store.createObj = expectedObj
 
-		result, err := setup.wrapper.Create(setup.ctx, obj, nil, createOpts)
+		result, err := setup.wrapper.Create(setup.ctx, obj, nil, &metaV1.CreateOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedObj, result)
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+
+		// With preserve identity, both authorizer and store should receive original user identity
+		require.True(t, matchesOriginalUser()(setup.auth.beforeCreateCtx))
+		require.True(t, matchesOriginalUser()(setup.store.createCtx))
 	})
 
 	t.Run("Get passes original user identity to inner store", func(t *testing.T) {
 		setup := newTestSetupWithPreserveIdentity(t)
 
 		obj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "fetched"}}
-
-		setup.mockStore.On("Get", mock.MatchedBy(matchesOriginalUser()), "fetched", mock.Anything).Return(obj, nil)
-		setup.mockAuth.On("AfterGet", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
+		setup.store.getObj = obj
 
 		result, err := setup.wrapper.Get(setup.ctx, "fetched", &metaV1.GetOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, obj, result)
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		require.True(t, matchesOriginalUser()(setup.auth.afterGetCtx))
+		require.True(t, matchesOriginalUser()(setup.store.getCtx))
 	})
 
 	t.Run("List passes original user identity to inner store", func(t *testing.T) {
 		setup := newTestSetupWithPreserveIdentity(t)
 
 		listObj := &metaV1.List{}
-
-		setup.mockStore.On("List", mock.MatchedBy(matchesOriginalUser()), mock.Anything).Return(listObj, nil)
-		setup.mockAuth.On("FilterList", mock.MatchedBy(matchesOriginalUser()), listObj).Return(listObj, nil)
+		setup.store.listObj = listObj
+		setup.auth.filterListResult = listObj
 
 		result, err := setup.wrapper.List(setup.ctx, &internalversion.ListOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, listObj, result)
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		require.True(t, matchesOriginalUser()(setup.auth.filterListCtx))
+		require.True(t, matchesOriginalUser()(setup.store.listCtx))
 	})
 
 	t.Run("Delete passes original user identity to inner store", func(t *testing.T) {
 		setup := newTestSetupWithPreserveIdentity(t)
 
 		obj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "to-delete"}}
-		deleteOpts := &metaV1.DeleteOptions{}
+		setup.store.getObj = obj
+		setup.store.deleteObj = obj
+		setup.store.deleteDeleted = true
 
-		setup.mockStore.On("Get", mock.MatchedBy(matchesOriginalUser()), "to-delete", mock.Anything).Return(obj, nil)
-		setup.mockAuth.On("BeforeDelete", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
-		setup.mockStore.On("Delete", mock.MatchedBy(matchesOriginalUser()), "to-delete", mock.Anything, deleteOpts).Return(obj, true, nil)
-
-		result, deleted, err := setup.wrapper.Delete(setup.ctx, "to-delete", nil, deleteOpts)
+		result, deleted, err := setup.wrapper.Delete(setup.ctx, "to-delete", nil, &metaV1.DeleteOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, obj, result)
 		assert.True(t, deleted)
-		setup.mockAuth.AssertExpectations(t)
-		setup.mockStore.AssertExpectations(t)
+		require.True(t, matchesOriginalUser()(setup.auth.beforeDeleteCtx))
+		require.True(t, matchesOriginalUser()(setup.store.getCtx))
+		require.True(t, matchesOriginalUser()(setup.store.deleteCtx))
 	})
 }
 
@@ -426,37 +399,155 @@ func TestWrapper_WithPreserveIdentity(t *testing.T) {
 // Fakes
 // -----
 
-type FakeAuthorizer struct {
-	mock.Mock
+// fakeAuthorizer implements ResourceStorageAuthorizer with configurable return values
+// and captures contexts for identity verification.
+type fakeAuthorizer struct {
+	beforeCreateErr    error
+	beforeCreateCtx    context.Context
+	beforeCreateCalled bool
+
+	beforeUpdateErr    error
+	beforeUpdateCtx    context.Context
+	beforeUpdateCalled bool
+
+	beforeDeleteErr    error
+	beforeDeleteCtx    context.Context
+	beforeDeleteCalled bool
+
+	afterGetErr    error
+	afterGetCtx    context.Context
+	afterGetCalled bool
+
+	filterListResult runtime.Object
+	filterListErr    error
+	filterListCtx    context.Context
+	filterListCalled bool
 }
 
-func (f *FakeAuthorizer) BeforeCreate(ctx context.Context, obj runtime.Object) error {
-	args := f.Called(ctx, obj)
-	return args.Error(0)
+func (f *fakeAuthorizer) BeforeCreate(ctx context.Context, obj runtime.Object) error {
+	f.beforeCreateCalled = true
+	f.beforeCreateCtx = ctx
+	return f.beforeCreateErr
 }
 
-func (f *FakeAuthorizer) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
-	args := f.Called(ctx, oldObj, obj)
-	return args.Error(0)
+func (f *fakeAuthorizer) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
+	f.beforeUpdateCalled = true
+	f.beforeUpdateCtx = ctx
+	return f.beforeUpdateErr
 }
 
-func (f *FakeAuthorizer) BeforeDelete(ctx context.Context, obj runtime.Object) error {
-	args := f.Called(ctx, obj)
-	return args.Error(0)
+func (f *fakeAuthorizer) BeforeDelete(ctx context.Context, obj runtime.Object) error {
+	f.beforeDeleteCalled = true
+	f.beforeDeleteCtx = ctx
+	return f.beforeDeleteErr
 }
 
-func (f *FakeAuthorizer) AfterGet(ctx context.Context, obj runtime.Object) error {
-	args := f.Called(ctx, obj)
-	return args.Error(0)
+func (f *fakeAuthorizer) AfterGet(ctx context.Context, obj runtime.Object) error {
+	f.afterGetCalled = true
+	f.afterGetCtx = ctx
+	return f.afterGetErr
 }
 
-func (f *FakeAuthorizer) FilterList(ctx context.Context, list runtime.Object) (runtime.Object, error) {
-	args := f.Called(ctx, list)
-	var res runtime.Object
-	if args.Get(0) != nil {
-		res = args.Get(0).(runtime.Object)
-	}
-	return res, args.Error(1)
+func (f *fakeAuthorizer) FilterList(ctx context.Context, list runtime.Object) (runtime.Object, error) {
+	f.filterListCalled = true
+	f.filterListCtx = ctx
+	return f.filterListResult, f.filterListErr
+}
+
+// fakeStore implements K8sStorage with configurable return values and call tracking.
+type fakeStore struct {
+	// New
+	newObj runtime.Object
+
+	// NewList
+	newListObj runtime.Object
+
+	// Destroy
+	destroyCalled bool
+
+	// GetSingularName
+	singularName string
+
+	// NamespaceScoped
+	namespaceScoped bool
+
+	// Create
+	createObj    runtime.Object
+	createErr    error
+	createCtx    context.Context
+	createCalled bool
+
+	// Get
+	getObj    runtime.Object
+	getErr    error
+	getCtx    context.Context
+	getCalled bool
+
+	// Update
+	updateObj     runtime.Object
+	updateCreated bool
+	updateErr     error
+	updateCtx     context.Context
+	updateCalled  bool
+	updateObjInfo k8srest.UpdatedObjectInfo
+
+	// Delete
+	deleteObj     runtime.Object
+	deleteDeleted bool
+	deleteErr     error
+	deleteCtx     context.Context
+	deleteCalled  bool
+
+	// List
+	listObj    runtime.Object
+	listErr    error
+	listCtx    context.Context
+	listCalled bool
+
+	// ConvertToTable
+	convertToTableResult *metaV1.Table
+	convertToTableErr    error
+}
+
+func (f *fakeStore) New() runtime.Object     { return f.newObj }
+func (f *fakeStore) NewList() runtime.Object { return f.newListObj }
+func (f *fakeStore) Destroy()                { f.destroyCalled = true }
+func (f *fakeStore) GetSingularName() string { return f.singularName }
+func (f *fakeStore) NamespaceScoped() bool   { return f.namespaceScoped }
+
+func (f *fakeStore) Create(ctx context.Context, obj runtime.Object, createValidation k8srest.ValidateObjectFunc, options *metaV1.CreateOptions) (runtime.Object, error) {
+	f.createCalled = true
+	f.createCtx = ctx
+	return f.createObj, f.createErr
+}
+
+func (f *fakeStore) Get(ctx context.Context, name string, options *metaV1.GetOptions) (runtime.Object, error) {
+	f.getCalled = true
+	f.getCtx = ctx
+	return f.getObj, f.getErr
+}
+
+func (f *fakeStore) Update(ctx context.Context, name string, objInfo k8srest.UpdatedObjectInfo, createValidation k8srest.ValidateObjectFunc, updateValidation k8srest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metaV1.UpdateOptions) (runtime.Object, bool, error) {
+	f.updateCalled = true
+	f.updateCtx = ctx
+	f.updateObjInfo = objInfo
+	return f.updateObj, f.updateCreated, f.updateErr
+}
+
+func (f *fakeStore) Delete(ctx context.Context, name string, deleteValidation k8srest.ValidateObjectFunc, options *metaV1.DeleteOptions) (runtime.Object, bool, error) {
+	f.deleteCalled = true
+	f.deleteCtx = ctx
+	return f.deleteObj, f.deleteDeleted, f.deleteErr
+}
+
+func (f *fakeStore) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	f.listCalled = true
+	f.listCtx = ctx
+	return f.listObj, f.listErr
+}
+
+func (f *fakeStore) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metaV1.Table, error) {
+	return f.convertToTableResult, f.convertToTableErr
 }
 
 type fakeObject struct {

--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -7,14 +7,48 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/registry/apis/secret"
 )
+
+// fakeSecureValueSupport is a hand-written fake for contracts.InlineSecureValueSupport.
+type fakeSecureValueSupport struct {
+	// createInlineResults maps RawSecureValue to the return value.
+	createInlineResults map[common.RawSecureValue]struct {
+		name string
+		err  error
+	}
+	createInlineCalls int
+
+	// deleteResults is a queue of errors to return from DeleteWhenOwnedByResource.
+	deleteResults []error
+	deleteCalls   int
+}
+
+func (f *fakeSecureValueSupport) CanReference(_ context.Context, _ common.ObjectReference, _ ...string) error {
+	return fmt.Errorf("CanReference: not expected")
+}
+
+func (f *fakeSecureValueSupport) CreateInline(_ context.Context, _ common.ObjectReference, value common.RawSecureValue, _ *string) (string, error) {
+	f.createInlineCalls++
+	if result, ok := f.createInlineResults[value]; ok {
+		return result.name, result.err
+	}
+	return "", fmt.Errorf("CreateInline: unexpected value %q", string(value))
+}
+
+func (f *fakeSecureValueSupport) DeleteWhenOwnedByResource(_ context.Context, _ common.ObjectReference, _ ...string) error {
+	if f.deleteCalls < len(f.deleteResults) {
+		err := f.deleteResults[f.deleteCalls]
+		f.deleteCalls++
+		return err
+	}
+	f.deleteCalls++
+	return fmt.Errorf("DeleteWhenOwnedByResource: unexpected call #%d", f.deleteCalls)
+}
 
 func TestSecureLifecycle(t *testing.T) {
 	resourceWithSecureValues := func(sv common.InlineSecureValues) utils.GrafanaMetaAccessor {
@@ -41,11 +75,15 @@ func TestSecureLifecycle(t *testing.T) {
 	}
 
 	t.Run("create secure values", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
-		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretAAA"), (*string)(nil)).
-			Return("NameForA", nil).Once()
-		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretBBB"), (*string)(nil)).
-			Return("NameForB", nil).Once()
+		secureStore := &fakeSecureValueSupport{
+			createInlineResults: map[common.RawSecureValue]struct {
+				name string
+				err  error
+			}{
+				"SecretAAA": {name: "NameForA"},
+				"SecretBBB": {name: "NameForB"},
+			},
+		}
 
 		info := &objectForStorage{}
 		obj := resourceWithSecureValues(common.InlineSecureValues{
@@ -68,7 +106,7 @@ func TestSecureLifecycle(t *testing.T) {
 		v := obj.GetAnnotation(utils.AnnoKeyKubectlLastAppliedConfig)
 		require.Empty(t, v, "should exclude the last config with raw secrets")
 
-		secureStore.AssertExpectations(t)
+		require.Equal(t, 2, secureStore.createInlineCalls)
 	})
 
 	t.Run("create secure values with errors", func(t *testing.T) {
@@ -79,20 +117,23 @@ func TestSecureLifecycle(t *testing.T) {
 
 		info := &objectForStorage{}
 		expectError := fmt.Errorf("expected error")
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
-		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretAAA"), (*string)(nil)).
-			Return("", expectError).Maybe()
-		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretBBB"), (*string)(nil)).
-			Return("", expectError).Maybe()
+		secureStore := &fakeSecureValueSupport{
+			createInlineResults: map[common.RawSecureValue]struct {
+				name string
+				err  error
+			}{
+				"SecretAAA": {err: expectError},
+				"SecretBBB": {err: expectError},
+			},
+		}
 
 		err := prepareSecureValues(context.Background(), secureStore, obj, nil, info)
 		require.Error(t, err, "should error when secure value creation fails")
 		require.Equal(t, expectError, err, "error should be propagated")
-		secureStore.AssertExpectations(t)
 	})
 
 	t.Run("change name manually", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore := &fakeSecureValueSupport{}
 
 		info := &objectForStorage{}
 		previous := resourceWithSecureValues(common.InlineSecureValues{
@@ -121,7 +162,7 @@ func TestSecureLifecycle(t *testing.T) {
 	})
 
 	t.Run("update without secrets", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore := &fakeSecureValueSupport{}
 
 		info := &objectForStorage{}
 		previousObject := resourceWithSecureValues(common.InlineSecureValues{
@@ -143,7 +184,9 @@ func TestSecureLifecycle(t *testing.T) {
 	})
 
 	t.Run("remove secure values", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore := &fakeSecureValueSupport{
+			deleteResults: []error{nil},
+		}
 		previous := resourceWithSecureValues(common.InlineSecureValues{
 			"a": common.InlineSecureValue{Name: "NameForA"},
 			"b": common.InlineSecureValue{Name: "NameForB"},
@@ -161,8 +204,9 @@ func TestSecureLifecycle(t *testing.T) {
 		info := &objectForStorage{}
 		err := prepareSecureValues(context.Background(), secureStore, obj, previous, info)
 		require.NoError(t, err)
-		require.True(t, info.hasChanged)  // value was removed
-		secureStore.AssertExpectations(t) // nothing called
+		require.True(t, info.hasChanged) // value was removed
+		require.Equal(t, 0, secureStore.createInlineCalls)
+		require.Equal(t, 0, secureStore.deleteCalls)
 
 		secure, err := obj.GetSecureValues()
 		require.NoError(t, err)
@@ -175,13 +219,10 @@ func TestSecureLifecycle(t *testing.T) {
 		require.NotEmpty(t, v, "should keep the annotations when a raw secret is not exposed")
 
 		// When there is not an error, the finish command will do a real delete
-		owner := utils.ToObjectReference(obj)
-		secureStore.On("DeleteWhenOwnedByResource", mock.Anything, owner, "NameForB").
-			Return(nil).Once()
 		err = info.finish(context.Background(), nil, secureStore)
 		require.NoError(t, err)
-		require.True(t, info.hasChanged)  // value was removed
-		secureStore.AssertExpectations(t) // nothing called
+		require.True(t, info.hasChanged) // value was removed
+		require.Equal(t, 1, secureStore.deleteCalls)
 
 		// When an error exists, no values will be deleted
 		err = fmt.Errorf("expected error")
@@ -190,7 +231,7 @@ func TestSecureLifecycle(t *testing.T) {
 	})
 
 	t.Run("remove invalid secure values", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore := &fakeSecureValueSupport{}
 		obj := resourceWithSecureValues(common.InlineSecureValues{
 			"b": common.InlineSecureValue{Remove: true}, // b does not exist in previous value
 		})
@@ -203,13 +244,19 @@ func TestSecureLifecycle(t *testing.T) {
 		secure, err := obj.GetSecureValues()
 		require.NoError(t, err)
 		require.Empty(t, secure, "noop remove should be stripped before the object is written")
-		secureStore.AssertExpectations(t)
+		require.Equal(t, 0, secureStore.createInlineCalls)
+		require.Equal(t, 0, secureStore.deleteCalls)
 	})
 
 	t.Run("remove invalid secure values while creating others", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
-		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretAAA"), (*string)(nil)).
-			Return("NameForA", nil).Once()
+		secureStore := &fakeSecureValueSupport{
+			createInlineResults: map[common.RawSecureValue]struct {
+				name string
+				err  error
+			}{
+				"SecretAAA": {name: "NameForA"},
+			},
+		}
 
 		obj := resourceWithSecureValues(common.InlineSecureValues{
 			"a": common.InlineSecureValue{Create: "SecretAAA"},
@@ -225,11 +272,13 @@ func TestSecureLifecycle(t *testing.T) {
 		require.JSONEq(t, `{
 			"a": {"name": "NameForA"}
 		}`, asJSON(secure, true))
-		secureStore.AssertExpectations(t)
+		require.Equal(t, 1, secureStore.createInlineCalls)
 	})
 
 	t.Run("delete resource", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore := &fakeSecureValueSupport{
+			deleteResults: []error{nil},
+		}
 		obj := resourceWithSecureValues(common.InlineSecureValues{
 			"a": common.InlineSecureValue{Name: "NameForA"},
 		})
@@ -237,13 +286,9 @@ func TestSecureLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, sv, 1)
 
-		owner := utils.ToObjectReference(obj)
-		secureStore.On("DeleteWhenOwnedByResource", mock.Anything, owner, "NameForA").
-			Return(nil).Once()
-
 		err = handleSecureValuesDelete(context.Background(), secureStore, obj)
 		require.NoError(t, err)
-		secureStore.AssertExpectations(t)
+		require.Equal(t, 1, secureStore.deleteCalls)
 		sv, err = obj.GetSecureValues()
 		require.NoError(t, err)
 		require.Empty(t, sv, "secure values should be empty after delete")
@@ -253,16 +298,16 @@ func TestSecureLifecycle(t *testing.T) {
 			"a": common.InlineSecureValue{Name: "NameForA"},
 		})
 		expectError := fmt.Errorf("expected error")
-		secureStore = secret.NewMockInlineSecureValueSupport(t)
-		secureStore.On("DeleteWhenOwnedByResource", mock.Anything, owner, "NameForA").
-			Return(expectError).Once()
+		secureStore = &fakeSecureValueSupport{
+			deleteResults: []error{expectError},
+		}
 		err = handleSecureValuesDelete(context.Background(), secureStore, obj)
 		require.Equal(t, expectError, err, "error should be passed through")
-		secureStore.AssertExpectations(t)
+		require.Equal(t, 1, secureStore.deleteCalls)
 	})
 
 	t.Run("invalid states", func(t *testing.T) {
-		secureStore := secret.NewMockInlineSecureValueSupport(t)
+		secureStore := &fakeSecureValueSupport{}
 
 		info := &objectForStorage{}
 		err := prepareSecureValues(context.Background(), secureStore, resourceWithSecureValues(common.InlineSecureValues{

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/authlib/types"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	dashboardv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
@@ -66,18 +65,12 @@ func (m *MockResourceIndex) UpdateIndex(_ context.Context) (int64, error) {
 	return 0, m.updateIndexError
 }
 
-var _ DocumentBuilder = &MockDocumentBuilder{}
+// fakeDocumentBuilder implements DocumentBuilder for testing.
+// BuildDocument is never called in these tests — the struct is only used as a cache entry.
+type fakeDocumentBuilder struct{}
 
-type MockDocumentBuilder struct {
-	mock.Mock
-}
-
-func (m *MockDocumentBuilder) BuildDocument(ctx context.Context, key *resourcepb.ResourceKey, resourceVersion int64, value []byte) (*IndexableDocument, error) {
-	args := m.Called(ctx, key, resourceVersion, value)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*IndexableDocument), nil
+func (f *fakeDocumentBuilder) BuildDocument(_ context.Context, _ *resourcepb.ResourceKey, _ int64, _ []byte) (*IndexableDocument, error) {
+	return nil, fmt.Errorf("not expected")
 }
 
 // mockStorageBackend implements StorageBackend for testing
@@ -759,7 +752,7 @@ func TestRebuildIndexes(t *testing.T) {
 	t.Run("Rebuild dashboard index (it has no build info), verify that builders cache was emptied.", func(t *testing.T) {
 		dashKey := NamespacedResource{Namespace: "idx3", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE}
 
-		support.builders.ns.Add(dashKey, &MockDocumentBuilder{})
+		support.builders.ns.Add(dashKey, &fakeDocumentBuilder{})
 		_, ok := support.builders.ns.Get(dashKey)
 		require.True(t, ok)
 


### PR DESCRIPTION
## Summary
- Replace `rest.MockStorage` (mockery-generated) and `FakeAuthorizer` (mock.Mock-based) with hand-written fakes in `pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go`
- Fakes use struct fields for configurable return values and captured contexts for identity verification
- The `matchesOriginalUser()` and `matchesServiceIdentity()` helper functions are kept but used as post-call assertions instead of mock matchers

## Test plan
- [x] `go test ./pkg/services/apiserver/auth/authorizer/storewrapper/ -count=1` — all 26 tests pass