### PR TITLE
QueryEditor: Fix transformation editor bug

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorRenderer.tsx
@@ -49,6 +49,7 @@ export function TransformationEditorRenderer() {
     <>
       <TransformationFilterDisplay />
       <TransformationEditor
+        key={selectedTransformation.transformId}
         inputData={inputData}
         onUpdate={updateTransformation}
         transformation={selectedTransformation}


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Fixes https://github.com/grafana/grafana/issues/122274

The transformation editor isn't properly remounting when switching between cards, causing stale state to bleed through — most visible with multiple transformations of the same type.

## Changes
<!--- Describe your changes in detail -->
* Adding `key={transformId}` (which is unique to each transformation card), forcing a full remount when switching transformation cards, preventing internal state from the previous editor from persisting. We do the same thing with the query card editors. This was missed in that previous bugfix.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

#### Before

https://github.com/user-attachments/assets/ed9b3c7d-b0d7-4390-b857-c8b6f9780ec2

#### After

https://github.com/user-attachments/assets/9f73d176-2cfc-497a-a59a-62891dd4a538

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* On `main`, ops, querynext instance, etc. add two of the same transformations with distinct settings.
* Toggle between them, notice that the first transformation shows stale settings from the second.
* Pull down the branch, same steps, it's fixed.

> [!NOTE]
> This is really hard to test with RTL, best tested with e2e. Issue here https://github.com/grafana/grafana/issues/122270

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable