### PR TITLE
annotations: set CreatedBy in k8sRestAdapter

### DIFF
--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -16,6 +16,7 @@ import (
 
 	authtypes "github.com/grafana/authlib/types"
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -209,6 +210,10 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 
 	if annotation.Name == "" && annotation.GenerateName != "" {
 		annotation.Name = annotation.GenerateName + util.GenerateShortUID()
+	}
+
+	if user, err := identity.GetRequester(ctx); err == nil {
+		annotation.SetCreatedBy(user.GetUID())
 	}
 
 	return s.store.Create(ctx, annotation)

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -212,9 +212,11 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 		annotation.Name = annotation.GenerateName + util.GenerateShortUID()
 	}
 
-	if user, err := identity.GetRequester(ctx); err == nil {
-		annotation.SetCreatedBy(user.GetUID())
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("failed to get requester from context"))
 	}
+	annotation.SetCreatedBy(user.GetUID())
 
 	return s.store.Create(ctx, annotation)
 }

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -214,7 +214,7 @@ func (s *k8sRESTAdapter) Create(ctx context.Context,
 
 	user, err := identity.GetRequester(ctx)
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("failed to get requester from context"))
+		return nil, apierrors.NewUnauthorized("failed to get requester from context")
 	}
 	annotation.SetCreatedBy(user.GetUID())
 

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -17,14 +17,21 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
-func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
-	ctx := identity.WithServiceIdentityContext(t.Context(), 1)
+func TestK8sRESTAdapter_Create(t *testing.T) {
+	const userUID = "test-user-uid-123"
+	ctx := identity.WithRequester(t.Context(), &identity.StaticRequester{
+		Type:    authtypes.TypeUser,
+		UserUID: userUID,
+		OrgID:   1,
+	})
 
 	store := NewMemoryStore()
 	adapter := &k8sRESTAdapter{
 		store:        store,
 		accessClient: authtypes.FixedAccessClient(true),
 	}
+
+	expectedCreatedBy := authtypes.NewTypeID(authtypes.TypeUser, userUID)
 
 	t.Run("should generate name from generateName", func(t *testing.T) {
 		anno := &annotationV0.Annotation{
@@ -49,6 +56,7 @@ func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
 			"expected name to start with prefix 'test-anno-', got: %s", result.Name)
 		assert.Greater(t, len(result.Name), len("test-anno-"),
 			"expected name to have random suffix appended")
+		assert.Equal(t, expectedCreatedBy, result.GetCreatedBy())
 	})
 
 	t.Run("should accept explicit name", func(t *testing.T) {
@@ -70,6 +78,7 @@ func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
 		result := created.(*annotationV0.Annotation)
 		assert.Equal(t, "my-annotation-name", result.Name,
 			"expected name to match the provided name")
+		assert.Equal(t, expectedCreatedBy, result.GetCreatedBy())
 	})
 
 	t.Run("should reject when both name and generateName are empty", func(t *testing.T) {
@@ -111,6 +120,7 @@ func TestK8sRESTAdapter_Create_GenerateName(t *testing.T) {
 		// When both are provided, name takes priority
 		assert.Equal(t, "my-special-name", result.Name,
 			"expected name to match the provided name, not the generateName")
+		assert.Equal(t, expectedCreatedBy, result.GetCreatedBy())
 	})
 }
 

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -98,6 +98,22 @@ func TestK8sRESTAdapter_Create(t *testing.T) {
 			"expected error message about missing name/generateName")
 	})
 
+	t.Run("should return error when identity is not in context", func(t *testing.T) {
+		anno := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "anno-no-identity",
+				Namespace: "default",
+			},
+			Spec: annotationV0.AnnotationSpec{
+				Text: "test annotation",
+				Time: 12345,
+			},
+		}
+
+		_, err := adapter.Create(t.Context(), anno, nil, nil)
+		require.Error(t, err)
+	})
+
 	t.Run("name takes precedence over generateName", func(t *testing.T) {
 		anno := &annotationV0.Annotation{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR sets the `CreatedBy` field on an annotation based on the identity of the requester within the k8s REST adapter layer of the annotations app platform API. Without this, store implementations are not able to store the user UID associated with the annotation.