### PR TITLE
Zanzana reconciler: add ServiceAccount translator

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/namespace.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace.go
@@ -129,6 +129,7 @@ func (r *Reconciler) fetchAndTranslateTuples(ctx context.Context, namespace stri
 		"resourcepermissions": TranslateResourcePermissionToTuples,
 		"teambindings":        TranslateTeamBindingToTuples,
 		"users":               TranslateUserToTuples,
+		"serviceaccounts":     TranslateServiceAccountToTuples,
 	}
 
 	// Process each GVR type and insert translated tuples directly into the map

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -88,6 +88,7 @@ var reconcileGVRs = []schema.GroupVersionResource{
 	iamv0.ResourcePermissionInfo.GroupVersionResource(),
 	iamv0.TeamBindingResourceInfo.GroupVersionResource(),
 	iamv0.UserResourceInfo.GroupVersionResource(),
+	iamv0.ServiceAccountResourceInfo.GroupVersionResource(),
 }
 
 // NewReconciler creates a new reconciler instance.

--- a/pkg/services/authz/zanzana/server/reconciler/translators.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators.go
@@ -216,6 +216,31 @@ func TranslateUserToTuples(obj *unstructured.Unstructured) ([]*openfgav1.TupleKe
 	return []*openfgav1.TupleKey{tuple}, nil
 }
 
+// TranslateServiceAccountToTuples converts a ServiceAccount CRD to basic role assignment tuples.
+func TranslateServiceAccountToTuples(obj *unstructured.Unstructured) ([]*openfgav1.TupleKey, error) {
+	var sa iamv0.ServiceAccount
+	if err := convertUnstructured(obj, &sa); err != nil {
+		return nil, err
+	}
+
+	role := string(sa.Spec.Role)
+	if sa.Spec.Role == "" {
+		return nil, nil
+	}
+
+	basicRole := common.TranslateBasicRole(role)
+	if basicRole == "" {
+		return nil, fmt.Errorf("invalid basic role: %s", role)
+	}
+
+	tuple := &openfgav1.TupleKey{
+		User:     common.NewTupleEntry(common.TypeServiceAccount, sa.Name, ""),
+		Relation: common.RelationAssignee,
+		Object:   common.NewTupleEntry(common.TypeRole, basicRole, ""),
+	}
+	return []*openfgav1.TupleKey{tuple}, nil
+}
+
 // convertUnstructured converts an unstructured object to a typed struct using the standard Kubernetes converter.
 func convertUnstructured(obj *unstructured.Unstructured, target any) error {
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, target); err != nil {

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -317,6 +317,72 @@ func TestTranslateUserToTuples(t *testing.T) {
 	}
 }
 
+func TestTranslateServiceAccountToTuples(t *testing.T) {
+	tests := []struct {
+		name           string
+		role           iamv0.ServiceAccountOrgRole
+		expectedTuples int
+		expectedUser   string
+		expectedObject string
+	}{
+		{
+			name:           "viewer role",
+			role:           iamv0.ServiceAccountOrgRoleViewer,
+			expectedTuples: 1,
+			expectedUser:   "service-account:sa-test",
+			expectedObject: "role:basic_viewer",
+		},
+		{
+			name:           "editor role",
+			role:           iamv0.ServiceAccountOrgRoleEditor,
+			expectedTuples: 1,
+			expectedUser:   "service-account:sa-test",
+			expectedObject: "role:basic_editor",
+		},
+		{
+			name:           "admin role",
+			role:           iamv0.ServiceAccountOrgRoleAdmin,
+			expectedTuples: 1,
+			expectedUser:   "service-account:sa-test",
+			expectedObject: "role:basic_admin",
+		},
+		{
+			name:           "none role maps to basic_none",
+			role:           iamv0.ServiceAccountOrgRoleNone,
+			expectedTuples: 1,
+			expectedUser:   "service-account:sa-test",
+			expectedObject: "role:basic_none",
+		},
+		{
+			name:           "empty role produces no tuples",
+			role:           "",
+			expectedTuples: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sa := &iamv0.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "sa-test"},
+				Spec:       iamv0.ServiceAccountSpec{Role: tt.role},
+			}
+
+			tuples, err := TranslateServiceAccountToTuples(toUnstructured(t, sa))
+			require.NoError(t, err)
+
+			if tt.expectedTuples == 0 {
+				assert.Nil(t, tuples)
+				return
+			}
+
+			require.Len(t, tuples, tt.expectedTuples)
+			assert.Equal(t, tt.expectedUser, tuples[0].GetUser())
+			assert.Equal(t, common.RelationAssignee, tuples[0].GetRelation())
+			assert.Equal(t, tt.expectedObject, tuples[0].GetObject())
+		})
+	}
+}
+
 func TestTranslateFolderToTuples(t *testing.T) {
 	t.Run("folder with parent", func(t *testing.T) {
 		folder := &folderv1.Folder{
@@ -815,6 +881,29 @@ func TestTranslatedTuplesAreSchemaValid(t *testing.T) {
 				}
 
 				tuples, err := TranslateUserToTuples(toUnstructured(t, user))
+				require.NoError(t, err)
+
+				for _, tuple := range tuples {
+					validateTupleAgainstSchema(t, ts, tuple)
+				}
+			})
+		}
+	})
+
+	t.Run("service account basic role assignments", func(t *testing.T) {
+		for _, role := range []iamv0.ServiceAccountOrgRole{
+			iamv0.ServiceAccountOrgRoleViewer,
+			iamv0.ServiceAccountOrgRoleEditor,
+			iamv0.ServiceAccountOrgRoleAdmin,
+			iamv0.ServiceAccountOrgRoleNone,
+		} {
+			t.Run(string(role), func(t *testing.T) {
+				sa := &iamv0.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: "sa-schema-test"},
+					Spec:       iamv0.ServiceAccountSpec{Role: role},
+				}
+
+				tuples, err := TranslateServiceAccountToTuples(toUnstructured(t, sa))
 				require.NoError(t, err)
 
 				for _, tuple := range tuples {


### PR DESCRIPTION
## Summary
- Add `TranslateServiceAccountToTuples` translator that converts ServiceAccount CRDs into basic role assignment tuples (viewer, editor, admin, none)
- Register the serviceaccounts GVR in the reconciler so ServiceAccount resources are fetched and reconciled
- Add comprehensive unit tests including schema validation for all ServiceAccount role types

## Test plan
- [x] Unit tests for all ServiceAccount org roles (viewer, editor, admin, none, empty)
- [x] Schema validation tests confirming generated tuples match the OpenFGA type system
- [ ] Verify reconciler picks up ServiceAccount resources in a dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)