### PR TITLE
Folders: Remove leftover thin wrappers from earlier refactors

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
-	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/supportbundles"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -107,7 +106,7 @@ func ProvideService(
 }
 
 func (s *Service) getUIDFromLegacyID(ctx context.Context, orgID int64, id int64) (string, error) {
-	f, err := s.getFolderByIDFromApiServer(ctx, id, orgID)
+	f, err := s.getFolderByID(ctx, id, orgID)
 	if err != nil {
 		return "", err
 	}
@@ -118,27 +117,6 @@ func (s *Service) CountFoldersInOrg(ctx context.Context, orgID int64) (int64, er
 	ctx, span := s.tracer.Start(ctx, "folder.CountFoldersInOrg")
 	defer span.End()
 	return s.unifiedStore.CountInOrg(ctx, orgID)
-}
-
-func (s *Service) SearchFolders(ctx context.Context, q folder.SearchFoldersQuery) (model.HitList, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.SearchFolders")
-	defer span.End()
-	// TODO:
-	// - implement filtering by alerting folders and k6 folders (see the dashboards store `FindDashboards` method for reference)
-	// - implement fallback on search client in unistore to go to legacy store (will need to read from dashboard store)
-	return s.searchFoldersFromApiServer(ctx, q)
-}
-
-func (s *Service) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.GetFolders")
-	defer span.End()
-	return s.getFoldersFromApiServer(ctx, q)
-}
-
-func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.Get")
-	defer span.End()
-	return s.getFromApiServer(ctx, q)
 }
 
 func (s *Service) setFullpath(ctx context.Context, f *folder.Folder, forceLegacy bool) (*folder.Folder, error) {
@@ -162,12 +140,6 @@ func (s *Service) setFullpath(ctx context.Context, f *folder.Folder, forceLegacy
 	// Escape forward slashes in the title
 	f.Fullpath, f.FullpathUIDs = computeFullPath(append(parents, f))
 	return f, nil
-}
-
-func (s *Service) GetChildren(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.GetChildren")
-	defer span.End()
-	return s.getChildrenFromApiServer(ctx, q)
 }
 
 // GetSharedWithMe returns folders available to user, which cannot be accessed from the root folders
@@ -282,28 +254,6 @@ func (s *Service) deduplicateAvailableFolders(ctx context.Context, folders []*fo
 	return foldersDedup
 }
 
-func (s *Service) GetParents(ctx context.Context, q folder.GetParentsQuery) ([]*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.GetParents")
-	defer span.End()
-	return s.getParentsFromApiServer(ctx, q)
-}
-
-func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (*folder.Folder, error) {
-	return s.createOnApiServer(ctx, cmd)
-}
-
-func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.Update")
-	defer span.End()
-	return s.updateOnApiServer(ctx, cmd)
-}
-
-func (s *Service) Delete(ctx context.Context, cmd *folder.DeleteFolderCommand) error {
-	ctx, span := s.tracer.Start(ctx, "folder.Delete")
-	defer span.End()
-	return s.deleteFromApiServer(ctx, cmd)
-}
-
 func (s *Service) deleteChildrenInFolder(ctx context.Context, orgID int64, folderUIDs []string, user identity.Requester) error {
 	ctx, span := s.tracer.Start(ctx, "folder.deleteChildrenInFolder")
 	defer span.End()
@@ -313,18 +263,6 @@ func (s *Service) deleteChildrenInFolder(ctx context.Context, orgID int64, folde
 		}
 	}
 	return nil
