### PR TITLE
CI: Change pr-commands back to pull_request_target

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,6 +1,6 @@
 name: PR automation
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - opened


### PR DESCRIPTION
Fixes the workflow not having permission to put labels on PRs from public forks. This is the trigger it had before.