### PR TITLE
[release-12.3.7] fix(deps): update dependency lodash to v4.18.1 [security]

### DIFF
--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -24,7 +24,7 @@
     "@grafana/ui": "12.3.8",
     "@react-awesome-query-builder/ui": "6.6.15",
     "immutable": "5.1.4",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-select": "5.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,7 +3672,7 @@ __metadata:
     i18next-cli: "npm:1.11.12"
     immutable: "npm:5.1.4"
     jest: "npm:^29.6.4"
-    lodash: "npm:^4.17.23"
+    lodash: "npm:^4.18.1"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-select: "npm:5.10.2"
@@ -23270,6 +23270,13 @@ __metadata:
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23266,17 +23266,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4, lodash@npm:^4.1.1, lodash@npm:^4.15.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.23, lodash@npm:^4.17.4, lodash@npm:~4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.18.1":
+"lodash@npm:^4, lodash@npm:^4.1.1, lodash@npm:^4.15.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.23, lodash@npm:^4.17.4, lodash@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
+  languageName: node
+  linkType: hard
+
+"lodash@npm:~4.17.21":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Manual backport 3caa9bb55d09067c7166ff9b3fc944f1368ba376 from #121737.

The remaining version of lodash 4.17.x is used by pally which is CI tooling and shouldn't make its way into prod js assets.

Note: Backporting these in the majority of cases won't have the same effect the original PR has on main due to conflicting yarn.lock changes. Running `yarn install` doesn't always fix merge conflicts as expected, resulting in the vulnerable version remaining.