### PR TITLE
Provisioning: simplify SyncAndWait integration test helper

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1957,32 +1957,84 @@ func (h *ProvisioningTestHelper) GetRepositories() *apis.K8sResourceClient {
 	return h.Repositories
 }
 
+// ---------------------------------------------------------------------------
+// Job matchers — composable assertions for completed sync jobs.
+// ---------------------------------------------------------------------------
+
+// JobMatcher asserts properties of a completed sync job.
+type JobMatcher func(t *testing.T, job *unstructured.Unstructured)
+
+// HasState returns a matcher that asserts the job finished in the given state.
+func HasState(expected provisioning.JobState) JobMatcher {
+	return func(t *testing.T, job *unstructured.Unstructured) {
+		t.Helper()
+		actual := MustNestedString(job.Object, "status", "state")
+		require.Equal(t, string(expected), actual,
+			"job %q should have state %s", job.GetName(), expected)
+	}
+}
+
+// HasNoErrors returns a matcher that asserts the job completed without errors.
+func HasNoErrors() JobMatcher {
+	return func(t *testing.T, job *unstructured.Unstructured) {
+		t.Helper()
+		errs := MustNestedStringSlice(job.Object, "status", "errors")
+		require.Empty(t, errs, "job %q has errors: %v", job.GetName(), errs)
+	}
+}
+
+// Succeeded returns a matcher that asserts success with no errors.
+func Succeeded() JobMatcher {
+	return func(t *testing.T, job *unstructured.Unstructured) {
+		t.Helper()
+		HasNoErrors()(t, job)
+		HasState(provisioning.JobStateSuccess)(t, job)
+	}
+}
+
+// Warning returns a matcher that asserts warning state with no errors.
+func Warning() JobMatcher {
+	return func(t *testing.T, job *unstructured.Unstructured) {
+		t.Helper()
+		HasNoErrors()(t, job)
+		HasState(provisioning.JobStateWarning)(t, job)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SyncAndWait — configurable pull-sync helper.
+// ---------------------------------------------------------------------------
+
 // SyncOption configures the behaviour of SyncAndWait.
 type SyncOption func(*syncOpts)
 
 type syncOpts struct {
-	incremental   bool
-	expectedState provisioning.JobState
+	incremental bool
+	matchers    []JobMatcher
 }
 
 // Incremental makes SyncAndWait trigger an incremental pull instead of a full one.
 func Incremental(o *syncOpts) { o.incremental = true }
 
-// ExpectWarning makes SyncAndWait assert the job finished with a warning state
-// instead of the default success state.
-func ExpectWarning(o *syncOpts) { o.expectedState = provisioning.JobStateWarning }
+// Expect adds job matchers that are applied to the completed job.
+// When no Expect option is provided, SyncAndWait defaults to Succeeded().
+func Expect(m ...JobMatcher) SyncOption {
+	return func(o *syncOpts) {
+		o.matchers = append(o.matchers, m...)
+	}
+}
 
 // SyncAndWait triggers a pull sync, waits for it to complete, and asserts the
 // expected outcome. By default it performs a full sync and expects success.
-// Pass Incremental to use an incremental sync, and/or ExpectWarning to assert
-// the job finished with warnings.
+// Pass Incremental to use an incremental sync, and/or Expect(Warning()) to
+// assert the job finished with warnings.
 //
 // Full (non-incremental) syncs also wait for the repository's lastRef to be
 // set, which is required before an incremental sync can be triggered.
 func SyncAndWait(t *testing.T, h SyncHelper, repoName string, opts ...SyncOption) {
 	t.Helper()
 
-	o := syncOpts{expectedState: provisioning.JobStateSuccess}
+	o := syncOpts{}
 	for _, fn := range opts {
 		fn(&o)
 	}
@@ -1992,11 +2044,11 @@ func SyncAndWait(t *testing.T, h SyncHelper, repoName string, opts ...SyncOption
 		Pull:   &provisioning.SyncJobOptions{Incremental: o.incremental},
 	})
 
-	switch o.expectedState {
-	case provisioning.JobStateWarning:
-		RequireJobWarning(t, job)
-	default:
-		requireJobSuccess(t, job)
+	if len(o.matchers) == 0 {
+		o.matchers = []JobMatcher{Succeeded()}
+	}
+	for _, m := range o.matchers {
+		m(t, job)
 	}
 
 	if !o.incremental {
@@ -2004,24 +2056,12 @@ func SyncAndWait(t *testing.T, h SyncHelper, repoName string, opts ...SyncOption
 	}
 }
 
-// RequireJobSuccess asserts that a completed job has state "success" and no errors.
-func requireJobSuccess(t *testing.T, job *unstructured.Unstructured) {
-	t.Helper()
-	lastState := MustNestedString(job.Object, "status", "state")
-	lastErrors := MustNestedStringSlice(job.Object, "status", "errors")
-	require.Empty(t, lastErrors, "job %q has errors: %v", job.GetName(), lastErrors)
-	require.Equal(t, string(provisioning.JobStateSuccess), lastState,
-		"job %q should succeed", job.GetName())
-}
-
 // RequireJobWarning asserts that a completed job has state "warning" and no errors.
+// Prefer Warning() matcher for use with SyncAndWait; this standalone function
+// is kept for callers that assert on a job obtained outside SyncAndWait.
 func RequireJobWarning(t *testing.T, job *unstructured.Unstructured) {
 	t.Helper()
-	lastState := MustNestedString(job.Object, "status", "state")
-	lastErrors := MustNestedStringSlice(job.Object, "status", "errors")
-	require.Empty(t, lastErrors, "job %q has errors: %v", job.GetName(), lastErrors)
-	require.Equal(t, string(provisioning.JobStateWarning), lastState,
-		"job %q should have warning state", job.GetName())
+	Warning()(t, job)
 }
 
 // GetFolderGeneration returns the current generation of the folder with the given UID.

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1957,31 +1957,51 @@ func (h *ProvisioningTestHelper) GetRepositories() *apis.K8sResourceClient {
 	return h.Repositories
 }
 
-// SyncAndWaitWithSuccess triggers a full pull sync, asserts that it succeeds,
-// and waits for the repository's lastRef to be set. Use this as the initial
-// sync in tests that later trigger incremental syncs, so that lastRef is
-// guaranteed to be populated.
-func SyncAndWaitWithSuccess(t *testing.T, h SyncHelper, repoName string) {
-	t.Helper()
+// SyncOption configures the behaviour of SyncAndWait.
+type SyncOption func(*syncOpts)
 
-	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{},
-	})
-	requireJobSuccess(t, job)
-	waitForRepoLastRef(t, h.GetRepositories(), repoName)
+type syncOpts struct {
+	incremental   bool
+	expectedState provisioning.JobState
 }
 
-// SyncAndWaitSuccessfulIncremental triggers an incremental pull sync, waits for
-// it to complete, and asserts that the job succeeded.
-func SyncAndWaitSuccessfulIncremental(t *testing.T, h SyncHelper, repoName string) {
+// Incremental makes SyncAndWait trigger an incremental pull instead of a full one.
+func Incremental(o *syncOpts) { o.incremental = true }
+
+// ExpectWarning makes SyncAndWait assert the job finished with a warning state
+// instead of the default success state.
+func ExpectWarning(o *syncOpts) { o.expectedState = provisioning.JobStateWarning }
+
+// SyncAndWait triggers a pull sync, waits for it to complete, and asserts the
+// expected outcome. By default it performs a full sync and expects success.
+// Pass Incremental to use an incremental sync, and/or ExpectWarning to assert
+// the job finished with warnings.
+//
+// Full (non-incremental) syncs also wait for the repository's lastRef to be
+// set, which is required before an incremental sync can be triggered.
+func SyncAndWait(t *testing.T, h SyncHelper, repoName string, opts ...SyncOption) {
 	t.Helper()
+
+	o := syncOpts{expectedState: provisioning.JobStateSuccess}
+	for _, fn := range opts {
+		fn(&o)
+	}
 
 	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
 		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{Incremental: true},
+		Pull:   &provisioning.SyncJobOptions{Incremental: o.incremental},
 	})
-	requireJobSuccess(t, job)
+
+	switch o.expectedState {
+	case provisioning.JobStateWarning:
+		RequireJobWarning(t, job)
+	default:
+		requireJobSuccess(t, job)
+	}
+
+	if !o.incremental {
+		waitForRepoLastRef(t, h.GetRepositories(), repoName)
+	}
 }
 
 // RequireJobSuccess asserts that a completed job has state "success" and no errors.
@@ -2002,32 +2022,6 @@ func RequireJobWarning(t *testing.T, job *unstructured.Unstructured) {
 	require.Empty(t, lastErrors, "job %q has errors: %v", job.GetName(), lastErrors)
 	require.Equal(t, string(provisioning.JobStateWarning), lastState,
 		"job %q should have warning state", job.GetName())
-}
-
-// SyncAndWaitWithWarning triggers a full pull sync, asserts that it completes
-// with a warning state (no errors), and waits for lastRef. Use this for syncs
-// where a warning is the expected outcome (e.g. missing folder metadata).
-func SyncAndWaitWithWarning(t *testing.T, h SyncHelper, repoName string) {
-	t.Helper()
-
-	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{},
-	})
-	RequireJobWarning(t, job)
-	waitForRepoLastRef(t, h.GetRepositories(), repoName)
-}
-
-// SyncAndWaitIncrementalWithWarning triggers an incremental pull sync, waits
-// for it to complete, and asserts that the job finished with a warning state.
-func SyncAndWaitIncrementalWithWarning(t *testing.T, h SyncHelper, repoName string) {
-	t.Helper()
-
-	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
-		Action: provisioning.JobActionPull,
-		Pull:   &provisioning.SyncJobOptions{Incremental: true},
-	})
-	RequireJobWarning(t, job)
 }
 
 // GetFolderGeneration returns the current generation of the folder with the given UID.

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1983,24 +1983,6 @@ func HasNoErrors() JobMatcher {
 	}
 }
 
