### PR TITLE
Starred: Fix dashboard name not updating in nav sidebar after rename

### DIFF
--- a/public/app/core/reducers/navBarTree.test.ts
+++ b/public/app/core/reducers/navBarTree.test.ts
@@ -1,0 +1,63 @@
+import { type NavModelItem } from '@grafana/data';
+
+import { ID_PREFIX, navTreeReducer, setStarred, updateDashboardName } from './navBarTree';
+
+function buildState(starredChildren: NavModelItem[] = []): NavModelItem[] {
+  return [
+    { id: 'home', text: 'Home', url: '/' },
+    { id: 'starred', text: 'Starred', children: starredChildren },
+  ];
+}
+
+describe('navBarTree reducer', () => {
+  describe('setStarred', () => {
+    it('adds a starred item with the ID_PREFIX', () => {
+      const state = buildState();
+      const next = navTreeReducer(state, setStarred({ id: 'abc', title: 'My Dash', url: '/d/abc', isStarred: true }));
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children).toHaveLength(1);
+      expect(starred?.children?.[0]).toMatchObject({ id: 'starred/abc', text: 'My Dash', url: '/d/abc' });
+    });
+
+    it('removes a starred item by prefixed ID', () => {
+      const state = buildState([{ id: ID_PREFIX + 'abc', text: 'My Dash', url: '/d/abc' }]);
+      const next = navTreeReducer(state, setStarred({ id: 'abc', title: '', url: '', isStarred: false }));
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children).toHaveLength(0);
+    });
+  });
+
+  describe('updateDashboardName', () => {
+    it('updates a starred item matching ID_PREFIX + id', () => {
+      const state = buildState([{ id: ID_PREFIX + 'abc', text: 'Old Name', url: '/d/abc/old-name' }]);
+      const next = navTreeReducer(state, updateDashboardName({ id: 'abc', title: 'New Name', url: '/d/abc/new-name' }));
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children?.[0]).toMatchObject({
+        id: 'starred/abc',
+        text: 'New Name',
+        url: '/d/abc/new-name',
+      });
+    });
+
+    it('no-ops when the dashboard is not starred', () => {
+      const state = buildState([{ id: ID_PREFIX + 'other', text: 'Other Dash', url: '/d/other' }]);
+      const next = navTreeReducer(state, updateDashboardName({ id: 'abc', title: 'New Name', url: '/d/abc/new-name' }));
+      const starred = next.find((n) => n.id === 'starred');
+      expect(starred?.children).toHaveLength(1);
+      expect(starred?.children?.[0]).toMatchObject({ id: 'starred/other', text: 'Other Dash', url: '/d/other' });
+    });
+
+    it('re-sorts children after rename', () => {
+      const state = buildState([
+        { id: ID_PREFIX + 'a', text: 'Alpha', url: '/d/a' },
+        { id: ID_PREFIX + 'b', text: 'Beta', url: '/d/b' },
+        { id: ID_PREFIX + 'c', text: 'Charlie', url: '/d/c' },
+      ]);
+      // Rename 'Alpha' to 'Zulu' — should move to end
+      const next = navTreeReducer(state, updateDashboardName({ id: 'a', title: 'Zulu', url: '/d/a/zulu' }));
+      const starred = next.find((n) => n.id === 'starred');
+      const names = starred?.children?.map((c) => c.text);
+      expect(names).toEqual(['Beta', 'Charlie', 'Zulu']);
+    });
+  });
+});

