### PR TITLE
Users: Use SHA-256 for Gravatar email identifier

### DIFF
--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -45,7 +45,7 @@ type AvatarCacheServer struct {
 }
 
 var (
-	looksLikeMD5 = regexp.MustCompile("^[a-fA-F0-9]{32}$")
+	looksLikeGravatarHash = regexp.MustCompile("^(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{64})$")
 
 	// Parameters needed to fetch Gravatar with a retro fallback
 	gravatarFetchParams = url.Values{"d": {"retro"}, "size": {"200"}, "r": {"pg"}}.Encode()
@@ -57,7 +57,7 @@ var (
 func (a *AvatarCacheServer) Handler(ctx *contextmodel.ReqContext) {
 	hash := web.Params(ctx.Req)[":hash"]
 
-	if !looksLikeMD5.MatchString(hash) {
+	if !looksLikeGravatarHash.MatchString(hash) {
 		ctx.JsonApiErr(404, "Avatar not found", nil)
 		return
 	}

--- a/pkg/api/avatar/avatar_test.go
+++ b/pkg/api/avatar/avatar_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	defaultHash = "9e107d9d372bb6826bd81d3542a419d6"
-	customHash  = "d2a9116d4a63304733ca0f3471e57d16"
+	defaultHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	customHash  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 )
 
 var nonsenseBody = []byte("Bogus API response")

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -1,21 +1,19 @@
 package dtos
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 var regNonAlphaNumeric = regexp.MustCompile("[^a-zA-Z0-9]+")
-var mlog = log.New("models")
 
 type AnyId struct {
 	Id int64 `json:"id"`
@@ -124,15 +122,13 @@ func GetGravatarUrl(cfg *setting.Cfg, text string) string {
 }
 
 func GetGravatarHash(text string) ([]byte, bool) {
-	if text == "" {
+	s := strings.TrimSpace(text)
+	if s == "" {
 		return make([]byte, 0), false
 	}
 
-	hasher := md5.New()
-	if _, err := hasher.Write([]byte(strings.ToLower(text))); err != nil {
-		mlog.Warn("Failed to hash text", "err", err)
-	}
-	return hasher.Sum(nil), true
+	sum := sha256.Sum256([]byte(strings.ToLower(s)))
+	return sum[:], true
 }
 
 func GetGravatarUrlWithDefault(cfg *setting.Cfg, text string, defaultText string) string {

--- a/pkg/api/dtos/models_test.go
+++ b/pkg/api/dtos/models_test.go
@@ -1,6 +1,7 @@
 package dtos
 
 import (
+	"encoding/hex"
 	"sort"
 	"testing"
 
@@ -69,6 +70,21 @@ func TestGetUniqueDatasourceTypes(t *testing.T) {
 			assert.Equal(t, testcase.result, result)
 		})
 	}
+}
+
+func TestGetGravatarHash(t *testing.T) {
+	t.Run("trim lowercase SHA256", func(t *testing.T) {
+		hash, ok := GetGravatarHash("MyEmailAddress@example.com ")
+		assert.True(t, ok)
+		assert.Equal(t, "84059b07d4be67b806386c0aad8070a23f18836bbaae342275dc0a83414c32ee", hex.EncodeToString(hash))
+	})
+
+	t.Run("empty or whitespace", func(t *testing.T) {
+		_, ok := GetGravatarHash("")
+		assert.False(t, ok)
+		_, ok = GetGravatarHash("   \t")
+		assert.False(t, ok)
+	})
 }
 
 func TestIsHiddenUser(t *testing.T) {

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -53,12 +53,12 @@ func TestIntegration_CreateLibraryElement(t *testing.T) {
 						CreatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 						UpdatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 					},
 				},
@@ -104,12 +104,12 @@ func TestIntegration_CreateLibraryElement(t *testing.T) {
 						CreatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 						UpdatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 					},
 				},
@@ -183,12 +183,12 @@ func TestIntegration_CreateLibraryElement(t *testing.T) {
 						CreatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 						UpdatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 					},
 				},

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -89,7 +89,7 @@ func TestIntegration_PatchLibraryElement(t *testing.T) {
 						UpdatedBy: model.LibraryElementDTOMetaUser{
 							Id:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/00c249f3bdb8ead55b7b551e293907924d644158062bddc4e29a578ec3f89018",
 						},
 					},
 				},

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 const userInDbName = "user_in_db"
-const userInDbAvatar = "/avatar/402d08de060496d6b6874495fe20f5ad"
+const userInDbAvatar = "/avatar/949f63d8d8631e6a689c580bc977d933a0c2d6bec94eef583b09d1da3bd1bbc4"
 
 func TestMain(m *testing.M) {
 	testsuite.Run(m)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const userInDbName = "user_in_db"
-const userInDbAvatar = "/avatar/402d08de060496d6b6874495fe20f5ad"
+const userInDbAvatar = "/avatar/949f63d8d8631e6a689c580bc977d933a0c2d6bec94eef583b09d1da3bd1bbc4"
 
 // run tests with cleanup
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Why

Gravatar’s current developer documentation specifies **trim → lowercase → SHA-256** for the email identifier and deprecates MD5 ([Getting started](https://docs.gravatar.com/guides/getting-started/)). Aligning Grafana avoids generating legacy hashes and matches what Gravatar documents for avatar URLs.

Default avatars will change but personalized ones will remain

## What

- **`GetGravatarHash` / `GetGravatarUrl`**: hash the normalized email (trim whitespace, lowercase) with **SHA-256** instead of MD5. Avatar paths remain `/avatar/<hex>` but are now **64** hex characters.
- **`/avatar/:hash` handler**: accept **32-hex (legacy MD5) or 64-hex (SHA-256)** so old bookmarked URLs and existing mocks that still use MD5-length IDs are not rejected with 404.
- **Tests**: Gravatar doc example vector; library element/panel expectations updated for SHA-256 of the fixture emails.

## How to test

```bash
make run
```
