### PR TITLE
Alerting: Alerts Activity Instance drawer drilldown, Silence flow

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { pickBy } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom-v5-compat';
 import { useDebounce } from 'react-use';
@@ -131,7 +131,6 @@ type SilencesEditorProps = {
   onSilenceCreated?: (response: SilenceCreatedResponse) => void;
   onCancel?: () => void;
   ruleUid?: string;
-  onFormValuesChange?: (values: SilenceFormFields) => void;
   showCancelButton?: boolean;
 };
 
@@ -145,7 +144,6 @@ export const SilencesEditor = ({
   onSilenceCreated,
   onCancel,
   ruleUid,
-  onFormValuesChange,
   showCancelButton = true,
 }: SilencesEditorProps) => {
   const [previewAlertsSupported, previewAlertsAllowed] = useAlertmanagerAbility(
@@ -158,13 +156,8 @@ export const SilencesEditor = ({
   const styles = useStyles2(getStyles);
 
   const { register, handleSubmit, formState, watch, setValue, clearErrors } = formAPI;
-  const allValues = watch();
 
   const [duration, startsAt, endsAt, matchers] = watch(['duration', 'startsAt', 'endsAt', 'matchers']);
-
-  useEffect(() => {
-    onFormValuesChange?.(allValues);
-  }, [allValues, onFormValuesChange]);
 
   /** Default action taken after creation or cancellation, if corresponding method is not defined */
   const defaultHandler = () => {

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { pickBy } from 'lodash';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom-v5-compat';
 import { useDebounce } from 'react-use';
@@ -131,6 +131,8 @@ type SilencesEditorProps = {
   onSilenceCreated?: (response: SilenceCreatedResponse) => void;
   onCancel?: () => void;
   ruleUid?: string;
+  onFormValuesChange?: (values: SilenceFormFields) => void;
+  showCancelButton?: boolean;
 };
 
 /**
@@ -143,6 +145,8 @@ export const SilencesEditor = ({
   onSilenceCreated,
   onCancel,
   ruleUid,
+  onFormValuesChange,
+  showCancelButton = true,
 }: SilencesEditorProps) => {
   const [previewAlertsSupported, previewAlertsAllowed] = useAlertmanagerAbility(
     AlertmanagerAction.PreviewSilencedInstances
@@ -150,12 +154,17 @@ export const SilencesEditor = ({
   const canPreview = previewAlertsSupported && previewAlertsAllowed;
 
   const [createSilence, { isLoading }] = alertSilencesApi.endpoints.createSilence.useMutation();
-  const formAPI = useForm({ defaultValues: formValues });
+  const formAPI = useForm<SilenceFormFields>({ defaultValues: formValues });
   const styles = useStyles2(getStyles);
 
   const { register, handleSubmit, formState, watch, setValue, clearErrors } = formAPI;
+  const allValues = watch();
 
   const [duration, startsAt, endsAt, matchers] = watch(['duration', 'startsAt', 'endsAt', 'matchers']);
+
+  useEffect(() => {
+    onFormValuesChange?.(allValues);
+  }, [allValues, onFormValuesChange]);
 
   /** Default action taken after creation or cancellation, if corresponding method is not defined */
   const defaultHandler = () => {
@@ -298,9 +307,11 @@ export const SilencesEditor = ({
               <Trans i18nKey="alerting.silences-editor.save-silence">Save silence</Trans>
             </Button>
           )}
-          <LinkButton onClick={onCancelHandler} variant={'secondary'}>
-            <Trans i18nKey="alerting.common.cancel">Cancel</Trans>
-          </LinkButton>
+          {showCancelButton && (
+            <LinkButton onClick={onCancelHandler} variant={'secondary'}>
+              <Trans i18nKey="alerting.common.cancel">Cancel</Trans>
+            </LinkButton>
+          )}
         </Stack>
       </form>
     </FormProvider>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -28,7 +28,6 @@ import { getThresholdsForQueries } from '../../components/rule-editor/util';
 import { EventState } from '../../components/rules/central-state-history/EventListSceneObject';
 import { type LogRecord, historyDataFrameToLogRecords } from '../../components/rules/state-history/common';
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
-import { type SilenceFormFields } from '../../types/silence-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { labelsToMatchersParam } from '../../utils/matchers';
 import { stringifyErrorLike } from '../../utils/misc';
@@ -74,7 +73,6 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
   const [timeRange] = useTimeRange();
   const { rightColumnWidth } = useWorkbenchContext();
   const [viewStack, setViewStack] = useState<DrawerView[]>([{ type: 'instance-details' }]);
-  const [silenceFormDraft, setSilenceFormDraft] = useState<SilenceFormFields | undefined>();
   const closeSilenceTimerRef = useRef<number | undefined>(undefined);
   const [isClosingSilenceDrawer, setIsClosingSilenceDrawer] = useState(false);
 
@@ -129,7 +127,6 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       closeSilenceTimerRef.current = undefined;
     }
     setIsClosingSilenceDrawer(false);
-    setSilenceFormDraft(undefined);
     setViewStack([{ type: 'instance-details' }]);
     onClose();
   };
@@ -335,8 +332,11 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
             <InstanceDetailsDrawerTitle
               {...sharedTitleProps}
               rule={rule.grafana_alert}
-              titleText={t('alerting.triage.instance-details-drawer.silence-title', 'Silence')}
+              titleText={t('alerting.triage.instance-details-drawer.silence-title-with-name', 'Silence {{name}}', {
+                name: rule.grafana_alert.title,
+              })}
               hideActions
+              showAlertState={false}
               titleSection={
                 <Button
                   variant="secondary"
@@ -351,16 +351,10 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
               }
             />
           }
-          onClose={animateCloseSilenceDrawer}
+          onClose={handleDrawerClose}
           width={drawerWidth}
         >
-          <InstanceSilenceForm
-            ruleUid={ruleUID}
-            instanceLabels={instanceLabels}
-            onClose={animateCloseSilenceDrawer}
-            formValues={silenceFormDraft}
-            onFormValuesChange={setSilenceFormDraft}
-          />
+          <InstanceSilenceForm ruleUid={ruleUID} instanceLabels={instanceLabels} onClose={animateCloseSilenceDrawer} />
         </Drawer>
       </>
     );

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { orderBy } from 'lodash';
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2, type Labels } from '@grafana/data';
@@ -36,6 +36,7 @@ import { useWorkbenchContext } from '../WorkbenchContext';
 
 import { DrawerTimeRangeInfoBanner } from './DrawerTimeRangeInfoBanner';
 import { InstanceDetailsDrawerTitle } from './InstanceDetailsDrawerTitle';
+import { InstanceSilenceForm } from './InstanceSilenceForm';
 import { InstanceStateInfoBanner } from './InstanceStateInfoBanner';
 import { InstanceTimelineSection } from './InstanceTimelineSection';
 import { QueryVisualization } from './QueryVisualization';
@@ -46,6 +47,7 @@ import { formatTimelineDate, noop } from './timelineUtils';
 
 const { useGetAlertRuleQuery } = alertRuleApi;
 const { useGetRuleHistoryQuery } = stateHistoryApi;
+const SILENCE_DRAWER_CLOSE_ANIMATION_MS = 180;
 
 function calculateDrawerWidth(rightColumnWidth: number): number {
   const calculatedWidth = rightColumnWidth + 32;
@@ -71,6 +73,8 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
   const [timeRange] = useTimeRange();
   const { rightColumnWidth } = useWorkbenchContext();
   const [viewStack, setViewStack] = useState<DrawerView[]>([{ type: 'instance-details' }]);
+  const closeSilenceTimerRef = useRef<number | undefined>(undefined);
+  const [isClosingSilenceDrawer, setIsClosingSilenceDrawer] = useState(false);
 
   const drawerWidth = calculateDrawerWidth(rightColumnWidth);
   const activeView = viewStack[viewStack.length - 1];
@@ -118,11 +122,24 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
   }, [rule, timeRange]);
 
   const handleDrawerClose = () => {
+    if (closeSilenceTimerRef.current !== undefined) {
+      window.clearTimeout(closeSilenceTimerRef.current);
+      closeSilenceTimerRef.current = undefined;
+    }
+    setIsClosingSilenceDrawer(false);
     setViewStack([{ type: 'instance-details' }]);
     onClose();
   };
 
