### PR TITLE
InfluxDB: Fix typo in config v2 URL section

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -168,7 +168,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       >
         <Text color="secondary">
           Enter the URL of your InfluxDB instance, then select your product and query language. This will determine the
-          available settings and authentication methods in the next steps. If you need futher guidance, visit the{' '}
+          available settings and authentication methods in the next steps. If you need further guidance, visit the{' '}
           <TextLink
             href="https://grafana.com/docs/grafana/latest/datasources/influxdb/"
             icon="external-link-alt"


### PR DESCRIPTION
## Summary
- Fixes a typo in the InfluxDB data source v2 config form: "futher" → "further" in the guidance text below the URL field (`UrlAndAuthenticationSection.tsx`)

## Test plan
- [x] Visually verify the text reads correctly in the InfluxDB data source config UI

## Screenshots
**Old**
<img width="1211" height="786" alt="image" src="https://github.com/user-attachments/assets/ff8859da-a7d8-4e4d-8868-e5ddd37d4c27" />

**New**
<img width="1211" height="785" alt="image" src="https://github.com/user-attachments/assets/f0a38ff2-d7ec-4647-b414-62f9084c32fe" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)