### PR TITLE
fix: bugs in stars migration while count validation

### DIFF
--- a/pkg/storage/unified/migrations/validator.go
+++ b/pkg/storage/unified/migrations/validator.go
@@ -119,7 +119,7 @@ func (v *CountValidator) Validate(ctx context.Context, sess *xorm.Session, respo
 
 	counter := sess.Table(v.opts.Table).Where(v.opts.Where, orgID)
 	if v.opts.Distinct != "" {
-		counter = sess.Distinct(v.opts.Distinct)
+		counter = counter.Distinct(v.opts.Distinct)
 	}
 	legacyCount, err := counter.Count()
 	if err != nil {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1936,12 +1936,14 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			}
 		}
 
-		summaries[NSGR(key)] = &resourcepb.BulkResponse_Summary{
+		summary := &resourcepb.BulkResponse_Summary{
 			Namespace:     key.Namespace,
 			Group:         key.Group,
 			Resource:      key.Resource,
 			PreviousCount: previousCount,
 		}
+		summaries[NSGR(key)] = summary
+		rsp.Summary = append(rsp.Summary, summary)
 	}
 
 	saved := make([]DataKey, 0)
@@ -1963,6 +1965,14 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 			Group:     item.dataKey.Group,
 			Resource:  item.dataKey.Resource,
 		}] = true
+		nsgr := NSGR(&resourcepb.ResourceKey{
+			Namespace: item.dataKey.Namespace,
+			Group:     item.dataKey.Group,
+			Resource:  item.dataKey.Resource,
+		})
+		if summary, ok := summaries[nsgr]; ok {
+			summary.Count++
+		}
 	}
 
 	batchIter, ok := iter.(BulkRequestBatchIterator)

--- a/pkg/storage/unified/resource/storage_backend_bulk_test.go
+++ b/pkg/storage/unified/resource/storage_backend_bulk_test.go
@@ -302,6 +302,67 @@ func TestKVStorageBackendProcessBulkRollsBackOnImportBatchError(t *testing.T) {
 	require.Empty(t, collectBulkImportNames(t, backend, namespace))
 }
 
+func TestKVStorageBackendProcessBulkReturnsSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend func() *kvStorageBackend
+	}{
+		{
+			name:    "badger kv",
+			backend: func() *kvStorageBackend { return setupTestStorageBackend(t) },
+		},
+		{
+			name:    "sql kv",
+			backend: func() *kvStorageBackend { return setupTestStorageBackend(t, withKV(setupSqlKV(t))) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := tc.backend()
+			const namespace = "summary-test"
+			collKey := &resourcepb.ResourceKey{
+				Namespace: namespace,
+				Group:     testBulkImportGroup,
+				Resource:  testBulkImportResource,
+			}
+
+			// First import: 3 items, 1 rejected (unknown action).
+			resp := backend.ProcessBulk(context.Background(), BulkSettings{
+				Collection: []*resourcepb.ResourceKey{collKey},
+			}, newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{
+				newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+				newBulkImportRequest(namespace, "item-2", resourcepb.BulkRequest_ADDED),
+				newBulkImportRequest(namespace, "item-bad", resourcepb.BulkRequest_UNKNOWN),
+			}))
+
+			require.Nil(t, resp.Error)
+			require.Len(t, resp.Summary, 1, "expected one summary entry per collection key")
+
+			summary := resp.Summary[0]
+			require.Equal(t, namespace, summary.Namespace)
+			require.Equal(t, testBulkImportGroup, summary.Group)
+			require.Equal(t, testBulkImportResource, summary.Resource)
+			require.Equal(t, int64(2), summary.Count, "only successfully written items should be counted")
+			require.Equal(t, int64(0), summary.PreviousCount, "nothing existed before the first import")
+
+			// Second import: replaces the collection with 1 item.
+			resp2 := backend.ProcessBulk(context.Background(), BulkSettings{
+				Collection: []*resourcepb.ResourceKey{collKey},
+			}, newBatchOnlyBulkIterator([]*resourcepb.BulkRequest{
+				newBulkImportRequest(namespace, "item-1", resourcepb.BulkRequest_ADDED),
+			}))
+
+			require.Nil(t, resp2.Error)
+			require.Len(t, resp2.Summary, 1)
+
+			summary2 := resp2.Summary[0]
+			require.Equal(t, int64(1), summary2.Count)
+			require.Equal(t, int64(2), summary2.PreviousCount, "previous import wrote 2 items")
+		})
+	}
+}
+
 func newBulkImportRequest(namespace, name string, action resourcepb.BulkRequest_Action) *resourcepb.BulkRequest {
 	return &resourcepb.BulkRequest{
 		Key: &resourcepb.ResourceKey{


### PR DESCRIPTION
I was testing the `stars` resource migration using a test instance (`mustafatest`) in dev. It succeeded but noticed some bugs along the way. [[logs](https://ops.grafana-ops.net/goto/efinlw1a8pddsd?orgId=stacks-27821)]

This PR fixes **2 important bugs**:

- The KV storage backend (used in cloud) built a `summaries` map for each collection but never wrote it into `rsp.Summary`.
- `counter = sess.Distinct(...)` started a fresh session from the base `sess`, silently dropping the `.Table()` and `.Where()` already chained onto `counter`. 

Ticket: https://github.com/grafana/search-and-storage-team/issues/738
