### PR TITLE
Unistore: Add per-resource namespace rollout for Zanzana

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -88,14 +88,7 @@ func ProvideAuthZClient(
 			return nil, err
 		}
 		if zanzanaEnabled {
-			if len(cfg.ZanzanaRollout.ResourcePercentages) > 0 {
-				shadowClient, err := zClient.WithShadowRBACClient(zanzanaClient, rbacClient, reg)
-				if err != nil {
-					return nil, err
-				}
-				return newRolloutAccessClient(rbacClient, shadowClient, cfg.ZanzanaRollout.ResourcePercentages), nil
-			}
-			return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
+			return newZanzanaAwareClient(cfg, rbacClient, zanzanaClient, reg)
 		}
 		return rbacClient, nil
 	default:
@@ -157,14 +150,7 @@ func ProvideAuthZClient(
 		)
 
 		if zanzanaEnabled {
-			if len(cfg.ZanzanaRollout.ResourcePercentages) > 0 {
-				shadowClient, err := zClient.WithShadowRBACClient(zanzanaClient, rbacClient, reg)
-				if err != nil {
-					return nil, err
-				}
-				return newRolloutAccessClient(rbacClient, shadowClient, cfg.ZanzanaRollout.ResourcePercentages), nil
-			}
-			return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
+			return newZanzanaAwareClient(cfg, rbacClient, zanzanaClient, reg)
 		}
 
 		return rbacClient, nil
@@ -209,6 +195,21 @@ func ProvideStandaloneAuthZClient(
 	}
 
 	return remoteRBACClient, nil
