### PR TITLE
Dashboards: Refactor to keep perms separated

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -6,11 +6,13 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 )
 
@@ -309,8 +311,8 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Create dashboards under the root folder.",
 			Group:       "Dashboards",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
-				{Action: dashboards.ActionDashboardsCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: dashboards.ActionDashboardsCreate, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
 			},
 		},
 		Grants: []string{"Editor"},
@@ -338,7 +340,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Permissions: ac.ConcatPermissions(dashboardsReaderRole.Role.Permissions, []ac.Permission{
 				{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeDashboardsAll},
 				{Action: dashboards.ActionDashboardsDelete, Scope: dashboards.ScopeDashboardsAll},
-				{Action: dashboards.ActionDashboardsCreate, Scope: dashboards.ScopeFoldersAll},
+				{Action: dashboards.ActionDashboardsCreate, Scope: folder.ScopeFoldersAll},
 				{Action: dashboards.ActionDashboardsPermissionsRead, Scope: dashboards.ScopeDashboardsAll},
 				{Action: dashboards.ActionDashboardsPermissionsWrite, Scope: dashboards.ScopeDashboardsAll},
 			}),
@@ -353,7 +355,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Create folders under root level",
 			Group:       "Folders",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionFoldersCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
+				{Action: folder.ActionFoldersCreate, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)},
 			},
 		},
 		Grants: []string{"Editor"},
@@ -368,8 +370,8 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Read all folders and dashboards.",
 			Group:       "Folders",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersAll},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
+				{Action: dashboards.ActionDashboardsRead, Scope: folder.ScopeFoldersAll},
 			},
 		},
 		Grants: []string{"Admin"},
@@ -384,7 +386,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Group:       "Folders",
 			Hidden:      true,
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
 			},
 		},
 		Grants: []string{string(org.RoleViewer)},
@@ -399,14 +401,14 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Permissions: ac.ConcatPermissions(
 				foldersReaderRole.Role.Permissions,
 				[]ac.Permission{
-					{Action: dashboards.ActionFoldersCreate, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionFoldersDelete, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionDashboardsDelete, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionDashboardsCreate, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionDashboardsPermissionsRead, Scope: dashboards.ScopeFoldersAll},
-					{Action: dashboards.ActionDashboardsPermissionsWrite, Scope: dashboards.ScopeFoldersAll},
+					{Action: folder.ActionFoldersCreate, Scope: folder.ScopeFoldersAll},
+					{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll},
+					{Action: folder.ActionFoldersDelete, Scope: folder.ScopeFoldersAll},
+					{Action: dashboards.ActionDashboardsWrite, Scope: folder.ScopeFoldersAll},
+					{Action: dashboards.ActionDashboardsDelete, Scope: folder.ScopeFoldersAll},
+					{Action: dashboards.ActionDashboardsCreate, Scope: folder.ScopeFoldersAll},
+					{Action: dashboards.ActionDashboardsPermissionsRead, Scope: folder.ScopeFoldersAll},
+					{Action: dashboards.ActionDashboardsPermissionsWrite, Scope: folder.ScopeFoldersAll},
 				}),
 		},
 		Grants: []string{"Admin"},
@@ -419,8 +421,8 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Create library panel under the root folder.",
 			Group:       "Library panels",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
-				{Action: libraryelements.ActionLibraryPanelsCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: libraryelements.ActionLibraryPanelsCreate, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
 			},
 		},
 		Grants: []string{"Editor"},
@@ -433,7 +435,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Read all library panels.",
 			Group:       "Library panels",
 			Permissions: []ac.Permission{
-				{Action: libraryelements.ActionLibraryPanelsRead, Scope: dashboards.ScopeFoldersAll},
+				{Action: libraryelements.ActionLibraryPanelsRead, Scope: folder.ScopeFoldersAll},
 			},
 		},
 		Grants: []string{"Admin"},
@@ -446,7 +448,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Read all library panels under the root folder.",
 			Group:       "Library panels",
 			Permissions: []ac.Permission{
-				{Action: libraryelements.ActionLibraryPanelsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: libraryelements.ActionLibraryPanelsRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
 			},
 		},
 		Grants: []string{"Viewer"},
@@ -459,9 +461,9 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Group:       "Library panels",
 			Description: "Create, read, write or delete all library panels and their permissions.",
 			Permissions: ac.ConcatPermissions(libraryPanelsReaderRole.Role.Permissions, []ac.Permission{
-				{Action: libraryelements.ActionLibraryPanelsWrite, Scope: dashboards.ScopeFoldersAll},
-				{Action: libraryelements.ActionLibraryPanelsDelete, Scope: dashboards.ScopeFoldersAll},
-				{Action: libraryelements.ActionLibraryPanelsCreate, Scope: dashboards.ScopeFoldersAll},
+				{Action: libraryelements.ActionLibraryPanelsWrite, Scope: folder.ScopeFoldersAll},
+				{Action: libraryelements.ActionLibraryPanelsDelete, Scope: folder.ScopeFoldersAll},
+				{Action: libraryelements.ActionLibraryPanelsCreate, Scope: folder.ScopeFoldersAll},
 			}),
 		},
 		Grants: []string{"Admin"},
@@ -474,9 +476,9 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Group:       "Library panels",
 			Description: "Create, read, write or delete all library panels and their permissions under the root folder.",
 			Permissions: ac.ConcatPermissions(libraryPanelsGeneralReaderRole.Role.Permissions, []ac.Permission{
-				{Action: libraryelements.ActionLibraryPanelsWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
-				{Action: libraryelements.ActionLibraryPanelsDelete, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
-				{Action: libraryelements.ActionLibraryPanelsCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: libraryelements.ActionLibraryPanelsWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: libraryelements.ActionLibraryPanelsDelete, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
+				{Action: libraryelements.ActionLibraryPanelsCreate, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)},
 			}),
 		},
 		Grants: []string{"Editor"},
@@ -489,7 +491,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Create, write or disable a public dashboard.",
 			Group:       "Dashboards",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionDashboardsPublicWrite, Scope: dashboards.ScopeDashboardsAll},
+				{Action: publicdashboards.ActionDashboardsPublicWrite, Scope: dashboards.ScopeDashboardsAll},
 			},
 		},
 		Grants: []string{"Admin"},
@@ -528,7 +530,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Create snapshots",
 			Group:       "Snapshots",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionSnapshotsCreate},
+				{Action: dashboardsnapshots.ActionSnapshotsCreate},
 			},
 		},
 		Grants: []string{string(org.RoleEditor)},
@@ -541,7 +543,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Delete snapshots",
 			Group:       "Snapshots",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionSnapshotsDelete},
+				{Action: dashboardsnapshots.ActionSnapshotsDelete},
 			},
 		},
 		Grants: []string{string(org.RoleEditor)},
@@ -554,7 +556,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Description: "Read snapshots",
 			Group:       "Snapshots",
 			Permissions: []ac.Permission{
-				{Action: dashboards.ActionSnapshotsRead},
+				{Action: dashboardsnapshots.ActionSnapshotsRead},
 			},
 		},
 		Grants: []string{string(org.RoleViewer)},
@@ -568,7 +570,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Group:       "Annotations",
 			Permissions: []ac.Permission{
 				{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsTypeOrganization},
-				{Action: ac.ActionAnnotationsRead, Scope: dashboards.ScopeFoldersAll},
+				{Action: ac.ActionAnnotationsRead, Scope: folder.ScopeFoldersAll},
 			},
 		},
 		Grants: []string{string(org.RoleAdmin)},
@@ -582,11 +584,11 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Group:       "Annotations",
 			Permissions: []ac.Permission{
 				{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsTypeOrganization},
-				{Action: ac.ActionAnnotationsCreate, Scope: dashboards.ScopeFoldersAll},
+				{Action: ac.ActionAnnotationsCreate, Scope: folder.ScopeFoldersAll},
 				{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsTypeOrganization},
-				{Action: ac.ActionAnnotationsDelete, Scope: dashboards.ScopeFoldersAll},
+				{Action: ac.ActionAnnotationsDelete, Scope: folder.ScopeFoldersAll},
 				{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeOrganization},
-				{Action: ac.ActionAnnotationsWrite, Scope: dashboards.ScopeFoldersAll},
+				{Action: ac.ActionAnnotationsWrite, Scope: folder.ScopeFoldersAll},
 			},
 		},
 		Grants: []string{string(org.RoleAdmin)},

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -585,14 +585,14 @@ func AnnotationTypeScopeResolver(annotationsRepo annotations.Repository, feature
 				scopes := []string{dashboards.ScopeDashboardsProvider.GetResourceScopeUID(dashboard.UID)}
 				// Append dashboard parent scopes if dashboard is in a folder or the general scope if dashboard is not in a folder
 				if dashboard.FolderUID != "" {
-					scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(dashboard.FolderUID))
-					inheritedScopes, err := dashboards.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderSvc)
+					scopes = append(scopes, folder.ScopeFoldersProvider.GetResourceScopeUID(dashboard.FolderUID))
+					inheritedScopes, err := folder.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderSvc)
 					if err != nil {
 						return nil, err
 					}
 					scopes = append(scopes, inheritedScopes...)
 				} else {
-					scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
+					scopes = append(scopes, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
 				}
 				return scopes, nil
 			})

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -77,7 +77,7 @@ func TestAPI_Annotations(t *testing.T) {
 			path:         "/api/annotations/2",
 			method:       http.MethodGet,
 			expectedCode: http.StatusOK,
-			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
 		},
 		{
 			desc:         "should not be able to fetch dashboard annotation by id with the old dashboard scope",
@@ -119,7 +119,7 @@ func TestAPI_Annotations(t *testing.T) {
 			path:         "/api/annotations/2",
 			method:       http.MethodPut,
 			expectedCode: http.StatusOK,
-			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
 		},
 		{
 			desc:         "should not be able to update dashboard annotation with the old dashboard scope",
@@ -161,7 +161,7 @@ func TestAPI_Annotations(t *testing.T) {
 			path:         "/api/annotations/2",
 			method:       http.MethodPatch,
 			expectedCode: http.StatusOK,
-			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
 		},
 		{
 			desc:         "should not be able to patch dashboard annotation with the old dashboard scope",
@@ -206,7 +206,7 @@ func TestAPI_Annotations(t *testing.T) {
 			method:       http.MethodPost,
 			body:         "{\"dashboardId\": 2,\"text\": \"test\"}",
 			expectedCode: http.StatusOK,
-			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsCreate, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
 		},
 		{
 			desc:         "should not be able to create dashboard annotation with the old dashboard scope",
@@ -251,7 +251,7 @@ func TestAPI_Annotations(t *testing.T) {
 			path:         "/api/annotations/2",
 			method:       http.MethodDelete,
 			expectedCode: http.StatusOK,
-			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsDelete, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsDelete, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
 		},
 		{
 			desc:         "should not be able to delete dashboard annotation with the old dashboard scope",
@@ -311,7 +311,7 @@ func TestAPI_Annotations(t *testing.T) {
 			body:         "{\"dashboardId\": 2, \"panelId\": 1}",
 			method:       http.MethodPost,
 			expectedCode: http.StatusOK,
-			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsDelete, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsDelete, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}},
 		},
 		{
 			desc:         "should not be able to mass delete dashboard annotation with the old dashboard scope",
@@ -412,7 +412,7 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 			given: "annotations:id:1",
 			want: []string{
 				dashboards.ScopeDashboardsProvider.GetResourceScopeUID(rootDashUID),
-				dashboards.ScopeFoldersProvider.GetResourceScopeUID(accesscontrol.GeneralFolderUID),
+				folder.ScopeFoldersProvider.GetResourceScopeUID(accesscontrol.GeneralFolderUID),
 			},
 			wantErr: nil,
 		},
@@ -421,7 +421,7 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 			given: "annotations:id:3",
 			want: []string{
 				dashboards.ScopeDashboardsProvider.GetResourceScopeUID(folderDashUID),
-				dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID),
+				folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID),
 			},
 			wantErr: nil,
 		},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -46,8 +46,10 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	publicdashboardsapi "github.com/grafana/grafana/pkg/services/publicdashboards/api"
@@ -367,7 +369,7 @@ func (hs *HTTPServer) registerRoutes() {
 				return ac.EvalAny(
 					ac.EvalPermission(ac.ActionOrgUsersRead),
 					ac.EvalPermission(ac.ActionTeamsPermissionsWrite),
-					ac.EvalPermission(dashboards.ActionFoldersPermissionsWrite),
+					ac.EvalPermission(folder.ActionFoldersPermissionsWrite),
 					ac.EvalPermission(dashboards.ActionDashboardsPermissionsWrite),
 				)
 			}
@@ -500,7 +502,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// Dashboard snapshots
 		apiRoute.Group("/dashboard/snapshots", func(dashboardRoute routing.RouteRegister) {
-			dashboardRoute.Get("/", authorize(ac.EvalPermission(dashboards.ActionSnapshotsRead)), routing.Wrap(hs.SearchDashboardSnapshots))
+			dashboardRoute.Get("/", authorize(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsRead)), routing.Wrap(hs.SearchDashboardSnapshots))
 		})
 
 		// Playlist
@@ -603,7 +605,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 	r.Post("/api/snapshots/", reqSnapshotPublicModeOrCreate, hs.getCreatedSnapshotHandler())
 	r.Get("/api/snapshots/:key", routing.Wrap(hs.GetDashboardSnapshot))
-	r.Delete("/api/snapshots/:key", authorize(ac.EvalPermission(dashboards.ActionSnapshotsDelete)), routing.Wrap(hs.DeleteDashboardSnapshot))
+	r.Delete("/api/snapshots/:key", authorize(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsDelete)), routing.Wrap(hs.DeleteDashboardSnapshot))
 
 	// Snapshots delete for public mode or using the deleteKey
 	r.Get("/api/snapshots-delete/:deleteKey", reqSnapshotPublicModeOrDelete, routing.Wrap(hs.DeleteDashboardSnapshotByDeleteKey))

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -90,7 +90,7 @@ func (hs *HTTPServer) CreateDashboardSnapshot(c *contextmodel.ReqContext) {
 	}
 
 	// Regular mode: check permissions
