### PR TITLE
unified-storage: fix case permission on folder list query

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -68,7 +69,7 @@ func (hs *HTTPServer) registerFolderAPI(apiRoute routing.RouteRegister, authoriz
 // 500: internalServerError
 func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 	permission := dashboardaccess.PERMISSION_VIEW
-	if c.Query("permission") == "Edit" {
+	if strings.EqualFold(c.Query("permission"), "edit") {
 		permission = dashboardaccess.PERMISSION_EDIT
 	}
 


### PR DESCRIPTION
Fixes a bug where the user is able to view all folders they have read access to when saving a dashboard, even if they can't actually save the dashboard in the folder (saving fails)