### PR TITLE
CommandPalette: Add provisioned badge to command palette search results

### DIFF
--- a/public/app/features/commandPalette/ResultItem.test.tsx
+++ b/public/app/features/commandPalette/ResultItem.test.tsx
@@ -1,0 +1,76 @@
+import { ActionImpl } from 'kbar';
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+import { ManagerKind } from 'app/features/apiserver/types';
+
+import { ResultItem } from './ResultItem';
+
+function createActionImpl(props: Record<string, unknown> = {}): ActionImpl {
+  const action = {
+    id: 'test-action',
+    name: 'Test Dashboard',
+    ...props,
+  };
+  return ActionImpl.create(action, { store: {} });
+}
+
+describe('ResultItem', () => {
+  let originalProvisioning: boolean | undefined;
+
+  beforeEach(() => {
+    originalProvisioning = config.featureToggles.provisioning;
+  });
+
+  afterEach(() => {
+    config.featureToggles.provisioning = originalProvisioning;
+  });
+
+  it('renders the action name', () => {
+    const action = createActionImpl();
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.getByText('Test Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders provisioned badge when managedBy is Repo and provisioning toggle is on', () => {
+    config.featureToggles.provisioning = true;
+    const action = createActionImpl({ managedBy: ManagerKind.Repo });
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.getByLabelText('Provisioned')).toBeInTheDocument();
+  });
+
+  it('does not render provisioned badge when managedBy is undefined', () => {
+    config.featureToggles.provisioning = true;
+    const action = createActionImpl();
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.queryByLabelText('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('does not render provisioned badge when managedBy is a non-Repo kind', () => {
+    config.featureToggles.provisioning = true;
+    const action = createActionImpl({ managedBy: ManagerKind.Terraform });
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.queryByLabelText('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('does not render provisioned badge for classic provisioning (Plugin)', () => {
+    config.featureToggles.provisioning = true;
+    const action = createActionImpl({ managedBy: ManagerKind.Plugin });
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.queryByLabelText('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('does not render provisioned badge when provisioning toggle is off', () => {
+    config.featureToggles.provisioning = false;
+    const action = createActionImpl({ managedBy: ManagerKind.Repo });
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.queryByLabelText('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('does not render provisioned badge when provisioning toggle is undefined', () => {
+    config.featureToggles.provisioning = undefined;
+    const action = createActionImpl({ managedBy: ManagerKind.Repo });
+    render(<ResultItem action={action} active={false} currentRootActionId="" />);
+    expect(screen.queryByLabelText('Provisioned')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -36,6 +36,9 @@ export const ResultItem = React.forwardRef(
 
     const styles = useStyles2(getResultItemStyles);
 
+    // type assertion needed because kbar's ActionImpl copies all properties from the input Action object at runtime,
+    // but itsTypeScript type doesn't reflect custom properties like managedBy or url.
+    // See the same pattern for `url` in KBarResults.tsx and below command url
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const managedBy = (action as ActionImpl & { managedBy?: ManagerKind }).managedBy;
     const showProvisionedBadge = config.featureToggles.provisioning && managedBy === ManagerKind.Repo;

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -37,7 +37,7 @@ export const ResultItem = React.forwardRef(
     const styles = useStyles2(getResultItemStyles);
 
     // type assertion needed because kbar's ActionImpl copies all properties from the input Action object at runtime,
-    // but itsTypeScript type doesn't reflect custom properties like managedBy or url.
+    // but its TS type doesn't reflect custom properties like managedBy or url.
     // See the same pattern for `url` in KBarResults.tsx and below command url
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const managedBy = (action as ActionImpl & { managedBy?: ManagerKind }).managedBy;

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -3,7 +3,10 @@ import { type ActionId, type ActionImpl } from 'kbar';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { Badge, useStyles2 } from '@grafana/ui';
+import { ManagerKind } from 'app/features/apiserver/types';
 
 export const ResultItem = React.forwardRef(
   (
@@ -32,6 +35,10 @@ export const ResultItem = React.forwardRef(
     }, [action.ancestors, currentRootActionId]);
 
     const styles = useStyles2(getResultItemStyles);
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const managedBy = (action as ActionImpl & { managedBy?: ManagerKind }).managedBy;
+    const showProvisionedBadge = config.featureToggles.provisioning && managedBy === ManagerKind.Repo;
 
     let name = action.name;
 
@@ -62,6 +69,14 @@ export const ResultItem = React.forwardRef(
             <span>{name}</span>
           </div>
           {action.subtitle && <span className={styles.subtitleText}>{action.subtitle}</span>}
+          {showProvisionedBadge && (
+            <Badge
+              color="purple"
+              icon="exchange-alt"
+              aria-label={t('command-palette.badge.provisioned', 'Provisioned')}
+              tooltip={t('command-palette.badge.provisioned', 'Provisioned')}
+            />
+          )}
         </div>
       </div>
     );

--- a/public/app/features/commandPalette/actions/dashboardActions.test.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.test.ts
@@ -4,6 +4,7 @@ import { type DataFrame, DataFrameView, FieldType } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type ContextSrv, contextSrv } from 'app/core/services/context_srv';
 import impressionSrv from 'app/core/services/impression_srv';
+import { ManagerKind } from 'app/features/apiserver/types';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult, type QueryResponse } from 'app/features/search/service/types';
 
@@ -96,6 +97,28 @@ describe('dashboardActions', () => {
           },
         ]);
       });
+
+      it('includes managedBy when present in search results', async () => {
+        const searchDataWithManagedBy: DataFrame = {
+          ...searchData,
+          fields: [
+            ...searchData.fields,
+            { name: 'managedBy', type: FieldType.string, config: {}, values: [ManagerKind.Repo] },
+          ],
+        };
+        grafanaSearcherSpy.mockResolvedValueOnce({
+          ...mockSearchResult,
+          view: new DataFrameView<DashboardQueryResult>(searchDataWithManagedBy),
+        });
+
+        const results = await getRecentDashboardActions();
+        expect(results).toEqual([
+          expect.objectContaining({
+            id: 'recent-dashboards/my-dashboard-1',
+            managedBy: ManagerKind.Repo,
+          }),
+        ]);
+      });
     });
   });
 
@@ -165,6 +188,33 @@ describe('dashboardActions', () => {
             url: '/my-dashboard-1',
           },
         ]);
+      });
+
+      it('includes managedBy in search result actions when present', async () => {
+        const searchDataWithManagedBy: DataFrame = {
+          ...searchData,
+          fields: [
+            ...searchData.fields,
+            { name: 'managedBy', type: FieldType.string, config: {}, values: [ManagerKind.Repo] },
+          ],
+        };
+        grafanaSearcherSpy.mockResolvedValueOnce({
+          ...mockSearchResult,
+          view: new DataFrameView<DashboardQueryResult>(searchDataWithManagedBy),
+        });
+
+        const results = await getSearchResultActions('mySearchQuery');
+        expect(results).toEqual([
+          expect.objectContaining({
+            id: 'go/dashboard/my-dashboard-1',
+            managedBy: ManagerKind.Repo,
+          }),
+        ]);
+      });
+
+      it('returns undefined managedBy when not present in search data', async () => {
+        const results = await getSearchResultActions('mySearchQuery');
+        expect(results[0].managedBy).toBeUndefined();
       });
     });
   });