-// Succeeded returns a matcher that asserts success with no errors.
-func Succeeded() JobMatcher {
-	return func(t *testing.T, job *unstructured.Unstructured) {
-		t.Helper()
-		HasNoErrors()(t, job)
-		HasState(provisioning.JobStateSuccess)(t, job)
-	}
-}
-
-// Warning returns a matcher that asserts warning state with no errors.
-func Warning() JobMatcher {
-	return func(t *testing.T, job *unstructured.Unstructured) {
-		t.Helper()
-		HasNoErrors()(t, job)
-		HasState(provisioning.JobStateWarning)(t, job)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // SyncAndWait — configurable pull-sync helper.
 // ---------------------------------------------------------------------------
@@ -2009,29 +1991,48 @@ func Warning() JobMatcher {
 type SyncOption func(*syncOpts)
 
 type syncOpts struct {
+	repoName    string
 	incremental bool
 	matchers    []JobMatcher
+}
+
+// Repo sets the repository name for the sync.
+func Repo(name string) SyncOption {
+	return func(o *syncOpts) { o.repoName = name }
 }
 
 // Incremental makes SyncAndWait trigger an incremental pull instead of a full one.
 func Incremental(o *syncOpts) { o.incremental = true }
 
-// Expect adds job matchers that are applied to the completed job.
-// When no Expect option is provided, SyncAndWait defaults to Succeeded().
+// Expect adds arbitrary job matchers that are applied to the completed job.
+// For the common cases prefer Succeeded() or Warning() directly.
 func Expect(m ...JobMatcher) SyncOption {
 	return func(o *syncOpts) {
 		o.matchers = append(o.matchers, m...)
 	}
 }
 
+// Succeeded is a SyncOption that asserts the job succeeded with no errors.
+func Succeeded() SyncOption {
+	return Expect(HasNoErrors(), HasState(provisioning.JobStateSuccess))
+}
+
+// Warning is a SyncOption that asserts the job finished with warning state
+// and no errors.
+func Warning() SyncOption {
+	return Expect(HasNoErrors(), HasState(provisioning.JobStateWarning))
+}
+
 // SyncAndWait triggers a pull sync, waits for it to complete, and asserts the
-// expected outcome. By default it performs a full sync and expects success.
-// Pass Incremental to use an incremental sync, and/or Expect(Warning()) to
-// assert the job finished with warnings.
+// expected outcome using the provided matchers.
+//
+// Every call must include Repo() to identify the target repository and an
+// expectation such as Succeeded() or Warning(). Pass Incremental for an
+// incremental sync.
 //
 // Full (non-incremental) syncs also wait for the repository's lastRef to be
 // set, which is required before an incremental sync can be triggered.
-func SyncAndWait(t *testing.T, h SyncHelper, repoName string, opts ...SyncOption) {
+func SyncAndWait(t *testing.T, h SyncHelper, opts ...SyncOption) {
 	t.Helper()
 
 	o := syncOpts{}
@@ -2039,29 +2040,30 @@ func SyncAndWait(t *testing.T, h SyncHelper, repoName string, opts ...SyncOption
 		fn(&o)
 	}
 
-	job := h.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
+	require.NotEmpty(t, o.repoName, "SyncAndWait requires Repo()")
+	require.NotEmpty(t, o.matchers, "SyncAndWait requires an expectation such as Succeeded() or Warning()")
+
+	job := h.TriggerJobAndWaitForComplete(t, o.repoName, provisioning.JobSpec{
 		Action: provisioning.JobActionPull,
 		Pull:   &provisioning.SyncJobOptions{Incremental: o.incremental},
 	})
 
-	if len(o.matchers) == 0 {
-		o.matchers = []JobMatcher{Succeeded()}
-	}
 	for _, m := range o.matchers {
 		m(t, job)
 	}
 
 	if !o.incremental {
-		waitForRepoLastRef(t, h.GetRepositories(), repoName)
+		waitForRepoLastRef(t, h.GetRepositories(), o.repoName)
 	}
 }
 
 // RequireJobWarning asserts that a completed job has state "warning" and no errors.
-// Prefer Warning() matcher for use with SyncAndWait; this standalone function
-// is kept for callers that assert on a job obtained outside SyncAndWait.
+// Prefer Warning() for use with SyncAndWait; this standalone function is kept
+// for callers that assert on a job obtained outside SyncAndWait.
 func RequireJobWarning(t *testing.T, job *unstructured.Unstructured) {
 	t.Helper()
-	Warning()(t, job)
+	HasNoErrors()(t, job)
+	HasState(provisioning.JobStateWarning)(t, job)
 }
 
 // GetFolderGeneration returns the current generation of the folder with the given UID.

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
@@ -30,7 +30,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync the root dashboard.
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		// Add a dashboard inside a folder that has no _folder.json.
 		require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(common.DashboardJSON("folder-dash", "Folder Dashboard", 1))))
@@ -68,7 +68,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 			"myfolder/dashboard.json": common.DashboardJSON("noop-dash", "Noop Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -128,7 +128,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		// Push a folder with _folder.json that has a custom title different from the directory name.
 		require.NoError(t, local.CreateFile("my-team/_folder.json", string(folderMetadataJSON("stable-uid-1", "My Team Display Name"))))
@@ -141,7 +141,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		require.NoError(t, err)
 
 		// Incremental sync.
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// Verify the Grafana folder was created with the metadata title, not the directory name.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "My Team Display Name")
@@ -156,7 +156,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash-2", "Root Dashboard", 1),
 		})
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		// Push a folder with _folder.json that has an empty title — should fall back to dir name.
 		require.NoError(t, local.CreateFile("reports/_folder.json", string(folderMetadataJSON("stable-uid-2", ""))))
@@ -168,7 +168,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// Should use directory name "reports" as the title.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "reports")
@@ -183,7 +183,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash-3", "Root Dashboard", 1),
 		})
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		// Push a folder without _folder.json.
 		require.NoError(t, local.CreateFile("analytics/dash.json", string(common.DashboardJSON("analytics-dash", "Analytics Dashboard", 1))))
