### PR TITLE
Graphite: Strip tagged path from `tags.name` when `aliasSub` wrapping is detected

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3250,9 +3250,6 @@
     }
   },
   "public/app/plugins/datasource/graphite/datasource.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 3
-    },
     "@typescript-eslint/no-explicit-any": {
       "count": 8
     }

--- a/pkg/tsdb/graphite/query.go
+++ b/pkg/tsdb/graphite/query.go
@@ -217,7 +217,15 @@ func (s *Service) toDataFrames(response *http.Response, refId string) (frames da
 		tags := make(map[string]string)
 		for name, value := range series.Tags {
 			if name == "name" {
-				value = series.Target
+				// Metrictank sets tags["name"] to the full internal series key
+				// (e.g. "cpu.usage;env=prod;host=web01") rather than just the
+				// base metric name. Strip everything from the first ';' so that
+				// transformations like joinByLabels(value:'name') work correctly.
+				target := series.Target
+				if idx := strings.IndexByte(target, ';'); idx != -1 {
+					target = target[:idx]
+				}
+				value = target
 			}
 			switch value := value.(type) {
 			case string:

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -829,6 +829,13 @@ func TestAliasMatching(t *testing.T) {
 			fromAlert:         false,
 			expectedLabelName: "stats.alias.web.hits",
 		},
+		{
+			name:              "Metrictank tagged path strips to base metric name",
+			target:            "cpu.usage;env=prod;host=web01",
+			tagsName:          "cpu.usage;env=prod;host=web01",
+			fromAlert:         false,
+			expectedLabelName: "cpu.usage",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -227,6 +227,62 @@ describe('graphiteDatasource', () => {
       expect(result.data[0].refId).toBe('A');
       expect(result.data[1].refId).toBe('B');
     });
+    it('strips refID suffix and full tagged path from tags.name (Metrictank aliasSub regression)', () => {
+      // Metrictank sets tags['name'] to the full internal series key when aliasSub
+      // is applied (e.g. "BytesReceived;host=web01;cluster=md1b;... A"). The
+      // joinByLabels(value:'name') transformation breaks because every series has a
+      // unique full path. Restore tags['name'] to the base metric name only.
+      const refIDMap = {
+        refIDA: 'A',
+        refIDB: 'B',
+      };
+      const result = ctx.ds.convertResponseToDataFrames(
+        createFetchResponse({
+          series: [
+            {
+              // target has the refID suffix; tags.name has the full Metrictank path without suffix
+              target: 'BytesReceived;host=web01;cluster=md1b refIDA',
+              tags: { name: 'BytesReceived;host=web01;cluster=md1b', host: 'web01', cluster: 'md1b' },
+              datapoints: [[100, 200]],
+            },
+            {
+              target: 'BytesReceived;host=web02;cluster=md1b refIDB',
+              tags: { name: 'BytesReceived;host=web02;cluster=md1b', host: 'web02', cluster: 'md1b' },
+              datapoints: [[200, 300]],
+            },
+          ],
+        }),
+        refIDMap
+      );
+
+      expect(result.data.length).toBe(2);
+      // tags['name'] must be just the base metric name — no semicolons, no refID suffix
+      const frame0Labels = result.data[0].fields[1]?.labels ?? {};
+      expect(frame0Labels['name']).toBe('BytesReceived');
+      const frame1Labels = result.data[1].fields[1]?.labels ?? {};
+      expect(frame1Labels['name']).toBe('BytesReceived');
+    });
+
+    it('leaves tags.name unchanged for standard graphite-web responses', () => {
+      // Standard graphite-web returns tags['name'] as the plain metric name with no
+      // semicolons, so the normalization should be a no-op.
+      const refIDMap = { refIDA: 'A' };
+      const result = ctx.ds.convertResponseToDataFrames(
+        createFetchResponse({
+          series: [
+            {
+              target: 'cpu.usage refIDA',
+              tags: { name: 'cpu.usage', host: 'web01' },
+              datapoints: [[100, 200]],
+            },
+          ],
+        }),
+        refIDMap
+      );
+
+      const frame0Labels = result.data[0].fields[1]?.labels ?? {};
+      expect(frame0Labels['name']).toBe('cpu.usage');
+    });
   });
 
   describe('When querying graphite with one target using query editor target spec', () => {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -175,7 +175,7 @@ export class GraphiteDatasource
 
         matchers.every((matcher: GraphiteMetricLokiMatcher, index: number) => {
           if (matcher.labelName) {
-            let value = (targetNodes[index] as string)!;
+            let value = String(targetNodes[index]);
 
             if (value === '*') {
               return true;
@@ -423,6 +423,24 @@ export class GraphiteDatasource
         // refID should always be the last element
         refId = splitTarget.pop() || '';
         s.target = splitTarget.join(' ');
+
+        // When aliasSub wrapping is applied, Metrictank sets tags['name'] to the
+        // full internal series key (e.g. "BytesReceived;host=web01;cluster=md1b;...").
+        // Restore it to just the base metric name (the portion before the first ';'),
+        // which is what standard graphite-web returns and what transformations like
+        // joinByLabels(value:'name') expect. Also strip the refID suffix in case
+        // Metrictank reflected it into tags['name'].
+        if (typeof s.tags?.['name'] === 'string') {
+          let tagName = s.tags['name'];
+          if (tagName.endsWith(` ${refId}`)) {
+            tagName = tagName.slice(0, -(refId.length + 1));
+          }
+          const semicolonIdx = tagName.indexOf(';');
+          if (semicolonIdx !== -1) {
+            tagName = tagName.slice(0, semicolonIdx);
+          }
+          s.tags['name'] = tagName;
+        }
       }
       // Disables Grafana own series naming
       s.title = s.target;
@@ -514,12 +532,18 @@ export class GraphiteDatasource
     if (target.target) {
       // Graphite query as target as annotation
       const targetAnnotation = this.templateSrv.replace(target.target, {}, 'glob');
-      const graphiteQuery = {
+      const graphiteQuery: DataQueryRequest<GraphiteQuery> = {
+        requestId: '',
+        interval: '',
+        intervalMs: 0,
         range: range,
+        scopedVars: {},
         targets: [{ target: targetAnnotation, refId: target.refId }],
-        format: 'json',
+        timezone: 'browser',
+        app: 'graphite',
+        startTime: Date.now(),
         maxDataPoints: 100,
-      } as unknown as DataQueryRequest<GraphiteQuery>;
+      };
 
       return lastValueFrom(
         this.query(graphiteQuery).pipe(


### PR DESCRIPTION
Fixes grafana/support-escalations#20542.

After upgrading to Grafana 12, Graphite dashboards using `joinByLabels` or `labelsToFields` with `value: 'name'` broke for Metrictank users. Grafana 12 wraps queries in `aliasSub(...)` to embed the refID in the series name. Metrictank responds by setting `tags["name"]` to the full internal series key (e.g. `BytesReceived;host=web01;cluster=xxx;...`). `convertResponseToDataFrames` stripped the refID from `s.target` but not from `s.tags["name"]`, so every series got a unique name that broke joins and label transformations.

When `aliasSub` wrapping is detected, normalise `tags["name"]` to the base metric name by stripping the refID suffix (if present) and everything from the first `;` onwards. This is a no-op for standard graphite-web responses where `tags["name"]` never contains `;`.
