### PR TITLE
Chore: Fix CUE formatting for logstable panelcfg

### DIFF
--- a/public/app/plugins/panel/logstable/panelcfg.cue
+++ b/public/app/plugins/panel/logstable/panelcfg.cue
@@ -33,7 +33,7 @@ composableKinds: PanelCfg: {
 					fieldSelectorWidth?: number | *220
 					displayedFields?: [...string]
 					buildLinkToLogLine?: _
-					wrapText?: bool
+					wrapText?:           bool
 				} @cuetsy(kind="interface")
 			}
 		}]


### PR DESCRIPTION
[CI failing](https://github.com/grafana/grafana/actions/runs/24151571281/job/70479713364?pr=121962). Run `make fix-cue` to align field formatting in the logstable panel config.



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
