### PR TITLE
Search: add dedicated title_ngram index field

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -592,7 +592,11 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 			}, {
 				Name:  resource.SEARCH_FIELD_TITLE,
 				Type:  resourcepb.QueryFieldType_TEXT,
-				Boost: 2, // standard analyzer (word-level matching with ngrams)
+				Boost: 2, // standard analyzer (word-level matching)
+			}, {
+				Name:  resource.SEARCH_FIELD_TITLE_NGRAM,
+				Type:  resourcepb.QueryFieldType_TEXT,
+				Boost: 1, // ngram analyzer (partial/prefix matching)
 			},
 		}
 

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -9,18 +9,19 @@ import (
 )
 
 type BleveIndexMetrics struct {
-	IndexLatency         *prometheus.HistogramVec
-	IndexSize            prometheus.Gauge
-	IndexedKinds         *prometheus.GaugeVec
-	IndexCreationTime    *prometheus.HistogramVec
-	OpenIndexes          *prometheus.GaugeVec
-	IndexBuilds          *prometheus.CounterVec
-	IndexBuildFailures   prometheus.Counter
-	IndexBuildSkipped    prometheus.Counter
-	UpdateLatency        prometheus.Histogram
-	UpdatedDocuments     prometheus.Summary
-	SearchUpdateWaitTime *prometheus.HistogramVec
-	RebuildQueueLength   prometheus.Gauge
+	IndexLatency            *prometheus.HistogramVec
+	IndexSize               prometheus.Gauge
+	IndexedKinds            *prometheus.GaugeVec
+	IndexCreationTime       *prometheus.HistogramVec
+	OpenIndexes             *prometheus.GaugeVec
+	IndexBuilds             *prometheus.CounterVec
+	IndexBuildFailures      prometheus.Counter
+	IndexBuildSkipped       prometheus.Counter
+	UpdateLatency           prometheus.Histogram
+	UpdatedDocuments        prometheus.Summary
+	SearchUpdateWaitTime    *prometheus.HistogramVec
+	RebuildQueueLength      prometheus.Gauge
+	SearchLegacyQueryFields prometheus.Counter
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -88,6 +89,10 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		RebuildQueueLength: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "index_server_rebuild_queue_length",
 			Help: "Number of indexes waiting for rebuild",
+		}),
+		SearchLegacyQueryFields: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "index_server_search_legacy_query_fields_total",
+			Help: "Search requests using query fields without title_ngram. Used to monitor when it is safe to remove ngram from title.",
 		}),
 	}
 

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -343,6 +343,7 @@ const (
 	SEARCH_FIELD_RV                 = "rv"
 	SEARCH_FIELD_TITLE              = "title"
 	SEARCH_FIELD_TITLE_PHRASE       = "title_phrase" // filtering/sorting on title by full phrase
+	SEARCH_FIELD_TITLE_NGRAM        = "title_ngram"  // ngram analysis for partial/prefix matching on title
 	SEARCH_FIELD_DESCRIPTION        = "description"
 	SEARCH_FIELD_TAGS               = "tags"
 	SEARCH_FIELD_LABELS             = "labels" // All labels, not a specific one

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -766,6 +766,7 @@ type bleveIndex struct {
 	updaterCancel   context.CancelFunc // If not nil, the updater goroutine is running with context associated with this cancel function.
 	updaterWg       sync.WaitGroup
 
+	indexMetrics     *resource.BleveIndexMetrics
 	updateLatency    prometheus.Histogram
 	updatedDocuments prometheus.Summary
 
@@ -793,6 +794,7 @@ func (b *bleveBackend) newBleveIndex(
 		logger:            logger,
 		updaterFn:         updaterFn,
 		minUpdateInterval: b.opts.IndexMinUpdateInterval,
+		indexMetrics:      b.indexMetrics,
 	}
 	bi.updaterCond = sync.NewCond(&bi.updaterMu)
 	if b.indexMetrics != nil {
@@ -1301,8 +1303,25 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 					}, {
 						Name:  resource.SEARCH_FIELD_TITLE,
 						Type:  resourcepb.QueryFieldType_TEXT,
-						Boost: 2, // standard analyzer (word-level matching with ngrams)
+						Boost: 2, // standard analyzer (word-level matching)
+					}, {
+						Name:  resource.SEARCH_FIELD_TITLE_NGRAM,
+						Type:  resourcepb.QueryFieldType_TEXT,
+						Boost: 1, // ngram analyzer (partial/prefix matching)
 					},
+				}
+			} else if b.indexMetrics != nil && b.indexMetrics.SearchLegacyQueryFields != nil {
+				// Track requests from clients that don't yet include title_ngram in their query fields.
+				// When this counter stops incrementing, it is safe to remove the ngram mapping from the title field.
+				hasNgram := false
+				for _, f := range queryFields {
+					if f.Name == resource.SEARCH_FIELD_TITLE_NGRAM {
+						hasNgram = true
+						break
+					}
+				}
+				if !hasNgram {
+					b.indexMetrics.SearchLegacyQueryFields.Inc()
 				}
 			}
 
