### PR TITLE
FT: use Generate instead of removed FrontendOnly field

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1618,12 +1618,12 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:         "teamLBACApiWriteFromAppPlatform",
-			Description:  "Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server",
-			Stage:        FeatureStageExperimental,
-			FrontendOnly: false,
-			Owner:        identityAccessTeam,
-			Expression:   "false",
+			Name:        "teamLBACApiWriteFromAppPlatform",
+			Description: "Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
+			Owner:       identityAccessTeam,
+			Expression:  "false",
 		},
 		{
 			Name:        "grafanaAdvisor",


### PR DESCRIPTION
A field was changed in feature toggle definitions between when I checked out `main` and when I merged the PR.

This broke the `main` build.  This PR fixes that by using the new feature toggle definition field.