@@ -194,7 +194,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		// Should use directory name "analytics" as the title.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "analytics")
@@ -209,7 +209,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash-4", "Root Dashboard", 1),
 		})
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		// Push nested folders, each with their own _folder.json and custom titles.
 		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON("parent-uid", "Parent Display"))))
@@ -222,7 +222,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// Both folders should use their metadata titles.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Display")
@@ -287,7 +287,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 			"dashboard.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		require.NoError(t, local.CreateFile("empty-team/_folder.json", string(folderMetadataJSON("empty-team-uid", "Empty Team"))))
 		_, err := local.Git("add", ".")
@@ -297,7 +297,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		common.RequireFolderState(t, helper.Folders, "empty-team-uid", "Empty Team", "empty-team", "")
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
@@ -328,7 +328,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
@@ -364,7 +364,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		childUID = common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "child")
@@ -401,7 +401,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
@@ -438,7 +438,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		_, err = helper.Folders.Resource.Get(ctx, oldParentUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
@@ -471,7 +471,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"alpha/dash.json":    common.DashboardJSON("alpha-dash", "Alpha Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha")
 
 		require.NoError(t, local.UpdateFile("alpha/_folder.json", string(folderMetadataJSON("alpha-uid", "Alpha Renamed"))))
@@ -482,7 +482,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha Renamed")
 	})
@@ -499,7 +499,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"parent/child/dash.json":    common.DashboardJSON("nested-upd-dash", "Nested Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Title")
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Title")
 
@@ -511,7 +511,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Title")
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Title Updated")
@@ -528,7 +528,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"team/dash.json":    common.DashboardJSON("combo-dash", "Original Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Original Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Original Dashboard")
 
@@ -541,7 +541,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Updated Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Updated Dashboard")
@@ -568,7 +568,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": common.DashboardJSON("rr-dash-001", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
 
 		folderBefore, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
@@ -586,7 +586,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		folderAfter, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
@@ -622,7 +622,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/old-child/dashboard1.json": common.DashboardJSON("nn-dash-001", "Child Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/old-child"})
 
 		childBefore, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
