### PR TITLE
Alerting: Add support for label selectors in AlertRule and RecordingRule legacy storage

### DIFF
--- a/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
@@ -15,6 +15,7 @@ import (
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/common"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
@@ -63,12 +64,22 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
+	groupFilter, err := common.ParseLabelSelectorFilter(opts.LabelSelector, model.GroupLabelKey)
+	if err != nil {
+		return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid label selector for %s: %s", model.GroupLabelKey, err))
+	}
+	folderFilter, err := common.ParseLabelSelectorFilter(opts.LabelSelector, model.FolderLabelKey)
+	if err != nil {
+		return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid label selector for %s: %s", model.FolderLabelKey, err))
+	}
+
 	rules, provenanceMap, continueToken, err := s.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
 		RuleType:      ngmodels.RuleTypeFilterAlerting,
 		Limit:         opts.Limit,
 		ContinueToken: opts.Continue,
+		GroupFilter:   groupFilter,
+		FolderFilter:  folderFilter,
 		// TODO: add field selectors for filtering
-		// TODO: add label selectors for filtering on group and folders
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/registry/apps/alerting/rules/common/selectors.go
+++ b/pkg/registry/apps/alerting/rules/common/selectors.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+)
+
+// ParseLabelSelectorFilter extracts a ListRuleStringFilter from a label selector for a specific key.
+// It supports Equals/In operators for include, NotEquals/NotIn for exclude, and Exists/DoesNotExist for presence filtering.
+func ParseLabelSelectorFilter(selector labels.Selector, key string) (provisioning.ListRuleStringFilter, error) {
+	filter := provisioning.ListRuleStringFilter{}
+	if selector == nil || selector.Empty() {
+		return filter, nil
+	}
+	reqs, selectable := selector.Requirements()
+	if !selectable {
+		return filter, nil
+	}
+	for _, req := range reqs {
+		if req.Key() != key {
+			continue
+		}
+		vals := req.Values()
+		switch req.Operator() {
+		case selection.Equals, selection.DoubleEquals, selection.In:
+			filter.Include = vals.UnsortedList()
+		case selection.NotEquals, selection.NotIn:
+			filter.Exclude = vals.UnsortedList()
+		case selection.Exists:
+			t := true
+			filter.Exists = &t
+		case selection.DoesNotExist:
+			f := false
+			filter.Exists = &f
+		default:
+			return filter, fmt.Errorf("unsupported operator %q", req.Operator())
+		}
+	}
+	return filter, nil
+}

--- a/pkg/registry/apps/alerting/rules/common/selectors_test.go
+++ b/pkg/registry/apps/alerting/rules/common/selectors_test.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestParseLabelSelectorFilter(t *testing.T) {
+	const key = "grafana.com/group"
+
+	t.Run("nil selector returns empty filter", func(t *testing.T) {
+		filter, err := ParseLabelSelectorFilter(nil, key)
+		require.NoError(t, err)
+		assert.Nil(t, filter.Exists)
+		assert.Empty(t, filter.Include)
+		assert.Empty(t, filter.Exclude)
+	})
+
+	t.Run("Everything selector returns empty filter", func(t *testing.T) {
+		filter, err := ParseLabelSelectorFilter(labels.Everything(), key)
+		require.NoError(t, err)
+		assert.Nil(t, filter.Exists)
+		assert.Empty(t, filter.Include)
+		assert.Empty(t, filter.Exclude)
+	})
+
+	t.Run("Equals operator populates Include", func(t *testing.T) {
+		sel, err := labels.Parse(key + "=value")
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"value"}, filter.Include)
+		assert.Empty(t, filter.Exclude)
+		assert.Nil(t, filter.Exists)
+	})
+
+	t.Run("DoubleEquals operator populates Include", func(t *testing.T) {
+		sel, err := labels.Parse(key + "==value")
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"value"}, filter.Include)
+		assert.Empty(t, filter.Exclude)
+		assert.Nil(t, filter.Exists)
+	})
+
+	t.Run("In operator populates Include with multiple values", func(t *testing.T) {
+		sel, err := labels.Parse(key + " in (v1,v2)")
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"v1", "v2"}, filter.Include)
+		assert.Empty(t, filter.Exclude)
+		assert.Nil(t, filter.Exists)
+	})
+
+	t.Run("NotEquals operator populates Exclude", func(t *testing.T) {
+		sel, err := labels.Parse(key + "!=value")
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"value"}, filter.Exclude)
+		assert.Empty(t, filter.Include)
+		assert.Nil(t, filter.Exists)
+	})
+
+	t.Run("NotIn operator populates Exclude with multiple values", func(t *testing.T) {
+		sel, err := labels.Parse(key + " notin (v1,v2)")
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"v1", "v2"}, filter.Exclude)
+		assert.Empty(t, filter.Include)
+		assert.Nil(t, filter.Exists)
+	})
+
+	t.Run("Exists operator sets Exists=true", func(t *testing.T) {
+		sel, err := labels.Parse(key)
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		require.NotNil(t, filter.Exists)
+		assert.True(t, *filter.Exists)
+		assert.Empty(t, filter.Include)
+		assert.Empty(t, filter.Exclude)
+	})
+
+	t.Run("DoesNotExist operator sets Exists=false", func(t *testing.T) {
+		sel, err := labels.Parse("!" + key)
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		require.NotNil(t, filter.Exists)
+		assert.False(t, *filter.Exists)
+		assert.Empty(t, filter.Include)
+		assert.Empty(t, filter.Exclude)
+	})
+
+	t.Run("requirement for a different key returns empty filter", func(t *testing.T) {
+		sel, err := labels.Parse("other.key=value")
+		require.NoError(t, err)
+		filter, err := ParseLabelSelectorFilter(sel, key)
+		require.NoError(t, err)
+		assert.Nil(t, filter.Exists)
+		assert.Empty(t, filter.Include)
+		assert.Empty(t, filter.Exclude)
+	})
+}

