### PR TITLE
annotations: use AnnotationID in sql adapter Get

### DIFF
--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	claims "github.com/grafana/authlib/types"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
@@ -48,7 +47,7 @@ func (a *sqlAdapter) Get(ctx context.Context, namespace, name string) (*annotati
 	query := &annotations.ItemQuery{
 		SignedInUser: user,
 		OrgID:        orgID,
-		Limit:        1000,
+		AnnotationID: id,
 		Type:         "annotation",
 	}
 
@@ -57,13 +56,11 @@ func (a *sqlAdapter) Get(ctx context.Context, namespace, name string) (*annotati
 		return nil, err
 	}
 
-	for _, item := range items {
-		if item.ID == id {
-			return a.toK8sResource(item, namespace), nil
-		}
+	if len(items) == 0 {
+		return nil, ErrNotFound
 	}
 
-	return nil, apierrors.NewNotFound(annotationGR, name)
+	return a.toK8sResource(items[0], namespace), nil
 }
 
 func (a *sqlAdapter) List(ctx context.Context, namespace string, opts ListOptions) (*AnnotationList, error) {

--- a/pkg/registry/apps/annotation/sql_adapter_test.go
+++ b/pkg/registry/apps/annotation/sql_adapter_test.go
@@ -2,6 +2,7 @@ package annotation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -47,6 +48,16 @@ func (f *fakeRepo) addItem(item *annotations.ItemDTO) {
 
 func (f *fakeRepo) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
 	f.lastQuery = query
+
+	if query.AnnotationID != 0 {
+		for _, item := range f.items {
+			if item.ID == query.AnnotationID {
+				return []*annotations.ItemDTO{item}, nil
+			}
+		}
+		return []*annotations.ItemDTO{}, nil
+	}
+
 	start := int(query.Offset)
 	end := start + int(query.Limit)
 
@@ -107,6 +118,39 @@ func TestSQLAdapter_QueriesExcludeAlertAnnotations(t *testing.T) {
 		require.NotNil(t, repo.lastQuery)
 		assert.Equal(t, "annotation", repo.lastQuery.Type)
 		assert.Zero(t, repo.lastQuery.AlertID)
+	})
+}
+
+func TestSQLAdapter_Get(t *testing.T) {
+	repo := newFakeRepo()
+	repo.addItem(&annotations.ItemDTO{ID: 1, Text: "first"})
+	repo.addItem(&annotations.ItemDTO{ID: 2, Text: "second"})
+	repo.addItem(&annotations.ItemDTO{ID: 3, Text: "third"})
+
+	adapter := NewSQLAdapter(repo, nil, annotations.CleanupSettings{})
+
+	ctx := identity.WithRequester(t.Context(), &identity.StaticRequester{
+		OrgID: 1,
+	})
+
+	t.Run("returns the matching annotation by ID", func(t *testing.T) {
+		result, err := adapter.Get(ctx, "default", "a-2")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "a-2", result.Name)
+		assert.Equal(t, "second", result.Spec.Text)
+		assert.Equal(t, int64(2), repo.lastQuery.AnnotationID)
+	})
+
+	t.Run("returns not found for non-existent ID", func(t *testing.T) {
+		_, err := adapter.Get(ctx, "default", "a-999")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+	})
+
+	t.Run("returns error for invalid name format", func(t *testing.T) {
+		_, err := adapter.Get(ctx, "default", "invalid")
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
This PR updates the sql adapter to query annotations by ID directly using the `AnnotationID` field on `ItemQuery`. Currently, it fetches up to 1000 annotations and iterates through them to find a match, which could miss results entirely if the target annotation falls outside that window. The new logic mimics what we do in the legacy API [here](https://github.com/grafana/grafana/blob/8a7d72892a5342f726c8402d6fa28cf2babcd9cb/pkg/api/annotations.go#L498-L515).