-	evaluator := ac.EvalAll(ac.EvalPermission(dashboards.ActionSnapshotsCreate), ac.EvalPermission(dashboards.ActionDashboardsRead, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(cmd.Dashboard.GetNestedString("uid"))))
+	evaluator := ac.EvalAll(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsCreate), ac.EvalPermission(dashboards.ActionDashboardsRead, dashboards.ScopeDashboardsProvider.GetResourceScopeUID(cmd.Dashboard.GetNestedString("uid"))))
 	if canSave, err := hs.AccessControl.Evaluate(c.Req.Context(), c.SignedInUser, evaluator); err != nil || !canSave {
 		c.JsonApiErr(http.StatusForbidden, "forbidden", err)
 		return

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -46,7 +46,7 @@ func TestHTTPServer_DeleteDashboardSnapshot(t *testing.T) {
 
 	allowedUser := userWithPermissions(1, []accesscontrol.Permission{
 		{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:1"},
-		{Action: dashboards.ActionSnapshotsDelete},
+		{Action: dashboardsnapshots.ActionSnapshotsDelete},
 	})
 
 	t.Run("User should not be able to delete snapshot without permissions", func(t *testing.T) {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
@@ -25,25 +24,25 @@ const REDACTED = "redacted"
 func (hs *HTTPServer) registerFolderAPI(apiRoute routing.RouteRegister, authorize func(accesscontrol.Evaluator) web.Handler) {
 	// #TODO add back auth part
 	apiRoute.Group("/folders", func(folderRoute routing.RouteRegister) {
-		idScope := dashboards.ScopeFoldersProvider.GetResourceScope(accesscontrol.Parameter(":id"))
-		uidScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(accesscontrol.Parameter(":uid"))
-		folderRoute.Get("/id/:id", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersRead, idScope)), routing.Wrap(hs.GetFolderByID))
+		idScope := folder.ScopeFoldersProvider.GetResourceScope(accesscontrol.Parameter(":id"))
+		uidScope := folder.ScopeFoldersProvider.GetResourceScopeUID(accesscontrol.Parameter(":uid"))
+		folderRoute.Get("/id/:id", authorize(accesscontrol.EvalPermission(folder.ActionFoldersRead, idScope)), routing.Wrap(hs.GetFolderByID))
 
 		folderRoute.Group("/:uid", func(folderUidRoute routing.RouteRegister) {
 			folderUidRoute.Group("/permissions", func(folderPermissionRoute routing.RouteRegister) {
-				folderPermissionRoute.Get("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsRead, uidScope)), routing.Wrap(hs.GetFolderPermissionList))
-				folderPermissionRoute.Post("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsWrite, uidScope)), routing.Wrap(hs.UpdateFolderPermissions))
+				folderPermissionRoute.Get("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersPermissionsRead, uidScope)), routing.Wrap(hs.GetFolderPermissionList))
+				folderPermissionRoute.Post("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersPermissionsWrite, uidScope)), routing.Wrap(hs.UpdateFolderPermissions))
 			})
 		})
 
-		folderRoute.Post("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersCreate)), routing.Wrap(hs.CreateFolder))
-		folderRoute.Get("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersRead)), routing.Wrap(hs.GetFolders))
+		folderRoute.Post("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersCreate)), routing.Wrap(hs.CreateFolder))
+		folderRoute.Get("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersRead)), routing.Wrap(hs.GetFolders))
 		folderRoute.Group("/:uid", func(folderUidRoute routing.RouteRegister) {
-			folderUidRoute.Put("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.UpdateFolder))
-			folderUidRoute.Delete("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, uidScope)), routing.Wrap(hs.DeleteFolder))
-			folderUidRoute.Get("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderByUID))
-			folderUidRoute.Get("/counts", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderDescendantCounts))
-			folderUidRoute.Post("/move", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.MoveFolder))
+			folderUidRoute.Put("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersWrite, uidScope)), routing.Wrap(hs.UpdateFolder))
+			folderUidRoute.Delete("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersDelete, uidScope)), routing.Wrap(hs.DeleteFolder))
+			folderUidRoute.Get("/", authorize(accesscontrol.EvalPermission(folder.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderByUID))
+			folderUidRoute.Get("/counts", authorize(accesscontrol.EvalPermission(folder.ActionFoldersRead, uidScope)), routing.Wrap(hs.GetFolderDescendantCounts))
+			folderUidRoute.Post("/move", authorize(accesscontrol.EvalPermission(folder.ActionFoldersWrite, uidScope)), routing.Wrap(hs.MoveFolder))
 		})
 	})
 }
@@ -328,15 +327,15 @@ func (hs *HTTPServer) GetFolderDescendantCounts(c *contextmodel.ReqContext) resp
 func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folder) (dtos.Folder, error) {
 	ctx := c.Req.Context()
 	toDTO := func(f *folder.Folder, checkCanView bool) (dtos.Folder, error) {
-		canEditEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
+		canEditEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 		canEdit, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canEditEvaluator)
 		canSave := canEdit
 		canAdminEvaluator := accesscontrol.EvalAll(
-			accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID)),
-			accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID)),
+			accesscontrol.EvalPermission(folder.ActionFoldersPermissionsRead, folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID)),
+			accesscontrol.EvalPermission(folder.ActionFoldersPermissionsWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID)),
 		)
 		canAdmin, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canAdminEvaluator)
-		canDeleteEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
+		canDeleteEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersDelete, folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 		canDelete, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canDeleteEvaluator)
 
 		// Finding creator and last updater of the folder
@@ -351,7 +350,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 		acMetadata, _ := hs.getFolderACMetadata(c, f)
 
 		if checkCanView {
-			canViewEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
+			canViewEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 			canView, _ := hs.AccessControl.Evaluate(ctx, c.SignedInUser, canViewEvaluator)
 			if !canView {
 				return dtos.Folder{
@@ -423,7 +422,7 @@ func (hs *HTTPServer) getFolderACMetadata(c *contextmodel.ReqContext, f *folder.
 		folderIDs[p.UID] = true
 	}
 
-	allMetadata := getMultiAccessControlMetadata(c, dashboards.ScopeFoldersPrefix, folderIDs)
+	allMetadata := getMultiAccessControlMetadata(c, folder.ScopeFoldersPrefix, folderIDs)
 	metadata := map[string]bool{}
 	// Flatten metadata - if any parent has a permission, the child folder inherits it
 	for _, md := range allMetadata {

--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -38,6 +38,7 @@ import (
 	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/service"
 	dashclient "github.com/grafana/grafana/pkg/services/dashboards/service/client"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -193,7 +194,7 @@ func setupDB(b testing.TB) benchScenario {
 	}
 
 	signedInUser := user.SignedInUser{UserID: userIDs[0], OrgID: orgID, Permissions: map[int64]map[string][]string{
-		orgID: {dashboards.ActionFoldersCreate: {}, dashboards.ActionFoldersWrite: {dashboards.ScopeFoldersAll}},
+		orgID: {folder.ActionFoldersCreate: {}, folder.ActionFoldersWrite: {folder.ScopeFoldersAll}},
 	}}
 
 	now := time.Now()
@@ -270,21 +271,21 @@ func setupDB(b testing.TB) benchScenario {
 		roleID := int64(i%TEAM_NUM + 1)
 		permissions = append(permissions, accesscontrol.Permission{
 			RoleID:  roleID,
-			Action:  dashboards.ActionFoldersRead,
-			Scope:   dashboards.ScopeFoldersProvider.GetResourceScopeUID(f0.UID),
+			Action:  folder.ActionFoldersRead,
+			Scope:   folder.ScopeFoldersProvider.GetResourceScopeUID(f0.UID),
 			Updated: now,
 			Created: now,
 		},
 			accesscontrol.Permission{
 				RoleID:  roleID,
 				Action:  dashboards.ActionDashboardsRead,
-				Scope:   dashboards.ScopeFoldersProvider.GetResourceScopeUID(f0.UID),
+				Scope:   folder.ScopeFoldersProvider.GetResourceScopeUID(f0.UID),
 				Updated: now,
 				Created: now,
 			},
 		)
-		signedInUser.Permissions[orgID][dashboards.ActionFoldersRead] = append(signedInUser.Permissions[orgID][dashboards.ActionFoldersRead], dashboards.ScopeFoldersProvider.GetResourceScopeUID(f0.UID))
-		signedInUser.Permissions[orgID][dashboards.ActionDashboardsRead] = append(signedInUser.Permissions[orgID][dashboards.ActionDashboardsRead], dashboards.ScopeFoldersProvider.GetResourceScopeUID(f0.UID))
+		signedInUser.Permissions[orgID][folder.ActionFoldersRead] = append(signedInUser.Permissions[orgID][folder.ActionFoldersRead], folder.ScopeFoldersProvider.GetResourceScopeUID(f0.UID))
+		signedInUser.Permissions[orgID][dashboards.ActionDashboardsRead] = append(signedInUser.Permissions[orgID][dashboards.ActionDashboardsRead], folder.ScopeFoldersProvider.GetResourceScopeUID(f0.UID))
 
 		for j := 0; j < LEVEL0_DASHBOARD_NUM; j++ {
 			str := fmt.Sprintf("dashboard_%d_%d", i, j)

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -39,7 +39,7 @@ func TestHTTPServer_GetFolderPermissionList(t *testing.T) {
 		})
 
 		res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/folders/1/permissions"), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsRead, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsRead, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestHTTPServer_GetFolderPermissionList(t *testing.T) {
 		})
 
 		res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/folders/1/permissions"), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsRead, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsRead, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -96,7 +96,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": []}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": [{ userId:1, teamId: 2 }]}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": [{ teamId:1, role: "Admin" }]}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": [{ userId:1, role: "Admin" }]}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": [{"role": "Viewer", "permission": 1}]}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -199,7 +199,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": [{"role": "Viewer", "permission": 1}]}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestHTTPServer_UpdateFolderPermissions(t *testing.T) {
 
 		body := `{"items": [{"role": "Viewer", "permission": 1}]}`
 		res, err := server.SendJSON(webtest.RequestWithSignedInUser(server.NewPostRequest("/api/folders/1/permissions", strings.NewReader(body)), userWithPermissions(1, []accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
+			{Action: folder.ActionFoldersPermissionsWrite, Scope: "folders:uid:1"},
 		})))
 
 		require.NoError(t, err)

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -51,7 +51,7 @@ func TestFoldersCreateAPIEndpoint(t *testing.T) {
 			input:          folderWithoutParentInput,
 			expectedCode:   http.StatusOK,
 			expectedFolder: &folder.Folder{UID: "uid", Title: "Folder"},
-			permissions:    []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:    []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:  "folder creation fails without permissions to create a folder",
@@ -64,49 +64,49 @@ func TestFoldersCreateAPIEndpoint(t *testing.T) {
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusConflict,
 			expectedFolderSvcError: dashboards.ErrFolderWithSameUIDExists,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusBadRequest,
 			expectedFolderSvcError: dashboards.ErrFolderTitleEmpty,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusBadRequest,
 			expectedFolderSvcError: dashboards.ErrDashboardInvalidUid,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusBadRequest,
 			expectedFolderSvcError: dashboards.ErrDashboardUidTooLong,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusForbidden,
 			expectedFolderSvcError: dashboards.ErrFolderAccessDenied,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusNotFound,
 			expectedFolderSvcError: dashboards.ErrFolderNotFound,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusPreconditionFailed,
 			expectedFolderSvcError: dashboards.ErrFolderVersionMismatch,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}},
 		},
 	}
 
@@ -159,7 +159,7 @@ func TestFoldersUpdateAPIEndpoint(t *testing.T) {
 			description:    "folder updating succeeds given the correct request and permissions to update a folder",
 			expectedCode:   http.StatusOK,
 			expectedFolder: &folder.Folder{UID: "uid", Title: "Folder upd"},
-			permissions:    []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:    []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:  "folder updating fails without permissions to update a folder",
@@ -170,43 +170,43 @@ func TestFoldersUpdateAPIEndpoint(t *testing.T) {
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusConflict,
 			expectedFolderSvcError: dashboards.ErrFolderWithSameUIDExists,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusBadRequest,
 			expectedFolderSvcError: dashboards.ErrFolderTitleEmpty,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusBadRequest,
 			expectedFolderSvcError: dashboards.ErrDashboardInvalidUid,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusBadRequest,
 			expectedFolderSvcError: dashboards.ErrDashboardUidTooLong,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusForbidden,
 			expectedFolderSvcError: dashboards.ErrFolderAccessDenied,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusNotFound,
 			expectedFolderSvcError: dashboards.ErrFolderNotFound,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 		{
 			description:            "folder updating fails given folder service error %s",
 			expectedCode:           http.StatusPreconditionFailed,
 			expectedFolderSvcError: dashboards.ErrFolderVersionMismatch,
-			permissions:            []accesscontrol.Permission{{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll}},
+			permissions:            []accesscontrol.Permission{{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll}},
 		},
 	}
 
@@ -267,8 +267,8 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		req := server.NewGetRequest("/api/folders/folderUid?accesscontrol=true")
 		webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{
 			1: accesscontrol.GroupScopesByActionContext(context.Background(), []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
 			}),
 		}})
 
@@ -280,8 +280,8 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		body := dtos.Folder{}
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
 
-		assert.True(t, body.AccessControl[dashboards.ActionFoldersRead])
-		assert.True(t, body.AccessControl[dashboards.ActionFoldersWrite])
+		assert.True(t, body.AccessControl[folder.ActionFoldersRead])
+		assert.True(t, body.AccessControl[folder.ActionFoldersWrite])
 	})
 
 	t.Run("Should attach access control metadata to folder response with permissions cascading from nested folders", func(t *testing.T) {
@@ -295,9 +295,9 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		req := server.NewGetRequest("/api/folders/folderUid?accesscontrol=true")
 		webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{
 			1: accesscontrol.GroupScopesByActionContext(context.Background(), []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("parentUid")},
-				{Action: dashboards.ActionDashboardsCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("parentUid")},
+				{Action: dashboards.ActionDashboardsCreate, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
 			}),
 		}})
 
@@ -309,8 +309,8 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		body := dtos.Folder{}
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
 
-		assert.True(t, body.AccessControl[dashboards.ActionFoldersRead])
-		assert.True(t, body.AccessControl[dashboards.ActionFoldersWrite])
+		assert.True(t, body.AccessControl[folder.ActionFoldersRead])
+		assert.True(t, body.AccessControl[folder.ActionFoldersWrite])
 		assert.True(t, body.AccessControl[dashboards.ActionDashboardsCreate])
 	})
 
@@ -320,8 +320,8 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		req := server.NewGetRequest("/api/folders/folderUid")
 		webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{
 			1: accesscontrol.GroupScopesByActionContext(context.Background(), []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
 			}),
 		}})
 
@@ -333,8 +333,8 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		body := dtos.Folder{}
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
 
-		assert.False(t, body.AccessControl[dashboards.ActionFoldersRead])
-		assert.False(t, body.AccessControl[dashboards.ActionFoldersWrite])
+		assert.False(t, body.AccessControl[folder.ActionFoldersRead])
+		assert.False(t, body.AccessControl[folder.ActionFoldersWrite])
 	})
 }
 
@@ -355,8 +355,8 @@ func TestFolderMoveAPIEndpoint(t *testing.T) {
 			newParentUid: "newParentUid",
 			expectedCode: http.StatusOK,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("uid")},
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("newParentUid")},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("uid")},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("newParentUid")},
 			},
 		},
 		{
@@ -364,7 +364,7 @@ func TestFolderMoveAPIEndpoint(t *testing.T) {
 			newParentUid: "",
 			expectedCode: http.StatusOK,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("uid")},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("uid")},
 			},
 		},
 		{
@@ -372,7 +372,7 @@ func TestFolderMoveAPIEndpoint(t *testing.T) {
 			newParentUid: "newParentUid",
 			expectedCode: http.StatusForbidden,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("newParentUid")},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("newParentUid")},
 			},
 		},
 	}
@@ -431,9 +431,9 @@ func TestFolderGetAPIEndpoint(t *testing.T) {
 			expectedParentOrgIDs: []int64{0, 0},
 			expectedParentTitles: []string{"parent title", "subfolder title"},
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("uid")},
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("parent")},
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("subfolder")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("uid")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("parent")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("subfolder")},
 			},
 		},
 		{
@@ -444,7 +444,7 @@ func TestFolderGetAPIEndpoint(t *testing.T) {
 			expectedParentOrgIDs: []int64{0, 0},
 			expectedParentTitles: []string{REDACTED, REDACTED},
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("uid")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("uid")},
 			},
 		},
 		{
@@ -455,8 +455,8 @@ func TestFolderGetAPIEndpoint(t *testing.T) {
 			expectedParentOrgIDs: []int64{0, 0},
 			expectedParentTitles: []string{REDACTED, "subfolder title"},
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("uid")},
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("subfolder")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("uid")},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("subfolder")},
 			},
 		},
 	}
@@ -613,8 +613,8 @@ func TestGetFolderLegacyAndUnifiedStorage(t *testing.T) {
 				req.Header.Set("Content-Type", "application/json")
 				webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{
 					1: accesscontrol.GroupScopesByActionContext(context.Background(), []accesscontrol.Permission{
-						{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
-						{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll},
+						{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
+						{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll},
 					}),
 				}})
 
@@ -671,7 +671,7 @@ func TestSetDefaultPermissionsWhenCreatingFolder(t *testing.T) {
 
 	input := strings.NewReader("{ \"uid\": \"uid\", \"title\": \"Folder\"}")
 	req := srv.NewPostRequest("/api/folders", input)
-	req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{{Action: dashboards.ActionFoldersCreate}}))
+	req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{{Action: folder.ActionFoldersCreate}}))
 	resp, err := srv.SendJSON(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -22,6 +22,7 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
@@ -142,7 +143,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	}
 
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
-	hasEditPerm := hasAccess(ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(dashboards.ActionFoldersCreate)))
+	hasEditPerm := hasAccess(ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(folder.ActionFoldersCreate)))
 
 	data := dtos.IndexViewData{
 		User: &dtos.CurrentUser{

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authn"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
@@ -246,7 +246,7 @@ func SnapshotPublicModeOrCreate(cfg *setting.Cfg, ac2 ac.AccessControl) web.Hand
 			return
 		}
 
-		ac.Middleware(ac2)(ac.EvalPermission(dashboards.ActionSnapshotsCreate))
+		ac.Middleware(ac2)(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsCreate))
 	}
 }
 
@@ -263,7 +263,7 @@ func SnapshotPublicModeOrDelete(cfg *setting.Cfg, ac2 ac.AccessControl) web.Hand
 			return
 		}
 
-		ac.Middleware(ac2)(ac.EvalPermission(dashboards.ActionSnapshotsDelete))
+		ac.Middleware(ac2)(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsDelete))
 	}
 }
 

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	dashboardsearch "github.com/grafana/grafana/pkg/services/dashboards/service/search"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/services/folder"
 	foldermodel "github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -350,13 +349,13 @@ var errEmptyResults = fmt.Errorf("empty results")
 func permissionToActions(p dashboardaccess.PermissionType) (dashboardAction string, folderAction string) {
 	switch p {
 	case dashboardaccess.PERMISSION_EDIT:
-		return dashboards.ActionDashboardsWrite, folder.ActionFoldersWrite
+		return dashboards.ActionDashboardsWrite, foldermodel.ActionFoldersWrite
 	case dashboardaccess.PERMISSION_ADMIN:
-		return dashboards.ActionDashboardsPermissionsWrite, folder.ActionFoldersPermissionsWrite
+		return dashboards.ActionDashboardsPermissionsWrite, foldermodel.ActionFoldersPermissionsWrite
 	case dashboardaccess.PERMISSION_VIEW:
 		fallthrough
 	default:
-		return dashboards.ActionDashboardsRead, folder.ActionFoldersRead
+		return dashboards.ActionDashboardsRead, foldermodel.ActionFoldersRead
 	}
 }
 
