### PR TITLE
IAM: Skip propagating None role to Zanzana for user hooks

### DIFF
--- a/pkg/registry/apis/iam/user_org_hooks.go
+++ b/pkg/registry/apis/iam/user_org_hooks.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	v1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 )
 
@@ -24,8 +25,8 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserCreate(obj runtime.Object,
 		return
 	}
 
-	// Skip if user has no role assigned
-	if user.Spec.Role == "" {
+	// Skip if user has no role assigned or role is None
+	if user.Spec.Role == "" || user.Spec.Role == string(identity.RoleNone) {
 		b.logger.Debug("user has no role assigned, skipping basic role sync",
 			"namespace", user.Namespace,
 			"name", user.Name,
@@ -107,6 +108,9 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 		return nil, nil
 	}
 
+	resourceType := "user"
+	operation := "update"
+
 	// Return a finish function that performs the zanzana write only on success
 	return func(ctx context.Context, success bool) {
 		if !success {
@@ -115,7 +119,7 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 
 		wait := time.Now()
 		b.zTickets <- true
-		HooksWaitHistogram.WithLabelValues("user", "update").Observe(time.Since(wait).Seconds())
+		HooksWaitHistogram.WithLabelValues(resourceType, operation).Observe(time.Since(wait).Seconds())
 
 		go func(namespace, subjectName, oldRole, newRole string) {
 			start := time.Now()
@@ -123,8 +127,8 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 
 			defer func() {
 				<-b.zTickets
-				HooksDurationHistogram.WithLabelValues("user", "update", status).Observe(time.Since(start).Seconds())
-				HooksOperationCounter.WithLabelValues("user", "update", status).Inc()
+				HooksDurationHistogram.WithLabelValues(resourceType, operation, status).Observe(time.Since(start).Seconds())
+				HooksOperationCounter.WithLabelValues(resourceType, operation, status).Inc()
 			}()
 
 			b.logger.Debug("updating user basic role in zanzana",
@@ -137,9 +141,17 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 			ctx, cancel := context.WithTimeout(context.Background(), DefaultWriteTimeout)
 			defer cancel()
 
-			err := b.zClient.Mutate(ctx, &v1.MutateRequest{
-				Namespace: namespace,
-				Operations: []*v1.MutateOperation{
+			var operations []*v1.MutateOperation
+			if newRole == "" || newRole == string(identity.RoleNone) {
+				operations = []*v1.MutateOperation{
+					{
+						Operation: &v1.MutateOperation_DeleteUserOrgRole{
+							DeleteUserOrgRole: &v1.DeleteUserOrgRoleOperation{User: subjectName, Role: oldRole},
+						},
+					},
+				}
+			} else {
+				operations = []*v1.MutateOperation{
 					{
 						Operation: &v1.MutateOperation_UpdateUserOrgRole{
 							UpdateUserOrgRole: &v1.UpdateUserOrgRoleOperation{User: subjectName, Role: newRole},
@@ -149,7 +161,12 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 							DeleteUserOrgRole: &v1.DeleteUserOrgRoleOperation{User: subjectName, Role: oldRole},
 						},
 					},
-				},
+				}
+			}
+
+			err := b.zClient.Mutate(ctx, &v1.MutateRequest{
+				Namespace:  namespace,
+				Operations: operations,
 			})
 			if err != nil {
 				status = "failure"
@@ -180,8 +197,8 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserDelete(obj runtime.Object,
 	resourceType := "user"
 	operation := "delete"
 
-	// Skip if user had no role assigned
-	if user.Spec.Role == "" {
+	// Skip if user had no role assigned or role is None
+	if user.Spec.Role == "" || user.Spec.Role == string(identity.RoleNone) {
 		b.logger.Debug("user had no role assigned, skipping basic role sync",
 			"namespace", user.Namespace,
 			"name", user.Name,

--- a/pkg/registry/apis/iam/user_org_hooks_test.go
+++ b/pkg/registry/apis/iam/user_org_hooks_test.go
@@ -134,6 +134,21 @@ func TestAfterUserCreate(t *testing.T) {
 		// If we get here without panic, the test passes
 	})
 
+	t.Run("should skip when user has None role", func(t *testing.T) {
+		user := iamv0.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nonerole",
+				Namespace: "org-5",
+			},
+			Spec: iamv0.UserSpec{
+				Role: "None",
+			},
+		}
+
+		b.zClient = nil
+		b.AfterUserCreate(&user, nil)
+	})
+
 	t.Run("should skip when zClient is nil", func(t *testing.T) {
 		builder := &IdentityAccessManagementAPIBuilder{
 			logger:   log.NewNopLogger(),
@@ -218,7 +233,7 @@ func TestBeginUserUpdate(t *testing.T) {
 		wg.Wait()
 	})
 
-	t.Run("should update role when new role is empty", func(t *testing.T) {
+	t.Run("should only delete old role when new role is None", func(t *testing.T) {
 		wg.Add(1)
 		oldUser := iamv0.User{
 			ObjectMeta: metav1.ObjectMeta{
@@ -236,7 +251,7 @@ func TestBeginUserUpdate(t *testing.T) {
 				Namespace: "org-2",
 			},
 			Spec: iamv0.UserSpec{
-				Role: "",
+				Role: "None",
 			},
 		}
 
@@ -244,16 +259,9 @@ func TestBeginUserUpdate(t *testing.T) {
 			defer wg.Done()
 			require.NotNil(t, req)
 			require.Equal(t, "org-2", req.Namespace)
-			require.Len(t, req.Operations, 2)
+			require.Len(t, req.Operations, 1)
 
-			// First operation should be UpdateUserOrgRole with empty role
-			updateOp := req.Operations[0].GetUpdateUserOrgRole()
-			require.NotNil(t, updateOp)
-			require.Equal(t, "testuser2", updateOp.User)
-			require.Equal(t, "", updateOp.Role)
-
-			// Second operation should be DeleteUserOrgRole with old role
-			deleteOp := req.Operations[1].GetDeleteUserOrgRole()
+			deleteOp := req.Operations[0].GetDeleteUserOrgRole()
 			require.NotNil(t, deleteOp)
 			require.Equal(t, "testuser2", deleteOp.User)
 			require.Equal(t, "Editor", deleteOp.Role)
@@ -543,6 +551,21 @@ func TestAfterUserDelete(t *testing.T) {
 		b.zClient = nil
 		b.AfterUserDelete(&user, nil)
 		// If we get here without panic, the test passes
+	})
+
+	t.Run("should skip when user has None role", func(t *testing.T) {
+		user := iamv0.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nonerole",
+				Namespace: "org-5",
+			},
+			Spec: iamv0.UserSpec{
+				Role: "None",
+			},
+		}
+
+		b.zClient = nil
+		b.AfterUserDelete(&user, nil)
 	})
 
 	t.Run("should skip when zClient is nil", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Align user hooks with service account behavior: when a user's role is set to `None`, only revoke the previous role assignment instead of writing a `None` role to Zanzana
- Skip Zanzana sync on create/delete when the user has a `None` role
- Extract `resourceType`/`operation` variables in `BeginUserUpdate` for consistency with other hooks

## Test plan
- [x] All user hook tests pass (`TestBeginUserUpdate`, `TestAfterUserCreate`, `TestAfterUserDelete`)
- [x] New tests for None role skip on create and delete
- [x] Updated test for None role on update (expects delete-only, not update+delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)