### PR TITLE
Feature flags: Fix teamLBACApiWriteFromAppPlatform build error

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -960,11 +960,6 @@ export interface FeatureToggles {
   */
   teamLBACApiReadFromAppPlatform?: boolean;
   /**
-  * Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server
-  * @default false
-  */
-  teamLBACApiWriteFromAppPlatform?: boolean;
-  /**
   * Enables Advisor app
   * @default true
   */

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -960,6 +960,11 @@ export interface FeatureToggles {
   */
   teamLBACApiReadFromAppPlatform?: boolean;
   /**
+  * Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server
+  * @default false
+  */
+  teamLBACApiWriteFromAppPlatform?: boolean;
+  /**
   * Enables Advisor app
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1623,7 +1623,7 @@ var (
 			Stage:       FeatureStageExperimental,
 			Owner:       identityAccessTeam,
 			Expression:  "false",
-			Generate:    Generate{LegacyGo: true},
+			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
 			Name:        "grafanaAdvisor",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1618,12 +1618,12 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:         "teamLBACApiWriteFromAppPlatform",
-			Description:  "Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server",
-			Stage:        FeatureStageExperimental,
-			FrontendOnly: false,
-			Owner:        identityAccessTeam,
-			Expression:   "false",
+			Name:        "teamLBACApiWriteFromAppPlatform",
+			Description: "Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server",
+			Stage:       FeatureStageExperimental,
+			Owner:       identityAccessTeam,
+			Expression:  "false",
+			Generate:    Generate{LegacyGo: true},
 		},
 		{
 			Name:        "grafanaAdvisor",


### PR DESCRIPTION
## Summary

Fixes build error caused by the `teamLBACApiWriteFromAppPlatform` feature flag using the removed `FrontendOnly` field. Replaces it with `Generate: Generate{LegacyGo: true}` to match the new feature flag struct.

## What changed

- **`pkg/services/featuremgmt/registry.go`** — Removed `FrontendOnly: false`, added `Generate: Generate{LegacyGo: true}`
- **Generated files** — Regenerated toggles

## Test plan

- `make gen-feature-toggles` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)