### PR TITLE
BrowseDashboards: Fix Recently Viewed caret toggle not working

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -71,7 +71,7 @@ export function RecentlyViewedDashboards() {
         </Stack>
       }
       isOpen={isOpen}
-      onToggle={handleSectionToggle}
+      onToggle={() => {}}
       className={styles.title}
       contentClassName={styles.content}
     >

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -59,7 +59,7 @@ export function RecentlyViewedDashboards() {
       headerDataTestId="browseDashboardsRecentlyViewedTitle"
       label={
         <Stack direction="row" justifyContent="space-between" alignItems="baseline" width="100%">
-          <Text variant="h5" element="h3">
+          <Text variant="h5" element="h3" onClick={handleSectionToggle}>
             <Trans i18nKey="browse-dashboards.recently-viewed.title">Recently viewed</Trans>
           </Text>
           <Button icon="times" size="xs" variant="secondary" fill="text" onClick={(e) => {
@@ -71,7 +71,9 @@ export function RecentlyViewedDashboards() {
         </Stack>
       }
       isOpen={isOpen}
-      onToggle={handleSectionToggle}
+      // passing empty function to disable controlled mode, we only want to control isOpen when click on title
+      // this avoid entire header section being clickable which can be confusing with the Clear history button
+      onToggle={() => { }}
       className={styles.title}
       contentClassName={styles.content}
     >
@@ -116,17 +118,9 @@ export function RecentlyViewedDashboards() {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     title: css({
-      cursor: 'pointer',
-      padding: theme.spacing(0.5, 0),
-      '& [id^="collapse-button-"]': {
-        padding: theme.spacing(0, 1),
-        svg: {
-          color: theme.colors.primary.text,
-          transition: theme.transitions.create('color'),
-        },
-        '&:hover svg': {
-          color: theme.colors.text.maxContrast,
-        },
+      cursor: 'default',
+      '& [id^="collapse-button-"] svg': {
+        color: theme.colors.primary.text,
       },
       h3: {
         background: `linear-gradient(90deg, ${theme.colors.primary.shade} 0%, ${theme.colors.primary.text} 100%)`,
@@ -135,6 +129,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         color: 'transparent',
         cursor: 'pointer',
       },
+      padding: 0,
     }),
     content: css({
       paddingTop: theme.spacing(0),

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -38,11 +38,11 @@ export function RecentlyViewedDashboards() {
     retry();
   };
 
-  const handleSectionToggle = () => {
+  const handleSectionToggle = (open: boolean) => {
     reportInteraction('grafana_recently_viewed_dashboards_toggle_section', {
-      expanded: !isOpen,
+      expanded: open,
     });
-    setIsOpen(prev => !prev);
+    setIsOpen(open);
   };
 
   useEffect(() => {
@@ -59,7 +59,7 @@ export function RecentlyViewedDashboards() {
       headerDataTestId="browseDashboardsRecentlyViewedTitle"
       label={
         <Stack direction="row" justifyContent="space-between" alignItems="baseline" width="100%">
-          <Text variant="h5" element="h3" onClick={handleSectionToggle}>
+          <Text variant="h5" element="h3">
             <Trans i18nKey="browse-dashboards.recently-viewed.title">Recently viewed</Trans>
           </Text>
           <Button icon="times" size="xs" variant="secondary" fill="text" onClick={(e) => {
@@ -71,7 +71,7 @@ export function RecentlyViewedDashboards() {
         </Stack>
       }
       isOpen={isOpen}
-      onToggle={() => {}}
+      onToggle={handleSectionToggle}
       className={styles.title}
       contentClassName={styles.content}
     >

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -42,7 +42,7 @@ export function RecentlyViewedDashboards() {
     reportInteraction('grafana_recently_viewed_dashboards_toggle_section', {
       expanded: !isOpen,
     });
-    setIsOpen(!isOpen);
+    setIsOpen(prev => !prev);
   };
 
   useEffect(() => {
@@ -71,9 +71,7 @@ export function RecentlyViewedDashboards() {
         </Stack>
       }
       isOpen={isOpen}
-      // passing empty function to disable controlled mode, we only want to control isOpen when click on title
-      // this avoid entire header section being clickable which can be confusing with the Clear history button
-      onToggle={() => { }}
+      onToggle={handleSectionToggle}
       className={styles.title}
       contentClassName={styles.content}
     >

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -62,10 +62,16 @@ export function RecentlyViewedDashboards() {
           <Text variant="h5" element="h3">
             <Trans i18nKey="browse-dashboards.recently-viewed.title">Recently viewed</Trans>
           </Text>
-          <Button icon="times" size="xs" variant="secondary" fill="text" onClick={(e) => {
-            e.stopPropagation();
-            handleClearHistory();
-          }}>
+          <Button
+            icon="times"
+            size="xs"
+            variant="secondary"
+            fill="text"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClearHistory();
+            }}
+          >
             {t('browse-dashboards.recently-viewed.clear', 'Clear history')}
           </Button>
         </Stack>

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -59,18 +59,19 @@ export function RecentlyViewedDashboards() {
       headerDataTestId="browseDashboardsRecentlyViewedTitle"
       label={
         <Stack direction="row" justifyContent="space-between" alignItems="baseline" width="100%">
-          <Text variant="h5" element="h3" onClick={handleSectionToggle}>
+          <Text variant="h5" element="h3">
             <Trans i18nKey="browse-dashboards.recently-viewed.title">Recently viewed</Trans>
           </Text>
-          <Button icon="times" size="xs" variant="secondary" fill="text" onClick={handleClearHistory}>
+          <Button icon="times" size="xs" variant="secondary" fill="text" onClick={(e) => {
+            e.stopPropagation();
+            handleClearHistory();
+          }}>
             {t('browse-dashboards.recently-viewed.clear', 'Clear history')}
           </Button>
         </Stack>
       }
       isOpen={isOpen}
-      // passing empty function to disable controlled mode, we only want to control isOpen when click on title
-      // this avoid entire header section being clickable which can be confusing with the Clear history button
-      onToggle={() => {}}
+      onToggle={handleSectionToggle}
       className={styles.title}
       contentClassName={styles.content}
     >
@@ -115,9 +116,17 @@ export function RecentlyViewedDashboards() {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     title: css({
-      cursor: 'default',
-      '& [id^="collapse-button-"] svg': {
-        color: theme.colors.primary.text,
+      cursor: 'pointer',
+      padding: theme.spacing(0.5, 0),
+      '& [id^="collapse-button-"]': {
+        padding: theme.spacing(0, 1),
+        svg: {
+          color: theme.colors.primary.text,
+          transition: theme.transitions.create('color'),
+        },
+        '&:hover svg': {
+          color: theme.colors.text.maxContrast,
+        },
       },
       h3: {
         background: `linear-gradient(90deg, ${theme.colors.primary.shade} 0%, ${theme.colors.primary.text} 100%)`,
@@ -126,7 +135,6 @@ const getStyles = (theme: GrafanaTheme2) => {
         color: 'transparent',
         cursor: 'pointer',
       },
-      padding: 0,
     }),
     content: css({
       paddingTop: theme.spacing(0),


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug in the "Recently viewed" section where clicking the caret (expand/collapse icon) did not toggle the section.

**Why do we need this feature?**

Users expect both the title and caret icon to control expand/collapse. Previously, only clicking the title worked, making the UI confusing.

**Who is this feature for?**

All Grafana users using the Browse Dashboards page.

**Which issue(s) does this PR fix?**:

Fixes #122012

**Special notes for your reviewer:**

- Clicking caret icon now expands/collapses the section
- Clicking title still works
- Clicking "Clear history" does not toggle (handled with stopPropagation)