### PR TITLE
Docs: Document minimum width/height for image rendering

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2595,11 +2595,11 @@ Path to the PEM-encoded CA certificate file from the Image Renderer server.
 
 #### `default_image_width`
 
-Configures the width of the rendered image. The default width is `1000`.
+Configures the width of the rendered image. The default and minimum width is `1000`.
 
 #### `default_image_height`
 
-Configures the height of the rendered image. The default height is `500`.
+Configures the height of the rendered image. The default and minimum height is `500`.
 
 #### `default_image_scale`
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2595,11 +2595,11 @@ Path to the PEM-encoded CA certificate file from the Image Renderer server.
 
 #### `default_image_width`
 
-Configures the width of the rendered image. The default and minimum width is `1000`.
+Configures the width of the rendered image. The default width is `1000`.
 
 #### `default_image_height`
 
-Configures the height of the rendered image. The default and minimum height is `500`.
+Configures the height of the rendered image. The default height is `500`.
 
 #### `default_image_scale`
 

--- a/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
@@ -251,11 +251,11 @@ To share a personalized, direct link to your panel within your organization, fol
 1. Click **Copy link**.
 1. Send the copied link to a Grafana user with authorization to view it.
 1. (Optional) To [generate an image of the panel as a PNG file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/image-rendering/), customize the image settings:
-   - **Width** - In pixels. The default is 1000.
-   - **Height** - In pixels. The default is 500.
+   - **Width** - In pixels. The default and minimum is 1000.
+   - **Height** - In pixels. The default and minimum is 500.
    - **Scale factor** - The default is 1.
 
-   There are maximums for width, height, and scale factor in the image renderer [configuration options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/image-rendering/troubleshooting/#available-configuration-options) that you can customize if needed.
+   There are minimums and maximums for width, height, and scale factor in the image renderer [configuration options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/image-rendering/troubleshooting/#available-configuration-options) that you can customize if needed.
 
 1. (Optional) Click **Generate image** to see a preview of the panel image.
 1. (Optional) Click **Download image**.
@@ -268,14 +268,14 @@ When you click **Generate image** in the panel link settings, Grafana generates 
 
 | Parameter | Description                                                                                                                    |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| width     | Width in pixels. Default is 1000.                                                                                              |
-| height    | Height in pixels. Default is 500.                                                                                              |
+| width     | Width in pixels. Default and minimum is 1000.                                                                                  |
+| height    | Height in pixels. Default and minimum is 500.                                                                                  |
 | tz        | Timezone in the format `UTC%2BHH%3AMM` where HH and MM are offset in hours and minutes after UTC.                              |
 | timeout   | Number of seconds. The timeout can be increased if the query for the panel needs more than the default 30 seconds.             |
 | scale     | Numeric value to configure device scale factor. Default is 1. Use a higher value to produce more detailed images (higher DPI). |
 
 {{< admonition type="note" >}}
-The image renderer enforces minimum width and height requirements. You can customize these minimums in self-managed Grafana installations through the [image renderer configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/image-rendering/#configuration). In Grafana Cloud, the configuration is managed by Grafana and can't be modified. If you encounter size-related errors when rendering images using the API, ensure your dimensions meet the minimum requirements.
+The image renderer enforces minimum dimensions of 1000px for width and 500px for height. You can customize these minimums in self-managed Grafana installations through the [image renderer configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/image-rendering/#configuration). In Grafana Cloud, the configuration is managed by Grafana and can't be modified. If you encounter size-related errors when rendering images using the API, ensure your dimensions meet the minimum requirements.
 {{< /admonition >}}
 
 You can also update these parameters in the [image rendering configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/image-rendering/#configuration).


### PR DESCRIPTION
## Summary
- Clarify that the image renderer enforces minimum dimensions of 1000px for width and 500px for height
- Update the share panel docs: step 7 bullet points, query string parameters table, and admonition note

## Test plan
- [ ] Verify docs render correctly with `make docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)