--- a/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
@@ -15,6 +15,7 @@ import (
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/common"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
@@ -64,12 +65,22 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
+	groupFilter, err := common.ParseLabelSelectorFilter(opts.LabelSelector, model.GroupLabelKey)
+	if err != nil {
+		return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid label selector for %s: %s", model.GroupLabelKey, err))
+	}
+	folderFilter, err := common.ParseLabelSelectorFilter(opts.LabelSelector, model.FolderLabelKey)
+	if err != nil {
+		return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid label selector for %s: %s", model.FolderLabelKey, err))
+	}
+
 	rules, provenanceMap, continueToken, err := s.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
 		RuleType:      ngmodels.RuleTypeFilterRecording,
 		Limit:         opts.Limit,
 		ContinueToken: opts.Continue,
+		GroupFilter:   groupFilter,
+		FolderFilter:  folderFilter,
 		// TODO: add field selectors for filtering
-		// TODO: add label selectors for filtering on group and folders
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -1045,8 +1045,15 @@ type ListAlertRulesQuery struct {
 	OrgID         int64
 	RuleUIDs      []string
 	NamespaceUIDs []string
-	ExcludeOrgs   []int64
-	RuleGroups    []string
+	// ExcludeNamespaceUIDs excludes rules in these namespace (folder) UIDs.
+	ExcludeNamespaceUIDs []string
+	ExcludeOrgs          []int64
+	RuleGroups           []string
+	// ExcludeRuleGroups excludes rules belonging to these rule groups.
+	ExcludeRuleGroups []string
+	// RuleGroupExists filters rules by whether they have a non-empty rule group set.
+	// true: only rules with a non-empty rule_group; false: only rules with an empty rule_group.
+	RuleGroupExists *bool
 
 	// DashboardUID and PanelID are optional and allow filtering rules
 	// to return just those for a dashboard and panel.

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -98,6 +98,7 @@ type ListAlertRulesOptions struct {
 	ContinueToken string
 	GroupFilter   ListRuleStringFilter
 	FolderFilter  ListRuleStringFilter
+	// TODO: add the following filters
 	// title filter - string
 	// paused filter - bool
 	// dashboard filter - string

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -81,17 +81,40 @@ func NewAlertRuleService(ruleStore RuleStore,
 	}
 }
 
+// ListRuleStringFilter provides filtering options for string fields in rules such as group and namespace (folder) uid
+type ListRuleStringFilter struct {
+	Exists  *bool
+	Include []string
+	Exclude []string
+}
+
+type ListRuleBoolFilter struct {
+	Value *bool
+}
+
 type ListAlertRulesOptions struct {
 	RuleType      models.RuleTypeFilter
 	Limit         int64
 	ContinueToken string
-	// TODO: plumb more options
+	GroupFilter   ListRuleStringFilter
+	FolderFilter  ListRuleStringFilter
+	// title filter - string
+	// paused filter - bool
+	// dashboard filter - string
+	// panel filter - string
+	// receiver filter - string
+	// metric filter - string
+	// targetDatasourceUID filter - string
 }
 
 func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identity.Requester, opts ListAlertRulesOptions) (rules []*models.AlertRule, provenances map[string]models.Provenance, nextToken string, err error) {
 	q := models.ListAlertRulesExtendedQuery{
 		ListAlertRulesQuery: models.ListAlertRulesQuery{
-			OrgID: user.GetOrgID(),
+			OrgID:                user.GetOrgID(),
+			RuleGroups:           opts.GroupFilter.Include,
+			ExcludeRuleGroups:    opts.GroupFilter.Exclude,
+			RuleGroupExists:      opts.GroupFilter.Exists,
+			ExcludeNamespaceUIDs: opts.FolderFilter.Exclude,
 		},
 		RuleType:      opts.RuleType,
 		Limit:         opts.Limit,
@@ -122,13 +145,31 @@ func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identi
 				folderUIDs = append(folderUIDs, f.UID)
 			}
 		}
-		q.NamespaceUIDs = folderUIDs
+		// Intersect accessible folders with any requested folder filter
+		if len(opts.FolderFilter.Include) > 0 {
+			requestedSet := make(map[string]struct{}, len(opts.FolderFilter.Include))
+			for _, uid := range opts.FolderFilter.Include {
+				requestedSet[uid] = struct{}{}
+			}
+			filtered := folderUIDs[:0]
+			for _, uid := range folderUIDs {
+				if _, ok := requestedSet[uid]; ok {
+					filtered = append(filtered, uid)
+				}
+			}
+			q.NamespaceUIDs = filtered
+		} else {
+			q.NamespaceUIDs = folderUIDs
+		}
+	} else if len(opts.FolderFilter.Include) > 0 {
+		q.NamespaceUIDs = opts.FolderFilter.Include
 	}
 
 	rules, nextToken, err = service.ruleStore.ListAlertRulesPaginated(ctx, &q)
 	if err != nil {
 		return nil, nil, "", err
 	}
