### PR TITLE
chore(grafana-ui): remove lodash set from mapper test

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/mapper.test.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/mapper.test.ts
@@ -1,5 +1,3 @@
-import { set } from 'lodash';
-
 import { type DateTime, dateTimeParse, type FeatureToggles } from '@grafana/data';
 import { initRegionalFormatForTests } from '@grafana/i18n';
 
@@ -28,7 +26,7 @@ const mockSetCommonFormat: (enabled: LocaleFormatPreferenceType) => void = commo
 
 function setRegionalFormatToggle(enabled: LocaleFormatPreferenceType) {
   mockSetCommonFormat(enabled);
-  set(window, 'grafanaBootData.settings.featureToggles.localeFormatPreference', enabled);
+  window.grafanaBootData.settings.featureToggles.localeFormatPreference = enabled;
 }
 
 beforeAll(() => {


### PR DESCRIPTION
## What

Remove `lodash.set` usage from `TimeRangePicker/mapper.test.ts` and replace it with native property assignment.

## Why

Part of the ongoing effort to remove lodash dependencies from `@grafana/ui`.

## Changes

- Removed `import { set } from 'lodash'` from `mapper.test.ts`
- Replaced `set(window, 'grafanaBootData.settings.featureToggles.localeFormatPreference', enabled)` with direct assignment `window.grafanaBootData.settings.featureToggles.localeFormatPreference = enabled`

`lodash.set` creates intermediate objects automatically, but `window.grafanaBootData.settings.featureToggles` is already initialized in `jest-setup.ts`, so direct assignment is safe and equivalent.

## Test

All existing tests pass without changes (`3/3`).