### PR TITLE
QueryEditor: SQL tile rework

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/SqlExpressionsCTA.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/SqlExpressionsCTA.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SqlExpressionsCTA } from './SqlExpressionsCTA';
+
+describe('SqlExpressionsCTA', () => {
+  it('renders the description text and action button', () => {
+    render(<SqlExpressionsCTA onAddSqlExpression={jest.fn()} />);
+
+    expect(screen.getByText(/Prefer SQL/i)).toBeInTheDocument();
+    expect(screen.getByTestId('sql-expressions-cta-button')).toBeInTheDocument();
+  });
+
+  it('calls onAddSqlExpression when the button is clicked', async () => {
+    const onAddSqlExpression = jest.fn();
+    render(<SqlExpressionsCTA onAddSqlExpression={onAddSqlExpression} />);
+
+    await userEvent.click(screen.getByTestId('sql-expressions-cta-button'));
+
+    expect(onAddSqlExpression).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/SqlExpressionsCTA.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/SqlExpressionsCTA.tsx
@@ -1,0 +1,28 @@
+import { Trans } from '@grafana/i18n';
+import { Box, Button, Icon, Stack, Text } from '@grafana/ui';
+
+export function SqlExpressionsCTA({ onAddSqlExpression }: { onAddSqlExpression: () => void }) {
+  return (
+    <Box backgroundColor="info" borderRadius="default" paddingX={1} paddingY={1.5}>
+      <Stack direction="row" alignItems="center" gap={1} justifyContent="space-between">
+        <Stack alignItems="center" gap={1}>
+          <Icon name="database" />
+          <Text variant="bodySmall" color="maxContrast">
+            <Trans i18nKey="dashboard.transformation-type-picker.sql-cta-description">
+              Prefer SQL? Add a SQL expression to your queries instead.
+            </Trans>
+          </Text>
+        </Stack>
+        <Button
+          variant="primary"
+          size="sm"
+          fill="outline"
+          onClick={onAddSqlExpression}
+          data-testid="sql-expressions-cta-button"
+        >
+          <Trans i18nKey="dashboard.transformation-type-picker.sql-cta-button">Add SQL expression</Trans>
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -1,24 +1,29 @@
 import { css } from '@emotion/css';
-import { type ChangeEvent, useMemo, useState } from 'react';
+import { type ChangeEvent, useCallback, useMemo, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { EmptyState, FilterPill, Grid, IconButton, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
-import { SqlExpressionsBanner } from 'app/features/dashboard/components/TransformationsEditor/SqlExpressions/SqlExpressionsBanner';
 import { TransformationCard } from 'app/features/dashboard/components/TransformationsEditor/TransformationCard';
+import { hasBackendDatasource } from 'app/features/dashboard-scene/panel-edit/PanelDataPane/utils';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 
 import { trackTransformationFilterChanged, trackTransformationSearch } from '../../tracking';
-import { useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
+import { useDatasourceContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
+import { SqlExpressionsCTA } from './SqlExpressionsCTA';
 import { useTransformationSearchAndFilter } from './useTransformationSearchAndFilter';
 
 export function TransformationTypePicker() {
   const styles = useStyles2(getStyles);
 
-  const { finalizePendingTransformation } = useQueryEditorUIContext();
-  const { data } = useQueryRunnerContext();
+  const { finalizePendingTransformation, setPendingTransformation, finalizePendingExpression } =
+    useQueryEditorUIContext();
+  const { data, queries } = useQueryRunnerContext();
+  const { dsSettings } = useDatasourceContext();
 
   const [showIllustrations, setShowIllustrations] = useState(true);
 
@@ -32,6 +37,19 @@ export function TransformationTypePicker() {
     onSearchKeyDown,
     allTransformationsCount,
   } = useTransformationSearchAndFilter(finalizePendingTransformation);
+
+  const showSqlCTA =
+    config.featureToggles.sqlExpressions && hasBackendDatasource({ datasourceUid: dsSettings?.uid, queries });
+
+  const handleAddSqlExpression = useCallback(() => {
+    reportInteraction('dashboards_expression_interaction', {
+      action: 'add_expression',
+      expression_type: 'sql',
+      context: 'transformation_picker_cta',
+    });
+    setPendingTransformation(null);
+    finalizePendingExpression(ExpressionQueryType.sql);
+  }, [setPendingTransformation, finalizePendingExpression]);
 
   const searchBoxSuffix = useMemo(() => {
     if (filteredTransformations.length === allTransformationsCount) {
@@ -51,8 +69,6 @@ export function TransformationTypePicker() {
 
   return (
     <Stack direction="column" gap={2}>
-      {config?.featureToggles?.sqlExpressions && <SqlExpressionsBanner />}
-
       <div className={styles.searchWrapper}>
         <Input
           autoFocus
@@ -77,6 +93,8 @@ export function TransformationTypePicker() {
           <Switch value={showIllustrations} onChange={() => setShowIllustrations((prev) => !prev)} />
         </Stack>
       </div>
+
+      {showSqlCTA && <SqlExpressionsCTA onAddSqlExpression={handleAddSqlExpression} />}
 
       <Stack direction="row" wrap="wrap" rowGap={1} columnGap={0.5}>
         <FilterPill

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/CardEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/CardEditorRenderer.tsx
@@ -1,56 +1,21 @@
-import { ExpressionQueryType } from 'app/features/expressions/types';
-
-import { EmptyTransformationsMessage } from '../../PanelDataPane/EmptyTransformationsMessage';
 import { QueryEditorType } from '../constants';
 
 import { AlertEditorRenderer } from './AlertEditorRenderer';
 import { ExpressionTypePicker } from './Body/ExpressionTypePicker';
 import { TransformationTypePicker } from './Body/TransformationTypePicker';
-import {
-  useDatasourceContext,
-  usePanelContext,
-  useQueryEditorUIContext,
-  useQueryRunnerContext,
-} from './QueryEditorContext';
+import { useQueryEditorUIContext } from './QueryEditorContext';
 import { QueryEditorRenderer } from './QueryEditorRenderer';
 import { TransformationEditorRenderer } from './TransformationEditorRenderer';
 
 export function CardEditorRenderer() {
-  const {
-    cardType,
-    pendingExpression,
-    pendingTransformation,
-    setPendingTransformation,
-    finalizePendingTransformation,
-    finalizePendingExpression,
-  } = useQueryEditorUIContext();
-  const { transformations } = usePanelContext();
-  const { data, queries } = useQueryRunnerContext();
-  const { dsSettings } = useDatasourceContext();
+  const { cardType, pendingExpression, pendingTransformation } = useQueryEditorUIContext();
 
   if (pendingExpression) {
     return <ExpressionTypePicker />;
   }
 
   if (pendingTransformation) {
-    const shouldShowPicker = pendingTransformation.showPicker || transformations.length > 0;
-
-    return shouldShowPicker ? (
-      <TransformationTypePicker />
-    ) : (
-      <EmptyTransformationsMessage
-        showHeaderText={false}
-        onShowPicker={() => setPendingTransformation({ showPicker: true })}
-        onAddTransformation={finalizePendingTransformation}
-        onGoToQueries={() => {
-          setPendingTransformation(null);
-          finalizePendingExpression(ExpressionQueryType.sql);
-        }}
-        data={data?.series ?? []}
-        datasourceUid={dsSettings?.uid}
-        queries={queries}
-      />
-    );
+    return <TransformationTypePicker />;
   }
 
   if (cardType === QueryEditorType.Alert) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6504,6 +6504,10 @@
       "title-add-another-transformation": "Add another transformation",
       "view-all": "View all"
     },
+    "transformation-type-picker": {
+      "sql-cta-button": "Add SQL expression",
+      "sql-cta-description": "Prefer SQL? Add a SQL expression to your queries instead."
+    },
     "un-theme-transformations-editor": {
       "body-delete-all-transformations": "By deleting all transformations, you will go back to the main selection screen."
     },


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

Resolves https://github.com/grafana/grafana/issues/122570

This PR reworks the flow of adding a transformation. 

Current: Click add ➡️ Empty transformations screen ➡️ "Show more" (falls below the fold) **or** "Transform with SQL" (visually jarring)

New: Click add ➡️ Full transformations picker ➡️ New SQL CTA based on applicability

## Changes
<!--- Describe your changes in detail -->
* See above, but this PR basically removes the intermediary step of the Empty Transformations state

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
N/A

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

<img width="1383" height="376" alt="image" src="https://github.com/user-attachments/assets/a4782865-2597-421d-97d2-f3b43996ae9e" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Pull the branch and test it out!

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable