### PR TITLE
Search: Fix title search scoring and add DoubleEquals exact match operator

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -586,17 +586,13 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		// Explicitly configure the query for dashboard+folder matching.
 		searchRequest.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{
 			{
-				Name:  resource.SEARCH_FIELD_TITLE,
-				Type:  resourcepb.QueryFieldType_KEYWORD,
-				Boost: 10, // exact match -- includes ngrams! If they lived on their own field, we could score them differently
-			}, {
-				Name:  resource.SEARCH_FIELD_TITLE,
-				Type:  resourcepb.QueryFieldType_TEXT,
-				Boost: 2, // standard analyzer (with ngrams!)
-			}, {
 				Name:  resource.SEARCH_FIELD_TITLE_PHRASE,
+				Type:  resourcepb.QueryFieldType_KEYWORD,
+				Boost: 10, // exact title match (case-insensitive via pre-lowered title_phrase)
+			}, {
+				Name:  resource.SEARCH_FIELD_TITLE,
 				Type:  resourcepb.QueryFieldType_TEXT,
-				Boost: 5, // standard analyzer
+				Boost: 2, // standard analyzer (word-level matching with ngrams)
 			},
 		}
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/blevesearch/bleve/v2"
-	"github.com/blevesearch/bleve/v2/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search"
@@ -1296,17 +1295,13 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 			if len(queryFields) == 0 {
 				queryFields = []*resourcepb.ResourceSearchRequest_QueryField{
 					{
-						Name:  resource.SEARCH_FIELD_TITLE,
-						Type:  resourcepb.QueryFieldType_KEYWORD,
-						Boost: 10, // exact match -- includes ngrams! If they lived on their own field, we could score them differently
-					}, {
-						Name:  resource.SEARCH_FIELD_TITLE,
-						Type:  resourcepb.QueryFieldType_TEXT,
-						Boost: 2, // standard analyzer (with ngrams!)
-					}, {
 						Name:  resource.SEARCH_FIELD_TITLE_PHRASE,
+						Type:  resourcepb.QueryFieldType_KEYWORD,
+						Boost: 10, // exact title match (case-insensitive via pre-lowered title_phrase)
+					}, {
+						Name:  resource.SEARCH_FIELD_TITLE,
 						Type:  resourcepb.QueryFieldType_TEXT,
-						Boost: 5, // standard analyzer
+						Boost: 2, // standard analyzer (word-level matching with ngrams)
 					},
 				}
 			}
@@ -1322,10 +1317,9 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 					disjoin.AddQuery(q)
 
 				case resourcepb.QueryFieldType_KEYWORD:
-					q := bleve.NewMatchQuery(req.Query)
+					q := bleve.NewTermQuery(strings.ToLower(req.Query))
 					q.SetBoost(float64(field.Boost))
 					q.SetField(field.Name)
-					q.Analyzer = keyword.Name // don't analyze the query input - treat it as a single token
 					disjoin.AddQuery(q)
 
 				case resourcepb.QueryFieldType_PHRASE:
