### PR TITLE
IAM: Set deprecatedInternalID label on TeamBinding

### DIFF
--- a/pkg/registry/apis/iam/teambinding/store.go
+++ b/pkg/registry/apis/iam/teambinding/store.go
@@ -16,6 +16,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
@@ -327,7 +328,7 @@ func mapToBindingObject(ns claims.NamespaceInfo, tm legacy.TeamMember) iamv0alph
 		ct = tm.Created
 	}
 
-	return iamv0alpha1.TeamBinding{
+	result := iamv0alpha1.TeamBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              tm.UID,
 			Namespace:         ns.Value,
@@ -346,4 +347,9 @@ func mapToBindingObject(ns claims.NamespaceInfo, tm legacy.TeamMember) iamv0alph
 			External:   tm.External,
 		},
 	}
+
+	meta, _ := utils.MetaAccessor(&result)
+	meta.SetDeprecatedInternalID(tm.TeamID) // nolint:staticcheck
+
+	return result
 }

--- a/pkg/tests/apis/iam/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/team_binding_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -125,6 +127,13 @@ func doTeamBindingCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHel
 		require.Equal(t, iamv0alpha1.TeamBindingTeamPermissionAdmin, actual.Spec.Permission)
 		require.False(t, actual.Spec.External)
 		require.Equal(t, createdUID, actual.Name)
+
+		// Verify deprecatedInternalID label matches the team's internal ID
+		teamDeprecatedID := team.GetLabels()[apiutils.LabelKeyDeprecatedInternalID]
+		require.NotEmpty(t, teamDeprecatedID, "team should have a deprecatedInternalID label")
+		bindingDeprecatedID := response.GetLabels()[apiutils.LabelKeyDeprecatedInternalID]
+		require.NotEmpty(t, bindingDeprecatedID, "team binding should have a deprecatedInternalID label")
+		require.Equal(t, teamDeprecatedID, bindingDeprecatedID, "team binding deprecatedInternalID should match the team's internal ID")
 
 		// Update the team binding
 		toUpdate := toCreate.DeepCopy()
@@ -526,6 +535,11 @@ func doTeamBindingCRUDTestsUsingTheLegacyAPIs(t *testing.T, helper *apis.K8sTest
 		require.Equal(t, userRsp.Result.UID, actual.Spec.Subject.Name)
 		require.Equal(t, teamRsp.Result.UID, actual.Spec.TeamRef.Name)
 		require.Equal(t, teamBindingName, actual.Name)
+
+		// Verify deprecatedInternalID label matches the legacy team ID
+		bindingDeprecatedID := response.GetLabels()[apiutils.LabelKeyDeprecatedInternalID]
+		require.Equal(t, strconv.FormatInt(teamRsp.Result.ID, 10), bindingDeprecatedID,
+			"team binding deprecatedInternalID should match the legacy team ID")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Set the `grafana.app/deprecatedInternalID` label on `TeamBinding` objects, mapping the team's legacy internal ID — matching the existing pattern used by `Team` and `User` resources.
- Extended integration tests in both Mode0 and Mode1 to verify the label is correctly populated (via new K8s API and legacy API flows).

## Test plan
- [ ] `go test ./pkg/tests/apis/iam/... -run TestIntegrationTeamBindings -count=1 -timeout 300s` passes in Mode0 and Mode1