--- a/public/app/features/commandPalette/actions/dashboardActions.test.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.test.ts
@@ -211,11 +211,6 @@ describe('dashboardActions', () => {
           }),
         ]);
       });
-
-      it('returns undefined managedBy when not present in search data', async () => {
-        const results = await getSearchResultActions('mySearchQuery');
-        expect(results[0].managedBy).toBeUndefined();
-      });
     });
   });
 

--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -6,6 +6,7 @@ import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getRecentlyViewedDashboards } from 'app/features/browse-dashboards/api/recentlyViewed';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+import { extractManagerKind } from 'app/features/search/service/utils';
 
 import { type CommandPaletteAction } from '../types';
 import { RECENT_DASHBOARDS_PRIORITY, SEARCH_RESULTS_PRIORITY } from '../values';
@@ -23,13 +24,14 @@ export async function getRecentDashboardActions(): Promise<CommandPaletteAction[
   const recentResults = await getRecentlyViewedDashboards(MAX_RECENT_DASHBOARDS);
 
   const recentDashboardActions: CommandPaletteAction[] = recentResults.map((item) => {
-    const { url, name } = item; // items are backed by DataFrameView, so must hold the url in a closure
+    const { url, name, managedBy } = item; // items are backed by DataFrameView, so must hold the url in a closure
     return {
       id: `recent-dashboards${url}`,
       name: `${name}`,
       section: t('command-palette.section.recent-dashboards', 'Recent dashboards'),
       priority: RECENT_DASHBOARDS_PRIORITY,
       url,
+      managedBy: extractManagerKind(managedBy),
     };
   });
 
@@ -49,7 +51,7 @@ export async function getSearchResultActions(searchQuery: string): Promise<Comma
   });
 
   const goToSearchResultActions: CommandPaletteAction[] = data.view.map((item) => {
-    const { url, name, kind, location } = item; // items are backed by DataFrameView, so must hold the url in a closure
+    const { url, name, kind, location, managedBy } = item; // items are backed by DataFrameView, so must hold the url in a closure
     return {
       id: `go/${kind}${url}`,
       name: `${name}`,
@@ -60,6 +62,7 @@ export async function getSearchResultActions(searchQuery: string): Promise<Comma
       priority: SEARCH_RESULTS_PRIORITY,
       url,
       subtitle: data.view.dataFrame.meta?.custom?.locationInfo[location]?.name,
+      managedBy: extractManagerKind(managedBy),
     };
   });
 