@@ -640,7 +640,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
@@ -676,7 +676,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"my-folder/dashboard1.json": common.DashboardJSON("rn-dash-001", "Moved Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "my-folder"})
 
 		folderBefore, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -694,7 +694,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		folderAfter, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -731,7 +731,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/my-folder/dashboard1.json": common.DashboardJSON("nr-dash-001", "Moved Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/my-folder"})
 
 		folderBefore, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -749,7 +749,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		folderAfter, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -787,7 +787,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-parent/child/child-dash.json": common.DashboardJSON("mx-child-dash", "Child Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-parent", "old-parent/child"})
 
 		parentBefore, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -814,7 +814,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// Verify parent folder updated in place.
 		parentAfter, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -862,7 +862,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": common.DashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
@@ -872,7 +872,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
 
@@ -1043,7 +1043,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			"team/dash.json":    common.DashboardJSON("chain-dash", "Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
 
 		// v1 -> v2
@@ -1055,7 +1055,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		_, err = helper.Folders.Resource.Get(ctx, "uid-v2", metav1.GetOptions{})
 		require.NoError(t, err, "v2 folder should exist")
@@ -1072,7 +1072,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		_, err = helper.Folders.Resource.Get(ctx, "uid-v3", metav1.GetOptions{})
 		require.NoError(t, err, "v3 folder should exist")
@@ -1098,7 +1098,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			"team/dash.json":    common.DashboardJSON("cleanup-dash", "Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
 
 		// Change UID via incremental sync
@@ -1110,7 +1110,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
 
 		// A subsequent full sync should be idempotent — still exactly 1 folder
@@ -1373,7 +1373,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 			"old-team/dash.json":    common.DashboardJSON("rename-orphan-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireFolderState(t, helper.Folders, folderUID, "Old Team", "old-team", "")
 		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 			"rename-orphan-dash": {Title: "Team Dashboard", SourcePath: "old-team/dash.json", Folder: folderUID},
@@ -1391,7 +1391,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// The folder should now be at new-team with the same UID (identity preserved).
 		common.RequireFolderState(t, helper.Folders, folderUID, "Old Team", "new-team", "")
@@ -1421,7 +1421,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 		// dst/ has no _folder.json, so the initial sync produces a
 		// missing-metadata warning.
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "src", "")
 		// dst/ gets a hash-derived UID since it has no metadata.
 		dstAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "dst")
@@ -1435,7 +1435,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		// dst/ should now carry the metadata UID and title.
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "dst", "")
@@ -1469,7 +1469,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 			"dst/dash-d.json":  common.DashboardJSON("dash-d", "Dst Dash", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireFolderState(t, helper.Folders, srcUID, "Source", "src", "")
 		common.RequireFolderState(t, helper.Folders, dstUID, "Destination", "dst", "")
 
@@ -1489,7 +1489,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		// loses its _folder.json (triggering a missing-metadata warning).
 		// The src UID is NOT scheduled for deletion because it is being
 		// actively written to dst/_folder.json.
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		// dst/ should now carry the source UID.
 		common.RequireFolderState(t, helper.Folders, srcUID, "Source", "dst", "")
@@ -1518,7 +1518,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 			"old-empty/_folder.json": folderMetadataJSON(folderUID, "Empty Folder"),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 		common.RequireFolderState(t, helper.Folders, folderUID, "Empty Folder", "old-empty", "")
 
 		// Move the _folder.json to a new path — this is a pure file rename.
@@ -1530,7 +1530,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// The folder should now be at new-empty with the same UID.
 		common.RequireFolderState(t, helper.Folders, folderUID, "Empty Folder", "new-empty", "")

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
@@ -68,7 +68,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 			"myfolder/dashboard.json": common.DashboardJSON("noop-dash", "Noop Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -194,7 +194,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		// Should use directory name "analytics" as the title.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "analytics")
@@ -364,7 +364,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		childUID = common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "child")
@@ -862,7 +862,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": common.DashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
@@ -872,7 +872,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
 
@@ -1421,7 +1421,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 		// dst/ has no _folder.json, so the initial sync produces a
 		// missing-metadata warning.
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "src", "")
 		// dst/ gets a hash-derived UID since it has no metadata.
 		dstAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "dst")
@@ -1435,7 +1435,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		// dst/ should now carry the metadata UID and title.
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "dst", "")
@@ -1489,7 +1489,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		// loses its _folder.json (triggering a missing-metadata warning).
 		// The src UID is NOT scheduled for deletion because it is being
 		// actively written to dst/_folder.json.
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		// dst/ should now carry the source UID.
 		common.RequireFolderState(t, helper.Folders, srcUID, "Source", "dst", "")

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
@@ -30,7 +30,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 		})
 
 		// Full sync the root dashboard.
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		// Add a dashboard inside a folder that has no _folder.json.
 		require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(common.DashboardJSON("folder-dash", "Folder Dashboard", 1))))
@@ -68,7 +68,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagEnabl
 			"myfolder/dashboard.json": common.DashboardJSON("noop-dash", "Noop Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
 		// Trigger incremental sync with no new commits — same ref.
 		job := helper.TriggerJobAndWaitForComplete(t, repoName, provisioning.JobSpec{
@@ -128,7 +128,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		// Push a folder with _folder.json that has a custom title different from the directory name.
 		require.NoError(t, local.CreateFile("my-team/_folder.json", string(folderMetadataJSON("stable-uid-1", "My Team Display Name"))))
@@ -141,7 +141,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		require.NoError(t, err)
 
 		// Incremental sync.
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Verify the Grafana folder was created with the metadata title, not the directory name.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "My Team Display Name")
@@ -156,7 +156,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash-2", "Root Dashboard", 1),
 		})
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		// Push a folder with _folder.json that has an empty title — should fall back to dir name.
 		require.NoError(t, local.CreateFile("reports/_folder.json", string(folderMetadataJSON("stable-uid-2", ""))))
@@ -168,7 +168,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Should use directory name "reports" as the title.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "reports")
@@ -183,7 +183,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash-3", "Root Dashboard", 1),
 		})
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		// Push a folder without _folder.json.
 		require.NoError(t, local.CreateFile("analytics/dash.json", string(common.DashboardJSON("analytics-dash", "Analytics Dashboard", 1))))
