### PR TITLE
unified-storage: retry with jitter on conflict in tenant watcher

### DIFF
--- a/pkg/storage/unified/resource/tenant_watcher.go
+++ b/pkg/storage/unified/resource/tenant_watcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"time"
@@ -38,6 +39,9 @@ var tenantGVR = schema.GroupVersionResource{
 const (
 	labelPendingDelete           = "cloud.grafana.com/pending-delete"
 	annotationPendingDeleteAfter = "cloud.grafana.com/pending-delete-after"
+
+	editLabelMaxAttempts   = 4
+	editLabelMaxRetryDelay = 2 * time.Second
 )
 
 // TenantWatcher watches Tenant CRDs via a Kubernetes informer and syncs
@@ -50,6 +54,7 @@ type TenantWatcher struct {
 	ctx                context.Context
 	stopCh             chan struct{}
 	factory            dynamicinformer.DynamicSharedInformerFactory
+	retryMaxDelay      time.Duration
 }
 
 // TenantWatcherConfig holds configuration for the TenantWatcher.
@@ -66,7 +71,9 @@ type TenantWatcherConfig struct {
 	AllowInsecure bool
 	// ResyncInterval is how often the informer re-lists all tenants.
 	ResyncInterval time.Duration
-	Log            log.Logger
+	// RetryMaxDelay is the maximum delay between retries in case of write conflicts when updating resource labels.
+	RetryMaxDelay time.Duration
+	Log           log.Logger
 }
 
 // NewTenantWatcherConfig creates TenantWatcherConfig from Grafana settings and returns nil
@@ -177,6 +184,11 @@ func NewTenantWatcher(ctx context.Context, ds *dataStore, writeEvent EventAppend
 		resync = 1 * time.Hour
 	}
 
+	retryMaxDelay := cfg.RetryMaxDelay
+	if retryMaxDelay <= 0 {
+		retryMaxDelay = editLabelMaxRetryDelay
+	}
+
 	client, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating dynamic client: %w", err)
@@ -189,6 +201,7 @@ func NewTenantWatcher(ctx context.Context, ds *dataStore, writeEvent EventAppend
 		writeEvent:         writeEvent,
 		ctx:                ctx,
 		stopCh:             make(chan struct{}),
+		retryMaxDelay:      retryMaxDelay,
 	}
 
 	tw.factory = dynamicinformer.NewDynamicSharedInformerFactory(client, resync)
@@ -309,6 +322,40 @@ func (tw *TenantWatcher) tenantResourcesEditPendingDeleteLabel(tenantName string
 }
 
 func (tw *TenantWatcher) editResourceLabel(dataKey DataKey, addLabel bool) error {
+	var err error
+	for attempt := range editLabelMaxAttempts {
+		if attempt > 0 {
+			jitter := time.Duration(rand.Int64N(int64(tw.retryMaxDelay)))
+			select {
+			case <-time.After(jitter):
+			case <-tw.ctx.Done():
+				return tw.ctx.Err()
+			}
+
+			// Re-fetch latest DataKey to get a fresh ResourceVersion.
+			dataKey, err = tw.dataStore.GetLatestResourceKey(tw.ctx, GetRequestKey{
+				Group:     dataKey.Group,
+				Resource:  dataKey.Resource,
+				Namespace: dataKey.Namespace,
+				Name:      dataKey.Name,
+			})
+			if err != nil {
+				return fmt.Errorf("fetching latest resource key for retry: %w", err)
+			}
+		}
+
+		err = tw.doEditResourceLabel(dataKey, addLabel)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("editing resource label failed after %d attempts: %w", editLabelMaxAttempts, err)
+}
+
+func (tw *TenantWatcher) doEditResourceLabel(dataKey DataKey, addLabel bool) error {
 	reader, err := tw.dataStore.Get(tw.ctx, dataKey)
 	if err != nil {
 		return fmt.Errorf("reading resource: %w", err)
@@ -365,52 +412,7 @@ func (tw *TenantWatcher) editResourceLabel(dataKey DataKey, addLabel bool) error
 	}
 
 	if _, err := tw.writeEvent(tw.ctx, event); err != nil {
-		if !apierrors.IsConflict(err) {
-			return fmt.Errorf("writing event: %w", err)
-		}
-		// Another pod may have already modified this resource. Re-read the
-		// latest version and check whether the label is already correct.
-		if checkErr := tw.verifyLabelState(dataKey, addLabel); checkErr != nil {
-			return fmt.Errorf("writing event: %w", err)
-		}
-		// The latest version already has the desired label state — treat as success.
-		return nil
-	}
-	return nil
-}
-
-// verifyLabelState reads the latest version of a resource and returns nil if
-// the pending-delete label is already in the desired state.
-func (tw *TenantWatcher) verifyLabelState(dataKey DataKey, wantLabel bool) error {
-	latestKey, err := tw.dataStore.GetLatestResourceKey(tw.ctx, GetRequestKey{
-		Group:     dataKey.Group,
-		Resource:  dataKey.Resource,
-		Namespace: dataKey.Namespace,
-		Name:      dataKey.Name,
-	})
-	if err != nil {
-		return fmt.Errorf("fetching latest key: %w", err)
-	}
-
-	reader, err := tw.dataStore.Get(tw.ctx, latestKey)
-	if err != nil {
-		return fmt.Errorf("reading latest resource: %w", err)
-	}
-	value, err := io.ReadAll(reader)
-	_ = reader.Close()
-	if err != nil {
-		return fmt.Errorf("reading latest resource bytes: %w", err)
-	}
-
-	tmp := &unstructured.Unstructured{}
-	if err := tmp.UnmarshalJSON(value); err != nil {
-		return fmt.Errorf("unmarshaling latest resource: %w", err)
-	}
-
-	labels := tmp.GetLabels()
-	hasLabel := labels[labelPendingDelete] == "true"
-	if hasLabel != wantLabel {
-		return fmt.Errorf("label state mismatch: want=%v, got=%v", wantLabel, hasLabel)
+		return fmt.Errorf("writing event: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/unified/resource/tenant_watcher_test.go
+++ b/pkg/storage/unified/resource/tenant_watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -320,10 +321,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 		// Save a newer version at RV 200 WITH the label (simulating another pod having already labelled it).
 		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 200, map[string]string{labelPendingDelete: "true"})
 
-		callCount := 0
-		conflictOnce := func(_ context.Context, _ *WriteEvent) (int64, error) {
-			callCount++
-			// Return a conflict error (as produced by the backwards-compatible update path).
+		conflictWriter := func(_ context.Context, _ *WriteEvent) (int64, error) {
 			return 0, apierrors.NewConflict(schema.GroupResource{
 				Group: "apps", Resource: "dashboards",
 			}, "dash1", fmt.Errorf("resource version does not match current value"))
@@ -333,15 +331,15 @@ func TestTenantResourceLabelling(t *testing.T) {
 			log:                log.NewNopLogger(),
 			pendingDeleteStore: newPendingDeleteStore(ds.kv),
 			dataStore:          ds,
-			writeEvent:         conflictOnce,
+			writeEvent:         conflictWriter,
 			ctx:                t.Context(),
 			stopCh:             make(chan struct{}),
 		}
 
 		tw.handleTenant(pendingDeleteTenant("tenant-1", "2026-03-01T00:00:00Z"))
 
-		// The write failed with a conflict, but the latest version already has
-		// the label, so the operation should have succeeded overall.
+		// The latest version already has the label, so doEditResourceLabel
+		// detects the no-op and the operation succeeds without writing.
 		_, err := tw.pendingDeleteStore.Get(t.Context(), "tenant-1")
 		require.NoError(t, err, "pending delete record should be created despite conflict error")
 	})
@@ -367,15 +365,80 @@ func TestTenantResourceLabelling(t *testing.T) {
 			writeEvent:         conflictWriter,
 			ctx:                t.Context(),
 			stopCh:             make(chan struct{}),
+			retryMaxDelay:      time.Millisecond,
 		}
 
 		tw.handleTenant(pendingDeleteTenant("tenant-1", "2026-03-01T00:00:00Z"))
 
-		// The intent record is written before labelling, so it should exist
-		// but with LabelingComplete=false since the conflict could not be resolved.
+		// All retry attempts are exhausted (conflicts every time), so the
+		// intent record exists but with LabelingComplete=false.
 		record, err := tw.pendingDeleteStore.Get(t.Context(), "tenant-1")
 		require.NoError(t, err, "intent record should exist")
 		assert.False(t, record.LabelingComplete, "labeling should not be marked complete")
+	})
+
+	t.Run("retry succeeds after transient conflict", func(t *testing.T) {
+		ds := newDataStore(setupBadgerKV(t))
+		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+		callCount := 0
+		conflictThenSucceed := func(_ context.Context, event *WriteEvent) (int64, error) {
+			callCount++
+			if callCount == 1 {
+				return 0, apierrors.NewConflict(schema.GroupResource{
+					Group: "apps", Resource: "dashboards",
+				}, "dash1", fmt.Errorf("resource version does not match current value"))
+			}
+			return 1, nil
+		}
+
+		tw := &TenantWatcher{
+			log:                log.NewNopLogger(),
+			pendingDeleteStore: newPendingDeleteStore(ds.kv),
+			dataStore:          ds,
+			writeEvent:         conflictThenSucceed,
+			ctx:                t.Context(),
+			stopCh:             make(chan struct{}),
+			retryMaxDelay:      time.Millisecond,
+		}
+
+		tw.handleTenant(pendingDeleteTenant("tenant-1", "2026-03-01T00:00:00Z"))
+
+		record, err := tw.pendingDeleteStore.Get(t.Context(), "tenant-1")
+		require.NoError(t, err)
+		assert.True(t, record.LabelingComplete, "labeling should succeed after retry")
+		assert.Equal(t, 2, callCount, "writeEvent should be called exactly twice")
+	})
+
+	t.Run("context cancellation stops retry on conflict", func(t *testing.T) {
+		ds := newDataStore(setupBadgerKV(t))
+		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		conflictAndCancel := func(_ context.Context, _ *WriteEvent) (int64, error) {
+			cancel()
+			return 0, apierrors.NewConflict(schema.GroupResource{
+				Group: "apps", Resource: "dashboards",
+			}, "dash1", fmt.Errorf("resource version does not match current value"))
+		}
+
+		tw := &TenantWatcher{
+			log:                log.NewNopLogger(),
+			pendingDeleteStore: newPendingDeleteStore(ds.kv),
+			dataStore:          ds,
+			writeEvent:         conflictAndCancel,
+			ctx:                ctx,
+			stopCh:             make(chan struct{}),
+			retryMaxDelay:      time.Millisecond,
+		}
+
+		dataKey := DataKey{
+			Group: "apps", Resource: "dashboards",
+			Namespace: "tenant-1", Name: "dash1",
+			ResourceVersion: 100, Action: DataActionCreated,
+		}
+		err := tw.editResourceLabel(dataKey, true)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("partial labelling failure followed by tenant unmark cleans up orphaned labels", func(t *testing.T) {


### PR DESCRIPTION
On conflict, retry with jitter which should cause at least one update to the labels succeed with high probability.