### PR TITLE
Dashboard profiling: Add per-operation timing to panel_render measurement

### DIFF
--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -54,6 +54,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
   private panelMetrics = new Map<string, PanelAnalyticsMetrics>();
   private dashboardUID = '';
   private dashboardTitle = '';
+  private currentOperationId = '';
 
   public initialize(uid: string, title: string) {
     // Clear previous dashboard data and set new context
@@ -85,8 +86,8 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
 
   // Dashboard-level events (we don't need to track these for panel analytics)
   onDashboardInteractionStart = (data: performanceUtils.DashboardInteractionStartData): void => {
-    // Clear metrics when new dashboard interaction starts
     this.clearMetrics();
+    this.currentOperationId = data.operationId;
   };
 
   onDashboardInteractionMilestone = (_data: performanceUtils.DashboardInteractionMilestoneData): void => {
@@ -105,7 +106,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
   };
 
   onPanelOperationComplete = (data: performanceUtils.PanelPerformanceData): void => {
-    // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
       console.warn('Panel not found for operation completion:', data.panelKey);
@@ -153,6 +153,26 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
       case 'plugin-load':
         panel.pluginLoadTime += duration;
         break;
+    }
+
+    // Send individual panel_operation measurement immediately for correct Faro timestamps
+    if (this.currentOperationId) {
+      const context: Record<string, string> = {
+        panelKey: data.panelKey,
+        pluginId: data.pluginId,
+        panelId: data.panelId,
+        operationId: this.currentOperationId,
+        operationType: data.operation,
+      };
+
+      if (data.operation === 'query' && data.metadata.queryType) {
+        context.queryType = data.metadata.queryType;
+      }
+      if (data.operation === 'transform' && data.metadata.transformationId) {
+        context.transformationId = data.metadata.transformationId;
+      }
+
+      logMeasurement('panel_operation', { duration: Math.round(duration * 10) / 10 }, context);
     }
   };
 
@@ -231,59 +251,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
         panelId: panel.panelId,
         operationId: data.operationId, // Shared operationId for correlating with dashboard_render
       });
-
-      // Send individual panel_operation measurements for granular per-operation analytics
-      const panelContext = {
-        panelKey: panel.panelKey,
-        pluginId: panel.pluginId,
-        panelId: panel.panelId,
-        operationId: data.operationId,
-      };
-
-      for (const op of panel.queryOperations) {
-        logMeasurement(
-          'panel_operation',
-          { duration: Math.round(op.duration * 10) / 10 },
-          {
-            ...panelContext,
-            operationType: 'query',
-            ...(op.queryType && { queryType: op.queryType }),
-          }
-        );
-      }
-
-      for (const op of panel.transformationOperations) {
-        logMeasurement(
-          'panel_operation',
-          { duration: Math.round(op.duration * 10) / 10 },
-          {
-            ...panelContext,
-            operationType: 'transform',
-            ...(op.transformationId && { transformationId: op.transformationId }),
-          }
-        );
-      }
-
-      for (const op of panel.renderOperations) {
-        logMeasurement('panel_operation', { duration: Math.round(op.duration * 10) / 10 }, {
-          ...panelContext,
-          operationType: 'render',
-        });
-      }
-
-      for (const op of panel.fieldConfigOperations) {
-        logMeasurement('panel_operation', { duration: Math.round(op.duration * 10) / 10 }, {
-          ...panelContext,
-          operationType: 'fieldConfig',
-        });
-      }
-
-      if (panel.pluginLoadTime > 0) {
-        logMeasurement('panel_operation', { duration: Math.round(panel.pluginLoadTime * 10) / 10 }, {
-          ...panelContext,
-          operationType: 'plugin-load',
-        });
-      }
     });
   }
 

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -218,6 +218,11 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
         renderCount: panel.renderOperations.length,
         fieldConfigCount: panel.fieldConfigOperations.length,
         pluginLoadCount: panel.pluginLoadTime > 0 ? 1 : 0,
+        queryTime: Math.round(panel.totalQueryTime * 10) / 10,
+        transformTime: Math.round(panel.totalTransformationTime * 10) / 10,
+        renderTime: Math.round(panel.totalRenderTime * 10) / 10,
+        fieldConfigTime: Math.round(panel.totalFieldConfigTime * 10) / 10,
+        pluginLoadTime: Math.round(panel.pluginLoadTime * 10) / 10,
       };
 
       logMeasurement('panel_render', measurementValues, {
@@ -226,6 +231,59 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
         panelId: panel.panelId,
         operationId: data.operationId, // Shared operationId for correlating with dashboard_render
       });