@@ -1399,7 +1418,7 @@ func removeSmallTerms(query string) string {
 	validWords := make([]string, 0, len(words))
 
 	for _, word := range words {
-		if len(word) >= EDGE_NGRAM_MIN_TOKEN {
+		if len(word) >= NGRAM_MIN_TOKEN {
 			validWords = append(validWords, word)
 		}
 	}

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -41,7 +41,14 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	titlePhraseMapping.Store = false // already stored in title
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_PHRASE, titlePhraseMapping)
 
-	// for searching by title - uses an edge ngram token filter
+	// for partial/prefix searching by title - uses ngram token filter
+	titleNgramMapping := bleve.NewTextFieldMapping()
+	titleNgramMapping.Analyzer = TITLE_ANALYZER
+	titleNgramMapping.Store = false // already stored in title
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_NGRAM, titleNgramMapping)
+
+	// for searching by title - uses ngram token filter
+	// TODO: remove this once all clients query title_ngram directly
 	titleSearchMapping := bleve.NewTextFieldMapping()
 	titleSearchMapping.Analyzer = TITLE_ANALYZER
 	titleSearchMapping.Store = false // already stored in title

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -50,5 +50,5 @@ func TestDocumentMapping(t *testing.T) {
 
 	fmt.Printf("DOC: fields %d\n", len(doc.Fields))
 	fmt.Printf("DOC: size %d\n", doc.Size())
-	require.Equal(t, 20, len(doc.Fields))
+	require.Equal(t, 21, len(doc.Fields))
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -150,8 +150,10 @@ func TestCanSearchByTitle(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("wonderfully"), []string{"name1"})
 		// search for word at end
 		checkSearchQuery(t, index, newTestQuery("world"), []string{"name1"})
-		// can search for word substring anchored at start of word (edge ngram)
+		// can search for word substring at start of word (ngram)
 		checkSearchQuery(t, index, newTestQuery("worl"), []string{"name1"})
+		// can search for word substring in middle of word (ngram, not edge-only)
+		checkSearchQuery(t, index, newTestQuery("ello"), []string{"name1"})
 		// can search for multiple, non-consecutive words in title
 		checkSearchQuery(t, index, newTestQuery("hello world"), []string{"name1"})
 		// can search for multiple, non-consecutive words in title
@@ -241,6 +243,107 @@ func TestCanSearchByTitle(t *testing.T) {
 
 		checkSearchQuery(t, index, newTestQuery("ash"), []string{"name2", "name3", "name1"})
 		checkSearchQuery(t, index, newTestQuery("ome"), []string{"name3"})
+	})
+}
+
+// TestTitleNgramFieldSearch queries exclusively against the title_ngram field
+// (via explicit QueryFields) to prove the dedicated ngram index mapping works
+// independently of the ngram mapping still present on the title field.
+// Once all instances have this mapping, the ngram mapping on title can be
+// removed and partial/prefix matching will rely entirely on title_ngram.
+func TestTitleNgramFieldSearch(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	newNgramOnlyQuery := func(q string) *resourcepb.ResourceSearchRequest {
+		return &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: "default",
+					Group:     "dashboard.grafana.app",
+					Resource:  "dashboards",
+				},
+			},
+			Limit: 100000,
+			Query: q,
+			QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{
+				{
+					Name:  resource.SEARCH_FIELD_TITLE_NGRAM,
+					Type:  resourcepb.QueryFieldType_TEXT,
+					Boost: 1,
+				},
+			},
+		}
+	}
+
+	t.Run("title_ngram field matches partial word at start", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Hello WORLD",
+			"name2": "Something Else",
+		})
+		checkSearchQuery(t, index, newNgramOnlyQuery("worl"), []string{"name1"})
+	})
+
+	t.Run("title_ngram field matches partial word in middle", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "new dashboard",
+			"name2": "somedash",
+			"name3": "unrelated",
+		})
+		// "ash" is a middle-of-word ngram in "dashboard" and "somedash"
+		// "somedash" (shorter, higher TF-IDF) ranks above "new dashboard" (longer)
+		checkSearchQuery(t, index, newNgramOnlyQuery("ash"), []string{"name2", "name1"})
+	})
+
+	t.Run("title_ngram field matches full word", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Hello World",
+			"name2": "Goodbye Moon",
+		})
+		checkSearchQuery(t, index, newNgramOnlyQuery("hello"), []string{"name1"})
+	})
+
+	t.Run("title_ngram field does not match short terms below ngram min", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "dashboard",
+		})
+		// "da" is 2 chars, below NGRAM_MIN_TOKEN (3) — removeSmallTerms strips it
+		checkSearchQuery(t, index, newNgramOnlyQuery("da"), nil)
+	})
+}
+
+func TestScoringHierarchy(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	t.Run("exact title match scores above word match and ngram match", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"exact":   "monitor",              // exact match on title_phrase (boost=10) + word match on title (boost=2)
+			"partial": "monitoring dashboard", // word match on "monitor" via ngram (boost=1+2)
+		})
+		// "monitor" should rank the exact title match first
+		checkSearchQuery(t, index, newTestQuery("monitor"), []string{"exact", "partial"})
+	})
+
+	t.Run("word match scores above ngram-only match", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"word":  "alerts overview",    // "alerts" is a full word — matches via standard analyzer (boost=2) and ngram (boost=1)
+			"ngram": "alertstate monitor", // "alert" is a substring of "alertstate" — matches only via ngram (boost=1)
+		})
+		// "alert" matches "alerts overview" via word+ngram, and "alertstate monitor" via ngram only
+		checkSearchQuery(t, index, newTestQuery("alert"), []string{"word", "ngram"})
 	})
 }
 