-  const handleBack = () => {
+  useEffect(() => {
+    return () => {
+      if (closeSilenceTimerRef.current !== undefined) {
+        window.clearTimeout(closeSilenceTimerRef.current);
+      }
+    };
+  }, []);
+
+  const popTopView = () => {
     setViewStack((current) => {
       if (current.length <= 1) {
         return current;
@@ -131,52 +148,64 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     });
   };
 
-  const getDrawerTitle = () => {
-    if (activeView.type === 'instance-details') {
-      return (
-        <InstanceDetailsDrawerTitle
-          instanceLabels={instanceLabels}
-          commonLabels={commonLabels}
-          alertState={instanceState}
-          rule={rule?.grafana_alert}
-        />
-      );
+  const animateCloseSilenceDrawer = () => {
+    if (isClosingSilenceDrawer) {
+      return;
     }
 
-    if (activeView.type === 'contact-point-list') {
-      return t('alerting.triage.instance-details-drawer.contact-point-list-title', 'Contact point list');
+    const drawers = document.querySelectorAll('.main-view .rc-drawer');
+    const topDrawer = drawers.item(drawers.length - 1);
+    const wrapper = topDrawer?.querySelector('.rc-drawer-content-wrapper');
+
+    if (wrapper instanceof HTMLElement) {
+      wrapper.style.transition = `transform ${SILENCE_DRAWER_CLOSE_ANIMATION_MS}ms ease-in`;
+      wrapper.style.transform = 'translateX(100%)';
     }
 
-    if (activeView.type === 'notification-history-details') {
-      return t('alerting.triage.instance-details-drawer.notification-history-details-title', 'Notification details');
-    }
-
-    if (activeView.type === 'silence') {
-      return t('alerting.triage.instance-details-drawer.silence-title', 'Silence');
-    }
-
-    if (activeView.type === 'declare-incident') {
-      return t('alerting.triage.instance-details-drawer.declare-incident-title', 'Declare incident');
-    }
-
-    return t('alerting.triage.instance-details-drawer.declare-incident-title', 'Declare incident');
+    setIsClosingSilenceDrawer(true);
+    closeSilenceTimerRef.current = window.setTimeout(() => {
+      popTopView();
+      setIsClosingSilenceDrawer(false);
+      closeSilenceTimerRef.current = undefined;
+    }, SILENCE_DRAWER_CLOSE_ANIMATION_MS);
   };
 
-  const getDrawerBody = () => {
-    if (activeView.type !== 'instance-details') {
-      return (
-        <Alert
-          severity="info"
-          title={t('alerting.triage.instance-details-drawer.drilldown-coming-soon', 'Coming soon')}
-        >
-          {t(
-            'alerting.triage.instance-details-drawer.drilldown-coming-soon-description',
-            'This drawer drilldown step will be added in a follow-up change.'
-          )}
-        </Alert>
-      );
+  const handleBack = () => {
+    if (activeView.type === 'silence') {
+      animateCloseSilenceDrawer();
+      return;
     }
 
+    popTopView();
+  };
+
+  const handleOpenSilence = () => {
+    setViewStack((current) => [...current, { type: 'silence' }]);
+  };
+
+  const sharedTitleProps = {
+    instanceLabels,
+    commonLabels,
+    alertState: instanceState,
+    onOpenSilence: handleOpenSilence,
+  };
+
+  const getDrawerTitle = () => {
+    switch (activeView.type) {
+      case 'instance-details':
+        return <InstanceDetailsDrawerTitle {...sharedTitleProps} rule={rule?.grafana_alert} />;
+      case 'contact-point-list':
+        return t('alerting.triage.instance-details-drawer.contact-point-list-title', 'Contact point list');
+      case 'notification-history-details':
+        return t('alerting.triage.instance-details-drawer.notification-history-details-title', 'Notification details');
+      case 'silence':
+        return t('alerting.triage.instance-details-drawer.silence-title', 'Silence');
+      case 'declare-incident':
+        return t('alerting.triage.instance-details-drawer.declare-incident-title', 'Declare incident');
+    }
+  };
+
+  const getInstanceDetailsBody = () => {
     if (error) {
       return <ErrorContent error={error} />;
     }
@@ -250,6 +279,28 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     );
   };
 
+  const getDrawerBody = () => {
+    switch (activeView.type) {
+      case 'instance-details':
+        return getInstanceDetailsBody();
+      case 'silence':
+        // Silence is rendered as a second overlaid drawer.
+        return getInstanceDetailsBody();
+      default:
+        return (
+          <Alert
+            severity="info"
+            title={t('alerting.triage.instance-details-drawer.drilldown-coming-soon', 'Coming soon')}
+          >
+            {t(
+              'alerting.triage.instance-details-drawer.drilldown-coming-soon-description',
+              'This drawer drilldown step will be added in a follow-up change.'
+            )}
+          </Alert>
+        );
+    }
+  };
+
   if (error) {
     return (
       <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
@@ -263,6 +314,46 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
         {getDrawerBody()}
       </Drawer>
+    );
+  }
+
+  if (activeView.type === 'silence' || isClosingSilenceDrawer) {
+    return (
+      <>
+        <Drawer
+          title={<InstanceDetailsDrawerTitle {...sharedTitleProps} rule={rule.grafana_alert} />}
+          onClose={handleDrawerClose}
+          width={drawerWidth}
+        >
+          {getInstanceDetailsBody()}
+        </Drawer>
+        <Drawer
+          title={
+            <InstanceDetailsDrawerTitle
+              {...sharedTitleProps}
+              rule={rule.grafana_alert}
+              titleText={t('alerting.triage.instance-details-drawer.silence-title', 'Silence')}
+              hideActions
+              titleSection={
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  fill="text"
+                  icon="arrow-left"
+                  onClick={handleBack}
+                  aria-label={t('alerting.triage.instance-details-drawer.back', 'Back')}
+                >
+                  {t('alerting.triage.instance-details-drawer.back', 'Back')}
+                </Button>
+              }
+            />
+          }
+          onClose={animateCloseSilenceDrawer}
+          width={drawerWidth}
+        >
+          <InstanceSilenceForm ruleUid={ruleUID} instanceLabels={instanceLabels} onClose={animateCloseSilenceDrawer} />
+        </Drawer>
+      </>
     );
   }
 

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -28,6 +28,7 @@ import { getThresholdsForQueries } from '../../components/rule-editor/util';
 import { EventState } from '../../components/rules/central-state-history/EventListSceneObject';
 import { type LogRecord, historyDataFrameToLogRecords } from '../../components/rules/state-history/common';
 import { isAlertQueryOfAlertData } from '../../rule-editor/formProcessing';
+import { type SilenceFormFields } from '../../types/silence-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { labelsToMatchersParam } from '../../utils/matchers';
 import { stringifyErrorLike } from '../../utils/misc';
@@ -73,6 +74,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
   const [timeRange] = useTimeRange();
   const { rightColumnWidth } = useWorkbenchContext();
   const [viewStack, setViewStack] = useState<DrawerView[]>([{ type: 'instance-details' }]);
+  const [silenceFormDraft, setSilenceFormDraft] = useState<SilenceFormFields | undefined>();
   const closeSilenceTimerRef = useRef<number | undefined>(undefined);
   const [isClosingSilenceDrawer, setIsClosingSilenceDrawer] = useState(false);
 
@@ -127,6 +129,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       closeSilenceTimerRef.current = undefined;
     }
     setIsClosingSilenceDrawer(false);
+    setSilenceFormDraft(undefined);
     setViewStack([{ type: 'instance-details' }]);
     onClose();
   };
@@ -351,7 +354,13 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
           onClose={animateCloseSilenceDrawer}
           width={drawerWidth}
         >
-          <InstanceSilenceForm ruleUid={ruleUID} instanceLabels={instanceLabels} onClose={animateCloseSilenceDrawer} />
+          <InstanceSilenceForm
+            ruleUid={ruleUID}
+            instanceLabels={instanceLabels}
+            onClose={animateCloseSilenceDrawer}
+            formValues={silenceFormDraft}
+            onFormValuesChange={setSilenceFormDraft}
+          />
         </Drawer>
       </>
     );

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { orderBy } from 'lodash';
-import { Fragment, useMemo } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2, type Labels } from '@grafana/data';
@@ -10,6 +10,7 @@ import { TimeRangePicker, useTimeRange } from '@grafana/scenes-react';
 import {
   Alert,
   Box,
+  Button,
   Drawer,
   Icon,
   LoadingBar,
@@ -58,12 +59,22 @@ interface InstanceDetailsDrawerProps {
   onClose: () => void;
 }
 
+type DrawerView =
+  | { type: 'instance-details' }
+  | { type: 'contact-point-list'; receiverName: string }
+  | { type: 'notification-history-details'; notificationUuid: string; timestampMs?: number }
+  | { type: 'silence' }
+  | { type: 'declare-incident' };
+
 export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, onClose }: InstanceDetailsDrawerProps) {
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
   const [timeRange] = useTimeRange();
   const { rightColumnWidth } = useWorkbenchContext();
+  const [viewStack, setViewStack] = useState<DrawerView[]>([{ type: 'instance-details' }]);
 
   const drawerWidth = calculateDrawerWidth(rightColumnWidth);
+  const activeView = viewStack[viewStack.length - 1];
+  const canGoBack = viewStack.length > 1;
 
   const { data: rule, isLoading: loading, error } = useGetAlertRuleQuery({ uid: ruleUID });
 
@@ -106,55 +117,75 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     return isDrawerRangeShorterThanQuery(rule.grafana_alert, timeRange);
   }, [rule, timeRange]);
 
