### PR TITLE
Combobox: preserve MultiCombobox caret position while typing

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -196,6 +196,28 @@ describe('MultiCombobox', () => {
     ]);
   });
 
+  it('keeps the caret position when typing in the middle of the input', async () => {
+    const options = [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+    ];
+
+    render(<MultiCombobox options={options} value={[]} onChange={jest.fn()} />);
+    const input = screen.getByRole<HTMLInputElement>('combobox');
+
+    await user.click(input);
+    await user.type(input, 'hello');
+
+    input.setSelectionRange(3, 3);
+
+    await user.keyboard('X');
+
+    expect(input).toHaveValue('helXlo');
+    expect(input.selectionStart).toBe(4);
+    expect(input.selectionEnd).toBe(4);
+  });
+
   it('should remove value when clicking on the close icon of the pill', async () => {
     const options = [
       { label: 'A', value: 'a' },

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@emotion/css';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 
@@ -63,6 +63,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
 
   const styles = useStyles2(getComboboxStyles);
   const [inputValue, setInputValue] = useState('');
+  const pendingSelectionRef = useRef<{ start: number; end: number; value: string } | null>(null);
 
   const allOptionItem = useMemo(() => {
     return {
@@ -266,6 +267,19 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
   const visibleItems = isOpen ? selectedItems.slice(0, MAX_SHOWN_ITEMS) : selectedItems.slice(0, shownItems);
 
   const { inputRef, inputWidth } = useMultiInputAutoSize(inputValue);
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    const pendingSelection = pendingSelectionRef.current;
+
+    if (!input || !pendingSelection || document.activeElement !== input || input.value !== pendingSelection.value) {
+      return;
+    }
+
+    input.setSelectionRange(pendingSelection.start, pendingSelection.end);
+    pendingSelectionRef.current = null;
+  }, [inputRef, inputValue]);
+
   return (
     <div className={multiStyles.container} ref={containerRef}>
       <div className={cx(multiStyles.wrapper, { [multiStyles.disabled]: disabled })} ref={measureRef}>
@@ -316,6 +330,13 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
                 ref: inputRef,
                 style: { width: inputWidth },
               }),
+              onChange: (event) => {
+                pendingSelectionRef.current = {
+                  start: event.currentTarget.selectionStart ?? event.currentTarget.value.length,
+                  end: event.currentTarget.selectionEnd ?? event.currentTarget.value.length,
+                  value: event.currentTarget.value,
+                };
+              },
               'aria-labelledby': ariaLabelledBy, // Label should be handled with the Field component
               'data-testid': dataTestId,
             })}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a `MultiCombobox` input bug where typing in the middle of existing text caused the caret to jump to the end of the field. The update preserves the input selection during controlled re-renders and adds a regression test for mid-string insertion.

**Why do we need this feature?**

When editing text in the `MultiCombobox` input, users expect the caret to stay at the insertion point. Instead, each typed character could move the caret to the end of the input, which made normal editing frustrating and easy to reproduce in Storybook and Grafana itself.

**Who is this feature for?**

This is for Grafana users and developers who use `MultiCombobox`, especially in places where they refine or edit typed filter/query values rather than always typing from the end.

**Which issue(s) does this PR fix?**:

Fixes #122205

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Tested with:
- `yarn.cmd jest --runInBand --no-watch packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx`
- `yarn.cmd jest --runInBand --no-watch packages/grafana-ui/src/components/Combobox/Combobox.test.tsx packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx`
