### PR TITLE
fix: disable render_key auth when renderer is disabled

### DIFF
--- a/pkg/services/rendering/auth.go
+++ b/pkg/services/rendering/auth.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -32,21 +31,15 @@ type renderJWT struct {
 }
 
 func (rs *RenderingService) GetRenderUser(ctx context.Context, key string) (*RenderUser, bool) {
+	if rs.perRequestRenderKeyProvider == nil {
+		// Rendering is not configured. Just reject the token; it has no reasonable use here.
+		return nil, false
+	}
+
 	var from string
 	start := time.Now()
 
-	var renderUser *RenderUser
-
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if looksLikeJWT(key) && rs.features.IsEnabled(ctx, featuremgmt.FlagRenderAuthJWT) {
-		from = "jwt"
-		renderUser = rs.getRenderUserFromJWT(key)
-	} else {
-		from = "cache"
-		renderUser = rs.getRenderUserFromCache(ctx, key)
-	}
-
-	found := renderUser != nil
+	renderUser, found := rs.perRequestRenderKeyProvider.validate(ctx, key)
 	success := strconv.FormatBool(found)
 	metrics.MRenderingUserLookupSummary.WithLabelValues(success, from).Observe(float64(time.Since(start)))
 
@@ -135,6 +128,25 @@ func (r *perRequestRenderKeyProvider) afterRequest(ctx context.Context, _ AuthOp
 	deleteRenderKey(r.cache, r.log, ctx, renderKey)
 }
 
+func (r *perRequestRenderKeyProvider) validate(ctx context.Context, key string) (*RenderUser, bool) {
+	val, err := r.cache.Get(ctx, fmt.Sprintf(renderKeyPrefix, key))
+	if err != nil {
+		r.log.Error("Could not get render user from remote cache", "err", err)
+		return nil, false
+	}
+
+	ru := new(RenderUser)
+	buf := bytes.NewBuffer(val)
+
+	err = gob.NewDecoder(buf).Decode(&ru)
+	if err != nil {
+		r.log.Error("Could not decode render user from remote cache", "err", err)
+		return nil, false
+	}
+
+	return ru, ru != nil
+}
+
 type jwtRenderKeyProvider struct {
 	log       log.Logger
 	authToken []byte
@@ -161,6 +173,24 @@ func (j *jwtRenderKeyProvider) buildJWTClaims(opts AuthOpts) renderJWT {
 
 func (j *jwtRenderKeyProvider) afterRequest(_ context.Context, _ AuthOpts, _ string) {
 	// do nothing - the JWT will just expire
+}
+
+func (j *jwtRenderKeyProvider) validate(_ context.Context, key string) (*RenderUser, bool) {
+	if !looksLikeJWT(key) {
+		return nil, false
+	}
+
+	claims := new(renderJWT)
+	tkn, err := jwt.ParseWithClaims(key, claims, func(_ *jwt.Token) (any, error) {
+		return []byte(j.authToken), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Alg()}))
+
+	if err != nil || !tkn.Valid {
+		j.log.Error("Could not get render user from JWT", "err", err)
+		return nil, false
+	}
+
+	return claims.RenderUser, claims.RenderUser != nil
 }
 
 func looksLikeJWT(key string) bool {

--- a/pkg/services/rendering/auth.go
+++ b/pkg/services/rendering/auth.go
@@ -46,39 +46,6 @@ func (rs *RenderingService) GetRenderUser(ctx context.Context, key string) (*Ren
 	return renderUser, found
 }
 
-func (rs *RenderingService) getRenderUserFromJWT(key string) *RenderUser {
-	claims := new(renderJWT)
-	tkn, err := jwt.ParseWithClaims(key, claims, func(_ *jwt.Token) (any, error) {
-		return []byte(rs.Cfg.RendererAuthToken), nil
-	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Alg()}))
-
-	if err != nil || !tkn.Valid {
-		rs.log.Error("Could not get render user from JWT", "err", err)
-		return nil
-	}
-
-	return claims.RenderUser
-}
-
-func (rs *RenderingService) getRenderUserFromCache(ctx context.Context, key string) *RenderUser {
-	val, err := rs.RemoteCacheService.Get(ctx, fmt.Sprintf(renderKeyPrefix, key))
-	if err != nil {
-		rs.log.Error("Could not get render user from remote cache", "err", err)
-		return nil
-	}
-
-	ru := new(RenderUser)
-	buf := bytes.NewBuffer(val)
-
-	err = gob.NewDecoder(buf).Decode(&ru)
-	if err != nil {
-		rs.log.Error("Could not decode render user from remote cache", "err", err)
-		return nil
-	}
-
-	return ru
-}
-
 func setRenderKey(cache *remotecache.RemoteCache, ctx context.Context, opts AuthOpts, renderKey string, expiry time.Duration) error {
 	buf := bytes.NewBuffer(nil)
 	err := gob.NewEncoder(buf).Encode(&RenderUser{
@@ -182,7 +149,7 @@ func (j *jwtRenderKeyProvider) validate(_ context.Context, key string) (*RenderU
 
 	claims := new(renderJWT)
 	tkn, err := jwt.ParseWithClaims(key, claims, func(_ *jwt.Token) (any, error) {
-		return []byte(j.authToken), nil
+		return j.authToken, nil
 	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Alg()}))
 
 	if err != nil || !tkn.Valid {

--- a/pkg/services/rendering/auth_test.go
+++ b/pkg/services/rendering/auth_test.go
@@ -10,17 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 	const authToken = "render-secret"
 
-	rs := &RenderingService{
-		Cfg: &setting.Cfg{
-			RendererAuthToken: authToken,
-		},
-		log: log.NewNopLogger(),
+	j := &jwtRenderKeyProvider{
+		authToken: []byte(authToken),
+		log:       log.NewNopLogger(),
+	}
+
+	assertNotAuthenticated := func(t *testing.T, key string) {
+		t.Helper()
+		user, found := j.validate(t.Context(), key)
+		require.False(t, found)
+		require.Nil(t, user)
 	}
 
 	t.Run("returns render user from valid token", func(t *testing.T) {
@@ -35,7 +39,8 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			},
 		})
 
-		renderUser := rs.getRenderUserFromJWT(key)
+		renderUser, found := j.validate(t.Context(), key)
+		require.True(t, found)
 		require.NotNil(t, renderUser)
 		require.Equal(t, &RenderUser{OrgID: 1, UserID: 2, OrgRole: "Viewer"}, renderUser)
 	})
@@ -48,8 +53,7 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			},
 		})
 
-		renderUser := rs.getRenderUserFromJWT(key)
-		require.Nil(t, renderUser)
+		assertNotAuthenticated(t, key)
 	})
 
 	t.Run("returns nil for jwt signed with unexpected algorithm", func(t *testing.T) {
@@ -67,7 +71,7 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 		key, err := token.SignedString([]byte(authToken))
 		require.NoError(t, err)
 
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 	})
 
 	t.Run("returns nil for expired token", func(t *testing.T) {
@@ -82,7 +86,7 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			},
 		})
 
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 	})
 
 	t.Run("returns nil for token signed with wrong key", func(t *testing.T) {
@@ -97,30 +101,30 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			},
 		})
 
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 	})
 
 	t.Run("returns nil for invalid JWTs", func(t *testing.T) {
-		require.Nil(t, rs.getRenderUserFromJWT(""))
+		assertNotAuthenticated(t, "")
 
-		require.Nil(t, rs.getRenderUserFromJWT("not.a.jwt"))
+		assertNotAuthenticated(t, "not.a.jwt")
 
 		key, err := jwt.SigningMethodHS512.Sign("null", []byte(authToken))
 		require.NoError(t, err)
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 
 		key, err = jwt.SigningMethodHS512.Sign("", []byte(authToken))
 		require.NoError(t, err)
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 
 		// missing parts, raw
 		key, err = jwt.SigningMethodHS512.Sign(base64.RawURLEncoding.EncodeToString([]byte(`{"exp":4102444800}`)), []byte(authToken))
 		require.NoError(t, err)
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 
 		key, err = jwt.SigningMethodHS512.Sign(base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS512","typ":"JWT"}`)), []byte(authToken))
 		require.NoError(t, err)
-		require.Nil(t, rs.getRenderUserFromJWT(key))
+		assertNotAuthenticated(t, key)
 	})
 
 	t.Run("returns nil for weak auth cases", func(t *testing.T) {
@@ -140,7 +144,7 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			key, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 			require.NoError(t, err)
 
-			require.Nil(t, rs.getRenderUserFromJWT(key))
+			assertNotAuthenticated(t, key)
 		})
 
 		t.Run("blank secret", func(t *testing.T) {
@@ -148,7 +152,7 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			key, err := token.SignedString([]byte(""))
 			require.NoError(t, err)
 
-			require.Nil(t, rs.getRenderUserFromJWT(key))
+			assertNotAuthenticated(t, key)
 		})
 
 		t.Run("null signature", func(t *testing.T) {
@@ -161,7 +165,7 @@ func TestRenderingService_GetRenderUserFromJWT(t *testing.T) {
 			require.Len(t, parts, 3)
 
 			nullSig := parts[0] + "." + parts[1] + "."
-			require.Nil(t, rs.getRenderUserFromJWT(nullSig))
+			assertNotAuthenticated(t, nullSig)
 		})
 	})
 }

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -94,6 +94,7 @@ type renderCSVFunc func(ctx context.Context, renderKey string, options CSVOpts) 
 type renderKeyProvider interface {
 	get(ctx context.Context, opts AuthOpts) (string, error)
 	afterRequest(ctx context.Context, opts AuthOpts, renderKey string)
+	validate(ctx context.Context, key string) (*RenderUser, bool)
 }
 
 type CapabilitySupportRequestResult struct {

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -109,10 +109,10 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, remot
 	}
 
 	var renderKeyProvider renderKeyProvider
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features.IsEnabledGlobally(featuremgmt.FlagRenderAuthJWT) {
-		// only check if the renderer is configured otherwise we dont need to force changing the default.
-		if cfg.RendererServerUrl != "" {
+	if cfg.RendererServerUrl != "" {
+		//nolint:staticcheck // not yet migrated to OpenFeature
+		if features.IsEnabledGlobally(featuremgmt.FlagRenderAuthJWT) {
+			// only check if the renderer is configured otherwise we dont need to force changing the default.
 			if strings.TrimSpace(cfg.RendererAuthToken) == "" {
 				err := "Using an empty [rendering]renderer_token is not allowed, set it to another value. " +
 					"Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security"
@@ -130,18 +130,19 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, remot
 					return nil, fmt.Errorf("failed to start rendering service: %v", err)
 				}
 			}
-		}
 
-		renderKeyProvider = &jwtRenderKeyProvider{
-			log:       logger,
-			authToken: []byte(cfg.RendererAuthToken),
-			keyExpiry: cfg.RendererRenderKeyLifeTime,
-		}
-	} else {
-		renderKeyProvider = &perRequestRenderKeyProvider{
-			cache:     remoteCache,
-			log:       logger,
-			keyExpiry: cfg.RendererRenderKeyLifeTime,
+			// overwrite the default key provider when we know we have a better way.
+			renderKeyProvider = &jwtRenderKeyProvider{
+				log:       logger,
+				authToken: []byte(cfg.RendererAuthToken),
+				keyExpiry: cfg.RendererRenderKeyLifeTime,
+			}
+		} else {
+			renderKeyProvider = &perRequestRenderKeyProvider{
+				cache:     remoteCache,
+				log:       logger,
+				keyExpiry: cfg.RendererRenderKeyLifeTime,
+			}
 		}
 	}
 
@@ -292,6 +293,10 @@ func (rs *RenderingService) Render(ctx context.Context, renderType RenderType, o
 	startTime := time.Now()
 
 	renderKeyProvider := rs.perRequestRenderKeyProvider
+	if renderKeyProvider == nil {
+		// Rendering is not configured. Just reject the token; it has no reasonable use here.
+		return nil, ErrRenderUnavailable
+	}
 
 	result, err := rs.render(ctx, renderType, opts, renderKeyProvider)
 
@@ -368,6 +373,10 @@ func (rs *RenderingService) RenderCSV(ctx context.Context, opts CSVOpts) (*Rende
 	startTime := time.Now()
 
 	renderKeyProvider := rs.perRequestRenderKeyProvider
+	if renderKeyProvider == nil {
+		// Rendering is not configured. Just reject the token; it has no reasonable use here.
+		return nil, ErrRenderUnavailable
+	}
 
 	result, err := rs.renderCSV(ctx, opts, renderKeyProvider)
 

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -133,6 +133,11 @@ func TestRenderLimitImage(t *testing.T) {
 			RendererServerUrl: "http://localhost:8081/render",
 		},
 		log: log.New("test"),
+		perRequestRenderKeyProvider: &jwtRenderKeyProvider{
+			authToken: []byte("test"),
+			keyExpiry: time.Hour,
+			log:       log.New("test"),
+		},
 	}
 	rs.inProgressCount.Store(2)
 
@@ -161,8 +166,8 @@ func TestRenderLimitImage(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := Opts{Theme: tc.theme, CommonOpts: CommonOpts{ConcurrentLimit: 1}}
-			result, err := rs.Render(context.Background(), RenderPNG, opts)
-			assert.NoError(t, err)
+			result, err := rs.Render(t.Context(), RenderPNG, opts)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result.FilePath)
 		})
 	}
@@ -174,6 +179,11 @@ func TestRenderLimitImageError(t *testing.T) {
 			RendererServerUrl: "http://localhost:8081/render",
 		},
 		log: log.New("test"),
+		perRequestRenderKeyProvider: &jwtRenderKeyProvider{
+			authToken: []byte("test"),
+			keyExpiry: time.Hour,
+			log:       log.New("test"),
+		},
 	}
 	rs.inProgressCount.Store(2)
 
@@ -182,7 +192,7 @@ func TestRenderLimitImageError(t *testing.T) {
 		ErrorOpts:  ErrorOpts{ErrorConcurrentLimitReached: true},
 		Theme:      models.ThemeDark,
 	}
-	result, err := rs.Render(context.Background(), RenderPNG, opts)
+	result, err := rs.Render(t.Context(), RenderPNG, opts)
 	assert.Equal(t, ErrConcurrentLimitReached, err)
 	assert.Nil(t, result)
 }


### PR DESCRIPTION
We don't have any reason to trust the key when there is no renderer. Right now, we just permit any key that is correctly signed, which could lead to dashboard reads we never fail on startup for if the key is default.