@@ -682,7 +681,7 @@ func (s *SearchHandler) getDashboardsUIDsSharedWithUser(ctx context.Context, use
 		}
 	}
 	for _, folderPermission := range folderPermissions {
-		if folderUid, found := strings.CutPrefix(folderPermission, folder.ScopeFoldersPrefix); found {
+		if folderUid, found := strings.CutPrefix(folderPermission, foldermodel.ScopeFoldersPrefix); found {
 			if !slices.Contains(dashboardUids, folderUid) && folderUid != foldermodel.SharedWithMeFolderUID && folderUid != foldermodel.GeneralFolderUID {
 				dashboardUids = append(dashboardUids, folderUid)
 			}

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	dashboardsearch "github.com/grafana/grafana/pkg/services/dashboards/service/search"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	foldermodel "github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -349,13 +350,13 @@ var errEmptyResults = fmt.Errorf("empty results")
 func permissionToActions(p dashboardaccess.PermissionType) (dashboardAction string, folderAction string) {
 	switch p {
 	case dashboardaccess.PERMISSION_EDIT:
-		return dashboards.ActionDashboardsWrite, dashboards.ActionFoldersWrite
+		return dashboards.ActionDashboardsWrite, folder.ActionFoldersWrite
 	case dashboardaccess.PERMISSION_ADMIN:
-		return dashboards.ActionDashboardsPermissionsWrite, dashboards.ActionFoldersPermissionsWrite
+		return dashboards.ActionDashboardsPermissionsWrite, folder.ActionFoldersPermissionsWrite
 	case dashboardaccess.PERMISSION_VIEW:
 		fallthrough
 	default:
-		return dashboards.ActionDashboardsRead, dashboards.ActionFoldersRead
+		return dashboards.ActionDashboardsRead, folder.ActionFoldersRead
 	}
 }
 
@@ -681,7 +682,7 @@ func (s *SearchHandler) getDashboardsUIDsSharedWithUser(ctx context.Context, use
 		}
 	}
 	for _, folderPermission := range folderPermissions {
-		if folderUid, found := strings.CutPrefix(folderPermission, dashboards.ScopeFoldersPrefix); found {
+		if folderUid, found := strings.CutPrefix(folderPermission, folder.ScopeFoldersPrefix); found {
 			if !slices.Contains(dashboardUids, folderUid) && folderUid != foldermodel.SharedWithMeFolderUID && folderUid != foldermodel.GeneralFolderUID {
 				dashboardUids = append(dashboardUids, folderUid)
 			}

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -347,7 +348,7 @@ func TestSearchHandlerSharedDashboards(t *testing.T) {
 		allPermissions := make(map[int64]map[string][]string)
 		permissions := make(map[string][]string)
 		permissions[dashboards.ActionDashboardsRead] = []string{"dashboards:uid:dashboardinroot", "dashboards:uid:dashboardinprivatefolder", "dashboards:uid:dashboardinpublicfolder"}
-		permissions[dashboards.ActionFoldersRead] = []string{"folders:uid:sharedfolder"}
+		permissions[folder.ActionFoldersRead] = []string{"folders:uid:sharedfolder"}
 		allPermissions[1] = permissions
 		// "Permissions" is where we store the uid of dashboards shared with the user
 		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test", OrgID: 1, Permissions: allPermissions}))
@@ -480,7 +481,7 @@ func TestSearchHandlerSharedDashboards(t *testing.T) {
 		permissions := make(map[string][]string)
 		permissions[dashboards.ActionDashboardsWrite] = []string{"dashboards:uid:dashboardinprivatefolder", "dashboards:uid:dashboardinpublicfolder"}
 		// user can view the private folder, but cannot edit it. This should still classify dashboards in it as "shared with me" for edit.
-		permissions[dashboards.ActionFoldersRead] = []string{"folders:uid:privatefolder"}
+		permissions[folder.ActionFoldersRead] = []string{"folders:uid:privatefolder"}
 		allPermissions[1] = permissions
 		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test", OrgID: 1, Permissions: allPermissions}))
 

--- a/pkg/registry/apis/dashboard/snapshot/authorizer.go
+++ b/pkg/registry/apis/dashboard/snapshot/authorizer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 )
 
 // NewSnapshotAuthorizer returns an authorizer that maps k8s verbs to snapshot RBAC actions.
@@ -28,9 +28,9 @@ func NewSnapshotAuthorizer(accessControl ac.AccessControl) authorizer.Authorizer
 				var action string
 				switch attr.GetSubresource() {
 				case "dashboard":
-					action = dashboards.ActionSnapshotsRead
+					action = dashboardsnapshots.ActionSnapshotsRead
 				case "deletekey":
-					action = dashboards.ActionSnapshotsDelete
+					action = dashboardsnapshots.ActionSnapshotsDelete
 				default:
 					return authorizer.DecisionDeny, "unsupported subresource", nil
 				}
@@ -45,11 +45,11 @@ func NewSnapshotAuthorizer(accessControl ac.AccessControl) authorizer.Authorizer
 			var action string
 			switch attr.GetVerb() {
 			case "get", "list":
-				action = dashboards.ActionSnapshotsRead
+				action = dashboardsnapshots.ActionSnapshotsRead
 			case "create":
-				action = dashboards.ActionSnapshotsCreate
+				action = dashboardsnapshots.ActionSnapshotsCreate
 			case "delete":
-				action = dashboards.ActionSnapshotsDelete
+				action = dashboardsnapshots.ActionSnapshotsDelete
 			default:
 				return authorizer.DecisionDeny, "unsupported verb", nil
 			}

--- a/pkg/registry/apis/dashboard/snapshot/routes.go
+++ b/pkg/registry/apis/dashboard/snapshot/routes.go
@@ -117,7 +117,7 @@ func GetRoutes(service dashboardsnapshots.Service, options dashv0.SnapshotSharin
 					}
 
 					// RBAC check for snapshot creation
-					if ok, err := accessControl.Evaluate(ctx, user, ac.EvalPermission(dashboards.ActionSnapshotsCreate)); !ok || err != nil {
+					if ok, err := accessControl.Evaluate(ctx, user, ac.EvalPermission(dashboardsnapshots.ActionSnapshotsCreate)); !ok || err != nil {
 						wrap.JsonApiErr(http.StatusForbidden, "access denied", err)
 						return
 					}
@@ -263,7 +263,7 @@ func GetRoutes(service dashboardsnapshots.Service, options dashv0.SnapshotSharin
 						errhttp.Write(ctx, err, w)
 						return
 					}
-					if ok, err := accessControl.Evaluate(ctx, user, ac.EvalPermission(dashboards.ActionSnapshotsDelete)); !ok || err != nil {
+					if ok, err := accessControl.Evaluate(ctx, user, ac.EvalPermission(dashboardsnapshots.ActionSnapshotsDelete)); !ok || err != nil {
 						w.WriteHeader(http.StatusForbidden)
 						_ = json.NewEncoder(w).Encode(&util.DynMap{"message": "access denied"})
 						return
@@ -348,7 +348,7 @@ func GetRoutes(service dashboardsnapshots.Service, options dashv0.SnapshotSharin
 					}
 
 					// RBAC check for reading snapshot settings
-					if ok, err := accessControl.Evaluate(ctx, user, ac.EvalPermission(dashboards.ActionSnapshotsRead)); !ok || err != nil {
+					if ok, err := accessControl.Evaluate(ctx, user, ac.EvalPermission(dashboardsnapshots.ActionSnapshotsRead)); !ok || err != nil {
 						wrap.JsonApiErr(http.StatusForbidden, "access denied", err)
 						return
 					}

--- a/pkg/registry/apis/dashboard/snapshot/routes_test.go
+++ b/pkg/registry/apis/dashboard/snapshot/routes_test.go
@@ -124,7 +124,7 @@ func TestCreateSnapshotDashboardValidation(t *testing.T) {
 			routes := GetRoutes(
 				snapshotService,
 				dashv0.SnapshotSharingOptions{SnapshotsEnabled: true},
-				acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
+				acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboardsnapshots.ActionSnapshotsCreate}}),
 				map[string]common.OpenAPIDefinition{},
 				tt.setupStorageMock(t),
 				dashboardService,

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/pluginutils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/seeding"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
@@ -47,8 +46,8 @@ const (
 )
 
 var SharedWithMeFolderPermission = accesscontrol.Permission{
-	Action: dashboards.ActionFoldersRead,
-	Scope:  dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
+	Action: folder.ActionFoldersRead,
+	Scope:  folder.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
 }
 
 var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}

--- a/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
@@ -125,20 +125,20 @@ func ProvideDashboardPermissions(
 				return nil, err
 			}
 
-			scopes := []string(accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix))
+			scopes := []string(accesscontrol.WildcardsFromPrefix(folder.ScopeFoldersPrefix))
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.AccessControl).Inc()
 			if dashboard.FolderUID != "" {
-				nestedScopes, err := dashboards.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderService)
+				nestedScopes, err := folder.GetInheritedScopes(ctx, orgID, dashboard.FolderUID, folderService)
 				if err != nil {
 					return nil, err
 				}
 
-				scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(dashboard.FolderUID))
+				scopes = append(scopes, folder.ScopeFoldersProvider.GetResourceScopeUID(dashboard.FolderUID))
 				scopes = append(scopes, nestedScopes...)
 				return scopes, nil
 			}
 
-			return append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)), nil
+			return append(scopes, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)), nil
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -28,10 +28,10 @@ type FolderPermissionsService struct {
 
 var ErrFolderUnhandledError = errutil.Internal("folder.unhandled-error", errutil.WithPublicMessage("Unhandled folder error"))
 
-var FolderViewActions = []string{dashboards.ActionFoldersRead, accesscontrol.ActionAlertingRuleRead, libraryelements.ActionLibraryPanelsRead, accesscontrol.ActionAlertingSilencesRead}
+var FolderViewActions = []string{folder.ActionFoldersRead, accesscontrol.ActionAlertingRuleRead, libraryelements.ActionLibraryPanelsRead, accesscontrol.ActionAlertingSilencesRead}
 var FolderEditActions = append(FolderViewActions, []string{
-	dashboards.ActionFoldersWrite,
-	dashboards.ActionFoldersDelete,
+	folder.ActionFoldersWrite,
+	folder.ActionFoldersDelete,
 	dashboards.ActionDashboardsCreate,
 	accesscontrol.ActionAlertingRuleCreate,
 	accesscontrol.ActionAlertingRuleUpdate,
@@ -42,7 +42,7 @@ var FolderEditActions = append(FolderViewActions, []string{
 	libraryelements.ActionLibraryPanelsWrite,
 	libraryelements.ActionLibraryPanelsDelete,
 }...)
-var FolderAdminActions = append(FolderEditActions, []string{dashboards.ActionFoldersPermissionsRead, dashboards.ActionFoldersPermissionsWrite}...)
+var FolderAdminActions = append(FolderEditActions, []string{folder.ActionFoldersPermissionsRead, folder.ActionFoldersPermissionsWrite}...)
 
 func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service accesscontrol.Service) error {
 	if !cfg.RBAC.PermissionsWildcardSeed("folder") {
@@ -55,7 +55,7 @@ func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service
 			DisplayName: "Viewer",
 			Description: "View all folders and dashboards.",
 			Group:       "Folders",
-			Permissions: accesscontrol.PermissionsForActions(append(DashboardViewActions, FolderViewActions...), dashboards.ScopeFoldersAll),
+			Permissions: accesscontrol.PermissionsForActions(append(DashboardViewActions, FolderViewActions...), folder.ScopeFoldersAll),
 			Hidden:      true,
 		},
 		Grants: []string{"Viewer"},
@@ -67,7 +67,7 @@ func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service
 			DisplayName: "Editor",
 			Description: "Edit all folders and dashboards.",
 			Group:       "Folders",
-			Permissions: accesscontrol.PermissionsForActions(append(DashboardEditActions, FolderEditActions...), dashboards.ScopeFoldersAll),
+			Permissions: accesscontrol.PermissionsForActions(append(DashboardEditActions, FolderEditActions...), folder.ScopeFoldersAll),
 			Hidden:      true,
 		},
 		Grants: []string{"Editor"},
@@ -79,7 +79,7 @@ func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service
 			DisplayName: "Admin",
 			Description: "Administer all folders and dashboards",
 			Group:       "folders",
-			Permissions: accesscontrol.PermissionsForActions(append(DashboardAdminActions, FolderAdminActions...), dashboards.ScopeFoldersAll),
+			Permissions: accesscontrol.PermissionsForActions(append(DashboardAdminActions, FolderAdminActions...), folder.ScopeFoldersAll),
 			Hidden:      true,
 		},
 		Grants: []string{"Admin"},
@@ -130,7 +130,7 @@ func ProvideFolderPermissions(
 		},
 		InheritedScopesSolver: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
 			ctx, _ = identity.WithServiceIdentity(ctx, orgID)
-			return dashboards.GetInheritedScopes(ctx, orgID, resourceID, folderService)
+			return folder.GetInheritedScopes(ctx, orgID, resourceID, folderService)
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/pluginutils"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
@@ -186,7 +187,7 @@ func (s *Service) GetPermissions(ctx context.Context, user identity.Requester, r
 				actionSetActions := s.actionSetSvc.ResolveActionSet(action)
 				if len(actionSetActions) > 0 {
 					// Folders and routes: expand all actions unconditionally (no inherited scope filtering needed).
-					if s.options.Resource == dashboards.ScopeFoldersRoot || s.options.Resource == accesscontrol.AlertingRoutesResource {
+					if s.options.Resource == folder.ScopeFoldersRoot || s.options.Resource == accesscontrol.AlertingRoutesResource {
 						expandedActions = append(expandedActions, actionSetActions...)
 						continue
 					}
@@ -396,7 +397,7 @@ func (s *Service) mapPermission(permission string) ([]string, error) {
 	var actions []string
 
 	// Write action sets for folders and dashboards
-	if s.options.Resource == dashboards.ScopeFoldersRoot || s.options.Resource == dashboards.ScopeDashboardsRoot {
+	if s.options.Resource == folder.ScopeFoldersRoot || s.options.Resource == dashboards.ScopeDashboardsRoot {
 		actions = append(actions, s.options.GetActionSetName(permission))
 
 		// If we only want to store action sets, return now
@@ -595,11 +596,11 @@ func (a *ActionSetSvc) ResolveActionSet(actionSet string) []string {
 // StoreActionSet stores action set. If a set with the given name has already been stored, the new actions will be appended to the existing actions.
 func (a *ActionSetSvc) StoreActionSet(name string, actions []string) {
 	// To avoid backwards incompatible changes, we don't want to store these actions in the DB
-	// Once action sets are fully enabled, we can include dashboards.ActionFoldersCreate in the list of other folder edit/admin actions
+	// Once action sets are fully enabled, we can include folder.ActionFoldersCreate in the list of other folder edit/admin actions
 	// Tracked in https://github.com/grafana/identity-access-team/issues/794
 	if name == "folders:edit" || name == "folders:admin" {
-		if !slices.Contains(a.ResolveActionSet(name), dashboards.ActionFoldersCreate) {
-			actions = append(actions, dashboards.ActionFoldersCreate)
+		if !slices.Contains(a.ResolveActionSet(name), folder.ActionFoldersCreate) {
+			actions = append(actions, folder.ActionFoldersCreate)
 		}
 	}
 
@@ -637,7 +638,7 @@ func (a *ActionSetSvc) RegisterActionSets(ctx context.Context, pluginID string, 
 
 func isActionSetEnabledResource(action string) bool {
 	return strings.HasPrefix(action, dashboards.ScopeDashboardsRoot) ||
-		strings.HasPrefix(action, dashboards.ScopeFoldersRoot) ||
+		strings.HasPrefix(action, folder.ScopeFoldersRoot) ||
 		strings.HasPrefix(action, accesscontrol.AlertingRoutesKind)
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
@@ -583,7 +584,7 @@ func TestStore_IsInherited(t *testing.T) {
 		{
 			description: "specific folder scope for dashboards is inherited",
 			permission: &flatResourcePermission{
-				Scope:    dashboards.ScopeFoldersProvider.GetResourceScopeUID("parent"),
+				Scope:    folder.ScopeFoldersProvider.GetResourceScopeUID("parent"),
 				RoleName: fmt.Sprintf("%stest_role", accesscontrol.ManagedRolePrefix),
 			},
 			requiredScope: dashboards.ScopeDashboardsProvider.GetResourceScopeUID("some_uid"),
@@ -601,10 +602,10 @@ func TestStore_IsInherited(t *testing.T) {
 		{
 			description: "parent folder scope for nested folders is inherited",
 			permission: &flatResourcePermission{
-				Scope:    dashboards.ScopeFoldersProvider.GetResourceScopeUID("parent"),
+				Scope:    folder.ScopeFoldersProvider.GetResourceScopeUID("parent"),
 				RoleName: fmt.Sprintf("%stest_role", accesscontrol.ManagedRolePrefix),
 			},
-			requiredScope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("some_folder"),
+			requiredScope: folder.ScopeFoldersProvider.GetResourceScopeUID("some_folder"),
 			expected:      true,
 		},
 	}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -28,7 +28,7 @@ var alertRulesPermissions = map[string][]string{
 	accesscontrol.ActionAlertingRuleRead:   {"*"},
 	accesscontrol.ActionAlertingRuleCreate: {"*"},
 	accesscontrol.ActionAlertingRuleUpdate: {"*"},
-	dashboards.ActionFoldersRead:           {"*"},
+	folder.ActionFoldersRead:               {"*"},
 	datasources.ActionQuery:                {"*"},
 }
 

--- a/pkg/services/dashboards/accesscontrol.go
+++ b/pkg/services/dashboards/accesscontrol.go
@@ -2,7 +2,6 @@ package dashboards
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -13,16 +12,6 @@ import (
 )
 
 const (
-	ScopeFoldersRoot   = "folders"
-	ScopeFoldersPrefix = "folders:uid:"
-
-	ActionFoldersCreate           = "folders:create"
-	ActionFoldersRead             = "folders:read"
-	ActionFoldersWrite            = "folders:write"
-	ActionFoldersDelete           = "folders:delete"
-	ActionFoldersPermissionsRead  = "folders.permissions:read"
-	ActionFoldersPermissionsWrite = "folders.permissions:write"
-
 	ScopeDashboardsRoot   = "dashboards"
 	ScopeDashboardsPrefix = "dashboards:uid:"
 
@@ -32,84 +21,13 @@ const (
 	ActionDashboardsDelete           = "dashboards:delete"
 	ActionDashboardsPermissionsRead  = "dashboards.permissions:read"
 	ActionDashboardsPermissionsWrite = "dashboards.permissions:write"
-	ActionDashboardsPublicWrite      = "dashboards.public:write"
-	ActionSnapshotsCreate            = "snapshots:create"
-	ActionSnapshotsDelete            = "snapshots:delete"
-	ActionSnapshotsRead              = "snapshots:read"
 )
 
 var (
-	ScopeFoldersProvider    = ac.NewScopeProvider(ScopeFoldersRoot)
-	ScopeFoldersAll         = ScopeFoldersProvider.GetResourceAllScope()
 	ScopeDashboardsProvider = ac.NewScopeProvider(ScopeDashboardsRoot)
 	ScopeDashboardsAll      = ScopeDashboardsProvider.GetResourceAllScope()
 	tracer                  = otel.Tracer("github.com/grafana/grafana/pkg/services/dashboards")
 )
-
-type UIDLookup = func(ctx context.Context, orgID int64, id int64) (string, error)
-
-// NewFolderIDScopeResolver provides an ScopeAttributeResolver that is able to convert a scope prefixed with "folders:id:" into an uid based scope.
-func NewFolderIDScopeResolver(lookup UIDLookup, folderSvc folder.Service) (string, ac.ScopeAttributeResolver) {
-	prefix := ScopeFoldersProvider.GetResourceScope("")
-	return prefix, ac.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
-		ctx, span := tracer.Start(ctx, "dashboards.NewFolderIDScopeResolver")
-		span.End()
-
-		if !strings.HasPrefix(scope, prefix) {
-			return nil, ac.ErrInvalidScope
-		}
-
-		id, err := ac.ParseScopeID(scope)
-		if err != nil {
-			return nil, err
-		}
-
-		if id == 0 {
-			return []string{ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)}, nil
-		}
-
-		return identity.WithServiceIdentityFn(ctx, orgID, func(ctx context.Context) ([]string, error) {
-			uid, err := lookup(ctx, orgID, id)
-			if err != nil {
-				return nil, err
-			}
-
-			result, err := GetInheritedScopes(ctx, orgID, uid, folderSvc)
-			if err != nil {
-				return nil, err
-			}
-
-			return append([]string{ScopeFoldersProvider.GetResourceScopeUID(uid)}, result...), nil
-		})
-	})
-}
-
-// NewFolderUIDScopeResolver provides an ScopeAttributeResolver that is able to convert a scope prefixed with "folders:uid:"
-// into uid based scopes for folder and its parents
-func NewFolderUIDScopeResolver(folderSvc folder.Service) (string, ac.ScopeAttributeResolver) {
-	prefix := ScopeFoldersProvider.GetResourceScopeUID("")
-	return prefix, ac.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
-		ctx, span := tracer.Start(ctx, "dashboards.NewFolderUIDScopeResolver")
-		span.End()
-
-		if !strings.HasPrefix(scope, prefix) {
-			return nil, ac.ErrInvalidScope
-		}
-
-		uid, err := ac.ParseScopeUID(scope)
-		if err != nil {
-			return nil, err
-		}
-
-		return identity.WithServiceIdentityFn(ctx, orgID, func(ctx context.Context) ([]string, error) {
-			inheritedScopes, err := GetInheritedScopes(ctx, orgID, uid, folderSvc)
-			if err != nil {
-				return nil, err
-			}
-			return append(inheritedScopes, ScopeFoldersProvider.GetResourceScopeUID(uid)), nil
-		})
-	})
-}
 
 // NewDashboardIDScopeResolver provides an ScopeAttributeResolver that is able to convert a scope prefixed with "dashboards:id:"
 // into uid based scopes for both dashboard and folder
@@ -178,44 +96,17 @@ func resolveDashboardScope(ctx context.Context, orgID int64, dashboard *Dashboar
 		folderUID = dashboard.FolderUID
 	}
 
-	result, err := GetInheritedScopes(ctx, orgID, folderUID, folderSvc)
+	result, err := folder.GetInheritedScopes(ctx, orgID, folderUID, folderSvc)
 	if err != nil {
 		return nil, err
 	}
 
 	result = append([]string{
 		ScopeDashboardsProvider.GetResourceScopeUID(dashboard.UID),
-		ScopeFoldersProvider.GetResourceScopeUID(folderUID),
+		folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID),
 	},
 		result...,
 	)
-
-	return result, nil
-}
-
-func GetInheritedScopes(ctx context.Context, orgID int64, folderUID string, folderSvc folder.Service) ([]string, error) {
-	ctx, span := tracer.Start(ctx, "dashboards.GetInheritedScopes")
-	span.End()
-
-	if folderUID == ac.GeneralFolderUID {
-		return nil, nil
-	}
-	ancestors, err := folderSvc.GetParents(ctx, folder.GetParentsQuery{
-		UID:   folderUID,
-		OrgID: orgID,
-	})
-
-	if err != nil {
-		if errors.Is(err, folder.ErrFolderNotFound) {
-			return nil, err
-		}
-		return nil, ac.ErrInternal.Errorf("could not retrieve folder parents: %w", err)
-	}
-
-	result := make([]string, 0, len(ancestors))
-	for _, ff := range ancestors {
-		result = append(result, ScopeFoldersProvider.GetResourceScopeUID(ff.UID))
-	}
 
 	return result, nil
 }

--- a/pkg/services/dashboards/accesscontrol_test.go
+++ b/pkg/services/dashboards/accesscontrol_test.go
@@ -2,7 +2,6 @@ package dashboards
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -11,56 +10,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 )
-
-func noOpLookup(ctx context.Context, orgID int64, id int64) (string, error) {
-	return fmt.Sprintf("%d", id), nil
-}
-
-func TestNewFolderIDScopeResolver(t *testing.T) {
-	t.Run("prefix should be expected", func(t *testing.T) {
-		prefix, _ := NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
-		require.Equal(t, "folders:id:", prefix)
-	})
-
-	t.Run("resolver should fail if input scope is not expected", func(t *testing.T) {
-		_, resolver := NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
-
-		_, err := resolver.Resolve(context.Background(), rand.Int63(), "folders:uid:123")
-		require.ErrorIs(t, err, ac.ErrInvalidScope)
-	})
-
-	t.Run("resolver should convert id 0 to general uid scope", func(t *testing.T) {
-		var (
-			orgId       = rand.Int63()
-			scope       = "folders:id:0"
-			_, resolver = NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
-		)
-
-		resolved, err := resolver.Resolve(context.Background(), orgId, scope)
-		require.NoError(t, err)
-
-		require.Len(t, resolved, 1)
-		require.Equal(t, "folders:uid:general", resolved[0])
-	})
-
-	t.Run("resolver should fail if resource of input scope is empty", func(t *testing.T) {
-		_, resolver := NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
-
-		_, err := resolver.Resolve(context.Background(), rand.Int63(), "folders:id:")
-		require.ErrorIs(t, err, ac.ErrInvalidScope)
-	})
-	t.Run("returns 'not found' if folder does not exist", func(t *testing.T) {
-		_, resolver := NewFolderIDScopeResolver(func(ctx context.Context, orgID int64, id int64) (string, error) {
-			return "", ErrDashboardNotFound
-		}, foldertest.NewFakeService())
-
-		orgId := rand.Int63()
-		scope := "folders:id:10"
-		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
-		require.ErrorIs(t, err, ErrDashboardNotFound)
-		require.Nil(t, resolvedScopes)
-	})
-}
 
 func TestNewDashboardIDScopeResolver(t *testing.T) {
 	t.Run("prefix should be expected", func(t *testing.T) {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -877,11 +877,11 @@ func (dr *DashboardServiceImpl) ValidateDashboardBeforeSave(ctx context.Context,
 func (dr *DashboardServiceImpl) canSaveDashboard(ctx context.Context, user identity.Requester, dash *dashboards.Dashboard) (bool, error) {
 	action := dashboards.ActionDashboardsWrite
 	if dash.IsFolder {
-		action = dashboards.ActionFoldersWrite
+		action = folder.ActionFoldersWrite
 	}
 	scope := dashboards.ScopeDashboardsProvider.GetResourceScopeUID(dash.UID)
 	if dash.IsFolder {
-		scope = dashboards.ScopeFoldersProvider.GetResourceScopeUID(dash.UID)
+		scope = folder.ScopeFoldersProvider.GetResourceScopeUID(dash.UID)
 	}
 	return dr.ac.Evaluate(ctx, user, accesscontrol.EvalPermission(action, scope))
 }
@@ -889,11 +889,11 @@ func (dr *DashboardServiceImpl) canSaveDashboard(ctx context.Context, user ident
 func (dr *DashboardServiceImpl) canCreateDashboard(ctx context.Context, user identity.Requester, dash *dashboards.Dashboard) (bool, error) {
 	action := dashboards.ActionDashboardsCreate
 	if dash.IsFolder {
-		action = dashboards.ActionFoldersCreate
+		action = folder.ActionFoldersCreate
 	}
-	scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(dash.FolderUID)
+	scope := folder.ScopeFoldersProvider.GetResourceScopeUID(dash.FolderUID)
 	if dash.FolderUID == "" {
-		scope = dashboards.ScopeFoldersProvider.GetResourceScopeUID(accesscontrol.GeneralFolderUID)
+		scope = folder.ScopeFoldersProvider.GetResourceScopeUID(accesscontrol.GeneralFolderUID)
 	}
 	return dr.ac.Evaluate(ctx, user, accesscontrol.EvalPermission(action, scope))
 }

--- a/pkg/services/dashboardsnapshots/models.go
+++ b/pkg/services/dashboardsnapshots/models.go
@@ -8,6 +8,12 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
+const (
+	ActionSnapshotsCreate = "snapshots:create"
+	ActionSnapshotsDelete = "snapshots:delete"
+	ActionSnapshotsRead   = "snapshots:read"
+)
+
 // DashboardSnapshot model
 type DashboardSnapshot struct {
 	ID                int64 `xorm:"pk autoincr 'id'"`

--- a/pkg/services/folder/access_control.go
+++ b/pkg/services/folder/access_control.go
@@ -1,0 +1,122 @@
+package folder
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+const (
+	ScopeFoldersRoot   = "folders"
+	ScopeFoldersPrefix = "folders:uid:"
+
+	ActionFoldersCreate           = "folders:create"
+	ActionFoldersRead             = "folders:read"
+	ActionFoldersWrite            = "folders:write"
+	ActionFoldersDelete           = "folders:delete"
+	ActionFoldersPermissionsRead  = "folders.permissions:read"
+	ActionFoldersPermissionsWrite = "folders.permissions:write"
+)
+
+var (
+	ScopeFoldersProvider = ac.NewScopeProvider(ScopeFoldersRoot)
+	ScopeFoldersAll      = ScopeFoldersProvider.GetResourceAllScope()
+	tracer               = otel.Tracer("github.com/grafana/grafana/pkg/services/folder")
+)
+
+type UIDLookup = func(ctx context.Context, orgID int64, id int64) (string, error)
+
+// NewFolderIDScopeResolver provides an ScopeAttributeResolver that is able to convert a scope prefixed with "folders:id:" into an uid based scope.
+func NewFolderIDScopeResolver(lookup UIDLookup, folderSvc Service) (string, ac.ScopeAttributeResolver) {
+	prefix := ScopeFoldersProvider.GetResourceScope("")
+	return prefix, ac.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
+		ctx, span := tracer.Start(ctx, "dashboards.NewFolderIDScopeResolver")
+		span.End()
+
+		if !strings.HasPrefix(scope, prefix) {
+			return nil, ac.ErrInvalidScope
+		}
+
+		id, err := ac.ParseScopeID(scope)
+		if err != nil {
+			return nil, err
+		}
+
+		if id == 0 {
+			return []string{ScopeFoldersProvider.GetResourceScopeUID(ac.GeneralFolderUID)}, nil
+		}
+
+		return identity.WithServiceIdentityFn(ctx, orgID, func(ctx context.Context) ([]string, error) {
+			uid, err := lookup(ctx, orgID, id)
+			if err != nil {
+				return nil, err
+			}
+
+			result, err := GetInheritedScopes(ctx, orgID, uid, folderSvc)
+			if err != nil {
+				return nil, err
+			}
+
+			return append([]string{ScopeFoldersProvider.GetResourceScopeUID(uid)}, result...), nil
+		})
+	})
+}
+
+// NewFolderUIDScopeResolver provides an ScopeAttributeResolver that is able to convert a scope prefixed with "folders:uid:"
+// into uid based scopes for folder and its parents
+func NewFolderUIDScopeResolver(folderSvc Service) (string, ac.ScopeAttributeResolver) {
+	prefix := ScopeFoldersProvider.GetResourceScopeUID("")
+	return prefix, ac.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
+		ctx, span := tracer.Start(ctx, "dashboards.NewFolderUIDScopeResolver")
+		span.End()
+
+		if !strings.HasPrefix(scope, prefix) {
+			return nil, ac.ErrInvalidScope
+		}
+
+		uid, err := ac.ParseScopeUID(scope)
+		if err != nil {
+			return nil, err
+		}
+
+		return identity.WithServiceIdentityFn(ctx, orgID, func(ctx context.Context) ([]string, error) {
+			inheritedScopes, err := GetInheritedScopes(ctx, orgID, uid, folderSvc)
+			if err != nil {
+				return nil, err
+			}
+			return append(inheritedScopes, ScopeFoldersProvider.GetResourceScopeUID(uid)), nil
+		})
+	})
+}
+
+func GetInheritedScopes(ctx context.Context, orgID int64, folderUID string, folderSvc Service) ([]string, error) {
+	ctx, span := tracer.Start(ctx, "dashboards.GetInheritedScopes")
+	span.End()
+
+	if folderUID == ac.GeneralFolderUID {
+		return nil, nil
+	}
+	ancestors, err := folderSvc.GetParents(ctx, GetParentsQuery{
+		UID:   folderUID,
+		OrgID: orgID,
+	})
+
+	if err != nil {
+		if errors.Is(err, ErrFolderNotFound) {
+			return nil, err
+		}
+		return nil, ac.ErrInternal.Errorf("could not retrieve folder parents: %w", err)
+	}
+
+	result := make([]string, 0, len(ancestors))
+	for _, ff := range ancestors {
+		result = append(result, ScopeFoldersProvider.GetResourceScopeUID(ff.UID))
+	}
+
+	return result, nil
+}

--- a/pkg/services/folder/folderimpl/access_control_test.go
+++ b/pkg/services/folder/folderimpl/access_control_test.go
@@ -1,0 +1,62 @@
+package folderimpl
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/stretchr/testify/require"
+)
+
+func noOpLookup(ctx context.Context, orgID int64, id int64) (string, error) {
+	return fmt.Sprintf("%d", id), nil
+}
+func TestNewFolderIDScopeResolver(t *testing.T) {
+	t.Run("prefix should be expected", func(t *testing.T) {
+		prefix, _ := folder.NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
+		require.Equal(t, "folders:id:", prefix)
+	})
+
+	t.Run("resolver should fail if input scope is not expected", func(t *testing.T) {
+		_, resolver := folder.NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
+
+		_, err := resolver.Resolve(context.Background(), rand.Int63(), "folders:uid:123")
+		require.ErrorIs(t, err, ac.ErrInvalidScope)
+	})
+
+	t.Run("resolver should convert id 0 to general uid scope", func(t *testing.T) {
+		var (
+			orgId       = rand.Int63()
+			scope       = "folders:id:0"
+			_, resolver = folder.NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
+		)
+
+		resolved, err := resolver.Resolve(context.Background(), orgId, scope)
+		require.NoError(t, err)
+
+		require.Len(t, resolved, 1)
+		require.Equal(t, "folders:uid:general", resolved[0])
+	})
+
+	t.Run("resolver should fail if resource of input scope is empty", func(t *testing.T) {
+		_, resolver := folder.NewFolderIDScopeResolver(noOpLookup, foldertest.NewFakeService())
+
+		_, err := resolver.Resolve(context.Background(), rand.Int63(), "folders:id:")
+		require.ErrorIs(t, err, ac.ErrInvalidScope)
+	})
+	t.Run("returns 'not found' if folder does not exist", func(t *testing.T) {
+		_, resolver := folder.NewFolderIDScopeResolver(func(ctx context.Context, orgID int64, id int64) (string, error) {
+			return "", folder.ErrFolderNotFound
+		}, foldertest.NewFakeService())
+
+		orgId := rand.Int63()
+		scope := "folders:id:10"
+		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
+		require.ErrorIs(t, err, folder.ErrFolderNotFound)
+		require.Nil(t, resolvedScopes)
+	})
+}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -78,8 +78,8 @@ func ProvideService(
 
 	supportBundles.RegisterSupportItemCollector(srv.supportBundleCollector())
 
-	ac.RegisterScopeAttributeResolver(dashboards.NewFolderIDScopeResolver(srv.getUIDFromLegacyID, srv))
-	ac.RegisterScopeAttributeResolver(dashboards.NewFolderUIDScopeResolver(srv))
+	ac.RegisterScopeAttributeResolver(folder.NewFolderIDScopeResolver(srv.getUIDFromLegacyID, srv))
+	ac.RegisterScopeAttributeResolver(folder.NewFolderUIDScopeResolver(srv))
 
 	k8sHandler := client.NewK8sHandler(
 		request.GetNamespaceMapper(cfg),
@@ -193,10 +193,10 @@ func (s *Service) getAvailableNonRootFolders(ctx context.Context, q *folder.GetC
 	permissions := q.SignedInUser.GetPermissions()
 	var folderPermissions []string
 	if q.Permission == dashboardaccess.PERMISSION_EDIT {
-		folderPermissions = permissions[dashboards.ActionFoldersWrite]
+		folderPermissions = permissions[folder.ActionFoldersWrite]
 		folderPermissions = append(folderPermissions, permissions[dashboards.ActionDashboardsWrite]...)
 	} else {
-		folderPermissions = permissions[dashboards.ActionFoldersRead]
+		folderPermissions = permissions[folder.ActionFoldersRead]
 		folderPermissions = append(folderPermissions, permissions[dashboards.ActionDashboardsRead]...)
 	}
 
@@ -207,7 +207,7 @@ func (s *Service) getAvailableNonRootFolders(ctx context.Context, q *folder.GetC
 	nonRootFolders := make([]*folder.Folder, 0)
 	folderUids := make([]string, 0, len(folderPermissions))
 	for _, p := range folderPermissions {
-		if folderUid, found := strings.CutPrefix(p, dashboards.ScopeFoldersPrefix); found {
+		if folderUid, found := strings.CutPrefix(p, folder.ScopeFoldersPrefix); found {
 			if !slices.Contains(folderUids, folderUid) {
 				folderUids = append(folderUids, folderUid)
 			}
@@ -406,7 +406,7 @@ func (s *Service) supportBundleCollector() supportbundles.Collector {
 					OrgRole:          "Admin",
 					IsGrafanaAdmin:   true,
 					IsServiceAccount: true,
-					Permissions:      map[int64]map[string][]string{accesscontrol.GlobalOrgID: {dashboards.ActionFoldersRead: {dashboards.ScopeFoldersAll}}},
+					Permissions:      map[int64]map[string][]string{accesscontrol.GlobalOrgID: {folder.ActionFoldersRead: {folder.ScopeFoldersAll}}},
 				},
 			})
 			if err != nil {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -41,19 +41,19 @@ func (s *Service) getFoldersFromApiServer(ctx context.Context, q folder.GetFolde
 
 	qry := folder.NewGetFoldersQuery(q)
 	permissions := q.SignedInUser.GetPermissions()
-	folderPermissions := permissions[dashboards.ActionFoldersRead]
+	folderPermissions := permissions[folder.ActionFoldersRead]
 	qry.AncestorUIDs = make([]string, 0, len(folderPermissions))
 	if len(folderPermissions) == 0 && !q.SignedInUser.GetIsGrafanaAdmin() {
 		return nil, nil
 	}
 	for _, p := range folderPermissions {
-		if p == dashboards.ScopeFoldersAll {
+		if p == folder.ScopeFoldersAll {
 			// no need to query for folders with permissions
 			// the user has permission to access all folders
 			qry.AncestorUIDs = nil
 			break
 		}
-		if folderUid, found := strings.CutPrefix(p, dashboards.ScopeFoldersPrefix); found {
+		if folderUid, found := strings.CutPrefix(p, folder.ScopeFoldersPrefix); found {
 			if !slices.Contains(qry.AncestorUIDs, folderUid) {
 				qry.AncestorUIDs = append(qry.AncestorUIDs, folderUid)
 			}
@@ -117,7 +117,7 @@ func (s *Service) getFromApiServer(ctx context.Context, q *folder.GetFolderQuery
 		return dashFolder, nil
 	}
 
-	evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(dashFolder.UID))
+	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(dashFolder.UID))
 	if canView, err := s.accessControl.Evaluate(ctx, q.SignedInUser, evaluator); err != nil || !canView {
 		if err != nil {
 			return nil, toFolderError(err)
@@ -367,9 +367,9 @@ func (s *Service) getChildrenFromApiServer(ctx context.Context, q *folder.GetChi
 
 	// we only need to check access to the folder
 	// if the parent is accessible then the subfolders are accessible as well (due to inheritance)
-	evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(q.UID))
+	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(q.UID))
 	if q.Permission == dashboardaccess.PERMISSION_EDIT {
-		evaluator = accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(q.UID))
+		evaluator = accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(q.UID))
 	}
 	if hasAccess, err := s.accessControl.Evaluate(ctx, q.SignedInUser, evaluator); err != nil || !hasAccess {
 		if err != nil {
@@ -392,9 +392,9 @@ func (s *Service) getRootFoldersFromApiServer(ctx context.Context, q *folder.Get
 	permissions := q.SignedInUser.GetPermissions()
 	var folderPermissions []string
 	if q.Permission == dashboardaccess.PERMISSION_EDIT {
-		folderPermissions = permissions[dashboards.ActionFoldersWrite]
+		folderPermissions = permissions[folder.ActionFoldersWrite]
 	} else {
-		folderPermissions = permissions[dashboards.ActionFoldersRead]
+		folderPermissions = permissions[folder.ActionFoldersRead]
 	}
 
 	if len(folderPermissions) == 0 && !q.SignedInUser.GetIsGrafanaAdmin() {
@@ -403,13 +403,13 @@ func (s *Service) getRootFoldersFromApiServer(ctx context.Context, q *folder.Get
 
 	q.FolderUIDs = make([]string, 0, len(folderPermissions))
 	for _, p := range folderPermissions {
-		if p == dashboards.ScopeFoldersAll {
+		if p == folder.ScopeFoldersAll {
 			// no need to query for folders with permissions
 			// the user has permission to access all folders
 			q.FolderUIDs = nil
 			break
 		}
-		if folderUid, found := strings.CutPrefix(p, dashboards.ScopeFoldersPrefix); found {
+		if folderUid, found := strings.CutPrefix(p, folder.ScopeFoldersPrefix); found {
 			if !slices.Contains(q.FolderUIDs, folderUid) {
 				q.FolderUIDs = append(q.FolderUIDs, folderUid)
 			}
@@ -453,9 +453,9 @@ func (s *Service) createOnApiServer(ctx context.Context, cmd *folder.CreateFolde
 
 	if cmd.ParentUID != "" {
 		// Check that the user is allowed to create a subfolder in this folder
-		parentUIDScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.ParentUID)
-		legacyEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, parentUIDScope)
-		newEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersCreate, parentUIDScope)
+		parentUIDScope := folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.ParentUID)
+		legacyEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, parentUIDScope)
+		newEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersCreate, parentUIDScope)
 		evaluator := accesscontrol.EvalAny(legacyEvaluator, newEvaluator)
 		hasAccess, evalErr := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator)
 		if evalErr != nil {
@@ -465,7 +465,7 @@ func (s *Service) createOnApiServer(ctx context.Context, cmd *folder.CreateFolde
 			return nil, dashboards.ErrFolderCreationAccessDenied.Errorf("user is missing the permission with action either folders:create or folders:write and scope %s or any of the parent folder scopes", parentUIDScope)
 		}
 	} else {
-		evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
+		evaluator := accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
 		hasAccess, evalErr := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator)
 		if evalErr != nil {
 			return nil, evalErr
@@ -535,7 +535,7 @@ func (s *Service) updateOnApiServer(ctx context.Context, cmd *folder.UpdateFolde
 		return nil, dashboards.ErrDashboardTitleEmpty
 	}
 
-	evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID))
+	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID))
 	if hasAccess, err := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator); err != nil || !hasAccess {
 		if err != nil {
 			return nil, err
@@ -580,7 +580,7 @@ func (s *Service) deleteFromApiServer(ctx context.Context, cmd *folder.DeleteFol
 		return folder.ErrBadRequest.Errorf("invalid orgID")
 	}
 
-	evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID))
+	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersDelete, folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID))
 	if hasAccess, err := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator); err != nil || !hasAccess {
 		if err != nil {
 			return toFolderError(err)
@@ -720,12 +720,12 @@ func (s *Service) canMoveViaApiServer(ctx context.Context, cmd *folder.MoveFolde
 	var evaluator accesscontrol.Evaluator
 	parentUID := cmd.NewParentUID
 	if parentUID != "" {
-		legacyEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.NewParentUID))
-		newEvaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.NewParentUID))
+		legacyEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.NewParentUID))
+		newEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.NewParentUID))
 		evaluator = accesscontrol.EvalAny(legacyEvaluator, newEvaluator)
 	} else {
 		// Evaluate folder creation permission when moving folder to the root level
-		evaluator = accesscontrol.EvalPermission(dashboards.ActionFoldersCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
+		evaluator = accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
 		parentUID = folder.GeneralFolderUID
 	}
 	if hasAccess, err := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator); err != nil {
@@ -745,7 +745,7 @@ func (s *Service) canMoveViaApiServer(ctx context.Context, cmd *folder.MoveFolde
 
 	permissions := cmd.SignedInUser.GetPermissions()
 	var evaluators []accesscontrol.Evaluator
-	currentFolderScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID)
+	currentFolderScope := folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID)
 	for action, scopes := range permissions {
 		for _, scope := range newFolderAndParentUIDs {
 			if slices.Contains(scopes, scope) {
@@ -767,7 +767,7 @@ func (s *Service) getFolderAndParentUIDScopesViaApiServer(ctx context.Context, f
 	ctx, span := s.tracer.Start(ctx, "folder.getFolderAndParentUIDScopesViaApiServer")
 	defer span.End()
 
-	folderAndParentUIDScopes := []string{dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}
+	folderAndParentUIDScopes := []string{folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}
 	if folderUID == folder.GeneralFolderUID {
 		return folderAndParentUIDScopes, nil
 	}
@@ -776,7 +776,7 @@ func (s *Service) getFolderAndParentUIDScopesViaApiServer(ctx context.Context, f
 		return nil, err
 	}
 	for _, newParent := range folderParents {
-		scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(newParent.UID)
+		scope := folder.ScopeFoldersProvider.GetResourceScopeUID(newParent.UID)
 		folderAndParentUIDScopes = append(folderAndParentUIDScopes, scope)
 	}
 	return folderAndParentUIDScopes, nil

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -251,12 +251,12 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		1: accesscontrol.GroupScopesByActionContext(
 			ctx,
 			[]accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersCreate, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionFoldersDelete, Scope: dashboards.ScopeFoldersAll},
-				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
-				{Action: accesscontrol.ActionAlertingRuleDelete, Scope: dashboards.ScopeFoldersAll},
-				{Action: accesscontrol.ActionLibraryPanelsDelete, Scope: dashboards.ScopeFoldersAll},
+				{Action: folder.ActionFoldersCreate, Scope: folder.ScopeFoldersAll},
+				{Action: folder.ActionFoldersWrite, Scope: folder.ScopeFoldersAll},
+				{Action: folder.ActionFoldersDelete, Scope: folder.ScopeFoldersAll},
+				{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
+				{Action: accesscontrol.ActionAlertingRuleDelete, Scope: folder.ScopeFoldersAll},
+				{Action: accesscontrol.ActionLibraryPanelsDelete, Scope: folder.ScopeFoldersAll},
 			}),
 	}}
 

--- a/pkg/services/libraryelements/accesscontrol.go
+++ b/pkg/services/libraryelements/accesscontrol.go
@@ -73,12 +73,12 @@ func LibraryPanelUIDScopeResolver(l *LibraryElementService, folderSvc folder.Ser
 		if tree != nil {
 			inheritedScopes = getInheritedScopesFromTree(libElDTO.FolderUID, tree)
 		} else {
-			inheritedScopes, err = dashboards.GetInheritedScopes(ctx, orgID, libElDTO.FolderUID, folderSvc)
+			inheritedScopes, err = folder.GetInheritedScopes(ctx, orgID, libElDTO.FolderUID, folderSvc)
 			if err != nil {
 				return nil, err
 			}
 		}
-		return append(inheritedScopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(libElDTO.FolderUID), ScopeLibraryPanelsProvider.GetResourceScopeUID(uid)), nil
+		return append(inheritedScopes, folder.ScopeFoldersProvider.GetResourceScopeUID(libElDTO.FolderUID), ScopeLibraryPanelsProvider.GetResourceScopeUID(uid)), nil
 	})
 }
 
@@ -90,7 +90,7 @@ func getInheritedScopesFromTree(folderUID string, tree *folder.FolderTree) []str
 
 	result := make([]string, 0)
 	for ancestor := range tree.Ancestors(folderUID) {
-		result = append(result, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ancestor.UID))
+		result = append(result, folder.ScopeFoldersProvider.GetResourceScopeUID(ancestor.UID))
 	}
 	return result
 }

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -180,7 +180,7 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 	}
 
 	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
-		allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)))
+		allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)))
 		if !allowed {
 			return fmt.Errorf("insufficient permissions for creating library panel in folder with UID: '%s'", folderUID)
 		}

