### PR TITLE
Permissions: Skip ds type check if wildcard

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -186,7 +186,10 @@ func (m *MappersRegistry) ParseScope(scope, datasourceType string) (*groupResour
 		return nil, fmt.Errorf("%w: %s", errUnknownGroupResource, parts[0])
 	}
 
-	group := resolveGroup(gr.Group, datasourceType)
+	group := gr.Group
+	if parts[2] != "*" || datasourceType != "" {
+		group = resolveGroup(group, datasourceType)
+	}
 
 	return &groupResourceName{Group: group, Resource: gr.Resource, Name: parts[2]}, nil
 }
@@ -283,7 +286,10 @@ func (m *MappersRegistry) ParseScopeCtx(ctx context.Context, ns types.NamespaceI
 	}
 
 	entry := m.entries[gr]
-	group := resolveGroup(gr.Group, datasourceType)
+	group := gr.Group
+	if parts[2] != "*" || datasourceType != "" {
+		group = resolveGroup(group, datasourceType)
+	}
 
 	name := parts[2]
 	if isIDScoped(entry.mapper) && store != nil {

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -325,6 +325,21 @@ func TestMappersRegistry_Wildcard_ParseScope(t *testing.T) {
 	assert.Equal(t, "loki.datasource.grafana.app", grn.Group)
 	assert.Equal(t, "datasources", grn.Resource)
 	assert.Equal(t, "ds1", grn.Name)
+
+	t.Run("wildcard scope identifier preserves wildcard group", func(t *testing.T) {
+		grn, err := m.ParseScope("datasources:uid:*", "")
+		require.NoError(t, err)
+		assert.Equal(t, "*.datasource.grafana.app", grn.Group)
+		assert.Equal(t, "datasources", grn.Resource)
+		assert.Equal(t, "*", grn.Name)
+	})
+
+	t.Run("wildcard scope identifier resolves group when type is provided", func(t *testing.T) {
+		grn, err := m.ParseScope("datasources:uid:*", "loki")
+		require.NoError(t, err)
+		assert.Equal(t, "loki.datasource.grafana.app", grn.Group)
+		assert.Equal(t, "*", grn.Name)
+	})
 }
 
 func TestMappersRegistry_MultipleWildcards(t *testing.T) {

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -227,7 +227,7 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 	}
 
 	var datasourceType string
-	if s.options.DatasourceTypeResolver != nil {
+	if s.options.DatasourceTypeResolver != nil && resourceID != "*" {
 		if t, err := s.options.DatasourceTypeResolver(ctx, orgID, resourceID); err == nil {
 			datasourceType = t
 		}
@@ -261,7 +261,7 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 	}
 
 	var datasourceType string
-	if s.options.DatasourceTypeResolver != nil {
+	if s.options.DatasourceTypeResolver != nil && resourceID != "*" {
 		if t, err := s.options.DatasourceTypeResolver(ctx, orgID, resourceID); err == nil {
 			datasourceType = t
 		}
@@ -295,7 +295,7 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 	}
 
 	var datasourceType string
-	if s.options.DatasourceTypeResolver != nil {
+	if s.options.DatasourceTypeResolver != nil && resourceID != "*" {
 		if t, err := s.options.DatasourceTypeResolver(ctx, orgID, resourceID); err == nil {
 			datasourceType = t
 		}
@@ -323,7 +323,7 @@ func (s *Service) SetPermissions(
 	}
 
 	var datasourceType string
-	if s.options.DatasourceTypeResolver != nil {
+	if s.options.DatasourceTypeResolver != nil && resourceID != "*" {
 		if t, err := s.options.DatasourceTypeResolver(ctx, orgID, resourceID); err == nil {
 			datasourceType = t
 		}


### PR DESCRIPTION
Previously, the lookups were only skipped if the scope was `datasources:*`, not `datasources:uid:*`. This PR skips it for the second one now too.