+}
+
+// newZanzanaAwareClient returns the appropriate access client when Zanzana is
+// enabled. If a rollout map is configured it wraps rbacClient in a shadow
+// comparison client and routes per-resource tenants deterministically via the
+// rollout percentages; otherwise it delegates to newShadowClient.
+func newZanzanaAwareClient(cfg *setting.Cfg, rbacClient, zanzanaClient authlib.AccessClient, reg prometheus.Registerer) (authlib.AccessClient, error) {
+	if len(cfg.ZanzanaRollout.ResourcePercentages) > 0 {
+		shadowClient, err := zClient.WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+		if err != nil {
+			return nil, err
+		}
+		return newRolloutAccessClient(rbacClient, shadowClient, cfg.ZanzanaRollout.ResourcePercentages), nil
+	}
+	return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
 }
 
 // newShadowClient returns either a ShadowClient (RBAC primary) or a

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -84,10 +84,20 @@ func ProvideAuthZClient(
 	switch authCfg.mode {
 	case clientModeCloud:
 		rbacClient, err := newRemoteRBACClient(authCfg, tracer, reg)
+		if err != nil {
+			return nil, err
+		}
 		if zanzanaEnabled {
+			if len(cfg.ZanzanaRollout.ResourcePercentages) > 0 {
+				shadowClient, err := zClient.WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+				if err != nil {
+					return nil, err
+				}
+				return newRolloutAccessClient(rbacClient, shadowClient, cfg.ZanzanaRollout.ResourcePercentages), nil
+			}
 			return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
 		}
-		return rbacClient, err
+		return rbacClient, nil
 	default:
 		sql := legacysql.NewDatabaseProvider(db)
 		rbacSettings := rbac.Settings{CacheTTL: authCfg.cacheTTL}
@@ -147,6 +157,13 @@ func ProvideAuthZClient(
 		)
 
 		if zanzanaEnabled {
+			if len(cfg.ZanzanaRollout.ResourcePercentages) > 0 {
+				shadowClient, err := zClient.WithShadowRBACClient(zanzanaClient, rbacClient, reg)
+				if err != nil {
+					return nil, err
+				}
+				return newRolloutAccessClient(rbacClient, shadowClient, cfg.ZanzanaRollout.ResourcePercentages), nil
+			}
 			return newShadowClient(cfg.ZanzanaClient.PrimaryEngine, rbacClient, zanzanaClient, reg)
 		}
 

--- a/pkg/services/authz/rollout.go
+++ b/pkg/services/authz/rollout.go
@@ -7,6 +7,7 @@ import (
 	claims "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
 var rolloutLog = log.New("authz.rollout")
@@ -31,11 +32,17 @@ type rolloutAccessClient struct {
 }
 
 func newRolloutAccessClient(rbac, zanzana claims.AccessClient, rollout map[string]float64) claims.AccessClient {
+	if rbac == nil {
+		panic("newRolloutAccessClient: rbac client is nil")
+	}
+	if zanzana == nil {
+		panic("newRolloutAccessClient: zanzana client is nil")
+	}
 	return &rolloutAccessClient{rbac: rbac, zanzana: zanzana, rollout: rollout}
 }
 
 func (c *rolloutAccessClient) clientFor(namespace, group, resource string) claims.AccessClient {
-	pct, ok := c.rollout[group+"/"+resource]
+	pct, ok := c.rollout[common.FormatGroupResource(group, resource, "")]
 	if !ok || pct <= 0 {
 		return c.rbac
 	}
@@ -70,6 +77,7 @@ func (c *rolloutAccessClient) BatchCheck(ctx context.Context, id claims.AuthInfo
 	for _, check := range req.Checks[1:] {
 		if check.Group != group || check.Resource != resource {
 			rolloutLog.Warn("batch contains mixed group/resource combinations, falling back to RBAC",
+				"namespace", req.Namespace,
 				"first_group", group, "first_resource", resource,
 				"conflict_group", check.Group, "conflict_resource", check.Resource,
 			)

--- a/pkg/services/authz/rollout.go
+++ b/pkg/services/authz/rollout.go
@@ -1,0 +1,82 @@
+package authz
+
+import (
+	"context"
+	"hash/fnv"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+var rolloutLog = log.New("authz.rollout")
+
+// rolloutBucket returns a deterministic value in [0.0, 1.0) for a given namespace and resource.
+// The resource is included in the hash so that each resource produces an independent namespace
+// distribution — the 20% of namespaces routed for dashboards is a different cohort from
+// the 20% routed for folders.
+func rolloutBucket(namespace, group, resource string) float64 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(namespace + "|" + group + "/" + resource))
+	return float64(h.Sum32()) / (1 << 32)
+}
+
+// rolloutAccessClient routes each authorization call to either the RBAC or Zanzana-primary
+// shadow client based on a deterministic per-namespace, per-resource hash.
+// Namespaces not covered by the rollout map always use the RBAC client.
+type rolloutAccessClient struct {
+	rbac    claims.AccessClient
+	zanzana claims.AccessClient
+	rollout map[string]float64 // "group/resource" → fraction 0.0–1.0
+}
+
+func newRolloutAccessClient(rbac, zanzana claims.AccessClient, rollout map[string]float64) claims.AccessClient {
+	return &rolloutAccessClient{rbac: rbac, zanzana: zanzana, rollout: rollout}
+}
+
+func (c *rolloutAccessClient) clientFor(namespace, group, resource string) claims.AccessClient {
+	pct, ok := c.rollout[group+"/"+resource]
+	if !ok || pct <= 0 {
+		return c.rbac
+	}
+	if pct >= 1 {
+		return c.zanzana
+	}
+	if rolloutBucket(namespace, group, resource) < pct {
+		return c.zanzana
+	}
+	return c.rbac
+}
+
+func (c *rolloutAccessClient) Check(ctx context.Context, id claims.AuthInfo, req claims.CheckRequest, folder string) (claims.CheckResponse, error) {
+	return c.clientFor(req.Namespace, req.Group, req.Resource).Check(ctx, id, req, folder)
+}
+
+//nolint:staticcheck // SA1019: Compile is deprecated but BatchCheck is not yet fully implemented
+func (c *rolloutAccessClient) Compile(ctx context.Context, id claims.AuthInfo, req claims.ListRequest) (claims.ItemChecker, claims.Zookie, error) {
+	return c.clientFor(req.Namespace, req.Group, req.Resource).Compile(ctx, id, req) //nolint:staticcheck
+}
+
+// BatchCheck routes the entire batch to a single client based on the group and resource of the
+// first item. All items in a batch are expected to share the same group and resource — this
+// matches how batches are constructed in practice (one List call, one resource type, one
+// namespace). If items with different group/resource combinations are detected, the batch falls
+// back to the RBAC client rather than misrouting, and a warning is logged.
+func (c *rolloutAccessClient) BatchCheck(ctx context.Context, id claims.AuthInfo, req claims.BatchCheckRequest) (claims.BatchCheckResponse, error) {
+	if len(req.Checks) == 0 {
+		return c.rbac.BatchCheck(ctx, id, req)
+	}
+	group, resource := req.Checks[0].Group, req.Checks[0].Resource
+	for _, check := range req.Checks[1:] {
+		if check.Group != group || check.Resource != resource {
+			rolloutLog.Warn("batch contains mixed group/resource combinations, falling back to RBAC",
+				"first_group", group, "first_resource", resource,
+				"conflict_group", check.Group, "conflict_resource", check.Resource,
+			)
+			return c.rbac.BatchCheck(ctx, id, req)
+		}
+	}
+	return c.clientFor(req.Namespace, group, resource).BatchCheck(ctx, id, req)
+}
+
+var _ claims.AccessClient = &rolloutAccessClient{}

--- a/pkg/services/authz/rollout_test.go
+++ b/pkg/services/authz/rollout_test.go
@@ -1,0 +1,234 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+func TestRolloutBucket_Determinism(t *testing.T) {
+	namespaces := []string{"stacks-1", "stacks-100", "stacks-999", "org-42", "default"}
+	for _, ns := range namespaces {
+		b1 := rolloutBucket(ns, "dashboard.grafana.app", "dashboards")
+		b2 := rolloutBucket(ns, "dashboard.grafana.app", "dashboards")
+		assert.Equal(t, b1, b2, "rolloutBucket must return the same value for namespace %s", ns)
+	}
+}
+
+func TestRolloutBucket_Range(t *testing.T) {
+	b := rolloutBucket("stacks-100", "dashboard.grafana.app", "dashboards")
+	assert.GreaterOrEqual(t, b, 0.0)
+	assert.Less(t, b, 1.0)
+}
+
+func TestRolloutBucket_PerResourceIndependence(t *testing.T) {
+	namespaces := []string{
+		"stacks-1", "stacks-2", "stacks-3", "stacks-4", "stacks-5",
+		"stacks-6", "stacks-7", "stacks-8", "stacks-9", "stacks-10",
+	}
+
+	diffCount := 0
+	for _, ns := range namespaces {
+		dashBucket := rolloutBucket(ns, "dashboard.grafana.app", "dashboards")
+		folderBucket := rolloutBucket(ns, "folder.grafana.app", "folders")
+		if dashBucket != folderBucket {
+			diffCount++
+		}
+	}
+	assert.Greater(t, diffCount, 0, "expected at least one namespace to route differently between the two resources")
+}
+
+func TestRolloutAccessClient_RoutesCorrectly(t *testing.T) {
+	// rbacClient returns allowed=true; zanzanaClient returns allowed=false.
+	// We distinguish which client was used by checking the result.
+	rbacClient := authlib.FixedAccessClient(true)
+	zanzanaClient := authlib.FixedAccessClient(false)
+
+	client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+		"dashboard.grafana.app/dashboards": 0.5,
+	})
+
+	for _, ns := range []string{"stacks-1", "stacks-2", "stacks-3", "stacks-10", "stacks-50"} {
+		req := authlib.CheckRequest{
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Namespace: ns,
+			Verb:      utils.VerbGet,
+		}
+		bucket := rolloutBucket(ns, "dashboard.grafana.app", "dashboards")
+		expectedZanzana := bucket < 0.5
+
+		resp, err := client.Check(context.Background(), &identity.StaticRequester{Namespace: ns}, req, "")
+		require.NoError(t, err)
+		if expectedZanzana {
+			assert.False(t, resp.Allowed, "ns=%s (bucket=%.4f) should route to zanzana", ns, bucket)
+		} else {
+			assert.True(t, resp.Allowed, "ns=%s (bucket=%.4f) should route to rbac", ns, bucket)
+		}
+	}
+}
+
+func TestRolloutAccessClient_ZeroPercent(t *testing.T) {
+	rbacClient := authlib.FixedAccessClient(true)
+	zanzanaClient := authlib.FixedAccessClient(false)
+	client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+		"dashboard.grafana.app/dashboards": 0.0,
+	})
+
+	for _, ns := range []string{"stacks-1", "stacks-50", "stacks-99"} {
+		req := authlib.CheckRequest{
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Namespace: ns,
+			Verb:      utils.VerbGet,
+		}
+		resp, err := client.Check(context.Background(), &identity.StaticRequester{Namespace: ns}, req, "")
+		require.NoError(t, err)
+		assert.True(t, resp.Allowed, "0%% rollout should always use RBAC for ns=%s", ns)
+	}
+}
+
+func TestRolloutAccessClient_HundredPercent(t *testing.T) {
+	rbacClient := authlib.FixedAccessClient(true)
+	zanzanaClient := authlib.FixedAccessClient(false)
+	client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+		"dashboard.grafana.app/dashboards": 1.0,
+	})
+
+	for _, ns := range []string{"stacks-1", "stacks-50", "stacks-99"} {
+		req := authlib.CheckRequest{
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Namespace: ns,
+			Verb:      utils.VerbGet,
+		}
+		resp, err := client.Check(context.Background(), &identity.StaticRequester{Namespace: ns}, req, "")
+		require.NoError(t, err)
+		assert.False(t, resp.Allowed, "100%% rollout should always use Zanzana for ns=%s", ns)
+	}
+}
+
+func TestRolloutAccessClient_ResourceNotInRollout(t *testing.T) {
+	rbacClient := authlib.FixedAccessClient(true)
+	zanzanaClient := authlib.FixedAccessClient(false)
+	client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+		"dashboard.grafana.app/dashboards": 0.5,
+	})
+
+	req := authlib.CheckRequest{
+		Group:     "folder.grafana.app",
+		Resource:  "folders",
+		Namespace: "stacks-1",
+		Verb:      utils.VerbGet,
+	}
+	resp, err := client.Check(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, req, "")
+	require.NoError(t, err)
+	assert.True(t, resp.Allowed, "resource not in rollout map should always use RBAC")
+}
+
+//nolint:staticcheck // SA1019: Compile is deprecated but still exercised here until BatchCheck is fully implemented
+func TestRolloutAccessClient_Compile(t *testing.T) {
+	rbacClient := authlib.FixedAccessClient(true)
+	zanzanaClient := authlib.FixedAccessClient(false)
+
+	t.Run("routes to zanzana at 100%", func(t *testing.T) {
+		client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+			"dashboard.grafana.app/dashboards": 1.0,
+		})
+		req := authlib.ListRequest{
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Namespace: "stacks-1",
+			Verb:      utils.VerbGet,
+		}
+		checker, _, err := client.Compile(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, req)
+		require.NoError(t, err)
+		require.NotNil(t, checker)
+		assert.False(t, checker("dash-uid", ""), "100%% rollout should route Compile to Zanzana (not allowed)")
+	})
+
+	t.Run("routes to rbac at 0%", func(t *testing.T) {
+		client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+			"dashboard.grafana.app/dashboards": 0.0,
+		})
+		req := authlib.ListRequest{
+			Group:     "dashboard.grafana.app",
+			Resource:  "dashboards",
+			Namespace: "stacks-1",
+			Verb:      utils.VerbGet,
+		}
+		checker, _, err := client.Compile(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, req)
+		require.NoError(t, err)
+		require.NotNil(t, checker)
+		assert.True(t, checker("dash-uid", ""), "0%% rollout should route Compile to RBAC (allowed)")
+	})
+}
+
+func TestRolloutAccessClient_BatchCheck(t *testing.T) {
+	rbacClient := authlib.FixedAccessClient(true)
+	zanzanaClient := authlib.FixedAccessClient(false)
+
+	t.Run("routes to zanzana at 100%", func(t *testing.T) {
+		client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+			"dashboard.grafana.app/dashboards": 1.0,
+		})
+		req := authlib.BatchCheckRequest{
+			Namespace: "stacks-1",
+			Checks: []authlib.BatchCheckItem{
+				{CorrelationID: "1", Group: "dashboard.grafana.app", Resource: "dashboards", Verb: utils.VerbGet, Name: "d1"},
+				{CorrelationID: "2", Group: "dashboard.grafana.app", Resource: "dashboards", Verb: utils.VerbGet, Name: "d2"},
+			},
+		}
+		resp, err := client.BatchCheck(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, req)
+		require.NoError(t, err)
+		assert.False(t, resp.Results["1"].Allowed, "100%% rollout should route BatchCheck to Zanzana")
+		assert.False(t, resp.Results["2"].Allowed, "100%% rollout should route BatchCheck to Zanzana")
+	})
+
+	t.Run("routes to rbac for resource not in rollout", func(t *testing.T) {
+		client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+			"dashboard.grafana.app/dashboards": 1.0,
+		})
+		req := authlib.BatchCheckRequest{
+			Namespace: "stacks-1",
+			Checks: []authlib.BatchCheckItem{
+				{CorrelationID: "1", Group: "folder.grafana.app", Resource: "folders", Verb: utils.VerbGet, Name: "f1"},
+			},
+		}
+		resp, err := client.BatchCheck(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, req)
+		require.NoError(t, err)
+		assert.True(t, resp.Results["1"].Allowed, "resource not in rollout should route BatchCheck to RBAC")
+	})
+
+	t.Run("empty batch routes to rbac", func(t *testing.T) {
+		client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+			"dashboard.grafana.app/dashboards": 1.0,
+		})
+		resp, err := client.BatchCheck(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, authlib.BatchCheckRequest{Namespace: "stacks-1"})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+	})
+
+	t.Run("mixed group/resource falls back to rbac", func(t *testing.T) {
+		client := newRolloutAccessClient(rbacClient, zanzanaClient, map[string]float64{
+			"dashboard.grafana.app/dashboards": 1.0,
+		})
+		req := authlib.BatchCheckRequest{
+			Namespace: "stacks-1",
+			Checks: []authlib.BatchCheckItem{
+				{CorrelationID: "1", Group: "dashboard.grafana.app", Resource: "dashboards", Verb: utils.VerbGet},
+				{CorrelationID: "2", Group: "folder.grafana.app", Resource: "folders", Verb: utils.VerbGet},
+			},
+		}
+		resp, err := client.BatchCheck(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, req)
+		require.NoError(t, err)
+		assert.True(t, resp.Results["1"].Allowed, "mixed-resource batch should fall back to RBAC (allowed)")
+		assert.True(t, resp.Results["2"].Allowed, "mixed-resource batch should fall back to RBAC (allowed)")
+	})
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -572,6 +572,7 @@ type Cfg struct {
 	ZanzanaServer     ZanzanaServerSettings
 	ZanzanaReconciler ZanzanaReconcilerSettings
 	ZanzanaGRPCStore  ZanzanaGRPCStoreSettings
+	ZanzanaRollout    ZanzanaRolloutSettings
 
 	// GRPC Server.
 	GRPCServer GRPCServerSettings

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"slices"
+	"strconv"
 	"time"
 )
 