-  if (error) {
-    return (
-      <Drawer
-        title={
-          <InstanceDetailsDrawerTitle
-            instanceLabels={instanceLabels}
-            commonLabels={commonLabels}
-            alertState={instanceState}
-          />
-        }
-        onClose={onClose}
-        width={drawerWidth}
-      >
-        <ErrorContent error={error} />
-      </Drawer>
-    );
-  }
+  const handleDrawerClose = () => {
+    setViewStack([{ type: 'instance-details' }]);
+    onClose();
+  };
 
-  if (loading || !rule) {
-    return (
-      <Drawer
-        title={
-          <InstanceDetailsDrawerTitle
-            instanceLabels={instanceLabels}
-            commonLabels={commonLabels}
-            alertState={instanceState}
-          />
-        }
-        onClose={onClose}
-        width={drawerWidth}
-      >
-        <LoadingPlaceholder text={t('alerting.common.loading', 'Loading...')} />
-      </Drawer>
-    );
-  }
+  const handleBack = () => {
+    setViewStack((current) => {
+      if (current.length <= 1) {
+        return current;
+      }
+      return current.slice(0, -1);
+    });
+  };
 
-  return (
-    <Drawer
-      title={
+  const getDrawerTitle = () => {
+    if (activeView.type === 'instance-details') {
+      return (
         <InstanceDetailsDrawerTitle
           instanceLabels={instanceLabels}
           commonLabels={commonLabels}
           alertState={instanceState}
-          rule={rule.grafana_alert}
+          rule={rule?.grafana_alert}
         />
-      }
-      onClose={onClose}
-      width={drawerWidth}
-    >
+      );
+    }
+
+    if (activeView.type === 'contact-point-list') {
+      return t('alerting.triage.instance-details-drawer.contact-point-list-title', 'Contact point list');
+    }
+
+    if (activeView.type === 'notification-history-details') {
+      return t('alerting.triage.instance-details-drawer.notification-history-details-title', 'Notification details');
+    }
+
+    if (activeView.type === 'silence') {
+      return t('alerting.triage.instance-details-drawer.silence-title', 'Silence');
+    }
+
+    if (activeView.type === 'declare-incident') {
+      return t('alerting.triage.instance-details-drawer.declare-incident-title', 'Declare incident');
+    }
+
+    return t('alerting.triage.instance-details-drawer.declare-incident-title', 'Declare incident');
+  };
+
+  const getDrawerBody = () => {
+    if (activeView.type !== 'instance-details') {
+      return (
+        <Alert
+          severity="info"
+          title={t('alerting.triage.instance-details-drawer.drilldown-coming-soon', 'Coming soon')}
+        >
+          {t(
+            'alerting.triage.instance-details-drawer.drilldown-coming-soon-description',
+            'This drawer drilldown step will be added in a follow-up change.'
+          )}
+        </Alert>
+      );
+    }
+
+    if (error) {
+      return <ErrorContent error={error} />;
+    }
+
+    if (loading || !rule) {
+      return <LoadingPlaceholder text={t('alerting.common.loading', 'Loading...')} />;
+    }
+
+    return (
       <Stack direction="column" gap={3}>
         <Stack justifyContent="flex-end">
           <TimeRangePicker />
@@ -216,6 +247,50 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
           </Box>
         )}
       </Stack>
+    );
+  };
+
+  if (error) {
+    return (
+      <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
+        {getDrawerBody()}
+      </Drawer>
+    );
+  }
+
+  if (loading || !rule) {
+    return (
+      <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
+        {getDrawerBody()}
+      </Drawer>
+    );
+  }
+
+  return (
+    <Drawer
+      title={
+        <Stack direction="column" gap={1}>
+          {canGoBack && (
+            <Stack direction="row" alignItems="center">
+              <Button
+                variant="secondary"
+                size="sm"
+                fill="text"
+                icon="arrow-left"
+                onClick={handleBack}
+                aria-label={t('alerting.triage.instance-details-drawer.back', 'Back')}
+              >
+                {t('alerting.triage.instance-details-drawer.back', 'Back')}
+              </Button>
+            </Stack>
+          )}
+          {getDrawerTitle()}
+        </Stack>
+      }
+      onClose={handleDrawerClose}
+      width={drawerWidth}
+    >
+      {getDrawerBody()}
     </Drawer>
   );
 }

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -224,20 +224,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     [instanceLabels, commonLabels, instanceState, handleOpenSilence]
   );
 