@@ -194,7 +194,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// Should use directory name "analytics" as the title.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "analytics")
@@ -209,7 +209,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
 			"dashboard.json": common.DashboardJSON("root-dash-4", "Root Dashboard", 1),
 		})
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		// Push nested folders, each with their own _folder.json and custom titles.
 		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON("parent-uid", "Parent Display"))))
@@ -222,7 +222,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Both folders should use their metadata titles.
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Display")
@@ -287,7 +287,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 			"dashboard.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		require.NoError(t, local.CreateFile("empty-team/_folder.json", string(folderMetadataJSON("empty-team-uid", "Empty Team"))))
 		_, err := local.Git("add", ".")
@@ -297,7 +297,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireFolderState(t, helper.Folders, "empty-team-uid", "Empty Team", "empty-team", "")
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
@@ -328,7 +328,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
@@ -364,7 +364,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		childUID = common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "child")
@@ -401,7 +401,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
@@ -438,7 +438,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		_, err = helper.Folders.Resource.Get(ctx, oldParentUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
@@ -471,7 +471,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"alpha/dash.json":    common.DashboardJSON("alpha-dash", "Alpha Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha")
 
 		require.NoError(t, local.UpdateFile("alpha/_folder.json", string(folderMetadataJSON("alpha-uid", "Alpha Renamed"))))
@@ -482,7 +482,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha Renamed")
 	})
@@ -499,7 +499,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"parent/child/dash.json":    common.DashboardJSON("nested-upd-dash", "Nested Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Title")
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Title")
 
@@ -511,7 +511,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Title")
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Title Updated")
@@ -528,7 +528,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 			"team/dash.json":    common.DashboardJSON("combo-dash", "Original Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Original Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Original Dashboard")
 
@@ -541,7 +541,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Updated Team")
 		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Updated Dashboard")
@@ -568,7 +568,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": common.DashboardJSON("rr-dash-001", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
 
 		folderBefore, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
@@ -586,7 +586,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		folderAfter, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
@@ -622,7 +622,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/old-child/dashboard1.json": common.DashboardJSON("nn-dash-001", "Child Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/old-child"})
 
 		childBefore, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
@@ -640,7 +640,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
@@ -676,7 +676,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"my-folder/dashboard1.json": common.DashboardJSON("rn-dash-001", "Moved Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "my-folder"})
 
 		folderBefore, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -694,7 +694,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		folderAfter, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -731,7 +731,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"parent/my-folder/dashboard1.json": common.DashboardJSON("nr-dash-001", "Moved Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/my-folder"})
 
 		folderBefore, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
@@ -749,7 +749,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		folderAfter, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
@@ -787,7 +787,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-parent/child/child-dash.json": common.DashboardJSON("mx-child-dash", "Child Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-parent", "old-parent/child"})
 
 		parentBefore, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -814,7 +814,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Verify parent folder updated in place.
 		parentAfter, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
@@ -862,7 +862,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 			"old-team/dashboard1.json": common.DashboardJSON("gr-nometa-001", "No Meta Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
@@ -872,7 +872,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
 
@@ -1043,7 +1043,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			"team/dash.json":    common.DashboardJSON("chain-dash", "Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
 
 		// v1 -> v2
@@ -1055,7 +1055,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		_, err = helper.Folders.Resource.Get(ctx, "uid-v2", metav1.GetOptions{})
 		require.NoError(t, err, "v2 folder should exist")
@@ -1072,7 +1072,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		_, err = helper.Folders.Resource.Get(ctx, "uid-v3", metav1.GetOptions{})
 		require.NoError(t, err, "v3 folder should exist")
@@ -1098,7 +1098,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			"team/dash.json":    common.DashboardJSON("cleanup-dash", "Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
 
 		// Change UID via incremental sync
@@ -1110,7 +1110,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
 
 		// A subsequent full sync should be idempotent — still exactly 1 folder
@@ -1373,7 +1373,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 			"old-team/dash.json":    common.DashboardJSON("rename-orphan-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireFolderState(t, helper.Folders, folderUID, "Old Team", "old-team", "")
 		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 			"rename-orphan-dash": {Title: "Team Dashboard", SourcePath: "old-team/dash.json", Folder: folderUID},
@@ -1391,7 +1391,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// The folder should now be at new-team with the same UID (identity preserved).
 		common.RequireFolderState(t, helper.Folders, folderUID, "Old Team", "new-team", "")
@@ -1421,7 +1421,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 		// dst/ has no _folder.json, so the initial sync produces a
 		// missing-metadata warning.
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "src", "")
 		// dst/ gets a hash-derived UID since it has no metadata.
 		dstAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "dst")
@@ -1435,7 +1435,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// dst/ should now carry the metadata UID and title.
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "dst", "")
@@ -1469,7 +1469,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 			"dst/dash-d.json":  common.DashboardJSON("dash-d", "Dst Dash", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireFolderState(t, helper.Folders, srcUID, "Source", "src", "")
 		common.RequireFolderState(t, helper.Folders, dstUID, "Destination", "dst", "")
 
@@ -1489,7 +1489,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		// loses its _folder.json (triggering a missing-metadata warning).
 		// The src UID is NOT scheduled for deletion because it is being
 		// actively written to dst/_folder.json.
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// dst/ should now carry the source UID.
 		common.RequireFolderState(t, helper.Folders, srcUID, "Source", "dst", "")
@@ -1518,7 +1518,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 			"old-empty/_folder.json": folderMetadataJSON(folderUID, "Empty Folder"),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireFolderState(t, helper.Folders, folderUID, "Empty Folder", "old-empty", "")
 
 		// Move the _folder.json to a new path — this is a pure file rename.
@@ -1530,7 +1530,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// The folder should now be at new-empty with the same UID.
 		common.RequireFolderState(t, helper.Folders, folderUID, "Empty Folder", "new-empty", "")

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
@@ -33,7 +33,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
@@ -220,7 +220,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"parent/child/second-dash.json": common.DashboardJSON("child-dash-2", "Child Dashboard Two", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 
 		oldBrokenUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "broken")
 		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "parent")

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
@@ -33,7 +33,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
@@ -74,7 +74,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"root.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		require.NoError(t, local.CreateFile("team/dashboard.json", string(common.DashboardJSON("team-dash", "Team Dashboard", 1))))
@@ -117,7 +117,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		require.NoError(t, local.CreateFile("team/dashboard.json", string(common.DashboardJSON("team-dash", "Team Dashboard Updated", 1))))
@@ -159,7 +159,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		_, err := local.Git("add", ".")
@@ -220,7 +220,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"parent/child/second-dash.json": common.DashboardJSON("child-dash-2", "Child Dashboard Two", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
 		oldBrokenUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "broken")
 		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "parent")
