### PR TITLE
fix: prevent refresh button text overflow in long translations

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -252,6 +252,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     contentWithIcon: css({
       display: 'none',
       paddingLeft: theme.spacing(1),
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      minWidth: 0,
 
       [`@media ${mediaUp(theme.v1.breakpoints.md)}`]: {
         display: 'block',


### PR DESCRIPTION
Closes #119789

## Problem

When Grafana is set to German, the "Refresh" button is translated to "Aktualisieren", which is significantly longer than the English text. Since the `ToolbarButton` component's `contentWithIcon` style lacks overflow handling, the longer translated text overflows the button boundary and overlaps with the adjacent refresh interval dropdown.

## Solution

Added `overflow: hidden`, `textOverflow: ellipsis`, and `minWidth: 0` to the `contentWithIcon` style in `ToolbarButton.tsx`. This ensures that when a fixed width is applied to the button (as the scenes refresh picker does to prevent layout shifts between "Refresh" and "Cancel" states), text that exceeds the available space is truncated with an ellipsis rather than overflowing.

The fix is intentionally applied at the `ToolbarButton` level rather than only in `RefreshPicker`, since any toolbar button with an icon and a fixed width could encounter the same overflow issue with longer translations.

## Testing

- Verified with German locale that "Aktualisieren" no longer overlaps the refresh interval dropdown
- Confirmed English "Refresh" text renders normally with no truncation