+
 	provenances = make(map[string]models.Provenance)
 	if len(rules) > 0 {
 		resourceType := rules[0].ResourceType()

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1936,6 +1936,155 @@ func TestListAlertRules(t *testing.T) {
 			assert.Equal(t, "HasAccessInFolder", ac.Calls[2].Method)
 		})
 	})
+
+	t.Run("GroupFilter", func(t *testing.T) {
+		t.Run("Include should return only rules in the specified groups", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				GroupFilter: ListRuleStringFilter{Include: []string{groupKey1.RuleGroup}},
+			})
+			require.NoError(t, err)
+
+			expected := make([]string, 0, len(rules1))
+			for _, r := range rules1 {
+				expected = append(expected, r.UID)
+			}
+			got := make([]string, 0, len(rules))
+			for _, r := range rules {
+				got = append(got, r.UID)
+			}
+			require.ElementsMatch(t, expected, got)
+		})
+
+		t.Run("Exclude should return rules not in the specified groups", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				GroupFilter: ListRuleStringFilter{Exclude: []string{groupKey1.RuleGroup}},
+			})
+			require.NoError(t, err)
+
+			expected := make([]string, 0, len(rules2))
+			for _, r := range rules2 {
+				expected = append(expected, r.UID)
+			}
+			got := make([]string, 0, len(rules))
+			for _, r := range rules {
+				got = append(got, r.UID)
+			}
+			require.ElementsMatch(t, expected, got)
+		})
+
+		t.Run("Exists true should return rules with a non-empty group", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+
+			trueVal := true
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				GroupFilter: ListRuleStringFilter{Exists: &trueVal},
+			})
+			require.NoError(t, err)
+			// all allRules have a non-empty group
+			require.Len(t, rules, len(allRules))
+		})
+
+		t.Run("Exists false should return rules without a group", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+
+			falseVal := false
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				GroupFilter: ListRuleStringFilter{Exists: &falseVal},
+			})
+			require.NoError(t, err)
+			// all rules have a group, so none should be returned
+			require.Empty(t, rules)
+		})
+	})
+
+	t.Run("FolderFilter", func(t *testing.T) {
+		t.Run("Include when user can read all should filter to requested folders", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				FolderFilter: ListRuleStringFilter{Include: []string{groupKey1.NamespaceUID}},
+			})
+			require.NoError(t, err)
+
+			expected := make([]string, 0, len(rules1))
+			for _, r := range rules1 {
+				expected = append(expected, r.UID)
+			}
+			got := make([]string, 0, len(rules))
+			for _, r := range rules {
+				got = append(got, r.UID)
+			}
+			require.ElementsMatch(t, expected, got)
+		})
+
+		t.Run("Include when user cannot read all should intersect with accessible folders", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return false, nil
+			}
+			// User can only access groupKey2's folder
+			ac.HasAccessInFolderFunc = func(ctx context.Context, user identity.Requester, folder models.Namespaced) (bool, error) {
+				return folder.GetNamespaceUID() == groupKey2.NamespaceUID, nil
+			}
+
+			// Request both folders; intersection should yield only groupKey2
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				FolderFilter: ListRuleStringFilter{Include: []string{groupKey1.NamespaceUID, groupKey2.NamespaceUID}},
+			})
+			require.NoError(t, err)
+
+			expected := make([]string, 0, len(rules2))
+			for _, r := range rules2 {
+				expected = append(expected, r.UID)
+			}
+			got := make([]string, 0, len(rules))
+			for _, r := range rules {
+				got = append(got, r.UID)
+			}
+			require.ElementsMatch(t, expected, got)
+		})
+
+		t.Run("Exclude should return rules not in the specified folders", func(t *testing.T) {
+			service, _, _, ac := initServiceWithData(t)
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				FolderFilter: ListRuleStringFilter{Exclude: []string{groupKey1.NamespaceUID}},
+			})
+			require.NoError(t, err)
+
+			expected := make([]string, 0, len(rules2))
+			for _, r := range rules2 {
+				expected = append(expected, r.UID)
+			}
+			got := make([]string, 0, len(rules))
+			for _, r := range rules {
+				got = append(got, r.UID)
+			}
+			require.ElementsMatch(t, expected, got)
+		})
+	})
 }
 
 func TestGetAlertRules(t *testing.T) {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -1058,6 +1058,36 @@ func buildRuleGroupFilter(q *xorm.Session, ruleGroups []string) (*xorm.Session, 
 	return q, nil, nil
 }
 
+// buildRuleGroupExcludeFilter adds NOT IN conditions to exclude the given rule groups.
+// It mirrors the logic of buildRuleGroupFilter but uses NOT IN semantics.
+func buildRuleGroupExcludeFilter(q *xorm.Session, ruleGroups []string) (*xorm.Session, error) {
+	if len(ruleGroups) == 0 {
+		return q, nil
+	}
+	var noGroupRuleUIDs []string
+	var realGroups []string
+	for _, group := range ruleGroups {
+		if ngmodels.IsNoGroupRuleGroup(group) {
+			noGroupRuleGroup, err := ngmodels.ParseNoRuleGroup(group)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse rule group %q: %w", group, err)
+			}
+			noGroupRuleUIDs = append(noGroupRuleUIDs, noGroupRuleGroup.GetRuleUID())
+		} else {
+			realGroups = append(realGroups, group)
+		}
+	}
+	if len(realGroups) > 0 {
+		args, notIn := getINSubQueryArgs(realGroups)
+		q = q.Where(fmt.Sprintf("rule_group NOT IN (%s)", strings.Join(notIn, ",")), args...)
+	}
+	if len(noGroupRuleUIDs) > 0 {
+		args, notIn := getINSubQueryArgs(noGroupRuleUIDs)
+		q = q.Where(fmt.Sprintf("uid NOT IN (%s)", strings.Join(notIn, ",")), args...)
+	}
+	return q, nil
+}
+
 // nolint:gocyclo
 func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.ListAlertRulesExtendedQuery) (q *xorm.Session, groupsSet map[string]struct{}, err error) {
 	q = sess.Table("alert_rule")
@@ -1077,6 +1107,11 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 		q = q.Where(fmt.Sprintf("namespace_uid IN (%s)", strings.Join(in, ",")), args...)
 	}
 