+
+      // Send individual panel_operation measurements for granular per-operation analytics
+      const panelContext = {
+        panelKey: panel.panelKey,
+        pluginId: panel.pluginId,
+        panelId: panel.panelId,
+        operationId: data.operationId,
+      };
+
+      for (const op of panel.queryOperations) {
+        logMeasurement(
+          'panel_operation',
+          { duration: Math.round(op.duration * 10) / 10 },
+          {
+            ...panelContext,
+            operationType: 'query',
+            ...(op.queryType && { queryType: op.queryType }),
+          }
+        );
+      }
+
+      for (const op of panel.transformationOperations) {
+        logMeasurement(
+          'panel_operation',
+          { duration: Math.round(op.duration * 10) / 10 },
+          {
+            ...panelContext,
+            operationType: 'transform',
+            ...(op.transformationId && { transformationId: op.transformationId }),
+          }
+        );
+      }
+
+      for (const op of panel.renderOperations) {
+        logMeasurement('panel_operation', { duration: Math.round(op.duration * 10) / 10 }, {
+          ...panelContext,
+          operationType: 'render',
+        });
+      }
+
+      for (const op of panel.fieldConfigOperations) {
+        logMeasurement('panel_operation', { duration: Math.round(op.duration * 10) / 10 }, {
+          ...panelContext,
+          operationType: 'fieldConfig',
+        });
+      }
+
+      if (panel.pluginLoadTime > 0) {
+        logMeasurement('panel_operation', { duration: Math.round(panel.pluginLoadTime * 10) / 10 }, {
+          ...panelContext,
+          operationType: 'plugin-load',
+        });
+      }
     });
   }
 

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -172,7 +172,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
         context.transformationId = data.metadata.transformationId;
       }
 
-      logMeasurement('panel_operation', { duration: Math.round(duration * 10) / 10 }, context);
+      logMeasurement('panel_operation', { duration }, context);
     }
   };
 