@@ -273,6 +274,14 @@ type OpenFgaCacheSettings struct {
 	SharedIteratorTTL time.Duration
 }
 
+// ZanzanaRolloutSettings controls per-resource tenant routing to Zanzana.
+// Keys are "group/resource" (e.g. "dashboard.grafana.app/dashboards"),
+// values are fractions in [0.0, 1.0]. Tenants are assigned deterministically
+// via a hash of namespace+resource; the same tenant always lands in the same bucket.
+type ZanzanaRolloutSettings struct {
+	ResourcePercentages map[string]float64
+}
+
 const (
 	defaultReadPageSize = 100
 )
@@ -425,4 +434,20 @@ func (cfg *Cfg) readZanzanaSettings() {
 		TLSCertPath: grpcStoreSec.Key("tls_cert_path").MustString(""),
 		TLSKeyPath:  grpcStoreSec.Key("tls_key_path").MustString(""),
 	}
+
+	// Rollout settings
+	rolloutSec := cfg.SectionWithEnvOverrides("zanzana.rollout")
+	rollout := ZanzanaRolloutSettings{ResourcePercentages: make(map[string]float64)}
+	for resource, value := range rolloutSec.KeysHash() {
+		if resource == "" {
+			continue
+		}
+		pct, err := strconv.ParseFloat(value, 64)
+		if err != nil || pct < 0 || pct > 1 {
+			cfg.Logger.Warn("invalid zanzana.rollout percentage, skipping", "resource", resource, "value", value)
+			continue
+		}
+		rollout.ResourcePercentages[resource] = pct
+	}
+	cfg.ZanzanaRollout = rollout
 }

