### PR TITLE
Alerting: Fix crash when MultiCombobox value contains duplicates

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -319,6 +319,32 @@ describe('MultiCombobox', () => {
     });
   });
 
+  describe('duplicate and undefined values', () => {
+    it('should render only unique pills when value array contains duplicates', () => {
+      const options = [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+        { label: 'C', value: 'c' },
+      ];
+      render(<MultiCombobox width={200} options={options} value={['a', 'a', 'b']} onChange={jest.fn()} />);
+      expect(screen.getByText('A')).toBeInTheDocument();
+      expect(screen.getByText('B')).toBeInTheDocument();
+      expect(screen.queryByText('C')).not.toBeInTheDocument();
+      expect(screen.getAllByText('A')).toHaveLength(1);
+    });
+
+    it('should render fallback pills for duplicate values not present in options', () => {
+      const options = [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+      ];
+      render(<MultiCombobox width={200} options={options} value={['d', 'd', 'a']} onChange={jest.fn()} />);
+      expect(screen.getByText('A')).toBeInTheDocument();
+      // 'd' is not in options but should appear once as a fallback pill, not twice
+      expect(screen.getAllByText('d')).toHaveLength(1);
+    });
+  });
+
   describe('async', () => {
     const onChangeHandler = jest.fn();
     let user: ReturnType<typeof userEvent.setup>;

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -380,7 +380,18 @@ function getSelectedItemsFromValue<T extends string | number>(
   if (isComboboxOptions(value)) {
     return value;
   }
-  const valueMap = new Map(value.map((val, index) => [val, index]));
+  // Deduplicate values before building the map. Without dedup, duplicate keys
+  // cause Map to keep the last index, leaving earlier indices as undefined holes
+  // in resultingItems (sparse array), which crashes when label is accessed.
+  const seen = new Set<T>();
+  const dedupedValues: T[] = [];
+  for (const v of value) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      dedupedValues.push(v);
+    }
+  }
+  const valueMap = new Map(dedupedValues.map((val, index) => [val, index]));
   const resultingItems: Array<ComboboxOption<T>> = [];
 
   for (const option of options) {

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -383,15 +383,14 @@ function getSelectedItemsFromValue<T extends string | number>(
   // Deduplicate values before building the map. Without dedup, duplicate keys
   // cause Map to keep the last index, leaving earlier indices as undefined holes
   // in resultingItems (sparse array), which crashes when label is accessed.
-  const seen = new Set<T>();
-  const dedupedValues: T[] = [];
-  for (const v of value) {
-    if (!seen.has(v)) {
-      seen.add(v);
-      dedupedValues.push(v);
+  const valueMap = new Map<T, number>();
+  let index = 0;
+  for (const val of value) {
+    if (!valueMap.has(val)) {
+      valueMap.set(val, index);
+      index++;
     }
   }
-  const valueMap = new Map(dedupedValues.map((val, index) => [val, index]));
   const resultingItems: Array<ComboboxOption<T>> = [];
 
   for (const option of options) {

--- a/packages/grafana-ui/src/components/Combobox/useMeasureMulti.ts
+++ b/packages/grafana-ui/src/components/Combobox/useMeasureMulti.ts
@@ -31,7 +31,7 @@ export function useMeasureMulti<T extends string | number>(
     for (let i = 0; i < selectedItems.length; i++) {
       // Measure text width and add size of padding, separator and close button
       currWidth +=
-        measureText(selectedItems[i].label || '', FONT_SIZE).width +
+        measureText(selectedItems[i]?.label || '', FONT_SIZE).width +
         (disabled ? EXTRA_PILL_DISABLED_SIZE : EXTRA_PILL_SIZE);
       if (currWidth > maxWidth) {
         // If there is no space for that item, show the current number of items,


### PR DESCRIPTION
**What is this feature?**

This PR fixes a crash in `MultiCombobox` when the value prop contains duplicate primitive entries (see error log [here](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22h4l%22:%7B%22datasource%22:%22grafanacloud-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22grafanacloud-logs%22%7D,%22expr%22:%22%7Bkind%3D%5C%22exception%5C%22%7D+%7C%3D+%5C%22useMeasureMulti%5C%22+%7C+logfmt+%7C+page_id%3D%60/alerting/list%60%22,%22queryType%22:%22range%22,%22instant%22:false,%22range%22:true,%22app%22:%22grafana-assistant-app%22,%22editorMode%22:%22code%22,%22direction%22:%22backward%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22sortOrder%22:%22Descending%22%7D%7D,%22compact%22:false%7D%7D&orgId=1)).  

**Why do we need this feature?**
When MultiCombobox receives a value array with duplicates (e.g. ['a', 'a', 'b']), the internal Map deduplicates keys keeping only the last index. This leaves earlier indices unassigned in the result array, creating undefined holes. Downstream code in useMeasureMulti then crashes with TypeError: Cannot read properties of undefined (reading 'label'). This has been observed in production on the /alerting/list page when search filters produce duplicate label or datasource values.

**Who is this feature for?**

Alerting users

**How to reproduce**
- Navigate directly to `/alerting/list?search=label:foo%20label:foo`
  - The duplicate label:foo tokens produce labels: ['foo', 'foo'], which hits the sparse array bug in the MultiCombobox and crashes the page.
  - For datasources, the equivalent is `/alerting/list?search=datasource:prometheus%20datasource:prometheus`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
