### PR TITLE
Dashboards: Reduce Rudderstack event frequency and payload size; fix discard for pasted styles

### DIFF
--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -22,6 +22,8 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
   });
 };
 
+const MAX_PAGE_URL_LENGTH = 2048;
+
 /**
  * Helper function to report pageview events to the {@link EchoSrv}.
  *
@@ -29,7 +31,8 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
  */
 export const reportPageview = () => {
   const location = locationService.getLocation();
-  const page = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
+  const fullPage = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
+  const page = fullPage.length > MAX_PAGE_URL_LENGTH ? fullPage.substring(0, MAX_PAGE_URL_LENGTH) : fullPage;
   getEchoSrv().addEvent<PageviewEchoEvent>({
     type: EchoEventType.Pageview,
     payload: {

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -40,7 +40,8 @@ export function GrafanaRoute(props: Props) {
     cleanupDOM();
     reportPageview();
     navigationLogger('GrafanaRoute', false, 'Updated', props);
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.location.pathname, props.location.search, props.location.hash]);
 
   navigationLogger('GrafanaRoute', false, 'Rendered', props.route);
 

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -4,6 +4,8 @@ import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
 
+const MAX_PAGE_URL_LENGTH = 2048;
+
 interface EchoConfig {
   // How often should metrics be reported
   flushInterval: number;
@@ -86,7 +88,10 @@ export class Echo implements EchoSrv {
       ts: new Date().getTime(),
       timeSinceNavigationStart: performance.now(),
       path: window.location.pathname,
-      url: window.location.href,
+      url:
+        window.location.href.length > MAX_PAGE_URL_LENGTH
+          ? window.location.href.substring(0, MAX_PAGE_URL_LENGTH)
+          : window.location.href,
     };
   };
 }

--- a/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
@@ -135,8 +135,6 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
         apiOptions
       );
     }
-
-    window.rudderanalytics?.page?.();
   }
 
   addEvent = (e: PageviewEchoEvent) => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -1,6 +1,13 @@
 import { of } from 'rxjs';
 
-import { type DataQueryRequest, type DataSourceApi, LoadingState, type PanelPlugin, store } from '@grafana/data';
+import {
+  type DataQueryRequest,
+  type DataSourceApi,
+  type FieldConfigSource,
+  LoadingState,
+  type PanelPlugin,
+  store,
+} from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { config } from '@grafana/runtime';
 import {
@@ -14,6 +21,7 @@ import {
   SceneVariableSet,
   VizPanel,
 } from '@grafana/scenes';
+import { type Dashboard } from '@grafana/schema';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
@@ -213,6 +221,43 @@ describe('PanelEditor', () => {
 
       // Change back to already saved state
       panel.setState({ title: 'changed title' });
+      expect(panelEditor.state.isDirty).toBe(false);
+    });
+  });
+
+  describe('When panel has pre-existing unsaved changes (e.g. styles pasted from dashboard view)', () => {
+    it('Should set isDirty to true immediately when entering panel edit', async () => {
+      const { panelEditor } = await setupWithPreExistingStyleChanges();
+      expect(panelEditor.state.isDirty).toBe(true);
+    });
+
+    it('Should not set isDirty when panel has no pre-existing changes', async () => {
+      const { panelEditor } = await setup({});
+      // No paste, so isDirty should remain undefined (not set)
+      expect(panelEditor.state.isDirty).toBe(undefined);
+    });
+
+    it('Should revert pasted fieldConfig when discarding panel changes', async () => {
+      const originalFieldConfig = { defaults: { color: { mode: 'fixed' } }, overrides: [] };
+      const { panelEditor, panel, dashboard } = await setupWithPreExistingStyleChanges({ originalFieldConfig });
+
+      expect(panelEditor.state.isDirty).toBe(true);
+
+      panelEditor.onDiscard();
+
+      const discardedPanel = findVizPanelByKey(dashboard, panel.state.key!)!;
+      expect(discardedPanel.state.fieldConfig).toEqual(originalFieldConfig);
+    });
+
+    it('Should track further changes relative to the initial (saved) state after entering panel edit', async () => {
+      const originalFieldConfig = { defaults: { color: { mode: 'fixed' } }, overrides: [] };
+      const { panelEditor, panel } = await setupWithPreExistingStyleChanges({ originalFieldConfig });
+
+      expect(panelEditor.state.isDirty).toBe(true);
+
+      // Restoring to the original fieldConfig via setState (same path as how the original was captured)
+      // should make the panel no longer dirty.
+      panel.setState({ fieldConfig: originalFieldConfig });
       expect(panelEditor.state.isDirty).toBe(false);
     });
   });