--- a/pkg/services/libraryelements/guard.go
+++ b/pkg/services/libraryelements/guard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/org"
 )
@@ -38,7 +39,7 @@ func (l *LibraryElementService) requireEditPermissionsOnFolderUID(ctx context.Co
 		return dashboards.ErrFolderAccessDenied
 	}
 
-	evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID))
+	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID))
 	canEdit, err := l.AccessControl.Evaluate(ctx, user, evaluator)
 	if err != nil {
 		return err
@@ -51,7 +52,7 @@ func (l *LibraryElementService) requireEditPermissionsOnFolderUID(ctx context.Co
 }
 
 func (l *LibraryElementService) requireViewPermissionsOnFolderUID(ctx context.Context, user identity.Requester, folderUID string) error {
-	evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID))
+	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID))
 	canView, err := l.AccessControl.Evaluate(ctx, user, evaluator)
 	if err != nil {
 		return err

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -76,7 +76,7 @@ func TestIntegration_GetLibraryElement(t *testing.T) {
 				}
 			}
 
-			sc.reqContext.Permissions[sc.reqContext.OrgID][dashboards.ActionFoldersRead] = []string{dashboards.ScopeFoldersAll}
+			sc.reqContext.Permissions[sc.reqContext.OrgID][folder.ActionFoldersRead] = []string{folder.ScopeFoldersAll}
 
 			// by uid
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
@@ -102,8 +102,8 @@ func TestIntegration_GetLibraryElement(t *testing.T) {
 			b, err := json.Marshal(map[string]string{"test": "test"})
 			require.NoError(t, err)
 			newFolder := createFolder(t, sc, "NewFolder", sc.folderSvc)
-			sc.reqContext.Permissions[sc.reqContext.OrgID][dashboards.ActionFoldersRead] = []string{dashboards.ScopeFoldersAll}
-			sc.reqContext.Permissions[sc.reqContext.OrgID][dashboards.ActionFoldersDelete] = []string{dashboards.ScopeFoldersAll}
+			sc.reqContext.Permissions[sc.reqContext.OrgID][folder.ActionFoldersRead] = []string{folder.ScopeFoldersAll}
+			sc.reqContext.Permissions[sc.reqContext.OrgID][folder.ActionFoldersDelete] = []string{folder.ScopeFoldersAll}
 			result, err := sc.service.CreateElement(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, model.CreateLibraryElementCommand{
 				FolderID:  newFolder.ID, // nolint:staticcheck
 				FolderUID: &newFolder.UID,

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -65,7 +65,7 @@ func TestIntegration_DeleteLibraryPanelsInFolder(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to delete a folder uid that doesn't exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			sc.service.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
-			sc.service.AccessControl.RegisterScopeAttributeResolver(dashboards.NewFolderUIDScopeResolver(sc.service.folderService))
+			sc.service.AccessControl.RegisterScopeAttributeResolver(folder.NewFolderUIDScopeResolver(sc.service.folderService))
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.folder.UID + "xxxx"})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, http.StatusNotFound, resp.Status())
@@ -225,9 +225,9 @@ func createFolder(t *testing.T, sc scenarioContext, title string, folderSvc *fol
 	folderSvc.ExpectedFolders = append(folderSvc.ExpectedFolders, f)
 
 	// Set user permissions on the newly created folder so that they can interact with library elements stored in it
-	sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionFoldersWrite] = append(sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionFoldersWrite], dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
-	sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionFoldersRead] = append(sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionFoldersRead], dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
-	sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionDashboardsCreate] = append(sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionDashboardsCreate], dashboards.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
+	sc.reqContext.Permissions[sc.user.OrgID][folder.ActionFoldersWrite] = append(sc.reqContext.Permissions[sc.user.OrgID][folder.ActionFoldersWrite], folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
+	sc.reqContext.Permissions[sc.user.OrgID][folder.ActionFoldersRead] = append(sc.reqContext.Permissions[sc.user.OrgID][folder.ActionFoldersRead], folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
+	sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionDashboardsCreate] = append(sc.reqContext.Permissions[sc.user.OrgID][dashboards.ActionDashboardsCreate], folder.ScopeFoldersProvider.GetResourceScopeUID(f.UID))
 
 	return f
 }