-  const getDrawerTitle = () => {
-    switch (activeView.type) {
-      case 'instance-details':
-        return <InstanceDetailsDrawerTitle {...sharedTitleProps} rule={rule?.grafana_alert} />;
-      case 'contact-point-list':
-        return t('alerting.triage.instance-details-drawer.contact-point-list-title', 'Contact point list');
-      case 'notification-history-details':
-        return t('alerting.triage.instance-details-drawer.notification-history-details-title', 'Notification details');
-      case 'silence':
-        return t('alerting.triage.instance-details-drawer.silence-title', 'Silence');
-      case 'declare-incident':
-        return t('alerting.triage.instance-details-drawer.declare-incident-title', 'Declare incident');
-    }
-  };
+  const getDrawerTitle = () => <InstanceDetailsDrawerTitle {...sharedTitleProps} rule={rule?.grafana_alert} />;
 
   const getInstanceDetailsBody = () => {
     if (error) {
@@ -313,16 +300,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     );
   };
 
-  const getDrawerBody = () => {
-    switch (activeView.type) {
-      case 'instance-details':
-      case 'silence':
-        // Silence step uses a second overlaid drawer for the form; body stays the instance details underneath.
-        return getInstanceDetailsBody();
-      default:
-        return getInstanceDetailsBody();
-    }
-  };
+  const getDrawerBody = () => getInstanceDetailsBody();
 
   if (error || loading || !rule) {
     return (

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -320,17 +320,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
         // Silence step uses a second overlaid drawer for the form; body stays the instance details underneath.
         return getInstanceDetailsBody();
       default:
-        return (
-          <Alert
-            severity="info"
-            title={t('alerting.triage.instance-details-drawer.drilldown-coming-soon', 'Coming soon')}
-          >
-            {t(
-              'alerting.triage.instance-details-drawer.drilldown-coming-soon-description',
-              'This drawer drilldown step will be added in a follow-up change.'
-            )}
-          </Alert>
-        );
+        return getInstanceDetailsBody();
     }
   };
 

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { orderBy } from 'lodash';
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2, type Labels } from '@grafana/data';
@@ -49,6 +49,17 @@ const { useGetAlertRuleQuery } = alertRuleApi;
 const { useGetRuleHistoryQuery } = stateHistoryApi;
 const SILENCE_DRAWER_CLOSE_ANIMATION_MS = 180;
 
