### PR TITLE
Provisioning: Enable API server auditing

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/apiserver/auditing"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -1511,6 +1512,11 @@ func (b *APIBuilder) GetHealthyRepository(ctx context.Context, name string) (rep
 	}
 
 	return repo, err
+}
+
+// GetPolicyRuleEvaluator defines the rules for logging auditing events from the API server.
+func (b *APIBuilder) GetPolicyRuleEvaluator() auditing.PolicyRuleEvaluator {
+	return auditing.NewDefaultGrafanaPolicyRuleEvaluator()
 }
 
 func (b *APIBuilder) asRepository(ctx context.Context, obj runtime.Object, old runtime.Object) (repository.Repository, error) {


### PR DESCRIPTION
**What is this feature?**

Implements `GetPolicyRuleEvaluator` for Provisioning API, which lets us capture k8s Audit Events and emit them.

This is currently for piloting with some APIs, the whole thing is behind a feature toggle `auditLoggingAppPlatform` that is disabled by default.

**Why do we need this feature?**

Transitioning to App Platform native auditing backed by k8s Audit Events.

**Who is this feature for?**

Developers/Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