@@ -232,17 +232,17 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
 
       // logMeasurement requires numeric values in second parameter, metadata in third
       const measurementValues = {
-        totalTime: Math.round(totalPanelTime * 10) / 10,
+        totalTime: totalPanelTime,
         queryCount: panel.queryOperations.length,
         transformCount: panel.transformationOperations.length,
         renderCount: panel.renderOperations.length,
         fieldConfigCount: panel.fieldConfigOperations.length,
         pluginLoadCount: panel.pluginLoadTime > 0 ? 1 : 0,
-        queryTime: Math.round(panel.totalQueryTime * 10) / 10,
-        transformTime: Math.round(panel.totalTransformationTime * 10) / 10,
-        renderTime: Math.round(panel.totalRenderTime * 10) / 10,
-        fieldConfigTime: Math.round(panel.totalFieldConfigTime * 10) / 10,
-        pluginLoadTime: Math.round(panel.pluginLoadTime * 10) / 10,
+        queryTime: panel.totalQueryTime,
+        transformTime: panel.totalTransformationTime,
+        renderTime: panel.totalRenderTime,
+        fieldConfigTime: panel.totalFieldConfigTime,
+        pluginLoadTime: panel.pluginLoadTime,
       };
 
       logMeasurement('panel_render', measurementValues, {

--- a/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
+++ b/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
@@ -472,7 +472,7 @@ Individual `panel_operation` measurements are sent in real-time as each operatio
 
 ```typescript
 {
-  duration: number              // Duration of the individual operation (ms)
+  duration: number; // Duration of the individual operation (ms)
 }
 ```
 
@@ -493,12 +493,12 @@ Individual `panel_operation` measurements are sent in real-time as each operatio
 
 **Operation types**:
 
-| operationType | When sent |
-| --- | --- |
-| `query` | One per query executed by the panel |
-| `transform` | One per transformation applied |
-| `render` | One per render cycle |
-| `fieldConfig` | One per field config application |
+| operationType | When sent                               |
+| ------------- | --------------------------------------- |
+| `query`       | One per query executed by the panel     |
+| `transform`   | One per transformation applied          |
+| `render`      | One per render cycle                    |
+| `fieldConfig` | One per field config application        |
 | `plugin-load` | One measurement if plugin load time > 0 |
 
 ## Debugging and Development

--- a/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
+++ b/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
@@ -308,6 +308,7 @@ Aggregates panel-level performance metrics for analytics reporting:
 - Sends comprehensive analytics reports via `reportInteraction` and `logMeasurement`
 - Provides detailed panel breakdowns including slow panel detection
 - Sends individual `panel_render` measurements for each panel with aggregated metrics via `logMeasurement`
+- Sends individual `panel_operation` measurements for each operation within a panel via `logMeasurement`
 
 #### ScenePerformanceLogger
 
@@ -433,7 +434,12 @@ For each dashboard interaction, individual `panel_render` measurements are sent 
   transformCount: number,       // Number of transformation operations
   renderCount: number,         // Number of render operations
   fieldConfigCount: number,     // Number of field config operations
-  pluginLoadCount: number       // Number of plugin load operations (0 or 1)
+  pluginLoadCount: number,      // Number of plugin load operations (0 or 1)
+  queryTime: number,            // Total time spent in queries (ms)
+  transformTime: number,        // Total time spent in transformations (ms)
+  renderTime: number,           // Total time spent in renders (ms)
+  fieldConfigTime: number,      // Total time spent in field config (ms)
+  pluginLoadTime: number        // Time spent loading the plugin (ms)
 }
 ```
 
@@ -453,6 +459,47 @@ For each dashboard interaction, individual `panel_render` measurements are sent 
 **Correlating panel_render with dashboard_render**:
 
 All `panel_render` measurements share the same `operationId` as their parent `dashboard_render` interaction.
+
+#### Panel Operation Measurements
+
+After each `panel_render` measurement, individual `panel_operation` measurements are sent for each operation that occurred during the panel's render lifecycle. This provides per-query, per-transform, and per-render timing data for fine-grained performance analysis.
+
+**When sent**: After `panel_render` measurement, one `panel_operation` measurement per individual operation
+
+**Correlation**: All `panel_operation` measurements share the same `operationId` as their parent `dashboard_render` and sibling `panel_render` measurements, enabling full correlation across dashboard, panel, and operation levels.
+
+**Measurement values** (via `logMeasurement`):
+
+```typescript
+{
+  duration: number              // Duration of the individual operation (ms)
+}
+```
+
+**Measurement metadata** (via `logMeasurement` context):
+
+```typescript
+{
+  panelKey: string,            // Panel key identifier
+  pluginId: string,            // Panel plugin identifier
+  panelId: string,             // Panel identifier
+  operationId: string,         // Shared operationId for correlating with dashboard_render
+  operationType: string,       // One of: 'query', 'transform', 'render', 'fieldConfig', 'plugin-load'
+  // Operation-specific metadata (included when available):
+  queryType?: string,          // Query type (only for operationType: 'query')
+  transformationId?: string    // Transformation ID (only for operationType: 'transform')
+}
+```
+
+**Operation types**:
+
+| operationType | Source | When sent |
+| --- | --- | --- |
+| `query` | `panel.queryOperations` | One per query executed by the panel |
+| `transform` | `panel.transformationOperations` | One per transformation applied |
+| `render` | `panel.renderOperations` | One per render cycle |
+| `fieldConfig` | `panel.fieldConfigOperations` | One per field config application |
+| `plugin-load` | `panel.pluginLoadTime` | One measurement if plugin load time > 0 |
 
 ## Debugging and Development
 

--- a/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
+++ b/public/app/features/dashboard/services/dashboard-render-performance-profiling.md
@@ -462,9 +462,9 @@ All `panel_render` measurements share the same `operationId` as their parent `da
 
 #### Panel Operation Measurements
 
-After each `panel_render` measurement, individual `panel_operation` measurements are sent for each operation that occurred during the panel's render lifecycle. This provides per-query, per-transform, and per-render timing data for fine-grained performance analysis.
+Individual `panel_operation` measurements are sent in real-time as each operation completes during the panel's render lifecycle. This provides per-query, per-transform, and per-render timing data for fine-grained performance analysis with accurate Faro ingestion timestamps.
 
-**When sent**: After `panel_render` measurement, one `panel_operation` measurement per individual operation
+**When sent**: Immediately when each panel operation completes (not batched at interaction end)
 
 **Correlation**: All `panel_operation` measurements share the same `operationId` as their parent `dashboard_render` and sibling `panel_render` measurements, enabling full correlation across dashboard, panel, and operation levels.
 
@@ -493,13 +493,13 @@ After each `panel_render` measurement, individual `panel_operation` measurements
 
 **Operation types**:
 
-| operationType | Source | When sent |
-| --- | --- | --- |
-| `query` | `panel.queryOperations` | One per query executed by the panel |
-| `transform` | `panel.transformationOperations` | One per transformation applied |
-| `render` | `panel.renderOperations` | One per render cycle |
-| `fieldConfig` | `panel.fieldConfigOperations` | One per field config application |
-| `plugin-load` | `panel.pluginLoadTime` | One measurement if plugin load time > 0 |
+| operationType | When sent |
+| --- | --- |
+| `query` | One per query executed by the panel |
+| `transform` | One per transformation applied |
+| `render` | One per render cycle |
+| `fieldConfig` | One per field config application |
+| `plugin-load` | One measurement if plugin load time > 0 |
 
 ## Debugging and Development
 


### PR DESCRIPTION
Adds per-operation duration breakdowns (`queryTime`, `transformTime`, `renderTime`, `fieldConfigTime`, `pluginLoadTime`) to the `panel_render` Faro measurement and introduces a new `panel_operation` measurement sent in real-time as each operation completes. This lets consumers identify whether a slow panel is query-bound or render-bound without browser console access. Correlated via shared `operationId` across `dashboard_render`, `panel_render`, and `panel_operation`.

**How to test:** Set `dashboard_performance_metrics = *` in `grafana.ini`, enable `localStorage.setItem('grafana.debug.sceneProfiling', 'true')`, load a dashboard and verify `panel_render` includes duration fields and `panel_operation` measurements appear in console with correct timestamps.
