### PR TITLE
Combobox: Fix portal z-index, initial open, explicit width

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,7 +1,6 @@
-import { cx } from '@emotion/css';
 import { useVirtualizer, type Range } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
-import React, { type ComponentProps, useCallback, useId, useMemo } from 'react';
+import React, { type ComponentProps, useCallback, useId, useLayoutEffect, useMemo, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 
@@ -389,6 +388,34 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     </>
   );
 
+  const [list, setList] = useState<React.ReactNode>();
+
+  useLayoutEffect(() => {
+    isOpen &&
+      setList(
+        <ComboboxList
+          loading={loading}
+          options={filteredOptions}
+          highlightedIndex={highlightedIndex}
+          selectedItems={selectedItem ? [selectedItem] : []}
+          scrollRef={scrollRef}
+          getItemProps={getItemProps}
+          error={asyncError}
+          noOptionsMessage={noOptionsMessage}
+        />
+      );
+  }, [
+    asyncError,
+    filteredOptions,
+    getItemProps,
+    highlightedIndex,
+    isOpen,
+    loading,
+    noOptionsMessage,
+    scrollRef,
+    selectedItem,
+  ]);
+
   const { Wrapper, wrapperProps } = isAutoSize
     ? {
         Wrapper: 'div',
@@ -417,32 +444,23 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
           'data-testid': dataTestId,
         })}
       />
-      <Portal root={portalContainer}>
-        <div
-          className={cx(styles.menu, !isOpen && styles.menuClosed)}
-          style={{
-            ...floatStyles,
-            pointerEvents: 'auto', // Override container's pointer-events: none
-          }}
-          {...getMenuProps({
-            ref: floatingRef,
-            'aria-labelledby': ariaLabelledBy,
-          })}
-        >
-          {isOpen && (
-            <ComboboxList
-              loading={loading}
-              options={filteredOptions}
-              highlightedIndex={highlightedIndex}
-              selectedItems={selectedItem ? [selectedItem] : []}
-              scrollRef={scrollRef}
-              getItemProps={getItemProps}
-              error={asyncError}
-              noOptionsMessage={noOptionsMessage}
-            />
-          )}
-        </div>
-      </Portal>
+      {isOpen && (
+        <Portal root={portalContainer}>
+          <div
+            className={styles.menu}
+            style={{
+              ...floatStyles,
+              pointerEvents: 'auto', // Override container's pointer-events: none
+            }}
+            {...getMenuProps({
+              ref: floatingRef,
+              'aria-labelledby': ariaLabelledBy,
+            })}
+          >
+            {list}
+          </div>
+        </Portal>
+      )}
     </Wrapper>
   );
 };

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -19,9 +19,6 @@ export const POPOVER_MAX_HEIGHT = MENU_OPTION_HEIGHT * 8.5;
 
 export const getComboboxStyles = (theme: GrafanaTheme2) => {
   return {
-    menuClosed: css({
-      display: 'none',
-    }),
     menu: css({
       label: 'combobox-menu',
       background: theme.components.dropdown.background,

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -48,7 +48,7 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
     suffix: suffixProp,
     invalid,
     loading,
-    width = 0,
+    width,
     ...restProps
   } = props;
   /**
@@ -80,7 +80,7 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
       className={cx(styles.wrapper, className)}
       // If the component is in an AutoSizeInput, set the width here to prevent emotion doing stuff
       // on every keypress
-      style={autoSizeWidth ? { width: theme.spacing(autoSizeWidth) } : undefined}
+      style={{ width: autoSizeWidth ? theme.spacing(autoSizeWidth) : width }}
       data-testid="input-wrapper"
     >
       {!!addonBefore && <div className={styles.addon}>{addonBefore}</div>}


### PR DESCRIPTION
(extracted from #122047)

here are some fixes that were necessary to unblock above PR. def let me know if any of this is just me holding Combobox wrong :)

there are several fixes here.

1. the Comobox's portal is initialized too soon (before `isOpen`), so when the popup is opened it ends up underneath other portals. the fix here was to defer creating the portal until `isOpen`. here is what it looked like without the fix when i swapped out time selection in DateTimePicker (which has its own portal) for the Combobox component:
    <img width="1167" height="1090" alt="image" src="https://github.com/user-attachments/assets/c826f82c-d2b9-42c1-b485-186f1d8b0fc1" />
2. after fixing the prior issue, i saw a lot of flakiness with initial open and then intermittently incorrect positioning of the menu on follow up re-opens. i fixed this by letting the portal creation happen first, and then populating the menu in a `useLayoutEffect`. this now works as expected.
3. i was not able to specify a `width={100}` that was respected (see previous screenshot). neither an explicit number width nor `width="auto"` with `minWidth={100}` and `maxWidth={100}`. looking deeper, the `width` css prop was never actually set inside the Input component. i'm not sure if this is the correct fix but it did work as expected. both in the DateTimePicker as well as the dashboard time regions settings.

there is another potential bug that i havent looked into which affects dashboard time region settings when used with combobox. in that case the menu opens upwards even though there is plenty of available viewport space below:

<img width="1034" height="1802" alt="image" src="https://github.com/user-attachments/assets/6f745c27-b592-46ff-8050-9b323299b90c" />

