### PR TITLE
VizLegend: Make table header sticky

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -148,6 +148,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
   header: css({
+    position: 'sticky',
+    top: 0,
+    backgroundColor: theme.colors.background.primary,
+    zIndex: 1,
     color: theme.colors.primary.text,
     fontWeight: theme.typography.fontWeightMedium,
     borderBottom: `1px solid ${theme.colors.border.weak}`,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Description of the changes is** :
The header is now sticky at the top of the container to improve legibility, as mentioned in the issue description. This is especially helpful for larger tables where users may lose context while scrolling, resulting in a better overall user experience.

**Which issue(s) does this PR fix?**:

Issue: #121805 

- Automatically closes linked issue when the Pull Request is merged.

Fixes #121805 

**Special notes for your reviewer:**
Previously The header is not sticky to Top: 


https://github.com/user-attachments/assets/8a362275-2995-4bd2-b4d0-84e285d451f2


Ater thhe fix it is sticky to the Top:


https://github.com/user-attachments/assets/f92a225b-ce45-41ba-b7ad-674bdc57ded1

 


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