--- a/pkg/storage/unified/search/custom_analyzers.go
+++ b/pkg/storage/unified/search/custom_analyzers.go
@@ -10,20 +10,20 @@ import (
 )
 
 const TITLE_ANALYZER = "title_analyzer"
-const EDGE_NGRAM_MIN_TOKEN = 3.0
+const NGRAM_MIN_TOKEN = 3.0
 const tokenFilterName = "ngram_filter"
 
 func RegisterCustomAnalyzers(mapper *mapping.IndexMappingImpl) error {
 	return registerTitleAnalyzer(mapper)
 }
 
-// The registerTitleAnalyzer function defines a custom analyzer using edge n-gram or full n-gram
+// The registerTitleAnalyzer function defines a custom analyzer using full n-gram tokenization
 func registerTitleAnalyzer(mapper *mapping.IndexMappingImpl) error {
 	// The ngram tokenFilter will create additional grams in the middle of each token.
 	// For example, the token "hello" will be tokenized into "hel", "hell", "hello", "ell", "ello", "llo".
 	tokenFilter := map[string]interface{}{
 		"type": ngram.Name,
-		"min":  EDGE_NGRAM_MIN_TOKEN,
+		"min":  NGRAM_MIN_TOKEN,
 		"max":  10.0,
 	}
 	err := mapper.AddCustomTokenFilter(tokenFilterName, tokenFilter)

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.065
+      "score": 0.122
     },
     {
       "resource": "dashboards",
@@ -21,8 +21,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.062
+      "score": 0.116
     }
   ],