--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -76,7 +76,7 @@ const navTreeSlice = createSlice({
       const { id, title, url } = action.payload;
       const starredItems = state.find((navItem) => navItem.id === 'starred');
       if (starredItems) {
-        const navItem = starredItems.children?.find((navItem) => navItem.id === id);
+        const navItem = starredItems.children?.find((navItem) => navItem.id === ID_PREFIX + id);
         if (navItem) {
           navItem.text = title;
           navItem.url = url;

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -14,7 +14,7 @@ import { appEvents } from 'app/core/app_events';
 import { buildNotificationButton } from 'app/core/components/AppNotifications/NotificationButton';
 import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
-import { setStarred } from 'app/core/reducers/navBarTree';
+import { setStarred, updateDashboardName } from 'app/core/reducers/navBarTree';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AnnoKeyFolder, type Resource, type ResourceList } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -479,10 +479,14 @@ export const browseDashboardsAPI = createApi({
         }
       },
 
-      onQueryStarted: ({ folderUid }, { queryFulfilled, dispatch }) => {
+      onQueryStarted: ({ folderUid, dashboard }, { queryFulfilled, dispatch }) => {
         dashboardWatcher.ignoreNextSave();
         queryFulfilled.then(async ({ data }) => {
-          await contextSrv.fetchUserPermissions();
+          try {
+            await contextSrv.fetchUserPermissions();
+          } catch (err) {
+            console.error('Failed to refresh user permissions after save', err);
+          }
           dispatch(
             refetchChildren({
               parentUID: folderUid,
@@ -492,6 +496,12 @@ export const browseDashboardsAPI = createApi({
           // version 1 means a newly created dashboard — only then does the resource count change
           if (data.version === 1) {
             invalidateQuotaUsage(dispatch);
+          }
+          // Update starred dashboard name in nav sidebar (no-ops if dashboard isn't starred)
+          const title = dashboard.title;
+          if (title && data.url) {
+            const url = locationUtil.stripBaseFromUrl(data.url);
+            dispatch(updateDashboardName({ id: data.uid, title, url }));
           }
         });
       },

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -7,14 +7,12 @@ import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { appEvents } from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
-import { updateDashboardName } from 'app/core/reducers/navBarTree';
 import { useSaveDashboardMutation } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import {
   type SaveDashboardAsOptions,
   type SaveDashboardOptions,
 } from 'app/features/dashboard/components/SaveDashboard/types';
 import { DashboardSavedEvent } from 'app/types/events';
-import { useDispatch } from 'app/types/store';
 
 import { updateDashboardUidLastUsedDatasource } from '../../dashboard/utils/dashboard';
 import { type DashboardScene } from '../scene/DashboardScene';
@@ -22,7 +20,6 @@ import { DashboardInteractions } from '../utils/interactions';
 import { trackDashboardSceneCreatedOrSaved } from '../utils/tracking';
 
 export function useSaveDashboard(isCopy = false) {
-  const dispatch = useDispatch();
   const notifyApp = useAppNotification();
   const [saveDashboardRtkQuery] = useSaveDashboardMutation();
 
@@ -100,20 +97,10 @@ export function useSaveDashboard(isCopy = false) {
           });
         }
 
-        if (scene.state.meta.isStarred) {
-          dispatch(
-            updateDashboardName({
-              id: resultData.uid,
-              title: scene.state.title,
-              url: newUrl,
-            })
-          );
-        }
-
         return result.data;
       }
     },
-    [dispatch, notifyApp]
+    [notifyApp]
   );
 
   return { state, onSaveDashboard };

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -7,12 +7,10 @@ import { locationService } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
-import { updateDashboardName } from 'app/core/reducers/navBarTree';
 import { useSaveDashboardMutation } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 import { DashboardSavedEvent } from 'app/types/events';
-import { useDispatch } from 'app/types/store';
 
 import { updateDashboardUidLastUsedDatasource } from '../../utils/dashboard';
 import { trackDashboardCreatedOrSaved } from '../../utils/tracking';
@@ -41,7 +39,6 @@ const saveDashboard = async (
 };
 
 export const useDashboardSave = (isCopy = false) => {
-  const dispatch = useDispatch();
   const notifyApp = useAppNotification();
   const [saveDashboardRtkQuery] = useSaveDashboardMutation();
   const [state, onDashboardSave] = useAsyncFn(
@@ -80,15 +77,6 @@ export const useDashboardSave = (isCopy = false) => {
         if (newUrl !== currentPath && result.url) {
           setTimeout(() => locationService.replace(newUrl));
         }
-        if (dashboard.meta.isStarred) {
-          dispatch(
-            updateDashboardName({
-              id: dashboard.uid,
-              title: dashboard.title,
-              url: newUrl,
-            })
-          );
-        }
         return result;
       } catch (error) {
         if (error instanceof Error) {
@@ -97,7 +85,7 @@ export const useDashboardSave = (isCopy = false) => {
         throw error;
       }
     },
-    [dispatch, notifyApp]
+    [notifyApp]
   );
 
   return { state, onDashboardSave };


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review, please fill out this template.
-->

**What is this feature?**

Fixes a bug where renaming a starred dashboard does not update its name in the navigation sidebar. The sidebar kept showing the old name until page reload.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/grafana/issues/122220