### PR TITLE
[release-12.3.7]  chore: update react-router-dom-v5-compat

### DIFF
--- a/packages/grafana-ui/src/components/Link/TextLink.test.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.test.tsx
@@ -36,6 +36,8 @@ describe('TextLink', () => {
     expect(screen.getByRole('link')).toHaveAttribute('href', link);
   });
   it('should turn it into a relative url, if not external', () => {
+    //Adding this due to React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     locationUtil.initialize({
       config: { appSubUrl: '/grafana' } as GrafanaConfig,
       getVariablesUrlParams: jest.fn(),
@@ -47,6 +49,7 @@ describe('TextLink', () => {
         <TextLink href={link}>Link to Grafana</TextLink>
       </MemoryRouter>
     );
+    jest.spyOn(console, 'warn').mockRestore();
     expect(screen.getByRole('link')).toHaveAttribute('href', '/after-sub-url');
   });
   it('should fire onclick', async () => {

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.test.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.test.tsx
@@ -23,6 +23,8 @@ describe('VizTooltipFooter', () => {
       origin: field,
       target: undefined,
     };
+    //Adding this due to React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(
       <MemoryRouter>
@@ -31,6 +33,7 @@ describe('VizTooltipFooter', () => {
     );
     await userEvent.click(screen.getByRole('link'));
     expect(onClick).toHaveBeenCalled();
+    jest.spyOn(console, 'warn').mockRestore();
   });
 
   it('should render ad hoc filter button and fire onclick', async () => {

--- a/public/app/features/admin/Users/UsersTable.test.tsx
+++ b/public/app/features/admin/Users/UsersTable.test.tsx
@@ -26,7 +26,10 @@ const setup = (propOverrides?: object) => {
 
 describe('Render', () => {
   it('should render component', () => {
+    //Adding this due to React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     expect(() => setup()).not.toThrow();
+    jest.spyOn(console, 'warn').mockRestore();
   });
 
   it('should render when user has licensed role None', () => {

--- a/public/app/features/alerting/unified/hooks/useReturnTo.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useReturnTo.test.tsx
@@ -12,9 +12,12 @@ describe('useReturnTo', () => {
   });
 
   it('should return the fallback value when `returnTo` is not present in the query string', () => {
+    //Adding this due to React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { result } = renderHook(() => useReturnTo('/fallback'), { wrapper: MemoryRouter });
 
     expect(result.current.returnTo).toBe('/fallback');
+    jest.spyOn(console, 'warn').mockRestore();
   });
 
   it('should return the sanitized `returnTo` value when it is present in the query string and is a valid URL within the Grafana app', () => {

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
@@ -25,6 +25,8 @@ describe('ScopesNavigationTreeLink', () => {
   });
 
   it('renders link with correct props', () => {
+    //Adding this due to React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     renderWithRouter(<ScopesNavigationTreeLink to="/test-path" title="Test Link" id="test-id" />);
 
     const link = screen.getByTestId('scopes-dashboards-test-id');
@@ -32,6 +34,7 @@ describe('ScopesNavigationTreeLink', () => {
     expect(link).toHaveAttribute('href', '/test-path');
     expect(link).toHaveAttribute('role', 'treeitem');
     expect(link).toHaveTextContent('Test Link');
+    jest.spyOn(console, 'warn').mockRestore();
   });
 
   it('sets aria-current when path matches', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,13 +7156,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.19.1":
-  version: 1.19.1
-  resolution: "@remix-run/router@npm:1.19.1"
-  checksum: 10/2800c2f6567a982fe942aacc4cb5b170e7cc89bd455960e3bea2424161ff7dac32d01886322d88dd19b88d1bea711f39566d17f02b73eeb74999affb471f8f52
-  languageName: node
-  linkType: hard
-
 "@remix-run/router@npm:1.23.2":
   version: 1.23.2
   resolution: "@remix-run/router@npm:1.23.2"
@@ -28595,17 +28588,17 @@ __metadata:
   linkType: hard
 
 "react-router-dom-v5-compat@npm:^6.26.1":
-  version: 6.26.1
-  resolution: "react-router-dom-v5-compat@npm:6.26.1"
+  version: 6.30.3
+  resolution: "react-router-dom-v5-compat@npm:6.30.3"
   dependencies:
-    "@remix-run/router": "npm:1.19.1"
+    "@remix-run/router": "npm:1.23.2"
     history: "npm:^5.3.0"
-    react-router: "npm:6.26.1"
+    react-router: "npm:6.30.3"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
     react-router-dom: 4 || 5
-  checksum: 10/c8249404e0b219ff00797ae0ff8818394a07309b62617a9a4e47d5a8769801098431ceec38eca8c712cbee4a04843326cb2334ed15ea08b7848b5ce5a58ad0a3
+  checksum: 10/af355cb7c38541c0766a23a140d431537fdeb5c4bda29a45a16242704731875d2ae8bfb96e0bedeb7232a2b6ebe710c47a090aea58f235258b22fbb9e48e903e
   languageName: node
   linkType: hard
 
@@ -28655,17 +28648,6 @@ __metadata:
   peerDependencies:
     react: ">=15"
   checksum: 10/99d54a99af6bc6d7cad2e5ea7eee9485b62a8b8e16a1182b18daa7fad7dafa5e526850eaeebff629848b297ae055a9cb5b4aba8760e81af8b903efc049d48f5c
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.26.1":
-  version: 6.26.1
-  resolution: "react-router@npm:6.26.1"
-  dependencies:
-    "@remix-run/router": "npm:1.19.1"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10/b3761515c75da65a1678f005d08a6285ceccd9df7237ae6fdd9ab2ab816ef328435b75610f705ecd9ecd41c6878fd22eb9b44c5391cdef2e1ed99ddbc78de8a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
A manual backport equivalent to #112800