### PR TITLE
QueryEditor: Replace hardcoded error color with theme token

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/Actions.tsx
@@ -3,9 +3,9 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { type AlertState, type GrafanaTheme2, type IconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Button, ConfirmModal, Icon, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, ConfirmModal, Icon, Stack, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 
-import { QUERY_EDITOR_COLORS, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from './constants';
+import { getQueryEditorColors, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from './constants';
 import { trackCardAction, type CardActionSource } from './tracking';
 
 export interface ActionItem {
@@ -57,6 +57,8 @@ export function Actions({
   onToggleHide,
   order,
 }: ActionsProps) {
+  const theme = useTheme2();
+  const queryEditorColors = getQueryEditorColors(theme);
   const styles = useStyles2(getStyles);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const config = QUERY_EDITOR_TYPE_CONFIG[item.type];
@@ -164,7 +166,7 @@ export function Actions({
               name="exclamation-triangle"
               aria-label={t('query-editor-next.action.error', 'Error')}
               className={styles.errorIcon}
-              color={QUERY_EDITOR_COLORS.error}
+              color={queryEditorColors.error}
             />
           </Tooltip>
         )}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -114,9 +114,7 @@ export const SidebarCard = ({
           <div>
             <div className={styles.cardContentIcons}>
               {item.isHidden && <Icon name="eye-slash" size="sm" />}
-              {!!item.error && (
-                <Icon name="exclamation-triangle" size="sm" color={queryEditorColors.error} />
-              )}
+              {!!item.error && <Icon name="exclamation-triangle" size="sm" color={queryEditorColors.error} />}
             </div>
             <div className={cx(styles.hoverActions, { [styles.hoverActionsVisible]: hasFocusWithin })}>
               <Actions

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -3,11 +3,10 @@ import { useCallback, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { Icon, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { type ActionItem, Actions } from '../../../Actions';
 import {
-  QUERY_EDITOR_COLORS,
   QUERY_EDITOR_TYPE_CONFIG,
   QueryEditorType,
   SIDEBAR_CARD_HEIGHT,
@@ -42,6 +41,8 @@ export const SidebarCard = ({
   onToggleHide,
   variant = 'default',
 }: SidebarCardProps) => {
+  const theme = useTheme2();
+  const queryEditorColors = getQueryEditorColors(theme);
   const addVariant = item.type === QueryEditorType.Transformation ? 'transformation' : 'query';
   const hasActions = onDelete || onDuplicate || onToggleHide;
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
@@ -113,7 +114,9 @@ export const SidebarCard = ({
           <div>
             <div className={styles.cardContentIcons}>
               {item.isHidden && <Icon name="eye-slash" size="sm" />}
-              {!!item.error && <Icon name="exclamation-triangle" size="sm" color={QUERY_EDITOR_COLORS.error} />}
+              {!!item.error && (
+                <Icon name="exclamation-triangle" size="sm" color={queryEditorColors.error} />
+              )}
             </div>
             <div className={cx(styles.hoverActions, { [styles.hoverActionsVisible]: hasFocusWithin })}>
               <Actions
@@ -194,7 +197,7 @@ function getStyles(
   });
 
   const cardBorder = !!item.error
-    ? `1px solid color-mix(in srgb, ${QUERY_EDITOR_COLORS.error} 50%, transparent)`
+    ? `1px solid color-mix(in srgb, ${themeColors.error} 50%, transparent)`
     : `1px solid ${isSelected ? borderColor : theme.colors.border.medium}`;
 
   return {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -4,7 +4,7 @@ import { type CustomTransformerDefinition } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 
-import { getAlertStateColor, QUERY_EDITOR_COLORS, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../constants';
+import { getAlertStateColor, getQueryEditorColors, QUERY_EDITOR_TYPE_CONFIG, QueryEditorType } from '../constants';
 
 import { type PendingExpression, type PendingTransformation } from './QueryEditorContext';
 import { type AlertRule, type Transformation } from './types';
@@ -85,7 +85,7 @@ export function getEditorBorderColor({
   isError?: boolean;
 }): string {
   if (isError) {
-    return QUERY_EDITOR_COLORS.error;
+    return getQueryEditorColors(theme).error;
   }
 
   if (editorType === QueryEditorType.Alert && alertState) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -43,7 +43,6 @@ export const QUERY_EDITOR_COLORS = {
   query: '#FF8904',
   expression: '#C27AFF',
   transformation: '#00D492',
-  error: '#E7000B',
 };
 
 // TODO: Remove this once all the new colors are finalized
@@ -55,6 +54,7 @@ export function getQueryEditorColors(theme: GrafanaTheme2) {
     footerBackground: USE_THEME_COLORS ? theme.colors.background.primary : '#1e2939',
     sidebarFooterBackground: USE_THEME_COLORS ? theme.colors.background.primary : '#141820',
     sidebarHeaderBackground: USE_THEME_COLORS ? theme.colors.background.secondary : '#20262F',
+    error: USE_THEME_COLORS ? theme.colors.error.main : '#E7000B',
     card: {
       activeBg: theme.isDark ? '#314158' : 'oklch(92.9% 0.013 255.508)',
       hoverBg: theme.isDark ? '#1D293D' : 'oklch(96.8% 0.007 247.896)',


### PR DESCRIPTION
## Description
Replaces the hardcoded error color with the theme error token

## Changes
* Adds `error` to `getQueryEditorColors` and removes it from `QUERY_EDITOR_COLORS`
* Replaces use of `QUERY_EDITOR_COLORS.error`

## Demo
<img width="310" height="226" alt="CleanShot 2026-04-07 at 12 06 01" src="https://github.com/user-attachments/assets/2746e644-35dc-441e-84f0-24200bf2d79d" />


## Testing Instructions
* Review code

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable