### PR TITLE
Logs Explore: cover logs datasources feature toggles to goff

### DIFF
--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -53,6 +53,7 @@ export const sharedDependenciesMap = {
   '@grafana/data': grafanaData,
   '@grafana/data/unstable': () => import('@grafana/data/unstable'),
   '@grafana/runtime': grafanaRuntime,
+  '@grafana/runtime/internal': () => import('@grafana/runtime/internal'),
   '@grafana/runtime/unstable': () => import('@grafana/runtime/unstable'),
   '@grafana/slate-react': () => import('slate-react'),
   '@grafana/ui': grafanaUI,

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { type SelectableValue } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { InlineField, Input, Stack } from '@grafana/ui';
 
 import { LokiQueryType, LokiQueryDirection } from '../dataquery.gen';
@@ -25,22 +26,26 @@ export const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
   },
 ];
 
-export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
-  { value: LokiQueryDirection.Backward, label: 'Backward', description: 'Search in backward direction.' },
-  {
-    value: LokiQueryDirection.Forward,
-    label: 'Forward',
-    description: 'Search in forward direction.',
-  },
-];
+export function getQueryDirections(): Array<SelectableValue<LokiQueryDirection>> {
+  const directions: Array<SelectableValue<LokiQueryDirection>> = [
+    { value: LokiQueryDirection.Backward, label: 'Backward', description: 'Search in backward direction.' },
+    {
+      value: LokiQueryDirection.Forward,
+      label: 'Forward',
+      description: 'Search in forward direction.',
+    },
+  ];
 
-if (config.featureToggles.lokiShardSplitting) {
-  queryDirections.push({
-    value: LokiQueryDirection.Scan,
-    label: 'Scan',
-    description: 'Experimental. Split the query into smaller units and stop at the requested log line limit.',
-    icon: 'exclamation-triangle',
-  });
+  if (getFeatureFlagClient().getBooleanValue(FlagKeys.LokiShardSplitting, false)) {
+    directions.push({
+      value: LokiQueryDirection.Scan,
+      label: 'Scan',
+      description: 'Experimental. Split the query into smaller units and stop at the requested log line limit.',
+      icon: 'exclamation-triangle',
+    });
+  }
+
+  return directions;
 }
 
 if (config.featureToggles.lokiExperimentalStreaming) {
@@ -52,7 +57,7 @@ if (config.featureToggles.lokiExperimentalStreaming) {
 }
 
 export function getQueryDirectionLabel(direction: LokiQueryDirection) {
-  return queryDirections.find((queryDirection) => queryDirection.value === direction)?.label ?? 'Unknown';
+  return getQueryDirections().find((queryDirection) => queryDirection.value === direction)?.label ?? 'Unknown';
 }
 
 export function LokiOptionFields(props: LokiOptionFieldsProps) {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -376,7 +376,10 @@ export class LokiDatasource
       return this.runLiveQueryThroughBackend(fixedRequest);
     }
 
-    if (getFeatureFlagClient().getBooleanValue(FlagKeys.LokiShardSplitting, false) && requestSupportsSharding(fixedRequest.targets)) {
+    if (
+      getFeatureFlagClient().getBooleanValue(FlagKeys.LokiShardSplitting, false) &&
+      requestSupportsSharding(fixedRequest.targets)
+    ) {
       return runShardSplitQuery(this, fixedRequest);
     } else if (config.featureToggles.lokiQuerySplitting && requestSupportsSplitting(fixedRequest.targets)) {
       return runSplitQuery(this, fixedRequest);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -53,6 +53,7 @@ import {
   getTemplateSrv,
   type TemplateSrv,
 } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type DataQuery } from '@grafana/schema';
 
 import LanguageProvider from './LanguageProvider';
@@ -375,7 +376,7 @@ export class LokiDatasource
       return this.runLiveQueryThroughBackend(fixedRequest);
     }
 
-    if (config.featureToggles.lokiShardSplitting && requestSupportsSharding(fixedRequest.targets)) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.LokiShardSplitting, false) && requestSupportsSharding(fixedRequest.targets)) {
       return runShardSplitQuery(this, fixedRequest);
     } else if (config.featureToggles.lokiQuerySplitting && requestSupportsSplitting(fixedRequest.targets)) {
       return runSplitQuery(this, fixedRequest);

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -18,13 +18,31 @@ import { LOKI_MAX_QUERY_BYTES_READ_ERROR_MSG_PREFIX, LOKI_TIMEOUT_ERROR_MSG } fr
 import { trackGroupedQueries } from './tracking';
 import { type LokiQuery } from './types';
 
+jest.mock('@grafana/runtime/internal', () => {
+  const actual = jest.requireActual('@grafana/runtime/internal');
+  const realClient = actual.getFeatureFlagClient();
+  return {
+    ...actual,
+    getFeatureFlagClient: () => ({
+      ...realClient,
+      getBooleanValue(key: string, defaultValue: boolean) {
+        if (key === 'lokiShardSplitting') {
+          return false;
+        }
+        if (key === 'lokiQueryLimitsContext') {
+          return true;
+        }
+        return realClient.getBooleanValue(key, defaultValue);
+      },
+    }),
+  };
+});
+
 jest.mock('./tracking');
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('uuid'),
 }));
 
