### PR TITLE
Provisioning: Allow GitLab subgroup URLs in repository URL validation

### DIFF
--- a/public/app/features/provisioning/Wizard/fields.test.ts
+++ b/public/app/features/provisioning/Wizard/fields.test.ts
@@ -1,0 +1,123 @@
+import { getGitProviderFields } from './fields';
+
+describe('URL validation patterns', () => {
+  function getUrlPattern(provider: 'github' | 'gitlab' | 'bitbucket' | 'git'): RegExp {
+    const fields = getGitProviderFields(provider);
+    const pattern = fields?.urlConfig.validation?.pattern?.value;
+    if (!pattern) {
+      throw new Error(`No URL pattern found for provider: ${provider}`);
+    }
+    return pattern;
+  }
+
+  describe('GitHub', () => {
+    let pattern: RegExp;
+    beforeAll(() => {
+      pattern = getUrlPattern('github');
+    });
+
+    it.each([
+      ['https://github.com/owner/repo', true],
+      ['https://github.com/owner/repo/', true],
+      ['https://github.example.com/owner/repo', true],
+    ])('%s → %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+
+    it.each([
+      ['https://github.com/owner/repo/extra', false],
+      ['https://github.com/owner', false],
+      ['http://github.com/owner/repo', false],
+      ['https://github.com/', false],
+      ['https://github.com/owner//repo', false],
+    ])('rejects %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+  });
+
+  describe('GitLab', () => {
+    let pattern: RegExp;
+    beforeAll(() => {
+      pattern = getUrlPattern('gitlab');
+    });
+
+    it.each([
+      // Standard 2-segment path
+      ['https://gitlab.com/owner/repo', true],
+      ['https://gitlab.com/owner/repo/', true],
+      // Subgroup paths (the fix)
+      ['https://gitlab.com/group/subgroup/repo', true],
+      ['https://gitlab.com/group/subgroup/repo/', true],
+      ['https://gitlab.com/group/sub1/sub2/repo', true],
+      ['https://gitlab.com/group/sub1/sub2/sub3/repo', true],
+      // Self-hosted
+      ['https://gitlab.example.com/org/team/project', true],
+    ])('%s → %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+
+    it.each([
+      // Must have at least 2 path segments
+      ['https://gitlab.com/owner', false],
+      // No http
+      ['http://gitlab.com/owner/repo', false],
+      // Empty segments
+      ['https://gitlab.com/owner//repo', false],
+      // No path
+      ['https://gitlab.com/', false],
+      // Bare hostname
+      ['https://gitlab.com', false],
+    ])('rejects %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+  });
+
+  describe('Bitbucket', () => {
+    let pattern: RegExp;
+    beforeAll(() => {
+      pattern = getUrlPattern('bitbucket');
+    });
+
+    it.each([
+      ['https://bitbucket.org/workspace/repo', true],
+      ['https://bitbucket.org/workspace/repo/', true],
+      ['https://bitbucket.example.com/workspace/repo', true],
+    ])('%s → %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+
+    it.each([
+      ['https://bitbucket.org/workspace/repo/extra', false],
+      ['https://bitbucket.org/workspace', false],
+      ['http://bitbucket.org/workspace/repo', false],
+      ['https://bitbucket.org/', false],
+      ['https://bitbucket.org/workspace//repo', false],
+    ])('rejects %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+  });
+
+  describe('Git (generic)', () => {
+    let pattern: RegExp;
+    beforeAll(() => {
+      pattern = getUrlPattern('git');
+    });
+
+    it.each([
+      ['https://git.example.com/owner/repo.git', true],
+      ['http://git.example.com/owner/repo.git', true],
+      ['https://git.example.com/owner/repo', true],
+      ['https://git.example.com/a/b/c/d', true],
+      ['http://anything', true],
+    ])('%s → %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+
+    it.each([
+      ['ftp://git.example.com/repo', false],
+      ['git@github.com:owner/repo.git', false],
+    ])('rejects %s', (url, expected) => {
+      expect(pattern.test(url)).toBe(expected);
+    });
+  });
+});

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -114,11 +114,17 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
         ...shared.url,
         description: t('provisioning.gitlab.url-description', 'The GitLab repository URL'),
         // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
-        placeholder: 'https://gitlab.com/owner/repository',
+        placeholder: 'https://gitlab.com/group/repository',
         required: true,
         validation: {
-          ...shared.url.validation,
           required: t('provisioning.gitlab.url-required', 'Repository URL is required'),
+          pattern: {
+            value: /^https:\/\/[^\/]+\/[^\/]+(\/[^\/]+)+\/?$/,
+            message: t(
+              'provisioning.gitlab.url-pattern',
+              'Must be a valid repository URL (https://hostname/group/repository or https://hostname/group/subgroup/repository)'
+            ),
+          },
         },
       },
       branch: {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13382,6 +13382,7 @@
       "token-label": "Project Access Token",
       "token-required": "GitLab token is required",
       "url-description": "The GitLab repository URL",
+      "url-pattern": "Must be a valid repository URL (https://hostname/group/repository or https://hostname/group/subgroup/repository)",
       "url-required": "Repository URL is required"
     },
     "history-view": {


### PR DESCRIPTION
**What is this feature?**

Updates the GitLab repository URL validation in the provisioning wizard to accept nested group/subgroup paths (e.g. `https://gitlab.com/group/subgroup/repo`). Previously the regex enforced exactly two path segments (`/owner/repo`), which rejected valid GitLab URLs with subgroups. The fix uses a provider-specific regex override for GitLab that accepts two or more path segments. GitHub and Bitbucket retain the existing two-segment constraint.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/1051
