### PR TITLE
QuickAdd: From template action rename to Use template

### DIFF
--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.test.tsx
@@ -118,29 +118,29 @@ describe('QuickAdd', () => {
     expect(within(ungroupedGroup!).getByRole('menuitem', { name: 'New import' })).toBeInTheDocument();
   });
 
-  describe('Dashboard from template button', () => {
+  describe('Use template button', () => {
     beforeEach(() => {
       config.featureToggles.dashboardTemplates = true;
     });
 
-    it('shows a `From template` button when the feature flag is enabled', async () => {
+    it('shows a `Use template` button when the feature flag is enabled', async () => {
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.getByRole('menuitem', { name: 'From template' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Use template' })).toBeInTheDocument();
     });
 
-    it('does not show a `Dashboard from template` button when the feature flag is disabled', async () => {
+    it('does not show a `Use template` button when the feature flag is disabled', async () => {
       config.featureToggles.dashboardTemplates = false;
       setup();
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      expect(screen.queryByRole('menuitem', { name: 'From template' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Use template' })).not.toBeInTheDocument();
     });
 
     it('redirects the user to the dashboard from template page when the button is clicked', async () => {
       setup();
 
       await userEvent.click(screen.getByRole('button', { name: 'New' }));
-      const link = screen.getByRole('menuitem', { name: 'From template' });
+      const link = screen.getByRole('menuitem', { name: 'Use template' });
       expect(link).toHaveAttribute('href', '/dashboards?templateDashboards=true&source=quickAdd');
     });
   });

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -36,7 +36,7 @@ export const QuickAdd = ({}: Props) => {
       if (testDataSources.length > 0) {
         const templateItem: NavModelItem = {
           id: 'browse-template-dashboard',
-          text: t('navigation.quick-add.new-template-dashboard-button', 'From template'),
+          text: t('navigation.quick-add.new-template-dashboard-button', 'Use template'),
           url: '/dashboards?templateDashboards=true&source=quickAdd',
           onClick: () => {
             isAnalyticsFrameworkEnabled

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12232,7 +12232,7 @@
     },
     "quick-add": {
       "aria-label": "New",
-      "new-template-dashboard-button": "From template"
+      "new-template-dashboard-button": "Use template"
     },
     "rss-button": "Latest from the blog"
   },


### PR DESCRIPTION
**What is this feature?**

QuickAdd: Rename `From template` to `Use template` - this aligns create new button   
<img width="300" height="272" alt="image" src="https://github.com/user-attachments/assets/a6da7b5b-ca9d-42e5-a4db-82383b41941f" />


**Why do we need this feature?**

Make action text consistent with other spots

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/119548

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
