### PR TITLE
Icon: Add Grid icon to avalable icons

### DIFF
--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -169,6 +169,7 @@ export const availableIconsIndex = {
   'gf-traces': true,
   globe: true,
   grafana: true,
+  grid: true,
   'graph-bar': true,
   'hand-pointer': true,
   heart: true,

--- a/public/app/core/icons/cached.json
+++ b/public/app/core/icons/cached.json
@@ -195,6 +195,7 @@
   "unicons/window-grid",
   "unicons/ban",
   "unicons/git",
+  "unicons/grid",
   "unicons/bitbucket",
   "unicons/tachometer-fast",
   "unicons/tachometer-empty",


### PR DESCRIPTION
**What is this feature?**

- Add the `grid` icon (from `unicons/grid.svg`) to the set of available icons
- icon file [here](https://github.com/grafana/grafana/blob/d383f84e58e70b9f091cf9c6b4e23b87608cbf09/public/img/icons/unicons/grid.svg)

**Why do we need this feature?**

Needed for new entry action design 

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
