### PR TITLE
Docs: Filter and group by public preview updates

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -54,8 +54,8 @@ Data sources with an asterisk also support group by:
 
 {{< column-list >}}
 
-- Prometheus*
-- Loki*
+- Prometheus\*
+- Loki\*
 - InfluxDB
 - Elasticsearch
 - OpenSearch.
@@ -70,7 +70,7 @@ To add a filter and group by, follow these steps:
 1. Navigate to the dashboard you want to update.
 1. Click **Edit**.
 1. Click the **Add new element** icon (blue plus sign).
-. Click **Filter and Group by**.
+   . Click **Filter and Group by**.
 1. Enter a **Name** for the filter.
 1. (Optional) In the **Label** field, enter the display name for the filter drop-down list.
 
@@ -88,14 +88,14 @@ To add a filter and group by, follow these steps:
 
 1. Under the **Filter options** section of the page, set the following options:
 
-   | Option | Description |
-   | ------ | ----------- |
-   | Data source | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/). |
-   | Default filters | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
-   | Enable group by | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping. |
-   | Default group by | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
-   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional. |
-   | Allow custom values | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional. |
+   | Option                    | Description                                                                                                                                                                                                                                                                                                                          |
+   | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+   | Data source               | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/). |
+   | Default filters           | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon.                                                                                                                                                                                                    |
+   | Enable group by           | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping.                                                                                                                                                                                                             |
+   | Default group by          | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon.                                                                                                                                                                                             |
+   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional.                                                                                                                                                                                   |
+   | Allow custom values       | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional.                                                                                                                                                                                                                       |
 
 1. Click **Save**.
 1. Enter an optional description of your dashboard changes, and then click **Save**.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -19,7 +19,7 @@ weight: 200
 
 In the **Dashboard controls** section of the sidebar in add mode, you can add filters and group by keys, variables, annotation queries, and dashboard links without leaving the dashboard.
 
-## Add filters and group by
+## Filters and group by
 
 <!-- vale Grafana.Spelling = NO -->
 
@@ -27,13 +27,18 @@ In the **Dashboard controls** section of the sidebar in add mode, you can add fi
 Filter and group by is currently in public preview.
 Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
-This feature replaces ad hoc filters, and extends them by adding grouping for Prometheus and Loki data sources.
+This feature replaces ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
 However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
-
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
+
+For information on ad hoc filters, refer to the [Variables documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters), which still reflects the generally available experience.
 {{< /admonition >}}
 
 <!-- vale Grafana.Spelling = YES -->
+
+<!-- TODO: conceptual content here -->
+
+### Add filters and group by
 
 To add a filter and group by, follow these steps:
 
@@ -99,7 +104,6 @@ Your selection is applied to the all the panels in the dashboard with the same d
 
 You can also further filter a time series panel, which allows you to drill down further into your data.
 After setting your group by and splitting your data, click on a series in a panel and click `Filter on this value` or `Filter out this value` which will filter by the labels found on that series, which are related to the set group by values.
-
 
 To enable this functionality, you need to add one or more overrides for the panel.
 In the following example, the override:

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -19,7 +19,7 @@ weight: 200
 
 In the **Dashboard controls** section of the sidebar in add mode, you can add filters and group by keys, variables, annotation queries, and dashboard links without leaving the dashboard.
 
-## Filters and group by
+## Filter and group by
 
 <!-- vale Grafana.Spelling = NO -->
 
@@ -59,7 +59,7 @@ Data sources with an asterisk also support group by:
 - InfluxDB
 - Elasticsearch
 - OpenSearch.
-- Special Dashboard data source - Use this to [apply filters to data from unsupported data sources](#filter-any-data-using-the-dashboard-data-source).
+- Special Dashboard data source - Use this to [apply filters to data from unsupported data sources](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#filter-any-data-using-the-dashboard-data-source).
 
 {{< /column-list >}}
 
@@ -268,9 +268,7 @@ To add a URL link to your dashboard, follow these steps:
 ## Manage dashboard controls
 
 After you add dashboard controls, you can manage them from the dashboard options.
-In this view, the sidebar includes collapsible sections for variables (including filter and group by), annotations, and links, including hidden controls that aren't otherwise visible on the dashboard:
-
-{{< figure src="../screenshot-dashboard-controls-mgmt-2-v13.0.png" alt="Dashboard controls in the Dashboard options sidebar view" max-width="500px" >}}
+In this view, the sidebar includes collapsible sections for variables (including filter and group by), annotations, and links, including hidden controls that aren't otherwise visible on the dashboard.
 
 To manage dashboard controls, follow these steps:
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -71,9 +71,51 @@ To add a filter and group by, follow these steps:
 1. Enter an optional description of your dashboard changes, and then click **Save**.
 1. Click **Exit edit**.
 
-{{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="filter-management" >}}
+Now you can filter and group data on the dashboard.
 
-{{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="panel-filter" >}}
+You can remove and reset default filters and group by selections, and see your recent ones:
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-reset-default-v13.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" caption="Reset default filters and group by selections" >}}
+
+{{< figure src="/media/docs/grafana/screenshot-filters-group-recent-v13.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" caption="Recent filter and group by settings" >}}
+
+To see every active filter and group by across the dashboard all at once, click the filter icon in the toolbar to open an overview.
+The overview lets you see your current filters and group by selections, search for specific keys, and adjust them without scrolling through the dashboard controls:
+
+{{< figure src="/media/docs/grafana/screenshot-filters-overview-v12.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" >}}
+
+Add an operator and value for a key to add it as a filter or select the **Group by** checkbox to set a group by key:
+You can use a key for both a filter and a group by.
+
+### Group and filter from the panel
+
+When the **Group by** switch is toggled on, you can also set a group by from a panel rather than from the dashboard-level control.
+Hover the cursor over any panel using the data source of the filter to show the **Group by** selector:
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-panel-groupby-v13.0.png" max-width="550px" alt="Group by control on a panel" >}}
+
+This can be helpful when you're working with a panel that's far away from the dashboard controls.
+Your selection is applied to the all the panels in the dashboard with the same data source.
+
+You can also further filter a time series panel, which allows you to drill down further into your data.
+After setting your group by and splitting your data, click on a series in a panel and click `Filter on this value` or `Filter out this value` which will filter by the labels found on that series, which are related to the set group by values.
+
+
+To enable this functionality, you need to add one or more overrides for the panel.
+In the following example, the override:
+
+- Adds a regular expression, so that all fields are filterable
+- Enables the **Ad-hoc filterable** switch
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-panel-filter-override-v13.0.png" max-width="400px" alt="Field override making all fields filterable" >}}
+
+However, you can create overrides to address specific fields.
+Be sure to also set your data as filterable by either returning the dataframe with the appropriate `filterable` property on the desired fields
+
+With the override in place, you can click a series on a time series panel and filter it in or out.
+The new filter is shown in the dashboard filter control and the it's applied to the whole dashboard.
+
+<!-- TODO: Add screenshot here when feature is working properly -->
 
 ## Add variables
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -38,11 +38,11 @@ While that documentation reflects the generally available experience, the inform
 <!-- vale Grafana.Spelling = YES -->
 
 The filter and group by is one of the most complex and flexible variable options available.
-Instead of creating a variable for each dimension by which you want to filter, it automatically creates variables (key/value pairs) for all the dimensions returned by your data source query.
+Instead of creating a variable for each dimension by which you want to filter, they automatically query your data source for available dimensions and let users add or remove filters and groupings on the dashboard dynamically.
 This allows you to quickly apply filters dashboard-wide.
 
 The group by function allows you to then group data by keys, letting you split it up.
-Group by functionality works when you have queries that are aggregators, such as `sum(your_metric_here)`.
+Group by is typically used with aggregation queries, such as `sum(your_metric_here)`, to split aggregated results by the selected dimensions.
 Then, you can use filters within panels to filter data in or out, drilling down further into the data.
 
 The filter and group by feature lets you add label/value filters that are automatically added to all queries that use the specified data source.
@@ -139,7 +139,7 @@ In the following example, the override:
 {{< figure src="/media/docs/grafana/dashboards/screenshot-panel-filter-override-v13.0.png" max-width="400px" alt="Field override making all fields filterable" >}}
 
 However, you can create overrides to address specific fields.
-Be sure to also set your data as filterable by either returning the dataframe with the appropriate `filterable` property on the desired fields
+You can also do this programmatically by returning the data frame with the appropriate `filterable` property on the desired fields.
 
 With the override in place, you can click a series on a time series panel and filter it in or out.
 The new filter is shown in the dashboard filter control and the it's applied to the whole dashboard.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -31,14 +31,39 @@ This feature replaces ad hoc filters and extends them by adding grouping for Pro
 However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
 
-For information on ad hoc filters, refer to the [Variables documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters), which still reflects the generally available experience.
+For information on ad hoc filters, refer to the [Variables documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
+While that documentation reflects the generally available experience, the information applies to the filter and group by feature.
 {{< /admonition >}}
 
 <!-- vale Grafana.Spelling = YES -->
 
-<!-- TODO: conceptual content here -->
+The filter and group by is one of the most complex and flexible variable options available.
+Instead of creating a variable for each dimension by which you want to filter, it automatically creates variables (key/value pairs) for all the dimensions returned by your data source query.
+This allows you to quickly apply filters dashboard-wide.
 
-### Add filters and group by
+The group by function allows you to then group data by keys, letting you further narrow your scope.
+Group by functionality works when you have queries that are aggregators, such as `sum(your_metric_here)`.
+Then, you can filter further with panel-level filters that let you drill down into your data.
+
+The filter and group by feature lets you add label/value filters that are automatically added to all metric queries that use the specified data source.
+Unlike other variables, you don't use these filters in queries.
+Instead, you use them to write filters for existing queries.
+
+The following data sources support filters.
+Data sources with an asterisk also support group by:
+
+{{< column-list >}}
+
+- Prometheus*
+- Loki*
+- InfluxDB
+- Elasticsearch
+- OpenSearch.
+- Special Dashboard data source - Use this to [apply filters to data from unsupported data sources](#filter-any-data-using-the-dashboard-data-source).
+
+{{< /column-list >}}
+
+### Add a filter and group by
 
 To add a filter and group by, follow these steps:
 
@@ -65,7 +90,7 @@ To add a filter and group by, follow these steps:
 
    | Option | Description |
    | ------ | ----------- |
-   | Data source | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](ref:add-a-data-source). |
+   | Data source | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/). |
    | Default filters | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
    | Enable group by | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping. |
    | Default group by | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
@@ -89,7 +114,7 @@ The overview lets you see your current filters and group by selections, search f
 
 {{< figure src="/media/docs/grafana/screenshot-filters-overview-v12.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" >}}
 
-Add an operator and value for a key to add it as a filter or select the **Group by** checkbox to set a group by key:
+Add an operator and value for a key to add it as a filter or select the **Group by** checkbox to set a group by key.
 You can use a key for both a filter and a group by.
 
 ### Group and filter from the panel

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -45,7 +45,7 @@ The group by function allows you to then group data by keys, letting you split i
 Group by functionality works when you have queries that are aggregators, such as `sum(your_metric_here)`.
 Then, you can use filters within panels to filter data in or out, drilling down further into the data.
 
-The filter and group by feature lets you add label/value filters that are automatically added to all metric queries that use the specified data source.
+The filter and group by feature lets you add label/value filters that are automatically added to all queries that use the specified data source.
 Unlike other variables, you don't use these filters in queries.
 Instead, you use them to write filters for existing queries.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -17,9 +17,7 @@ weight: 200
 
 # Dashboard controls
 
-In the **Dashboard controls** section of the sidebar in add mode, you can add variables, annotation queries, and dashboard links without leaving the dashboard.
-
-{{< figure src="../screenshot-dashboard-controls-v13.0.png" max-width="500px" alt="Dashboard controls in the Dashboard options sidebar view" >}}
+In the **Dashboard controls** section of the sidebar in add mode, you can add filters and group by keys, variables, annotation queries, and dashboard links without leaving the dashboard.
 
 ## Add filters and group by
 
@@ -39,15 +37,39 @@ To use this feature, enable the `dashboardUnifiedDrilldownControls` feature togg
 
 To add a filter and group by, follow these steps:
 
-{{< docs/list >}}
-
 1. Navigate to the dashboard you want to update.
 1. Click **Edit**.
 1. Click the **Add new element** icon (blue plus sign).
+. Click **Filter and Group by**.
+1. Enter a **Name** for the filter.
+1. (Optional) In the **Label** field, enter the display name for the filter drop-down list.
 
-{{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="add-filter" >}}
+   If you don't enter a display name, then the drop-down list label is the filter name.
 
-{{< /docs/list >}}
+1. (Optional) In the **Description** field, enter a description of the filter. The description appears as an info icon tooltip next to the filter name on the dashboard.
+
+   Descriptions support links. You can use Markdown-style links (`[link text](https://example.com)`) or paste bare URLs (`https://example.com`). Only `http` and `https` URLs are rendered as clickable links—other protocols are displayed as plain text.
+
+1. Choose a **Display** option:
+   - **Above dashboard** - The filter drop-down list displays above the dashboard with the filter **Name** or **Label** value. This is the default.
+   - **Above dashboard, label hidden** - The filter drop-down list displays above the dashboard, but without showing the name of the filter.
+   - **Controls menu** - The filter is displayed in the dashboard controls menu instead of above the dashboard. The dashboard controls menu appears as a button in the dashboard toolbar.
+   - **Hidden** - No filter drop-down list is displayed on the dashboard.
+
+1. Under the **Filter options** section of the page, set the following options:
+
+   | Option | Description |
+   | ------ | ----------- |
+   | Data source | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](ref:add-a-data-source). |
+   | Default filters | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
+   | Enable group by | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping. |
+   | Default group by | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
+   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional. |
+   | Allow custom values | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional. |
+
+1. Click **Save**.
+1. Enter an optional description of your dashboard changes, and then click **Save**.
+1. Click **Exit edit**.
 
 {{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="filter-management" >}}
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -17,7 +17,7 @@ weight: 200
 
 # Dashboard controls
 
-In the **Dashboard controls** section of the sidebar in add mode, you can add filters and group by keys, variables, annotation queries, and dashboard links without leaving the dashboard.
+In the **Dashboard controls** section of the sidebar, you can add variables, annotation queries, dashboard links, and controls to filter and group data, without leaving the dashboard.
 
 ## Filter and group by
 
@@ -27,7 +27,7 @@ In the **Dashboard controls** section of the sidebar in add mode, you can add fi
 Filter and group by is currently in public preview.
 Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
-This feature replaces ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
+This feature renames _ad hoc filters_ to simply _filters_ and extends them by adding grouping for Prometheus and Loki data sources.
 However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
 
@@ -41,9 +41,9 @@ The filter and group by is one of the most complex and flexible variable options
 Instead of creating a variable for each dimension by which you want to filter, it automatically creates variables (key/value pairs) for all the dimensions returned by your data source query.
 This allows you to quickly apply filters dashboard-wide.
 
-The group by function allows you to then group data by keys, letting you further narrow your scope.
+The group by function allows you to then group data by keys, letting you split it up.
 Group by functionality works when you have queries that are aggregators, such as `sum(your_metric_here)`.
-Then, you can filter further with panel-level filters that let you drill down into your data.
+Then, you can use filters within panels to filter data in or out, drilling down further into the data.
 
 The filter and group by feature lets you add label/value filters that are automatically added to all metric queries that use the specified data source.
 Unlike other variables, you don't use these filters in queries.
@@ -103,13 +103,13 @@ To add a filter and group by, follow these steps:
 
 Now you can filter and group data on the dashboard.
 
-You can remove and reset default filters and group by selections, and see your recent ones:
+You can remove and reset default filters and groupings, and see your recent ones:
 
 {{< figure src="/media/docs/grafana/dashboards/screenshot-reset-default-v13.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" caption="Reset default filters and group by selections" >}}
 
 {{< figure src="/media/docs/grafana/screenshot-filters-group-recent-v13.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" caption="Recent filter and group by settings" >}}
 
-To see every active filter and group by across the dashboard all at once, click the filter icon in the toolbar to open an overview.
+To see every active filter and grouping across the dashboard all at once, click the filter icon in the toolbar to open an overview.
 The overview lets you see your current filters and group by selections, search for specific keys, and adjust them without scrolling through the dashboard controls:
 
 {{< figure src="/media/docs/grafana/screenshot-filters-overview-v12.0.png" max-width="500px" alt="Dashboard with the filters and group by selections" >}}

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -88,18 +88,14 @@ To add a filter and group by, follow these steps:
 
 1. Under the **Filter options** section of the page, set the following options:
 
-<!-- prettier-ignore-start -->
-
-   | Option                    | Description                                                        |
-   | ------------------------- | ------------------------------------------------------------------ |
+   | Option                    | Description                                                                                                                                                                                                                                                                                                                          |
+   | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
    | Data source               | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/). |