@@ -1634,7 +1628,31 @@ var exactTermFields = []string{
 func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, *resourcepb.ErrorResult) {
 	useExactTermQuery := slices.Contains(exactTermFields, req.Key) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
 	switch selection.Operator(req.Operator) {
-	case selection.Equals, selection.DoubleEquals:
+	case selection.DoubleEquals:
+		if len(req.Values) == 0 {
+			return query.NewMatchAllQuery(), nil
+		}
+		// DoubleEquals always does exact matching via TermQuery.
+		// For title, route to the pre-lowered title_phrase field.
+		key := req.Key
+		values := req.Values
+		if key == resource.SEARCH_FIELD_TITLE {
+			key = resource.SEARCH_FIELD_TITLE_PHRASE
+			values = make([]string, len(req.Values))
+			for i, v := range req.Values {
+				values[i] = strings.ToLower(v)
+			}
+		}
+		if len(values) == 1 {
+			return newExactTermsQuery(key, values[0], prefix), nil
+		}
+		conjuncts := []query.Query{}
+		for _, v := range values {
+			conjuncts = append(conjuncts, newExactTermsQuery(key, v, prefix))
+		}
+		return query.NewConjunctionQuery(conjuncts), nil
+
+	case selection.Equals:
 		if len(req.Values) == 0 {
 			return query.NewMatchAllQuery(), nil
 		}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1629,28 +1629,17 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 	useExactTermQuery := slices.Contains(exactTermFields, req.Key) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
 	switch selection.Operator(req.Operator) {
 	case selection.DoubleEquals:
-		if len(req.Values) == 0 {
-			return query.NewMatchAllQuery(), nil
-		}
-		// DoubleEquals always does exact matching via TermQuery.
+		// DoubleEquals does exact matching via TermQuery (single value only).
 		// For title, route to the pre-lowered title_phrase field.
-		key := req.Key
-		values := req.Values
-		if key == resource.SEARCH_FIELD_TITLE {
-			key = resource.SEARCH_FIELD_TITLE_PHRASE
-			values = make([]string, len(req.Values))
-			for i, v := range req.Values {
-				values[i] = strings.ToLower(v)
+		if len(req.Values) == 1 {
+			key := req.Key
+			value := req.Values[0]
+			if key == resource.SEARCH_FIELD_TITLE {
+				key = resource.SEARCH_FIELD_TITLE_PHRASE
+				value = strings.ToLower(value)
 			}
+			return newExactTermsQuery(key, value, prefix), nil
 		}
-		if len(values) == 1 {
-			return newExactTermsQuery(key, values[0], prefix), nil
-		}
-		conjuncts := []query.Query{}
-		for _, v := range values {
-			conjuncts = append(conjuncts, newExactTermsQuery(key, v, prefix))
-		}
-		return query.NewConjunctionQuery(conjuncts), nil
 
 	case selection.Equals:
 		if len(req.Values) == 0 {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -315,6 +315,53 @@ func TestDoubleEqualsExactMatch(t *testing.T) {
 		checkSearchQuery(t, index, newExactQueryByTitle("QUICK BROWN FOX"), []string{"name1"})
 	})
 
+	t.Run("double equals with no values returns error", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Test",
+		})
+		req := &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "default",
+					Group:     "dashboard.grafana.app",
+					Resource:  "dashboards",
+				},
+				Fields: []*resourcepb.Requirement{{Key: "title", Operator: "==", Values: []string{}}},
+			},
+			Limit: 100000,
+		}
+		res, err := index.Search(context.Background(), nil, req, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, res.Error)
+		require.Equal(t, int32(400), res.Error.Code)
+		require.Contains(t, res.Error.Message, "unsupported query operation")
+	})
+
+	t.Run("double equals with multiple values returns error", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Test",
+			"name2": "Other",
+		})
+		req := &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "default",
+					Group:     "dashboard.grafana.app",
+					Resource:  "dashboards",
+				},
+				Fields: []*resourcepb.Requirement{{Key: "title", Operator: "==", Values: []string{"Test", "Other"}}},
+			},
+			Limit: 100000,
+		}
+		res, err := index.Search(context.Background(), nil, req, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, res.Error)
+		require.Equal(t, int32(400), res.Error.Code)
+		require.Contains(t, res.Error.Message, "unsupported query operation")
+	})
+
 	t.Run("single equals on title keeps fuzzy behavior", func(t *testing.T) {
 		index := newTestDashboardsIndex(t, threshold, 2, noop)
 		indexDocumentsWithTitles(t, index, key, map[string]string{

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -210,6 +210,27 @@ func TestCanSearchByTitle(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("new das"), []string{"name2", "name1"})
 	})
 
+	t.Run("multi-word exact title match gets highest score", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Quick Brown Fox",
+			"name2": "Quick Brown Fox Jumps",
+		})
+		// exact title "Quick Brown Fox" should score highest (boost=10 on title_phrase)
+		checkSearchQuery(t, index, newTestQuery("Quick Brown Fox"), []string{"name1", "name2"})
+	})
+
+	t.Run("lowercase search matches via exact match boost", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Quick Brown Fox Jumps Over",
+			"name2": "Quick Brown Fox",
+		})
+		// lowercase query should get exact-match boost via pre-lowered title_phrase
+		// name2 is exact match (boost=10) so it ranks first despite name ordering
+		checkSearchQuery(t, index, newTestQuery("quick brown fox"), []string{"name2", "name1"})
+	})
+
 	t.Run("title search will%smatch term in the middle/end", func(t *testing.T) {
 		index := newTestDashboardsIndex(t, threshold, 2, noop)
 		indexDocumentsWithTitles(t, index, key, map[string]string{
@@ -249,6 +270,60 @@ func newQueryByTitle(query string) *resourcepb.ResourceSearchRequest {
 		},
 		Limit: 100000,
 	}
+}
+
+func newExactQueryByTitle(query string) *resourcepb.ResourceSearchRequest {
+	return &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+			},
+			Fields: []*resourcepb.Requirement{{Key: "title", Operator: "==", Values: []string{query}}},
+		},
+		Limit: 100000,
+	}
+}
+
+func TestDoubleEqualsExactMatch(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	t.Run("double equals on title matches only exact title", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Test",
+			"name2": "Test Team 1",
+			"name3": "Testing Fox Tales",
+		})
+		// == should only match the document with title exactly "Test"
+		checkSearchQuery(t, index, newExactQueryByTitle("Test"), []string{"name1"})
+	})
+
+	t.Run("double equals on title is case insensitive", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Quick Brown Fox",
+			"name2": "Another Fox Story",
+		})
+		// == with different casing should still match
+		checkSearchQuery(t, index, newExactQueryByTitle("quick brown fox"), []string{"name1"})
+		checkSearchQuery(t, index, newExactQueryByTitle("QUICK BROWN FOX"), []string{"name1"})
+	})
+
+	t.Run("single equals on title keeps fuzzy behavior", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Test",
+			"name2": "Test Team 1",
+		})
+		// = should still match documents containing "Test" (fuzzy/word match)
+		checkSearchQuery(t, index, newQueryByTitle("Test"), []string{"name1", "name2"})
+	})
 }
 
 func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer resource.BuildFn) resource.ResourceIndex {

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.691
+      "score": 0.065
     },
     {
       "resource": "dashboards",
@@ -21,8 +21,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.662
+      "score": 0.062
     }
   ],