+function DrawerBackButton({ onClick }: { onClick: () => void }) {
+  const backLabel = t('alerting.triage.instance-details-drawer.back', 'Back');
+  return (
+    <Stack direction="row" alignItems="center">
+      <Button variant="secondary" size="sm" fill="text" icon="arrow-left" onClick={onClick} aria-label={backLabel}>
+        {backLabel}
+      </Button>
+    </Stack>
+  );
+}
+
 function calculateDrawerWidth(rightColumnWidth: number): number {
   const calculatedWidth = rightColumnWidth + 32;
   return Math.max(700, Math.min(calculatedWidth, 1400));
@@ -61,6 +72,7 @@ interface InstanceDetailsDrawerProps {
   onClose: () => void;
 }
 
+/** Stacked drilldown views inside the instance drawer. Only `instance-details` and `silence` are wired today; to do: contact point list, notification details, declare incident. */
 type DrawerView =
   | { type: 'instance-details' }
   | { type: 'contact-point-list'; receiverName: string }
@@ -74,6 +86,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
   const { rightColumnWidth } = useWorkbenchContext();
   const [viewStack, setViewStack] = useState<DrawerView[]>([{ type: 'instance-details' }]);
   const closeSilenceTimerRef = useRef<number | undefined>(undefined);
+  const silencePanelContentRef = useRef<HTMLDivElement>(null);
   const [isClosingSilenceDrawer, setIsClosingSilenceDrawer] = useState(false);
 
   const drawerWidth = calculateDrawerWidth(rightColumnWidth);
@@ -121,11 +134,20 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     return isDrawerRangeShorterThanQuery(rule.grafana_alert, timeRange);
   }, [rule, timeRange]);
 
+  const resetSilencePanelStyles = useCallback(() => {
+    const el = silencePanelContentRef.current;
+    if (el) {
+      el.style.removeProperty('transition');
+      el.style.removeProperty('transform');
+    }
+  }, []);
+
   const handleDrawerClose = () => {
     if (closeSilenceTimerRef.current !== undefined) {
       window.clearTimeout(closeSilenceTimerRef.current);
       closeSilenceTimerRef.current = undefined;
     }
+    resetSilencePanelStyles();
     setIsClosingSilenceDrawer(false);
     setViewStack([{ type: 'instance-details' }]);
     onClose();
@@ -136,8 +158,9 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       if (closeSilenceTimerRef.current !== undefined) {
         window.clearTimeout(closeSilenceTimerRef.current);
       }
+      resetSilencePanelStyles();
     };
-  }, []);
+  }, [resetSilencePanelStyles]);
 
   const popTopView = () => {
     setViewStack((current) => {
@@ -153,17 +176,19 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       return;
     }
 
-    const drawers = document.querySelectorAll('.main-view .rc-drawer');
-    const topDrawer = drawers.item(drawers.length - 1);
-    const wrapper = topDrawer?.querySelector('.rc-drawer-content-wrapper');
-
-    if (wrapper instanceof HTMLElement) {
-      wrapper.style.transition = `transform ${SILENCE_DRAWER_CLOSE_ANIMATION_MS}ms ease-in`;
-      wrapper.style.transform = 'translateX(100%)';
+    const el = silencePanelContentRef.current;
+    if (el) {
+      el.style.transition = `transform ${SILENCE_DRAWER_CLOSE_ANIMATION_MS}ms ease-in`;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          el.style.transform = 'translateX(100%)';
+        });
+      });
     }
 
     setIsClosingSilenceDrawer(true);
     closeSilenceTimerRef.current = window.setTimeout(() => {
+      resetSilencePanelStyles();
       popTopView();
       setIsClosingSilenceDrawer(false);
       closeSilenceTimerRef.current = undefined;
@@ -179,16 +204,19 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     popTopView();
   };
 
-  const handleOpenSilence = () => {
+  const handleOpenSilence = useCallback(() => {
     setViewStack((current) => [...current, { type: 'silence' }]);
-  };
+  }, []);
 
-  const sharedTitleProps = {
-    instanceLabels,
-    commonLabels,
-    alertState: instanceState,
-    onOpenSilence: handleOpenSilence,
-  };
+  const sharedTitleProps = useMemo(
+    () => ({
+      instanceLabels,
+      commonLabels,
+      alertState: instanceState,
+      onOpenSilence: handleOpenSilence,
+    }),
+    [instanceLabels, commonLabels, instanceState, handleOpenSilence]
+  );
 
   const getDrawerTitle = () => {
     switch (activeView.type) {
@@ -282,9 +310,8 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
   const getDrawerBody = () => {
     switch (activeView.type) {
       case 'instance-details':
-        return getInstanceDetailsBody();
       case 'silence':
-        // Silence is rendered as a second overlaid drawer.
+        // Silence step uses a second overlaid drawer for the form; body stays the instance details underneath.
         return getInstanceDetailsBody();
       default:
         return (
@@ -301,15 +328,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     }
   };
 
-  if (error) {
-    return (
-      <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
-        {getDrawerBody()}
-      </Drawer>
-    );
-  }
-
-  if (loading || !rule) {
+  if (error || loading || !rule) {
     return (
       <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
         {getDrawerBody()}
@@ -337,24 +356,19 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
               })}
               hideActions
               showAlertState={false}
-              titleSection={
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  fill="text"
-                  icon="arrow-left"
-                  onClick={handleBack}
-                  aria-label={t('alerting.triage.instance-details-drawer.back', 'Back')}
-                >
-                  {t('alerting.triage.instance-details-drawer.back', 'Back')}
-                </Button>
-              }
+              titleSection={<DrawerBackButton onClick={handleBack} />}
             />
           }
           onClose={handleDrawerClose}
           width={drawerWidth}
         >
-          <InstanceSilenceForm ruleUid={ruleUID} instanceLabels={instanceLabels} onClose={animateCloseSilenceDrawer} />
+          <Box ref={silencePanelContentRef}>
+            <InstanceSilenceForm
+              ruleUid={ruleUID}
+              instanceLabels={instanceLabels}
+              onClose={animateCloseSilenceDrawer}
+            />
+          </Box>
         </Drawer>
       </>
     );
@@ -364,20 +378,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     <Drawer
       title={
         <Stack direction="column" gap={1}>
-          {canGoBack && (
-            <Stack direction="row" alignItems="center">
-              <Button
-                variant="secondary"
-                size="sm"
-                fill="text"
-                icon="arrow-left"
-                onClick={handleBack}
-                aria-label={t('alerting.triage.instance-details-drawer.back', 'Back')}
-              >
-                {t('alerting.triage.instance-details-drawer.back', 'Back')}
-              </Button>
-            </Stack>
-          )}
+          {canGoBack && <DrawerBackButton onClick={handleBack} />}
           {getDrawerTitle()}
         </Stack>
       }

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -19,6 +19,7 @@ import {
   Text,
   TextLink,
   useStyles2,
+  useTheme2,
 } from '@grafana/ui';
 import { type AlertQuery, GrafanaAlertState, type GrafanaRuleDefinition } from 'app/types/unified-alerting-dto';
 
@@ -47,7 +48,6 @@ import { formatTimelineDate, noop } from './timelineUtils';
 
 const { useGetAlertRuleQuery } = alertRuleApi;
 const { useGetRuleHistoryQuery } = stateHistoryApi;
-const SILENCE_DRAWER_CLOSE_ANIMATION_MS = 180;
 
 function DrawerBackButton({ onClick }: { onClick: () => void }) {
   const backLabel = t('alerting.triage.instance-details-drawer.back', 'Back');
@@ -83,13 +83,14 @@ type DrawerView =
 export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, onClose }: InstanceDetailsDrawerProps) {
   const [ref, { width: loadingBarWidth }] = useMeasure<HTMLDivElement>();
   const [timeRange] = useTimeRange();
+  const theme = useTheme2();
   const { rightColumnWidth } = useWorkbenchContext();
   const [viewStack, setViewStack] = useState<DrawerView[]>([{ type: 'instance-details' }]);
   const closeSilenceTimerRef = useRef<number | undefined>(undefined);
-  const silencePanelContentRef = useRef<HTMLDivElement>(null);
   const [isClosingSilenceDrawer, setIsClosingSilenceDrawer] = useState(false);
 
   const drawerWidth = calculateDrawerWidth(rightColumnWidth);
+  const silenceDrawerCloseAnimationMs = Number(theme.transitions.duration.standard ?? 180);
   const activeView = viewStack[viewStack.length - 1];
   const canGoBack = viewStack.length > 1;
 
@@ -134,13 +135,18 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     return isDrawerRangeShorterThanQuery(rule.grafana_alert, timeRange);
   }, [rule, timeRange]);
 