-   | Default filters           | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon.  |
-   | Enable group by           | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping.  |
-   | Default group by          | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
-   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional. |
-   | Allow custom values       | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional. |
-
-<!-- prettier-ignore-end -->
+   | Default filters           | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon.                                                                                                                                                                                                    |
+   | Enable group by           | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping.                                                                                                                                                                                                             |
+   | Default group by          | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon.                                                                                                                                                                                             |
+   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional.                                                                                                                                                                                   |
+   | Allow custom values       | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional.                                                                                                                                                                                                                       |
 
 1. Click **Save**.
 1. Enter an optional description of your dashboard changes, and then click **Save**.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -17,15 +17,45 @@ weight: 200
 
 # Dashboard controls
 
-In the **Dashboard controls** section of the sidebar, you can add variables, annotation queries, and dashboard links without leaving the dashboard.
+In the **Dashboard controls** section of the sidebar in add mode, you can add variables, annotation queries, and dashboard links without leaving the dashboard.
 
-<!-- TODO: Add screenshot after filters work is done -->
+{{< figure src="../screenshot-dashboard-controls-v13.0.png" max-width="500px" alt="Dashboard controls in the Dashboard options sidebar view" >}}
+
+## Add filters and group by
+
+<!-- vale Grafana.Spelling = NO -->
+
+{{< admonition type="note" >}}
+Filter and group by is currently in public preview.
+Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+
+This feature replaces ad hoc filters, and extends them by adding grouping for Prometheus and Loki data sources.
+However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
+
+To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
+{{< /admonition >}}
+
+<!-- vale Grafana.Spelling = YES -->
+
+To add a filter and group by, follow these steps:
+
+{{< docs/list >}}
+
+1. Navigate to the dashboard you want to update.
+1. Click **Edit**.
+1. Click the **Add new element** icon (blue plus sign).
+
+{{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="add-filter" >}}
+
+{{< /docs/list >}}
+
+{{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="filter-management" >}}
+
+{{< shared-snippet path="/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/index.md" id="panel-filter" >}}
 
 ## Add variables
 
 To add a variable, follow these steps:
-
-<!-- vale Grafana.Spelling = NO -->
 
 {{< docs/list >}}
 
@@ -46,7 +76,6 @@ To add a variable, follow these steps:
 - [Constant](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/#add-a-constant-variable)
 - [Data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/#add-a-data-source-variable)
 - [Interval](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/#add-an-interval-variable)
-- [Ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/#add-ad-hoc-filters)
 - [Switch](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/#add-a-switch-variable)
 
 {{< /column-list >}}
@@ -57,8 +86,6 @@ To add a variable, follow these steps:
 1. Click **Exit edit**.
 
 {{< /docs/list >}}
-
-<!-- vale Grafana.Spelling = YES -->
 
 For more detailed information on variables, refer to the full [Variables documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/).
 
@@ -145,41 +172,19 @@ To add a URL link to your dashboard, follow these steps:
 
 {{< /docs/list >}}
 
-<!-- ## Add filters
-
-To add a filter, follow these steps:
-
-<!-- vale Grafana.Spelling = NO
-
-{{< docs/list >}}
-
-1. Navigate to the dashboard you want to update.
-1. Click **Edit**.
-1. Click the **Add new element** icon (blue plus sign) and select **Filter**.
-1. Choose a filter type from the list.
-
-1. Click **Save**.
-1. (Optional) Enter a description of the changes you've made.
-1. Click **Save**.
-1. Click **Exit edit**.
-
-{{< /docs/list >}}
-
-<!-- vale Grafana.Spelling = YES -->
-
 ## Manage dashboard controls
 
 After you add dashboard controls, you can manage them from the dashboard options.
-The sidebar includes collapsible sections for variables, annotations, and links, including hidden controls that aren't otherwise visible on the dashboard:
+In this view, the sidebar includes collapsible sections for variables (including filter and group by), annotations, and links, including hidden controls that aren't otherwise visible on the dashboard:
 
-<!-- TODO: Add screenshot here after filters work is done -->
+{{< figure src="../screenshot-dashboard-controls-mgmt-2-v13.0.png" alt="Dashboard controls in the Dashboard options sidebar view" max-width="500px" >}}
 
 To manage dashboard controls, follow these steps:
 
 1. Click the **Dashboard options** icon in the sidebar.
 1. In the sidebar, expand the appropriate collapsible section.
 1. Do one or more of the following:
-   - **Edit**: Click **Select** on the control to open the sidebar so you can make updates.
+   - **Edit**: Click **Select** on the control to open it in the sidebar so you can make updates.
    - **Reorder**: Drag and drop controls to reorder them.
    - **Change display**: Drag and drop controls between sub-sections **Above dashboard**, **Controls menu**, and **Hidden** to update the control display option. Note that links can't be hidden.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -144,7 +144,7 @@ You can also do this programmatically by returning the data frame with the appro
 With the override in place, you can click a series on a time series panel and filter it in or out.
 The new filter is shown in the dashboard filter control and the it's applied to the whole dashboard.
 
-<!-- TODO: Add screenshot here when feature is working properly -->
+{{< figure src="/media/docs/grafana/dashboards/screenshot-panel-filters-v13.0.png" max-width="675px" alt="Panel with tooltip open showing options to filter on a value or filter it out" >}}
 
 ## Add variables
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -27,12 +27,7 @@ In the **Dashboard controls** section of the sidebar, you can add variables, ann
 Filter and group by is currently in public preview.
 Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
-This feature renames _ad hoc filters_ to simply _filters_ and extends them by adding grouping for Prometheus and Loki data sources.
-However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
-
-For information on ad hoc filters, refer to the [Variables documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
-While that documentation reflects the generally available experience, the information applies to the filter and group by feature.
 {{< /admonition >}}
 
 <!-- vale Grafana.Spelling = YES -->

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -88,14 +88,18 @@ To add a filter and group by, follow these steps:
 
 1. Under the **Filter options** section of the page, set the following options:
 
-   | Option                    | Description                                                                                                                                                                                                                                                                                                                          |
-   | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+<!-- prettier-ignore-start -->
+
+   | Option                    | Description                                                        |
+   | ------------------------- | ------------------------------------------------------------------ |
    | Data source               | Select a target data source in the drop-down list. You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only). For more information about data sources, refer to [Add a data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/). |
-   | Default filters           | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon.                                                                                                                                                                                                    |
-   | Enable group by           | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping.                                                                                                                                                                                                             |
-   | Default group by          | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon.                                                                                                                                                                                             |
-   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional.                                                                                                                                                                                   |
-   | Allow custom values       | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional.                                                                                                                                                                                                                       |
+   | Default filters           | Set a default key/value pair. Optional. In the dashboard filter control, the default value is indicated with an information icon.  |
+   | Enable group by           | This option only appears if you selected a Prometheus or Loki data source. Toggle the switch on to enable data grouping.  |
+   | Default group by          | Set a default key for the dashboard. Optional. In the dashboard filter control, the default value is indicated with an information icon. |
+   | Use static key dimensions | To provide the filter dimensions as comma-separated values (CSV), toggle the switch on, and then enter the values in the space provided. Optional. |
+   | Allow custom values       | Toggle the switch on to allow dashboard users to add custom values to the filter and group by lists. Optional. |
+
+<!-- prettier-ignore-end -->
 
 1. Click **Save**.
 1. Enter an optional description of your dashboard changes, and then click **Save**.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -324,7 +324,7 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 
 {{< admonition type="note" >}}
 In Grafana v13, we released the filter and group by feature in public preview.
-It replaces ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
+It renames ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
 However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
 
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -323,13 +323,13 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 ## Add ad hoc filters
 
 {{< admonition type="note" >}}
-In Grafana v13, we released the filter and group by variable in public preview.
-This feature replaces ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
+In Grafana v13, we released the filter and group by feature in public preview.
+It replaces ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
 However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
 
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
 
-For more information on filter and group by variables, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
+For more information on filter and group by, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
 {{< /admonition >}}
 
 _Ad hoc filters_ are one of the most complex and flexible variable options available.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -322,6 +322,16 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 
 ## Add ad hoc filters
 
+{{< admonition type="note" >}}
+In Grafana v13, we released the filter and group by variable in public preview.
+This feature replaces ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
+However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
+
+To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
+
+For more information on filter and group by variables, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
+{{< /admonition >}}
+
 _Ad hoc filters_ are one of the most complex and flexible variable options available.
 Instead of creating a variable for each dimension by which you want to filter, ad hoc filters automatically create variables (key/value pairs) for all the dimensions returned by your data source query.
 This allows you to apply filters dashboard-wide.


### PR DESCRIPTION
This PR 

- Adds a Filter and group by section to the Dashboard controls page
- This section explains that this feature replaces ad hoc filters and reuses some conceptual content from the variables page to explain the feature
- Adds a note to the ad hoc filters content pointing to the filter and group by content

Full rip and replace will happen when the feature is GA.