-  "maxScore": 0.691
+  "maxScore": 0.065
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.053
+      "score": 0.098
     }
   ],
-  "maxScore": 0.053
+  "maxScore": 0.098
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 1.041
+      "score": 0.112
     }
   ],
-  "maxScore": 1.041
+  "maxScore": 0.112
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 1.041
+      "score": 0.112
     }
   ],
-  "maxScore": 1.041
+  "maxScore": 0.112
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.093,
+      "score": 0.137,
       "explain": {
         "children": [
           {
@@ -31,11 +31,11 @@
                           },
                           {
                             "message": "queryNorm",
-                            "value": 0.023
+                            "value": 0.026
                           }
                         ],
                         "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
-                        "value": 0.292
+                        "value": 0.322
                       },
                       {
                         "children": [
@@ -63,26 +63,26 @@
                       }
                     ],
                     "message": "weight(fields.panel_title:orange^5.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001), product of:",
-                    "value": 0.373
+                    "value": 0.411
                   }
                 ],
                 "message": "sum of:",
-                "value": 0.373
+                "value": 0.411
               }
             ],
             "message": "sum of:",
-            "value": 0.373
+            "value": 0.411
           },
           {
-            "message": "coord(1/4)",
-            "value": 0.25
+            "message": "coord(1/3)",
+            "value": 0.333
           }
         ],
         "message": "product of:",
         "partial_match": true,
-        "value": 0.093
+        "value": 0.137
       }
     }
   ],
-  "maxScore": 0.093
+  "maxScore": 0.137
 }


### PR DESCRIPTION
## Summary

Fix broken title search query construction and add support for exact title matching via the `==` operator in field requirements.

Tracked in grafana/search-and-storage-team#737. Reported by @mgyongyosi.

### Phase 1: Fix search query scoring

The title search had two broken boost queries:

- **Boost=10 KEYWORD query on `title`**: Used `MatchQuery` with keyword analyzer, but the `title` field stores keyword terms with original case. Users rarely type exact case, so this boost almost never fired.
- **Boost=5 TEXT query on `title_phrase`**: Used `MatchQuery` with standard analyzer, but `title_phrase` is keyword-analyzed (single term = full title). Standard analyzer splits the query into individual word tokens (e.g. "Quick Brown Fox" -> "quick", "brown", "fox"), but `title_phrase` only has one term ("quick brown fox"). None of the individual words match the full-title term, so multi-word titles never matched via this query. It was dead weight.

**Fix**: Replace both with a single boost=10 `TermQuery` + `strings.ToLower` targeting `title_phrase` (pre-lowered keyword field). This gives case-insensitive exact title matching that reliably fires. The boost=2 TEXT query on `title` (standard analyzer, word-level matching with ngrams) is unchanged.

Also updates the duplicate `QueryFields` in `pkg/registry/apis/dashboard/search.go` to match.

### DoubleEquals operator for exact matching

`selection.Equals` (`=`) and `selection.DoubleEquals` (`==`) were previously treated identically in `requirementQuery`. This splits them:

- `=` keeps current fuzzy/word match behavior (unchanged)
- `==` always does exact matching via `TermQuery`. For `title`, routes to `title_phrase` with lowered values. For keyword fields (tags, folder), behaves same as `=` (already exact).

This lets callers express exact title matching without knowing about `title_phrase` field internals:
```go
// Exact match: only "Test", not "Test Team 1"
Fields: []*resourcepb.Requirement{{Key: "title", Operator: "==", Values: []string{"Test"}}}

// Fuzzy match: "Test" and "Test Team 1" (current behavior, unchanged)
Fields: []*resourcepb.Requirement{{Key: "title", Operator: "=", Values: []string{"Test"}}}
```

## Test plan

- [x] New tests for multi-word exact match scoring (boost=10 via title_phrase)
- [x] New tests for case-insensitive exact match boost (lowercase query on mixed-case title)
- [x] New tests for `==` exact matching (only exact title, not partial)
- [x] New tests for `==` case insensitivity
- [x] Regression test: `=` on title keeps current fuzzy behavior
- [x] All 88 existing search tests pass
- [ ] CI