### PR TITLE
Themes: use opaque border colors instead of semi-transparent rgba

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -122,9 +122,9 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   whiteBase = '204, 204, 220';
 
   border = {
-    weak: `rgba(${this.whiteBase}, 0.12)`,
-    medium: `rgba(${this.whiteBase}, 0.2)`,
-    strong: `rgba(${this.whiteBase}, 0.30)`,
+    weak: palette.gray20,
+    medium: palette.gray25,
+    strong: palette.gray35,
   };
 
   text = {
@@ -217,9 +217,9 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   border = {
-    weak: `rgba(${this.blackBase}, 0.12)`,
-    medium: `rgba(${this.blackBase}, 0.3)`,
-    strong: `rgba(${this.blackBase}, 0.4)`,
+    weak: palette.gray85,
+    medium: palette.gray70,
+    strong: palette.gray65,
   };
 
   secondary = {


### PR DESCRIPTION
This replaces the semi-transparent rgba border tokens (weak/medium/strong) with opaque palette values, fixing the visual artifact where modal borders showed underlying content bleeding through.

The previous border tokens used rgba with low alpha (0.12, 0.2, 0.3 for dark; 0.12, 0.3, 0.4 for light), which works well when the border sits on a known solid background. But for overlaying elements like modals, the transparency lets the backdrop content show through the border, creating what looks like a gap in the modal edge.

The opaque replacements are chosen from the existing palette to approximate what the rgba values resolve to on their intended primary backgrounds:

- Dark: gray20, gray25, gray35
- Light: gray85, gray70, gray65

This is the global token approach per the thread discussion. If the visual delta is too large across the board, a modal-only override using emphasize() on the background color is another option.

Fixes #102190