### PR TITLE
CI: Fix pr-commands not running when labels changed

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,6 +1,10 @@
 name: PR automation
 on:
   pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
 
 concurrency:
   group: pr-commands-${{ github.event.number }}


### PR DESCRIPTION
Fixes regression added in https://github.com/grafana/grafana/pull/121988 that prevents the check from running when PR labels are changed.