+  const getTopDrawerContentWrapper = useCallback(() => {
+    const wrappers = document.querySelectorAll<HTMLElement>('.main-view .rc-drawer-content-wrapper');
+    return wrappers.item(wrappers.length - 1) ?? null;
+  }, []);
+
   const resetSilencePanelStyles = useCallback(() => {
-    const el = silencePanelContentRef.current;
+    const el = getTopDrawerContentWrapper();
     if (el) {
       el.style.removeProperty('transition');
       el.style.removeProperty('transform');
     }
-  }, []);
+  }, [getTopDrawerContentWrapper]);
 
   const handleDrawerClose = () => {
     if (closeSilenceTimerRef.current !== undefined) {
@@ -171,14 +177,14 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     });
   };
 
-  const animateCloseSilenceDrawer = () => {
+  const animateCloseSilenceDrawer = useCallback(() => {
     if (isClosingSilenceDrawer) {
       return;
     }
 
-    const el = silencePanelContentRef.current;
+    const el = getTopDrawerContentWrapper();
     if (el) {
-      el.style.transition = `transform ${SILENCE_DRAWER_CLOSE_ANIMATION_MS}ms ease-in`;
+      el.style.transition = `transform ${silenceDrawerCloseAnimationMs}ms ease-in`;
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           el.style.transform = 'translateX(100%)';
@@ -192,8 +198,8 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       popTopView();
       setIsClosingSilenceDrawer(false);
       closeSilenceTimerRef.current = undefined;
-    }, SILENCE_DRAWER_CLOSE_ANIMATION_MS);
-  };
+    }, silenceDrawerCloseAnimationMs);
+  }, [getTopDrawerContentWrapper, isClosingSilenceDrawer, silenceDrawerCloseAnimationMs, resetSilencePanelStyles]);
 
   const handleBack = () => {
     if (activeView.type === 'silence') {
@@ -362,13 +368,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
           onClose={handleDrawerClose}
           width={drawerWidth}
         >
-          <Box ref={silencePanelContentRef}>
-            <InstanceSilenceForm
-              ruleUid={ruleUID}
-              instanceLabels={instanceLabels}
-              onClose={animateCloseSilenceDrawer}
-            />
-          </Box>
+          <InstanceSilenceForm ruleUid={ruleUID} instanceLabels={instanceLabels} onClose={animateCloseSilenceDrawer} />
         </Drawer>
       </>
     );

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -300,12 +300,10 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
     );
   };
 
-  const getDrawerBody = () => getInstanceDetailsBody();
-
   if (error || loading || !rule) {
     return (
       <Drawer title={getDrawerTitle()} onClose={handleDrawerClose} width={drawerWidth}>
-        {getDrawerBody()}
+        {getInstanceDetailsBody()}
       </Drawer>
     );
   }
@@ -353,7 +351,7 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
       onClose={handleDrawerClose}
       width={drawerWidth}
     >
