### PR TITLE
GrafanaTheme: Add tertiary color to core theme

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -16,6 +16,7 @@ const createThemeColorsBaseSchema = <TColor>(color: TColor) =>
 
       primary: color,
       secondary: color,
+      tertiary: color,
       info: color,
       error: color,
       success: color,
@@ -89,11 +90,12 @@ const createThemeColorsBaseSchema = <TColor>(color: TColor) =>
 export type ThemeColorsBase<TColor> = DeepRequired<
   Omit<
     z.infer<ReturnType<typeof createThemeColorsBaseSchema>>,
-    'primary' | 'secondary' | 'info' | 'error' | 'success' | 'warning'
+    'primary' | 'secondary' | 'tertiary' | 'info' | 'error' | 'success' | 'warning'
   >
 > & {
   primary: TColor;
   secondary: TColor;
+  tertiary: TColor;
   info: TColor;
   error: TColor;
   success: TColor;
@@ -148,6 +150,11 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
     text: this.text.primary,
     contrastText: `rgb(${this.whiteBase})`,
     border: `rgba(${this.whiteBase}, 0.08)`,
+  };
+
+  tertiary = {
+    main: palette.purpleDarkMain,
+    text: palette.purpleDarkText,
   };
 
   info = this.primary;
@@ -231,6 +238,11 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
     border: this.border.weak,
   };
 
+  tertiary = {
+    main: palette.purpleLightMain,
+    text: palette.purpleLightText,
+  };
+
   info = {
     main: palette.blueLightMain,
     text: palette.blueLightText,
@@ -289,6 +301,7 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
   const {
     primary = base.primary,
     secondary = base.secondary,
+    tertiary = base.tertiary,
     info = base.info,
     warning = base.warning,
     success = base.success,
@@ -339,6 +352,7 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
       ...base,
       primary: getRichColor({ color: primary, name: 'primary' }),
       secondary: getRichColor({ color: secondary, name: 'secondary' }),
+      tertiary: getRichColor({ color: tertiary, name: 'tertiary' }),
       info: getRichColor({ color: info, name: 'info' }),
       error: getRichColor({ color: error, name: 'error' }),
       success: getRichColor({ color: success, name: 'success' }),
@@ -352,8 +366,7 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
   );
 }
 
-type RichColorNames = 'primary' | 'secondary' | 'info' | 'error' | 'success' | 'warning';
-
+type RichColorNames = 'primary' | 'secondary' | 'tertiary' | 'info' | 'error' | 'success' | 'warning';
 interface GetRichColorProps {
   color: Partial<ThemeRichColor>;
   name: RichColorNames;

--- a/packages/grafana-data/src/themes/palette.ts
+++ b/packages/grafana-data/src/themes/palette.ts
@@ -31,6 +31,8 @@ export const palette = {
   greenDarkText: '#6ccf8e',
   orangeDarkMain: '#ff9900',
   orangeDarkText: '#fbad37',
+  purpleDarkMain: '#C27AFF',
+  purpleDarkText: '#D4A0FF',
 
   blueLightMain: '#3871dc',
   blueLightText: '#1f62e0',
@@ -40,4 +42,6 @@ export const palette = {
   greenLightText: '#0a764e',
   orangeLightMain: '#ff9900',
   orangeLightText: '#b5510d',
+  purpleLightMain: '#A24BC8',
+  purpleLightText: '#7c2ea3',
 };

--- a/packages/grafana-data/src/themes/schema.generated.json
+++ b/packages/grafana-data/src/themes/schema.generated.json
@@ -78,6 +78,36 @@
           },
           "additionalProperties": false
         },
+        "tertiary": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "main": {
+              "type": "string"
+            },
+            "shade": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "transparent": {
+              "type": "string"
+            },
+            "borderTransparent": {
+              "type": "string"
+            },
+            "contrastText": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "info": {
           "type": "object",
           "properties": {

--- a/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
@@ -95,6 +95,7 @@ export const ThemeDemo = () => {
   const richColors = [
     t.colors.primary,
     t.colors.secondary,
+    t.colors.tertiary,
     t.colors.success,
     t.colors.error,
     t.colors.warning,


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Adds a new tertiary color to the core Grafana theme. The variants are as follows:

- `purpleDarkMain: '#C27AFF'`
- `purpleDarkText: '#D4A0FF'`
- `purpleLightMain: '#A24BC8'`
- `purpleLightText: '#7c2ea3'`

## Changes
<!--- Describe your changes in detail -->
* Please see the notes listed above.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
#### Dark Mode

<img width="902" height="62" alt="image" src="https://github.com/user-attachments/assets/c5ad22a1-81b0-4df9-924b-4ab3cdb7d381" />

#### Light Mode

<img width="898" height="61" alt="image" src="https://github.com/user-attachments/assets/87a427a6-dc18-4e51-88d8-48e5dee837f0" />