### PR TITLE
chore(grafana-ui): remove lodash groupBy from DataLinkSuggestions

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkSuggestions.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkSuggestions.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { groupBy, capitalize } from 'lodash';
+import { capitalize } from 'lodash';
 import { useRef, useMemo } from 'react';
 import * as React from 'react';
 import { useClickAway } from 'react-use';
@@ -65,7 +65,14 @@ export const DataLinkSuggestions = ({ suggestions, ...otherProps }: DataLinkSugg
   });
 
   const groupedSuggestions = useMemo(() => {
-    return groupBy(suggestions, (s) => s.origin);
+    return suggestions.reduce<Record<string, VariableSuggestion[]>>((acc, s) => {
+      const key = s.origin;
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(s);
+      return acc;
+    }, {});
   }, [suggestions]);
 
   const styles = useStyles2(getStyles);


### PR DESCRIPTION
## What

Remove `lodash.groupBy` usage from `DataLinkSuggestions.tsx` and replace it with native `Array.reduce`.

## Why

Part of the ongoing effort to remove lodash dependencies from `@grafana/ui`.

## Changes

- Removed `groupBy` from the lodash import
- Replaced `groupBy(suggestions, (s) => s.origin)` with a typed `reduce` that builds a `Record<string, VariableSuggestion[]>`

### Why not `Object.groupBy`?

`Object.groupBy` is an ES2024 feature. The project targets `es2022` in `tsconfig.json`, so it's not available without changing the lib target. `Array.reduce` achieves the same result and is universally supported.
