### PR TITLE
fix(Modal): remove backgroundClip causing transparent border gap

### DIFF
--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -11,7 +11,6 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
       boxShadow: theme.shadows.z3,
       borderRadius: theme.shape.radius.lg,
       border: `1px solid ${theme.colors.border.weak}`,
-      backgroundClip: 'padding-box',
       outline: 'none',
       width: '750px',
       maxWidth: '100%',


### PR DESCRIPTION
## Summary

Fixes #102190

The modal had `backgroundClip: 'padding-box'` which prevented the modal's background color from extending under the border area. Since `theme.colors.border.weak` uses a semi-transparent `rgba` value, the page content behind the modal was visible through the border, creating a visual "gap" in the backdrop overlay.

**The fix**: Remove `backgroundClip: 'padding-box'` from the modal styles. With the default `backgroundClip: border-box`, the modal's opaque background now extends under the border. The semi-transparent border blends with the modal background (which is opaque) instead of the page content underneath, eliminating the gap effect.

This is a minimal, single-line change that resolves the visual artifact without needing to change any theme border tokens.

## Test plan

- [ ] Open any modal in Grafana (e.g. a survey modal, settings dialog)
- [ ] Place it over bright/colorful content
- [ ] Verify the modal border no longer shows underlying content bleeding through
- [ ] Check both dark and light themes
- [ ] Verify modal border radius still renders correctly (no clipping artifacts)