### PR TITLE
fix: remove intermediary type from datasource migration

### DIFF
--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -63,6 +63,12 @@ func ProvideDataSourceMigrator(
 					return nil, fmt.Errorf("converting datasource %s (type=%s): %w", ds.UID, ds.Type, err)
 				}
 
+				// AsDataSource does not set APIVersion when the legacy datasource has none.
+				// Set it explicitly so MigrateDataSources can recover the group.
+				if obj.APIVersion == "" {
+					obj.APIVersion = group + "/" + datasourceV0.VERSION
+				}
+
 				// Override Secure with plaintext Create values. AsDataSource sets stub
 				// Name-references from SecureJsonData keys; we replace them with actual
 				// secret creation requests carrying the decrypted plaintext values.
@@ -108,36 +114,38 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	// Clean up any existing secrets in the MT secret service
 	plugins := map[string]bool{}
 	for _, ds := range dsList {
-		dsType := ds.Spec.GetString("type")
-		if !plugins[dsType] {
+		gv, err := schema.ParseGroupVersion(ds.APIVersion)
+		if err != nil {
+			return fmt.Errorf("invalid apiVersion for datasource %s: %w", ds.Name, err)
+		}
+		apiGroup := gv.Group
+		if !plugins[apiGroup] {
 			if err = m.secretStore.DeleteWhenOwnedByResource(ctx, common.ObjectReference{
-				APIGroup:   dsType + ".datasource.grafana.app",
+				APIGroup:   apiGroup,
 				APIVersion: datasourceV0.VERSION,
 				Namespace:  opts.Namespace,
 				Kind:       "DataSource",
 				Name:       "*",
 				UID:        "*",
 			}, "*"); err != nil {
-				return fmt.Errorf("error deleting secrets for datasource type %s: %w", dsType, err)
+				return fmt.Errorf("error deleting secrets for datasource type %s: %w", apiGroup, err)
 			}
 		}
-		plugins[dsType] = true
+		plugins[apiGroup] = true
 	}
 
 	for count, ds := range dsList {
-		dsType := ds.Spec.GetString("type")
-		group := dsType + ".datasource.grafana.app"
+		gv, err := schema.ParseGroupVersion(ds.APIVersion)
+		if err != nil {
+			return fmt.Errorf("invalid apiVersion for datasource %s: %w", ds.Name, err)
+		}
+		group := gv.Group
 
 		// Shallow-copy the struct so we can set TypeMeta without mutating the slice element.
 		obj := *ds
 		obj.TypeMeta = metav1.TypeMeta{
-			APIVersion: group + "/" + datasourceV0.VERSION,
+			APIVersion: ds.APIVersion,
 			Kind:       "DataSource",
-		}
-
-		gv, err := schema.ParseGroupVersion(obj.APIVersion)
-		if err != nil {
-			return fmt.Errorf("invalid apiVersion: %w", err)
 		}
 
 		if len(ds.Secure) > 0 {
@@ -151,7 +159,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 			}
 			secure, err := m.createSecrets(ctx, ds.Secure, objRef)
 			if err != nil {
-				return fmt.Errorf("error create secrets for datasource %s (type=%s): %w, %#v", ds.Name, dsType, err, obj)
+				return fmt.Errorf("error create secrets for datasource %s (group=%s): %w, %#v", ds.Name, group, err, obj)
 			}
 			obj.Secure = secure
 		}
@@ -172,7 +180,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 			Action: resourcepb.BulkRequest_ADDED,
 		}
 
