### PR TITLE
Auth: Use dedicated token for requests to Grafana.com

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1896,6 +1896,7 @@ url = https://grafana.com
 url = https://grafana.com
 api_url = https://grafana.com/api
 sso_api_token = ""
+proxy_token = ""
 
 #################################### Distributed tracing ############
 # Opentracing is deprecated use opentelemetry instead
@@ -2044,8 +2045,6 @@ public_key_retrieval_disabled = false
 public_key_retrieval_on_startup = false
 # Enter a comma-separated list of plugin identifiers to avoid loading (including core plugins). These plugins will be hidden in the catalog.
 disable_plugins =
-# Auth token for plugin install and discoverability requests to Grafana.com
-install_token =
 # Comma separated list of plugin ids for which all host environment variables should be forwarded to the plugin process.
 forward_host_env_vars =
 # Comma separated list of plugin ids to install as part of the startup process.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2044,6 +2044,8 @@ public_key_retrieval_disabled = false
 public_key_retrieval_on_startup = false
 # Enter a comma-separated list of plugin identifiers to avoid loading (including core plugins). These plugins will be hidden in the catalog.
 disable_plugins =
+# Auth token for proxying requests to the Grafana.com /plugins API
+install_token =
 # Comma separated list of plugin ids for which all host environment variables should be forwarded to the plugin process.
 forward_host_env_vars =
 # Comma separated list of plugin ids to install as part of the startup process.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2044,7 +2044,7 @@ public_key_retrieval_disabled = false
 public_key_retrieval_on_startup = false
 # Enter a comma-separated list of plugin identifiers to avoid loading (including core plugins). These plugins will be hidden in the catalog.
 disable_plugins =