@@ -281,13 +281,13 @@ func setupTestScenario(t *testing.T) scenarioContext {
 		// Allow user to create folders and library elements
 		Permissions: map[int64]map[string][]string{
 			1: {
-				dashboards.ActionFoldersCreate: {dashboards.ScopeFoldersAll},
-				dashboards.ActionFoldersWrite:  {dashboards.ScopeFoldersAll},
-				dashboards.ActionFoldersRead:   {dashboards.ScopeFoldersAll},
-				ActionLibraryPanelsCreate:      {dashboards.ScopeFoldersAll},
-				ActionLibraryPanelsRead:        {ScopeLibraryPanelsAll},
-				ActionLibraryPanelsWrite:       {ScopeLibraryPanelsAll},
-				ActionLibraryPanelsDelete:      {ScopeLibraryPanelsAll},
+				folder.ActionFoldersCreate: {folder.ScopeFoldersAll},
+				folder.ActionFoldersWrite:  {folder.ScopeFoldersAll},
+				folder.ActionFoldersRead:   {folder.ScopeFoldersAll},
+				ActionLibraryPanelsCreate:  {folder.ScopeFoldersAll},
+				ActionLibraryPanelsRead:    {ScopeLibraryPanelsAll},
+				ActionLibraryPanelsWrite:   {ScopeLibraryPanelsAll},
+				ActionLibraryPanelsDelete:  {ScopeLibraryPanelsAll},
 			},
 		},
 	}

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -519,7 +519,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			LastSeenAt: time.Now(),
 			Permissions: map[int64]map[string][]string{
 				orgID: {
-					dashboards.ActionFoldersRead: {dashboards.ScopeFoldersAll},
+					folder.ActionFoldersRead: {folder.ScopeFoldersAll},
 				},
 			},
 		}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -12,8 +12,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -105,7 +107,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 	}
 
 	if c.IsPublicDashboardView() || hasAccess(ac.EvalAny(
-		ac.EvalPermission(dashboards.ActionFoldersRead), ac.EvalPermission(dashboards.ActionFoldersCreate),
+		ac.EvalPermission(folder.ActionFoldersRead), ac.EvalPermission(folder.ActionFoldersCreate),
 		ac.EvalPermission(dashboards.ActionDashboardsRead), ac.EvalPermission(dashboards.ActionDashboardsCreate)),
 	) {
 		dashboardChildLinks := s.buildDashboardNavLinks(c)
@@ -375,7 +377,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navt
 			})
 		}
 
-		if s.cfg.SnapshotEnabled && hasAccess(ac.EvalPermission(dashboards.ActionSnapshotsRead)) {
+		if s.cfg.SnapshotEnabled && hasAccess(ac.EvalPermission(dashboardsnapshots.ActionSnapshotsRead)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 				Text:     "Snapshots",
 				SubTitle: "Interactive, publicly available, point-in-time representations of dashboards",

--- a/pkg/services/ngalert/accesscontrol/roles.go
+++ b/pkg/services/ngalert/accesscontrol/roles.go
@@ -2,9 +2,9 @@ package accesscontrol
 
 import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 )
@@ -19,7 +19,7 @@ var (
 			Permissions: []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingRuleRead,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 				{
 					Action: accesscontrol.ActionAlertingRuleExternalRead,
@@ -27,7 +27,7 @@ var (
 				},
 				{
 					Action: accesscontrol.ActionAlertingSilencesRead,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 				// Following are needed for simplified notification policies
 				{
@@ -50,15 +50,15 @@ var (
 			Permissions: accesscontrol.ConcatPermissions(rulesReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingRuleCreate,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 				{
 					Action: accesscontrol.ActionAlertingRuleUpdate,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 				{
 					Action: accesscontrol.ActionAlertingRuleDelete,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 				{
 					Action: accesscontrol.ActionAlertingRuleExternalWrite,
@@ -66,11 +66,11 @@ var (
 				},
 				{
 					Action: accesscontrol.ActionAlertingSilencesWrite,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 				{
 					Action: accesscontrol.ActionAlertingSilencesCreate,
-					Scope:  dashboards.ScopeFoldersAll,
+					Scope:  folder.ScopeFoldersAll,
 				},
 			}),
 		},
@@ -383,8 +383,8 @@ var (
 					Action: accesscontrol.ActionAlertingNotificationsProvisioningWrite, // organization scope
 				},
 				{
-					Action: dashboards.ActionFoldersRead,
-					Scope:  dashboards.ScopeFoldersAll,
+					Action: folder.ActionFoldersRead,
+					Scope:  folder.ScopeFoldersAll,
 				},
 			},
 		},

--- a/pkg/services/ngalert/accesscontrol/rules.go
+++ b/pkg/services/ngalert/accesscontrol/rules.go
@@ -8,8 +8,8 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 )
@@ -40,8 +40,8 @@ func NewRuleService(ac accesscontrol.AccessControl) *RuleService {
 // getReadFolderAccessEvaluator constructs accesscontrol.Evaluator that checks all permissions required to read rules in  specific folder
 func getReadFolderAccessEvaluator(folderUID string) accesscontrol.Evaluator {
 	return accesscontrol.EvalAll(
-		accesscontrol.EvalPermission(ruleRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)),
-		accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)),
+		accesscontrol.EvalPermission(ruleRead, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)),
+		accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)),
 	)
 }
 
