### PR TITLE
Dashboards: Fix auto-import of plugin dashboards on version upgrade

### DIFF
--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -76,13 +76,17 @@ func (du *DashboardUpdater) updateAppDashboards(ctx context.Context) {
 		serviceCtx, _ := identity.WithServiceIdentity(ctx, pluginSetting.OrgID)
 		if pluginDef, exists := du.pluginStore.Plugin(serviceCtx, pluginSetting.PluginID); exists {
 			if pluginDef.Info.Version != pluginSetting.PluginVersion {
-				du.syncPluginDashboards(serviceCtx, pluginDef, pluginSetting.OrgID)
+				du.syncPluginDashboardsWithOptions(serviceCtx, pluginDef, pluginSetting.OrgID, false)
 			}
 		}
 	}
 }
 
 func (du *DashboardUpdater) syncPluginDashboards(ctx context.Context, plugin pluginstore.Plugin, orgID int64) {
+	du.syncPluginDashboardsWithOptions(ctx, plugin, orgID, true)
+}
+
+func (du *DashboardUpdater) syncPluginDashboardsWithOptions(ctx context.Context, plugin pluginstore.Plugin, orgID int64, importNew bool) {
 	du.logger.Info("Syncing plugin dashboards to DB", "pluginId", plugin.ID)
 
 	// Get plugin dashboards
@@ -107,6 +111,10 @@ func (du *DashboardUpdater) syncPluginDashboards(ctx context.Context, plugin plu
 				return
 			}
 
+			continue
+		}
+
+		if !importNew && !dash.Imported {
 			continue
 		}
 

--- a/pkg/services/plugindashboards/service/dashboard_updater_test.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater_test.go
@@ -178,6 +178,7 @@ func TestDashboardUpdater(t *testing.T) {
 						DashboardId:      5,
 						PluginId:         "test",
 						Reference:        "updated.json",
+						Imported:         true,
 						Revision:         1,
 						ImportedRevision: 2,
 					},
@@ -197,6 +198,54 @@ func TestDashboardUpdater(t *testing.T) {
 				require.Equal(t, org.RoleAdmin, ctx.importDashboardArgs[0].User.GetOrgRole())
 				require.Equal(t, string(""), ctx.importDashboardArgs[0].FolderUid)
 				require.True(t, ctx.importDashboardArgs[0].Overwrite)
+			})
+
+		scenario(t, "With stored enabled plugin and installed with different versions should not auto-import dashboards that were never imported",
+			scenarioInput{
+				storedPluginSettings: []*pluginsettings.DTO{
+					{
+						PluginID:      "test",
+						Enabled:       true,
+						PluginVersion: "1.0.0",
+						OrgID:         2,
+					},
+				},
+				installedPlugins: []pluginstore.Plugin{
+					{
+						JSONData: plugins.JSONData{
+							ID: "test",
+							Info: plugins.Info{
+								Version: "1.0.1",
+							},
+						},
+					},
+				},
+				pluginDashboards: []*plugindashboards.PluginDashboard{
+					{
+						PluginId:         "test",
+						Reference:        "never-imported.json",
+						Imported:         false,
+						Revision:         1,
+						ImportedRevision: 0,
+					},
+					{
+						DashboardId:      5,
+						PluginId:         "test",
+						Reference:        "previously-imported.json",
+						Imported:         true,
+						Revision:         2,
+						ImportedRevision: 1,
+					},
+				},
+			}, func(ctx *scenarioContext) {
+				ctx.dashboardUpdater.updateAppDashboards(context.Background())
+
+				require.NotEmpty(t, ctx.pluginSettingsService.getPluginSettingsArgs)
+				require.Empty(t, ctx.dashboardService.deleteDashboardArgs)
+
+				require.Len(t, ctx.importDashboardArgs, 1)
+				require.Equal(t, "test", ctx.importDashboardArgs[0].PluginId)
+				require.Equal(t, "previously-imported.json", ctx.importDashboardArgs[0].Path)
 			})
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Fixes a bug where the `DashboardUpdater` background service would auto-import ALL bundled plugin dashboards on Grafana startup when a plugin version mismatch is detected, even for dashboards that were never manually imported by the user.

**Why do we need this feature?**

When Grafana is upgraded, the `DashboardUpdater.updateAppDashboards()` runs on startup and checks if the installed plugin version differs from the stored `plugin_setting.plugin_version`. If they differ, it calls `syncPluginDashboards` which would import ALL bundled dashboards — including ones the user never imported. This caused GCP Cloud Monitoring dashboards to appear automatically in the root folder across all stacks after a version upgrade, as reported in a customer escalation.

The root cause: `syncPluginDashboards` treats un-imported dashboards (where `ImportedRevision=0, Revision=1`) the same as dashboards that need updating (`ImportedRevision != Revision`), causing them to be auto-imported.

**Who is this feature for?**

All Grafana users who have plugins with bundled dashboards (e.g., Cloud Monitoring/stackdriver) and a `plugin_setting` entry. Particularly affects Hosted Grafana users where plugin settings may be created by policies/integrations.

**Which issue(s) does this PR fix?**:

Fixes the issue where GCP Cloud Monitoring dashboards were automatically deployed across all stacks without user action.

**Special notes for your reviewer:**

The fix introduces an `importNew` parameter to `syncPluginDashboards`:
- **Startup path** (`updateAppDashboards`): `importNew=false` — only updates previously-imported dashboards, skips never-imported ones
- **Plugin enable path** (`handlePluginStateChanged`): `importNew=true` — preserves existing behavior of importing all dashboards when a user explicitly enables a plugin

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

CC: @ivanortegaalba
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a656c5a-66b6-4c27-9e0e-a1bce00ada37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a656c5a-66b6-4c27-9e0e-a1bce00ada37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