-# Auth token for proxying requests to the Grafana.com /plugins API
+# Auth token for plugin install and discoverability requests to Grafana.com
 install_token =
 # Comma separated list of plugin ids for which all host environment variables should be forwarded to the plugin process.
 forward_host_env_vars =

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2319,6 +2319,13 @@ The `[grafana_net]` configuration is still accepted and parsed as `[grafana_com]
 Default is https://grafana.com.
 The default authentication identity provider for Grafana Cloud.
 
+#### `proxy_token`
+
+Default is empty.
+A dedicated API token for plugin catalog browsing and plugin installs via `grafana-cli`. Requires the `dedicatedGrafanaComProxyAPIToken` [feature toggle]({{< relref "#feature_toggles" >}}) to be enabled.
+
+Set via environment variable: `GF_GRAFANA_COM_PROXY_TOKEN`.
+
 <hr>
 
 ### `[tracing.jaeger]`

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -51,7 +51,7 @@ func ReverseProxyGnetReq(logger log.Logger, proxyPath, version, grafanaComAPIUrl
 
 func (hs *HTTPServer) ProxyGnetRequest(c *contextmodel.ReqContext) {
 	proxyPath := web.Params(c.Req)["*"]
-	proxy := ReverseProxyGnetReq(c.Logger, proxyPath, hs.Cfg.BuildVersion, hs.Cfg.GrafanaComAPIURL, hs.Cfg.GrafanaComSSOAPIToken)
+	proxy := ReverseProxyGnetReq(c.Logger, proxyPath, hs.Cfg.BuildVersion, hs.Cfg.GrafanaComAPIURL, hs.Cfg.PluginInstallToken)
 	proxy.Transport = grafanaComProxyTransport
 	proxy.ServeHTTP(c.Resp, c.Req)
 }

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -51,7 +51,7 @@ func ReverseProxyGnetReq(logger log.Logger, proxyPath, version, grafanaComAPIUrl
 
 func (hs *HTTPServer) ProxyGnetRequest(c *contextmodel.ReqContext) {
 	proxyPath := web.Params(c.Req)["*"]
-	proxy := ReverseProxyGnetReq(c.Logger, proxyPath, hs.Cfg.BuildVersion, hs.Cfg.GrafanaComAPIURL, hs.Cfg.PluginInstallToken)
+	proxy := ReverseProxyGnetReq(c.Logger, proxyPath, hs.Cfg.BuildVersion, hs.Cfg.GrafanaComAPIURL, hs.Cfg.GrafanaComProxyAPIToken)
 	proxy.Transport = grafanaComProxyTransport
 	proxy.ServeHTTP(c.Resp, c.Req)
 }

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -99,7 +99,7 @@ func newInstallPluginOpts(c utils.CommandLine) pluginInstallOpts {
 		repoURL:   c.PluginRepoURL(),
 		pluginURL: c.PluginURL(),
 		pluginDir: c.PluginDirectory(),
-		gcomToken: c.GcomToken(),
+		gcomToken: c.PluginInstallToken(),
 	}
 }
 

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -99,7 +99,7 @@ func newInstallPluginOpts(c utils.CommandLine) pluginInstallOpts {
 		repoURL:   c.PluginRepoURL(),
 		pluginURL: c.PluginURL(),
 		pluginDir: c.PluginDirectory(),
-		gcomToken: c.PluginInstallToken(),
+		gcomToken: c.GrafanaComProxyAPIToken(),
 	}
 }
 

--- a/pkg/cmd/grafana-cli/commands/upgrade_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_command_test.go
@@ -120,18 +120,18 @@ func (a simpleArgs) Slice() []string { return []string(a) }
 // Base struct with default implementations for unused CommandLine methods
 type baseCommandLine struct{}
 
-func (b baseCommandLine) ShowHelp() error               { return nil }
-func (b baseCommandLine) ShowVersion()                  {}
-func (b baseCommandLine) Application() *cli.App         { return nil }
-func (b baseCommandLine) Int(_ string) int              { return 0 }
-func (b baseCommandLine) String(_ string) string        { return "" }
-func (b baseCommandLine) StringSlice(_ string) []string { return nil }
-func (b baseCommandLine) FlagNames() []string           { return nil }
-func (b baseCommandLine) Generic(_ string) any          { return nil }
-func (b baseCommandLine) Bool(_ string) bool            { return false }
-func (b baseCommandLine) PluginURL() string             { return "" }
-func (b baseCommandLine) GcomToken() string             { return "" }
-func (b baseCommandLine) PluginInstallToken() string    { return "" }
+func (b baseCommandLine) ShowHelp() error                 { return nil }
+func (b baseCommandLine) ShowVersion()                    {}
+func (b baseCommandLine) Application() *cli.App           { return nil }
+func (b baseCommandLine) Int(_ string) int                { return 0 }
+func (b baseCommandLine) String(_ string) string          { return "" }
+func (b baseCommandLine) StringSlice(_ string) []string   { return nil }
+func (b baseCommandLine) FlagNames() []string             { return nil }
+func (b baseCommandLine) Generic(_ string) any            { return nil }
+func (b baseCommandLine) Bool(_ string) bool              { return false }
+func (b baseCommandLine) PluginURL() string               { return "" }
+func (b baseCommandLine) GcomToken() string               { return "" }
+func (b baseCommandLine) GrafanaComProxyAPIToken() string { return "" }
 
 // Test implementation - only implements what we actually need
 type testCommandLine struct {

--- a/pkg/cmd/grafana-cli/commands/upgrade_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_command_test.go
@@ -131,6 +131,7 @@ func (b baseCommandLine) Generic(_ string) any          { return nil }
 func (b baseCommandLine) Bool(_ string) bool            { return false }
 func (b baseCommandLine) PluginURL() string             { return "" }
 func (b baseCommandLine) GcomToken() string             { return "" }
+func (b baseCommandLine) PluginInstallToken() string    { return "" }
 
 // Test implementation - only implements what we actually need
 type testCommandLine struct {

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -27,7 +27,7 @@ type CommandLine interface {
 	PluginRepoURL() string
 	PluginURL() string
 	GcomToken() string
-	PluginInstallToken() string
+	GrafanaComProxyAPIToken() string
 }
 
 type ApiClient interface {
@@ -108,15 +108,15 @@ func (c *ContextCommandLine) GcomToken() string {
 	return cfg.GrafanaComSSOAPIToken
 }
 
-func (c *ContextCommandLine) PluginInstallToken() string {
+func (c *ContextCommandLine) GrafanaComProxyAPIToken() string {
 	cfg, err := c.Config()
 
 	if err != nil {
 		logger.Debug("Could not parse config file", err)
 		return ""
 	}
-	if cfg.PluginInstallToken != "" {
-		return cfg.PluginInstallToken
+	if cfg.GrafanaComProxyAPIToken != "" {
+		return cfg.GrafanaComProxyAPIToken
 	}
 	return cfg.GrafanaComSSOAPIToken
 }

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -27,6 +27,7 @@ type CommandLine interface {
 	PluginRepoURL() string
 	PluginURL() string
 	GcomToken() string
+	PluginInstallToken() string
 }
 
 type ApiClient interface {
@@ -104,7 +105,20 @@ func (c *ContextCommandLine) GcomToken() string {
 		logger.Debug("Could not parse config file", err)
 		return ""
 	}
-	return cfg.PluginInstallToken
+	return cfg.GrafanaComSSOAPIToken
+}
+
+func (c *ContextCommandLine) PluginInstallToken() string {
+	cfg, err := c.Config()
+
+	if err != nil {
+		logger.Debug("Could not parse config file", err)
+		return ""
+	}
+	if cfg.PluginInstallToken != "" {
+		return cfg.PluginInstallToken
+	}
+	return cfg.GrafanaComSSOAPIToken
 }
 
 func (c *ContextCommandLine) PluginURL() string {

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -104,7 +104,7 @@ func (c *ContextCommandLine) GcomToken() string {
 		logger.Debug("Could not parse config file", err)
 		return ""
 	}
-	return cfg.GrafanaComSSOAPIToken
+	return cfg.PluginInstallToken
 }
 
 func (c *ContextCommandLine) PluginURL() string {

--- a/pkg/cmd/grafana-cli/utils/command_line_mock.go
+++ b/pkg/cmd/grafana-cli/utils/command_line_mock.go
@@ -159,7 +159,7 @@ func (_m *MockCommandLine) GcomToken() string {
 	return r0
 }
 
-func (_m *MockCommandLine) PluginInstallToken() string {
+func (_m *MockCommandLine) GrafanaComProxyAPIToken() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/pkg/cmd/grafana-cli/utils/command_line_mock.go
+++ b/pkg/cmd/grafana-cli/utils/command_line_mock.go
@@ -159,6 +159,19 @@ func (_m *MockCommandLine) GcomToken() string {
 	return r0
 }
 
+func (_m *MockCommandLine) PluginInstallToken() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // ShowHelp provides a mock function with given fields:
 func (_m *MockCommandLine) ShowHelp() error {
 	ret := _m.Called()

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -110,6 +110,7 @@ func RunServer(opts standalone.BuildInfo, cli *cli.Context) error {
 	if err := featuremgmt.InitOpenFeatureWithCfg(cfg); err != nil {
 		return err
 	}
+	cfg.ResolvePluginInstallToken()
 
 	s, err := server.Initialize(
 		cli.Context,

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -110,7 +110,7 @@ func RunServer(opts standalone.BuildInfo, cli *cli.Context) error {
 	if err := featuremgmt.InitOpenFeatureWithCfg(cfg); err != nil {
 		return err
 	}
-	cfg.ResolvePluginInstallToken()
+	cfg.ResolveGrafanaComProxyAPIToken()
 
 	s, err := server.Initialize(
 		cli.Context,

--- a/pkg/cmd/grafana-server/commands/target.go
+++ b/pkg/cmd/grafana-server/commands/target.go
@@ -96,6 +96,8 @@ func RunTargetServer(opts standalone.BuildInfo, cli *cli.Context) error {
 	if err := featuremgmt.InitOpenFeatureWithCfg(cfg); err != nil {
 		return err
 	}
+	cfg.ResolvePluginInstallToken()
+
 	s, err := server.InitializeModuleServer(
 		cfg,
 		server.Options{

--- a/pkg/cmd/grafana-server/commands/target.go
+++ b/pkg/cmd/grafana-server/commands/target.go
@@ -96,7 +96,7 @@ func RunTargetServer(opts standalone.BuildInfo, cli *cli.Context) error {
 	if err := featuremgmt.InitOpenFeatureWithCfg(cfg); err != nil {
 		return err
 	}
-	cfg.ResolvePluginInstallToken()
+	cfg.ResolveGrafanaComProxyAPIToken()
 
 	s, err := server.InitializeModuleServer(
 		cfg,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2250,6 +2250,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "pluginsDedicatedInstallToken",
+			Description: "Use a dedicated auth token for Grafana.com plugin API requests and plugin installs",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyGo: true},
+			Owner:       grafanaPluginsPlatformSquad,
+			Expression:  "false",
+		},
+		{
 			Name:        "newVizSuggestions",
 			Description: "Enable new visualization suggestions",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2250,10 +2250,10 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "dedicatedGrafanaComProxyAPIToken",
+			Name:        "grafana.dedicatedGrafanaComProxyAPIToken",
 			Description: "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
 			Stage:       FeatureStageExperimental,
-			Generate:    Generate{LegacyGo: true},
+			Generate:    Generate{Go: true},
 			Owner:       grafanaPluginsPlatformSquad,
 			Expression:  "false",
 		},

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2250,8 +2250,8 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "pluginsDedicatedInstallToken",
-			Description: "Use a dedicated auth token for Grafana.com plugin API requests and plugin installs",
+			Name:        "dedicatedGrafanaComProxyAPIToken",
+			Description: "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
 			Stage:       FeatureStageExperimental,
 			Generate:    Generate{LegacyGo: true},
 			Owner:       grafanaPluginsPlatformSquad,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -262,7 +262,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-08-29,cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-08-29,cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-10-24,pluginInstallAPISync,experimental,@grafana/plugins-platform-backend,false,false,false
-2026-04-29,dedicatedGrafanaComProxyAPIToken,experimental,@grafana/plugins-platform-backend,false,false,false
+2026-05-05,grafana.dedicatedGrafanaComProxyAPIToken,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-11-12,newVizSuggestions,GA,@grafana/dataviz-squad,false,false,true
 2026-02-18,panelStyleActions,experimental,@grafana/dataviz-squad,false,false,true
 2026-02-18,vizPresets,preview,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -262,7 +262,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-08-29,cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-08-29,cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-10-24,pluginInstallAPISync,experimental,@grafana/plugins-platform-backend,false,false,false
-2026-04-28,pluginsDedicatedInstallToken,experimental,@grafana/plugins-platform-backend,false,false,false
+2026-04-29,dedicatedGrafanaComProxyAPIToken,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-11-12,newVizSuggestions,GA,@grafana/dataviz-squad,false,false,true
 2026-02-18,panelStyleActions,experimental,@grafana/dataviz-squad,false,false,true
 2026-02-18,vizPresets,preview,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -262,6 +262,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-08-29,cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-08-29,cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-10-24,pluginInstallAPISync,experimental,@grafana/plugins-platform-backend,false,false,false
+2026-04-28,pluginsDedicatedInstallToken,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-11-12,newVizSuggestions,GA,@grafana/dataviz-squad,false,false,true
 2026-02-18,panelStyleActions,experimental,@grafana/dataviz-squad,false,false,true
 2026-02-18,vizPresets,preview,@grafana/dataviz-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -722,9 +722,9 @@ const (
 	// Enable syncing plugin installations to the installs API
 	FlagPluginInstallAPISync = "pluginInstallAPISync"
 
-	// FlagPluginsDedicatedInstallToken
-	// Use a dedicated auth token for Grafana.com plugin API requests and plugin installs
-	FlagPluginsDedicatedInstallToken = "pluginsDedicatedInstallToken"
+	// FlagDedicatedGrafanaComProxyAPIToken
+	// Use a dedicated auth token for Grafana.com proxy requests and plugin installs
+	FlagDedicatedGrafanaComProxyAPIToken = "dedicatedGrafanaComProxyAPIToken"
 
 	// FlagJaegerEnableGrpcEndpoint
 	// Enable querying trace data through Jaeger's gRPC endpoint (HTTP)

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -722,9 +722,9 @@ const (
 	// Enable syncing plugin installations to the installs API
 	FlagPluginInstallAPISync = "pluginInstallAPISync"
 
-	// FlagDedicatedGrafanaComProxyAPIToken
+	// FlagGrafanaDedicatedGrafanaComProxyAPIToken
 	// Use a dedicated auth token for Grafana.com proxy requests and plugin installs
-	FlagDedicatedGrafanaComProxyAPIToken = "dedicatedGrafanaComProxyAPIToken"
+	FlagGrafanaDedicatedGrafanaComProxyAPIToken = "grafana.dedicatedGrafanaComProxyAPIToken"
 
 	// FlagJaegerEnableGrpcEndpoint
 	// Enable querying trace data through Jaeger's gRPC endpoint (HTTP)

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -722,6 +722,10 @@ const (
 	// Enable syncing plugin installations to the installs API
 	FlagPluginInstallAPISync = "pluginInstallAPISync"
 
+	// FlagPluginsDedicatedInstallToken
+	// Use a dedicated auth token for Grafana.com plugin API requests and plugin installs
+	FlagPluginsDedicatedInstallToken = "pluginsDedicatedInstallToken"
+
 	// FlagJaegerEnableGrpcEndpoint
 	// Enable querying trace data through Jaeger's gRPC endpoint (HTTP)
 	FlagJaegerEnableGrpcEndpoint = "jaegerEnableGrpcEndpoint"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2042,6 +2042,47 @@
     },
     {
       "metadata": {
+        "name": "dedicatedGnetProxyToken",
+        "resourceVersion": "1777400900377",
+        "creationTimestamp": "2026-04-28T18:28:20Z",
+        "deletionTimestamp": "2026-04-29T00:45:54Z"
+      },
+      "spec": {
+        "description": "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dedicatedGrafanaComProxyAPIToken",
+        "resourceVersion": "1777425647409",
+        "creationTimestamp": "2026-04-29T01:20:47Z"
+      },
+      "spec": {
+        "description": "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dedicatedGrafanaComProxyToken",
+        "resourceVersion": "1777423554751",
+        "creationTimestamp": "2026-04-29T00:45:54Z",
+        "deletionTimestamp": "2026-04-29T01:20:47Z"
+      },
+      "spec": {
+        "description": "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "disableNumericMetricsSortingInExpressions",
         "resourceVersion": "1775137669107",
         "creationTimestamp": "2024-04-16T14:52:47Z",
@@ -4501,7 +4542,8 @@
       "metadata": {
         "name": "pluginsDedicatedInstallToken",
         "resourceVersion": "1777390418301",
-        "creationTimestamp": "2026-04-28T15:33:38Z"
+        "creationTimestamp": "2026-04-28T15:33:38Z",
+        "deletionTimestamp": "2026-04-28T18:28:20Z"
       },
       "spec": {
         "description": "Use a dedicated auth token for Grafana.com plugin API requests and plugin installs",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4499,6 +4499,19 @@
     },
     {
       "metadata": {
+        "name": "pluginsDedicatedInstallToken",
+        "resourceVersion": "1777390418301",
+        "creationTimestamp": "2026-04-28T15:33:38Z"
+      },
+      "spec": {
+        "description": "Use a dedicated auth token for Grafana.com plugin API requests and plugin installs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "pluginsSriChecks",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2024-10-04T12:55:09Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2058,7 +2058,8 @@
       "metadata": {
         "name": "dedicatedGrafanaComProxyAPIToken",
         "resourceVersion": "1777425647409",
-        "creationTimestamp": "2026-04-29T01:20:47Z"
+        "creationTimestamp": "2026-04-29T01:20:47Z",
+        "deletionTimestamp": "2026-05-05T12:28:16Z"
       },
       "spec": {
         "description": "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
@@ -2619,6 +2620,19 @@
         "description": "Route any calls to legacy correlations endpoints to call through to app platform",
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafana.dedicatedGrafanaComProxyAPIToken",
+        "resourceVersion": "1777984096821",
+        "creationTimestamp": "2026-05-05T12:28:16Z"
+      },
+      "spec": {
+        "description": "Use a dedicated auth token for Grafana.com proxy requests and plugin installs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
         "expression": "false"
       }
     },

--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -36,7 +36,7 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 		cfg.GrafanaComAPIURL,
 		cfg.DisablePlugins,
 		cfg.ForwardHostEnvVars,
-		cfg.GrafanaComSSOAPIToken,
+		cfg.PluginInstallToken,
 	), nil
 }
 

--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -36,7 +36,7 @@ func ProvidePluginManagementConfig(cfg *setting.Cfg, settingProvider setting.Pro
 		cfg.GrafanaComAPIURL,
 		cfg.DisablePlugins,
 		cfg.ForwardHostEnvVars,
-		cfg.PluginInstallToken,
+		cfg.GrafanaComProxyAPIToken,
 	), nil
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -535,6 +535,9 @@ type Cfg struct {
 	// Grafana.com SSO API token used for Unified SSO between instances and Grafana.com.
 	GrafanaComSSOAPIToken string
 
+	// PluginInstallToken is the auth token for requests to the Grafana.com /plugins API.
+	PluginInstallToken string
+
 	// Geomap base layer config
 	GeomapDefaultBaseLayerConfig map[string]any
 	GeomapEnableCustomBaseLayers bool
@@ -1658,6 +1661,10 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.GrafanaComAPIURL = valueAsString(iniFile.Section("grafana_com"), "api_url", grafanaComUrl+"/api")
 	cfg.GrafanaComSSOAPIToken = valueAsString(iniFile.Section("grafana_com"), "sso_api_token", "")
+	// Fall back to sso_api_token when install_token is not explicitly configured.
+	if cfg.PluginInstallToken == "" {
+		cfg.PluginInstallToken = cfg.GrafanaComSSOAPIToken
+	}
 	imageUploadingSection := iniFile.Section("external_image_storage")
 	cfg.ImageUploadProvider = valueAsString(imageUploadingSection, "provider", "")
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -5,6 +5,7 @@ package setting
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/prometheus/common/model"
 	"gopkg.in/ini.v1"
 
@@ -535,7 +537,7 @@ type Cfg struct {
 	// Grafana.com SSO API token used for Unified SSO between instances and Grafana.com.
 	GrafanaComSSOAPIToken string
 
-	// PluginInstallToken is the auth token for requests to the Grafana.com /plugins API.
+	// PluginInstallToken is the dedicated auth token for plugin-related requests to Grafana.com.
 	PluginInstallToken string
 
 	// Geomap base layer config
@@ -752,6 +754,16 @@ type InstallPlugin struct {
 	ID      string `json:"id"`
 	Version string `json:"version"`
 	URL     string `json:"url,omitempty"`
+}
+
+// ResolvePluginInstallToken must be called after OpenFeature is initialized.
+// It sets PluginInstallToken to the dedicated token when the pluginsDedicatedInstallToken
+// flag is enabled and install_token is configured; otherwise falls back to sso_api_token.
+func (cfg *Cfg) ResolvePluginInstallToken() {
+	if openfeature.NewDefaultClient().Boolean(context.Background(), "pluginsDedicatedInstallToken", false, openfeature.EvaluationContext{}) && cfg.PluginInstallToken != "" {
+		return
+	}
+	cfg.PluginInstallToken = cfg.GrafanaComSSOAPIToken
 }
 
 // AddChangePasswordLink returns if login form is disabled or not since
@@ -1661,10 +1673,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.GrafanaComAPIURL = valueAsString(iniFile.Section("grafana_com"), "api_url", grafanaComUrl+"/api")
 	cfg.GrafanaComSSOAPIToken = valueAsString(iniFile.Section("grafana_com"), "sso_api_token", "")
-	// Fall back to sso_api_token when install_token is not explicitly configured.
-	if cfg.PluginInstallToken == "" {
-		cfg.PluginInstallToken = cfg.GrafanaComSSOAPIToken
-	}
 	imageUploadingSection := iniFile.Section("external_image_storage")
 	cfg.ImageUploadProvider = valueAsString(imageUploadingSection, "provider", "")
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -537,8 +537,8 @@ type Cfg struct {
 	// Grafana.com SSO API token used for Unified SSO between instances and Grafana.com.
 	GrafanaComSSOAPIToken string
 
-	// PluginInstallToken is the dedicated auth token for plugin-related requests to Grafana.com.
-	PluginInstallToken string
+	// GrafanaComProxyAPIToken is the dedicated auth token for Grafana.com proxy requests and plugin installs.
+	GrafanaComProxyAPIToken string
 
 	// Geomap base layer config
 	GeomapDefaultBaseLayerConfig map[string]any
@@ -756,14 +756,14 @@ type InstallPlugin struct {
 	URL     string `json:"url,omitempty"`
 }
 
-// ResolvePluginInstallToken must be called after OpenFeature is initialized.
-// It sets PluginInstallToken to the dedicated token when the pluginsDedicatedInstallToken
-// flag is enabled and install_token is configured; otherwise falls back to sso_api_token.
-func (cfg *Cfg) ResolvePluginInstallToken() {
-	if openfeature.NewDefaultClient().Boolean(context.Background(), "pluginsDedicatedInstallToken", false, openfeature.EvaluationContext{}) && cfg.PluginInstallToken != "" {
+// ResolveGrafanaComProxyAPIToken must be called after OpenFeature is initialized.
+// It sets GrafanaComProxyAPIToken to the dedicated token when the dedicatedGrafanaComProxyAPIToken
+// flag is enabled and proxy_token is configured; otherwise falls back to sso_api_token.
+func (cfg *Cfg) ResolveGrafanaComProxyAPIToken() {
+	if openfeature.NewDefaultClient().Boolean(context.Background(), "dedicatedGrafanaComProxyAPIToken", false, openfeature.EvaluationContext{}) && cfg.GrafanaComProxyAPIToken != "" {
 		return
 	}
-	cfg.PluginInstallToken = cfg.GrafanaComSSOAPIToken
+	cfg.GrafanaComProxyAPIToken = cfg.GrafanaComSSOAPIToken
 }
 
 // AddChangePasswordLink returns if login form is disabled or not since
@@ -828,6 +828,7 @@ func RedactedValue(key, value string) string {
 		"API_TOKEN$",
 		"WEBHOOK_TOKEN$",
 		"INSTALL_TOKEN$",
+		"PROXY_TOKEN$",
 	} {
 		if match, err := regexp.MatchString(pattern, uppercased); match && err == nil {
 			return RedactedPassword
@@ -1673,6 +1674,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	cfg.GrafanaComAPIURL = valueAsString(iniFile.Section("grafana_com"), "api_url", grafanaComUrl+"/api")
 	cfg.GrafanaComSSOAPIToken = valueAsString(iniFile.Section("grafana_com"), "sso_api_token", "")
+	cfg.GrafanaComProxyAPIToken = valueAsString(iniFile.Section("grafana_com"), "proxy_token", "")
 	imageUploadingSection := iniFile.Section("external_image_storage")
 	cfg.ImageUploadProvider = valueAsString(imageUploadingSection, "provider", "")
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -757,10 +757,10 @@ type InstallPlugin struct {
 }
 
 // ResolveGrafanaComProxyAPIToken must be called after OpenFeature is initialized.
-// It sets GrafanaComProxyAPIToken to the dedicated token when the dedicatedGrafanaComProxyAPIToken
+// It sets GrafanaComProxyAPIToken to the dedicated token when the grafana.dedicatedGrafanaComProxyAPIToken
 // flag is enabled and proxy_token is configured; otherwise falls back to sso_api_token.
 func (cfg *Cfg) ResolveGrafanaComProxyAPIToken() {
-	if openfeature.NewDefaultClient().Boolean(context.Background(), "dedicatedGrafanaComProxyAPIToken", false, openfeature.EvaluationContext{}) && cfg.GrafanaComProxyAPIToken != "" {
+	if openfeature.NewDefaultClient().Boolean(context.Background(), "grafana.dedicatedGrafanaComProxyAPIToken", false, openfeature.EvaluationContext{}) && cfg.GrafanaComProxyAPIToken != "" {
 		return
 	}
 	cfg.GrafanaComProxyAPIToken = cfg.GrafanaComSSOAPIToken

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -191,6 +191,7 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	cfg.PluginCatalogURL = pluginsSection.Key("plugin_catalog_url").MustString("https://grafana.com/grafana/plugins/")
 	cfg.PluginAdminEnabled = pluginsSection.Key("plugin_admin_enabled").MustBool(true)
 	cfg.PluginAdminExternalManageEnabled = pluginsSection.Key("plugin_admin_external_manage_enabled").MustBool(false)
+	cfg.PluginInstallToken = pluginsSection.Key("install_token").MustString("")
 	cfg.PluginCatalogHiddenPlugins = util.SplitString(pluginsSection.Key("plugin_catalog_hidden_plugins").MustString(""))
 
 	// Pull disabled plugins from the catalog

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -191,7 +191,6 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	cfg.PluginCatalogURL = pluginsSection.Key("plugin_catalog_url").MustString("https://grafana.com/grafana/plugins/")
 	cfg.PluginAdminEnabled = pluginsSection.Key("plugin_admin_enabled").MustBool(true)
 	cfg.PluginAdminExternalManageEnabled = pluginsSection.Key("plugin_admin_external_manage_enabled").MustBool(false)
-	cfg.PluginInstallToken = pluginsSection.Key("install_token").MustString("")
 	cfg.PluginCatalogHiddenPlugins = util.SplitString(pluginsSection.Key("plugin_catalog_hidden_plugins").MustString(""))
 
 	// Pull disabled plugins from the catalog

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -281,17 +281,13 @@ func Test_readPluginSettings(t *testing.T) {
 	})
 }
 
-func Test_readPluginSettings_InstallToken(t *testing.T) {
-	t.Run("reads install_token into PluginInstallToken when set", func(t *testing.T) {
+func Test_readGrafanaComSettings_GrafanaComProxyAPIToken(t *testing.T) {
+	t.Run("reads proxy_token into GrafanaComProxyAPIToken when set", func(t *testing.T) {
+		t.Setenv("GF_GRAFANA_COM_PROXY_TOKEN", "test-gnet-proxy-token")
 		cfg := NewCfg()
-		sec, err := cfg.Raw.NewSection("plugins")
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
 		require.NoError(t, err)
-		_, err = sec.NewKey("install_token", "test-install-token")
-		require.NoError(t, err)
-
-		err = cfg.readPluginSettings(cfg.Raw)
-		require.NoError(t, err)
-		assert.Equal(t, "test-install-token", cfg.PluginInstallToken)
+		assert.Equal(t, "test-gnet-proxy-token", cfg.GrafanaComProxyAPIToken)
 	})
 }
 

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -281,6 +281,20 @@ func Test_readPluginSettings(t *testing.T) {
 	})
 }
 
+func Test_readPluginSettings_InstallToken(t *testing.T) {
+	t.Run("reads install_token into PluginInstallToken when set", func(t *testing.T) {
+		cfg := NewCfg()
+		sec, err := cfg.Raw.NewSection("plugins")
+		require.NoError(t, err)
+		_, err = sec.NewKey("install_token", "test-install-token")
+		require.NoError(t, err)
+
+		err = cfg.readPluginSettings(cfg.Raw)
+		require.NoError(t, err)
+		assert.Equal(t, "test-install-token", cfg.PluginInstallToken)
+	})
+}
+
 func Test_migrateInstallPluginsToPreinstallPluginsSync(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
-	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
@@ -383,62 +382,58 @@ func TestLoadingSettings(t *testing.T) {
 		require.Equal(t, "https://grafana.com", cfg.GrafanaComURL)
 		require.Equal(t, "https://grafana.com/api", cfg.GrafanaComAPIURL)
 	})
+}
 
-	testProvider := oftesting.NewTestProvider()
-	err := openfeature.SetProviderAndWait(testProvider)
-	require.NoError(t, err)
+func TestResolveGrafanaComProxyAPIToken(t *testing.T) {
+	skipStaticRootValidation = true
 
-	flagEnabled := map[string]memprovider.InMemoryFlag{
-		"pluginsDedicatedInstallToken": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "enabled",
-			Variants:       map[string]any{"enabled": true},
-		},
+	setProvider := func(t *testing.T, flagOn bool) {
+		t.Helper()
+		variant := "disabled"
+		if flagOn {
+			variant = "enabled"
+		}
+		p := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+			"dedicatedGrafanaComProxyAPIToken": {
+				State:          memprovider.Enabled,
+				DefaultVariant: variant,
+				Variants:       map[string]any{"enabled": true, "disabled": false},
+			},
+		})
+		require.NoError(t, openfeature.SetProviderAndWait(p))
+		t.Cleanup(func() { _ = openfeature.SetProviderAndWait(openfeature.NoopProvider{}) })
 	}
-	flagDisabled := map[string]memprovider.InMemoryFlag{
-		"pluginsDedicatedInstallToken": {
-			State:          memprovider.Enabled,
-			DefaultVariant: "disabled",
-			Variants:       map[string]any{"disabled": false},
-		},
-	}
 
-	t.Run("PluginInstallToken falls back to sso_api_token when flag is off", func(t *testing.T) {
-		defer testProvider.Cleanup()
-		testProvider.UsingFlags(t, flagDisabled)
+	t.Run("falls back to sso_api_token when flag is off", func(t *testing.T) {
+		setProvider(t, false)
 		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
-		t.Setenv("GF_PLUGINS_INSTALL_TOKEN", "dedicated-token")
+		t.Setenv("GF_GRAFANA_COM_PROXY_TOKEN", "dedicated-token")
 
 		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
-		require.NoError(t, err)
-		cfg.ResolvePluginInstallToken()
-		require.Equal(t, "sso-token", cfg.PluginInstallToken)
+		require.NoError(t, cfg.Load(CommandLineArgs{HomePath: "../../"}))
+		cfg.ResolveGrafanaComProxyAPIToken()
+		require.Equal(t, "sso-token", cfg.GrafanaComProxyAPIToken)
 	})
 
-	t.Run("PluginInstallToken uses dedicated token when flag is on and install_token is set", func(t *testing.T) {
-		defer testProvider.Cleanup()
-		testProvider.UsingFlags(t, flagEnabled)
+	t.Run("uses dedicated token when flag is on and proxy_token is set", func(t *testing.T) {
+		setProvider(t, true)
 		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
-		t.Setenv("GF_PLUGINS_INSTALL_TOKEN", "dedicated-token")
+		t.Setenv("GF_GRAFANA_COM_PROXY_TOKEN", "dedicated-token")
 
 		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
-		require.NoError(t, err)
-		cfg.ResolvePluginInstallToken()
-		require.Equal(t, "dedicated-token", cfg.PluginInstallToken)
+		require.NoError(t, cfg.Load(CommandLineArgs{HomePath: "../../"}))
+		cfg.ResolveGrafanaComProxyAPIToken()
+		require.Equal(t, "dedicated-token", cfg.GrafanaComProxyAPIToken)
 	})
 
-	t.Run("PluginInstallToken falls back to sso_api_token when flag is on but install_token is not set", func(t *testing.T) {
-		defer testProvider.Cleanup()
-		testProvider.UsingFlags(t, flagEnabled)
+	t.Run("falls back to sso_api_token when flag is on but proxy_token is not set", func(t *testing.T) {
+		setProvider(t, true)
 		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
 
 		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
-		require.NoError(t, err)
-		cfg.ResolvePluginInstallToken()
-		require.Equal(t, "sso-token", cfg.PluginInstallToken)
+		require.NoError(t, cfg.Load(CommandLineArgs{HomePath: "../../"}))
+		cfg.ResolveGrafanaComProxyAPIToken()
+		require.Equal(t, "sso-token", cfg.GrafanaComProxyAPIToken)
 	})
 }
 
@@ -662,6 +657,12 @@ func TestRedactedValue(t *testing.T) {
 			desc:     "client token",
 			key:      "token",
 			value:    "test",
+			expected: RedactedPassword,
+		},
+		{
+			desc:     "proxy_token",
+			key:      "GF_GRAFANA_COM_PROXY_TOKEN",
+			value:    "some-token",
 			expected: RedactedPassword,
 		},
 	}

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -380,6 +380,25 @@ func TestLoadingSettings(t *testing.T) {
 		require.Equal(t, "https://grafana.com", cfg.GrafanaComURL)
 		require.Equal(t, "https://grafana.com/api", cfg.GrafanaComAPIURL)
 	})
+
+	t.Run("PluginInstallToken falls back to sso_api_token when install_token is not set", func(t *testing.T) {
+		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.NoError(t, err)
+		require.Equal(t, "sso-token", cfg.PluginInstallToken)
+	})
+
+	t.Run("PluginInstallToken uses install_token when explicitly configured", func(t *testing.T) {
+		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
+		t.Setenv("GF_PLUGINS_INSTALL_TOKEN", "dedicated-token")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.NoError(t, err)
+		require.Equal(t, "dedicated-token", cfg.PluginInstallToken)
+	})
 }
 
 func TestParseAppURLAndSubURL(t *testing.T) {

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
@@ -381,23 +384,61 @@ func TestLoadingSettings(t *testing.T) {
 		require.Equal(t, "https://grafana.com/api", cfg.GrafanaComAPIURL)
 	})
 
-	t.Run("PluginInstallToken falls back to sso_api_token when install_token is not set", func(t *testing.T) {
-		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
+	testProvider := oftesting.NewTestProvider()
+	err := openfeature.SetProviderAndWait(testProvider)
+	require.NoError(t, err)
 
-		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
-		require.NoError(t, err)
-		require.Equal(t, "sso-token", cfg.PluginInstallToken)
-	})
+	flagEnabled := map[string]memprovider.InMemoryFlag{
+		"pluginsDedicatedInstallToken": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "enabled",
+			Variants:       map[string]any{"enabled": true},
+		},
+	}
+	flagDisabled := map[string]memprovider.InMemoryFlag{
+		"pluginsDedicatedInstallToken": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "disabled",
+			Variants:       map[string]any{"disabled": false},
+		},
+	}
 
-	t.Run("PluginInstallToken uses install_token when explicitly configured", func(t *testing.T) {
+	t.Run("PluginInstallToken falls back to sso_api_token when flag is off", func(t *testing.T) {
+		defer testProvider.Cleanup()
+		testProvider.UsingFlags(t, flagDisabled)
 		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
 		t.Setenv("GF_PLUGINS_INSTALL_TOKEN", "dedicated-token")
 
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
 		require.NoError(t, err)
+		cfg.ResolvePluginInstallToken()
+		require.Equal(t, "sso-token", cfg.PluginInstallToken)
+	})
+
+	t.Run("PluginInstallToken uses dedicated token when flag is on and install_token is set", func(t *testing.T) {
+		defer testProvider.Cleanup()
+		testProvider.UsingFlags(t, flagEnabled)
+		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
+		t.Setenv("GF_PLUGINS_INSTALL_TOKEN", "dedicated-token")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.NoError(t, err)
+		cfg.ResolvePluginInstallToken()
 		require.Equal(t, "dedicated-token", cfg.PluginInstallToken)
+	})
+
+	t.Run("PluginInstallToken falls back to sso_api_token when flag is on but install_token is not set", func(t *testing.T) {
+		defer testProvider.Cleanup()
+		testProvider.UsingFlags(t, flagEnabled)
+		t.Setenv("GF_GRAFANA_COM_SSO_API_TOKEN", "sso-token")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.NoError(t, err)
+		cfg.ResolvePluginInstallToken()
+		require.Equal(t, "sso-token", cfg.PluginInstallToken)
 	})
 }
 

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -394,7 +394,7 @@ func TestResolveGrafanaComProxyAPIToken(t *testing.T) {
 			variant = "enabled"
 		}
 		p := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
-			"dedicatedGrafanaComProxyAPIToken": {
+			"grafana.dedicatedGrafanaComProxyAPIToken": {
 				State:          memprovider.Enabled,
 				DefaultVariant: variant,
 				Variants:       map[string]any{"enabled": true, "disabled": false},


### PR DESCRIPTION
**What is this feature?**

Introduces `proxy_token` in the `[grafana_com]` config section as a dedicated auth token for Grafana.com proxy requests and plugin installs (catalog browsing via `/api/gnet/*`, plugin downloads, and `grafana-cli plugin install`).

Related PR https://github.com/grafana/hosted-grafana/pull/7687

**Why do we need this feature?**

Plugin-related requests to Grafana.com were using `sso_api_token`, which is intended for SSO operations. A dedicated token for these requests makes the separation of concerns explicit and allows independent rotation and scoping per use case.

**Who is this feature for?**

Grafana Cloud operators provisioning Grafana instances. Self-hosted users are unaffected — when `proxy_token` is not configured, the code falls back to `sso_api_token`.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-catalog-team/issues/833

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (`dedicatedGrafanaComProxyAPIToken`, off by default)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

## Summary

- Adds `proxy_token` setting to `[grafana_com]` config section, read into `cfg.GrafanaComProxyAPIToken`
- Guards usage behind `dedicatedGrafanaComProxyAPIToken` feature flag (off by default)
- When flag is on: `/api/gnet/*` proxy and plugin manager use `GrafanaComProxyAPIToken`
- When flag is off (or `proxy_token` is not set): falls back to `sso_api_token`, preserving backward compatibility
- `grafana-cli plugin install` uses `GrafanaComProxyAPIToken` when set, falls back to `sso_api_token`
- `GF_GRAFANA_COM_PROXY_TOKEN` env var is redacted in `/api/admin/settings` responses

## Test plan

- [ ] Verify `proxy_token` is read from `[grafana_com]` section into `cfg.GrafanaComProxyAPIToken`
- [ ] Verify fallback to `sso_api_token` when `proxy_token` is empty
- [ ] Verify `/api/gnet/*` proxy uses `GrafanaComProxyAPIToken` when flag `dedicatedGrafanaComProxyAPIToken` is on
- [ ] Verify `/api/gnet/*` proxy falls back to `sso_api_token` when flag is off
- [ ] Verify plugin manager passes `GrafanaComProxyAPIToken` when flag is on
- [ ] Verify `grafana-cli plugin install` uses `GrafanaComProxyAPIToken` when set
- [ ] Verify existing instances with only `sso_api_token` continue to work without changes