### PR TITLE
Chore: Bump basic-ftp

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13827,9 +13827,9 @@ __metadata:
   linkType: hard
 
 "basic-ftp@npm:^5.0.2":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10/f5a15d789aa98859af4da9e976154b2aeae19052e1762dc68d259d2bce631dafa40c667aa06d7346cd630aa6f9cc9a26f515b468e0bd24243fbae2149c7d01ad
+  version: 5.2.1
+  resolution: "basic-ftp@npm:5.2.1"
+  checksum: 10/1530d83a41b184fb2d091e910350981a3f9dc4cf1485370efed6535ad833955e43343300a496fec81849cbf625efeab42a170a734a5596701280812dba5e5f5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps basic-ftp from 5.2.0 to 5.2.1. This is a transitive dev dependency.


```
❯ yarn why -R basic-ftp
└─ grafana@workspace:.
   └─ jsdom-testing-mocks@npm:1.15.2 (via npm:^1.13.1)
      └─ puppeteer@npm:24.15.0 (via npm:^24.15.0)
         └─ @puppeteer/browsers@npm:2.10.6 (via npm:2.10.6)
            └─ proxy-agent@npm:6.5.0 (via npm:^6.5.0)
               └─ pac-proxy-agent@npm:7.2.0 (via npm:^7.1.0)
                  └─ get-uri@npm:6.0.5 (via npm:^6.0.1)
                     └─ basic-ftp@npm:5.2.1 (via npm:^5.0.2)
```