-  "maxScore": 0.065
+  "maxScore": 0.122
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.098
+      "score": 0.184
     }
   ],
-  "maxScore": 0.098
+  "maxScore": 0.184
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.112
+      "score": 0.225
     }
   ],
-  "maxScore": 0.112
+  "maxScore": 0.225
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.112
+      "score": 0.225
     }
   ],
-  "maxScore": 0.112
+  "maxScore": 0.225
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.137,
+      "score": 0.102,
       "explain": {
         "children": [
           {
@@ -35,7 +35,7 @@
                           }
                         ],
                         "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
-                        "value": 0.322
+                        "value": 0.321
                       },
                       {
                         "children": [
@@ -63,26 +63,26 @@
                       }
                     ],
                     "message": "weight(fields.panel_title:orange^5.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001), product of:",
-                    "value": 0.411
+                    "value": 0.409
                   }
                 ],
                 "message": "sum of:",
-                "value": 0.411
+                "value": 0.409
               }
             ],
             "message": "sum of:",
-            "value": 0.411
+            "value": 0.409
           },
           {
-            "message": "coord(1/3)",
-            "value": 0.333
+            "message": "coord(1/4)",
+            "value": 0.25
           }
         ],
         "message": "product of:",
         "partial_match": true,
-        "value": 0.137
+        "value": 0.102
       }
     }
   ],
-  "maxScore": 0.137
+  "maxScore": 0.102
 }


### PR DESCRIPTION
## Summary

Adds a dedicated `title_ngram` index mapping for ngram-based partial/prefix search, as the next step in cleaning up the `title` field's triple-mapping (standard + ngram + keyword analyzers on one field).

- Adds `SEARCH_FIELD_TITLE_NGRAM` constant and `title_ngram` index mapping with the ngram analyzer
- Includes `title_ngram` (TEXT, boost=1) in default and dashboard QueryFields, giving a scoring hierarchy: exact match (boost=10) > word match (boost=2) > ngram/partial match (boost=1)
- Keeps the existing triple-mapping on `title` for backward compatibility — indexers deploy before clients with a gap up to a month; a follow-up will remove the redundant ngram + keyword from `title` once all clients include `title_ngram`
- Adds `index_server_search_legacy_query_fields_total` Prometheus counter to track when old clients stop sending QueryFields without `title_ngram` — when this stops incrementing, it is safe to do the cleanup
- Renames `EDGE_NGRAM_MIN_TOKEN` → `NGRAM_MIN_TOKEN` (the analyzer uses full ngrams, not edge ngrams)
- Adds unit tests for `title_ngram` field independently and for scoring hierarchy
- Updates integration test snapshots (score changes due to 2→3 member disjunction)

Follow-up to #122226. Tracked in grafana/search-and-storage-team#737.

## Test plan

- [x] `go test ./pkg/storage/unified/search/...` — 115 tests pass (including new `TestTitleNgramFieldSearch` and `TestScoringHierarchy`)
- [x] `go test -run TestIntegrationSearchDevDashboards ./pkg/tests/apis/dashboard/...` — 8 integration tests pass with updated snapshots
- [x] `go build ./pkg/storage/unified/search/... ./pkg/storage/unified/resource/... ./pkg/registry/apis/dashboard/...` — compiles