### PR TITLE
chore(grafana-ui): replace lodash difference in StatsPicker

### DIFF
--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -51,7 +51,8 @@ export const StatsPicker = memo<StatsPickerProps>(
       const current = fieldReducers.list(stats);
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
-        const notFound = stats.filter((stat) => !found.includes(stat));
+        const foundSet = new Set(found);
+        const notFound = stats.filter((stat) => !foundSet.has(stat));
         console.warn('Unknown stats', notFound, stats);
         onChange(current.map((stat) => stat.id));
       }

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -1,4 +1,3 @@
-import { difference } from 'lodash';
 import { memo, useEffect } from 'react';
 
 import { fieldReducers, type FieldReducerInfo } from '@grafana/data';
@@ -52,7 +51,7 @@ export const StatsPicker = memo<StatsPickerProps>(
       const current = fieldReducers.list(stats);
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
-        const notFound = difference(stats, found);
+        const notFound = stats.filter((stat) => !found.includes(stat));
         console.warn('Unknown stats', notFound, stats);
         onChange(current.map((stat) => stat.id));
       }


### PR DESCRIPTION
## What
Replace `lodash/difference` in `StatsPicker` with native JavaScript.

## Change
- File: [packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx](packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx)
- Replaced:
  - `difference(stats, found)`
  - with `const foundSet = new Set(found);`
        `const notFound = stats.filter((stat) => !foundSet.has(stat));`
- Removed lodash `difference` import.

## Impact
No functional change intended.

## Test
- `npx yarn jest --no-watch packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx`
