### PR TITLE
Apiserver: Use ClusterKeyRootFunc for cluster-scoped resources

### DIFF
--- a/pkg/apiserver/registry/generic/storage.go
+++ b/pkg/apiserver/registry/generic/storage.go
@@ -47,16 +47,19 @@ func NewRegistryStoreWithSelectableFields(scheme *runtime.Scheme, resourceInfo u
 	}
 
 	var keyFunc func(ctx context.Context, name string) (string, error)
+	var keyRootFunc func(ctx context.Context) string
 	if resourceInfo.IsClusterScoped() {
 		keyFunc = ClusterScopedKeyFunc(resourceInfo.GroupResource())
+		keyRootFunc = ClusterKeyRootFunc(resourceInfo.GroupResource())
 	} else {
 		keyFunc = NamespaceKeyFunc(resourceInfo.GroupResource())
+		keyRootFunc = KeyRootFunc(resourceInfo.GroupResource())
 	}
 
 	store := &registry.Store{
 		NewFunc:                   resourceInfo.NewFunc,
 		NewListFunc:               resourceInfo.NewListFunc,
-		KeyRootFunc:               KeyRootFunc(resourceInfo.GroupResource()),
+		KeyRootFunc:               keyRootFunc,
 		KeyFunc:                   keyFunc,
 		PredicateFunc:             predicateFunc,
 		DefaultQualifiedResource:  resourceInfo.GroupResource(),

--- a/pkg/apiserver/registry/generic/storage.go
+++ b/pkg/apiserver/registry/generic/storage.go
@@ -47,16 +47,19 @@ func NewRegistryStoreWithSelectableFields(scheme *runtime.Scheme, resourceInfo u
 	}
 
 	var keyFunc func(ctx context.Context, name string) (string, error)
+	var keyRootFunc func(ctx context.Context) string
 	if resourceInfo.IsClusterScoped() {
 		keyFunc = ClusterScopedKeyFunc(resourceInfo.GroupResource())
+		keyRootFunc = ClusterKeyRootFunc(resourceInfo.GroupResource())
 	} else {
 		keyFunc = NamespaceKeyFunc(resourceInfo.GroupResource())
+		keyRootFunc = KeyRootFunc(resourceInfo.GroupResource())
 	}
 
 	store := &registry.Store{
 		NewFunc:                   resourceInfo.NewFunc,
 		NewListFunc:               resourceInfo.NewListFunc,
-		KeyRootFunc:               buildKeyRootFunc(resourceInfo),
+		KeyRootFunc:               keyRootFunc,
 		KeyFunc:                   keyFunc,
 		PredicateFunc:             predicateFunc,
 		DefaultQualifiedResource:  resourceInfo.GroupResource(),
@@ -83,16 +86,6 @@ func NewCompleteRegistryStore(scheme *runtime.Scheme, resourceInfo utils.Resourc
 	registryStore.UpdateStrategy = strategy
 	registryStore.DeleteStrategy = strategy
 	return registryStore, nil
-}
-
-// buildKeyRootFunc returns the appropriate KeyRootFunc for the resource.
-// Cluster-scoped resources use ClusterKeyRootFunc (no namespace in key),
-// while namespaced resources use KeyRootFunc (includes namespace).
-func buildKeyRootFunc(resourceInfo utils.ResourceInfo) func(ctx context.Context) string {
-	if resourceInfo.IsClusterScoped() {
-		return ClusterKeyRootFunc(resourceInfo.GroupResource())
-	}
-	return KeyRootFunc(resourceInfo.GroupResource())
 }
 
 func NewRegistryStatusStore(scheme *runtime.Scheme, specStore *registry.Store) *StatusREST {

--- a/pkg/apiserver/registry/generic/storage.go
+++ b/pkg/apiserver/registry/generic/storage.go
@@ -47,19 +47,16 @@ func NewRegistryStoreWithSelectableFields(scheme *runtime.Scheme, resourceInfo u
 	}
 
 	var keyFunc func(ctx context.Context, name string) (string, error)
-	var keyRootFunc func(ctx context.Context) string
 	if resourceInfo.IsClusterScoped() {
 		keyFunc = ClusterScopedKeyFunc(resourceInfo.GroupResource())
-		keyRootFunc = ClusterKeyRootFunc(resourceInfo.GroupResource())
 	} else {
 		keyFunc = NamespaceKeyFunc(resourceInfo.GroupResource())
-		keyRootFunc = KeyRootFunc(resourceInfo.GroupResource())
 	}
 
 	store := &registry.Store{
 		NewFunc:                   resourceInfo.NewFunc,
 		NewListFunc:               resourceInfo.NewListFunc,
-		KeyRootFunc:               keyRootFunc,
+		KeyRootFunc:               buildKeyRootFunc(resourceInfo),
 		KeyFunc:                   keyFunc,
 		PredicateFunc:             predicateFunc,
 		DefaultQualifiedResource:  resourceInfo.GroupResource(),
@@ -86,6 +83,16 @@ func NewCompleteRegistryStore(scheme *runtime.Scheme, resourceInfo utils.Resourc
 	registryStore.UpdateStrategy = strategy
 	registryStore.DeleteStrategy = strategy
 	return registryStore, nil
+}
+
+// buildKeyRootFunc returns the appropriate KeyRootFunc for the resource.
+// Cluster-scoped resources use ClusterKeyRootFunc (no namespace in key),
+// while namespaced resources use KeyRootFunc (includes namespace).
+func buildKeyRootFunc(resourceInfo utils.ResourceInfo) func(ctx context.Context) string {
+	if resourceInfo.IsClusterScoped() {
+		return ClusterKeyRootFunc(resourceInfo.GroupResource())
+	}
+	return KeyRootFunc(resourceInfo.GroupResource())
 }
 
 func NewRegistryStatusStore(scheme *runtime.Scheme, specStore *registry.Store) *StatusREST {

--- a/pkg/apiserver/registry/generic/storage_test.go
+++ b/pkg/apiserver/registry/generic/storage_test.go
@@ -148,6 +148,44 @@ func TestKeyRootFunc_ClusterScoped(t *testing.T) {
 	}
 }
 
+func TestNewRegistryStore_KeyRootFuncSelection(t *testing.T) {
+	ctx := genericapirequest.WithNamespace(context.Background(), "stacks-4060")
+
+	t.Run("cluster-scoped store list key excludes namespace", func(t *testing.T) {
+		ri := utils.NewResourceInfo(
+			"iam.grafana.app", "v1alpha1", "globalroles", "globalrole", "GlobalRole",
+			func() runtime.Object { return &mockObject{} },
+			func() runtime.Object { return &mockObjectList{} },
+			utils.TableColumns{},
+		)
+		ri = ri.WithClusterScope()
+
+		keyRootFunc := buildKeyRootFunc(ri)
+		key := keyRootFunc(ctx)
+		if strings.Contains(key, "namespace") || strings.Contains(key, "stacks-4060") {
+			t.Errorf("Cluster-scoped KeyRootFunc key %q should not contain namespace", key)
+		}
+		if !strings.Contains(key, "globalroles") {
+			t.Errorf("Cluster-scoped KeyRootFunc key %q should contain resource name", key)
+		}
+	})
+
+	t.Run("namespaced store list key includes namespace", func(t *testing.T) {
+		ri := utils.NewResourceInfo(
+			"example.grafana.app", "v1alpha1", "roles", "role", "Role",
+			func() runtime.Object { return &mockObject{} },
+			func() runtime.Object { return &mockObjectList{} },
+			utils.TableColumns{},
+		)
+
+		keyRootFunc := buildKeyRootFunc(ri)
+		key := keyRootFunc(ctx)
+		if !strings.Contains(key, "stacks-4060") {
+			t.Errorf("Namespaced KeyRootFunc key %q should contain namespace stacks-4060", key)
+		}
+	})
+}
+
 type mockObject struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta

--- a/pkg/apiserver/registry/generic/storage_test.go
+++ b/pkg/apiserver/registry/generic/storage_test.go
@@ -126,30 +126,17 @@ func TestNewRegistryStore_KeyFuncSelection(t *testing.T) {
 	}
 }
 
-func TestKeyRootFunc_ClusterScoped(t *testing.T) {
-	gr := schema.GroupResource{Group: "iam.grafana.app", Resource: "globalroles"}
-
-	// ClusterKeyRootFunc should never include namespace, even when context has one.
-	clusterRoot := ClusterKeyRootFunc(gr)
-	ctx := genericapirequest.WithNamespace(context.Background(), "stacks-4060")
-	key := clusterRoot(ctx)
-	if strings.Contains(key, "namespace") || strings.Contains(key, "stacks-4060") {
-		t.Errorf("ClusterKeyRootFunc key %q should not contain namespace", key)
-	}
-	if !strings.Contains(key, "globalroles") {
-		t.Errorf("ClusterKeyRootFunc key %q should contain resource name", key)
-	}
-
-	// KeyRootFunc should include namespace when context has one.
-	namespacedRoot := KeyRootFunc(gr)
-	key = namespacedRoot(ctx)
-	if !strings.Contains(key, "stacks-4060") {
-		t.Errorf("KeyRootFunc key %q should contain namespace stacks-4060", key)
-	}
-}
-
 func TestNewRegistryStore_KeyRootFuncSelection(t *testing.T) {
-	ctx := genericapirequest.WithNamespace(context.Background(), "stacks-4060")
+	ctx := genericapirequest.WithNamespace(context.Background(), "namespace_123")
+
+	// selectKeyRootFunc mirrors the logic in NewRegistryStoreWithSelectableFields
+	// to verify it selects the correct KeyRootFunc based on resource scope.
+	selectKeyRootFunc := func(ri utils.ResourceInfo) func(ctx context.Context) string {
+		if ri.IsClusterScoped() {
+			return ClusterKeyRootFunc(ri.GroupResource())
+		}
+		return KeyRootFunc(ri.GroupResource())
+	}
 
 	t.Run("cluster-scoped store list key excludes namespace", func(t *testing.T) {
 		ri := utils.NewResourceInfo(
@@ -160,9 +147,8 @@ func TestNewRegistryStore_KeyRootFuncSelection(t *testing.T) {
 		)
 		ri = ri.WithClusterScope()
 
-		keyRootFunc := buildKeyRootFunc(ri)
-		key := keyRootFunc(ctx)
-		if strings.Contains(key, "namespace") || strings.Contains(key, "stacks-4060") {
+		key := selectKeyRootFunc(ri)(ctx)
+		if strings.Contains(key, "namespace") || strings.Contains(key, "namespace_123") {
 			t.Errorf("Cluster-scoped KeyRootFunc key %q should not contain namespace", key)
 		}
 		if !strings.Contains(key, "globalroles") {
@@ -178,10 +164,9 @@ func TestNewRegistryStore_KeyRootFuncSelection(t *testing.T) {
 			utils.TableColumns{},
 		)
 
-		keyRootFunc := buildKeyRootFunc(ri)
-		key := keyRootFunc(ctx)
-		if !strings.Contains(key, "stacks-4060") {
-			t.Errorf("Namespaced KeyRootFunc key %q should contain namespace stacks-4060", key)
+		key := selectKeyRootFunc(ri)(ctx)
+		if !strings.Contains(key, "namespace_123") {
+			t.Errorf("Namespaced KeyRootFunc key %q should contain namespace namespace_123", key)
 		}
 	})
 }

--- a/pkg/apiserver/registry/generic/storage_test.go
+++ b/pkg/apiserver/registry/generic/storage_test.go
@@ -126,6 +126,28 @@ func TestNewRegistryStore_KeyFuncSelection(t *testing.T) {
 	}
 }
 
+func TestKeyRootFunc_ClusterScoped(t *testing.T) {
+	gr := schema.GroupResource{Group: "iam.grafana.app", Resource: "globalroles"}
+
+	// ClusterKeyRootFunc should never include namespace, even when context has one.
+	clusterRoot := ClusterKeyRootFunc(gr)
+	ctx := genericapirequest.WithNamespace(context.Background(), "stacks-4060")
+	key := clusterRoot(ctx)
+	if strings.Contains(key, "namespace") || strings.Contains(key, "stacks-4060") {
+		t.Errorf("ClusterKeyRootFunc key %q should not contain namespace", key)
+	}
+	if !strings.Contains(key, "globalroles") {
+		t.Errorf("ClusterKeyRootFunc key %q should contain resource name", key)
+	}
+
+	// KeyRootFunc should include namespace when context has one.
+	namespacedRoot := KeyRootFunc(gr)
+	key = namespacedRoot(ctx)
+	if !strings.Contains(key, "stacks-4060") {
+		t.Errorf("KeyRootFunc key %q should contain namespace stacks-4060", key)
+	}
+}
+
 type mockObject struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta


### PR DESCRIPTION
Standalone Zanzana MT reconciler was getting empty GlobalRoles from the IAM API. This caused `basic_admin`/`basic_editor`/`basic_viewer` role permissions to never be synced to OpenFGA, producing shadow client mismatches (`expected=true actual=false`)

## Summary
- Fix `KeyRootFunc` in the generic registry store to use `ClusterKeyRootFunc` for cluster-scoped resources (e.g. GlobalRoles), preventing namespace from being included in list storage keys
- The `ClusterKeyRootFunc` already existed but was never wired in — the fix mirrors the existing `KeyFunc` conditional that already correctly selects `ClusterScopedKeyFunc` vs `NamespaceKeyFunc`

## Test plan
- [x] Existing `TestNewRegistryStore_KeyFuncSelection` passes
- [x] New `TestKeyRootFunc_ClusterScoped` verifies `ClusterKeyRootFunc` excludes namespace even when context has one

🤖 Generated with [Claude Code](https://claude.com/claude-code)