@@ -85,8 +85,8 @@ func (r *RuleService) getRulesQueryEvaluator(rules ...*models.AlertRule) accessc
 // CanReadAllRules returns true when user has access to all folders and can read rules in them.
 func (r *RuleService) CanReadAllRules(ctx context.Context, user identity.Requester) (bool, error) {
 	return r.HasAccess(ctx, user, accesscontrol.EvalAll(
-		accesscontrol.EvalPermission(ruleRead, dashboards.ScopeFoldersProvider.GetResourceAllScope()),
-		accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceAllScope()),
+		accesscontrol.EvalPermission(ruleRead, folder.ScopeFoldersProvider.GetResourceAllScope()),
+		accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceAllScope()),
 	))
 }
 
@@ -176,16 +176,16 @@ func checkFolderAccessByFullpath(user identity.Requester, rule models.Namespaced
 	}
 
 	folderUID := rule.GetNamespaceUID()
-	targetScopes := []string{dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}
+	targetScopes := []string{folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}
 	for _, uid := range strings.Split(fullpath, "/") {
 		if uid != "" && uid != folderUID {
-			targetScopes = append(targetScopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(uid))
+			targetScopes = append(targetScopes, folder.ScopeFoldersProvider.GetResourceScopeUID(uid))
 		}
 	}
 
 	evaluator := accesscontrol.EvalAll(
 		accesscontrol.EvalPermission(ruleRead, targetScopes...),
-		accesscontrol.EvalPermission(dashboards.ActionFoldersRead, targetScopes...),
+		accesscontrol.EvalPermission(folder.ActionFoldersRead, targetScopes...),
 	)
 
 	return evaluator.Evaluate(user.GetPermissions())
