### PR TITLE
QueryEditor: Distinguish between editor versions in event

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/ExpressionTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/ExpressionTypePicker.tsx
@@ -33,7 +33,7 @@ export function ExpressionTypePicker() {
               reportInteraction('dashboards_expression_interaction', {
                 action: 'add_expression',
                 expression_type: item.value,
-                context: 'panel_query_section',
+                context: 'query_editor_next',
               });
               finalizePendingExpression(item.value);
             }}


### PR DESCRIPTION
## Motivation

This PR closes #122282.

## What does this PR do?

It adjusts event `context` so that we can accurately distinguish between v1 & v2 interactions related to adding a new expression.