### PR TITLE
Alerting: Fix notification policies tab hidden for Viewer/Editor after managed routes migration

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/permissions.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/permissions.ts
@@ -3,12 +3,20 @@ import { AccessControlAction } from 'app/types/accessControl';
 /**
  * List of granular permissions that allow viewing notification policies
  */
-export const PERMISSIONS_NOTIFICATION_POLICIES_READ = [AccessControlAction.AlertingRoutesRead];
+export const PERMISSIONS_NOTIFICATION_POLICIES_READ = [
+  AccessControlAction.AlertingRoutesRead,
+  AccessControlAction.ActionAlertingManagedRoutesRead,
+];
 
 /**
  * List of granular permissions that allow modifying notification policies
  */
-export const PERMISSIONS_NOTIFICATION_POLICIES_MODIFY = [AccessControlAction.AlertingRoutesWrite];
+export const PERMISSIONS_NOTIFICATION_POLICIES_MODIFY = [
+  AccessControlAction.AlertingRoutesWrite,
+  AccessControlAction.ActionAlertingManagedRoutesCreate,
+  AccessControlAction.ActionAlertingManagedRoutesWrite,
+  AccessControlAction.ActionAlertingManagedRoutesDelete,
+];
 
 export const PERMISSIONS_NOTIFICATION_POLICIES = [
   ...PERMISSIONS_NOTIFICATION_POLICIES_READ,

--- a/public/app/features/alerting/unified/navigation/useNotificationConfigNav.test.ts
+++ b/public/app/features/alerting/unified/navigation/useNotificationConfigNav.test.ts
@@ -214,6 +214,48 @@ describe('useNotificationConfigNav', () => {
       expect(result.current.pageNav?.children).toHaveLength(4);
     });
 
+    it('should include notification policies when user has only AlertingRoutesRead (granular legacy permission)', () => {
+      mockHasPermission.mockImplementation((action: AccessControlAction) => {
+        return (
+          action === AccessControlAction.AlertingRoutesRead || action === AccessControlAction.AlertingReceiversRead
+        );
+      });
+
+      const { result } = renderHook(() => useNotificationConfigNav());
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const tabs = result.current.pageNav?.children;
+      expect(tabs).toHaveLength(2);
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(tabs?.[0].id).toBe('notification-config-contact-points');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(tabs?.[1].id).toBe('notification-config-policies');
+    });
+
+    it('should include notification policies when user has only ActionAlertingManagedRoutesRead (k8s API permission)', () => {
+      // This covers the case where a user has the newer Kubernetes API-style routingtrees:get
+      // permission but neither the legacy alert.notifications:read nor alert.notifications.routes:read.
+      // When only one tab is visible the tabs bar is suppressed (children === undefined) but the page
+      // itself is still accessible, so we verify pageNav exists and that combining this permission with
+      // at least one other causes the policies tab to appear.
+      mockHasPermission.mockImplementation((action: AccessControlAction) => {
+        return (
+          action === AccessControlAction.ActionAlertingManagedRoutesRead ||
+          action === AccessControlAction.AlertingReceiversRead
+        );
+      });
+
+      const { result } = renderHook(() => useNotificationConfigNav());
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const tabs = result.current.pageNav?.children;
+      expect(tabs).toHaveLength(2);
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(tabs?.[0].id).toBe('notification-config-contact-points');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(tabs?.[1].id).toBe('notification-config-policies');
+    });
+
     it('should not show tabs bar when only one tab is visible', () => {
       // Only allow contact points
       mockHasPermission.mockImplementation((action: AccessControlAction) => {

--- a/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
+++ b/public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts
@@ -37,7 +37,8 @@ function canViewContactPoints(): boolean {
 function canViewNotificationPolicies(): boolean {
   return (
     contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead) ||
-    contextSrv.hasPermission(AccessControlAction.AlertingRoutesRead)
+    contextSrv.hasPermission(AccessControlAction.AlertingRoutesRead) ||
+    contextSrv.hasPermission(AccessControlAction.ActionAlertingManagedRoutesRead)
   );
 }
 

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -145,9 +145,15 @@ export enum AccessControlAction {
   AlertingReceiversRead = 'alert.notifications.receivers:read',
   AlertingReceiversUpdateProtected = 'alert.notifications.receivers.protected:write',
 
-  // Alerting routes actions
+  // Legacy Alerting routes actions
   AlertingRoutesRead = 'alert.notifications.routes:read',
   AlertingRoutesWrite = 'alert.notifications.routes:write',
+
+  // Alerting managed routes actions (new, scoped per-resource)
+  ActionAlertingManagedRoutesRead = 'notifications.alerting.grafana.app/routingtrees:get',
+  ActionAlertingManagedRoutesWrite = 'notifications.alerting.grafana.app/routingtrees:update',
+  ActionAlertingManagedRoutesCreate = 'notifications.alerting.grafana.app/routingtrees:create',
+  ActionAlertingManagedRoutesDelete = 'notifications.alerting.grafana.app/routingtrees:delete',
 
   // Alerting time intervals actions
   AlertingTimeIntervalsRead = 'alert.notifications.time-intervals:read',


### PR DESCRIPTION
**What is this feature?**

Fixes the Notification Policies tab being invisible for Viewer and Editor users after the backend migration in #121034 (merged March 31) replaced `alert.notifications.routes:read` with the K8s-scoped permission `notifications.alerting.grafana.app/routingtrees:get` on managed builtin roles.

**Why do we need this feature?**

The backend migration correctly grants the new K8s permission to Viewer/Editor managed builtin roles, but the frontend's `canViewNotificationPolicies()` function only checked for `alert.notifications:read` and `alert.notifications.routes:read` — it was unaware of the new permission. As a result, every Viewer and Editor on an instance running backend ≥ #121034 cannot see the Notification Policies tab, even though they can still access the page directly at `/alerting/routes`.

This fix was part of the reverted PR #121652. This PR extracts only the tab visibility fix, leaving the per-resource annotation UI gating (the likely reason for the revert) out.

**Who is this feature for?**

All Grafana alerting users with Viewer or Editor roles.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The route guard at `/alerting/routes` already accepted the new K8s permission (via `PERMISSIONS_NOTIFICATION_POLICIES_READ`), so the page itself was always accessible via direct URL — only the tab in the nav was hidden.
- Three permission paths are now tested explicitly: `alert.notifications:read` (legacy broad), `alert.notifications.routes:read` (granular legacy), and `notifications.alerting.grafana.app/routingtrees:get` (new K8s managed).
- `ActionAlertingManagedRoutesWrite` / `Create` / `Delete` enum entries are also added to `PERMISSIONS_NOTIFICATION_POLICIES_MODIFY` for consistency, matching what #121652 had.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.