+	if len(query.ExcludeNamespaceUIDs) > 0 {
+		args, notIn := getINSubQueryArgs(query.ExcludeNamespaceUIDs)
+		q = q.Where(fmt.Sprintf("namespace_uid NOT IN (%s)", strings.Join(notIn, ",")), args...)
+	}
+
 	if len(query.RuleUIDs) > 0 {
 		args, in := getINSubQueryArgs(query.RuleUIDs)
 		q = q.Where(fmt.Sprintf("uid IN (%s)", strings.Join(in, ",")), args...)
@@ -1085,6 +1120,19 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 	q, groupsSet, err = buildRuleGroupFilter(q, query.RuleGroups)
 	if err != nil {
 		return nil, groupsSet, err
+	}
+
+	q, err = buildRuleGroupExcludeFilter(q, query.ExcludeRuleGroups)
+	if err != nil {
+		return nil, groupsSet, err
+	}
+
+	if query.RuleGroupExists != nil {
+		if *query.RuleGroupExists {
+			q = q.Where("rule_group != ''")
+		} else {
+			q = q.Where("rule_group = ''")
+		}
 	}
 
 	if query.ReceiverName != "" {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -3138,6 +3138,127 @@ func TestIntegration_ListAlertRulesPaginated(t *testing.T) {
 	})
 }
 
+func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
+	tutil.SkipIntegrationTestInShortMode(t)
+
+	cfg := setting.NewCfg()
+	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{
+		BaseInterval: time.Duration(rand.Int64N(100)+1) * time.Second,
+	}
+	orgID := int64(1)
+	ruleGen := models.RuleGen.With(
+		models.RuleGen.WithIntervalMatching(cfg.UnifiedAlerting.BaseInterval),
+		models.RuleGen.WithOrgID(orgID),
+	)
+	b := &fakeBus{}
+
+	t.Run("ExcludeNamespaceUIDs", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		nsAGen := ruleGen.With(ruleGen.WithNamespaceUID("ns-a"))
+		nsBGen := ruleGen.With(ruleGen.WithNamespaceUID("ns-b"))
+
+		createRule(t, store, nsAGen)
+		createRule(t, store, nsAGen)
+		nsBRule1 := createRule(t, store, nsBGen)
+		nsBRule2 := createRule(t, store, nsBGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                orgID,
+				ExcludeNamespaceUIDs: []string{"ns-a"},
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{nsBRule1.UID, nsBRule2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludeRuleGroups", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		group1Gen := ruleGen.With(ruleGen.WithGroupName("group-1"))
+		group2Gen := ruleGen.With(ruleGen.WithGroupName("group-2"))
+
+		createRule(t, store, group1Gen)
+		createRule(t, store, group1Gen)
+		g2Rule1 := createRule(t, store, group2Gen)
+		g2Rule2 := createRule(t, store, group2Gen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:             orgID,
+				ExcludeRuleGroups: []string{"group-1"},
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{g2Rule1.UID, g2Rule2.UID}, gotUIDs)
+	})
+
+	t.Run("RuleGroupExists=true", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		withGroupGen := ruleGen.With(ruleGen.WithGroupName("some-group"))
+		noGroupGen := ruleGen.With(ruleGen.WithGroupName(""))
+
+		withGroupRule := createRule(t, store, withGroupGen)
+		createRule(t, store, noGroupGen)
+
+		trueVal := true
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:           orgID,
+				RuleGroupExists: &trueVal,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, withGroupRule.UID, result[0].UID)
+	})
+
+	t.Run("RuleGroupExists=false", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		withGroupGen := ruleGen.With(ruleGen.WithGroupName("some-group"))
+		noGroupGen := ruleGen.With(ruleGen.WithGroupName(""))
+
+		createRule(t, store, withGroupGen)
+		noGroupRule := createRule(t, store, noGroupGen)
+
+		falseVal := false
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:           orgID,
+				RuleGroupExists: &falseVal,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, noGroupRule.UID, result[0].UID)
+	})
+}
+
 func TestIntegration_ListDeletedRules(t *testing.T) {
 	tutil.SkipIntegrationTestInShortMode(t)
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -2112,6 +2112,17 @@ func TestIntegration_ListAlertRulesByGroup(t *testing.T) {
 		require.NotEmpty(t, continueToken, "continue token should not be empty when limit is set")
 	})
 