@@ -501,4 +546,86 @@ async function setup(options: SetupOptions = {}) {
   }
 
   return { dashboard, panel, gridItem, panelEditor, pluginResolve };
+}
+
+interface SetupWithPreExistingStyleChangesOptions {
+  originalFieldConfig?: FieldConfigSource;
+}
+
+/**
+ * Sets up a panel editor scenario where styles were pasted from dashboard view
+ * before entering panel edit. This simulates the bug where the discard button
+ * is disabled even though the panel has unsaved changes.
+ */
+async function setupWithPreExistingStyleChanges(options: SetupWithPreExistingStyleChangesOptions = {}) {
+  const originalFieldConfig = options.originalFieldConfig ?? {
+    defaults: { color: { mode: 'palette-classic' } },
+    overrides: [],
+  };
+  const pastedFieldConfig = { defaults: { color: { mode: 'fixed' }, custom: { lineWidth: 3 } }, overrides: [] };
+
+  const pluginToLoad = getPanelPlugin({ id: 'timeseries', skipDataQuery: false });
+  pluginPromise = Promise.resolve(pluginToLoad);
+
+  // Create the panel with original fieldConfig
+  const panel = new VizPanel({
+    key: 'panel-1',
+    pluginId: 'timeseries',
+    title: 'original title',
+    fieldConfig: originalFieldConfig,
+    $data: new SceneDataTransformer({
+      transformations: [],
+      $data: new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        maxDataPoints: 500,
+        datasource: { uid: 'ds1' },
+      }),
+    }),
+  });
+
+  const gridItem = new DashboardGridItem({ body: panel });
+
+  const dashboard = new DashboardScene({
+    isEditing: true,
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [gridItem],
+      }),
+    }),
+  });
+
+  // Set the initial save model to represent what was last saved (with the original fieldConfig)
+  const initialSaveModel: Dashboard = {
+    schemaVersion: 36,
+    title: 'test dashboard',
+    panels: [
+      {
+        id: 1,
+        type: 'timeseries',
+        title: 'original title',
+        fieldConfig: vizPanelToPanel(panel).fieldConfig,
+        options: {},
+        targets: [{ refId: 'A', datasource: { uid: 'ds1' } }],
+        datasource: { uid: 'ds1' },
+        gridPos: { x: 0, y: 0, h: 8, w: 12 },
+      },
+    ],
+  };
+  dashboard.setInitialSaveModel(initialSaveModel);
+
+  // Simulate paste styles from dashboard view (before entering panel edit).
+  // Use setState directly because onFieldConfigChange requires the panel plugin to be loaded,
+  // which is not the case when pasting from dashboard view (mirrors how DashboardScene.pastePanelStyles works).
+  panel.setState({ fieldConfig: pastedFieldConfig });
+
+  // Now enter panel edit (AFTER the paste — this is the bug scenario)
+  const panelEditor = buildPanelEditScene(panel);
+  dashboard.setState({ editPanel: panelEditor });
+
+  panelEditor.debounceSaveModelDiff = false;
+  deactivate = activateFullSceneTree(dashboard);
+  await new Promise((r) => setTimeout(r, 1));
+
+  return { dashboard, panel, gridItem, panelEditor };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -2,7 +2,7 @@ import deepEqual from 'fast-deep-equal';
 import type * as H from 'history';
 import { debounce } from 'lodash';
 
