### PR TITLE
[release-11.6.15] Rendering: Prevent reload of dashboard when query changes

### DIFF
--- a/public/app/features/dashboard-scene/solo/SoloPanelPage.tsx
+++ b/public/app/features/dashboard-scene/solo/SoloPanelPage.tsx
@@ -31,7 +31,7 @@ export function SoloPanelPage({ queryParams }: Props) {
   useEffect(() => {
     stateManager.loadDashboard({ uid, type, slug, route: DashboardRoutes.Embedded });
     return () => stateManager.clearState();
-  }, [stateManager, queryParams, uid, type, slug]);
+  }, [stateManager, uid, type, slug]);
 
   if (!queryParams.panelId) {
     return <EntityNotFound entity="Panel" />;


### PR DESCRIPTION
Backport 80daf0a7f83f79301157ec33b4afcdabbe709190 from #120260

---

Attempts to fix a `d-solo` reload loop in Scenes when the URL is updated during variable sync by removing the `queryParams` from the `useEffect`.

This copies the behavior present in `public/app/features/dashboard-scene/pages/DashboardScenePage.tsx` , which also uses `updateUrlOnInit={true}`: https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx#L45-L71