@@ -310,7 +310,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"root.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		_, err := local.Git("mv", "root.json", "team/")
@@ -353,7 +353,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		_, err := local.Git("mv", "team", "moved")
 		require.NoError(t, err)
@@ -404,7 +404,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"old-parent/child/dashboard.json": common.DashboardJSON("child-dash", "Child Dashboard", 1),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		common.RequireFolderState(t, helper.Folders, parentStableUID, "Parent", "old-parent", "")
 		common.RequireFolderState(t, helper.Folders, childUID, "Child", "old-parent/child", parentStableUID)

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
@@ -33,7 +33,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
@@ -74,7 +74,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"root.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		require.NoError(t, local.CreateFile("team/dashboard.json", string(common.DashboardJSON("team-dash", "Team Dashboard", 1))))
@@ -117,7 +117,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		require.NoError(t, local.CreateFile("team/dashboard.json", string(common.DashboardJSON("team-dash", "Team Dashboard Updated", 1))))
@@ -159,7 +159,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		_, err := local.Git("add", ".")
@@ -220,7 +220,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"parent/child/second-dash.json": common.DashboardJSON("child-dash-2", "Child Dashboard Two", 1),
 		})
 
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 
 		oldBrokenUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "broken")
 		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "parent")
@@ -310,7 +310,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"root.json": common.DashboardJSON("root-dash", "Root Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		_, err := local.Git("mv", "root.json", "team/")
@@ -353,7 +353,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"team/dashboard.json": common.DashboardJSON("team-dash", "Team Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		_, err := local.Git("mv", "team", "moved")
 		require.NoError(t, err)
@@ -404,7 +404,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			"old-parent/child/dashboard.json": common.DashboardJSON("child-dash", "Child Dashboard", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		common.RequireFolderState(t, helper.Folders, parentStableUID, "Parent", "old-parent", "")
 		common.RequireFolderState(t, helper.Folders, childUID, "Child", "old-parent/child", parentStableUID)

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -40,7 +40,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"teamB/_folder.json": folderMetadataJSON("team-b-uid", "Team B"),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		requireGitFolderState(t, helper, ctx, "team-a-uid", "Team A", "teamA", repoName)
 		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamB", repoName)
@@ -88,7 +88,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		// teamB should now live under teamA with the same stable UID.
 		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
@@ -127,7 +127,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"plain/.keep":         {},
 		})
 
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 
 		requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", repoName)
 		plainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "plain")
@@ -158,7 +158,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// parent/plain still has no _folder.json after the move, so the incremental
 		// sync warns about missing metadata.
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		// The old folder object must be gone — without metadata the path change
 		// causes a delete-and-recreate rather than an in-place update.
@@ -199,7 +199,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"destination/_folder.json":           folderMetadataJSON("destination-uid", "Destination"),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		requireGitFolderState(t, helper, ctx, "root-uid", "Root", "root", repoName)
 		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "root/child", "root-uid")
@@ -229,7 +229,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", repoName)
 		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "destination/child", "destination-uid")
@@ -253,7 +253,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"container/inner/_folder.json": folderMetadataJSON("inner-uid", "Inner"),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "top", repoName)
 		requireGitFolderState(t, helper, ctx, "container-uid", "Container", "container", repoName)
@@ -282,7 +282,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "container/inner/top", "inner-uid")
 
@@ -309,7 +309,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"parent/deep/leaf/_folder.json": folderMetadataJSON("ltroot-leaf-uid", "Leaf"),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName)
 
 		requireGitFolderState(t, helper, ctx, "ltroot-parent-uid", "Parent", "parent", repoName)
 		requireGitFolderState(t, helper, ctx, "ltroot-deep-uid", "Deep", "parent/deep", "ltroot-parent-uid")
@@ -338,7 +338,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 		requireGitFolderState(t, helper, ctx, "ltroot-leaf-uid", "Leaf", "leaf", repoName)
 
@@ -361,7 +361,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		})
 
 		// legacy-parent has no _folder.json, so the sync correctly warns about missing metadata.
-		common.SyncAndWaitWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
 
 		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "child-with-meta", repoName)
 		legacyParentUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "legacy-parent")
@@ -392,7 +392,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// After the move, legacy-parent still has no _folder.json, so the incremental sync
 		// also warns about missing metadata.
-		common.SyncAndWaitIncrementalWithWarning(t, helper, repoName)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
 
 		// The legacy parent keeps its original hash-based UID (its path did not change).
 		requireGitFolderState(t, helper, ctx, legacyParentUID, "legacy-parent", "legacy-parent", repoName)

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -40,7 +40,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"teamB/_folder.json": folderMetadataJSON("team-b-uid", "Team B"),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "team-a-uid", "Team A", "teamA", repoName)
 		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamB", repoName)
@@ -88,7 +88,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// teamB should now live under teamA with the same stable UID.
 		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
@@ -127,7 +127,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"plain/.keep":         {},
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
 		requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", repoName)
 		plainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "plain")
@@ -158,7 +158,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// parent/plain still has no _folder.json after the move, so the incremental
 		// sync warns about missing metadata.
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// The old folder object must be gone — without metadata the path change
 		// causes a delete-and-recreate rather than an in-place update.
@@ -199,7 +199,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"destination/_folder.json":           folderMetadataJSON("destination-uid", "Destination"),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "root-uid", "Root", "root", repoName)
 		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "root/child", "root-uid")
@@ -229,7 +229,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", repoName)
 		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "destination/child", "destination-uid")
@@ -253,7 +253,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"container/inner/_folder.json": folderMetadataJSON("inner-uid", "Inner"),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "top", repoName)
 		requireGitFolderState(t, helper, ctx, "container-uid", "Container", "container", repoName)
