### PR TITLE
Rendering: Rollback and remove rendererDisableAppPluginsPreload feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1030,11 +1030,6 @@ export interface FeatureToggles {
   */
   newShareReportDrawer?: boolean;
   /**
-  * Disable pre-loading app plugins when the request is coming from the renderer
-  * @default false
-  */
-  rendererDisableAppPluginsPreload?: boolean;
-  /**
   * Enables SRI checks for Grafana JavaScript assets
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1621,15 +1621,6 @@ var (
 			Expression:   "false",
 		},
 		{
-			Name:         "rendererDisableAppPluginsPreload",
-			Description:  "Disable pre-loading app plugins when the request is coming from the renderer",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaOperatorExperienceSquad,
-			HideFromDocs: true,
-			FrontendOnly: true,
-			Expression:   "false",
-		},
-		{
 			Name:         "assetSriChecks",
 			Description:  "Enables SRI checks for Grafana JavaScript assets",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -201,7 +201,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-04-14,scopeSearchAllLevels,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2025-02-17,alertingRuleVersionHistoryRestore,GA,@grafana/alerting-squad,false,false,true
 2025-02-17,newShareReportDrawer,preview,@grafana/grafana-operator-experience-squad,false,false,false
-2025-02-24,rendererDisableAppPluginsPreload,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2025-03-04,assetSriChecks,experimental,@grafana/frontend-ops,false,false,true
 2025-03-05,alertRuleRestore,preview,@grafana/alerting-squad,false,false,false
 2025-03-14,infinityRunQueriesInParallel,privatePreview,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4656,7 +4656,8 @@
       "metadata": {
         "name": "rendererDisableAppPluginsPreload",
         "resourceVersion": "1771434338561",
-        "creationTimestamp": "2025-02-24T14:43:06Z"
+        "creationTimestamp": "2025-02-24T14:43:06Z",
+        "deletionTimestamp": "2026-04-09T15:47:18Z"
       },
       "spec": {
         "description": "Disable pre-loading app plugins when the request is coming from the renderer",

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -256,10 +256,7 @@ export class GrafanaApp {
       setDataSourceSrv(dataSourceSrv);
       initWindowRuntime();
 
-      // Do not pre-load apps if rendererDisableAppPluginsPreload is true and the request comes from the image renderer
-      const skipAppPluginsPreload =
-        config.featureToggles.rendererDisableAppPluginsPreload && contextSrv.user.authenticatedBy === 'render';
-      if (contextSrv.user.orgRole !== '' && !skipAppPluginsPreload) {
+      if (contextSrv.user.orgRole !== '') {
         preloadPlugins(await getAppPluginsToPreload());
       }
 


### PR DESCRIPTION
This has not been used or rolled out for more than a year, the experiments done about it were not conclusive either: https://github.com/grafana/grafana-enterprise/issues/7811

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1619

`no-check-mt-service-compatibility`: removing the feature toggle and it is not rolling out, so safe to merge together.