### PR TITLE
Alerting: Fix missing permission check for routing preview

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, within } from 'test/test-utils';
+import { render, screen, waitFor, within } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
 import { setAlertmanagerConfig } from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
@@ -164,6 +164,43 @@ describe('NotificationPreview', () => {
 
     expect(matchingContactPoint[1]).toHaveTextContent(/Delivered to slack/);
     expect(matchingContactPoint[1]).toHaveTextContent(/1 instance/);
+  });
+
+  it('should show routing preview when user has only managed routes read permission', async () => {
+    grantUserPermissions([AccessControlAction.ActionAlertingManagedRoutesRead]);
+    mockOneAlertManager();
+    mockPreviewApiResponse(server, [
+      mockAlertmanagerAlert({
+        labels: { tomato: 'red', avocate: 'green' },
+      }),
+    ]);
+
+    render(<NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />);
+
+    await waitFor(async () => {
+      const matchingContactPoint = await ui.contactPointGroup.findAll();
+      expect(matchingContactPoint).toHaveLength(1);
+    });
+
+    expect(screen.queryByRole('alert', { name: /preview not available/i })).not.toBeInTheDocument();
+  });
+
+  it('should show permission warning when user has no alerting notification permissions', async () => {
+    grantUserPermissions([]);
+    mockOneAlertManager();
+    mockPreviewApiResponse(server, [
+      mockAlertmanagerAlert({
+        labels: { tomato: 'red', avocate: 'green' },
+      }),
+    ]);
+
+    render(<NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert', { name: /preview not available/i })).toBeInTheDocument();
+    });
+
+    expect(ui.contactPointGroup.query()).not.toBeInTheDocument();
   });
 
   it('should render details when clicking see details button', async () => {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -179,12 +179,14 @@ export const NotificationPreview = ({
  * We check for either:
  * - alert.notifications:read (legacy permission)
  * - alert.notifications.routes:read (new granular permission)
+ * - notifications.alerting.grafana.app/routingtrees:get (K8s managed routes permission)
  */
 function NotificationPreviewGrafanaPermissionCheck({ children }: React.PropsWithChildren) {
   const hasLegacyNotificationPermission = contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead);
   const hasNotificationPolicyTreePermission = contextSrv.hasPermission(AccessControlAction.AlertingRoutesRead);
+  const hasManagedRoutesPermission = contextSrv.hasPermission(AccessControlAction.ActionAlertingManagedRoutesRead);
 
-  if (hasLegacyNotificationPermission || hasNotificationPolicyTreePermission) {
+  if (hasLegacyNotificationPermission || hasNotificationPolicyTreePermission || hasManagedRoutesPermission) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes a permission check for `AccessControlAction.ActionAlertingManagedRoutesRead` that was removed after rolling back the changes from PR #121652. 

**Why do we need this feature?**

The missing permission check was causing users that has only managed routes read permission (`AccessControlAction.ActionAlertingManagedRoutesRead`) to see a missing permission warning when trying to use the route preview functionality

**Who is this feature for?**

Alerting users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