--- a/public/app/features/commandPalette/types.ts
+++ b/public/app/features/commandPalette/types.ts
@@ -1,5 +1,7 @@
 import { type Action } from 'kbar';
 
+import { type ManagerKind } from 'app/features/apiserver/types';
+
 type NotNullable<T> = Exclude<T, null | undefined>;
 
 // Create our own action type to make priority mandatory.
@@ -13,6 +15,7 @@ type RootCommandPaletteAction = Omit<Action, 'parent'> & {
   priority: NotNullable<Action['priority']>;
   target?: React.HTMLAttributeAnchorTarget;
   url?: string | URLCallback;
+  managedBy?: ManagerKind;
 };
 
 type ChildCommandPaletteAction = Action & {
@@ -20,4 +23,5 @@ type ChildCommandPaletteAction = Action & {
   priority: NotNullable<Action['priority']>;
   target?: React.HTMLAttributeAnchorTarget;
   url?: string | URLCallback;
+  managedBy?: ManagerKind;
 };

--- a/public/app/features/commandPalette/types.ts
+++ b/public/app/features/commandPalette/types.ts
@@ -23,5 +23,4 @@ type ChildCommandPaletteAction = Action & {
   priority: NotNullable<Action['priority']>;
   target?: React.HTMLAttributeAnchorTarget;
   url?: string | URLCallback;
-  managedBy?: ManagerKind;
 };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4923,6 +4923,9 @@
       "light-theme": "Light",
       "scopes": "Scopes"
     },
+    "badge": {
+      "provisioned": "Provisioned"
+    },
     "empty-state": {
       "button-title": "Search with Grafana Assistant",
       "message": "No results found"


### PR DESCRIPTION
**What is this feature?**

- Added"Provisioned" badge next to dashboards managed by git provisioning (ManagerKind.Repo) in the command palette search results
- Badge is gated behind the provisioning feature toggle. 
<img width="700" height="706" alt="image" src="https://github.com/user-attachments/assets/049b9172-b5c1-41da-a870-9b9e284b3427" />


**Why do we need this feature?**

When users search for dashboards via the command palette, there's no visual indicator that a dashboard is provisioned through git. 

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1045

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