--- a/pkg/setting/settings_zanzana_test.go
+++ b/pkg/setting/settings_zanzana_test.go
@@ -1,0 +1,90 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadZanzanaSettings_Rollout(t *testing.T) {
+	t.Run("parses valid percentages", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+dashboard.grafana.app/dashboards = 0.5
+folder.grafana.app/folders = 1.0
+`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{
+			"dashboard.grafana.app/dashboards": 0.5,
+			"folder.grafana.app/folders":       1.0,
+		}, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+
+	t.Run("zero and one boundaries are accepted", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+dashboard.grafana.app/dashboards = 0.0
+folder.grafana.app/folders = 1.0
+`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{
+			"dashboard.grafana.app/dashboards": 0.0,
+			"folder.grafana.app/folders":       1.0,
+		}, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+
+	t.Run("skips entries with non-float values", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+dashboard.grafana.app/dashboards = not-a-number
+folder.grafana.app/folders = 0.5
+`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{
+			"folder.grafana.app/folders": 0.5,
+		}, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+
+	t.Run("skips entries with percentage below zero", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+dashboard.grafana.app/dashboards = -0.1
+folder.grafana.app/folders = 0.5
+`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{
+			"folder.grafana.app/folders": 0.5,
+		}, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+
+	t.Run("skips entries with percentage above one", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+dashboard.grafana.app/dashboards = 1.5
+folder.grafana.app/folders = 0.5
+`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]float64{
+			"folder.grafana.app/folders": 0.5,
+		}, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+
+	t.Run("produces empty map when all entries are invalid", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+dashboard.grafana.app/dashboards = bad
+folder.grafana.app/folders = 2.0
+`))
+		require.NoError(t, err)
+		assert.Empty(t, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+
+	t.Run("empty section produces empty map", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.rollout]
+`))
+		require.NoError(t, err)
+		assert.Empty(t, cfg.ZanzanaRollout.ResourcePercentages)
+	})
+}


### PR DESCRIPTION
 This PR adds a way to rollout Zanzana incrementally in unified storage.

Specifically it adds a `[zanzana.rollout]` config section that is per-resource and percentage-based.

These namespaces are deterministically assigned to a rollout bucket, so the same namespace always hits the same backend for a given resource, but not all namespaces are selected for the same rollout pattern outside of that (i.e. it isn't always the same namespace being the first to be rolled out to).

It looks like:
```
[feature_toggles]
zanzana = true

[zanzana.rollout]
dashboard.grafana.app/dashboards = 0.2 # 20% of tenants use Zanzana for dashboards
folder.grafana.app/folders = 0.5 # 50% of tenants use Zanzana for folders
```

If a BatchCheck is shared across multiple kinds, it falls back to legacy and logs a warning.