### PR TITLE
Dashboards: Cleanup logs

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -308,7 +308,7 @@ func (dr *DashboardServiceImpl) getLastResourceVersion(ctx context.Context, orgI
 	}
 
 	if !ok {
-		dr.log.Info("No last resource version found, starting from scratch", "orgID", orgID)
+		dr.log.Debug("No last deleted resource version found, skipping", "orgID", orgID)
 		return "0", nil
 	}
 


### PR DESCRIPTION
This will happen if no dashboards have been deleted on an instance, and is pretty noisy (runs every 30s) for new instances. We should move this to a debug log, and make it clearer what is happening