### PR TITLE
Alerting: support matcher operators in rules history label filters

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_history.go
+++ b/pkg/services/ngalert/api/api_ruler_history.go
@@ -44,6 +44,29 @@ func (srv *HistorySrv) RouteQueryStateHistory(c *contextmodel.ReqContext) respon
 
 const labelQueryPrefix = "labels_"
 
+// labelQueryParamToMatcher parses a labels_* query value into a Prometheus-style label matcher.
+// If rawValue starts with =, !=, =~, or !~, it is appended to labelName (Prometheus matcher syntax).
+// Otherwise rawValue is treated as an equality operand (backward compatible with labels_key=value).
+func labelQueryParamToMatcher(labelName, rawValue string) (*labels.Matcher, error) {
+	if labelName == "" {
+		return nil, fmt.Errorf("empty label name")
+	}
+	var matcherStr string
+	switch {
+	case strings.HasPrefix(rawValue, "!="):
+		matcherStr = labelName + rawValue
+	case strings.HasPrefix(rawValue, "!~"):
+		matcherStr = labelName + rawValue
+	case strings.HasPrefix(rawValue, "=~"):
+		matcherStr = labelName + rawValue
+	case strings.HasPrefix(rawValue, "="):
+		matcherStr = labelName + rawValue
+	default:
+		matcherStr = labelName + "=" + rawValue
+	}
+	return labels.ParseMatcher(matcherStr)
+}
+
 // ParseHistoryQuery parses a HistoryQuery from request parameters.
 func ParseHistoryQuery(orgID int64, user identity.Requester, query url.Values) (models.HistoryQuery, error) {
 	from, _ := strconv.ParseInt(query.Get("from"), 10, 64)
@@ -72,7 +95,11 @@ func ParseHistoryQuery(orgID int64, user identity.Requester, query url.Values) (
 	var matchers labels.Matchers
 	for k, v := range query {
 		if strings.HasPrefix(k, labelQueryPrefix) {
-			m, err := labels.ParseMatcher(k[len(labelQueryPrefix):] + "=" + v[0])
+			if len(v) == 0 {
+				return models.HistoryQuery{}, fmt.Errorf("missing value for label filter %q", k)
+			}
+			labelName := k[len(labelQueryPrefix):]
+			m, err := labelQueryParamToMatcher(labelName, v[0])
 			if err != nil {
 				return models.HistoryQuery{}, fmt.Errorf("invalid label filter %q: %w", k, err)
 			}

--- a/pkg/services/ngalert/api/api_ruler_history_test.go
+++ b/pkg/services/ngalert/api/api_ruler_history_test.go
@@ -61,6 +61,50 @@ func TestRouteQueryStateHistory(t *testing.T) {
 			assert.Equal(t, tt.expectedCode, resp.Status())
 		})
 	}
+
+	labelParamCases := []struct {
+		name         string
+		values       url.Values
+		expectedCode int
+	}{
+		{
+			name:         "valid labels_ not-equal",
+			values:       url.Values{"labels_severity": {`!="critical"`}},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "valid labels_ regex",
+			values:       url.Values{"labels_severity": {`=~"crit.*"`}},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "valid labels_ not-regex",
+			values:       url.Values{"labels_env": {`!~"prod.*"`}},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "valid labels_ explicit equal",
+			values:       url.Values{"labels_env": {`="prod"`}},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "invalid labels_ regex",
+			values:       url.Values{"labels_severity": {`=~"[invalid"`}},
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range labelParamCases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.values.Encode(), nil)
+			c := &contextmodel.ReqContext{
+				Context:      &web.Context{Req: req},
+				SignedInUser: &user.SignedInUser{OrgID: 1},
+			}
+			resp := srv.RouteQueryStateHistory(c)
+			assert.Equal(t, tt.expectedCode, resp.Status())
+		})
+	}
 }
 
 func TestParseHistoryQuery(t *testing.T) {
@@ -78,6 +122,49 @@ func TestParseHistoryQuery(t *testing.T) {
 		require.Equal(t, "critical", byName["severity"].Value)
 		require.Equal(t, labels.MatchEqual, byName["env"].Type)
 		require.Equal(t, "prod", byName["env"].Value)
+	})
+
+	t.Run("labels_ prefix supports comparison operators", func(t *testing.T) {
+		q := url.Values{
+			"labels_severity": {`!="critical"`},
+			"labels_region":   {`=~"us-.*"`},
+			"labels_zone":     {`!~"eu-.*"`},
+			"labels_team":     {`="alerting"`},
+		}
+		result, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.NoError(t, err)
+		require.Len(t, result.Labels, 4)
+
+		byName := matchersByName(result.Labels)
+		assert.Equal(t, labels.MatchNotEqual, byName["severity"].Type)
+		assert.Equal(t, "critical", byName["severity"].Value)
+		assert.Equal(t, labels.MatchRegexp, byName["region"].Type)
+		assert.Equal(t, "us-.*", byName["region"].Value)
+		assert.Equal(t, labels.MatchNotRegexp, byName["zone"].Type)
+		assert.Equal(t, "eu-.*", byName["zone"].Value)
+		assert.Equal(t, labels.MatchEqual, byName["team"].Type)
+		assert.Equal(t, "alerting", byName["team"].Value)
+	})
+
+	t.Run("invalid regex in labels_ returns error", func(t *testing.T) {
+		q := url.Values{"labels_severity": {`=~"[invalid"`}}
+		_, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid label filter")
+	})
+
+	t.Run("labels_ without name returns error", func(t *testing.T) {
+		q := url.Values{"labels_": {"foo"}}
+		_, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid label filter")
+	})
+
+	t.Run("labels_ without value returns error", func(t *testing.T) {
+		q := url.Values{"labels_severity": {}}
+		_, err := ParseHistoryQuery(1, &user.SignedInUser{}, q)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing value for label filter")
 	})
 
 	t.Run("matchers param supports all operators", func(t *testing.T) {

--- a/pkg/services/ngalert/api/tooling/definitions/ruler_state_history.go
+++ b/pkg/services/ngalert/api/tooling/definitions/ruler_state_history.go
@@ -7,8 +7,11 @@ import "github.com/grafana/grafana-plugin-sdk-go/data"
 // Query state history.
 //
 // Allows to query alerting state history.
-// In addition to defined query parameters it accepts filter by labels. The query parameter name must start with 'labels_'
-//   Example: /v1/rules/history?labels_myKey1=myValue1&labels_myKey2=myValue2
+// In addition to defined query parameters it accepts filter by labels. The query parameter name must start with 'labels_'.
+// Equality (default): pass the label value only, e.g. labels_severity=critical maps to severity="critical".
+// Other operators: the query value must start with the operator and Prometheus matcher operand, e.g.
+// labels_severity!="critical", labels_severity=~"crit.*", labels_env!~"prod.*", labels_team="alerting".
+// Multiple label filters and the 'matchers' parameter can be combined.
 //
 //     Produces:
 //     - application/json

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -9910,7 +9910,7 @@
   },
   "/v1/rules/history": {
    "get": {
-    "description": "Allows to query alerting state history.\nIn addition to defined query parameters it accepts filter by labels. The query parameter name must start with 'labels_'\nExample: /v1/rules/history?labels_myKey1=myValue1\u0026labels_myKey2=myValue2",
+    "description": "Allows to query alerting state history.\nIn addition to defined query parameters it accepts filter by labels. The query parameter name must start with 'labels_'.\nEquality (default): pass the label value only, e.g. labels_severity=critical maps to severity=\"critical\".\nOther operators: the query value must start with the operator and Prometheus matcher operand, e.g.\nlabels_severity!=\"critical\", labels_severity=~\"crit.*\", labels_env!~\"prod.*\", labels_team=\"alerting\".\nMultiple label filters and the 'matchers' parameter can be combined.",
     "operationId": "RouteGetStateHistory",
     "parameters": [
      {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -4467,7 +4467,7 @@
     },
     "/v1/rules/history": {
       "get": {
-        "description": "Allows to query alerting state history.\nIn addition to defined query parameters it accepts filter by labels. The query parameter name must start with 'labels_'\nExample: /v1/rules/history?labels_myKey1=myValue1\u0026labels_myKey2=myValue2",
+        "description": "Allows to query alerting state history.\nIn addition to defined query parameters it accepts filter by labels. The query parameter name must start with 'labels_'.\nEquality (default): pass the label value only, e.g. labels_severity=critical maps to severity=\"critical\".\nOther operators: the query value must start with the operator and Prometheus matcher operand, e.g.\nlabels_severity!=\"critical\", labels_severity=~\"crit.*\", labels_env!~\"prod.*\", labels_team=\"alerting\".\nMultiple label filters and the 'matchers' parameter can be combined.",
         "produces": [
           "application/json"
         ],


### PR DESCRIPTION
## What is this feature?

This PR updates the Alerting state history API (`/api/v1/rules/history`) to support all matcher operators for `labels_*` query parameters.

Previously, `labels_*` only behaved as equality filters. Now, values can start with matcher operators and are parsed as Prometheus matchers:

* `=` (explicit equality)
* `!=`
* `=~`
* `!~`

Backward compatibility is preserved:

* `labels_alertname=history-test-rule` still works as equality.

---

## Why do we need this feature?

Issue [[#100059](https://github.com/grafana/grafana/issues/100059)](https://github.com/grafana/grafana/issues/100059) asks to improve state history filtering by labels with full comparison operator support.

Without this change, users cannot express non-equality or regex filters via `labels_*` parameters, which is limiting and inconsistent with existing matcher capabilities.

---

## Who is this feature for?

Grafana Alerting users and API consumers who query rule state history and need richer label-based filtering for:

* Troubleshooting
* Triage
* Analysis workflows

---

## Which issue(s) does this PR fix?

Fixes #100059

---

## Special notes for your reviewer

Please check that:

* It works as expected from a user's perspective.
* If this is a pre-GA feature, it is behind a feature toggle.
* The docs are updated, and if this is a notable improvement, it is added to the "What's New" documentation.

---

## Additional context

### Tests added

Added tests in:

* `pkg/services/ngalert/api/api_ruler_history_test.go`

Covering:

* `labels_*` with `!=`, `=~`, `!~`, and explicit `=`
* Backward-compatible plain equality
* Invalid regex/syntax error paths

---

### Documentation updates

Updated API docs in:

* `pkg/services/ngalert/api/tooling/definitions/ruler_state_history.go`
* `pkg/services/ngalert/api/tooling/spec.json`
* `pkg/services/ngalert/api/tooling/post.json`

---

### Manual verification

Tested against local rule history (`ruleUID=efijwgjli8e80c`):

* Verified correct filtering behavior
* Verified malformed regex returns `400 Bad Request`

---

### Note on local backend behavior

Local logs show:

> Annotation state history backend does not support label queries, ignoring that filter

So on the annotations backend, result sets may remain unchanged even when label filters are provided. This is existing backend behavior and separate from the parser support added in this PR.