-const originalShardingFlagState = config.featureToggles.lokiShardSplitting;
-const originalLokiQueryLimitsContextState = config.featureToggles.lokiQueryLimitsContext;
 const originalLokiAlignedQuerySplitting = config.featureToggles.lokiAlignedQuerySplitting;
 const originalErr = console.error;
 beforeEach(() => {
@@ -35,13 +53,9 @@ beforeAll(() => {
   jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
     callback();
   });
-  config.featureToggles.lokiShardSplitting = false;
-  config.featureToggles.lokiQueryLimitsContext = true;
 });
 afterAll(() => {
   jest.mocked(global.setTimeout).mockReset();
-  config.featureToggles.lokiShardSplitting = originalShardingFlagState;
-  config.featureToggles.lokiQueryLimitsContext = originalLokiQueryLimitsContextState;
   config.featureToggles.lokiAlignedQuerySplitting = originalLokiAlignedQuerySplitting;
   console.error = originalErr;
 });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -14,6 +14,7 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 
 import { LokiQueryType, LokiQueryDirection } from './dataquery.gen';
 import { type LokiDatasource } from './datasource';
@@ -143,7 +144,7 @@ export function runSplitGroupedQueries(
   const shardQueryIndex = options.shardQueryIndex ?? 0;
 
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number, requestGroup: number) => {
-    if (config.featureToggles.lokiQueryLimitsContext) {
+    if (getFeatureFlagClient().getBooleanValue('lokiQueryLimitsContext', false)) {
       requests = addLimitsToSplitRequests(splitQueryIndex, shardQueryIndex, requests);
     }
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, LogSortOrderChangeEvent, LogsSortOrder, store } from '@grafana/data';
-import { config, getAppEvents } from '@grafana/runtime';
+import { getAppEvents } from '@grafana/runtime';
 
 import { LokiQueryType, LokiQueryDirection } from '../../dataquery.gen';
 import { createLokiDatasource } from '../../mocks/datasource';
@@ -10,21 +10,30 @@ import { type LokiQuery } from '../../types';
 
 import { LokiQueryBuilderOptions, type Props } from './LokiQueryBuilderOptions';
 
+jest.mock('@grafana/runtime/internal', () => {
+  const actual = jest.requireActual('@grafana/runtime/internal');
+  const realClient = actual.getFeatureFlagClient();
+  return {
+    ...actual,
+    getFeatureFlagClient: () => ({
+      ...realClient,
+      getBooleanValue(key: string, defaultValue: boolean) {
+        if (key === 'lokiShardSplitting') {
+          return true;
+        }
+        return realClient.getBooleanValue(key, defaultValue);
+      },
+    }),
+  };
+});
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  config: {
-    ...jest.requireActual('@grafana/runtime').config,
-    featureToggles: {
-      ...jest.requireActual('@grafana/runtime').featureToggles,
-      lokiShardSplitting: true,
-    },
-  },
   getAppEvents: jest.fn(),
 }));
 
 const subscribeMock = jest.fn();
 beforeAll(() => {
-  config.featureToggles.lokiShardSplitting = true;
   subscribeMock.mockImplementation(() => ({ unsubscribe: jest.fn() }));
   jest.mocked(getAppEvents).mockReturnValue({
     publish: jest.fn(),

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -9,8 +9,8 @@ import { AutoSizeInput, Box, RadioButtonGroup } from '@grafana/ui';
 
 import {
   getQueryDirectionLabel,
+  getQueryDirections,
   preprocessMaxLines,
-  queryDirections,
   queryTypeOptions,
 } from '../../components/LokiOptionFields';
 import { placeHolderScopedVars } from '../../components/monaco-query-field/monaco-completion-provider/validation';
@@ -171,7 +171,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
               </EditorField>
               <EditorField label="Direction" tooltip="Direction to search for logs.">
                 <RadioButtonGroup
-                  options={queryDirections}
+                  options={getQueryDirections()}
                   value={query.direction ?? getDefaultQueryDirection(app)}
                   onChange={onQueryDirectionChange}
                 />

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -1,7 +1,6 @@
 import { of } from 'rxjs';
 
 import { type DataQueryRequest, type DataQueryResponse, dateTime, LoadingState } from '@grafana/data';
-import { config } from '@grafana/runtime';
 
 import { LokiQueryDirection, LokiQueryType } from './dataquery.gen';
 import { type LokiDatasource } from './datasource';
@@ -11,11 +10,26 @@ import { LOKI_MAX_QUERY_BYTES_READ_ERROR_MSG_PREFIX, LOKI_TIMEOUT_ERROR_MSG } fr
 import { runShardSplitQuery } from './shardQuerySplitting';
 import { type LokiQuery } from './types';
 
+jest.mock('@grafana/runtime/internal', () => {
+  const actual = jest.requireActual('@grafana/runtime/internal');
+  const realClient = actual.getFeatureFlagClient();
+  return {
+    ...actual,
+    getFeatureFlagClient: () => ({
+      ...realClient,
+      getBooleanValue(key: string, defaultValue: boolean) {
+        if (key === 'lokiQueryLimitsContext') {
+          return true;
+        }
+        return realClient.getBooleanValue(key, defaultValue);
+      },
+    }),
+  };
+});
+
 jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('uuid'),
 }));
-
-const originalLokiQueryLimitsContextState = config.featureToggles.lokiQueryLimitsContext;
 
 const originalLog = console.log;
 const originalWarn = console.warn;
@@ -25,14 +39,10 @@ beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   jest.spyOn(console, 'error').mockImplementation(() => {});
 });
