### PR TITLE
Dashboards: Reduce Rudderstack event frequency and payload size for large URL dashboards

### DIFF
--- a/packages/grafana-runtime/src/analytics/utils.test.ts
+++ b/packages/grafana-runtime/src/analytics/utils.test.ts
@@ -1,0 +1,73 @@
+import { config } from '../config';
+import { locationService } from '../services';
+import { getEchoSrv, EchoEventType } from '../services/EchoSrv';
+
+import { MAX_PAGE_URL_LENGTH, TRUNCATION_MARKER, reportPageview } from './utils';
+
+jest.mock('../services/EchoSrv');
+jest.mock('../services', () => ({
+  locationService: {
+    getLocation: jest.fn(),
+  },
+}));
+jest.mock('../config', () => ({
+  config: { appSubUrl: '' },
+}));
+
+const mockAddEvent = jest.fn();
+jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as ReturnType<typeof getEchoSrv>);
+
+describe('reportPageview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as ReturnType<typeof getEchoSrv>);
+    config.appSubUrl = '';
+  });
+
+  it('reports the full URL when it is within the length limit', () => {
+    const shortUrl = '/d/abc?var-cluster=prod';
+    jest.mocked(locationService.getLocation).mockReturnValue({
+      pathname: '/d/abc',
+      search: '?var-cluster=prod',
+      hash: '',
+    } as ReturnType<typeof locationService.getLocation>);
+
+    reportPageview();
+
+    expect(mockAddEvent).toHaveBeenCalledWith({
+      type: EchoEventType.Pageview,
+      payload: { page: shortUrl },
+    });
+  });
+
+  it('truncates and appends the marker when the URL exceeds MAX_PAGE_URL_LENGTH', () => {
+    const longSearch = '?var-cluster=' + 'x'.repeat(MAX_PAGE_URL_LENGTH);
+    jest.mocked(locationService.getLocation).mockReturnValue({
+      pathname: '/d/abc',
+      search: longSearch,
+      hash: '',
+    } as ReturnType<typeof locationService.getLocation>);
+
+    reportPageview();
+
+    const reportedPage: string = mockAddEvent.mock.calls[0][0].payload.page;
+    expect(reportedPage.length).toBe(MAX_PAGE_URL_LENGTH);
+    expect(reportedPage.endsWith(TRUNCATION_MARKER)).toBe(true);
+  });
+
+  it('includes appSubUrl in the URL', () => {
+    config.appSubUrl = '/grafana';
+    jest.mocked(locationService.getLocation).mockReturnValue({
+      pathname: '/d/abc',
+      search: '',
+      hash: '',
+    } as ReturnType<typeof locationService.getLocation>);
+
+    reportPageview();
+
+    expect(mockAddEvent).toHaveBeenCalledWith({
+      type: EchoEventType.Pageview,
+      payload: { page: '/grafana/d/abc' },
+    });
+  });
+});

--- a/packages/grafana-runtime/src/analytics/utils.test.ts
+++ b/packages/grafana-runtime/src/analytics/utils.test.ts
@@ -15,12 +15,12 @@ jest.mock('../config', () => ({
 }));
 
 const mockAddEvent = jest.fn();
-jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as ReturnType<typeof getEchoSrv>);
+jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as unknown as ReturnType<typeof getEchoSrv>);
 
 describe('reportPageview', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as ReturnType<typeof getEchoSrv>);
+    jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as unknown as ReturnType<typeof getEchoSrv>);
     config.appSubUrl = '';
   });
 

--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -22,7 +22,7 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
   });
 };
 