-import { type NavIndex, type PanelPlugin } from '@grafana/data';
+import { type FieldConfigSource, type NavIndex, type PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -20,6 +20,7 @@ import {
   type VizPanel,
 } from '@grafana/scenes';
 import { type Panel } from '@grafana/schema';
+import { isDashboardV1Spec } from 'app/features/dashboard/api/utils';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
 import { getLastUsedDatasourceFromStorage } from 'app/features/dashboard/utils/dashboard';
 import { saveLibPanel } from 'app/features/library-panels/state/api';
@@ -188,6 +189,53 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   }
 
   /**
+   * Detects if the panel has unsaved changes that were made before entering panel edit
+   * (e.g., styles pasted from dashboard view). When detected, `isDirty` is set to true
+   * and `_layoutItemState` is updated so discard will correctly revert those changes.
+   */
+  private _detectPreExistingChanges(panel: VizPanel) {
+    const initialPanel = this._getInitialPanelSaveModel();
+    if (!initialPanel) {
+      return;
+    }
+
+    const currentPanelData = vizPanelToPanel(panel);
+    // Only compare fieldConfig — the only field that pastePanelStyles modifies
+    const hasFieldConfigChanges = !deepEqual(currentPanelData.fieldConfig, initialPanel.fieldConfig);
+
+    if (!hasFieldConfigChanges) {
+      return;
+    }
+
+    // Override _originalSaveModel so future dirty checks compare against the pre-paste fieldConfig
+    this._originalSaveModel = {
+      ...currentPanelData,
+      fieldConfig: initialPanel.fieldConfig ?? { defaults: {}, overrides: [] },
+    };
+
+    const fc: unknown = initialPanel.fieldConfig;
+    if (isFieldConfigSource(fc)) {
+      panel.setState({ fieldConfig: fc });
+    }
+
+    this.setState({ isDirty: true });
+  }
+
+  /**
+   * Returns the panel's save model from before any unsaved edits were made to the dashboard.
+   * Returns undefined for V2 dashboards or when the panel is not found.
+   */
+  private _getInitialPanelSaveModel(): Panel | undefined {
+    const dashboard = getDashboardSceneFor(this);
+    const initialSaveModel = dashboard.getInitialSaveModel();
+    if (!initialSaveModel || !isDashboardV1Spec(initialSaveModel)) {
+      return undefined;
+    }
+    const panelId = getPanelIdForVizPanel(this.getPanel());
+    return initialSaveModel.panels?.find((p) => p.id === panelId);
+  }
+
+  /**
    * Useful for testing to turn on debounce
    */
   public debounceSaveModelDiff = true;
@@ -226,6 +274,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     if (this.state.isInitializing) {
       this.setOriginalState(this.state.panelRef);
       this._setupChangeDetection();
+      this._detectPreExistingChanges(panel);
       this._updateDataPane(plugin);
 
       // Listen for panel plugin changes
@@ -433,4 +482,8 @@ export function buildPanelEditScene(panel: VizPanel, isNewPanel = false): PanelE
     panelRef: panel.getRef(),
     isNewPanel,
   });
+}
+
+function isFieldConfigSource(value: unknown): value is FieldConfigSource {
+  return typeof value === 'object' && value !== null && 'defaults' in value && 'overrides' in value;
 }


### PR DESCRIPTION
Removes the double pageview call fired on RudderstackV3Backend init and simplifies deduplication in GrafanaRoute using useEffect deps. Also caps the URL in echo metadata at 2048 chars to reduce payload size for dashboards with large URLs.

Separately, fixes the Discard button being disabled in panel edit when styles were pasted from dashboard view, the pre-existing fieldConfig change is now detected on init and isDirty is set correctly. Fixes #121808