-beforeAll(() => {
-  config.featureToggles.lokiQueryLimitsContext = true;
-});
 afterAll(() => {
   console.log = originalLog;
   console.warn = originalWarn;
   console.error = originalErr;
-  config.featureToggles.lokiQueryLimitsContext = originalLokiQueryLimitsContextState;
 });
 
 describe('runShardSplitQuery()', () => {

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -3,7 +3,7 @@ import { Observable, type Subscriber, type Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 
 import { type LokiDatasource } from './datasource';
 import { combineResponses, replaceResponses } from './mergeResponses';
@@ -85,7 +85,7 @@ function splitQueriesByStreamShard(
   let queryIndex = 0;
 
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, group: number, groups: ShardedQueryGroup[]) => {
-    if (config.featureToggles.lokiQueryLimitsContext) {
+    if (getFeatureFlagClient().getBooleanValue('lokiQueryLimitsContext', false)) {
       groups = addLimitsToShardGroups(queryIndex, groups, request);
     }
     queryIndex++;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- https://github.com/grafana/logs-drilldown/issues/1704
- Attempting to close out this epic
## Summary 📝

- The e2e fail because it cannot find `grafana/runtime/internal`. Adding it to `shared/dependencies` fixes it, but it's unlikely that is okay to expose.
- Loki datasource and query splitting now read **`lokiShardSplitting`** via OpenFeature (`getFeatureFlagClient().getBooleanValue` + `FlagKeys.LokiShardSplitting`) instead of `config.featureToggles`, including the shard-splitting code path in `datasource.ts` and the **Scan** direction in `LokiOptionFields` / `LokiQueryBuilderOptions` (via `getQueryDirections()`).
- **`lokiQueryLimitsContext`** is evaluated with **`getFeatureFlagClient().getBooleanValue('lokiQueryLimitsContext', false)`** in `querySplitting.ts` and `shardQuerySplitting.ts` (string key; no React codegen dependency for this toggle).
- Unit tests stub **`@grafana/runtime/internal`** with fixed `getBooleanValue` overrides instead of mutating `config.featureToggles`, aligned with the new evaluation path.

## Test 🧪

- [x] `yarn test:ci` in `public/app/plugins/datasource/loki` for `querySplitting.test.ts`, `shardQuerySplitting.test.ts`, and `querybuilder/components/LokiQueryBuilderOptions.test.tsx` (all tests in those files passed).
- [x] Manual: enable `lokiShardSplitting` / `lokiQueryLimitsContext` (e.g. `conf/custom.ini` `[feature_toggles]` or your env), restart backend, Explore with Loki — confirm shard splitting / Scan direction and limits-context behavior match expectations; optional DevTools → Network filter `flags` to confirm keys.
- [x] Regression: with flags off, confirm time-based splitting still follows `lokiQuerySplitting` / existing config toggles unchanged by this PR.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