-		opts.Progress(count, fmt.Sprintf("%s/%s (%d) %s", dsType, obj.Spec.Title(), len(req.Value), req.Key))
+		opts.Progress(count, fmt.Sprintf("%s/%s (%d) %s", group, obj.Spec.Title(), len(req.Value), req.Key))
 
 		err = stream.Send(req)
 		if err != nil {

--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -25,7 +25,7 @@ type DataSourceMigrator interface {
 }
 
 type dataSourceMigrator struct {
-	getter      func(ctx context.Context, namespace string) ([]*datasources.DataSource, error)
+	getter      func(ctx context.Context, namespace string) ([]*datasourceV0.DataSource, error)
 	secretStore secret.InlineSecureValueSupport
 }
 
@@ -35,7 +35,7 @@ func ProvideDataSourceMigrator(
 	secretStore secret.InlineSecureValueSupport,
 ) DataSourceMigrator {
 	return &dataSourceMigrator{
-		getter: func(ctx context.Context, namespace string) ([]*datasources.DataSource, error) {
+		getter: func(ctx context.Context, namespace string) ([]*datasourceV0.DataSource, error) {
 			orgId, err := migrations.ParseOrgIDFromNamespace(namespace)
 			if err != nil {
 				return nil, err
@@ -48,19 +48,35 @@ func ProvideDataSourceMigrator(
 				return nil, err
 			}
 
-			result := make([]*datasources.DataSource, len(dss))
+			namespacer := func(_ int64) string { return namespace }
+			result := make([]*datasourceV0.DataSource, len(dss))
 			for i, ds := range dss {
 				dsSecrets, err := dsService.DecryptedValues(ctx, ds)
 				if err != nil {
 					return nil, fmt.Errorf("error decrypting existing secrets for datasource %s (type=%s): %w", ds.UID, ds.Type, err)
 				}
-				// Always replace SecureJsonData with decrypted plaintext values so
-				// that the migrator never operates on stale encrypted bytes from the DB.
-				ds.SecureJsonData = make(map[string][]byte, len(dsSecrets))
-				for k, v := range dsSecrets {
-					ds.SecureJsonData[k] = []byte(v)
+
+				group := ds.Type + ".datasource.grafana.app"
+				conv := converter.NewConverter(namespacer, group, ds.Type, nil)
+				obj, err := conv.AsDataSource(ds)
+				if err != nil {
+					return nil, fmt.Errorf("converting datasource %s (type=%s): %w", ds.UID, ds.Type, err)
 				}
-				result[i] = ds
+
+				// Override Secure with plaintext Create values. AsDataSource sets stub
+				// Name-references from SecureJsonData keys; we replace them with actual
+				// secret creation requests carrying the decrypted plaintext values.
+				obj.Secure = nil
+				for k, v := range dsSecrets {
+					if v != "" {
+						if obj.Secure == nil {
+							obj.Secure = make(common.InlineSecureValues)
+						}
+						obj.Secure[k] = common.InlineSecureValue{Create: common.NewSecretValue(v)}
+					}
+				}
+
+				result[i] = obj
 			}
 			return result, nil
 		},
@@ -70,7 +86,7 @@ func ProvideDataSourceMigrator(
 
 // This is useful for the cloud controller, where we populate values from cloudconfig
 func NewDataSourceMigrator(
-	getter func(ctx context.Context, namespace string) ([]*datasources.DataSource, error),
+	getter func(ctx context.Context, namespace string) ([]*datasourceV0.DataSource, error),
 	secretStore secret.InlineSecureValueSupport,
 ) DataSourceMigrator {
 	return &dataSourceMigrator{
@@ -84,42 +100,36 @@ func NewDataSourceMigrator(
 // types found in the database, grouping by type and using per-plugin converters.
 func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
 	opts.Progress(-1, "migrating datasources...")
-	datasources, err := m.getter(ctx, opts.Namespace)
+	dsList, err := m.getter(ctx, opts.Namespace)
 	if err != nil {
 		return err
 	}
 
 	// Clean up any existing secrets in the MT secret service
 	plugins := map[string]bool{}
-	for _, ds := range datasources {
-		if !plugins[ds.Type] {
+	for _, ds := range dsList {
+		dsType := ds.Spec.GetString("type")
+		if !plugins[dsType] {
 			if err = m.secretStore.DeleteWhenOwnedByResource(ctx, common.ObjectReference{
-				APIGroup:   ds.Type + ".datasource.grafana.app",
+				APIGroup:   dsType + ".datasource.grafana.app",
 				APIVersion: datasourceV0.VERSION,
 				Namespace:  opts.Namespace,
 				Kind:       "DataSource",
 				Name:       "*",
 				UID:        "*",
 			}, "*"); err != nil {
-				return fmt.Errorf("error deleting secrets for datasource type %s: %w", ds.Type, err)
+				return fmt.Errorf("error deleting secrets for datasource type %s: %w", dsType, err)
 			}
 		}
-		plugins[ds.Type] = true
+		plugins[dsType] = true
 	}
 
-	namespacer := func(orgId int64) string {
-		return opts.Namespace
-	}
+	for count, ds := range dsList {
+		dsType := ds.Spec.GetString("type")
+		group := dsType + ".datasource.grafana.app"
 
-	for count, ds := range datasources {
-		group := ds.Type + ".datasource.grafana.app"
-		dsConverter := converter.NewConverter(namespacer, group, ds.Type, nil)
-		obj, err := dsConverter.AsDataSource(ds)
-		if err != nil {
-			return fmt.Errorf("converting datasource %s (type=%s): %w", ds.UID, ds.Type, err)
-		}
-
-		// Set TypeMeta with the per-plugin group
+		// Shallow-copy the struct so we can set TypeMeta without mutating the slice element.
+		obj := *ds
 		obj.TypeMeta = metav1.TypeMeta{
 			APIVersion: group + "/" + datasourceV0.VERSION,
 			Kind:       "DataSource",
@@ -130,7 +140,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 			return fmt.Errorf("invalid apiVersion: %w", err)
 		}
 
-		if len(ds.SecureJsonData) > 0 {
+		if len(ds.Secure) > 0 {
 			objRef := common.ObjectReference{
 				APIGroup:   gv.Group,
 				APIVersion: gv.Version,
@@ -139,16 +149,16 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 				Name:       obj.Name,
 				UID:        obj.UID,
 			}
-			secure, err := m.createSecrets(ctx, ds.SecureJsonData, objRef)
+			secure, err := m.createSecrets(ctx, ds.Secure, objRef)
 			if err != nil {
-				return fmt.Errorf("error create secrets for datasource %s (type=%s): %w, %#v", ds.UID, ds.Type, err, obj)
+				return fmt.Errorf("error create secrets for datasource %s (type=%s): %w, %#v", ds.Name, dsType, err, obj)
 			}
 			obj.Secure = secure
 		}
 
 		body, err := json.Marshal(obj)
 		if err != nil {
-			return fmt.Errorf("marshaling datasource %s: %w", ds.UID, err)
+			return fmt.Errorf("marshaling datasource %s: %w", ds.Name, err)
 		}
 
 		req := &resourcepb.BulkRequest{
@@ -156,13 +166,13 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 				Namespace: opts.Namespace,
 				Group:     gv.Group,
 				Resource:  "datasources",
-				Name:      ds.UID,
+				Name:      ds.Name,
 			},
 			Value:  body,
 			Action: resourcepb.BulkRequest_ADDED,
 		}
 
-		opts.Progress(count, fmt.Sprintf("%s/%s (%d) %s", ds.Type, ds.Name, len(req.Value), req.Key))
+		opts.Progress(count, fmt.Sprintf("%s/%s (%d) %s", dsType, obj.Spec.Title(), len(req.Value), req.Key))
 
 		err = stream.Send(req)
 		if err != nil {
@@ -173,21 +183,25 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 		}
 	}
 
-	opts.Progress(-2, fmt.Sprintf("finished datasources... (%d)", len(datasources)))
+	opts.Progress(-2, fmt.Sprintf("finished datasources... (%d)", len(dsList)))
 	return nil
 }
 
-func (m *dataSourceMigrator) createSecrets(ctx context.Context, dsSecrets map[string][]byte, objRef common.ObjectReference) (common.InlineSecureValues, error) {
+func (m *dataSourceMigrator) createSecrets(ctx context.Context, dsSecrets common.InlineSecureValues, objRef common.ObjectReference) (common.InlineSecureValues, error) {
 	if len(dsSecrets) == 0 {
 		return nil, nil
 	}
 
 	values := make(common.InlineSecureValues)
-	for k, v := range dsSecrets {
-		if len(v) == 0 {
+	for k, sv := range dsSecrets {
+		if sv.Create.IsZero() {
+			continue // skip Name-references and empty entries
+		}
+		v := sv.Create.DangerouslyExposeAndConsumeValue()
+		if v == "" {
 			continue // do not create empty secret values
 		}
-		name, err := m.secretStore.CreateInline(ctx, objRef, common.NewSecretValue(string(v)), nil)
+		name, err := m.secretStore.CreateInline(ctx, objRef, common.NewSecretValue(v), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -197,6 +211,9 @@ func (m *dataSourceMigrator) createSecrets(ctx context.Context, dsSecrets map[st
 		values[k] = common.InlineSecureValue{
 			Name: name,
 		}
+	}
+	if len(values) == 0 {
+		return nil, nil
 	}
 	return values, nil
 }

--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -25,13 +25,8 @@ type DataSourceMigrator interface {
 }
 
 type dataSourceMigrator struct {
-	getter      func(ctx context.Context, namespace string) ([]DataSourceData, error)
+	getter      func(ctx context.Context, namespace string) ([]*datasources.DataSource, error)
 	secretStore secret.InlineSecureValueSupport
-}
-
-type DataSourceData struct {
-	Config *datasources.DataSource
-	Secure map[string]string
 }
 
 // ProvideDataSourceMigrator creates a dataSourceMigrator for use in wire DI.
@@ -40,7 +35,7 @@ func ProvideDataSourceMigrator(
 	secretStore secret.InlineSecureValueSupport,
 ) DataSourceMigrator {
 	return &dataSourceMigrator{
-		getter: func(ctx context.Context, namespace string) ([]DataSourceData, error) {
+		getter: func(ctx context.Context, namespace string) ([]*datasources.DataSource, error) {
 			orgId, err := migrations.ParseOrgIDFromNamespace(namespace)
 			if err != nil {
 				return nil, err
@@ -53,16 +48,19 @@ func ProvideDataSourceMigrator(
 				return nil, err
 			}
 
-			result := make([]DataSourceData, len(dss))
+			result := make([]*datasources.DataSource, len(dss))
 			for i, ds := range dss {
 				dsSecrets, err := dsService.DecryptedValues(ctx, ds)
 				if err != nil {
 					return nil, fmt.Errorf("error decrypting existing secrets for datasource %s (type=%s): %w", ds.UID, ds.Type, err)
 				}
-				result[i] = DataSourceData{
-					Config: ds,
-					Secure: dsSecrets,
+				// Always replace SecureJsonData with decrypted plaintext values so
+				// that the migrator never operates on stale encrypted bytes from the DB.
+				ds.SecureJsonData = make(map[string][]byte, len(dsSecrets))
+				for k, v := range dsSecrets {
+					ds.SecureJsonData[k] = []byte(v)
 				}
+				result[i] = ds
 			}
 			return result, nil
 		},
@@ -72,7 +70,7 @@ func ProvideDataSourceMigrator(
 
 // This is useful for the cloud controller, where we populate values from cloudconfig
 func NewDataSourceMigrator(
-	getter func(ctx context.Context, namespace string) ([]DataSourceData, error),
+	getter func(ctx context.Context, namespace string) ([]*datasources.DataSource, error),
 	secretStore secret.InlineSecureValueSupport,
 ) DataSourceMigrator {
 	return &dataSourceMigrator{
@@ -94,27 +92,26 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	// Clean up any existing secrets in the MT secret service
 	plugins := map[string]bool{}
 	for _, ds := range datasources {
-		if !plugins[ds.Config.Type] {
+		if !plugins[ds.Type] {
 			if err = m.secretStore.DeleteWhenOwnedByResource(ctx, common.ObjectReference{
-				APIGroup:   ds.Config.Type + ".datasource.grafana.app",
+				APIGroup:   ds.Type + ".datasource.grafana.app",
 				APIVersion: datasourceV0.VERSION,
 				Namespace:  opts.Namespace,
 				Kind:       "DataSource",
 				Name:       "*",
 				UID:        "*",
 			}, "*"); err != nil {
-				return fmt.Errorf("error deleting secrets for datasource type %s: %w", ds.Config.Type, err)
+				return fmt.Errorf("error deleting secrets for datasource type %s: %w", ds.Type, err)
 			}
 		}
-		plugins[ds.Config.Type] = true
+		plugins[ds.Type] = true
 	}
 
 	namespacer := func(orgId int64) string {
 		return opts.Namespace
 	}
 
-	for count, info := range datasources {
-		ds := info.Config
+	for count, ds := range datasources {
 		group := ds.Type + ".datasource.grafana.app"
 		dsConverter := converter.NewConverter(namespacer, group, ds.Type, nil)
 		obj, err := dsConverter.AsDataSource(ds)
@@ -133,7 +130,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 			return fmt.Errorf("invalid apiVersion: %w", err)
 		}
 
-		if len(info.Secure) > 0 {
+		if len(ds.SecureJsonData) > 0 {
 			objRef := common.ObjectReference{
 				APIGroup:   gv.Group,
 				APIVersion: gv.Version,
@@ -142,7 +139,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 				Name:       obj.Name,
 				UID:        obj.UID,
 			}
-			secure, err := m.createSecrets(ctx, info.Secure, objRef)
+			secure, err := m.createSecrets(ctx, ds.SecureJsonData, objRef)
 			if err != nil {
 				return fmt.Errorf("error create secrets for datasource %s (type=%s): %w, %#v", ds.UID, ds.Type, err, obj)
 			}
@@ -180,17 +177,17 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	return nil
 }
 
-func (m *dataSourceMigrator) createSecrets(ctx context.Context, dsSecrets map[string]string, objRef common.ObjectReference) (common.InlineSecureValues, error) {
+func (m *dataSourceMigrator) createSecrets(ctx context.Context, dsSecrets map[string][]byte, objRef common.ObjectReference) (common.InlineSecureValues, error) {
 	if len(dsSecrets) == 0 {
 		return nil, nil
 	}
 
 	values := make(common.InlineSecureValues)
 	for k, v := range dsSecrets {
-		if v == "" {
+		if len(v) == 0 {
 			continue // do not create empty secret values
 		}
-		name, err := m.secretStore.CreateInline(ctx, objRef, common.NewSecretValue(v), nil)
+		name, err := m.secretStore.CreateInline(ctx, objRef, common.NewSecretValue(string(v)), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -8,7 +8,6 @@ import (
 	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
@@ -114,11 +113,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	// Clean up any existing secrets in the MT secret service
 	plugins := map[string]bool{}
 	for _, ds := range dsList {
-		gv, err := schema.ParseGroupVersion(ds.APIVersion)
-		if err != nil {
-			return fmt.Errorf("invalid apiVersion for datasource %s: %w", ds.Name, err)
-		}
-		apiGroup := gv.Group
+		apiGroup := ds.GroupVersionKind().Group
 		if !plugins[apiGroup] {
 			if err = m.secretStore.DeleteWhenOwnedByResource(ctx, common.ObjectReference{
 				APIGroup:   apiGroup,
@@ -135,11 +130,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	}
 
 	for count, ds := range dsList {
-		gv, err := schema.ParseGroupVersion(ds.APIVersion)
-		if err != nil {
-			return fmt.Errorf("invalid apiVersion for datasource %s: %w", ds.Name, err)
-		}
-		group := gv.Group
+		gvk := ds.GroupVersionKind()
 
 		// Shallow-copy the struct so we can set TypeMeta without mutating the slice element.
 		obj := *ds
@@ -150,16 +141,16 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 
 		if len(ds.Secure) > 0 {
 			objRef := common.ObjectReference{
-				APIGroup:   gv.Group,
-				APIVersion: gv.Version,
-				Kind:       obj.Kind,
-				Namespace:  obj.Namespace,
-				Name:       obj.Name,
-				UID:        obj.UID,
+				APIGroup:   gvk.Group,
+				APIVersion: gvk.Version,
+				Kind:       "DataSource",
+				Namespace:  ds.Namespace,
+				Name:       ds.Name,
+				UID:        ds.UID,
 			}
 			secure, err := m.createSecrets(ctx, ds.Secure, objRef)
 			if err != nil {
-				return fmt.Errorf("error create secrets for datasource %s (group=%s): %w, %#v", ds.Name, group, err, obj)
+				return fmt.Errorf("error creating secrets for datasource %s (group=%s): %w", ds.Name, gvk.Group, err)
 			}
 			obj.Secure = secure
 		}
@@ -172,7 +163,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 		req := &resourcepb.BulkRequest{
 			Key: &resourcepb.ResourceKey{
 				Namespace: opts.Namespace,
-				Group:     gv.Group,
+				Group:     gvk.Group,
 				Resource:  "datasources",
 				Name:      ds.Name,
 			},
@@ -180,7 +171,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 			Action: resourcepb.BulkRequest_ADDED,
 		}
 
-		opts.Progress(count, fmt.Sprintf("%s/%s (%d) %s", group, obj.Spec.Title(), len(req.Value), req.Key))
+		opts.Progress(count, fmt.Sprintf("%s/%s (%d) %s", gvk.Group, obj.Spec.Title(), len(req.Value), req.Key))
 
 		err = stream.Send(req)
 		if err != nil {


### PR DESCRIPTION
Remove the intermediary type (`DataSourceData`) from the mapping system in the datasource migration. We are now converting directly to `[]*datasourceV0.DataSource` (the k8s object). This would help us remove the toll of re-mapping fields in the migration controller: https://github.com/grafana/unistore-migration-controller/pull/236 (I will update this PR once we merge this one).

Ticket: https://github.com/grafana/search-and-storage-team/issues/732