-const MAX_PAGE_URL_LENGTH = 2048;
+export const MAX_PAGE_URL_LENGTH = 2048;
 
 /**
  * Helper function to report pageview events to the {@link EchoSrv}.

--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -23,6 +23,7 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
 };
 
 export const MAX_PAGE_URL_LENGTH = 2048;
+export const TRUNCATION_MARKER = '[url too long]';
 
 /**
  * Helper function to report pageview events to the {@link EchoSrv}.
@@ -32,7 +33,10 @@ export const MAX_PAGE_URL_LENGTH = 2048;
 export const reportPageview = () => {
   const location = locationService.getLocation();
   const fullPage = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
-  const page = fullPage.length > MAX_PAGE_URL_LENGTH ? fullPage.substring(0, MAX_PAGE_URL_LENGTH) : fullPage;
+  const page =
+    fullPage.length > MAX_PAGE_URL_LENGTH
+      ? `${fullPage.substring(0, MAX_PAGE_URL_LENGTH - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`
+      : fullPage;
   getEchoSrv().addEvent<PageviewEchoEvent>({
     type: EchoEventType.Pageview,
     payload: {

--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -22,6 +22,8 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
   });
 };
 
+const MAX_PAGE_URL_LENGTH = 2048;
+
 /**
  * Helper function to report pageview events to the {@link EchoSrv}.
  *
@@ -29,7 +31,8 @@ export const reportMetaAnalytics = (payload: MetaAnalyticsEventPayload) => {
  */
 export const reportPageview = () => {
   const location = locationService.getLocation();
-  const page = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
+  const fullPage = `${config.appSubUrl ?? ''}${location.pathname}${location.search}${location.hash}`;
+  const page = fullPage.length > MAX_PAGE_URL_LENGTH ? fullPage.substring(0, MAX_PAGE_URL_LENGTH) : fullPage;
   getEchoSrv().addEvent<PageviewEchoEvent>({
     type: EchoEventType.Pageview,
     payload: {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -9,6 +9,7 @@ export * from './analytics/types';
 export { loadPluginCss, type PluginCssOptions, setPluginImportUtils, getPluginImportUtils } from './utils/plugin';
 export {
   MAX_PAGE_URL_LENGTH,
+  TRUNCATION_MARKER,
   reportMetaAnalytics,
   reportInteraction,
   reportPageview,

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -7,7 +7,13 @@ export * from './services';
 export * from './config';
 export * from './analytics/types';
 export { loadPluginCss, type PluginCssOptions, setPluginImportUtils, getPluginImportUtils } from './utils/plugin';
-export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView } from './analytics/utils';
+export {
+  MAX_PAGE_URL_LENGTH,
+  reportMetaAnalytics,
+  reportInteraction,
+  reportPageview,
+  reportExperimentView,
+} from './analytics/utils';
 export { featureEnabled } from './utils/licensing';
 export {
   logInfo,

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -40,7 +40,8 @@ export function GrafanaRoute(props: Props) {
     cleanupDOM();
     reportPageview();
     navigationLogger('GrafanaRoute', false, 'Updated', props);
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.location.pathname, props.location.search, props.location.hash]);
 
   navigationLogger('GrafanaRoute', false, 'Rendered', props.route);
 

--- a/public/app/core/services/echo/Echo.test.ts
+++ b/public/app/core/services/echo/Echo.test.ts
@@ -1,0 +1,44 @@
+import { MAX_PAGE_URL_LENGTH, TRUNCATION_MARKER } from '@grafana/runtime';
+
+import { Echo } from './Echo';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  MAX_PAGE_URL_LENGTH: 2048,
+  TRUNCATION_MARKER: '[url too long]',
+}));
+
+jest.mock('../context_srv', () => ({
+  contextSrv: {
+    user: { id: 1, login: 'admin', isSignedIn: true, orgRole: 'Admin', orgId: 1 },
+  },
+}));
+
+describe('Echo.getMeta URL truncation', () => {
+  it('returns the full href when it is within the length limit', () => {
+    const shortUrl = 'http://localhost:3000/d/abc?var-cluster=prod';
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, href: shortUrl, pathname: '/d/abc' },
+      writable: true,
+    });
+
+    const echo = new Echo();
+    const meta = echo.getMeta();
+
+    expect(meta.url).toBe(shortUrl);
+  });
+
+  it('truncates href and appends the marker when it exceeds MAX_PAGE_URL_LENGTH', () => {
+    const longHref = 'http://localhost:3000/d/abc?' + 'x'.repeat(MAX_PAGE_URL_LENGTH);
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, href: longHref, pathname: '/d/abc' },
+      writable: true,
+    });
+
+    const echo = new Echo();
+    const meta = echo.getMeta();
+
+    expect(meta.url.length).toBe(MAX_PAGE_URL_LENGTH);
+    expect(meta.url.endsWith(TRUNCATION_MARKER)).toBe(true);
+  });
+});

--- a/public/app/core/services/echo/Echo.test.ts
+++ b/public/app/core/services/echo/Echo.test.ts
@@ -37,8 +37,9 @@ describe('Echo.getMeta URL truncation', () => {
 
     const echo = new Echo();
     const meta = echo.getMeta();
+    const url = meta.url ?? '';
 
-    expect(meta.url.length).toBe(MAX_PAGE_URL_LENGTH);
-    expect(meta.url.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(url.length).toBe(MAX_PAGE_URL_LENGTH);
+    expect(url.endsWith(TRUNCATION_MARKER)).toBe(true);
   });
 });

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -1,10 +1,8 @@
-import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv } from '@grafana/runtime';
+import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv, MAX_PAGE_URL_LENGTH } from '@grafana/runtime';
 
 import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
-
-const MAX_PAGE_URL_LENGTH = 2048;
 
 interface EchoConfig {
   // How often should metrics be reported

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -4,6 +4,8 @@ import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
 
+const MAX_PAGE_URL_LENGTH = 2048;
+
 interface EchoConfig {
   // How often should metrics be reported
   flushInterval: number;
@@ -86,7 +88,10 @@ export class Echo implements EchoSrv {
       ts: new Date().getTime(),
       timeSinceNavigationStart: performance.now(),
       path: window.location.pathname,
-      url: window.location.href,
+      url:
+        window.location.href.length > MAX_PAGE_URL_LENGTH
+          ? window.location.href.substring(0, MAX_PAGE_URL_LENGTH)
+          : window.location.href,
     };
   };
 }

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -1,4 +1,11 @@
-import { type EchoBackend, type EchoMeta, type EchoEvent, type EchoSrv, MAX_PAGE_URL_LENGTH } from '@grafana/runtime';
+import {
+  type EchoBackend,
+  type EchoMeta,
+  type EchoEvent,
+  type EchoSrv,
+  MAX_PAGE_URL_LENGTH,
+  TRUNCATION_MARKER,
+} from '@grafana/runtime';
 
 import { contextSrv } from '../context_srv';
 
@@ -88,7 +95,7 @@ export class Echo implements EchoSrv {
       path: window.location.pathname,
       url:
         window.location.href.length > MAX_PAGE_URL_LENGTH
-          ? window.location.href.substring(0, MAX_PAGE_URL_LENGTH)
+          ? `${window.location.href.substring(0, MAX_PAGE_URL_LENGTH - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`
           : window.location.href,
     };
   };

--- a/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
@@ -135,8 +135,6 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
         apiOptions
       );
     }
-
-    window.rudderanalytics?.page?.();
   }
 
   addEvent = (e: PageviewEchoEvent) => {


### PR DESCRIPTION
Removes the double pageview call fired on RudderstackV3Backend construction so each navigation only sends one event. Simplifies the deduplication logic in GrafanaRoute using useEffect dependency array instead of a ref. Also caps the URL in echo metadata at 2048 chars to reduce payload size for dashboards with large URLs, with the constant exported from @grafana/runtime so both utils.ts and Echo.ts stay in sync.