### PR TITLE
chore(grafana-ui): remove lodash defaultsDeep from RadialGauge test

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
@@ -1,5 +1,3 @@
-import { defaultsDeep } from 'lodash';
-
 import { createTheme, type Field, type FieldDisplay, FieldType, ThresholdsMode } from '@grafana/data';
 import { FieldColorModeId } from '@grafana/schema';
 
@@ -38,17 +36,29 @@ describe('RadialGauge color utils', () => {
         values: [70, 40, 30, 90, 55],
       }) satisfies Field;
 
-    const buildFieldDisplay = (field: Field, part = {}): FieldDisplay =>
-      defaultsDeep(part, {
-        field: field.config,
+    const buildFieldDisplay = (field: Field, part: DeepPartial<FieldDisplay> = {}): FieldDisplay =>
+      ({
+        name: field.name,
         colIndex: 0,
+        hasLinks: false,
+        field: {
+          ...field.config,
+          ...part.field,
+          thresholds: {
+            ...field.config.thresholds,
+            ...part.field?.thresholds,
+          },
+        },
         view: {
           getFieldDisplayProcessor: jest.fn(() => jest.fn(() => ({ color: undefined }))),
+          ...part.view,
         },
         display: {
+          text: '75',
           numeric: 75,
+          ...part.display,
         },
-      });
+      }) as unknown as FieldDisplay;
 
     it('should map threshold colors correctly (with baseColor if displayProcessor does not return colors)', () => {
       expect(


### PR DESCRIPTION
## What

Remove `lodash.defaultsDeep` usage from `RadialGauge/colors.test.ts` and replace it with native spread operators.

## Why

Part of the ongoing effort to remove lodash dependencies from `@grafana/ui`.

## Changes

- Removed `import { defaultsDeep } from 'lodash'`
- Replaced `defaultsDeep(part, defaults)` with nested spread operators that merge defaults with overrides
- Deep merge of `thresholds` is handled explicitly via `...field.config.thresholds, ...part.field?.thresholds`

The test only has a known, fixed structure (2 levels deep at most), so explicit spreads are clearer and safer than a generic deep merge utility.

## Test

All existing tests pass (`4 suites, 99 tests, 14 snapshots`).