@@ -195,7 +195,7 @@ func checkFolderAccessByFullpath(user identity.Requester, rule models.Namespaced
 // NOTE: if there are rules for deletion, and the user does not have access to data sources that a rule uses, the rule is removed from the list.
 // If the user is not authorized to perform the changes the function returns ErrAuthorization with a description of what action is not authorized.
 func (r *RuleService) AuthorizeRuleChanges(ctx context.Context, user identity.Requester, change *store.GroupDelta) error {
-	namespaceScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(change.GroupKey.NamespaceUID)
+	namespaceScope := folder.ScopeFoldersProvider.GetResourceScopeUID(change.GroupKey.NamespaceUID)
 
 	rules, existingGroup := change.AffectedGroups[change.GroupKey]
 	if existingGroup { // not existingGroup can be when user creates a new rule group or moves existing alerts to a new group
@@ -253,7 +253,7 @@ func (r *RuleService) AuthorizeRuleChanges(ctx context.Context, user identity.Re
 
 		// Check if the rule is moved from one folder to the current. If yes, then the user must have the authorization to delete rules from the source folder and add rules to the target folder.
 		if rule.Existing.NamespaceUID != rule.New.NamespaceUID {
-			ev := accesscontrol.EvalPermission(ruleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.Existing.NamespaceUID))
+			ev := accesscontrol.EvalPermission(ruleDelete, folder.ScopeFoldersProvider.GetResourceScopeUID(rule.Existing.NamespaceUID))
 			if err := r.HasAccessOrError(ctx, user, ev, func() string {
 				return fmt.Sprintf("move alert rules from folder %s", rule.Existing.NamespaceUID)
 			}); err != nil {

--- a/pkg/services/ngalert/accesscontrol/rules_test.go
+++ b/pkg/services/ngalert/accesscontrol/rules_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -137,7 +136,7 @@ func getShallowQueryDiffs(queries []models.AlertQuery) []cmputil.Diff {
 
 func TestAuthorizeRuleChanges(t *testing.T) {
 	groupKey := models.GenerateGroupKey(rand.Int63())
-	namespaceIdScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(groupKey.NamespaceUID)
+	namespaceIdScope := folder.ScopeFoldersProvider.GetResourceScopeUID(groupKey.NamespaceUID)
 	gen := models.RuleGen
 	genWithGroupKey := gen.With(gen.WithGroupKey(groupKey))
 
@@ -164,7 +163,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 					ruleRead: {
 						namespaceIdScope,
 					},
-					dashboards.ActionFoldersRead: {
+					folder.ActionFoldersRead: {
 						namespaceIdScope,
 					},
 					datasources.ActionQuery:                   getDatasourceScopesForRules(c.New),
@@ -192,7 +191,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 					ruleRead: {
 						namespaceIdScope,
 					},
-					dashboards.ActionFoldersRead: {
+					folder.ActionFoldersRead: {
 						namespaceIdScope,
 					},
 					ruleDelete: {
@@ -236,7 +235,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 					ruleRead: {
 						namespaceIdScope,
 					},
-					dashboards.ActionFoldersRead: {
+					folder.ActionFoldersRead: {
 						namespaceIdScope,
 					},
 					ruleUpdate: {
@@ -286,7 +285,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 					ruleRead: {
 						namespaceIdScope,
 					},
-					dashboards.ActionFoldersRead: {
+					folder.ActionFoldersRead: {
 						namespaceIdScope,
 					},
 					ruleUpdate: {
@@ -337,13 +336,13 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 			permissions: func(c *store.GroupDelta) map[string][]string {
 				deleteScopes := make([]string, 0, len(c.AffectedGroups))
 				for key := range c.AffectedGroups {
-					deleteScopes = append(deleteScopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(key.NamespaceUID))
+					deleteScopes = append(deleteScopes, folder.ScopeFoldersProvider.GetResourceScopeUID(key.NamespaceUID))
 				}
 
 				return map[string][]string{
 					ruleDelete: deleteScopes,
 					ruleCreate: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
 				}
 			},
@@ -399,13 +398,13 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 			permissions: func(c *store.GroupDelta) map[string][]string {
 				return map[string][]string{
 					ruleRead: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
-					dashboards.ActionFoldersRead: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+					folder.ActionFoldersRead: {
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
 					ruleUpdate: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
 				}
 			},
@@ -470,13 +469,13 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 				return map[string][]string{
 					ruleRead: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
-					dashboards.ActionFoldersRead: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+					folder.ActionFoldersRead: {
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
 					ruleUpdate: {
-						dashboards.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
+						folder.ScopeFoldersProvider.GetResourceScopeUID(c.GroupKey.NamespaceUID),
 					},
 					datasources.ActionQuery: dsScopes,
 				}
@@ -502,7 +501,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 					ruleRead: {
 						namespaceIdScope,
 					},
-					dashboards.ActionFoldersRead: {
+					folder.ActionFoldersRead: {
 						namespaceIdScope,
 					},
 					datasources.ActionQuery:                   getDatasourceScopesForRules(c.New),
@@ -550,7 +549,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 					ruleRead: {
 						namespaceIdScope,
 					},
-					dashboards.ActionFoldersRead: {
+					folder.ActionFoldersRead: {
 						namespaceIdScope,
 					},
 					ruleUpdate: {
@@ -616,10 +615,10 @@ func TestCheckDatasourcePermissionsForRule(t *testing.T) {
 	t.Run("should check only expressions", func(t *testing.T) {
 		permissions := map[string][]string{
 			ruleRead: {
-				dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID),
+				folder.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID),
 			},
-			dashboards.ActionFoldersRead: {
-				dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID),
+			folder.ActionFoldersRead: {
+				folder.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID),
 			},
 			datasources.ActionQuery: scopes,
 		}
@@ -653,11 +652,11 @@ func Test_authorizeAccessToRuleGroup(t *testing.T) {
 		rules := models.RuleGen.GenerateManyRef(1, 5)
 		namespaceScopes := make([]string, 0, len(rules))
 		for _, rule := range rules {
-			namespaceScopes = append(namespaceScopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID))
+			namespaceScopes = append(namespaceScopes, folder.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID))
 		}
 		permissions := map[string][]string{
-			ruleRead:                     namespaceScopes,
-			dashboards.ActionFoldersRead: namespaceScopes,
+			ruleRead:                 namespaceScopes,
+			folder.ActionFoldersRead: namespaceScopes,
 		}
 		ac := &recordingAccessControlFake{}
 		svc := NewRuleService(ac)
@@ -694,8 +693,8 @@ func TestCanReadAllRules(t *testing.T) {
 	}{
 		{
 			permissions: map[string][]string{
-				ruleRead:                     {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
-				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ruleRead:                 {folder.ScopeFoldersProvider.GetResourceAllScope()},
+				folder.ActionFoldersRead: {folder.ScopeFoldersProvider.GetResourceAllScope()},
 			},
 			expected: true,
 		},
@@ -704,24 +703,24 @@ func TestCanReadAllRules(t *testing.T) {
 		},
 		{
 			permissions: map[string][]string{
-				ruleRead:                     {dashboards.ScopeFoldersProvider.GetResourceScopeUID("test")},
-				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ruleRead:                 {folder.ScopeFoldersProvider.GetResourceScopeUID("test")},
+				folder.ActionFoldersRead: {folder.ScopeFoldersProvider.GetResourceAllScope()},
 			},
 		},
 		{
 			permissions: map[string][]string{
-				ruleRead:                     {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
-				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceScopeUID("test")},
+				ruleRead:                 {folder.ScopeFoldersProvider.GetResourceAllScope()},
+				folder.ActionFoldersRead: {folder.ScopeFoldersProvider.GetResourceScopeUID("test")},
 			},
 		},
 		{
 			permissions: map[string][]string{
-				ruleRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				ruleRead: {folder.ScopeFoldersProvider.GetResourceAllScope()},
 			},
 		},
 		{
 			permissions: map[string][]string{
-				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				folder.ActionFoldersRead: {folder.ScopeFoldersProvider.GetResourceAllScope()},
 			},
 		},
 	}
@@ -735,7 +734,7 @@ func TestCanReadAllRules(t *testing.T) {
 
 func TestHasAccessInFolder(t *testing.T) {
 	folderScope := func(uid string) string {
-		return dashboards.ScopeFoldersProvider.GetResourceScopeUID(uid)
+		return folder.ScopeFoldersProvider.GetResourceScopeUID(uid)
 	}
 
 	testCases := []struct {
@@ -752,8 +751,8 @@ func TestHasAccessInFolder(t *testing.T) {
 				FullpathUIDs:    "folder1",
 			},
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("folder1")},
-				dashboards.ActionFoldersRead: {folderScope("folder1")},
+				ruleRead:                 {folderScope("folder1")},
+				folder.ActionFoldersRead: {folderScope("folder1")},
 			},
 			expected:       true,
 			expectEvaluate: false,
@@ -765,8 +764,8 @@ func TestHasAccessInFolder(t *testing.T) {
 				FullpathUIDs:    "parent/child",
 			},
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("parent")},
-				dashboards.ActionFoldersRead: {folderScope("parent")},
+				ruleRead:                 {folderScope("parent")},
+				folder.ActionFoldersRead: {folderScope("parent")},
 			},
 			expected:       true,
 			expectEvaluate: false,
@@ -778,8 +777,8 @@ func TestHasAccessInFolder(t *testing.T) {
 				FullpathUIDs:    "parent/child",
 			},
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("parent")},
-				dashboards.ActionFoldersRead: {folderScope("child")},
+				ruleRead:                 {folderScope("parent")},
+				folder.ActionFoldersRead: {folderScope("child")},
 			},
 			expected:       true,
 			expectEvaluate: false,
@@ -791,8 +790,8 @@ func TestHasAccessInFolder(t *testing.T) {
 				FullpathUIDs:    "root/middle/leaf",
 			},
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("root")},
-				dashboards.ActionFoldersRead: {folderScope("root")},
+				ruleRead:                 {folderScope("root")},
+				folder.ActionFoldersRead: {folderScope("root")},
 			},
 			expected:       true,
 			expectEvaluate: false,
@@ -816,7 +815,7 @@ func TestHasAccessInFolder(t *testing.T) {
 				FullpathUIDs:    "folder1",
 			},
 			permissions: map[string][]string{
-				dashboards.ActionFoldersRead: {folderScope("folder1")},
+				folder.ActionFoldersRead: {folderScope("folder1")},
 			},
 			expected:       false,
 			expectEvaluate: true,
@@ -835,8 +834,8 @@ func TestHasAccessInFolder(t *testing.T) {
 			name:      "without fullpath UIDs, user has permissions",
 			namespace: models.NewNamespaceUID("folder1"),
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("folder1")},
-				dashboards.ActionFoldersRead: {folderScope("folder1")},
+				ruleRead:                 {folderScope("folder1")},
+				folder.ActionFoldersRead: {folderScope("folder1")},
 			},
 			expected:       true,
 			expectEvaluate: true,
@@ -863,7 +862,7 @@ func TestHasAccessInFolder(t *testing.T) {
 
 func TestAuthorizeAccessInFolder(t *testing.T) {
 	folderScope := func(uid string) string {
-		return dashboards.ScopeFoldersProvider.GetResourceScopeUID(uid)
+		return folder.ScopeFoldersProvider.GetResourceScopeUID(uid)
 	}
 
 	testCases := []struct {
@@ -880,8 +879,8 @@ func TestAuthorizeAccessInFolder(t *testing.T) {
 				FullpathUIDs:    "parent/child",
 			},
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("parent")},
-				dashboards.ActionFoldersRead: {folderScope("child")},
+				ruleRead:                 {folderScope("parent")},
+				folder.ActionFoldersRead: {folderScope("child")},
 			},
 			expectErr:      false,
 			expectEvaluate: false,
@@ -890,8 +889,8 @@ func TestAuthorizeAccessInFolder(t *testing.T) {
 			name:      "without fullpath UIDs, user has permissions",
 			namespace: models.NewNamespaceUID("folder1"),
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("folder1")},
-				dashboards.ActionFoldersRead: {folderScope("folder1")},
+				ruleRead:                 {folderScope("folder1")},
+				folder.ActionFoldersRead: {folderScope("folder1")},
 			},
 			expectErr:      false,
 			expectEvaluate: true,
@@ -942,7 +941,7 @@ func TestAuthorizeAccessInFolder(t *testing.T) {
 // the fallback to the scope resolver correctly handles folder hierarchy permissions.
 func TestHasAccessInFolderWithScopeResolver(t *testing.T) {
 	folderScope := func(uid string) string {
-		return dashboards.ScopeFoldersProvider.GetResourceScopeUID(uid)
+		return folder.ScopeFoldersProvider.GetResourceScopeUID(uid)
 	}
 
 	// Set up folder service that returns parent folder for "child"
@@ -953,7 +952,7 @@ func TestHasAccessInFolderWithScopeResolver(t *testing.T) {
 
 	// Create real AccessControl with scope resolver
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
-	ac.RegisterScopeAttributeResolver(dashboards.NewFolderUIDScopeResolver(folderSvc))
+	ac.RegisterScopeAttributeResolver(folder.NewFolderUIDScopeResolver(folderSvc))
 
 	svc := NewRuleService(ac)
 
@@ -965,32 +964,32 @@ func TestHasAccessInFolderWithScopeResolver(t *testing.T) {
 		{
 			name: "both permissions on parent folder",
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("parent")},
-				dashboards.ActionFoldersRead: {folderScope("parent")},
+				ruleRead:                 {folderScope("parent")},
+				folder.ActionFoldersRead: {folderScope("parent")},
 			},
 			expected: true,
 		},
 		{
 			name: "both permissions on child folder",
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("child")},
-				dashboards.ActionFoldersRead: {folderScope("child")},
+				ruleRead:                 {folderScope("child")},
+				folder.ActionFoldersRead: {folderScope("child")},
 			},
 			expected: true,
 		},
 		{
 			name: "split permissions - ruleRead on parent, foldersRead on child",
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("parent")},
-				dashboards.ActionFoldersRead: {folderScope("child")},
+				ruleRead:                 {folderScope("parent")},
+				folder.ActionFoldersRead: {folderScope("child")},
 			},
 			expected: true,
 		},
 		{
 			name: "split permissions - ruleRead on child, foldersRead on parent",
 			permissions: map[string][]string{
-				ruleRead:                     {folderScope("child")},
-				dashboards.ActionFoldersRead: {folderScope("parent")},
+				ruleRead:                 {folderScope("child")},
+				folder.ActionFoldersRead: {folderScope("parent")},
 			},
 			expected: true,
 		},
@@ -1004,7 +1003,7 @@ func TestHasAccessInFolderWithScopeResolver(t *testing.T) {
 		{
 			name: "only foldersRead permission",
 			permissions: map[string][]string{
-				dashboards.ActionFoldersRead: {folderScope("parent")},
+				folder.ActionFoldersRead: {folderScope("parent")},
 			},
 			expected: false,
 		},

--- a/pkg/services/ngalert/accesscontrol/silences.go
+++ b/pkg/services/ngalert/accesscontrol/silences.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -23,14 +23,14 @@ const (
 
 var (
 	// asserts full read-only access to silences
-	readAllSilencesEvaluator = ac.EvalAny(ac.EvalPermission(instancesRead), ac.EvalPermission(silenceRead, dashboards.ScopeFoldersProvider.GetResourceAllScope()))
+	readAllSilencesEvaluator = ac.EvalAny(ac.EvalPermission(instancesRead), ac.EvalPermission(silenceRead, folder.ScopeFoldersProvider.GetResourceAllScope()))
 	// shortcut assertion that to check if user can read silences
 	readSomeSilenceEvaluator = ac.EvalAny(ac.EvalPermission(instancesRead), ac.EvalPermission(silenceRead))
 	// asserts whether user has read access to rules in a specific folder
 	readRuleSilenceEvaluator = func(folderUID string) ac.Evaluator {
 		return ac.EvalAny(
 			ac.EvalPermission(instancesRead),
-			ac.EvalPermission(silenceRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)),
+			ac.EvalPermission(silenceRead, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)),
 		)
 	}
 
@@ -50,7 +50,7 @@ var (
 		return ac.EvalAll(
 			ac.EvalAny(
 				ac.EvalPermission(instancesCreate),
-				ac.EvalPermission(silenceCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(uid)),
+				ac.EvalPermission(silenceCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(uid)),
 			),
 			readRuleSilenceEvaluator(uid),
 		)
@@ -72,7 +72,7 @@ var (
 		return ac.EvalAll(
 			ac.EvalAny(
 				ac.EvalPermission(instancesWrite),
-				ac.EvalPermission(silenceWrite, dashboards.ScopeFoldersProvider.GetResourceScopeUID(uid)),
+				ac.EvalPermission(silenceWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(uid)),
 			),
 			readRuleSilenceEvaluator(uid),
 		)

--- a/pkg/services/ngalert/accesscontrol/silences_test.go
+++ b/pkg/services/ngalert/accesscontrol/silences_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
@@ -26,7 +26,7 @@ func TestFilterByAccess(t *testing.T) {
 	global := testSilence("global", nil)
 	ruleSilence1 := testSilence("rule-1", utils.Pointer("rule-1-uid"))
 	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
+	folder1Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder1)
 	ruleSilence2 := testSilence("rule-2", utils.Pointer("rule-2-uid"))
 	folder2 := "rule-2-folder-uid"
 	notFoundRule := testSilence("unknown-rule", utils.Pointer("unknown-rule-uid"))
@@ -65,7 +65,7 @@ func TestFilterByAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard should get all",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expected: []*models.Silence{
 				global,
 				ruleSilence1,
@@ -85,7 +85,7 @@ func TestFilterByAccess(t *testing.T) {
 		},
 		{
 			name: "silence reader with no accessible rule silences, global only",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("unknown-folder")}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceScopeUID("unknown-folder")}),
 			expected: []*models.Silence{
 				global,
 			},
@@ -126,7 +126,7 @@ func TestAuthorizeReadSilence(t *testing.T) {
 	global := testSilence("global", nil)
 	ruleSilence1 := testSilence("rule-1", utils.Pointer("rule-1-uid"))
 	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
+	folder1Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder1)
 	ruleSilence2 := testSilence("rule-2", utils.Pointer("rule-2-uid"))
 	folder2 := "rule-2-folder-uid"
 	notFoundRule := testSilence("unknown-rule", utils.Pointer("unknown-rule-uid"))
@@ -154,7 +154,7 @@ func TestAuthorizeReadSilence(t *testing.T) {
 		},
 		{
 			name:             "silence wildcard reader can read any silence",
-			user:             newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user:             newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			silence:          []*models.Silence{global, ruleSilence1, notFoundRule},
 			expectedErr:      nil,
 			expectedDbAccess: false,
@@ -229,10 +229,10 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 	global := testSilence("global", nil)
 	ruleSilence1 := testSilence("rule-1", utils.Pointer("rule-1-uid"))
 	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
+	folder1Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder1)
 	ruleSilence2 := testSilence("rule-2", utils.Pointer("rule-2-uid"))
 	folder2 := "rule-2-folder-uid"
-	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2)
+	folder2Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder2)
 	notFoundRule := testSilence("unknown-rule", utils.Pointer("unknown-rule-uid"))
 
 	silences := []*models.Silence{
@@ -265,7 +265,7 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 		},
 		{
 			name:        "no create access, silence wildcard reader",
-			user:        newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user:        newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expectedErr: ErrAuthorizationBase,
 		},
 		{
@@ -290,7 +290,7 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 		},
 		{
 			name:        "silence wildcard read + instance create can do everything",
-			user:        newUser(ac.Permission{Action: instancesCreate}, ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user:        newUser(ac.Permission{Action: instancesCreate}, ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expectedErr: nil,
 		},
 		{
@@ -327,7 +327,7 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 		},
 		{
 			name: "silence read + silence wildcard create",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceCreate, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			overrides: map[*models.Silence]override{
 				global: {
 					expectedErr:      ErrAuthorizationBase,
@@ -406,10 +406,10 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 	global := testSilence("global", nil)
 	ruleSilence1 := testSilence("rule-1", utils.Pointer("rule-1-uid"))
 	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
+	folder1Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder1)
 	ruleSilence2 := testSilence("rule-2", utils.Pointer("rule-2-uid"))
 	folder2 := "rule-2-folder-uid"
-	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2)
+	folder2Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder2)
 	notFoundRule := testSilence("unknown-rule", utils.Pointer("unknown-rule-uid"))
 
 	silences := []*models.Silence{
@@ -442,7 +442,7 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 		},
 		{
 			name:        "no write access, silence wildcard reader",
-			user:        newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user:        newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expectedErr: ErrAuthorizationBase,
 		},
 		{
@@ -467,7 +467,7 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 		},
 		{
 			name:        "silence wildcard read + instance write can do everything",
-			user:        newUser(ac.Permission{Action: instancesWrite}, ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user:        newUser(ac.Permission{Action: instancesWrite}, ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expectedErr: nil,
 		},
 		{
@@ -504,7 +504,7 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 		},
 		{
 			name: "silence read + silence wildcard write",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceWrite, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			overrides: map[*models.Silence]override{
 				global: {
 					expectedErr:      ErrAuthorizationBase,
@@ -583,10 +583,10 @@ func TestSilenceAccess(t *testing.T) {
 	global := testSilence("global", nil)
 	ruleSilence1 := testSilence("rule-1", utils.Pointer("rule-1-uid"))
 	folder1 := "rule-1-folder-uid"
-	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
+	folder1Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder1)
 	ruleSilence2 := testSilence("rule-2", utils.Pointer("rule-2-uid"))
 	folder2 := "rule-2-folder-uid"
-	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2)
+	folder2Scope := folder.ScopeFoldersProvider.GetResourceScopeUID(folder2)
 	notFoundRule := testSilence("unknown-rule", utils.Pointer("unknown-rule-uid"))
 
 	silences := []*models.Silence{
@@ -636,7 +636,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard read gives read access to everything",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expectedPermissions: models.SilencePermissionSet{
 				models.SilencePermissionRead: true,
 			},
@@ -663,7 +663,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard read + instance write+create can do everything",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesCreate}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesCreate}),
 			expectedPermissions: models.SilencePermissionSet{
 				models.SilencePermissionRead:   true,
 				models.SilencePermissionCreate: true,
@@ -680,7 +680,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard read + instance write can read and write",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesWrite}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesWrite}),
 			expectedPermissions: models.SilencePermissionSet{
 				models.SilencePermissionRead:  true,
 				models.SilencePermissionWrite: true,
@@ -696,7 +696,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard read + instance create can read and create",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesCreate}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesCreate}),
 			expectedPermissions: models.SilencePermissionSet{
 				models.SilencePermissionRead:   true,
 				models.SilencePermissionCreate: true,
@@ -709,7 +709,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name:                "cannot write/create without read - silence permissions",
-			user:                newUser(ac.Permission{Action: silenceWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user:                newUser(ac.Permission{Action: silenceWrite, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceCreate, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			expectedPermissions: models.SilencePermissionSet{},
 		},
 		{
@@ -756,7 +756,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard write doesn't provide global write but does provide unknown rule write",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceWrite, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			overrides: map[*models.Silence]override{
 				global:       deny(models.SilencePermissionWrite),
 				notFoundRule: deny(models.SilencePermissionWrite), // This is arguable, can consider changing this in the future.
@@ -769,7 +769,7 @@ func TestSilenceAccess(t *testing.T) {
 		},
 		{
 			name: "silence wildcard create doesn't provide global create but does provide unknown rule create",
-			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceCreate, Scope: folder.ScopeFoldersProvider.GetResourceAllScope()}),
 			overrides: map[*models.Silence]override{
 				global:       deny(models.SilencePermissionCreate),
 				notFoundRule: deny(models.SilencePermissionCreate), // This is arguable, can consider changing this in the future.

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -510,11 +510,11 @@ func (srv *ConvertPrometheusSrv) getOrCreateNamespace(c *contextmodel.ReqContext
 			c.Permissions[orgID] = make(map[string][]string)
 		}
 
-		folderScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ns.UID)
-		if c.Permissions[orgID][dashboards.ActionFoldersRead] == nil {
-			c.Permissions[orgID][dashboards.ActionFoldersRead] = []string{}
+		folderScope := folder.ScopeFoldersProvider.GetResourceScopeUID(ns.UID)
+		if c.Permissions[orgID][folder.ActionFoldersRead] == nil {
+			c.Permissions[orgID][folder.ActionFoldersRead] = []string{}
 		}
-		c.Permissions[orgID][dashboards.ActionFoldersRead] = append(c.Permissions[orgID][dashboards.ActionFoldersRead], folderScope)
+		c.Permissions[orgID][folder.ActionFoldersRead] = append(c.Permissions[orgID][folder.ActionFoldersRead], folderScope)
 	}
 
 	logger.Debug("Using folder for the converted rules", "folder_uid", ns.UID)

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2245,7 +2245,7 @@ func createTestEnv(t *testing.T, testConfig string) testEnvironment {
 		OrgID: 1,
 		/*
 			Permissions: map[int64]map[string][]string{
-				1: {dashboards.ActionFoldersCreate: {}, dashboards.ActionFoldersRead: {dashboards.ScopeFoldersAll}},
+				1: {folder.ActionFoldersCreate: {}, folder.ActionFoldersRead: {folder.ScopeFoldersAll}},
 			},
 		*/
 	}
@@ -2336,7 +2336,7 @@ func createTestRequestCtx() contextmodel.ReqContext {
 		SignedInUser: &user.SignedInUser{
 			OrgID: 1,
 			Permissions: map[int64]map[string][]string{
-				1: {dashboards.ActionFoldersRead: {dashboards.ScopeFoldersAll}},
+				1: {folder.ActionFoldersRead: {folder.ScopeFoldersAll}},
 			},
 		},
 		Logger: &logtest.Fake{},

--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/services/folder"
 	folder2 "github.com/grafana/grafana/pkg/services/folder"
 	. "github.com/grafana/grafana/pkg/services/ngalert/api/compat"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -420,8 +419,8 @@ func TestExportRules(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			rc := createRequestContextWithPerms(orgID, map[int64]map[string][]string{
 				orgID: {
-					folder.ActionFoldersRead:             []string{folder.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), folder.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
-					accesscontrol.ActionAlertingRuleRead: []string{folder.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), folder.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
+					folder2.ActionFoldersRead:            []string{folder2.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), folder2.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
+					accesscontrol.ActionAlertingRuleRead: []string{folder2.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), folder2.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
 					datasources.ActionQuery:              []string{datasources.ScopeProvider.GetResourceScopeUID(accessQuery.DatasourceUID)},
 				},
 			}, nil)

--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
 	folder2 "github.com/grafana/grafana/pkg/services/folder"
 	. "github.com/grafana/grafana/pkg/services/ngalert/api/compat"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -420,8 +420,8 @@ func TestExportRules(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			rc := createRequestContextWithPerms(orgID, map[int64]map[string][]string{
 				orgID: {
-					dashboards.ActionFoldersRead:         []string{dashboards.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), dashboards.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
-					accesscontrol.ActionAlertingRuleRead: []string{dashboards.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), dashboards.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
+					folder.ActionFoldersRead:             []string{folder.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), folder.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
+					accesscontrol.ActionAlertingRuleRead: []string{folder.ScopeFoldersProvider.GetResourceScopeUID(f1.UID), folder.ScopeFoldersProvider.GetResourceScopeUID(f2.UID)},
 					datasources.ActionQuery:              []string{datasources.ScopeProvider.GetResourceScopeUID(accessQuery.DatasourceUID)},
 				},
 			}, nil)

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -24,7 +24,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -1123,8 +1122,8 @@ func createPermissionsForRules(rules []*models.AlertRule, orgID int64) map[int64
 	permissions := map[string][]string{}
 	for _, rule := range rules {
 		if _, ok := ns[rule.NamespaceUID]; !ok {
-			scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID)
-			permissions[dashboards.ActionFoldersRead] = append(permissions[dashboards.ActionFoldersRead], scope)
+			scope := folder.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID)
+			permissions[folder.ActionFoldersRead] = append(permissions[folder.ActionFoldersRead], scope)
 			permissions[ac.ActionAlertingRuleRead] = append(permissions[ac.ActionAlertingRuleRead], scope)
 			permissions[ac.ActionAlertingRuleUpdate] = append(permissions[ac.ActionAlertingRuleUpdate], scope)
 			ns[rule.NamespaceUID] = struct{}{}
@@ -1141,8 +1140,8 @@ func createPermissionsForRulesWithoutDS(rules []*models.AlertRule, orgID int64) 
 	permissions := map[string][]string{}
 	for _, rule := range rules {
 		if _, ok := ns[rule.NamespaceUID]; !ok {
-			scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID)
-			permissions[dashboards.ActionFoldersRead] = append(permissions[dashboards.ActionFoldersRead], scope)
+			scope := folder.ScopeFoldersProvider.GetResourceScopeUID(rule.NamespaceUID)
+			permissions[folder.ActionFoldersRead] = append(permissions[folder.ActionFoldersRead], scope)
 			permissions[ac.ActionAlertingRuleRead] = append(permissions[ac.ActionAlertingRuleRead], scope)
 			ns[rule.NamespaceUID] = struct{}{}
 		}
@@ -1403,7 +1402,7 @@ func TestRoutePostNameRulesConfig(t *testing.T) {
 
 		permissions := map[int64]map[string][]string{
 			orgID: {
-				dashboards.ScopeFoldersProvider.GetResourceScopeUID(managedFolder.UID): {dashboards.ActionFoldersRead},
+				folder.ScopeFoldersProvider.GetResourceScopeUID(managedFolder.UID): {folder.ActionFoldersRead},
 			},
 		}
 		requestCtx := createRequestContextWithPerms(orgID, permissions, nil)

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/middleware"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/web"
@@ -25,19 +25,19 @@ func (api *API) authorize(method, path string) web.Handler {
 	case http.MethodDelete + "/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}",
 		http.MethodDelete + "/api/ruler/grafana/api/v1/rules/{Namespace}":
 		eval = ac.EvalAll(
-			ac.EvalPermission(ac.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
-			ac.EvalPermission(ac.ActionAlertingRuleRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
-			ac.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(ac.ActionAlertingRuleDelete, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(ac.ActionAlertingRuleRead, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
 		)
 	case http.MethodGet + "/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}":
 		eval = ac.EvalAll(
-			ac.EvalPermission(ac.ActionAlertingRuleRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
-			ac.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(ac.ActionAlertingRuleRead, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
 		)
 	case http.MethodGet + "/api/ruler/grafana/api/v1/rules/{Namespace}":
 		eval = ac.EvalAll(
-			ac.EvalPermission(ac.ActionAlertingRuleRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
-			ac.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(ac.ActionAlertingRuleRead, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
+			ac.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))),
 		)
 	case http.MethodGet + "/api/ruler/grafana/api/v1/rules",
 		http.MethodGet + "/api/ruler/grafana/api/v1/export/rules":
@@ -46,21 +46,21 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodGet + "/api/ruler/grafana/api/v1/rule/{RuleUID}/versions":
 		eval = ac.EvalAll(
 			ac.EvalPermission(ac.ActionAlertingRuleRead),
-			ac.EvalPermission(dashboards.ActionFoldersRead),
+			ac.EvalPermission(folder.ActionFoldersRead),
 		)
 	case http.MethodPost + "/api/ruler/grafana/api/v1/rules/{Namespace}/export":
-		scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))
+		scope := folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))
 		// more granular permissions are enforced by the handler via "authorizeRuleChanges"
 		eval = ac.EvalAll(ac.EvalPermission(ac.ActionAlertingRuleRead, scope),
-			ac.EvalPermission(dashboards.ActionFoldersRead, scope),
+			ac.EvalPermission(folder.ActionFoldersRead, scope),
 		)
 	case http.MethodPost + "/api/ruler/grafana/api/v1/rules/{Namespace}",
 		http.MethodPatch + "/api/ruler/grafana/api/v1/rules/{Namespace}":
-		scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))
+		scope := folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":Namespace"))
 		// more granular permissions are enforced by the handler via "authorizeRuleChanges"
 		eval = ac.EvalAll(
 			ac.EvalPermission(ac.ActionAlertingRuleRead, scope),
-			ac.EvalPermission(dashboards.ActionFoldersRead, scope),
+			ac.EvalPermission(folder.ActionFoldersRead, scope),
 			ac.EvalAny(
 				ac.EvalPermission(ac.ActionAlertingRuleUpdate, scope),
 				ac.EvalPermission(ac.ActionAlertingRuleCreate, scope),
@@ -125,14 +125,14 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodGet + "/api/convert/api/prom/rules/{NamespaceTitle}":
 		eval = ac.EvalAll(
 			ac.EvalPermission(ac.ActionAlertingRuleRead),
-			ac.EvalPermission(dashboards.ActionFoldersRead),
+			ac.EvalPermission(folder.ActionFoldersRead),
 		)
 
 	case http.MethodGet + "/api/convert/prometheus/config/v1/rules",
 		http.MethodGet + "/api/convert/api/prom/rules":
 		eval = ac.EvalAll(
 			ac.EvalPermission(ac.ActionAlertingRuleRead),
-			ac.EvalPermission(dashboards.ActionFoldersRead),
+			ac.EvalPermission(folder.ActionFoldersRead),
 		)
 
 	case http.MethodPost + "/api/convert/prometheus/config/v1/rules/{NamespaceTitle}",
@@ -150,7 +150,7 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodDelete + "/api/convert/api/prom/rules/{NamespaceTitle}":
 		eval = ac.EvalAll(
 			ac.EvalPermission(ac.ActionAlertingRuleRead),
-			ac.EvalPermission(dashboards.ActionFoldersRead),
+			ac.EvalPermission(folder.ActionFoldersRead),
 			ac.EvalPermission(ac.ActionAlertingRuleDelete),
 			ac.EvalPermission(ac.ActionAlertingProvisioningSetStatus),
 		)
@@ -327,7 +327,7 @@ func (api *API) authorize(method, path string) web.Handler {
 			ac.EvalPermission(ac.ActionAlertingProvisioningReadSecrets),
 			ac.EvalAll( // scopes are enforced in the handler
 				ac.EvalPermission(ac.ActionAlertingRuleRead),
-				ac.EvalPermission(dashboards.ActionFoldersRead),
+				ac.EvalPermission(folder.ActionFoldersRead),
 			),
 		)
 	case http.MethodGet + "/api/v1/provisioning/alert-rules/{UID}",
@@ -338,20 +338,20 @@ func (api *API) authorize(method, path string) web.Handler {
 			ac.EvalPermission(ac.ActionAlertingProvisioningReadSecrets),
 			ac.EvalAll(
 				ac.EvalPermission(ac.ActionAlertingRuleRead),
-				ac.EvalPermission(dashboards.ActionFoldersRead),
+				ac.EvalPermission(folder.ActionFoldersRead),
 			),
 		)
 
 	case http.MethodGet + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
 		http.MethodGet + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}/export":
-		scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":FolderUID"))
+		scope := folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":FolderUID"))
 		eval = ac.EvalAny(
 			ac.EvalPermission(ac.ActionAlertingProvisioningRead),
 			ac.EvalPermission(ac.ActionAlertingRulesProvisioningRead),
 			ac.EvalPermission(ac.ActionAlertingProvisioningReadSecrets),
 			ac.EvalAll(
 				ac.EvalPermission(ac.ActionAlertingRuleRead, scope),
-				ac.EvalPermission(dashboards.ActionFoldersRead, scope),
+				ac.EvalPermission(folder.ActionFoldersRead, scope),
 			),
 		)
 
@@ -422,25 +422,25 @@ func (api *API) authorize(method, path string) web.Handler {
 			),
 		)
 	case http.MethodDelete + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
-		scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":FolderUID"))
+		scope := folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":FolderUID"))
 		eval = ac.EvalAny(
 			ac.EvalPermission(ac.ActionAlertingProvisioningWrite),
 			ac.EvalPermission(ac.ActionAlertingRulesProvisioningWrite),
 			ac.EvalAll(
 				ac.EvalPermission(ac.ActionAlertingRuleDelete, scope),
 				ac.EvalPermission(ac.ActionAlertingRuleRead, scope),
-				ac.EvalPermission(dashboards.ActionFoldersRead, scope),
+				ac.EvalPermission(folder.ActionFoldersRead, scope),
 				ac.EvalPermission(ac.ActionAlertingProvisioningSetStatus),
 			),
 		)
 	case http.MethodPut + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
-		scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":FolderUID"))
+		scope := folder.ScopeFoldersProvider.GetResourceScopeUID(ac.Parameter(":FolderUID"))
 		eval = ac.EvalAny(
 			ac.EvalPermission(ac.ActionAlertingProvisioningWrite),
 			ac.EvalPermission(ac.ActionAlertingRulesProvisioningWrite),
 			ac.EvalAll(
 				ac.EvalPermission(ac.ActionAlertingRuleRead, scope),
-				ac.EvalPermission(dashboards.ActionFoldersRead, scope),
+				ac.EvalPermission(folder.ActionFoldersRead, scope),
 				ac.EvalPermission(ac.ActionAlertingProvisioningSetStatus),
 				ac.EvalAny( // the exact permissions will be checked after the operations are determined
 					ac.EvalPermission(ac.ActionAlertingRuleUpdate, scope),

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -180,7 +180,7 @@ func (st DBstore) getFolderFullpaths(ctx context.Context, orgID int64, folderUID
 		return nil, fmt.Errorf("folder service is not configured")
 	}
 	bgUser := accesscontrol.BackgroundUser("ngalert", orgID, org.RoleAdmin, []accesscontrol.Permission{
-		{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
+		{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
 	})
 	folders, err := st.FolderService.GetFolders(ctx, folder.GetFoldersQuery{
 		OrgID:        orgID,
@@ -1425,7 +1425,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 				schedulerUser := accesscontrol.BackgroundUser("grafana_scheduler", orgID, org.RoleAdmin,
 					[]accesscontrol.Permission{
 						{
-							Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll,
+							Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll,
 						},
 					})
 
@@ -1450,7 +1450,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 // DeleteInFolder deletes the rules contained in a given folder along with their associated data.
 func (st DBstore) DeleteInFolders(ctx context.Context, orgID int64, folderUIDs []string, user identity.Requester) error {
 	for _, folderUID := range folderUIDs {
-		evaluator := accesscontrol.EvalPermission(accesscontrol.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID))
+		evaluator := accesscontrol.EvalPermission(accesscontrol.ActionAlertingRuleDelete, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID))
 		canSave, err := st.AccessControl.Evaluate(ctx, user, evaluator)
 		if err != nil {
 			st.Logger.Error("Failed to evaluate access control", "error", err)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -583,7 +583,7 @@ func TestIntegration_DeleteInFolder(t *testing.T) {
 
 	t.Run("should be able to delete folder with permissions to delete rules", func(t *testing.T) {
 		store.AccessControl = acmock.New().WithPermissions([]accesscontrol.Permission{
-			{Action: accesscontrol.ActionAlertingRuleDelete, Scope: dashboards.ScopeFoldersAll},
+			{Action: accesscontrol.ActionAlertingRuleDelete, Scope: folder.ScopeFoldersAll},
 		})
 		err := store.DeleteInFolders(context.Background(), rule.OrgID, []string{rule.NamespaceUID}, &user.SignedInUser{})
 		require.NoError(t, err)

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -121,8 +121,8 @@ func CreateTestAlertRuleWithLabels(t testing.TB, ctx context.Context, dbstore *s
 		IsGrafanaAdmin: true,
 		Permissions: map[int64]map[string][]string{
 			orgID: {
-				dashboards.ActionFoldersCreate: {dashboards.ScopeFoldersAll},
-				dashboards.ActionFoldersRead:   {dashboards.ScopeFoldersAll},
+				folder.ActionFoldersCreate: {folder.ScopeFoldersAll},
+				folder.ActionFoldersRead:   {folder.ScopeFoldersAll},
 			},
 		},
 	}

--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginsettings"
@@ -180,8 +181,8 @@ func (du *DashboardUpdater) autoUpdateAppDashboard(ctx context.Context, pluginDa
 	_, err = du.dashboardImportService.ImportDashboard(ctx, &dashboardimport.ImportDashboardRequest{
 		PluginId: pluginDashInfo.PluginId,
 		User: accesscontrol.BackgroundUser("dashboard_updater", orgID, org.RoleAdmin, []accesscontrol.Permission{
-			{Action: dashboards.ActionDashboardsCreate, Scope: dashboards.ScopeFoldersAll},
-			{Action: dashboards.ActionDashboardsWrite, Scope: dashboards.ScopeFoldersAll},
+			{Action: dashboards.ActionDashboardsCreate, Scope: folder.ScopeFoldersAll},
+			{Action: dashboards.ActionDashboardsWrite, Scope: folder.ScopeFoldersAll},
 		}),
 		Path:      pluginDashInfo.Reference,
 		Dashboard: resp.Dashboard.Data,

--- a/pkg/services/provisioning/alerting/rules_provisioner.go
+++ b/pkg/services/provisioning/alerting/rules_provisioner.go
@@ -165,7 +165,7 @@ var provisionerUser = func(orgID int64) identity.Requester {
 		orgID,
 		org.RoleAdmin,
 		[]accesscontrol.Permission{
-			{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
+			{Action: folder.ActionFoldersRead, Scope: folder.ScopeFoldersAll},
 			{Action: accesscontrol.ActionAlertingProvisioningReadSecrets},
 			{Action: accesscontrol.ActionAlertingProvisioningWrite},
 			{Action: accesscontrol.ActionAlertingReceiversCreate},

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -87,17 +87,17 @@ func (api *Api) RegisterAPIEndpoints() {
 
 	// Create Public Dashboard
 	api.routeRegister.Post("/api/dashboards/uid/:dashboardUid/public-dashboards",
-		auth(accesscontrol.EvalPermission(dashboards.ActionDashboardsPublicWrite, uidScope)),
+		auth(accesscontrol.EvalPermission(publicdashboards.ActionDashboardsPublicWrite, uidScope)),
 		routing.Wrap(api.CreatePublicDashboard))
 
 	// Update Public Dashboard
 	api.routeRegister.Patch("/api/dashboards/uid/:dashboardUid/public-dashboards/:uid",
-		auth(accesscontrol.EvalPermission(dashboards.ActionDashboardsPublicWrite, uidScope)),
+		auth(accesscontrol.EvalPermission(publicdashboards.ActionDashboardsPublicWrite, uidScope)),
 		routing.Wrap(api.UpdatePublicDashboard))
 
 	// Delete Public dashboard
 	api.routeRegister.Delete("/api/dashboards/uid/:dashboardUid/public-dashboards/:uid",
-		auth(accesscontrol.EvalPermission(dashboards.ActionDashboardsPublicWrite, uidScope)),
+		auth(accesscontrol.EvalPermission(publicdashboards.ActionDashboardsPublicWrite, uidScope)),
 		routing.Wrap(api.DeletePublicDashboard))
 }
 

--- a/pkg/services/publicdashboards/api/api_test.go
+++ b/pkg/services/publicdashboards/api/api_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var userNoRBACPerms = &user.SignedInUser{UserID: 1, OrgID: 1, OrgRole: org.RoleAdmin, Login: "testAdminUserNoRBACPerms"}
-var userAdmin = &user.SignedInUser{UserID: 2, OrgID: 1, OrgRole: org.RoleAdmin, Login: "testAdminUserRBAC", Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsPublicWrite: {dashboards.ScopeDashboardsAll}}}}
+var userAdmin = &user.SignedInUser{UserID: 2, OrgID: 1, OrgRole: org.RoleAdmin, Login: "testAdminUserRBAC", Permissions: map[int64]map[string][]string{1: {publicdashboards.ActionDashboardsPublicWrite: {dashboards.ScopeDashboardsAll}}}}
 var userViewer = &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleViewer, Login: "testViewerUserRBAC", Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsRead: {dashboards.ScopeDashboardsAll}}}}
 var anonymousUser = &user.SignedInUser{IsAnonymous: true}
 
@@ -156,9 +156,9 @@ func TestAPIListPublicDashboard(t *testing.T) {
 func TestAPIDeletePublicDashboard(t *testing.T) {
 	dashboardUid := "abc1234"
 	publicDashboardUid := "1234asdfasdf"
-	userEditorAllPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Login: "testEditorUser", Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsPublicWrite: {dashboards.ScopeDashboardsAll}}}}
-	userEditorAnotherPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Login: "testEditorUser", Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsPublicWrite: {"another-uid"}}}}
-	userEditorPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Login: "testEditorUser", Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsPublicWrite: {fmt.Sprintf("dashboards:uid:%s", dashboardUid)}}}}
+	userEditorAllPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Login: "testEditorUser", Permissions: map[int64]map[string][]string{1: {publicdashboards.ActionDashboardsPublicWrite: {dashboards.ScopeDashboardsAll}}}}
+	userEditorAnotherPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Login: "testEditorUser", Permissions: map[int64]map[string][]string{1: {publicdashboards.ActionDashboardsPublicWrite: {"another-uid"}}}}
+	userEditorPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Login: "testEditorUser", Permissions: map[int64]map[string][]string{1: {publicdashboards.ActionDashboardsPublicWrite: {fmt.Sprintf("dashboards:uid:%s", dashboardUid)}}}}
 
 	testCases := []struct {
 		Name                    string
@@ -481,8 +481,8 @@ func TestApiCreatePublicDashboard(t *testing.T) {
 func TestAPIUpdatePublicDashboard(t *testing.T) {
 	dashboardUid := "abc1234"
 	publicDashboardUid := "1234asdfasdf"
-	userEditorPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsPublicWrite: {fmt.Sprintf("dashboards:uid:%s", dashboardUid)}}}}
-	userEditorAnotherPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Permissions: map[int64]map[string][]string{1: {dashboards.ActionDashboardsPublicWrite: {"another-uid"}}}}
+	userEditorPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Permissions: map[int64]map[string][]string{1: {publicdashboards.ActionDashboardsPublicWrite: {fmt.Sprintf("dashboards:uid:%s", dashboardUid)}}}}
+	userEditorAnotherPublicDashboard := &user.SignedInUser{UserID: 4, OrgID: 1, OrgRole: org.RoleEditor, Permissions: map[int64]map[string][]string{1: {publicdashboards.ActionDashboardsPublicWrite: {"another-uid"}}}}
 
 	testCases := []struct {
 		Name                 string

--- a/pkg/services/publicdashboards/publicdashboard.go
+++ b/pkg/services/publicdashboards/publicdashboard.go
@@ -13,6 +13,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
+const (
+	ActionDashboardsPublicWrite = "dashboards.public:write"
+)
+
 // These are the api contracts. The API should match the underlying service and store
 
 //go:generate go run ./commands/generate_datasources/main.go

--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -11,6 +11,7 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
@@ -35,20 +36,20 @@ var dashboardPermissionTranslation = map[dashboardaccess.PermissionType][]string
 
 var folderPermissionTranslation = map[dashboardaccess.PermissionType][]string{
 	dashboardaccess.PERMISSION_VIEW: append(dashboardPermissionTranslation[dashboardaccess.PERMISSION_VIEW], []string{
-		dashboards.ActionFoldersRead,
+		folder.ActionFoldersRead,
 	}...),
 	dashboardaccess.PERMISSION_EDIT: append(dashboardPermissionTranslation[dashboardaccess.PERMISSION_EDIT], []string{
 		dashboards.ActionDashboardsCreate,
-		dashboards.ActionFoldersRead,
-		dashboards.ActionFoldersWrite,
-		dashboards.ActionFoldersDelete,
+		folder.ActionFoldersRead,
+		folder.ActionFoldersWrite,
+		folder.ActionFoldersDelete,
 	}...),
 	dashboardaccess.PERMISSION_ADMIN: append(dashboardPermissionTranslation[dashboardaccess.PERMISSION_ADMIN], []string{
-		dashboards.ActionFoldersRead,
-		dashboards.ActionFoldersWrite,
-		dashboards.ActionFoldersDelete,
-		dashboards.ActionFoldersPermissionsRead,
-		dashboards.ActionFoldersPermissionsWrite,
+		folder.ActionFoldersRead,
+		folder.ActionFoldersWrite,
+		folder.ActionFoldersDelete,
+		folder.ActionFoldersPermissionsRead,
+		folder.ActionFoldersPermissionsWrite,
 	}...),
 }
 
@@ -196,7 +197,7 @@ func (m dashboardPermissionsMigrator) setPermissions(allRoles []*ac.Role, permis
 func (m dashboardPermissionsMigrator) mapPermission(id int64, p dashboardaccess.PermissionType, isFolder bool) []*ac.Permission {
 	if isFolder {
 		actions := folderPermissionTranslation[p]
-		scope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(id, 10))
+		scope := folder.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(id, 10))
 		permissions := make([]*ac.Permission, 0, len(actions))
 		for _, action := range actions {
 			permissions = append(permissions, &ac.Permission{Action: action, Scope: scope})

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/scope_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/scope_migrator_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
 	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
@@ -60,7 +60,7 @@ func TestScopeMigration(t *testing.T) {
 				{
 					RoleID:     1,
 					Action:     accesscontrol.ActionAlertingInstanceRead,
-					Scope:      dashboards.ScopeFoldersAll,
+					Scope:      folder.ScopeFoldersAll,
 					Kind:       "folders",
 					Attribute:  "uid",
 					Identifier: "*",

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -779,7 +779,7 @@ func TestIntegrationFolderGetPermissions(t *testing.T) {
 			expectedParentTitles: []string{"testparent"},
 			permissions: []resourcepermissions.SetResourcePermissionCommand{
 				{
-					Actions:           []string{dashboards.ActionFoldersRead},
+					Actions:           []string{folder.ActionFoldersRead},
 					Resource:          "folders",
 					ResourceAttribute: "uid",
 					ResourceID:        "*",
@@ -794,7 +794,7 @@ func TestIntegrationFolderGetPermissions(t *testing.T) {
 			expectedParentTitles: []string{},
 			permissions: []resourcepermissions.SetResourcePermissionCommand{
 				{
-					Actions:           []string{dashboards.ActionFoldersRead},
+					Actions:           []string{folder.ActionFoldersRead},
 					Resource:          "folders",
 					ResourceAttribute: "uid",
 					ResourceID:        "descuid",
@@ -888,8 +888,8 @@ func TestIntegrationFolderGetPermissions(t *testing.T) {
 
 					if tc.expectedCode == http.StatusOK {
 						require.NotNil(t, getResp.Result)
-						require.False(t, getResp.Result.AccessControl[dashboards.ActionFoldersRead])
-						require.False(t, getResp.Result.AccessControl[dashboards.ActionFoldersWrite])
+						require.False(t, getResp.Result.AccessControl[folder.ActionFoldersRead])
+						require.False(t, getResp.Result.AccessControl[folder.ActionFoldersWrite])
 
 						parents := getResp.Result.Parents
 						require.Equal(t, len(expectedParentUIDs), len(parents))
@@ -903,13 +903,13 @@ func TestIntegrationFolderGetPermissions(t *testing.T) {
 						if tc.checkAccessControl {
 							acPerms := []resourcepermissions.SetResourcePermissionCommand{
 								{
-									Actions:           []string{dashboards.ActionFoldersRead},
+									Actions:           []string{folder.ActionFoldersRead},
 									Resource:          "folders",
 									ResourceAttribute: "uid",
 									ResourceID:        "*",
 								},
 								{
-									Actions:           []string{dashboards.ActionFoldersWrite},
+									Actions:           []string{folder.ActionFoldersWrite},
 									Resource:          "folders",
 									ResourceAttribute: "uid",
 									ResourceID:        parentUID,
@@ -930,8 +930,8 @@ func TestIntegrationFolderGetPermissions(t *testing.T) {
 							require.Equal(t, tc.expectedCode, getWithAC.Response.StatusCode)
 							require.NotNil(t, getWithAC.Result)
 
-							require.True(t, getWithAC.Result.AccessControl[dashboards.ActionFoldersRead])
-							require.True(t, getWithAC.Result.AccessControl[dashboards.ActionFoldersWrite])
+							require.True(t, getWithAC.Result.AccessControl[folder.ActionFoldersRead])
+							require.True(t, getWithAC.Result.AccessControl[folder.ActionFoldersWrite])
 						}
 					}
 				})


### PR DESCRIPTION
[no-op this is purely moving definitions around to the correct services]

Background: Folders used to be a part of the dashboard table, so the folder permission defintions were a part of the folder service. Now that folders and dashboards are in unistore, they are fully separated resources. We should keep their definitions separated as well into the proper services.

This also ended up extending to snapshots & public dashboards, so moving those to the proper services as well
