### PR TITLE
Dashboards: Fix getVariablesCompability

### DIFF
--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -2,6 +2,7 @@ import { config } from '@grafana/runtime';
 import {
   type AdHocFilterWithLabels as SceneAdHocFilterWithLabels,
   type MultiValueVariable,
+  type SceneObject,
   type SceneVariables,
   sceneUtils,
 } from '@grafana/scenes';
@@ -48,12 +49,23 @@ import {
  *                           This should be set to `false` when variables are saved in the dashboard model,
  *                           but should be set to `true` when variables are used in the templateSrv to keep them in sync.
  *                           If `true`, the options for query variables are kept.
+ * @param excludeVariable - (Optional) Scene variable instance to omit. Is used to avoid self-reference in that variable's editor.
+ *                          e.g when editing it as a section variable.
+ *
+ *
  *  */
 
-export function sceneVariablesSetToVariables(set: SceneVariables, keepQueryOptions?: boolean) {
+export function sceneVariablesSetToVariables(
+  set: SceneVariables,
+  keepQueryOptions?: boolean,
+  excludedVariable?: SceneObject
+) {
   const variables: VariableModel[] = [];
 
   for (const variable of set.state.variables) {
+    if (excludedVariable !== undefined && variable === excludedVariable) {
+      continue;
+    }
     // Skipping default variables
     // (Default variables don't get persisted to the JSON schema.)
     if (variable.state.origin !== undefined) {

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
@@ -1,4 +1,4 @@
-import { CustomVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { CustomVariable, QueryVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
@@ -16,6 +16,10 @@ jest.mock('../serialization/sceneVariablesSetToVariables', () => ({
 
 function makeVar(name: string) {
   return new CustomVariable({ name, query: name, value: name, text: name });
+}
+
+function makeQueryVar(name: string) {
+  return new QueryVariable({ name, query: '', value: '', text: '' });
 }
 
 describe('getVariablesCompatibility', () => {
@@ -62,9 +66,9 @@ describe('getVariablesCompatibility', () => {
 
   describe('edit pane selection', () => {
     it('scopes to the selected object ancestry', () => {
-      const dashVar = makeVar('dashVar');
-      const sectionVar = makeVar('sectionVar');
-      const otherSectionVar = makeVar('otherVar');
+      const dashVar = makeQueryVar('dashVar');
+      const sectionVar = makeQueryVar('sectionVar');
+      const otherSectionVar = makeQueryVar('otherVar');
 
       const row1 = new RowItem({
         title: 'Row 1',
@@ -86,12 +90,12 @@ describe('getVariablesCompatibility', () => {
       const result = getVariablesCompatibility(dashboard);
       const names = result.map((v) => v.name);
 
-      expect(names).toContain('sectionVar');
       expect(names).toContain('dashVar');
+      expect(names).not.toContain('sectionVar');
       expect(names).not.toContain('otherVar');
     });
 
-    it('falls back to all variables when nothing is selected', () => {
+    it('falls back to global variables when nothing is selected', () => {
       const dashVar = makeVar('dashVar');
       const sectionVar = makeVar('sectionVar');
 
@@ -109,12 +113,35 @@ describe('getVariablesCompatibility', () => {
       const names = result.map((v) => v.name);
 
       expect(names).toContain('dashVar');
-      expect(names).toContain('sectionVar');
+      expect(names).not.toContain('sectionVar');
+    });
+
+    it('excludes the currently selected query variable from ancestry results', () => {
+      const dashVar = makeVar('dashVar');
+      const queryVar = makeQueryVar('queryVar');
+
+      const row = new RowItem({
+        title: 'Row 1',
+        $variables: new SceneVariableSet({ variables: [queryVar] }),
+      });
+
+      const dashboard = new DashboardScene({
+        $variables: new SceneVariableSet({ variables: [dashVar] }),
+        body: new RowsLayoutManager({ rows: [row] }),
+      });
+
+      dashboard.state.editPane.selectObject(queryVar);
+
+      const result = getVariablesCompatibility(dashboard);
+      const names = result.map((v) => v.name);
+
+      expect(names).toContain('dashVar');
+      expect(names).not.toContain('queryVar');
     });
   });
 
   describe('dashboard view mode (no editPanel, no selection)', () => {
-    it('returns all variables from dashboard and all sections', () => {
+    it('returns global variables from dashboard', () => {
       const dashVar = makeVar('dashVar');
       const sectionVar1 = makeVar('sectionVar1');
       const sectionVar2 = makeVar('sectionVar2');
@@ -138,8 +165,8 @@ describe('getVariablesCompatibility', () => {
       const names = result.map((v) => v.name);
 
       expect(names).toContain('dashVar');
-      expect(names).toContain('sectionVar1');
-      expect(names).toContain('sectionVar2');
+      expect(names).not.toContain('sectionVar1');
+      expect(names).not.toContain('sectionVar2');
     });
 
     it('deduplicates: dashboard variables take precedence over section variables with the same name', () => {
@@ -164,33 +191,6 @@ describe('getVariablesCompatibility', () => {
   });
 
   describe('called with a child scene object (not the DashboardScene root)', () => {
-    it('walks up ancestry and collects variables from all ancestor levels', () => {
-      const dashVar = makeVar('dashVar');
-      const sectionVar = makeVar('sectionVar');
-
-      const panel = new VizPanel({ key: 'panel-1', pluginId: 'text' });
-      const gridItem = new DashboardGridItem({ body: panel });
-
-      const row = new RowItem({
-        title: 'Row 1',
-        $variables: new SceneVariableSet({ variables: [sectionVar] }),
-        layout: new DefaultGridLayoutManager({
-          grid: new SceneGridLayout({ children: [gridItem] }),
-        }),
-      });
-
-      new DashboardScene({
-        $variables: new SceneVariableSet({ variables: [dashVar] }),
-        body: new RowsLayoutManager({ rows: [row] }),
-      });
-
-      const result = getVariablesCompatibility(panel);
-      const names = result.map((v) => v.name);
-
-      expect(names).toContain('sectionVar');
-      expect(names).toContain('dashVar');
-    });
-
     it('gives precedence to closer ancestor variables on name collision', () => {
       const sectionVar = makeVar('sharedName');
 

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
@@ -9,8 +9,14 @@ import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { getVariablesCompatibility } from './getVariablesCompatibility';
 
 jest.mock('../serialization/sceneVariablesSetToVariables', () => ({
-  sceneVariablesSetToVariables: (set: { state: { variables: Array<{ state: { name: string; type?: string } }> } }) => {
-    return set.state.variables.map((v) => ({ name: v.state.name, type: v.state.type ?? 'custom' }));
+  sceneVariablesSetToVariables: (
+    set: { state: { variables: Array<{ state: { name: string; type?: string } }> } },
+    _keepQueryOptions?: boolean,
+    excludeVariable?: unknown
+  ) => {
+    return set.state.variables
+      .filter((v) => v !== excludeVariable)
+      .map((v) => ({ name: v.state.name, type: v.state.type ?? 'custom' }));
   },
 }));
 

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
@@ -1,5 +1,5 @@
 import { type TypedVariableModel, type VariableModel } from '@grafana/data';
-import { type SceneObject, SceneVariableSet, sceneGraph } from '@grafana/scenes';
+import { QueryVariable, type SceneObject, SceneVariableSet, sceneGraph } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { sceneVariablesSetToVariables } from '../serialization/sceneVariablesSetToVariables';
@@ -19,23 +19,22 @@ export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariab
   // the same section + dashboard globals.
   if (sceneObject instanceof DashboardScene) {
     const selectedObject = sceneObject.state.editPane.getSelectedObject();
-    if (selectedObject && selectedObject !== sceneObject) {
+    const isQueryVariable = selectedObject instanceof QueryVariable;
+
+    if (isQueryVariable) {
+      // The selected variable is a child of SceneVariableSet, so exclude it
+      // from ancestor options to avoid self-reference in the query editor.
+      const excludedVariableNames = new Set([selectedObject.state.name]);
       // @ts-expect-error
-      return collectAncestorVariables(selectedObject);
+      return collectAncestorVariables(selectedObject, excludedVariableNames);
     }
   }
 
-  // If called with a non-root scene object, walk up its ancestry
-  if (!(sceneObject instanceof DashboardScene)) {
-    // @ts-expect-error
-    return collectAncestorVariables(sceneObject);
-  }
-
-  // Default: dashboard vars + all section vars (for dashboard view mode)
-  return collectAllVariables(sceneObject);
+  // Default: dashboard global vars
+  return collectGlobalVariables(sceneObject);
 }
 
-function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
+function collectAncestorVariables(sceneObject: SceneObject, excludedVariableNames?: Set<string>): VariableModel[] {
   const allModels: VariableModel[] = [];
   const seenNames = new Set<string>();
   const keepQueryOptions = true;
@@ -45,6 +44,9 @@ function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
     if (current.state.$variables instanceof SceneVariableSet) {
       const models = sceneVariablesSetToVariables(current.state.$variables, keepQueryOptions);
       for (const model of models) {
+        if (excludedVariableNames?.has(model.name)) {
+          continue;
+        }
         if (!seenNames.has(model.name)) {
           allModels.push(model);
           seenNames.add(model.name);
@@ -57,25 +59,11 @@ function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
   return allModels;
 }
 
-function collectAllVariables(sceneObject: SceneObject): TypedVariableModel[] {
+function collectGlobalVariables(sceneObject: SceneObject): TypedVariableModel[] {
   const set = sceneGraph.getVariables(sceneObject);
   const keepQueryOptions = true;
 
   const legacyModels = sceneVariablesSetToVariables(set, keepQueryOptions);
-  const dashboardNames = new Set(legacyModels.map((v) => v.name));
-
-  const sectionSets: SceneVariableSet[] = [];
-  collectChildVariableSets(sceneObject, sectionSets);
-
-  for (const sectionSet of sectionSets) {
-    const sectionModels = sceneVariablesSetToVariables(sectionSet, keepQueryOptions);
-    for (const model of sectionModels) {
-      if (!dashboardNames.has(model.name)) {
-        legacyModels.push(model);
-        dashboardNames.add(model.name);
-      }
-    }
-  }
 
   // Sadly templateSrv.getVariables returns TypedVariableModel but sceneVariablesSetToVariables return persisted schema model
   // They look close to identical (differ in what is optional in some places).
@@ -83,13 +71,4 @@ function collectAllVariables(sceneObject: SceneObject): TypedVariableModel[] {
   // So type and name are important. Maybe some external data sources also check current value so that is also important.
   // @ts-expect-error
   return legacyModels;
-}
-
-function collectChildVariableSets(sceneObject: SceneObject, result: SceneVariableSet[]): void {
-  sceneObject.forEachChild((child) => {
-    if (child.state.$variables instanceof SceneVariableSet) {
-      result.push(child.state.$variables);
-    }
-    collectChildVariableSets(child, result);
-  });
 }

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
@@ -37,20 +37,12 @@ function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
 
   // The variable being edited is excluded from its own set
   // this is to avoid self-reference in that variable's editor
-  const excludeVariable = sceneObject;
+  const excludedVariable = sceneObject;
   let current: SceneObject | undefined = sceneObject;
   while (current) {
     if (current.state.$variables instanceof SceneVariableSet) {
       const set = current.state.$variables;
-      let models = sceneVariablesSetToVariables(set, keepQueryOptions);
-
-      if (excludeVariable && set.state.variables.some((v) => v === excludeVariable)) {
-        const rawName = Reflect.get(excludeVariable.state, 'name');
-        const excludeName = typeof rawName === 'string' ? rawName : undefined;
-        if (excludeName !== undefined) {
-          models = models.filter((m) => m.name !== excludeName);
-        }
-      }
+      const models = sceneVariablesSetToVariables(set, keepQueryOptions, excludedVariable);
 
       for (const model of models) {
         if (!seenNames.has(model.name)) {

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
@@ -1,5 +1,5 @@
 import { type TypedVariableModel, type VariableModel } from '@grafana/data';
-import { QueryVariable, type SceneObject, SceneVariableSet, sceneGraph } from '@grafana/scenes';
+import { type SceneObject, SceneVariableSet, sceneGraph } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { sceneVariablesSetToVariables } from '../serialization/sceneVariablesSetToVariables';
@@ -19,14 +19,10 @@ export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariab
   // the same section + dashboard globals.
   if (sceneObject instanceof DashboardScene) {
     const selectedObject = sceneObject.state.editPane.getSelectedObject();
-    const isQueryVariable = selectedObject instanceof QueryVariable;
 
-    if (isQueryVariable) {
-      // The selected variable is a child of SceneVariableSet, so exclude it
-      // from ancestor options to avoid self-reference in the query editor.
-      const excludedVariableNames = new Set([selectedObject.state.name]);
+    if (selectedObject) {
       // @ts-expect-error
-      return collectAncestorVariables(selectedObject, excludedVariableNames);
+      return collectAncestorVariables(selectedObject);
     }
   }
 
@@ -34,19 +30,29 @@ export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariab
   return collectGlobalVariables(sceneObject);
 }
 
-function collectAncestorVariables(sceneObject: SceneObject, excludedVariableNames?: Set<string>): VariableModel[] {
+function collectAncestorVariables(sceneObject: SceneObject): VariableModel[] {
   const allModels: VariableModel[] = [];
   const seenNames = new Set<string>();
   const keepQueryOptions = true;
 
+  // The variable being edited is excluded from its own set
+  // this is to avoid self-reference in that variable's editor
+  const excludeVariable = sceneObject;
   let current: SceneObject | undefined = sceneObject;
   while (current) {
     if (current.state.$variables instanceof SceneVariableSet) {
-      const models = sceneVariablesSetToVariables(current.state.$variables, keepQueryOptions);
-      for (const model of models) {
-        if (excludedVariableNames?.has(model.name)) {
-          continue;
+      const set = current.state.$variables;
+      let models = sceneVariablesSetToVariables(set, keepQueryOptions);
+
+      if (excludeVariable && set.state.variables.some((v) => v === excludeVariable)) {
+        const rawName = Reflect.get(excludeVariable.state, 'name');
+        const excludeName = typeof rawName === 'string' ? rawName : undefined;
+        if (excludeName !== undefined) {
+          models = models.filter((m) => m.name !== excludeName);
         }
+      }
+
+      for (const model of models) {
         if (!seenNames.has(model.name)) {
           allModels.push(model);
           seenNames.add(model.name);


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/121788

It removes `collectAllVariables` and defaults to returning only dashboard-level variables. This is so we don't introduce any breaking behavior for the panel plugins that rely on `templateSrv.getVariables` where only global variables are expected. 

Fixes a bug with editing a query variable where the same variable was referenced in its own query editor. 

Fixes #121796  
