### PR TITLE
QuickAdd: Update QuickAdd menu to grouped category layout

### DIFF
--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -30,6 +30,7 @@ const setup = () => {
       url: '/dashboards',
       children: [
         { text: 'New dashboard', id: 'dashboards/new', url: '/dashboard/new', isCreateAction: true },
+        { text: 'Import dashboard', id: 'dashboards/import', url: '/dashboard/import', isCreateAction: true },
         { text: 'Browse', id: 'dashboards-browse', url: '/dashboards' },
       ],
     },
@@ -39,6 +40,7 @@ const setup = () => {
       url: '/alerting',
       children: [{ text: 'New alert rule', id: 'alert', url: '/alerting/new', isCreateAction: true }],
     },
+    // Synthetic top-level create action — not in production navtree today, but exercises the ungrouped code path
     {
       text: 'New import',
       id: 'standalone-import',
@@ -71,6 +73,7 @@ describe('QuickAdd', () => {
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
     expect(screen.getByRole('menuitem', { name: 'New dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Import dashboard' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'New alert rule' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'New import' })).toBeInTheDocument();
   });
@@ -94,6 +97,7 @@ describe('QuickAdd', () => {
 
     const dashboardGroup = screen.getByRole('group', { name: 'Dashboards' });
     expect(within(dashboardGroup).getByRole('menuitem', { name: 'New dashboard' })).toBeInTheDocument();
+    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Import dashboard' })).toBeInTheDocument();
 
     const alertingGroup = screen.getByRole('group', { name: 'Alerting' });
     expect(within(alertingGroup).getByRole('menuitem', { name: 'New alert rule' })).toBeInTheDocument();

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -22,27 +22,33 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
-function setup(navBarTreeOverride?: NavModelItem[]) {
-  const navBarTree: NavModelItem[] = navBarTreeOverride ?? [
+const setup = () => {
+  const navBarTree: NavModelItem[] = [
     {
       text: 'Dashboards',
       id: 'dashboards/browse',
       url: '/dashboards',
       children: [
-        { text: 'New dashboard', id: 'dashboards/new', url: '#', isCreateAction: true },
-        { text: 'Import dashboard', id: 'dashboards/import', url: '/dashboard/import', isCreateAction: true },
+        { text: 'New dashboard', id: 'dashboards/new', url: '/dashboard/new', isCreateAction: true },
+        { text: 'Browse', id: 'dashboards-browse', url: '/dashboards' },
       ],
     },
     {
       text: 'Alerting',
       id: 'alerting',
       url: '/alerting',
-      children: [{ text: 'Create alert rule', id: 'alert', url: '/alerting/new', isCreateAction: true }],
+      children: [{ text: 'New alert rule', id: 'alert', url: '/alerting/new', isCreateAction: true }],
+    },
+    {
+      text: 'New import',
+      id: 'standalone-import',
+      url: '/import',
+      isCreateAction: true,
     },
   ];
   const store = configureStore({ navBarTree });
   return render(<QuickAdd />, { store });
-}
+};
 
 describe('QuickAdd', () => {
   beforeAll(() => {
@@ -61,80 +67,77 @@ describe('QuickAdd', () => {
     expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
   });
 
-  it('renders grouped menu items with labels from the nav tree', async () => {
+  it('shows isCreateAction options when clicked', async () => {
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
-
-    const dashboardGroup = screen.getByRole('group', { name: 'Dashboards' });
-    expect(within(dashboardGroup).getByRole('menuitem', { name: 'New dashboard' })).toBeInTheDocument();
-    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Import dashboard' })).toBeInTheDocument();
-
-    const alertGroup = screen.getByRole('group', { name: 'Alerting' });
-    expect(within(alertGroup).getByRole('menuitem', { name: 'Create alert rule' })).toBeInTheDocument();
-  });
-
-  it('renders both groups inside the menu', async () => {
-    setup();
-    await userEvent.click(screen.getByRole('button', { name: 'New' }));
-    const menu = screen.getByRole('menu');
-    expect(within(menu).getAllByRole('group')).toHaveLength(2);
+    expect(screen.getByRole('menuitem', { name: 'New dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'New alert rule' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'New import' })).toBeInTheDocument();
   });
 
   it('reports interaction when a menu item is clicked', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
     await userEvent.click(screen.getByRole('menuitem', { name: 'New dashboard' }));
 
     expect(reportInteraction).toHaveBeenCalledWith('grafana_menu_item_clicked', {
-      url: '#',
+      url: '/dashboard/new',
       from: 'quickadd',
     });
+    errorSpy.mockRestore();
   });
 
-  it('falls back to nav item text for unknown item IDs', async () => {
-    setup([
-      {
-        text: 'Custom Section',
-        id: 'custom',
-        url: '/custom',
-        children: [{ text: 'Custom action', id: 'custom/action', url: '/custom/new', isCreateAction: true }],
-      },
-    ]);
+  it('renders items under their correct group', async () => {
+    setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
-    expect(screen.getByRole('menuitem', { name: 'Custom action' })).toBeInTheDocument();
+
+    const dashboardGroup = screen.getByRole('group', { name: 'Dashboards' });
+    expect(within(dashboardGroup).getByRole('menuitem', { name: 'New dashboard' })).toBeInTheDocument();
+
+    const alertingGroup = screen.getByRole('group', { name: 'Alerting' });
+    expect(within(alertingGroup).getByRole('menuitem', { name: 'New alert rule' })).toBeInTheDocument();
   });
 
-  describe('From template button', () => {
+  it('renders ungrouped items without a group header', async () => {
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: 'New' }));
+
+    const importItem = screen.getByRole('menuitem', { name: 'New import' });
+    expect(importItem).toBeInTheDocument();
+
+    const allGroups = screen.getAllByRole('group');
+    const ungroupedGroup = allGroups.find(
+      (group) => !group.hasAttribute('aria-labelledby') && !group.hasAttribute('aria-label')
+    );
+    expect(ungroupedGroup).toBeDefined();
+    expect(within(ungroupedGroup!).getByRole('menuitem', { name: 'New import' })).toBeInTheDocument();
+  });
+
+  describe('Dashboard from template button', () => {
     beforeEach(() => {
       config.featureToggles.dashboardTemplates = true;
     });
 
-    it('shows when the feature flag is enabled', async () => {
+    it('shows a `Dashboard from template` button when the feature flag is enabled', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
       expect(screen.getByRole('menuitem', { name: 'Dashboard from template' })).toBeInTheDocument();
     });
 
-    it('is hidden when the feature flag is disabled', async () => {
+    it('does not show a `Dashboard from template` button when the feature flag is disabled', async () => {
       config.featureToggles.dashboardTemplates = false;
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
       expect(screen.queryByRole('menuitem', { name: 'Dashboard from template' })).not.toBeInTheDocument();
     });
 
-    it('links to the template dashboards page', async () => {
+    it('redirects the user to the dashboard from template page when the button is clicked', async () => {
       setup();
+
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
       const link = screen.getByRole('menuitem', { name: 'Dashboard from template' });
       expect(link).toHaveAttribute('href', '/dashboards?templateDashboards=true&source=quickAdd');
-    });
-
-    it('is placed in the dashboard group', async () => {
-      setup();
-      await userEvent.click(screen.getByRole('button', { name: 'New' }));
-
-      const dashboardGroup = screen.getByRole('group', { name: 'Dashboards' });
-      expect(within(dashboardGroup).getByRole('menuitem', { name: 'Dashboard from template' })).toBeInTheDocument();
     });
   });
 });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
@@ -22,27 +22,27 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
-const setup = () => {
-  const navBarTree: NavModelItem[] = [
+function setup(navBarTreeOverride?: NavModelItem[]) {
+  const navBarTree: NavModelItem[] = navBarTreeOverride ?? [
     {
-      text: 'Section 1',
-      id: 'section1',
-      url: 'section1',
+      text: 'Dashboards',
+      id: 'dashboards/browse',
+      url: '/dashboards',
       children: [
-        { text: 'New child 1', id: 'child1', url: '#', isCreateAction: true },
-        { text: 'Child2', id: 'child2', url: 'section1/child2' },
+        { text: 'New dashboard', id: 'dashboards/new', url: '/dashboard/new', isCreateAction: true },
+        { text: 'Import dashboard', id: 'dashboards/import', url: '/dashboard/import', isCreateAction: true },
       ],
     },
     {
-      text: 'Section 2',
-      id: 'section2',
-      url: 'section2',
-      children: [{ text: 'New child 3', id: 'child3', url: 'section2/child3', isCreateAction: true }],
+      text: 'Alerting',
+      id: 'alerting',
+      url: '/alerting',
+      children: [{ text: 'Create alert rule', id: 'alert', url: '/alerting/new', isCreateAction: true }],
     },
   ];
   const store = configureStore({ navBarTree });
   return render(<QuickAdd />, { store });
-};
+}
 
 describe('QuickAdd', () => {
   beforeAll(() => {
@@ -61,48 +61,83 @@ describe('QuickAdd', () => {
     expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
   });
 
-  it('shows isCreateAction options when clicked', async () => {
+  it('renders grouped menu items with correct labels', async () => {
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
-    expect(screen.getByRole('menuitem', { name: 'New child 1' })).toBeInTheDocument();
-    expect(screen.getByRole('menuitem', { name: 'New child 3' })).toBeInTheDocument();
+
+    const dashboardGroup = screen.getByRole('group', { name: 'New dashboard' });
+    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Blank' })).toBeInTheDocument();
+    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Import' })).toBeInTheDocument();
+
+    const alertGroup = screen.getByRole('group', { name: 'New alert rule' });
+    expect(within(alertGroup).getByRole('menuitem', { name: 'Create' })).toBeInTheDocument();
+  });
+
+  it('renders both groups inside the menu', async () => {
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: 'New' }));
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getAllByRole('group')).toHaveLength(2);
   });
 
   it('reports interaction when a menu item is clicked', async () => {
+    // jsdom doesn't support navigation; suppress the expected error
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
-    await userEvent.click(screen.getByRole('menuitem', { name: 'New child 1' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Blank' }));
 
     expect(reportInteraction).toHaveBeenCalledWith('grafana_menu_item_clicked', {
-      url: '#',
+      url: '/dashboard/new',
       from: 'quickadd',
     });
+    consoleSpy.mockRestore();
   });
 
-  describe('Dashboard from template button', () => {
+  it('falls back to nav item text for unknown item IDs', async () => {
+    setup([
+      {
+        text: 'Custom Section',
+        id: 'custom',
+        url: '/custom',
+        children: [{ text: 'Custom action', id: 'custom/action', url: '/custom/new', isCreateAction: true }],
+      },
+    ]);
+    await userEvent.click(screen.getByRole('button', { name: 'New' }));
+    expect(screen.getByRole('menuitem', { name: 'Custom action' })).toBeInTheDocument();
+  });
+
+  describe('From template button', () => {
     beforeEach(() => {
       config.featureToggles.dashboardTemplates = true;
     });
 
-    it('shows a `Dashboard from template` button when the feature flag is enabled', async () => {
+    it('shows when the feature flag is enabled', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.getByRole('menuitem', { name: 'Dashboard from template' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'From template' })).toBeInTheDocument();
     });
 
-    it('does not show a `Dashboard from template` button when the feature flag is disabled', async () => {
+    it('is hidden when the feature flag is disabled', async () => {
       config.featureToggles.dashboardTemplates = false;
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.queryByRole('menuitem', { name: 'Dashboard from template' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'From template' })).not.toBeInTheDocument();
     });
 
-    it('redirects the user to the dashboard from template page when the button is clicked', async () => {
+    it('links to the template dashboards page', async () => {
       setup();
-
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      const link = screen.getByRole('menuitem', { name: 'Dashboard from template' });
+      const link = screen.getByRole('menuitem', { name: 'From template' });
       expect(link).toHaveAttribute('href', '/dashboards?templateDashboards=true&source=quickAdd');
+    });
+
+    it('is placed in the dashboard group', async () => {
+      setup();
+      await userEvent.click(screen.getByRole('button', { name: 'New' }));
+
+      const dashboardGroup = screen.getByRole('group', { name: 'New dashboard' });
+      expect(within(dashboardGroup).getByRole('menuitem', { name: 'From template' })).toBeInTheDocument();
     });
   });
 });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -123,24 +123,24 @@ describe('QuickAdd', () => {
       config.featureToggles.dashboardTemplates = true;
     });
 
-    it('shows a `Dashboard from template` button when the feature flag is enabled', async () => {
+    it('shows a `From template` button when the feature flag is enabled', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.getByRole('menuitem', { name: 'Dashboard from template' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'From template' })).toBeInTheDocument();
     });
 
     it('does not show a `Dashboard from template` button when the feature flag is disabled', async () => {
       config.featureToggles.dashboardTemplates = false;
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.queryByRole('menuitem', { name: 'Dashboard from template' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'From template' })).not.toBeInTheDocument();
     });
 
     it('redirects the user to the dashboard from template page when the button is clicked', async () => {
       setup();
 
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      const link = screen.getByRole('menuitem', { name: 'Dashboard from template' });
+      const link = screen.getByRole('menuitem', { name: 'From template' });
       expect(link).toHaveAttribute('href', '/dashboards?templateDashboards=true&source=quickAdd');
     });
   });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -61,16 +61,16 @@ describe('QuickAdd', () => {
     expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
   });
 
-  it('renders grouped menu items with correct labels', async () => {
+  it('renders grouped menu items with labels from the nav tree', async () => {
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
 
-    const dashboardGroup = screen.getByRole('group', { name: 'New dashboard' });
-    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Blank' })).toBeInTheDocument();
-    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Import' })).toBeInTheDocument();
+    const dashboardGroup = screen.getByRole('group', { name: 'Dashboards' });
+    expect(within(dashboardGroup).getByRole('menuitem', { name: 'New dashboard' })).toBeInTheDocument();
+    expect(within(dashboardGroup).getByRole('menuitem', { name: 'Import dashboard' })).toBeInTheDocument();
 
-    const alertGroup = screen.getByRole('group', { name: 'New alert rule' });
-    expect(within(alertGroup).getByRole('menuitem', { name: 'Create' })).toBeInTheDocument();
+    const alertGroup = screen.getByRole('group', { name: 'Alerting' });
+    expect(within(alertGroup).getByRole('menuitem', { name: 'Create alert rule' })).toBeInTheDocument();
   });
 
   it('renders both groups inside the menu', async () => {
@@ -85,7 +85,7 @@ describe('QuickAdd', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
-    await userEvent.click(screen.getByRole('menuitem', { name: 'Blank' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'New dashboard' }));
 
     expect(reportInteraction).toHaveBeenCalledWith('grafana_menu_item_clicked', {
       url: '/dashboard/new',
@@ -115,20 +115,20 @@ describe('QuickAdd', () => {
     it('shows when the feature flag is enabled', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.getByRole('menuitem', { name: 'From template' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Dashboard from template' })).toBeInTheDocument();
     });
 
     it('is hidden when the feature flag is disabled', async () => {
       config.featureToggles.dashboardTemplates = false;
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.queryByRole('menuitem', { name: 'From template' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Dashboard from template' })).not.toBeInTheDocument();
     });
 
     it('links to the template dashboards page', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      const link = screen.getByRole('menuitem', { name: 'From template' });
+      const link = screen.getByRole('menuitem', { name: 'Dashboard from template' });
       expect(link).toHaveAttribute('href', '/dashboards?templateDashboards=true&source=quickAdd');
     });
 
@@ -136,8 +136,8 @@ describe('QuickAdd', () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
 
-      const dashboardGroup = screen.getByRole('group', { name: 'New dashboard' });
-      expect(within(dashboardGroup).getByRole('menuitem', { name: 'From template' })).toBeInTheDocument();
+      const dashboardGroup = screen.getByRole('group', { name: 'Dashboards' });
+      expect(within(dashboardGroup).getByRole('menuitem', { name: 'Dashboard from template' })).toBeInTheDocument();
     });
   });
 });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -29,7 +29,7 @@ function setup(navBarTreeOverride?: NavModelItem[]) {
       id: 'dashboards/browse',
       url: '/dashboards',
       children: [
-        { text: 'New dashboard', id: 'dashboards/new', url: '/dashboard/new', isCreateAction: true },
+        { text: 'New dashboard', id: 'dashboards/new', url: '#', isCreateAction: true },
         { text: 'Import dashboard', id: 'dashboards/import', url: '/dashboard/import', isCreateAction: true },
       ],
     },
@@ -81,17 +81,14 @@ describe('QuickAdd', () => {
   });
 
   it('reports interaction when a menu item is clicked', async () => {
-    // jsdom doesn't support navigation; suppress the expected error
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
     setup();
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
     await userEvent.click(screen.getByRole('menuitem', { name: 'New dashboard' }));
 
     expect(reportInteraction).toHaveBeenCalledWith('grafana_menu_item_clicked', {
-      url: '/dashboard/new',
+      url: '#',
       from: 'quickadd',
     });
-    consoleSpy.mockRestore();
   });
 
   it('falls back to nav item text for unknown item IDs', async () => {

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -12,7 +12,7 @@ import { useSelector } from 'app/types/store';
 
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 
-import { GROUP_DISPLAY, ITEM_DISPLAY, findCreateActionGroups } from './utils';
+import { ITEM_ICONS, findCreateActionGroups } from './utils';
 
 export interface Props {}
 
@@ -74,20 +74,22 @@ export const QuickAdd = ({}: Props) => {
   const MenuActions = () => (
     <Menu>
       {actionGroups.map((group, groupIdx) => {
-        const groupDisplay = GROUP_DISPLAY[group.parentId];
-        const iconColor = groupDisplay?.iconColor(theme);
+        const groupColors: Record<string, string> = {
+          'dashboards/browse': theme.visualization.getColorByName('green'),
+          alerting: theme.visualization.getColorByName('purple'),
+        };
+        const iconColor = groupColors[group.parentId];
         return (
           <Fragment key={group.parentId}>
             {groupIdx > 0 && <Menu.Divider />}
-            <Menu.Group label={groupDisplay?.label() ?? group.parentText}>
+            <Menu.Group label={group.parentText}>
               {group.items.map((item) => {
-                const itemDisplay = item.id ? ITEM_DISPLAY[item.id] : undefined;
                 return (
                   <Menu.Item
                     key={item.id}
                     url={item.url}
-                    label={itemDisplay?.label() ?? item.text}
-                    icon={itemDisplay?.icon}
+                    label={item.text}
+                    icon={item.id ? ITEM_ICONS[item.id] : undefined}
                     iconColor={iconColor}
                     onClick={() => {
                       reportInteraction('grafana_menu_item_clicked', { url: item.url, from: 'quickadd' });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -71,39 +71,43 @@ export const QuickAdd = ({}: Props) => {
     setIsOpen(!isOpen);
   };
 
-  const MenuActions = () => (
-    <Menu>
-      {actionGroups.map((group, groupIdx) => {
-        const groupColors: Record<string, string> = {
-          'dashboards/browse': theme.visualization.getColorByName('green'),
-          alerting: theme.visualization.getColorByName('purple'),
-        };
-        const iconColor = groupColors[group.parentId];
-        return (
-          <Fragment key={group.parentId}>
-            {groupIdx > 0 && <Menu.Divider />}
-            <Menu.Group label={group.parentText || undefined}>
-              {group.items.map((item) => {
-                return (
-                  <Menu.Item
-                    key={item.id}
-                    url={item.url}
-                    label={item.text}
-                    icon={item.id ? ITEM_ICONS[item.id] : undefined}
-                    iconColor={iconColor}
-                    onClick={() => {
-                      reportInteraction('grafana_menu_item_clicked', { url: item.url, from: 'quickadd' });
-                      item.onClick?.();
-                    }}
-                  />
-                );
-              })}
-            </Menu.Group>
-          </Fragment>
-        );
-      })}
-    </Menu>
-  );
+  const MenuActions = () => {
+    const groupColors: Record<string, string> = {
+      'dashboards/browse': theme.visualization.getColorByName('green'),
+      alerting: theme.visualization.getColorByName('purple'),
+    };
+
+    return (
+      <Menu>
+        {actionGroups.map((group, groupIdx) => {
+          const iconColor = groupColors[group.parentId];
+          return (
+            <Fragment key={group.parentId}>
+              {groupIdx > 0 && <Menu.Divider />}
+              {/* Empty parentText (ungrouped items) becomes undefined to suppress the group header */}
+              <Menu.Group label={group.parentText || undefined}>
+                {group.items.map((item) => {
+                  return (
+                    <Menu.Item
+                      key={item.id ?? item.url}
+                      url={item.url}
+                      label={item.text}
+                      icon={item.id ? ITEM_ICONS[item.id] : undefined}
+                      iconColor={iconColor}
+                      onClick={() => {
+                        reportInteraction('grafana_menu_item_clicked', { url: item.url, from: 'quickadd' });
+                        item.onClick?.();
+                      }}
+                    />
+                  );
+                })}
+              </Menu.Group>
+            </Fragment>
+          );
+        })}
+      </Menu>
+    );
+  };
 
   return (
     <>

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -30,7 +30,7 @@ export const QuickAdd = ({}: Props) => {
       if (testDataSources.length > 0) {
         const templateItem: NavModelItem = {
           id: 'browse-template-dashboard',
-          text: t('navigation.quick-add.new-template-dashboard-button', 'Dashboard from template'),
+          text: 'Dashboard from template',
           url: '/dashboards?templateDashboards=true&source=quickAdd',
           onClick: () => {
             isAnalyticsFrameworkEnabled
@@ -45,6 +45,7 @@ export const QuickAdd = ({}: Props) => {
           },
         };
 
+        // Matches NavIDDashboards ("dashboards/browse") from pkg/services/navtree/models.go
         const dashboardGroup = groups.find((g) => g.parentId === 'dashboards/browse');
         if (dashboardGroup) {
           dashboardGroup.items.push(templateItem);
@@ -56,6 +57,10 @@ export const QuickAdd = ({}: Props) => {
   }, [isAnalyticsFrameworkEnabled, navBarTree]);
 
   const showQuickAdd = actionGroups.some((g) => g.items.length > 0);
+
+  if (!showQuickAdd) {
+    return null;
+  }
 
   const handleVisibleChange = () => {
     if (!isOpen) {
@@ -98,7 +103,7 @@ export const QuickAdd = ({}: Props) => {
     </Menu>
   );
 
-  return showQuickAdd ? (
+  return (
     <>
       <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={handleVisibleChange}>
         <ToolbarButton
@@ -110,5 +115,5 @@ export const QuickAdd = ({}: Props) => {
       </Dropdown>
       <NavToolbarSeparator />
     </>
-  ) : null;
+  );
 };

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -73,8 +73,11 @@ export const QuickAdd = ({}: Props) => {
 
   const MenuActions = () => {
     const groupColors: Record<string, string> = {
-      'dashboards/browse': theme.visualization.getColorByName('green'),
-      alerting: theme.visualization.getColorByName('purple'),
+      'dashboards/browse': theme.visualization.getColorByName('semi-dark-green'),
+      alerting:
+        theme.colors.mode === 'dark'
+          ? theme.visualization.getColorByName('light-purple') // #CA95E5 — lighter, better contrast on dark bg
+          : theme.visualization.getColorByName('semi-dark-purple'), // #8F3BB8 — darker, better contrast on white
     };
 
     return (

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -30,7 +30,7 @@ export const QuickAdd = ({}: Props) => {
       if (testDataSources.length > 0) {
         const templateItem: NavModelItem = {
           id: 'browse-template-dashboard',
-          text: 'Dashboard from template',
+          text: t('navigation.quick-add.new-template-dashboard-button', 'Dashboard from template'),
           url: '/dashboards?templateDashboards=true&source=quickAdd',
           onClick: () => {
             isAnalyticsFrameworkEnabled

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -30,7 +30,7 @@ export const QuickAdd = ({}: Props) => {
       if (testDataSources.length > 0) {
         const templateItem: NavModelItem = {
           id: 'browse-template-dashboard',
-          text: t('navigation.quick-add.new-template-dashboard-button', 'Dashboard from template'),
+          text: t('navigation.quick-add.new-template-dashboard-button', 'From template'),
           url: '/dashboards?templateDashboards=true&source=quickAdd',
           onClick: () => {
             isAnalyticsFrameworkEnabled

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -82,7 +82,7 @@ export const QuickAdd = ({}: Props) => {
         return (
           <Fragment key={group.parentId}>
             {groupIdx > 0 && <Menu.Divider />}
-            <Menu.Group label={group.parentText}>
+            <Menu.Group label={group.parentText || undefined}>
               {group.items.map((item) => {
                 return (
                   <Menu.Item

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -1,9 +1,10 @@
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 
+import { type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getDataSourceSrv, reportInteraction, config } from '@grafana/runtime';
-import { Menu, Dropdown, ToolbarButton } from '@grafana/ui';
+import { Menu, Dropdown, ToolbarButton, useTheme2 } from '@grafana/ui';
 import { NewDashboardLibraryInteractions } from 'app/features/dashboard/dashgrid/DashboardLibrary/analytics/main';
 import { CONTENT_KINDS, SOURCE_ENTRY_POINTS } from 'app/features/dashboard/dashgrid/DashboardLibrary/constants';
 import { DashboardLibraryInteractions } from 'app/features/dashboard/dashgrid/DashboardLibrary/interactions';
@@ -11,7 +12,7 @@ import { useSelector } from 'app/types/store';
 
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 
-import { findCreateActions } from './utils';
+import { GROUP_DISPLAY, ITEM_DISPLAY, findCreateActionGroups } from './utils';
 
 export interface Props {}
 
@@ -19,13 +20,15 @@ export const QuickAdd = ({}: Props) => {
   const navBarTree = useSelector((state) => state.navBarTree);
   const [isOpen, setIsOpen] = useState(false);
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
-  const createActions = useMemo(() => {
-    const createActions = findCreateActions(navBarTree);
+  const theme = useTheme2();
+
+  const actionGroups = useMemo(() => {
+    const groups = findCreateActionGroups(navBarTree);
 
     if (config.featureToggles.dashboardTemplates) {
       const testDataSources = getDataSourceSrv().getList({ type: 'grafana-testdata-datasource' });
       if (testDataSources.length > 0) {
-        createActions.splice(1, 0, {
+        const templateItem: NavModelItem = {
           id: 'browse-template-dashboard',
           text: t('navigation.quick-add.new-template-dashboard-button', 'Dashboard from template'),
           url: '/dashboards?templateDashboards=true&source=quickAdd',
@@ -40,17 +43,20 @@ export const QuickAdd = ({}: Props) => {
                   contentKind: CONTENT_KINDS.TEMPLATE_DASHBOARD,
                 });
           },
-        });
+        };
+
+        const dashboardGroup = groups.find((g) => g.parentId === 'dashboards/browse');
+        if (dashboardGroup) {
+          dashboardGroup.items.push(templateItem);
+        }
       }
     }
 
-    return createActions;
+    return groups;
   }, [isAnalyticsFrameworkEnabled, navBarTree]);
-  const showQuickAdd = createActions.length > 0;
 
-  if (!showQuickAdd) {
-    return null;
-  }
+  const showQuickAdd = actionGroups.some((g) => g.items.length > 0);
+
   const handleVisibleChange = () => {
     if (!isOpen) {
       reportInteraction('grafana_create_new_button_menu_opened', {
@@ -60,23 +66,37 @@ export const QuickAdd = ({}: Props) => {
     setIsOpen(!isOpen);
   };
 
-  const MenuActions = () => {
-    return (
-      <Menu>
-        {createActions.map((createAction, index) => (
-          <Menu.Item
-            key={index}
-            url={createAction.url}
-            label={createAction.text}
-            onClick={() => {
-              reportInteraction('grafana_menu_item_clicked', { url: createAction.url, from: 'quickadd' });
-              createAction.onClick?.();
-            }}
-          />
-        ))}
-      </Menu>
-    );
-  };
+  const MenuActions = () => (
+    <Menu>
+      {actionGroups.map((group, groupIdx) => {
+        const groupDisplay = GROUP_DISPLAY[group.parentId];
+        const iconColor = groupDisplay?.iconColor(theme);
+        return (
+          <Fragment key={group.parentId}>
+            {groupIdx > 0 && <Menu.Divider />}
+            <Menu.Group label={groupDisplay?.label() ?? group.parentText}>
+              {group.items.map((item) => {
+                const itemDisplay = item.id ? ITEM_DISPLAY[item.id] : undefined;
+                return (
+                  <Menu.Item
+                    key={item.id}
+                    url={item.url}
+                    label={itemDisplay?.label() ?? item.text}
+                    icon={itemDisplay?.icon}
+                    iconColor={iconColor}
+                    onClick={() => {
+                      reportInteraction('grafana_menu_item_clicked', { url: item.url, from: 'quickadd' });
+                      item.onClick?.();
+                    }}
+                  />
+                );
+              })}
+            </Menu.Group>
+          </Fragment>
+        );
+      })}
+    </Menu>
+  );
 
   return showQuickAdd ? (
     <>

--- a/public/app/core/components/AppChrome/QuickAdd/utils.ts
+++ b/public/app/core/components/AppChrome/QuickAdd/utils.ts
@@ -21,21 +21,29 @@ export function findCreateActionGroups(navTree: NavModelItem[]): CreateActionGro
   return Array.from(groupMap.values());
 }
 
+/**
+ * Recursively walks the nav tree, collecting items marked with `isCreateAction`
+ * into groups keyed by their parent node. Top-level items (no parent) are placed
+ * in an ungrouped bucket with an empty key, which renders without a group header.
+ */
 function collectCreateActions(
   items: NavModelItem[],
   groupMap: Map<string, CreateActionGroup>,
   parent: NavModelItem | undefined
 ) {
   for (const navItem of items) {
-    if (navItem.isCreateAction && parent) {
-      const key = parent.id ?? parent.text;
+    if (navItem.isCreateAction) {
+      // Use parent id as group key; empty string for top-level (ungrouped) items
+      const key = parent ? (parent.id ?? parent.text) : '';
       let group = groupMap.get(key);
       if (!group) {
-        group = { parentId: key, parentText: parent.text, items: [] };
+        // parentText is empty for ungrouped items, which suppresses the Menu.Group label
+        group = { parentId: key, parentText: parent?.text ?? '', items: [] };
         groupMap.set(key, group);
       }
       group.items.push(navItem);
     }
+    // Recurse into children, passing the current node as the new parent
     if (navItem.children) {
       collectCreateActions(navItem.children, groupMap, navItem);
     }

--- a/public/app/core/components/AppChrome/QuickAdd/utils.ts
+++ b/public/app/core/components/AppChrome/QuickAdd/utils.ts
@@ -1,5 +1,4 @@
-import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { type NavModelItem } from '@grafana/data';
 import { type IconName } from '@grafana/ui';
 
 export interface CreateActionGroup {
@@ -8,32 +7,11 @@ export interface CreateActionGroup {
   items: NavModelItem[];
 }
 
-export interface GroupDisplay {
-  label: () => string;
-  iconColor: (theme: GrafanaTheme2) => string;
-}
-
-export interface ItemDisplay {
-  label: () => string;
-  icon: IconName;
-}
-
-export const GROUP_DISPLAY: Record<string, GroupDisplay> = {
-  'dashboards/browse': {
-    label: () => t('navigation.quick-add.group-dashboard', 'New dashboard'),
-    iconColor: (theme) => theme.visualization.getColorByName('green'),
-  },
-  alerting: {
-    label: () => t('navigation.quick-add.group-alert-rule', 'New alert rule'),
-    iconColor: (theme) => theme.visualization.getColorByName('purple'),
-  },
-};
-
-export const ITEM_DISPLAY: Record<string, ItemDisplay> = {
-  'dashboards/new': { label: () => t('navigation.quick-add.blank', 'Blank'), icon: 'plus' },
-  'browse-template-dashboard': { label: () => t('navigation.quick-add.from-template', 'From template'), icon: 'apps' },
-  'dashboards/import': { label: () => t('navigation.quick-add.import', 'Import'), icon: 'cloud-download' },
-  alert: { label: () => t('navigation.quick-add.create', 'Create'), icon: 'plus' },
+export const ITEM_ICONS: Record<string, IconName> = {
+  'dashboards/new': 'plus',
+  'browse-template-dashboard': 'apps',
+  'dashboards/import': 'cloud-download',
+  alert: 'plus',
 };
 
 export function findCreateActionGroups(navTree: NavModelItem[]): CreateActionGroup[] {

--- a/public/app/core/components/AppChrome/QuickAdd/utils.ts
+++ b/public/app/core/components/AppChrome/QuickAdd/utils.ts
@@ -1,14 +1,65 @@
-import { type NavModelItem } from '@grafana/data';
+import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { type IconName } from '@grafana/ui';
 
-export function findCreateActions(navTree: NavModelItem[]): NavModelItem[] {
-  const results: NavModelItem[] = [];
-  for (const navItem of navTree) {
-    if (navItem.isCreateAction) {
-      results.push(navItem);
+export interface CreateActionGroup {
+  parentId: string;
+  parentText: string;
+  items: NavModelItem[];
+}
+
+export interface GroupDisplay {
+  label: () => string;
+  iconColor: (theme: GrafanaTheme2) => string;
+}
+
+export interface ItemDisplay {
+  label: () => string;
+  icon: IconName;
+}
+
+export const GROUP_DISPLAY: Record<string, GroupDisplay> = {
+  'dashboards/browse': {
+    label: () => t('navigation.quick-add.group-dashboard', 'New dashboard'),
+    iconColor: (theme) => theme.visualization.getColorByName('green'),
+  },
+  alerting: {
+    label: () => t('navigation.quick-add.group-alert-rule', 'New alert rule'),
+    iconColor: (theme) => theme.visualization.getColorByName('purple'),
+  },
+};
+
+export const ITEM_DISPLAY: Record<string, ItemDisplay> = {
+  'dashboards/new': { label: () => t('navigation.quick-add.blank', 'Blank'), icon: 'plus' },
+  'browse-template-dashboard': { label: () => t('navigation.quick-add.from-template', 'From template'), icon: 'apps' },
+  'dashboards/import': { label: () => t('navigation.quick-add.import', 'Import'), icon: 'cloud-download' },
+  alert: { label: () => t('navigation.quick-add.create', 'Create'), icon: 'plus' },
+};
+
+export function findCreateActionGroups(navTree: NavModelItem[]): CreateActionGroup[] {
+  const groupMap = new Map<string, CreateActionGroup>();
+  collectCreateActions(navTree, groupMap, undefined);
+
+  return Array.from(groupMap.values());
+}
+
+function collectCreateActions(
+  items: NavModelItem[],
+  groupMap: Map<string, CreateActionGroup>,
+  parent: NavModelItem | undefined
+) {
+  for (const navItem of items) {
+    if (navItem.isCreateAction && parent) {
+      const key = parent.id ?? parent.text;
+      let group = groupMap.get(key);
+      if (!group) {
+        group = { parentId: key, parentText: parent.text, items: [] };
+        groupMap.set(key, group);
+      }
+      group.items.push(navItem);
     }
     if (navItem.children) {
-      results.push(...findCreateActions(navItem.children));
+      collectCreateActions(navItem.children, groupMap, navItem);
     }
   }
-  return results;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12181,7 +12181,12 @@
     },
     "quick-add": {
       "aria-label": "New",
-      "new-template-dashboard-button": "Dashboard from template"
+      "blank": "Blank",
+      "create": "Create",
+      "from-template": "From template",
+      "group-alert-rule": "New alert rule",
+      "group-dashboard": "New dashboard",
+      "import": "Import"
     },
     "rss-button": "Latest from the blog"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12180,13 +12180,7 @@
       "aria-label": "Profile"
     },
     "quick-add": {
-      "aria-label": "New",
-      "blank": "Blank",
-      "create": "Create",
-      "from-template": "From template",
-      "group-alert-rule": "New alert rule",
-      "group-dashboard": "New dashboard",
-      "import": "Import"
+      "aria-label": "New"
     },
     "rss-button": "Latest from the blog"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12180,7 +12180,8 @@
       "aria-label": "Profile"
     },
     "quick-add": {
-      "aria-label": "New"
+      "aria-label": "New",
+      "new-template-dashboard-button": "Dashboard from template"
     },
     "rss-button": "Latest from the blog"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12181,7 +12181,7 @@
     },
     "quick-add": {
       "aria-label": "New",
-      "new-template-dashboard-button": "Dashboard from template"
+      "new-template-dashboard-button": "From template"
     },
     "rss-button": "Latest from the blog"
   },


### PR DESCRIPTION
**What is this feature?**

Updates the top bar QuickAdd ("+") dropdown menu from a flat list of create actions to a grouped category layout using `Menu.Group`.

<img width="502" height="242" alt="image" src="https://github.com/user-attachments/assets/f8c3b11a-e6ec-4878-89ab-f4e6c806acee" />


**Why do we need this feature?**

Provide user clearer quick add action visualization 

**Who is this feature for?**

Users who create dashboards and alerts from top bar

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/119548

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