+	t.Run("should return all groups when group limit exceeds total groups", func(t *testing.T) {
+		groupLimit := int64(totalGroups + rand.IntN(10) + 1) // totalGroups + random number to ensure it exceeds totalGroups
+		result, continueToken, err := store.ListAlertRulesByGroup(context.Background(), &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{OrgID: orgID},
+			Limit:               groupLimit,
+		})
+		require.NoError(t, err)
+		require.Len(t, result, numRules, "should return all rules when group limit exceeds total groups")
+		require.Empty(t, continueToken, "continue token should be empty when all rules are fetched")
+	})
+
 	t.Run("pagination should all for continuation", func(t *testing.T) {
 		groupLimit := int64(2) // fixed group limit for this test
 		result, continueToken, err := store.ListAlertRulesByGroup(context.Background(), &models.ListAlertRulesExtendedQuery{

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -378,6 +378,19 @@ func (f *RuleStore) listAlertRules(q *models.ListAlertRulesQuery) (models.RulesG
 			}
 		}
 
+		if len(q.ExcludeNamespaceUIDs) > 0 && slices.Contains(q.ExcludeNamespaceUIDs, r.NamespaceUID) {
+			continue
+		}
+		if len(q.ExcludeRuleGroups) > 0 && slices.Contains(q.ExcludeRuleGroups, r.RuleGroup) {
+			continue
+		}
+		if q.RuleGroupExists != nil {
+			hasGroup := r.RuleGroup != ""
+			if *q.RuleGroupExists != hasGroup {
+				continue
+			}
+		}
+
 		copyR := models.CopyRule(r)
 		ruleList = append(ruleList, copyR)
 	}

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -710,3 +710,88 @@ func TestIntegrationFolderLabelSyncAndValidation(t *testing.T) {
 		require.Nil(t, created)
 	})
 }
+
+func TestIntegrationListWithLabelSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	client := common.NewAlertRuleClient(t, helper.Org1.Admin)
+
+	common.CreateTestFolder(t, helper, "folder-alpha")
+	common.CreateTestFolder(t, helper, "folder-beta")
+
+	makeRule := func(folder string) *v0alpha1.AlertRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUniqueUID(),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return &v0alpha1.AlertRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Annotations: map[string]string{
+					"grafana.app/folder": folder,
+				},
+			},
+			Spec: v0alpha1.AlertRuleSpec{
+				Title: rule.Title,
+				Expressions: v0alpha1.AlertRuleExpressionMap{
+					"A": {
+						QueryType:     util.Pointer("query"),
+						DatasourceUID: util.Pointer(v0alpha1.AlertRuleDatasourceUID(rule.Data[0].DatasourceUID)),
+						Model:         rule.Data[0].Model,
+						Source:        util.Pointer(true),
+						RelativeTimeRange: &v0alpha1.AlertRuleRelativeTimeRange{
+							From: v0alpha1.AlertRulePromDurationWMillis("5m"),
+							To:   v0alpha1.AlertRulePromDurationWMillis("0s"),
+						},
+					},
+				},
+				Trigger: v0alpha1.AlertRuleIntervalTrigger{
+					Interval: v0alpha1.AlertRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
+				},
+				NoDataState:  string(rule.NoDataState),
+				ExecErrState: string(rule.ExecErrState),
+			},
+		}
+	}
+
+	// Create 2 rules in folder-alpha and 2 in folder-beta.
+	// Group selector tests are covered in the compat tests since the k8s API does not
+	// support assigning rules to groups directly.
+	alpha1, err := client.Create(ctx, makeRule("folder-alpha"), v1.CreateOptions{})
+	require.NoError(t, err)
+	alpha2, err := client.Create(ctx, makeRule("folder-alpha"), v1.CreateOptions{})
+	require.NoError(t, err)
+	beta1, err := client.Create(ctx, makeRule("folder-beta"), v1.CreateOptions{})
+	require.NoError(t, err)
+	beta2, err := client.Create(ctx, makeRule("folder-beta"), v1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = client.Delete(ctx, alpha1.Name, v1.DeleteOptions{})
+		_ = client.Delete(ctx, alpha2.Name, v1.DeleteOptions{})
+		_ = client.Delete(ctx, beta1.Name, v1.DeleteOptions{})
+		_ = client.Delete(ctx, beta2.Name, v1.DeleteOptions{})
+	})
+
+	t.Run("filter by folder label include", func(t *testing.T) {
+		list, err := client.List(ctx, v1.ListOptions{LabelSelector: "grafana.app/folder=folder-alpha"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 2)
+		for _, item := range list.Items {
+			require.Equal(t, "folder-alpha", item.Labels[v0alpha1.FolderLabelKey])
+		}
+	})
+
+	t.Run("filter by folder label exclude", func(t *testing.T) {
+		list, err := client.List(ctx, v1.ListOptions{LabelSelector: "grafana.app/folder!=folder-alpha"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 2)
+		for _, item := range list.Items {
+			require.Equal(t, "folder-beta", item.Labels[v0alpha1.FolderLabelKey])
+		}
+	})
+}

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -752,8 +752,8 @@ func TestIntegrationListWithLabelSelectors(t *testing.T) {
 				Trigger: v0alpha1.AlertRuleIntervalTrigger{
 					Interval: v0alpha1.AlertRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
 				},
-				NoDataState:  string(rule.NoDataState),
-				ExecErrState: string(rule.ExecErrState),
+				NoDataState:  v0alpha1.AlertRuleNoDataState(rule.NoDataState),
+				ExecErrState: v0alpha1.AlertRuleExecErrState(rule.ExecErrState),
 			},
 		}
 	}

--- a/pkg/tests/apis/alerting/rules/compat/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/compat/alertrule_test.go
@@ -414,3 +414,152 @@ func TestIntegrationAlertRuleCompatCreateViaProvisioningChangeGroupInK8s(t *test
 		}
 	})
 }