@@ -282,7 +282,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "container/inner/top", "inner-uid")
 
@@ -309,7 +309,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"parent/deep/leaf/_folder.json": folderMetadataJSON("ltroot-leaf-uid", "Leaf"),
 		})
 
-		common.SyncAndWait(t, helper, repoName)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "ltroot-parent-uid", "Parent", "parent", repoName)
 		requireGitFolderState(t, helper, ctx, "ltroot-deep-uid", "Deep", "parent/deep", "ltroot-parent-uid")
@@ -338,7 +338,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		_, err = local.Git("push")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repoName, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		requireGitFolderState(t, helper, ctx, "ltroot-leaf-uid", "Leaf", "leaf", repoName)
 
@@ -361,7 +361,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		})
 
 		// legacy-parent has no _folder.json, so the sync correctly warns about missing metadata.
-		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
 		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "child-with-meta", repoName)
 		legacyParentUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "legacy-parent")
@@ -392,7 +392,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// After the move, legacy-parent still has no _folder.json, so the incremental sync
 		// also warns about missing metadata.
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
+		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// The legacy parent keeps its original hash-based UID (its path did not change).
 		requireGitFolderState(t, helper, ctx, legacyParentUID, "legacy-parent", "legacy-parent", repoName)

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -127,7 +127,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"plain/.keep":         {},
 		})
 
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 
 		requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", repoName)
 		plainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "plain")
@@ -158,7 +158,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// parent/plain still has no _folder.json after the move, so the incremental
 		// sync warns about missing metadata.
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		// The old folder object must be gone — without metadata the path change
 		// causes a delete-and-recreate rather than an in-place update.
@@ -361,7 +361,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		})
 
 		// legacy-parent has no _folder.json, so the sync correctly warns about missing metadata.
-		common.SyncAndWait(t, helper, repoName, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Expect(common.Warning()))
 
 		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "child-with-meta", repoName)
 		legacyParentUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "legacy-parent")
@@ -392,7 +392,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// After the move, legacy-parent still has no _folder.json, so the incremental sync
 		// also warns about missing metadata.
-		common.SyncAndWait(t, helper, repoName, common.Incremental, common.ExpectWarning)
+		common.SyncAndWait(t, helper, repoName, common.Incremental, common.Expect(common.Warning()))
 
 		// The legacy parent keeps its original hash-based UID (its path did not change).
 		requireGitFolderState(t, helper, ctx, legacyParentUID, "legacy-parent", "legacy-parent", repoName)

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -24,7 +24,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(common.DashboardJSON("incr-dash-002", "Dashboard Two", 1))))
@@ -35,7 +35,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }
 
@@ -51,7 +51,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(common.DashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
@@ -62,7 +62,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "incr-dash-001", "Dashboard One Updated")
 }
@@ -80,7 +80,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 		"dashboard2.json": common.DashboardJSON("incr-dash-002", "Dashboard Two", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
@@ -90,7 +90,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -111,10 +111,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 }
 
@@ -130,7 +130,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -146,7 +146,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
 	})
@@ -168,7 +168,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 		"dashboard1.json": common.DashboardJSON("move-in-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -186,7 +186,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
 	})
@@ -210,7 +210,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 		"folder-b/.keep":           {},
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
@@ -227,7 +227,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
 	})
@@ -250,7 +250,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 		"team-x/dashboard1.json": common.DashboardJSON("move-root-001", "Dashboard Root", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
@@ -267,7 +267,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
@@ -292,7 +292,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 		"old-team/dashboard2.json": common.DashboardJSON("ren-fold-002", "Folder Dash Two", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
@@ -314,7 +314,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
@@ -343,7 +343,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 		"parent/child-b/.keep":           {},
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
@@ -360,7 +360,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
 	})
@@ -384,7 +384,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 		"parent/sibling/dashboard2.json":   common.DashboardJSON("ren-nest-002", "Sibling Dash", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
@@ -402,7 +402,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -24,7 +24,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(common.DashboardJSON("incr-dash-002", "Dashboard Two", 1))))
@@ -35,7 +35,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 }
 
@@ -51,7 +51,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(common.DashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
@@ -62,7 +62,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "incr-dash-001", "Dashboard One Updated")
 }
@@ -80,7 +80,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 		"dashboard2.json": common.DashboardJSON("incr-dash-002", "Dashboard Two", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
@@ -90,7 +90,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -111,10 +111,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 }
 
@@ -130,7 +130,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 		"dashboard1.json": common.DashboardJSON("incr-dash-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -146,7 +146,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
 	})
@@ -168,7 +168,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 		"dashboard1.json": common.DashboardJSON("move-in-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
@@ -186,7 +186,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
 	})
@@ -210,7 +210,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 		"folder-b/.keep":           {},
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
@@ -227,7 +227,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
 	})
@@ -250,7 +250,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 		"team-x/dashboard1.json": common.DashboardJSON("move-root-001", "Dashboard Root", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
@@ -267,7 +267,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
@@ -292,7 +292,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 		"old-team/dashboard2.json": common.DashboardJSON("ren-fold-002", "Folder Dash Two", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
@@ -314,7 +314,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
@@ -343,7 +343,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 		"parent/child-b/.keep":           {},
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
@@ -360,7 +360,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
 	})
@@ -384,7 +384,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 		"parent/sibling/dashboard2.json":   common.DashboardJSON("ren-nest-002", "Sibling Dash", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
@@ -402,7 +402,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -26,7 +26,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		"dashboard1.json": common.DashboardJSON("name-change-incr-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
 
@@ -39,7 +39,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWaitSuccessfulIncremental(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName, common.Incremental)
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -26,7 +26,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		"dashboard1.json": common.DashboardJSON("name-change-incr-001", "Dashboard One", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
 
@@ -39,7 +39,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	_, err = local.Git("push")
 	require.NoError(t, err)
 
-	common.SyncAndWait(t, helper, repoName, common.Incremental)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/git/missing_metadata_incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/missing_metadata_incremental_test.go
@@ -20,7 +20,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisab
 	})
 
 	// Full sync.
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 	// Add a dashboard inside a folder with no _folder.json.
 	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(common.DashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))

