### PR TITLE
Add usePolling hook and LiveMetricCard component

### DIFF
--- a/public/app/core/components/LiveMetricCard/LiveMetricCard.test.tsx
+++ b/public/app/core/components/LiveMetricCard/LiveMetricCard.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { LiveMetricCard } from './LiveMetricCard';
+
+describe('LiveMetricCard', () => {
+  it('shows loading state initially', () => {
+    const fetchMetric = jest.fn().mockResolvedValue(42);
+    render(<LiveMetricCard title="CPU Usage" fetchMetric={fetchMetric} />);
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('displays the metric value after fetch resolves', async () => {
+    const fetchMetric = jest.fn().mockResolvedValue(73);
+    render(<LiveMetricCard title="CPU Usage" fetchMetric={fetchMetric} />);
+    await waitFor(() => expect(screen.getByText('73')).toBeInTheDocument());
+  });
+
+  it('displays the metric value with a unit', async () => {
+    const fetchMetric = jest.fn().mockResolvedValue(512);
+    render(<LiveMetricCard title="Memory" unit="MB" fetchMetric={fetchMetric} />);
+    await waitFor(() => expect(screen.getByText('512 MB')).toBeInTheDocument());
+  });
+
+  it('displays an error message when fetch fails', async () => {
+    const fetchMetric = jest.fn().mockRejectedValue(new Error('timeout'));
+    render(<LiveMetricCard title="CPU Usage" fetchMetric={fetchMetric} />);
+    await waitFor(() => expect(screen.getByText('Error: timeout')).toBeInTheDocument());
+  });
+});

--- a/public/app/core/components/LiveMetricCard/LiveMetricCard.tsx
+++ b/public/app/core/components/LiveMetricCard/LiveMetricCard.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { usePolling } from '../../hooks/usePolling';
+
+interface Props {
+  title: string;
+  unit?: string;
+  /** Async function that fetches the current metric value. */
+  fetchMetric: () => Promise<number>;
+  /** Polling interval in milliseconds. Defaults to 5000. */
+  refreshInterval?: number;
+}
+
+/**
+ * Displays a single numeric metric that refreshes automatically at a fixed interval.
+ */
+export function LiveMetricCard({ title, unit, fetchMetric, refreshInterval = 5000 }: Props) {
+  const { data, loading, error } = usePolling(fetchMetric, refreshInterval);
+
+  return (
+    <div className="live-metric-card">
+      <h4>{title}</h4>
+      {loading && <span>Loading…</span>}
+      {error && <span>Error: {error.message}</span>}
+      {!loading && !error && (
+        <span className="live-metric-card__value">
+          {data !== null ? `${data}${unit ? ` ${unit}` : ''}` : '—'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/public/app/core/hooks/usePolling.test.ts
+++ b/public/app/core/hooks/usePolling.test.ts
@@ -3,6 +3,10 @@ import { renderHook, act } from '@testing-library/react';
 import { usePolling } from './usePolling';
 
 describe('usePolling', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('starts in a loading state', () => {
     const fetchFn = jest.fn().mockResolvedValue(42);
     const { result } = renderHook(() => usePolling(fetchFn, 1000));
@@ -27,12 +31,72 @@ describe('usePolling', () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it('normalizes non-Error thrown values into an Error', async () => {
+    const fetchFn = jest.fn().mockRejectedValue('plain string rejection');
+    const { result } = renderHook(() => usePolling(fetchFn, 1000));
+    await act(async () => {});
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('plain string rejection');
+  });
+
   it('does not update state after unmount', async () => {
     let resolve!: (v: number) => void;
     const fetchFn = jest.fn().mockReturnValue(new Promise<number>((r) => (resolve = r)));
     const { result, unmount } = renderHook(() => usePolling(fetchFn, 1000));
     unmount();
-    await act(async () => { resolve(99); });
+    await act(async () => {
+      resolve(99);
+    });
     expect(result.current.data).toBeNull();
+  });
+
+  it('calls fetchFn repeatedly at the specified interval', async () => {
+    jest.useFakeTimers();
+    const fetchFn = jest.fn().mockResolvedValue(1);
+    renderHook(() => usePolling(fetchFn, 1000));
+
+    await act(async () => {});
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('ignores stale responses when concurrent fetches resolve out of order', async () => {
+    jest.useFakeTimers();
+
+    let resolveFirst!: (v: number) => void;
+    let resolveSecond!: (v: number) => void;
+
+    const fetchFn = jest
+      .fn()
+      .mockReturnValueOnce(new Promise<number>((r) => (resolveFirst = r)))
+      .mockReturnValueOnce(new Promise<number>((r) => (resolveSecond = r)));
+
+    const { result } = renderHook(() => usePolling(fetchFn, 500));
+
+    // Trigger second poll before first resolves
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Second resolves first with newer data
+    await act(async () => {
+      resolveSecond(99);
+    });
+    expect(result.current.data).toBe(99);
+
+    // First resolves late — stale, should be discarded
+    await act(async () => {
+      resolveFirst(1);
+    });
+    expect(result.current.data).toBe(99);
   });
 });

--- a/public/app/core/hooks/usePolling.test.ts
+++ b/public/app/core/hooks/usePolling.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { usePolling } from './usePolling';
+
+describe('usePolling', () => {
+  it('starts in a loading state', () => {
+    const fetchFn = jest.fn().mockResolvedValue(42);
+    const { result } = renderHook(() => usePolling(fetchFn, 1000));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('populates data after the first fetch resolves', async () => {
+    const fetchFn = jest.fn().mockResolvedValue(42);
+    const { result } = renderHook(() => usePolling(fetchFn, 1000));
+    await act(async () => {});
+    expect(result.current.data).toBe(42);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sets error state when fetch throws', async () => {
+    const fetchFn = jest.fn().mockRejectedValue(new Error('fetch failed'));
+    const { result } = renderHook(() => usePolling(fetchFn, 1000));
+    await act(async () => {});
+    expect(result.current.error).toEqual(new Error('fetch failed'));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does not update state after unmount', async () => {
+    let resolve!: (v: number) => void;
+    const fetchFn = jest.fn().mockReturnValue(new Promise<number>((r) => (resolve = r)));
+    const { result, unmount } = renderHook(() => usePolling(fetchFn, 1000));
+    unmount();
+    await act(async () => { resolve(99); });
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/public/app/core/hooks/usePolling.ts
+++ b/public/app/core/hooks/usePolling.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+export interface PollingState<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Polls an async function at a fixed interval, returning the latest result.
+ *
+ * @param fetchFn - Async function to call on each poll. Should be stable (e.g. wrapped
+ *   in useCallback) to avoid triggering unnecessary effect re-runs.
+ * @param intervalMs - Polling interval in milliseconds.
+ */
+export function usePolling<T>(fetchFn: () => Promise<T>, intervalMs: number): PollingState<T> {
+  const [state, setState] = useState<PollingState<T>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const data = await fetchFn();
+        if (!cancelled) {
+          setState({ data, loading: false, error: null });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState((prev) => ({ ...prev, loading: false, error: err as Error }));
+        }
+      }
+    };
+
+    poll();
+    const intervalId = setInterval(poll, intervalMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [fetchFn]); // intervalMs intentionally omitted — changing interval has no effect at runtime
+
+  return state;
+}

--- a/public/app/core/hooks/usePolling.ts
+++ b/public/app/core/hooks/usePolling.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export interface PollingState<T> {
   data: T | null;
@@ -9,9 +9,15 @@ export interface PollingState<T> {
 /**
  * Polls an async function at a fixed interval, returning the latest result.
  *
- * @param fetchFn - Async function to call on each poll. Should be stable (e.g. wrapped
- *   in useCallback) to avoid triggering unnecessary effect re-runs.
- * @param intervalMs - Polling interval in milliseconds.
+ * Note: `loading` is `true` only during the initial fetch. Subsequent polls do
+ * not reset `loading` to `true` — this is intentional to avoid spinner flicker
+ * on every refresh cycle.
+ *
+ * @param fetchFn - Async function to call on each poll. Must be stable (e.g. wrapped
+ *   in `useCallback`). An unstable reference continuously resets the interval,
+ *   effectively preventing polling if the parent re-renders on every tick.
+ * @param intervalMs - Polling interval in milliseconds. Changes take effect on the
+ *   next render cycle.
  */
 export function usePolling<T>(fetchFn: () => Promise<T>, intervalMs: number): PollingState<T> {
   const [state, setState] = useState<PollingState<T>>({
@@ -19,19 +25,25 @@ export function usePolling<T>(fetchFn: () => Promise<T>, intervalMs: number): Po
     loading: true,
     error: null,
   });
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
 
     const poll = async () => {
+      const requestId = ++requestIdRef.current;
       try {
         const data = await fetchFn();
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setState({ data, loading: false, error: null });
         }
       } catch (err) {
-        if (!cancelled) {
-          setState((prev) => ({ ...prev, loading: false, error: err as Error }));
+        if (!cancelled && requestId === requestIdRef.current) {
+          setState((prev) => ({
+            ...prev,
+            loading: false,
+            error: err instanceof Error ? err : new Error(String(err)),
+          }));
         }
       }
     };
@@ -43,7 +55,7 @@ export function usePolling<T>(fetchFn: () => Promise<T>, intervalMs: number): Po
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [fetchFn]);
+  }, [fetchFn, intervalMs]);
 
   return state;
 }

--- a/public/app/core/hooks/usePolling.ts
+++ b/public/app/core/hooks/usePolling.ts
@@ -43,7 +43,7 @@ export function usePolling<T>(fetchFn: () => Promise<T>, intervalMs: number): Po
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [fetchFn]); // intervalMs intentionally omitted — changing interval has no effect at runtime
+  }, [fetchFn]);
 
   return state;
 }


### PR DESCRIPTION
## Summary

- Adds `usePolling<T>(fetchFn, intervalMs)` hook to `public/app/core/hooks/` — polls an async function at a fixed interval and manages loading/data/error state
- Adds `LiveMetricCard` component to `public/app/core/components/LiveMetricCard/` — displays a single auto-refreshing numeric metric using `usePolling`

## Test plan

- [ ] `yarn jest public/app/core/hooks/usePolling.test.ts --watchAll=false`
- [ ] `yarn jest public/app/core/components/LiveMetricCard/LiveMetricCard.test.tsx --watchAll=false`

> Draft PR for AI review loop demo.