+
+func TestIntegrationAlertRuleCompatListWithGroupLabelSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	k8sClient := common.NewAlertRuleClient(t, helper.Org1.Admin)
+	legacyClient := alerting.NewAlertingLegacyAPIClient(helper.GetListenerAddress(), "admin", "admin")
+
+	common.CreateTestFolder(t, helper, "compat-ar-group-sel-folder")
+
+	makeRule := func(uid, title, folder string) apimodels.ProvisionedAlertRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUID(uid),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return apimodels.ProvisionedAlertRule{
+			UID:   uid,
+			Title: title,
+			OrgID: 1,
+			Data: []apimodels.AlertQuery{
+				{
+					RefID:         "A",
+					DatasourceUID: rule.Data[0].DatasourceUID,
+					Model:         rule.Data[0].Model,
+					RelativeTimeRange: apimodels.RelativeTimeRange{
+						From: apimodels.Duration(time.Duration(5) * time.Minute),
+						To:   apimodels.Duration(0),
+					},
+				},
+			},
+			Condition:    "A",
+			FolderUID:    folder,
+			NoDataState:  apimodels.NoDataState(rule.NoDataState),
+			ExecErrState: apimodels.ExecutionErrorState(rule.ExecErrState),
+		}
+	}
+
+	rulesAlpha := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+	).GenerateMany(2)
+	rulesBeta := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+	).GenerateMany(2)
+
+	groupAlpha := apimodels.AlertRuleGroup{
+		Title:     "group-alpha",
+		FolderUID: "compat-ar-group-sel-folder",
+		Interval:  10,
+		Rules: []apimodels.ProvisionedAlertRule{
+			makeRule(rulesAlpha[0].UID, rulesAlpha[0].Title, "compat-ar-group-sel-folder"),
+			makeRule(rulesAlpha[1].UID, rulesAlpha[1].Title, "compat-ar-group-sel-folder"),
+		},
+	}
+	groupBeta := apimodels.AlertRuleGroup{
+		Title:     "group-beta",
+		FolderUID: "compat-ar-group-sel-folder",
+		Interval:  10,
+		Rules: []apimodels.ProvisionedAlertRule{
+			makeRule(rulesBeta[0].UID, rulesBeta[0].Title, "compat-ar-group-sel-folder"),
+			makeRule(rulesBeta[1].UID, rulesBeta[1].Title, "compat-ar-group-sel-folder"),
+		},
+	}
+
+	createdAlpha, status, body := legacyClient.CreateOrUpdateRuleGroupProvisioning(t, groupAlpha)
+	require.Equalf(t, 200, status, "Expected status 200, got %d. Response body: %s", status, body)
+	createdBeta, status, body := legacyClient.CreateOrUpdateRuleGroupProvisioning(t, groupBeta)
+	require.Equalf(t, 200, status, "Expected status 200, got %d. Response body: %s", status, body)
+
+	alphaUIDs := map[string]struct{}{createdAlpha.Rules[0].UID: {}, createdAlpha.Rules[1].UID: {}}
+	betaUIDs := map[string]struct{}{createdBeta.Rules[0].UID: {}, createdBeta.Rules[1].UID: {}}
+
+	t.Cleanup(func() {
+		legacyClient.DeleteRulesGroupProvisioning(t, "compat-ar-group-sel-folder", "group-alpha")
+		legacyClient.DeleteRulesGroupProvisioning(t, "compat-ar-group-sel-folder", "group-beta")
+	})
+
+	resultUIDs := func(list *v0alpha1.AlertRuleList) map[string]struct{} {
+		m := make(map[string]struct{}, len(list.Items))
+		for _, item := range list.Items {
+			m[item.Name] = struct{}{}
+		}
+		return m
+	}
+
+	t.Run("filter by group label include", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "grafana.com/group=group-alpha"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.Equal(t, "group-alpha", item.Labels[v0alpha1.GroupLabelKey])
+		}
+		names := resultUIDs(list)
+		for uid := range alphaUIDs {
+			require.Contains(t, names, uid, "group-alpha rule must appear in include results")
+		}
+		for uid := range betaUIDs {
+			require.NotContains(t, names, uid, "group-beta rule must not appear in group-alpha include results")
+		}
+	})
+
+	t.Run("filter by group label exclude", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "grafana.com/group!=group-alpha"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.NotEqual(t, "group-alpha", item.Labels[v0alpha1.GroupLabelKey])
+		}
+		names := resultUIDs(list)
+		for uid := range betaUIDs {
+			require.Contains(t, names, uid, "group-beta rule must appear in exclude results")
+		}
+		for uid := range alphaUIDs {
+			require.NotContains(t, names, uid, "group-alpha rule must not appear in exclude results")
+		}
+	})
+
+	t.Run("filter by group label exists", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "grafana.com/group"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.Contains(t, item.Labels, v0alpha1.GroupLabelKey)
+		}
+		names := resultUIDs(list)
+		for uid := range alphaUIDs {
+			require.Contains(t, names, uid, "group-alpha rule must appear in exists results")
+		}
+		for uid := range betaUIDs {
+			require.Contains(t, names, uid, "group-beta rule must appear in exists results")
+		}
+	})
+
+	t.Run("filter by group label does not exist", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "!grafana.com/group"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.NotContains(t, item.Labels, v0alpha1.GroupLabelKey)
+		}
+		names := resultUIDs(list)
+		for uid := range alphaUIDs {
+			require.NotContains(t, names, uid, "group-alpha rule must not appear in does-not-exist results")
+		}
+		for uid := range betaUIDs {
+			require.NotContains(t, names, uid, "group-beta rule must not appear in does-not-exist results")
+		}
+	})
+}