--- a/pkg/tests/apis/provisioning/git/missing_metadata_incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/missing_metadata_incremental_test.go
@@ -20,7 +20,7 @@ func TestIntegrationProvisioning_IncrementalSync_MissingFolderMetadata_FlagDisab
 	})
 
 	// Full sync.
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 
 	// Add a dashboard inside a folder with no _folder.json.
 	require.NoError(t, local.CreateFile("myfolder/dashboard2.json", string(common.DashboardJSON("disabled-folder-dash", "Folder Dashboard", 1))))

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -26,7 +26,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync fills the quota (2/2).
-		common.SyncAndWaitWithSuccess(t, helper, repo)
+		common.SyncAndWait(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -77,7 +77,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": common.DashboardJSON("incr-swap-dash-001", "Dashboard One", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repo)
+		common.SyncAndWait(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -136,7 +136,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard2.json": common.DashboardJSON("incr-rel-dash-002", "Dashboard Two", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repo)
+		common.SyncAndWait(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -150,7 +150,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
+		common.SyncAndWait(t, helper, repo, common.Incremental)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
@@ -165,7 +165,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
+		common.SyncAndWait(t, helper, repo, common.Incremental)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
@@ -185,7 +185,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: 2 dashboards + 1 implicit folder = 3/3 resources.
-		common.SyncAndWaitWithSuccess(t, helper, repo)
+		common.SyncAndWait(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -239,7 +239,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: folder1 + dash1 + dash2 = 3/3 resources.
-		common.SyncAndWaitWithSuccess(t, helper, repo)
+		common.SyncAndWait(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -254,7 +254,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		// Incremental sync processes the deletion; orphan cleanup removes folder1.
-		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
+		common.SyncAndWait(t, helper, repo, common.Incremental)
 
 		// dashboard1 and folder1 are gone; only dashboard2 remains.
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
@@ -273,7 +273,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": common.DashboardJSON("incr-ulim-dash-001", "Dashboard One", 1),
 		})
 
-		common.SyncAndWaitWithSuccess(t, helper, repo)
+		common.SyncAndWait(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 
 		// Add three more dashboards as separate git commits pushed to the remote.

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -26,7 +26,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync fills the quota (2/2).
-		common.SyncAndWait(t, helper, repo)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -77,7 +77,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": common.DashboardJSON("incr-swap-dash-001", "Dashboard One", 1),
 		})
 
-		common.SyncAndWait(t, helper, repo)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -136,7 +136,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard2.json": common.DashboardJSON("incr-rel-dash-002", "Dashboard Two", 1),
 		})
 
-		common.SyncAndWait(t, helper, repo)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
@@ -150,7 +150,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repo, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
@@ -165,7 +165,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		_, err = local.Git("push", "origin", "main")
 		require.NoError(t, err)
 
-		common.SyncAndWait(t, helper, repo, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
@@ -185,7 +185,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: 2 dashboards + 1 implicit folder = 3/3 resources.
-		common.SyncAndWait(t, helper, repo)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -239,7 +239,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		// Initial full sync: folder1 + dash1 + dash2 = 3/3 resources.
-		common.SyncAndWait(t, helper, repo)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -254,7 +254,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		// Incremental sync processes the deletion; orphan cleanup removes folder1.
-		common.SyncAndWait(t, helper, repo, common.Incremental)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
 
 		// dashboard1 and folder1 are gone; only dashboard2 remains.
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
@@ -273,7 +273,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"dashboard1.json": common.DashboardJSON("incr-ulim-dash-001", "Dashboard One", 1),
 		})
 
-		common.SyncAndWait(t, helper, repo)
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 
 		// Add three more dashboards as separate git commits pushed to the remote.

--- a/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
+++ b/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
@@ -27,7 +27,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 		"dashboard_b.json": common.DashboardJSON("takeover-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"takeover-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"takeover-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -81,7 +81,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.
 		"dashboard_b.json": common.DashboardJSON("swap-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"swap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"swap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -132,7 +132,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 		"dashboard_b.json": common.DashboardJSON("full-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"full-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"full-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -157,7 +157,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 	// A second full sync compares the git tree against the current Grafana
 	// state and re-creates any resources that went missing in the first sync.
 	// After this, the state must converge to the correct result.
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"full-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
@@ -189,7 +189,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T
 		"dashboard_b.json": common.DashboardJSON("fswap-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"fswap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"fswap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -212,7 +212,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T
 
 	// A second full sync re-compares the git tree and recovers any missing
 	// resources, converging to the correct state.
-	common.SyncAndWait(t, helper, repoName)
+	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"fswap-uid-a": {Title: "Dashboard B Swapped", SourcePath: "dashboard_b.json"},

--- a/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
+++ b/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
@@ -27,7 +27,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 		"dashboard_b.json": common.DashboardJSON("takeover-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"takeover-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"takeover-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -81,7 +81,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.
 		"dashboard_b.json": common.DashboardJSON("swap-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"swap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"swap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -132,7 +132,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 		"dashboard_b.json": common.DashboardJSON("full-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"full-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"full-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -157,7 +157,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 	// A second full sync compares the git tree against the current Grafana
 	// state and re-creates any resources that went missing in the first sync.
 	// After this, the state must converge to the correct result.
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"full-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
@@ -189,7 +189,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T
 		"dashboard_b.json": common.DashboardJSON("fswap-uid-b", "Dashboard B", 1),
 	}, "write", "branch")
 
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"fswap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"fswap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
@@ -212,7 +212,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T
 
 	// A second full sync re-compares the git tree and recovers any missing
 	// resources, converging to the correct state.
-	common.SyncAndWaitWithSuccess(t, helper, repoName)
+	common.SyncAndWait(t, helper, repoName)
 
 	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
 		"fswap-uid-a": {Title: "Dashboard B Swapped", SourcePath: "dashboard_b.json"},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Simplify sync and wait integration test helpers by using a single method that can handle different expectations (fulls vs incremental syncs and success vs warnings).

**Why do we need this feature?**

Sync and wait is a common operation, having a separated method for small behavior differences clutter the test helper file.

**Who is this feature for?**

Provisioning feature devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of 

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
