### PR TITLE
Prometheus: fetch new labels on blur instead of change in metrics browser

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -51,7 +51,7 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onBlur={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'


### PR DESCRIPTION
## Summary
Fixes #120727

Changes the metrics browser series limit input to trigger label fetches on `onBlur` instead of `onChange`. This prevents unnecessary API calls on every keystroke and improves UX by only fetching when the user finishes editing.

## Changes
- `packages/grafana-prometheus/src/components/metric-browser/MetricSelector.tsx`: Changed `onChange` to `onBlur` for the series limit input

## Testing
- Verified the change compiles without errors
- The change is minimal (1 line) and only affects when the fetch is triggered, not the fetch logic itself

Bahtya