--- a/pkg/tests/apis/alerting/rules/compat/recordingrule_test.go
+++ b/pkg/tests/apis/alerting/rules/compat/recordingrule_test.go
@@ -426,3 +426,157 @@ func TestIntegrationRecordingRuleCompatCreateViaProvisioningChangeGroupInK8s(t *
 		}
 	})
 }
+
+func TestIntegrationRecordingRuleCompatListWithGroupLabelSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	k8sClient := common.NewRecordingRuleClient(t, helper.Org1.Admin)
+	legacyClient := alerting.NewAlertingLegacyAPIClient(helper.GetListenerAddress(), "admin", "admin")
+
+	common.CreateTestFolder(t, helper, "compat-rr-group-sel-folder")
+
+	makeRule := func(uid, title, folder string) apimodels.ProvisionedAlertRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUID(uid),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithAllRecordingRules(),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return apimodels.ProvisionedAlertRule{
+			UID:   uid,
+			Title: title,
+			OrgID: 1,
+			Data: []apimodels.AlertQuery{
+				{
+					RefID:         "A",
+					DatasourceUID: rule.Data[0].DatasourceUID,
+					Model:         rule.Data[0].Model,
+					RelativeTimeRange: apimodels.RelativeTimeRange{
+						From: apimodels.Duration(time.Duration(5) * time.Minute),
+						To:   apimodels.Duration(0),
+					},
+				},
+			},
+			Record: &apimodels.Record{
+				Metric:              rule.Record.Metric,
+				From:                "A",
+				TargetDatasourceUID: rule.Record.TargetDatasourceUID,
+			},
+			FolderUID: folder,
+		}
+	}
+
+	rulesAlpha := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithAllRecordingRules(),
+		ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+	).GenerateMany(2)
+	rulesBeta := ngmodels.RuleGen.With(
+		ngmodels.RuleMuts.WithUniqueUID(),
+		ngmodels.RuleMuts.WithAllRecordingRules(),
+		ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+	).GenerateMany(2)
+
+	groupAlpha := apimodels.AlertRuleGroup{
+		Title:     "group-alpha",
+		FolderUID: "compat-rr-group-sel-folder",
+		Interval:  10,
+		Rules: []apimodels.ProvisionedAlertRule{
+			makeRule(rulesAlpha[0].UID, rulesAlpha[0].Title, "compat-rr-group-sel-folder"),
+			makeRule(rulesAlpha[1].UID, rulesAlpha[1].Title, "compat-rr-group-sel-folder"),
+		},
+	}
+	groupBeta := apimodels.AlertRuleGroup{
+		Title:     "group-beta",
+		FolderUID: "compat-rr-group-sel-folder",
+		Interval:  10,
+		Rules: []apimodels.ProvisionedAlertRule{
+			makeRule(rulesBeta[0].UID, rulesBeta[0].Title, "compat-rr-group-sel-folder"),
+			makeRule(rulesBeta[1].UID, rulesBeta[1].Title, "compat-rr-group-sel-folder"),
+		},
+	}
+
+	createdAlpha, status, body := legacyClient.CreateOrUpdateRuleGroupProvisioning(t, groupAlpha)
+	require.Equalf(t, 200, status, "Expected status 200, got %d. Response body: %s", status, body)
+	createdBeta, status, body := legacyClient.CreateOrUpdateRuleGroupProvisioning(t, groupBeta)
+	require.Equalf(t, 200, status, "Expected status 200, got %d. Response body: %s", status, body)
+
+	alphaUIDs := map[string]struct{}{createdAlpha.Rules[0].UID: {}, createdAlpha.Rules[1].UID: {}}
+	betaUIDs := map[string]struct{}{createdBeta.Rules[0].UID: {}, createdBeta.Rules[1].UID: {}}
+
+	t.Cleanup(func() {
+		legacyClient.DeleteRulesGroupProvisioning(t, "compat-rr-group-sel-folder", "group-alpha")
+		legacyClient.DeleteRulesGroupProvisioning(t, "compat-rr-group-sel-folder", "group-beta")
+	})
+
+	resultUIDs := func(list *v0alpha1.RecordingRuleList) map[string]struct{} {
+		m := make(map[string]struct{}, len(list.Items))
+		for _, item := range list.Items {
+			m[item.Name] = struct{}{}
+		}
+		return m
+	}
+
+	t.Run("filter by group label include", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "grafana.com/group=group-alpha"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.Equal(t, "group-alpha", item.Labels[v0alpha1.GroupLabelKey])
+		}
+		names := resultUIDs(list)
+		for uid := range alphaUIDs {
+			require.Contains(t, names, uid, "group-alpha rule must appear in include results")
+		}
+		for uid := range betaUIDs {
+			require.NotContains(t, names, uid, "group-beta rule must not appear in group-alpha include results")
+		}
+	})
+
+	t.Run("filter by group label exclude", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "grafana.com/group!=group-alpha"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.NotEqual(t, "group-alpha", item.Labels[v0alpha1.GroupLabelKey])
+		}
+		names := resultUIDs(list)
+		for uid := range betaUIDs {
+			require.Contains(t, names, uid, "group-beta rule must appear in exclude results")
+		}
+		for uid := range alphaUIDs {
+			require.NotContains(t, names, uid, "group-alpha rule must not appear in exclude results")
+		}
+	})
+
+	t.Run("filter by group label exists", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "grafana.com/group"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.Contains(t, item.Labels, v0alpha1.GroupLabelKey)
+		}
+		names := resultUIDs(list)
+		for uid := range alphaUIDs {
+			require.Contains(t, names, uid, "group-alpha rule must appear in exists results")
+		}
+		for uid := range betaUIDs {
+			require.Contains(t, names, uid, "group-beta rule must appear in exists results")
+		}
+	})
+
+	t.Run("filter by group label does not exist", func(t *testing.T) {
+		list, err := k8sClient.List(ctx, v1.ListOptions{LabelSelector: "!grafana.com/group"})
+		require.NoError(t, err)
+		for _, item := range list.Items {
+			require.NotContains(t, item.Labels, v0alpha1.GroupLabelKey)
+		}
+		names := resultUIDs(list)
+		for uid := range alphaUIDs {
+			require.NotContains(t, names, uid, "group-alpha rule must not appear in does-not-exist results")
+		}
+		for uid := range betaUIDs {
+			require.NotContains(t, names, uid, "group-beta rule must not appear in does-not-exist results")
+		}
+	})
+}

