### PR TITLE
[release-12.3.7] Deps: Bump Lodash es

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23141,9 +23141,9 @@ __metadata:
   linkType: hard
 
 "lodash-es@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10/03f39878ea1e42b3199bd3f478150ab723f93cc8730ad86fec1f2804f4a07c6e30deaac73cad53a88e9c3db33348bb8ceeb274552390e7a75d7849021c02df43
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10/8bfad225ef09ef42b04283cdaf7830efcc2ba29ae41b56501c74422155ee1ccaa1f0f6e8319def3451a1fe54dec501c8e4bee622bae2b2d98ac993731e0a5cce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport a1489a583c5523f75f885980e4496c705d7f3c69 from #121723

---

Bumps lodash-es, inside monaco kusto, to 4.18.1