-}
-
-func (s *Service) Move(ctx context.Context, cmd *folder.MoveFolderCommand) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.Move")
-	defer span.End()
-	return s.moveOnApiServer(ctx, cmd)
-}
-
-func (s *Service) GetDescendantCounts(ctx context.Context, q *folder.GetDescendantCountsQuery) (folder.DescendantCounts, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.GetDescendantCounts")
-	defer span.End()
-	return s.getDescendantCountsFromApiServer(ctx, q)
 }
 
 // SplitFullpath splits a string into an array of strings using the FULLPATH_SEPARATOR as the delimiter.

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -31,8 +31,8 @@ import (
 const folderSearchLimit = 100000
 const folderListLimit = 100000
 
-func (s *Service) getFoldersFromApiServer(ctx context.Context, q folder.GetFoldersQuery) ([]*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getFoldersFromApiServer")
+func (s *Service) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.GetFolders")
 	defer span.End()
 
 	if q.SignedInUser == nil {
@@ -72,8 +72,8 @@ func (s *Service) getFoldersFromApiServer(ctx context.Context, q folder.GetFolde
 	return dashFolders, nil
 }
 
-func (s *Service) getFromApiServer(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getFromApiServer")
+func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.Get")
 	defer span.End()
 
 	if q.SignedInUser == nil {
@@ -100,12 +100,12 @@ func (s *Service) getFromApiServer(ctx context.Context, q *folder.GetFolderQuery
 		}
 	// nolint:staticcheck
 	case q.ID != nil && *q.ID != 0:
-		dashFolder, err = s.getFolderByIDFromApiServer(ctx, *q.ID, q.OrgID)
+		dashFolder, err = s.getFolderByID(ctx, *q.ID, q.OrgID)
 		if err != nil {
 			return nil, toFolderError(err)
 		}
 	case q.Title != nil && *q.Title != "":
-		dashFolder, err = s.getFolderByTitleFromApiServer(ctx, q.OrgID, *q.Title, q.ParentUID)
+		dashFolder, err = s.getFolderByTitle(ctx, q.OrgID, *q.Title, q.ParentUID)
 		if err != nil {
 			return nil, toFolderError(err)
 		}
@@ -150,10 +150,13 @@ func (s *Service) getFromApiServer(ctx context.Context, q *folder.GetFolderQuery
 	return f, err
 }
 
-// searchFoldesFromApiServer uses the search grpc connection to search folders and returns the hit list
-func (s *Service) searchFoldersFromApiServer(ctx context.Context, query folder.SearchFoldersQuery) (model.HitList, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.searchFoldersFromApiServer")
+// SearchFolders uses the search grpc connection to search folders and returns the hit list
+func (s *Service) SearchFolders(ctx context.Context, query folder.SearchFoldersQuery) (model.HitList, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.SearchFolders")
 	defer span.End()
+	// TODO:
+	// - implement filtering by alerting folders and k6 folders (see the dashboards store `FindDashboards` method for reference)
+	// - implement fallback on search client in unistore to go to legacy store (will need to read from dashboard store)
 
 	if query.OrgID == 0 {
 		requester, err := identity.GetRequester(ctx)
@@ -234,8 +237,8 @@ func (s *Service) searchFoldersFromApiServer(ctx context.Context, query folder.S
 	return hitList, nil
 }
 
-func (s *Service) getFolderByIDFromApiServer(ctx context.Context, id int64, orgID int64) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getFolderByIDFromApiServer")
+func (s *Service) getFolderByID(ctx context.Context, id int64, orgID int64) (*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.getFolderByID")
 	defer span.End()
 
 	if id == 0 {
@@ -294,8 +297,8 @@ func (s *Service) returnFirstFolderSearchResult(ctx context.Context, orgID int64
 	return f, nil
 }
 
-func (s *Service) getFolderByTitleFromApiServer(ctx context.Context, orgID int64, title string, parentUID *string) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getFolderByTitleFromApiServer")
+func (s *Service) getFolderByTitle(ctx context.Context, orgID int64, title string, parentUID *string) (*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.getFolderByTitle")
 	defer span.End()
 
 	if title == "" {
@@ -349,8 +352,8 @@ func (s *Service) getFolderByTitleFromApiServer(ctx context.Context, orgID int64
 	return s.returnFirstFolderSearchResult(ctx, orgID, hits)
 }
 
-func (s *Service) getChildrenFromApiServer(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getChildrenFromApiServer")
+func (s *Service) GetChildren(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.GetChildren")
 	defer span.End()
 
 	if q.SignedInUser == nil {
@@ -362,7 +365,7 @@ func (s *Service) getChildrenFromApiServer(ctx context.Context, q *folder.GetChi
 	}
 
 	if q.UID == "" {
-		return s.getRootFoldersFromApiServer(ctx, q)
+		return s.getRootFolders(ctx, q)
 	}
 
 	// we only need to check access to the folder
@@ -386,8 +389,8 @@ func (s *Service) getChildrenFromApiServer(ctx context.Context, q *folder.GetChi
 	return children, nil
 }
 
-func (s *Service) getRootFoldersFromApiServer(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getRootFoldersFromApiServer")
+func (s *Service) getRootFolders(ctx context.Context, q *folder.GetChildrenQuery) ([]*folder.FolderReference, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.getRootFolders")
 	defer span.End()
 	permissions := q.SignedInUser.GetPermissions()
 	var folderPermissions []string
@@ -429,8 +432,8 @@ func (s *Service) getRootFoldersFromApiServer(ctx context.Context, q *folder.Get
 	return children, nil
 }
 
-func (s *Service) getParentsFromApiServer(ctx context.Context, q folder.GetParentsQuery) ([]*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getParentsFromApiServer")
+func (s *Service) GetParents(ctx context.Context, q folder.GetParentsQuery) ([]*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.GetParents")
 	defer span.End()
 
 	if q.UID == accesscontrol.GeneralFolderUID {
@@ -443,8 +446,8 @@ func (s *Service) getParentsFromApiServer(ctx context.Context, q folder.GetParen
 	return s.unifiedStore.GetParents(ctx, q)
 }
 
-func (s *Service) createOnApiServer(ctx context.Context, cmd *folder.CreateFolderCommand) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.createOnApiServer")
+func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.Create")
 	defer span.End()
 
 	if cmd.SignedInUser == nil || cmd.SignedInUser.IsNil() {
@@ -506,8 +509,8 @@ func (s *Service) createOnApiServer(ctx context.Context, cmd *folder.CreateFolde
 	return f, nil
 }
 
-func (s *Service) updateOnApiServer(ctx context.Context, cmd *folder.UpdateFolderCommand) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.updateOnApiServer")
+func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.Update")
 	defer span.End()
 
 	if cmd.SignedInUser == nil {
@@ -566,8 +569,8 @@ func (s *Service) updateOnApiServer(ctx context.Context, cmd *folder.UpdateFolde
 	return folder, nil
 }
 
-func (s *Service) deleteFromApiServer(ctx context.Context, cmd *folder.DeleteFolderCommand) error {
-	ctx, span := s.tracer.Start(ctx, "folder.deleteFromApiServer")
+func (s *Service) Delete(ctx context.Context, cmd *folder.DeleteFolderCommand) error {
+	ctx, span := s.tracer.Start(ctx, "folder.Delete")
 	defer span.End()
 
 	if cmd.SignedInUser == nil {
@@ -678,8 +681,8 @@ func (s *Service) deleteFromApiServer(ctx context.Context, cmd *folder.DeleteFol
 	return nil
 }
 
-func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCommand) (*folder.Folder, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.moveOnApiServer")
+func (s *Service) Move(ctx context.Context, cmd *folder.MoveFolderCommand) (*folder.Folder, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.Move")
 	defer span.End()
 
 	if cmd.SignedInUser == nil {
@@ -692,7 +695,7 @@ func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCom
 	}
 
 	// Check that the user is allowed to move the folder to the destination folder
-	hasAccess, evalErr := s.canMoveViaApiServer(ctx, cmd)
+	hasAccess, evalErr := s.canMove(ctx, cmd)
 	if evalErr != nil {
 		return nil, evalErr
 	}
@@ -712,8 +715,8 @@ func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCom
 	return f, nil
 }
 
-func (s *Service) canMoveViaApiServer(ctx context.Context, cmd *folder.MoveFolderCommand) (bool, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.canMoveViaApiServer")
+func (s *Service) canMove(ctx context.Context, cmd *folder.MoveFolderCommand) (bool, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.canMove")
 	defer span.End()
 
 	// Check that the user is allowed to move the folder to the destination folder
@@ -738,7 +741,7 @@ func (s *Service) canMoveViaApiServer(ctx context.Context, cmd *folder.MoveFolde
 	// This is needed for plugins, as different folders can have different plugin configs
 	// We do this by checking that there are no permissions that user has on the destination parent folder but not on the source folder
 	// We also need to look at the folder tree for the destination folder, as folder permissions are inherited
-	newFolderAndParentUIDs, err := s.getFolderAndParentUIDScopesViaApiServer(ctx, parentUID, cmd.OrgID)
+	newFolderAndParentUIDs, err := s.getFolderAndParentUIDScopes(ctx, parentUID, cmd.OrgID)
 	if err != nil {
 		return false, err
 	}
@@ -763,8 +766,8 @@ func (s *Service) canMoveViaApiServer(ctx context.Context, cmd *folder.MoveFolde
 	return true, nil
 }
 
-func (s *Service) getFolderAndParentUIDScopesViaApiServer(ctx context.Context, folderUID string, orgID int64) ([]string, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getFolderAndParentUIDScopesViaApiServer")
+func (s *Service) getFolderAndParentUIDScopes(ctx context.Context, folderUID string, orgID int64) ([]string, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.getFolderAndParentUIDScopes")
 	defer span.End()
 
 	folderAndParentUIDScopes := []string{folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)}
@@ -782,8 +785,8 @@ func (s *Service) getFolderAndParentUIDScopesViaApiServer(ctx context.Context, f
 	return folderAndParentUIDScopes, nil
 }
 
-func (s *Service) getDescendantCountsFromApiServer(ctx context.Context, q *folder.GetDescendantCountsQuery) (folder.DescendantCounts, error) {
-	ctx, span := s.tracer.Start(ctx, "folder.getDescendantCountsFromApiServer")
+func (s *Service) GetDescendantCounts(ctx context.Context, q *folder.GetDescendantCountsQuery) (folder.DescendantCounts, error) {
+	ctx, span := s.tracer.Start(ctx, "folder.GetDescendantCounts")
 	defer span.End()
 
 	if q.SignedInUser == nil {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -819,7 +819,7 @@ func TestSearchFolders(t *testing.T) {
 	})
 }
 
-func TestGetFolders(t *testing.T) {
+func TestGetFolderByTitle(t *testing.T) {
 	fakeK8sClient := new(client.MockK8sHandler)
 	folderStore := folder.NewFakeStore()
 	folderStore.ExpectedFolder = &folder.Folder{
@@ -827,7 +827,7 @@ func TestGetFolders(t *testing.T) {
 		ID:    2,
 		Title: "parent title",
 	}
-	tracer := noop.NewTracerProvider().Tracer("TestGetFolders")
+	tracer := noop.NewTracerProvider().Tracer("TestGetFolderByTitle")
 	service := Service{
 		k8sclient:     fakeK8sClient,
 		features:      featuremgmt.WithFeatures(),

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -573,7 +573,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 	})
 }
 
-func TestSearchFoldersFromApiServer(t *testing.T) {
+func TestSearchFolders(t *testing.T) {
 	fakeK8sClient := new(client.MockK8sHandler)
 	folderStore := folder.NewFakeStore()
 	folderStore.ExpectedFolder = &folder.Folder{
@@ -581,7 +581,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 		ID:    2,
 		Title: "parent title",
 	}
-	tracer := noop.NewTracerProvider().Tracer("TestSearchFoldersFromApiServer")
+	tracer := noop.NewTracerProvider().Tracer("TestSearchFolders")
 	service := Service{
 		k8sclient:     fakeK8sClient,
 		features:      featuremgmt.WithFeatures(),
@@ -653,7 +653,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 			IDs:          []int64{1, 2}, // will ignore these because uid is passed in
 			SignedInUser: user,
 		}
-		result, err := service.searchFoldersFromApiServer(ctx, query)
+		result, err := service.SearchFolders(ctx, query)
 		require.NoError(t, err)
 
 		expectedResult := model.HitList{
@@ -730,7 +730,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 			TotalHits: 1,
 		}, nil).Once()
 
-		result, err := service.searchFoldersFromApiServer(ctx, query)
+		result, err := service.SearchFolders(ctx, query)
 		require.NoError(t, err)
 		expectedResult := model.HitList{
 			{
@@ -800,7 +800,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 			Title:        "test",
 			SignedInUser: user,
 		}
-		result, err := service.searchFoldersFromApiServer(ctx, query)
+		result, err := service.SearchFolders(ctx, query)
 		require.NoError(t, err)
 
 		expectedResult := model.HitList{
@@ -819,7 +819,7 @@ func TestSearchFoldersFromApiServer(t *testing.T) {
 	})
 }
 
-func TestGetFoldersFromApiServer(t *testing.T) {
+func TestGetFolders(t *testing.T) {
 	fakeK8sClient := new(client.MockK8sHandler)
 	folderStore := folder.NewFakeStore()
 	folderStore.ExpectedFolder = &folder.Folder{
@@ -827,7 +827,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 		ID:    2,
 		Title: "parent title",
 	}
-	tracer := noop.NewTracerProvider().Tracer("TestGetFoldersFromApiServer")
+	tracer := noop.NewTracerProvider().Tracer("TestGetFolders")
 	service := Service{
 		k8sclient:     fakeK8sClient,
 		features:      featuremgmt.WithFeatures(),
@@ -887,7 +887,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 				TotalHits: 1,
 			}, nil).Once()
 
-		_, err := service.getFolderByTitleFromApiServer(ctx, 1, "foo title", nil)
+		_, err := service.getFolderByTitle(ctx, 1, "foo title", nil)
 		// Since parentUID=nil and there's no top-level folder with the name, we return folder not found error.
 		require.Error(t, err, dashboards.ErrFolderNotFound)
 		fakeK8sClient.AssertExpectations(t)
@@ -944,7 +944,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 			}, nil).Once()
 
 		parentid := "parentuid"
-		result, err := service.getFolderByTitleFromApiServer(ctx, 1, "foo title", &parentid)
+		result, err := service.getFolderByTitle(ctx, 1, "foo title", &parentid)
 		require.NoError(t, err)
 
 		expectedResult := &folder.Folder{
@@ -960,7 +960,7 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 	})
 }
 
-func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
+func TestIntegrationDeleteFolders(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	fakeK8sClient := new(client.MockK8sHandler)
@@ -968,7 +968,7 @@ func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
 	dashboardK8sclient := new(client.MockK8sHandler)
 	fakeFolderStore := folder.NewFakeStore()
 	publicDashboardFakeService := publicdashboards.NewFakePublicDashboardServiceWrapper(t)
-	tracer := noop.NewTracerProvider().Tracer("TestDeleteFoldersFromApiServer")
+	tracer := noop.NewTracerProvider().Tracer("TestDeleteFolders")
 	service := Service{
 		k8sclient:              fakeK8sClient,
 		dashboardK8sClient:     dashboardK8sclient,
@@ -1006,7 +1006,7 @@ func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
 	t.Run("Should delete folder", func(t *testing.T) {
 		publicDashboardFakeService.On("DeleteByDashboardUIDs", mock.Anything, int64(1), []string{}).Return(nil).Once()
 		dashboardK8sclient.On("Search", mock.Anything, int64(1), mock.Anything).Return(&resourcepb.ResourceSearchResponse{Results: &resourcepb.ResourceTable{}}, nil).Once()
-		err := service.deleteFromApiServer(ctx, &folder.DeleteFolderCommand{
+		err := service.Delete(ctx, &folder.DeleteFolderCommand{
 			UID:          "uid1",
 			OrgID:        1,
 			SignedInUser: user,
@@ -1070,7 +1070,7 @@ func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
 			TotalHits: 1,
 		}, nil).Once()
 		publicDashboardFakeService.On("DeleteByDashboardUIDs", mock.Anything, int64(1), []string{"test", "test2"}).Return(nil).Once()
-		err := service.deleteFromApiServer(ctx, &folder.DeleteFolderCommand{
+		err := service.Delete(ctx, &folder.DeleteFolderCommand{
 			UID:          "uid",
 			OrgID:        1,
 			SignedInUser: user,


### PR DESCRIPTION
This is a no-op refactor that removes mentions to `ApiServer` from Folder Service method names.

These mentions to ApiServer are leftovers from past refactors and are not needed anymore, since that everything goes through the Folder Api Server now.


### Context
When the Folder Service started to dual write to both Legacy and Unified Storage, we extended the interface to accomodate Legacy methods, as follows:

```
type Service interface {
	RegisterService(service RegistryService) error

	Create(ctx context.Context, cmd *CreateFolderCommand) (*Folder, error)
	CreateLegacy(ctx context.Context, cmd *CreateFolderCommand) (*Folder, error)
```

Taking `Create` as an example, the idea was that the legacy implementation (SQL backend)  would be kept intact in `CreateLegacy()`, while `Create()` would be the main entry point, in where we could decide if requests would be sent to the Folder Api Server (`s.createOnApiServer()`) or it would be handled by the Legacy implementation (`s.LegacyCreate`)

Recently, we removed the Legacy code and now everything goes to the Folder API Server, which eliminates the need of having `Create()` as a thin wrapper for `createOnApiServer`

This PR simply moves the actual implementation, that today lives in internal methods, back to the original methods.

For reference (Original method -> internal method)
```
SearchFolders -> searchFoldersFromApiServer
GetFolders -> getFoldersFromApiServer
Get -> getFromApiServer
GetChildren -> getChildrenFromApiServer
GetParents -> getParentsFromApiServer
Create -> createOnApiServer
Update -> updateOnApiServer
Delete -> deleteFromApiServer
```