--- a/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
+++ b/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
@@ -694,3 +694,88 @@ func TestIntegrationFolderLabelSyncAndValidation(t *testing.T) {
 		require.Nil(t, created)
 	})
 }
+
+func TestIntegrationListWithLabelSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	client := common.NewRecordingRuleClient(t, helper.Org1.Admin)
+
+	common.CreateTestFolder(t, helper, "rr-folder-alpha")
+	common.CreateTestFolder(t, helper, "rr-folder-beta")
+
+	makeRule := func(folder string) *v0alpha1.RecordingRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUniqueUID(),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithAllRecordingRules(),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return &v0alpha1.RecordingRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Annotations: map[string]string{
+					"grafana.app/folder": folder,
+				},
+			},
+			Spec: v0alpha1.RecordingRuleSpec{
+				Title:  rule.Title,
+				Metric: rule.Record.Metric,
+				Expressions: v0alpha1.RecordingRuleExpressionMap{
+					"A": {
+						QueryType:     util.Pointer(rule.Data[0].QueryType),
+						DatasourceUID: util.Pointer(v0alpha1.RecordingRuleDatasourceUID(rule.Data[0].DatasourceUID)),
+						Model:         rule.Data[0].Model,
+						Source:        util.Pointer(true),
+						RelativeTimeRange: &v0alpha1.RecordingRuleRelativeTimeRange{
+							From: v0alpha1.RecordingRulePromDurationWMillis("5m"),
+							To:   v0alpha1.RecordingRulePromDurationWMillis("0s"),
+						},
+					},
+				},
+				Trigger: v0alpha1.RecordingRuleIntervalTrigger{
+					Interval: v0alpha1.RecordingRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
+				},
+			},
+		}
+	}
+
+	// Create 2 rules in rr-folder-alpha and 2 in rr-folder-beta.
+	// Group selector tests are covered in the compat tests since the k8s API does not
+	// support assigning rules to groups directly.
+	alpha1, err := client.Create(ctx, makeRule("rr-folder-alpha"), v1.CreateOptions{})
+	require.NoError(t, err)
+	alpha2, err := client.Create(ctx, makeRule("rr-folder-alpha"), v1.CreateOptions{})
+	require.NoError(t, err)
+	beta1, err := client.Create(ctx, makeRule("rr-folder-beta"), v1.CreateOptions{})
+	require.NoError(t, err)
+	beta2, err := client.Create(ctx, makeRule("rr-folder-beta"), v1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = client.Delete(ctx, alpha1.Name, v1.DeleteOptions{})
+		_ = client.Delete(ctx, alpha2.Name, v1.DeleteOptions{})
+		_ = client.Delete(ctx, beta1.Name, v1.DeleteOptions{})
+		_ = client.Delete(ctx, beta2.Name, v1.DeleteOptions{})
+	})
+
+	t.Run("filter by folder label include", func(t *testing.T) {
+		list, err := client.List(ctx, v1.ListOptions{LabelSelector: "grafana.app/folder=rr-folder-alpha"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 2)
+		for _, item := range list.Items {
+			require.Equal(t, "rr-folder-alpha", item.Labels[v0alpha1.FolderLabelKey])
+		}
+	})
+
+	t.Run("filter by folder label exclude", func(t *testing.T) {
+		list, err := client.List(ctx, v1.ListOptions{LabelSelector: "grafana.app/folder!=rr-folder-alpha"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 2)
+		for _, item := range list.Items {
+			require.Equal(t, "rr-folder-beta", item.Labels[v0alpha1.FolderLabelKey])
+		}
+	})
+}

--- a/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
+++ b/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
@@ -722,7 +722,7 @@ func TestIntegrationListWithLabelSelectors(t *testing.T) {
 			},
 			Spec: v0alpha1.RecordingRuleSpec{
 				Title:  rule.Title,
-				Metric: rule.Record.Metric,
+				Metric: v0alpha1.RecordingRuleMetricName(rule.Record.Metric),
 				Expressions: v0alpha1.RecordingRuleExpressionMap{
 					"A": {
 						QueryType:     util.Pointer(rule.Data[0].QueryType),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This extends store support for exclusion filters on Groups and Namespaces as well as GroupExistence so that we can support legacy storage label selectors on `grafana.app/folder` and `grafana.com/group` labels. It allows you to filter AlertRules and RecordingRules using these labels with the standard label selectors.

**Why do we need this feature?**

Fulfilling the kubernetes list operations functionalities in legacy storage for label selectors.


**Who is this feature for?**

Consumers of the AlertRules and RecordingRules APIs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Addresses https://github.com/grafana/alerting-squad/issues/1199


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