-      {getDrawerBody()}
+      {getInstanceDetailsBody()}
     </Drawer>
   );
 }

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -51,6 +51,7 @@ interface InstanceDetailsDrawerTitleProps {
   titleText?: string;
   hideActions?: boolean;
   titleSection?: ReactNode;
+  showAlertState?: boolean;
 }
 
 export function InstanceDetailsDrawerTitle({
@@ -62,6 +63,7 @@ export function InstanceDetailsDrawerTitle({
   titleText,
   hideActions = false,
   titleSection,
+  showAlertState = true,
 }: InstanceDetailsDrawerTitleProps) {
   const { folder } = useFolder(rule?.namespace_uid);
   const { pluginId, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
@@ -107,7 +109,9 @@ export function InstanceDetailsDrawerTitle({
                 <Trans i18nKey="alerting.triage.instance-details-drawer.instance-details">Instance details</Trans>
               )}
             </Text>
-            {alertState && <StateText type="alerting" {...grafanaAlertStateToStateTextProps(alertState)} />}
+            {showAlertState && alertState && (
+              <StateText type="alerting" {...grafanaAlertStateToStateTextProps(alertState)} />
+            )}
           </Stack>
           {!hideActions && (
             <Stack direction="row" gap={1} alignItems="center">

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 import { AlertLabels, StateText } from '@grafana/alerting/unstable';
 import { type Labels } from '@grafana/data';
@@ -47,6 +47,10 @@ interface InstanceDetailsDrawerTitleProps {
   commonLabels?: Labels;
   alertState?: GrafanaAlertState | null;
   rule?: GrafanaRuleDefinition;
+  onOpenSilence?: () => void;
+  titleText?: string;
+  hideActions?: boolean;
+  titleSection?: ReactNode;
 }
 
 export function InstanceDetailsDrawerTitle({
@@ -54,6 +58,10 @@ export function InstanceDetailsDrawerTitle({
   commonLabels,
   alertState,
   rule,
+  onOpenSilence,
+  titleText,
+  hideActions = false,
+  titleSection,
 }: InstanceDetailsDrawerTitleProps) {
   const { folder } = useFolder(rule?.namespace_uid);
   const { pluginId, installed, settings } = useIrmPlugin(SupportedPlugin.Incident);
@@ -75,9 +83,11 @@ export function InstanceDetailsDrawerTitle({
     : false;
   const hasFolderSilencePermission = folder?.accessControl?.[AccessControlAction.AlertingSilenceCreate] ?? false;
   const canSilence = canCreateSilence || hasFolderSilencePermission;
+
   return (
     <Stack direction="column" gap={2}>
-      {folder && rule && (
+      {titleSection && <Stack direction="row">{titleSection}</Stack>}
+      {!titleSection && folder && rule && (
         <InstanceLocation
           folderTitle={stringifyFolder(folder)}
           groupName={rule.rule_group}
@@ -93,68 +103,78 @@ export function InstanceDetailsDrawerTitle({
         <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
           <Stack direction="row" alignItems="center" gap={1} minWidth={0}>
             <Text variant="h3" element="h3" truncate>
-              {rule?.title ?? (
+              {titleText ?? rule?.title ?? (
                 <Trans i18nKey="alerting.triage.instance-details-drawer.instance-details">Instance details</Trans>
               )}
             </Text>
             {alertState && <StateText type="alerting" {...grafanaAlertStateToStateTextProps(alertState)} />}
           </Stack>
-          <Stack direction="row" gap={1} alignItems="center">
-            {silenceLink && (
-              <>
-                {canSilence ? (
-                  <LinkButton
-                    href={silenceLink}
-                    icon="bell-slash"
-                    variant="secondary"
-                    size="sm"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
-                  </LinkButton>
-                ) : (
-                  <Tooltip
-                    content={t(
-                      'alerting.triage.instance-details-drawer.silence-no-permission',
-                      'You do not have permission to create silences'
-                    )}
-                  >
-                    <Button icon="bell-slash" variant="secondary" size="sm" disabled>
+          {!hideActions && (
+            <Stack direction="row" gap={1} alignItems="center">
+              {silenceLink && (
+                <>
+                  {canSilence && onOpenSilence && (
+                    <Button icon="bell-slash" variant="secondary" size="sm" onClick={onOpenSilence}>
                       <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
                     </Button>
-                  </Tooltip>
-                )}
-              </>
-            )}
-            {shouldShowDeclareIncident && (
-              <>
-                {canAccessIncident ? (
-                  <LinkButton
-                    href={incidentURL}
-                    icon="fire"
-                    variant="secondary"
-                    size="sm"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>
-                  </LinkButton>
-                ) : (
-                  <Tooltip
-                    content={t(
-                      'alerting.triage.instance-details-drawer.declare-incident-no-permission',
-                      'You do not have permission to access Incident'
-                    )}
-                  >
-                    <Button icon="fire" variant="secondary" size="sm" disabled>
+                  )}
+                  {canSilence && !onOpenSilence && (
+                    <LinkButton
+                      href={silenceLink}
+                      icon="bell-slash"
+                      variant="secondary"
+                      size="sm"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
+                    </LinkButton>
+                  )}
+                  {!canSilence && (
+                    <Tooltip
+                      content={t(
+                        'alerting.triage.instance-details-drawer.silence-no-permission',
+                        'You do not have permission to create silences'
+                      )}
+                    >
+                      <Button icon="bell-slash" variant="secondary" size="sm" disabled>
+                        <Trans i18nKey="alerting.triage.instance-details-drawer.silence-button">Silence</Trans>
+                      </Button>
+                    </Tooltip>
+                  )}
+                </>
+              )}
+              {shouldShowDeclareIncident && (
+                <>
+                  {canAccessIncident ? (
+                    <LinkButton
+                      href={incidentURL}
+                      icon="fire"
+                      variant="secondary"
+                      size="sm"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">Declare incident</Trans>
-                    </Button>
-                  </Tooltip>
-                )}
-              </>
-            )}
-          </Stack>
+                    </LinkButton>
+                  ) : (
+                    <Tooltip
+                      content={t(
+                        'alerting.triage.instance-details-drawer.declare-incident-no-permission',
+                        'You do not have permission to access Incident'
+                      )}
+                    >
+                      <Button icon="fire" variant="secondary" size="sm" disabled>
+                        <Trans i18nKey="alerting.triage.instance-details-drawer.declare-incident">
+                          Declare incident
+                        </Trans>
+                      </Button>
+                    </Tooltip>
+                  )}
+                </>
+              )}
+            </Stack>
+          )}
         </Stack>
       </Stack>
       <Box>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import { type Labels } from '@grafana/data';
+import { SilencesEditor } from 'app/features/alerting/unified/components/silences/SilencesEditor';
+import { getDefaultSilenceFormValues } from 'app/features/alerting/unified/components/silences/utils';
+import { AlertmanagerProvider } from 'app/features/alerting/unified/state/AlertmanagerContext';
+import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
+
+interface InstanceSilenceFormProps {
+  ruleUid: string;
+  instanceLabels: Labels;
+  onClose: () => void;
+}
+
+export function InstanceSilenceForm({ ruleUid, instanceLabels, onClose }: InstanceSilenceFormProps) {
+  const formValues = useMemo(
+    () =>
+      getDefaultSilenceFormValues({
+        matchers: Object.entries(instanceLabels).map(([name, value]) => ({
+          name,
+          value,
+          operator: MatcherOperator.equal,
+        })),
+      }),
+    [instanceLabels]
+  );
+
+  return (
+    <AlertmanagerProvider accessType="instance">
+      <SilencesEditor
+        ruleUid={ruleUid}
+        formValues={formValues}
+        alertManagerSourceName={GRAFANA_RULES_SOURCE_NAME}
+        onSilenceCreated={onClose}
+        onCancel={onClose}
+      />
+    </AlertmanagerProvider>
+  );
+}

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
@@ -4,6 +4,7 @@ import { type Labels } from '@grafana/data';
 import { SilencesEditor } from 'app/features/alerting/unified/components/silences/SilencesEditor';
 import { getDefaultSilenceFormValues } from 'app/features/alerting/unified/components/silences/utils';
 import { AlertmanagerProvider } from 'app/features/alerting/unified/state/AlertmanagerContext';
+import { type SilenceFormFields } from 'app/features/alerting/unified/types/silence-form';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
@@ -11,11 +12,20 @@ interface InstanceSilenceFormProps {
   ruleUid: string;
   instanceLabels: Labels;
   onClose: () => void;
+  formValues?: SilenceFormFields;
+  onFormValuesChange?: (values: SilenceFormFields) => void;
 }
 
-export function InstanceSilenceForm({ ruleUid, instanceLabels, onClose }: InstanceSilenceFormProps) {
-  const formValues = useMemo(
+export function InstanceSilenceForm({
+  ruleUid,
+  instanceLabels,
+  onClose,
+  formValues,
+  onFormValuesChange,
+}: InstanceSilenceFormProps) {
+  const initialFormValues = useMemo(
     () =>
+      formValues ??
       getDefaultSilenceFormValues({
         matchers: Object.entries(instanceLabels).map(([name, value]) => ({
           name,
@@ -23,17 +33,19 @@ export function InstanceSilenceForm({ ruleUid, instanceLabels, onClose }: Instan
           operator: MatcherOperator.equal,
         })),
       }),
-    [instanceLabels]
+    [formValues, instanceLabels]
   );
 
   return (
     <AlertmanagerProvider accessType="instance">
       <SilencesEditor
         ruleUid={ruleUid}
-        formValues={formValues}
+        formValues={initialFormValues}
         alertManagerSourceName={GRAFANA_RULES_SOURCE_NAME}
         onSilenceCreated={onClose}
         onCancel={onClose}
+        onFormValuesChange={onFormValuesChange}
+        showCancelButton={false}
       />
     </AlertmanagerProvider>
   );

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
@@ -4,7 +4,6 @@ import { type Labels } from '@grafana/data';
 import { SilencesEditor } from 'app/features/alerting/unified/components/silences/SilencesEditor';
 import { getDefaultSilenceFormValues } from 'app/features/alerting/unified/components/silences/utils';
 import { AlertmanagerProvider } from 'app/features/alerting/unified/state/AlertmanagerContext';
-import { type SilenceFormFields } from 'app/features/alerting/unified/types/silence-form';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
@@ -12,20 +11,11 @@ interface InstanceSilenceFormProps {
   ruleUid: string;
   instanceLabels: Labels;
   onClose: () => void;
-  formValues?: SilenceFormFields;
-  onFormValuesChange?: (values: SilenceFormFields) => void;
 }
 
-export function InstanceSilenceForm({
-  ruleUid,
-  instanceLabels,
-  onClose,
-  formValues,
-  onFormValuesChange,
-}: InstanceSilenceFormProps) {
-  const initialFormValues = useMemo(
+export function InstanceSilenceForm({ ruleUid, instanceLabels, onClose }: InstanceSilenceFormProps) {
+  const formValues = useMemo(
     () =>
-      formValues ??
       getDefaultSilenceFormValues({
         matchers: Object.entries(instanceLabels).map(([name, value]) => ({
           name,
@@ -33,18 +23,17 @@ export function InstanceSilenceForm({
           operator: MatcherOperator.equal,
         })),
       }),
-    [formValues, instanceLabels]
+    [instanceLabels]
   );
 
   return (
     <AlertmanagerProvider accessType="instance">
       <SilencesEditor
         ruleUid={ruleUid}
-        formValues={initialFormValues}
+        formValues={formValues}
         alertManagerSourceName={GRAFANA_RULES_SOURCE_NAME}
         onSilenceCreated={onClose}
         onCancel={onClose}
-        onFormValuesChange={onFormValuesChange}
         showCancelButton={false}
       />
     </AlertmanagerProvider>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3590,8 +3590,6 @@
         "declare-incident": "Declare incident",
         "declare-incident-no-permission": "You do not have permission to access Incident",
         "declare-incident-title": "Declare incident",
-        "drilldown-coming-soon": "Coming soon",
-        "drilldown-coming-soon-description": "This drawer drilldown step will be added in a follow-up change.",
         "instance-details": "Instance details",
         "notification-history-details-title": "Notification details",
         "silence-button": "Silence",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3585,11 +3585,19 @@
       },
       "instance-details-drawer": {
         "alert-instance-label": "Alert Instance",
+        "back": "Back",
+        "contact-point-list-title": "Contact point list",
         "declare-incident": "Declare incident",
         "declare-incident-no-permission": "You do not have permission to access Incident",
+        "declare-incident-title": "Declare incident",
+        "drilldown-coming-soon": "Coming soon",
+        "drilldown-coming-soon-description": "This drawer drilldown step will be added in a follow-up change.",
         "instance-details": "Instance details",
+        "notification-history-details-title": "Notification details",
         "silence-button": "Silence",
-        "silence-no-permission": "You do not have permission to create silences"
+        "silence-no-permission": "You do not have permission to create silences",
+        "silence-title": "Silence",
+        "silence-title-with-name": "Silence {{name}}"
       },
       "labels-column-title": "Labels",
       "no-firing-or-pending-instances": "You have no alert instances in a firing or pending state for the selected time range.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3586,15 +3586,11 @@
       "instance-details-drawer": {
         "alert-instance-label": "Alert Instance",
         "back": "Back",
-        "contact-point-list-title": "Contact point list",
         "declare-incident": "Declare incident",
         "declare-incident-no-permission": "You do not have permission to access Incident",
-        "declare-incident-title": "Declare incident",
         "instance-details": "Instance details",
-        "notification-history-details-title": "Notification details",
         "silence-button": "Silence",
         "silence-no-permission": "You do not have permission to create silences",
-        "silence-title": "Silence",
         "silence-title-with-name": "Silence {{name}}"
       },
       "labels-column-title": "Labels",


### PR DESCRIPTION
This PR:
- Adds drawer drilldown to the Instance drawer: introducing a stacked drawer flow for Silence instead of opening a new tab.
- Adds showCancelButton support in SilencesEditor and disabled Cancel for the triage silence drawer flow.
- Refactors InstanceDetailsDrawer / InstanceDetailsDrawerTitle to support reusable title sections, silence-specific title/state behavior, and cleaner view handling.

https://github.com/user-attachments/assets/da63c55e-d85b-46c7-824a-eefb3ccea076

