### PR TITLE
[DOC] Clarify trace ID cardinality guidance in trace correlations

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs.md
@@ -116,6 +116,12 @@ This guide uses Loki, but Trace to logs also supports Elasticsearch, Splunk, Ope
    {${__tags}} | logfmt | trace_id=`${__trace.traceId}`
    ```
 
+   If a tag like `pod` is stored as Loki [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) instead of an indexed label, it can't appear in the stream selector `{}`. Move it to a pipeline filter instead:
+
+   ```logql
+   {${__tags}} | pod=`${__span.tags["k8s.pod.name"]}` |= `${__trace.traceId}`
+   ```
+
    Refer to [Custom query variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#custom-query-variables) for the full list of available variables.
 
 1. Click **Save & test**.

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/trace-correlations.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/trace-correlations.md
@@ -112,6 +112,11 @@ In this example, you configure trace to logs by service name and a trace identif
      {service_name="$serviceName"} | trace_id=`$traceID` |= ``
      ```
 
+     In this query, `service_name` is the only [stream label](https://grafana.com/docs/loki/latest/get-started/labels/) used inside `{}`. Stream labels should be low-cardinality values that describe the source of your logs.
+     The `trace_id` field appears after the `|` pipe as a [pipeline filter](https://grafana.com/docs/loki/latest/query/log_queries/#line-filter-expression), which searches log content or [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) without creating additional streams.
+     Don't use trace IDs or other high-cardinality values as stream labels because each unique value creates a separate stream, which degrades Loki performance.
+     For more information, refer to [Label best practices](https://grafana.com/docs/loki/latest/get-started/labels/bp-labels/) and [Cardinality](https://grafana.com/docs/loki/latest/get-started/labels/cardinality/).
+
      {{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-correlations-example-1-step-2.png" max-width="900px" class="docs-image--no-shadow" alt="Using correlations for a trace" >}}
 
 1. On step 3, configure the correlation source:
@@ -161,6 +166,13 @@ In this example, you configure trace correlations with a custom URL.
 
 - **Name clearly:** Use descriptive names indicating source and target. For example: **Trace to errors in logs**.
 
-- **Limit scope**: For high-cardinality fields (like `traceID`), ensure your target system can handle frequent queries.
+- **Use low-cardinality stream labels:** When targeting Loki, use only low-cardinality values like `service_name`, `namespace`, or `cluster` inside the stream selector `{}`. Place high-cardinality values like trace IDs in [pipeline filters](https://grafana.com/docs/loki/latest/query/log_queries/#line-filter-expression) (after `|`) or store them as [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/). Using trace IDs as stream labels creates excessive streams and degrades Loki performance. For more information, refer to [Cardinality](https://grafana.com/docs/loki/latest/get-started/labels/cardinality/) and [Label best practices](https://grafana.com/docs/loki/latest/get-started/labels/bp-labels/). For detailed guidance on mapping span attributes to Loki labels, refer to [Configure trace to logs correlation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs/).
 
 - **Template wisely:** Use multiple `$variable` tokens if you need to inject more than one field.
+
+## Next steps
+
+- [Configure trace to logs correlation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs/): Link spans to log queries in Loki with tag mapping and cardinality guidance.
+- [Configure trace to metrics correlation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-metrics/): Link spans to metrics queries in Prometheus.
+- [Configure trace to profiles correlation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-profiles/): Link spans to profiling data in Grafana Pyroscope.
+- [Configure the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/): Return to connection, authentication, and streaming settings.

--- a/docs/sources/datasources/tempo/troubleshooting/index.md
+++ b/docs/sources/datasources/tempo/troubleshooting/index.md
@@ -113,7 +113,7 @@ For issues with Tempo itself (not the data source), refer to the Tempo product d
 
 Additional resources for Grafana Cloud:
 
-- [Troubleshoot Grafana Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshooting/), which covers quick checks, ingestion issues, TraceQL and search, service graph, exemplars, and rate limiting and retry.
+- [Troubleshoot Grafana Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshoot/), which covers quick checks, ingestion issues, TraceQL and search, service graph, exemplars, and rate limiting and retry.
 - [Investigate traces with Grafana Assistant](https://grafana.com/docs/grafana-cloud/send-data/traces/investigate-traces-with-assistant/) - Use Grafana Assistant to help troubleshoot any issues.
 - [Troubleshoot traces collection with Alloy](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/traces-with-alloy/#troubleshoot)
 - [Troubleshoot errors with metrics-generator in Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/configure/metrics-generator/#troubleshoot-errors)
@@ -243,7 +243,7 @@ These errors occur when there are issues with TraceQL queries or trace lookups.
 
    If this returns results, traces are being ingested but your specific trace ID may have been dropped by sampling or aged out. For more query examples, refer to the [TraceQL cookbook](https://grafana.com/docs/grafana-cloud/send-data/traces/traces-query-editor/traceql-cookbook/).
 
-1. For Grafana Cloud users, refer to [Troubleshoot TraceQL and search](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshooting/#traceql-and-search) for TraceQL queries that can help investigate missing traces.
+1. For Grafana Cloud users, refer to [Troubleshoot TraceQL and search](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshoot/#traceql-and-search) for TraceQL queries that can help investigate missing traces.
 
 ### TraceQL syntax errors
 
@@ -382,7 +382,7 @@ The Service Graph visualizes service dependencies and highlights request rate, e
    ```
 
 1. Check the Prometheus data source connection is working.
-1. For Grafana Cloud Traces users, refer to [Troubleshoot service graph and RED metrics](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshooting/#troubleshoot-service-graph-and-red-metrics).
+1. For Grafana Cloud Traces users, refer to [Troubleshoot service graph and RED metrics](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshoot/#troubleshoot-service-graph-and-red-metrics).
 
 ### Service Graph view table is empty
 
@@ -473,6 +473,7 @@ These issues relate to the correlation features that link traces to other teleme
 1. Adjust the **Span start time shift** and **Span end time shift** to widen the time range.
 1. Verify that log or metric labels match the span attributes.
 1. Check that the tag mappings correctly translate attribute names between data sources. Span attributes use dots (for example, `service.name`) but Loki labels use underscores (for example, `service_name`). Ensure tag mappings account for this difference. Refer to [Trace to logs](ref:trace-to-logs) for tag mapping configuration.
+1. If a tag like `pod` is stored as Loki [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) rather than an indexed label, the auto-generated stream selector `{pod="..."}` returns no results. Enable **Use custom query** and move the tag to a pipeline filter. Refer to [Trace to logs](ref:trace-to-logs) for a custom query example.
 1. Run the generated query directly in the target data source's Explore view to confirm it returns data outside of the trace context.
 1. Use the Query Inspector to view the generated query and verify it's correct.
 


### PR DESCRIPTION

Addresses [grafana/loki#18373](https://github.com/grafana/loki/issues/18373) by clarifying that trace_id in the Loki query example is a pipeline filter, not a stream label, and doesn't cause high-cardinality issues
Replaces the vague "Limit scope" best practice with actionable cardinality guidance and links to Loki's label, cardinality, and structured metadata docs
Adds a Next steps section linking to related correlation pages

Fixes https://github.com/grafana/loki/issues/18373
Fixes https://github.com/grafana/support-escalations/issues/18558

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
