### PR TITLE
Geomap: Improve tooltip behavior at edge

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -72,6 +72,7 @@ export class GeomapPanel extends Component<Props, State> {
 
   map?: OpenLayersMap;
   mapDiv?: HTMLDivElement;
+  tooltipPointerMoveDebounced?: { cancel: () => void };
   layers: MapLayerState[] = [];
   readonly byName = new Map<string, MapLayerState>();
 
@@ -296,6 +297,7 @@ export class GeomapPanel extends Component<Props, State> {
       return;
     }
     this.mapDiv = div;
+    this.tooltipPointerMoveDebounced?.cancel();
     if (this.map) {
       this.map.dispose();
     }
@@ -357,6 +359,7 @@ export class GeomapPanel extends Component<Props, State> {
   };
 
   clearTooltip = () => {
+    this.tooltipPointerMoveDebounced?.cancel();
     if (this.state.ttip && !this.state.ttipOpen) {
       this.tooltipPopupClosed();
     }

--- a/public/app/plugins/panel/geomap/utils/tooltip.test.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.test.ts
@@ -4,13 +4,13 @@ import { Point } from 'ol/geom';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 import VectorSource from 'ol/source/Vector';
 
-import { type DataFrame, type PanelProps } from '@grafana/data';
+import { DataHoverClearEvent, type DataFrame, type PanelProps } from '@grafana/data';
 
 import { GeomapPanel } from '../GeomapPanel';
 import { type GeomapHoverPayload, type GeomapLayerHover } from '../event';
 import { type Options } from '../panelcfg.gen';
 
-import { pointerMoveListener } from './tooltip';
+import { pointerMoveListener, setTooltipListeners } from './tooltip';
 
 // Mock the GeomapPanel class
 jest.mock('../GeomapPanel', () => {
@@ -217,5 +217,75 @@ describe('tooltip utils', () => {
       // The last feature (feature4) has no rowIndex, so it should be at the end
       expect(layerHover.features[3].getProperties()['rowIndex']).toBeUndefined();
     });
+  });
+});
+
+describe('setTooltipListeners', () => {
+  function createPanelForSetListeners(overrides?: { tooltipPointerMoveDebounced?: { cancel: jest.Mock } }) {
+    let pointerLeaveHandler: () => void;
+    const viewport = {
+      addEventListener: jest.fn((type: string, fn: () => void) => {
+        if (type === 'pointerleave') {
+          pointerLeaveHandler = fn;
+        }
+      }),
+    };
+    const publish = jest.fn();
+    const clearTooltip = jest.fn();
+    const panel = {
+      tooltipPointerMoveDebounced: overrides?.tooltipPointerMoveDebounced,
+      map: {
+        on: jest.fn(),
+        getViewport: jest.fn().mockReturnValue(viewport),
+      },
+      props: { eventBus: { publish } },
+      clearTooltip,
+    } as unknown as GeomapPanel;
+
+    return {
+      panel,
+      viewport,
+      publish,
+      clearTooltip,
+      simulateViewportPointerLeave: () => pointerLeaveHandler(),
+    };
+  }
+
+  it('attaches pointerleave to the map viewport', () => {
+    const { panel, viewport } = createPanelForSetListeners();
+    setTooltipListeners(panel);
+    expect(panel.map?.getViewport).toHaveBeenCalled();
+    expect(viewport.addEventListener).toHaveBeenCalledWith('pointerleave', expect.any(Function));
+  });
+
+  it('on viewport pointerleave, publishes DataHoverClearEvent and calls clearTooltip', () => {
+    const { panel, publish, clearTooltip, simulateViewportPointerLeave } = createPanelForSetListeners();
+    setTooltipListeners(panel);
+    simulateViewportPointerLeave();
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(expect.any(DataHoverClearEvent));
+    expect(clearTooltip).toHaveBeenCalledTimes(1);
+  });
+
+  it('on viewport pointerleave, cancels the debounced pointermove handler', () => {
+    const { panel, simulateViewportPointerLeave } = createPanelForSetListeners();
+    setTooltipListeners(panel);
+
+    const debounced = panel.tooltipPointerMoveDebounced;
+    expect(debounced).toBeDefined();
+    const cancelSpy = jest.spyOn(debounced!, 'cancel');
+    simulateViewportPointerLeave();
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels any existing debounced handler before replacing listeners', () => {
+    const previousCancel = jest.fn();
+    const { panel } = createPanelForSetListeners({
+      tooltipPointerMoveDebounced: { cancel: previousCancel },
+    });
+    setTooltipListeners(panel);
+    expect(previousCancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/app/plugins/panel/geomap/utils/tooltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.ts
@@ -15,14 +15,17 @@ import { type MapLayerState } from '../types';
 import { getMapLayerState } from './layers';
 
 export const setTooltipListeners = (panel: GeomapPanel) => {
-  // Tooltip listener
+  panel.tooltipPointerMoveDebounced?.cancel();
+
+  const debouncedMove = debounce((evt: MapBrowserEvent) => pointerMoveListener(evt, panel), 200);
+  panel.tooltipPointerMoveDebounced = debouncedMove;
+
   panel.map?.on('singleclick', (evt) => pointerClickListener(evt, panel));
-  panel.map?.on(
-    'pointermove',
-    debounce((evt) => pointerMoveListener(evt, panel), 200)
-  );
-  panel.map?.getViewport().addEventListener('mouseout', (evt: MouseEvent) => {
+  panel.map?.on('pointermove', debouncedMove);
+  panel.map?.getViewport().addEventListener('pointerleave', () => {
+    debouncedMove.cancel();
     panel.props.eventBus.publish(new DataHoverClearEvent());
+    panel.clearTooltip();
   });
 };
 


### PR DESCRIPTION
When a map element is being hovered toward the edge of the panel, if the mouse is moved outside of the panel without first leaving the map element within the map itself, a mouseout was not being detected, causing the tooltip to continue being rendered. The `pointerleave` event is more appropriate here.

Before:
![Apr-09-2026 23-03-57](https://github.com/user-attachments/assets/95cfbe86-be3d-48b7-b35e-0aa5ffd6aa8b)

After:
![Apr-09-2026 23-02-18](https://github.com/user-attachments/assets/3ee10383-b90c-4d26-aa58-a4f5e890592a)

Fixes https://github.com/grafana/support-escalations/issues/21634