### PR TITLE
Catalog: Redirect marketplace plugin install to grafana.com

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -244,6 +244,48 @@ describe('InstallControlsButton', () => {
     });
   });
 
+  describe('marketplace plugin', () => {
+    it('should render a link to grafana.com installation tab instead of install button', () => {
+      render(
+        <TestProvider>
+          <InstallControlsButton
+            plugin={{ ...plugin, distributionType: 'marketplace' }}
+            pluginStatus={PluginStatus.INSTALL}
+          />
+        </TestProvider>
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveTextContent(/install/i);
+      expect(link).toHaveAttribute('href', expect.stringContaining('/plugins/test-plugin?tab=installation'));
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('should not render marketplace link when distributionType is not set', () => {
+      render(
+        <TestProvider>
+          <InstallControlsButton plugin={{ ...plugin }} pluginStatus={PluginStatus.INSTALL} />
+        </TestProvider>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent(/install/i);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should not render marketplace link for non-marketplace distribution types', () => {
+      render(
+        <TestProvider>
+          <InstallControlsButton
+            plugin={{ ...plugin, distributionType: 'catalog' }}
+            pluginStatus={PluginStatus.INSTALL}
+          />
+        </TestProvider>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent(/install/i);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+
   describe('update button', () => {
     it('should be hidden when plugin is managed', () => {
       render(

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -255,7 +255,7 @@ describe('InstallControlsButton', () => {
         </TestProvider>
       );
       const link = screen.getByRole('link');
-      expect(link).toHaveTextContent(/install/i);
+      expect(link).toHaveTextContent(/contact us/i);
       expect(link).toHaveAttribute('href', expect.stringContaining('/plugins/test-plugin?tab=installation'));
       expect(link).toHaveAttribute('target', '_blank');
     });

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -212,7 +212,7 @@ export function InstallControlsButton({
         rel="noopener noreferrer"
         icon="external-link-alt"
       >
-        <Trans i18nKey="plugins.install-controls.install">Install</Trans>
+        <Trans i18nKey="plugins.install-controls.contact-us">Contact us</Trans>
       </LinkButton>
     );
   }

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -11,7 +11,7 @@ import { removePluginFromNavTree } from 'app/core/reducers/navBarTree';
 import { isOpenSourceBuildOrUnlicenced } from 'app/features/admin/EnterpriseAuthFeaturesCard';
 import { useDispatch } from 'app/types/store';
 
-import { getExternalManageLink, isDisabledAngularPlugin } from '../../helpers';
+import { getExternalManageLink, isDisabledAngularPlugin, isMarketplacePlugin } from '../../helpers';
 import {
   useInstallStatus,
   useUninstallStatus,
@@ -201,6 +201,19 @@ export function InstallControlsButton({
         )}
         {uninstallControls}
       </Stack>
+    );
+  }
+
+  if (isMarketplacePlugin(plugin)) {
+    return (
+      <LinkButton
+        href={`${getExternalManageLink(plugin.id)}?tab=installation`}
+        target="_blank"
+        rel="noopener noreferrer"
+        icon="external-link-alt"
+      >
+        <Trans i18nKey="plugins.install-controls.install">Install</Trans>
+      </LinkButton>
     );
   }
 

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -245,6 +245,7 @@ describe('Plugins/Helpers', () => {
           enabled: false,
           strategy: undefined,
         },
+        distributionType: undefined,
       });
     });
 
@@ -413,6 +414,7 @@ describe('Plugins/Helpers', () => {
           enabled: false,
           strategy: undefined,
         },
+        distributionType: undefined,
       });
     });
 
@@ -472,6 +474,7 @@ describe('Plugins/Helpers', () => {
           enabled: false,
           strategy: undefined,
         },
+        distributionType: undefined,
       });
     });
 

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -157,6 +157,7 @@ export function mapRemoteToCatalog(plugin: RemotePlugin, error?: PluginError): C
           ? PluginUpdateStrategy.Assigned
           : undefined,
     },
+    distributionType: plugin.versionDistributionType,
   };
 }
 
@@ -286,10 +287,15 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
           ? PluginUpdateStrategy.Assigned
           : undefined,
     },
+    distributionType: remote?.versionDistributionType,
   };
 }
 
 export const getExternalManageLink = (pluginId: string) => `${config.pluginCatalogURL}${pluginId}`;
+
+export function isMarketplacePlugin(plugin: CatalogPlugin): boolean {
+  return plugin.distributionType === 'marketplace';
+}
 
 export enum Sorters {
   nameAsc = 'nameAsc',

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -69,6 +69,7 @@ export interface CatalogPlugin extends WithAccessControlMetadata {
     enabled: boolean;
     strategy?: PluginUpdateStrategy;
   };
+  distributionType?: string;
 }
 export interface Screenshots {
   path: string;
@@ -197,6 +198,7 @@ export type RemotePlugin = {
     enabled: boolean;
     strategy?: PluginUpdateStrategy;
   };
+  versionDistributionType?: string;
 };
 
 export enum PluginUpdateStrategy {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12826,6 +12826,7 @@
       "title-button-disabled": "The plugin isn't usable yet, it may take some time to complete the installation."
     },
     "install-controls": {
+      "contact-us": "Contact us",
       "install": "Install",
       "installing": "Installing",
       "update": "Update",


### PR DESCRIPTION
Related GCOM PR: https://github.com/grafana/grafana-com/pull/17788

### What changed?

When a plugin has a `marketplace` distribution type (returned by GCOM as `versionDistributionType`), the install button now renders as a link that opens the plugin's installation tab on grafana.com (`?tab=installation`) in a new tab, instead of triggering the normal install flow.

This is resilient to GCOM not returning the field — `distributionType` is optional, and the check uses strict equality (`=== "marketplace"`), so `undefined` gracefully falls through to the normal install button.

<img width="1533" height="714" alt="Screenshot 2026-04-13 at 10 07 48" src="https://github.com/user-attachments/assets/6f44e615-637f-43d3-b909-79654603106b" />


### Test locally
The easiest way is probably to override the response content for `/api/gnet/plugin`, and set `"versionDistributionType": "marketplace",` for the clock panel, then refresh. (Don't forget to remove the override afterwards :))

<img width="853" height="655" alt="Screenshot 2026-04-07 at 18 32 46" src="https://github.com/user-attachments/assets/39440e20-1210-49a3-921d-9646b7b8e7af" />
