### PR TITLE
Docs: Replace "ad hoc filters" with "filters" in several places

### DIFF
--- a/docs/sources/datasources/elasticsearch/template-variables/index.md
+++ b/docs/sources/datasources/elasticsearch/template-variables/index.md
@@ -26,12 +26,12 @@ Grafana refers to such variables as template variables.
 
 For an introduction to templating and template variables, refer to the [Templating](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/) and [Add and manage variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/) documentation.
 
-## Use ad hoc filters
+## Use filters
 
-Elasticsearch supports the **Ad hoc filters** variable type.
+Elasticsearch supports the **Filters** variable type.
 You can use this variable type to specify any number of key/value filters, and Grafana applies them automatically to all of your Elasticsearch queries.
 
-Ad hoc filters support the following operators:
+Filters support the following operators:
 
 | Operator | Description                                                   |
 | -------- | ------------------------------------------------------------- |
@@ -42,7 +42,7 @@ Ad hoc filters support the following operators:
 | `>`      | Greater than. Adds `AND field:>value` to the query.           |
 | `<`      | Less than. Adds `AND field:<value` to the query.              |
 
-For more information, refer to [Add ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
+For more information, refer to [Add Filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
 
 ## Choose a variable syntax
 

--- a/docs/sources/datasources/influxdb/template-variables/index.md
+++ b/docs/sources/datasources/influxdb/template-variables/index.md
@@ -61,11 +61,11 @@ SHOW TAG KEYS [FROM <measurement_name>]
 
 If you have a variable containing key names, you can use it in a **GROUP BY** clause. This allows you to adjust the grouping by selecting from the variable list at the top of the dashboard
 
-## Use ad hoc filters
+## Use filters
 
-InfluxDB supports the **Ad hoc filters** variable type. This variable type allows you to define multiple key/value filters, which Grafana then automatically applies to all your InfluxDB queries.
+InfluxDB supports the **Filters** variable type. This variable type allows you to define multiple key/value filters, which Grafana then automatically applies to all your InfluxDB queries.
 
-For more information, refer to [Add ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
+For more information, refer to [Add filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
 
 ## Choose a variable syntax
 

--- a/docs/sources/datasources/loki/template-variables/index.md
+++ b/docs/sources/datasources/loki/template-variables/index.md
@@ -40,12 +40,12 @@ The form has these options:
 | Label values | `label`       |                         | Label values for `label`.                                        |
 | Label values | `label`       | `log stream selector`   | Label values for `label` in the specified `log stream selector`. |
 
-## Use ad hoc filters
+## Use filters
 
-Loki supports the special **Ad hoc filters** variable type.
+Loki supports the special **Filters** variable type.
 You can use this variable type to specify any number of key/value filters, and Grafana applies them automatically to all of your Loki queries.
 
-For more information, refer to [Add ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
+For more information, refer to [Add filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
 
 ## Use $\_\_auto variable for Loki metric queries
 

--- a/docs/sources/datasources/prometheus/template-variables/_index.md
+++ b/docs/sources/datasources/prometheus/template-variables/_index.md
@@ -142,6 +142,6 @@ The Prometheus data source supports two variable syntaxes for use in the **Query
 
 If you've enabled the `Multi-value` or `Include all value` options, Grafana converts the labels from plain text to a regex-compatible string, which requires you to use `=~` instead of `=`.
 
-## Use the ad hoc filters variable type
+## Use the filters variable type
 
-Prometheus supports the special [ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters) variable type, which allows you to dynamically apply label/value filters across your dashboards. These filters are automatically added to all Prometheus queries, allowing dynamic filtering without modifying individual queries.
+Prometheus supports the special [filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters) variable type, which allows you to dynamically apply label/value filters across your dashboards. These filters are automatically added to all Prometheus queries, allowing dynamic filtering without modifying individual queries.

--- a/docs/sources/datasources/testdata/template-variables/index.md
+++ b/docs/sources/datasources/testdata/template-variables/index.md
@@ -120,4 +120,4 @@ With a variable named `env` set to `production`, entering `env=$env` in the **La
 
 ## Limitations
 
-TestData doesn't support [ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters). Ad hoc filters require the data source to implement tag key and value lookups, which TestData doesn't provide.
+TestData doesn't support the [filters variable](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters). Filters require the data source to implement tag key and value lookups, which TestData doesn't provide.

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -330,7 +330,7 @@
     },
     "multiValueFilterOperators": {
       "type": "boolean",
-      "description": "For data source plugins, if the plugin supports multi value operators in adhoc filters."
+      "description": "For data source plugins, if the plugin supports multi value operators in filters."
     },
     "pascalName": {
       "type": "string",

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/index.md
@@ -81,9 +81,9 @@ Grafana interprets `var-example=value1&var-example=value2` as the dashboard vari
 
 [This dashboard in Grafana Play](https://play.grafana.org/d/000000074/alerting?var-app=backend&var-server=backend_01&var-server=backend_03&var-interval=1h) passes the variable `server` with multiple values, and the variables `app` and `interval` with a single value each.
 
-## Ad hoc filters
+## Filters
 
-Ad hoc filters apply key/value filters to all metric queries that use the specified data source. For more information, refer to [Add ad hoc filters](ref:ad-hoc-filters).
+Filters apply key/value filters to all metric queries that use the specified data source. For more information, refer to [Add filters](ref:ad-hoc-filters).
 
 To pass an ad hoc filter as a query parameter, use the variable syntax to pass the ad hoc filter variable. Then provide the key, operator, and value as a pipe-separated list.
 
@@ -96,12 +96,12 @@ https://${your-domain}/path/to/your/dashboard?var-adhoc=example_key|=|example_va
 In this URL, the query parameter `var-adhoc=key|=|value` applies the ad hoc filter configured as the `adhoc` dashboard variable using the `example_key` key, the `=` operator, and the `example_value` value.
 
 {{< admonition type="note" >}}
-When sharing URLs with ad hoc filters, remember to encode the URL. In the preceding example, replace the pipes (`|`) with `%7C` and the equality operator (`=`) with `%3D`.
+When sharing URLs with filters, remember to encode the URL. In the preceding example, replace the pipes (`|`) with `%7C` and the equality operator (`=`) with `%3D`.
 {{< /admonition >}}
 
 ### Example
 
-[This dashboard in Grafana Play](https://play.grafana.org/d/p-k6QtkGz/template-redux?var-interval=$__auto&orgId=1&from=now-5m&to=now&timezone=utc&var-query=$__all&var-query2=$__all&var-query3=$__all&var-Filters=job%7C%3D%7Cmetrictank%2Ftsdb-gw&var-textbox=foo&var-custom=lisa&var-datasource=grafanacloud-demoinfra-prom) passes the ad hoc filter variable `Filters` with the filter value `job = metrictank/tsdb-gw`.
+[This dashboard in Grafana Play](https://play.grafana.org/d/p-k6QtkGz/template-redux?var-interval=$__auto&orgId=1&from=now-5m&to=now&timezone=utc&var-query=$__all&var-query2=$__all&var-query3=$__all&var-Filters=job%7C%3D%7Cmetrictank%2Ftsdb-gw&var-textbox=foo&var-custom=lisa&var-datasource=grafanacloud-demoinfra-prom) passes the filter variable `Filters` with the filter value `job = metrictank/tsdb-gw`.
 
 ## Time range control using the URL
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/index.md
@@ -18,7 +18,7 @@ title: Dashboard URL variables
 description: Use variables in dashboard URLs to add more context to your links
 weight: 250
 refs:
-  ad-hoc-filters:
+  filters:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#add-ad-hoc-filters
     - pattern: /docs/grafana-cloud/
@@ -83,7 +83,7 @@ Grafana interprets `var-example=value1&var-example=value2` as the dashboard vari
 
 ## Filters
 
-Filters apply key/value filters to all metric queries that use the specified data source. For more information, refer to [Add filters](ref:ad-hoc-filters).
+Filters apply key/value filters to all metric queries that use the specified data source. For more information, refer to [Add filters](ref:filters).
 
 To pass a filter as a query parameter, use the variable syntax to pass the filter variable. Then provide the key, operator, and value as a pipe-separated list.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/index.md
@@ -85,7 +85,7 @@ Grafana interprets `var-example=value1&var-example=value2` as the dashboard vari
 
 Filters apply key/value filters to all metric queries that use the specified data source. For more information, refer to [Add filters](ref:ad-hoc-filters).
 
-To pass an ad hoc filter as a query parameter, use the variable syntax to pass the ad hoc filter variable. Then provide the key, operator, and value as a pipe-separated list.
+To pass a filter as a query parameter, use the variable syntax to pass the filter variable. Then provide the key, operator, and value as a pipe-separated list.
 
 For example:
 
@@ -93,7 +93,7 @@ For example:
 https://${your-domain}/path/to/your/dashboard?var-adhoc=example_key|=|example_value
 ```
 
-In this URL, the query parameter `var-adhoc=key|=|value` applies the ad hoc filter configured as the `adhoc` dashboard variable using the `example_key` key, the `=` operator, and the `example_value` value.
+In this URL, the query parameter `var-adhoc=key|=|value` applies the filter configured as the `adhoc` dashboard variable using the `example_key` key, the `=` operator, and the `example_value` value.
 
 {{< admonition type="note" >}}
 When sharing URLs with filters, remember to encode the URL. In the preceding example, replace the pipes (`|`) with `%7C` and the equality operator (`=`) with `%3D`.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -29,10 +29,14 @@ In the **Dashboard controls** section of the sidebar, you can add variables, ann
 Filter and group by is currently in public preview.
 Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
-To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
-{{< /admonition >}}
+This feature renames the **Filters** variable (formerly ad hoc filter) to **Filter and Group by** and extends it by adding grouping for Prometheus and Loki data sources.
+However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
 
-<!--TODO: -->
+To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
+
+For information on the generally available filters experience, refer to the [Variables documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters).
+While that documentation reflects the generally available experience, the information applies to the filter and group by feature as well.
+{{< /admonition >}}
 
 <!-- vale Grafana.Spelling = YES -->
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls.md
@@ -32,6 +32,8 @@ Grafana Labs offers limited support, and breaking changes might occur prior to t
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
 {{< /admonition >}}
 
+<!--TODO: -->
+
 <!-- vale Grafana.Spelling = YES -->
 
 The filter and group by is one of the most complex and flexible variable options available.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
@@ -245,4 +245,4 @@ Also, grouping-level variables carry over when you convert between rows and tabs
 
 Grouping-level variables are supported for all variable types.
 However, they aren't supported for the public preview **Filter and group by** feature, which replaces the **Filters** variable when the `dashboardUnifiedDrilldownControls` feature toggle is enabled.
-For more information on **Filter and group by**, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
+For more information on **Filter and group by**, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/#filter-and-group-by).

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
@@ -243,10 +243,6 @@ Panels in the grouping resolve grouping-level variables first, then fall back to
 The panel query editor is context-aware, so the autocomplete only shows the variables available to the panel you're editing.
 Also, grouping-level variables carry over when you convert between rows and tabs, change layouts, and work with repeating rows and tabs.
 
-<!-- vale Grafana.Spelling = NO -->
-
-Grouping-level variables are supported for all variable types except **Filter and group by** (formerly ad hoc variables).
-
-<!-- vale Grafana.Spelling = YES -->
-
-<!-- TODO: -->
+Grouping-level variables are supported for all variable types.
+However, they aren't supported for the public preview **Filter and group by** feature, which replaces the **Filters** variable when the `dashboardUnifiedDrilldownControls` feature toggle is enabled.
+For more information on **Filter and group by**, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
@@ -248,3 +248,5 @@ Also, grouping-level variables carry over when you convert between rows and tabs
 Grouping-level variables are supported for all variable types except **Filter and group by** (formerly ad hoc variables).
 
 <!-- vale Grafana.Spelling = YES -->
+
+<!-- TODO: -->

--- a/docs/sources/visualizations/dashboards/use-dashboards/index.md
+++ b/docs/sources/visualizations/dashboards/use-dashboards/index.md
@@ -371,7 +371,6 @@ To filter dashboard data, follow these steps:
 1. Repeat this process as needed until you have all the filters you need.
 
    ![Filters](/media/docs/grafana/dashboards/screenshot-adhoc-filters-v11.3.png)
-   <!-- TODO: Update screenshot -->
 
 ### Edit or delete filters
 
@@ -381,7 +380,7 @@ To edit or delete filters, follow these steps:
 1. Do one of the following:
    - To edit the operator or value of a filter, click anywhere on the filter and update it.
 
-     ![Editing an ad hoc filter](/media/docs/grafana/dashboards/screenshot-edit-filters-v11.3.png)
+     ![Editing a filter](/media/docs/grafana/dashboards/screenshot-edit-filters-v11.3.png)
 
    - To change the filter label, you must delete the filter and create a new one.
    - To delete a filter, click the **X** next to it.

--- a/docs/sources/visualizations/dashboards/use-dashboards/index.md
+++ b/docs/sources/visualizations/dashboards/use-dashboards/index.md
@@ -67,7 +67,7 @@ image_maps:
         content: |
           **Variables**
 
-          Use [variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/), including ad hoc filters, to create more interactive and dynamic dashboards.
+          Use [variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/), including filters, to create more interactive and dynamic dashboards.
       - x_coord: 45
         y_coord: 23
         content: |
@@ -370,7 +370,8 @@ To filter dashboard data, follow these steps:
 
 1. Repeat this process as needed until you have all the filters you need.
 
-   ![Ad hoc filters](/media/docs/grafana/dashboards/screenshot-adhoc-filters-v11.3.png)
+   ![Filters](/media/docs/grafana/dashboards/screenshot-adhoc-filters-v11.3.png)
+   <!-- TODO: Update screenshot -->
 
 ### Edit or delete filters
 

--- a/docs/sources/visualizations/dashboards/use-dashboards/index.md
+++ b/docs/sources/visualizations/dashboards/use-dashboards/index.md
@@ -358,7 +358,7 @@ Selecting the **Auto** interval schedules a refresh based on the query time rang
 
 ## Filter dashboard data
 
-Once you've [added a filter](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters) in the dashboard settings, you can create label/value filter pairs on the dashboard.
+After you've [added a filter](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters) in the dashboard settings, you can create label/value filter pairs on the dashboard.
 These filters are applied to all metric queries that use the specified data source and to all panels on the dashboard.
 
 To filter dashboard data, follow these steps:

--- a/docs/sources/visualizations/dashboards/use-dashboards/index.md
+++ b/docs/sources/visualizations/dashboards/use-dashboards/index.md
@@ -358,7 +358,7 @@ Selecting the **Auto** interval schedules a refresh based on the query time rang
 
 ## Filter dashboard data
 
-Once you've [added an ad hoc filter](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters) in the dashboard settings, you can create label/value filter pairs on the dashboard.
+Once you've [added a filter](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters) in the dashboard settings, you can create label/value filter pairs on the dashboard.
 These filters are applied to all metric queries that use the specified data source and to all panels on the dashboard.
 
 To filter dashboard data, follow these steps:

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -339,6 +339,8 @@ To use this feature, enable the `dashboardUnifiedDrilldownControls` feature togg
 For more information on filter and group by, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
 {{< /admonition >}}
 
+<!--TODO: -->
+
 _Filters_ are one of the most complex and flexible variable options available.
 Instead of creating a variable for each dimension by which you want to filter, filters automatically create variables (key/value pairs) for all the dimensions returned by your data source query.
 This allows you to apply filters dashboard-wide.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -356,7 +356,7 @@ The following data sources support filters:
 - Elasticsearch
 - OpenSearch
 
-To create an ad hoc filter, follow these steps:
+To create a filter, follow these steps:
 
 1. [Enter general options](#enter-general-options).
 1. Under the **Filter options** section of the page, select a target data source in the **Data source** drop-down list.
@@ -408,7 +408,7 @@ To use filters on data from an unsupported data source, follow these steps:
    - **AdHoc Filters** - Toggle on the switch to make the data from the referenced panel filterable.
 
    {{< admonition type="note">}}
-   If you're referencing multiple panels in a dashboard with the Dashboard data source, you can only use one of those source panels at a time for ad hoc filtering.
+   If you're referencing multiple panels in a dashboard with the Dashboard data source, you can only use one of those source panels at a time for filtering.
    {{< /admonition >}}
 
 1. Configure any other needed options for the panel.
@@ -422,27 +422,27 @@ Add as many panels as you need.
 ### Dashboard drilldown with filters
 
 In table and bar chart visualizations, you can apply filters directly from the visualization.
-To quickly apply ad hoc filter variables, follow these steps:
+To quickly apply filter variables, follow these steps:
 
 1. To display the filter icons, hover your cursor over the table cell with the value for which you want to filter. In this example, the cell value is `ConfigMap Updated`, which is in the `alertname` column:
 
-   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-v12.2.png" max-width="550px" alt="Table and bar chart with ad hoc filter icon displayed on a table cell" >}}
+   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-v12.2.png" max-width="550px" alt="Table and bar chart with a filter icon displayed on a table cell" >}}
 
    In bar chart visualizations, hover and click the bar to display the filter button:
 
-   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-bar-v12.2.png" max-width="300px" alt="The ad hoc filter button in a bar chart tooltip">}}
+   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-bar-v12.2.png" max-width="300px" alt="The filter button in a bar chart tooltip">}}
 
 1. Click the add filter icon.
 
-   The variable pair `alertname = ConfigMap Updated` is added to the ad hoc filter and all panels using the same data source that include that variable value are filtered by that value:
+   The variable pair `alertname = ConfigMap Updated` is added to the filter and all panels using the same data source that include that variable value are filtered by that value:
 
    {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-applied-v12.2.png" max-width="550px" alt="Table and bar chart, filtered" >}}
 
-If one of the panels in the dashboard using that data source doesn't include that variable value, the panel won't return any data. In this example, the variable pair `_name_ = ALERTS` has been added to the ad hoc filter so the bar chart doesn't return any results:
+If one of the panels in the dashboard using that data source doesn't include that variable value, the panel won't return any data. In this example, the variable pair `_name_ = ALERTS` has been added to the filter so the bar chart doesn't return any results:
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-no-data-v12.2.png" max-width="650px" alt="Table, filtered and bar chart returning no results" >}}
 
-In cases where the data source you're using doesn't support ad hoc filtering, consider using the special Dashboard data source.
+In cases where the data source you're using doesn't support filtering, consider using the special Dashboard data source.
 For more information, refer to [Filter any data using the Dashboard data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#filter-any-data-using-the-dashboard-data-source).
 
 ## Add a switch variable

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -91,9 +91,9 @@ refs:
 
 # Add variables
 
-<!-- vale Grafana.Spelling = NO -->
-
 The following table lists the types of variables shipped with Grafana.
+
+<!-- vale Grafana.Spelling = NO -->
 
 <!-- prettier-ignore-start -->
 
@@ -105,7 +105,7 @@ The following table lists the types of variables shipped with Grafana.
 | Constant          | Define a hidden constant. [Add a constant variable](#add-a-constant-variable).                                                                                                          |
 | Data source       | Quickly change the data source for an entire dashboard. [Add a data source variable](#add-a-data-source-variable).                                                                      |
 | Interval          | Interval variables represent time spans. [Add an interval variable](#add-an-interval-variable).                                                                                         |
-| Ad hoc filters    | Key/value filters that are automatically added to all metric queries for a data source (Prometheus, Loki, InfluxDB, and Elasticsearch only). [Add ad hoc filters](#add-ad-hoc-filters). |
+| Filters    | Key/value filters that are automatically added to all metric queries for a data source (Prometheus, Loki, InfluxDB, and Elasticsearch only). [Add filters](#add-ad-hoc-filters). |
 | Switch            | Display a switch that allows you to toggle between two configurable values for enabled and disabled states. [Add a switch variable](#add-a-switch-variable).                            |
 | Global variables  | Built-in variables that can be used in expressions in the query editor. Refer to [Global variables](#global-variables).                                                                 |
 | Chained variables | Variable queries can contain other variables. Refer to [Chained variables](#chained-variables).                                                                                         |
@@ -152,7 +152,7 @@ To create a variable, follow these steps:
    - [Constant](#add-a-constant-variable)
    - [Data source](#add-a-data-source-variable)
    - [Interval](#add-an-interval-variable)
-   - [Ad hoc filters](#add-ad-hoc-filters)
+   - [Filters](#add-ad-hoc-filters)
    - [Switch](#add-a-switch-variable)
 
 {{< /docs/list >}}
@@ -327,7 +327,7 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 <!-- vale Grafana.WordList = NO -->
 <!-- vale Grafana.Spelling = NO -->
 
-## Add ad hoc filters
+## Add filters
 
 {{< admonition type="note" >}}
 In Grafana v13, we released the filter and group by feature in public preview.
@@ -339,17 +339,17 @@ To use this feature, enable the `dashboardUnifiedDrilldownControls` feature togg
 For more information on filter and group by, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
 {{< /admonition >}}
 
-_Ad hoc filters_ are one of the most complex and flexible variable options available.
-Instead of creating a variable for each dimension by which you want to filter, ad hoc filters automatically create variables (key/value pairs) for all the dimensions returned by your data source query.
+_Filters_ are one of the most complex and flexible variable options available.
+Instead of creating a variable for each dimension by which you want to filter, filters automatically create variables (key/value pairs) for all the dimensions returned by your data source query.
 This allows you to apply filters dashboard-wide.
 
-Ad hoc filters let you add label/value filters that are automatically added to all metric queries that use the specified data source.
-Unlike other variables, you don't use ad hoc filters in queries.
-Instead, you use ad hoc filters to write filters for existing queries.
+Filters let you add label/value filters that are automatically added to all metric queries that use the specified data source.
+Unlike other variables, you don't use filters in queries.
+Instead, you use filters to write filters for existing queries.
 
-The following data sources support ad hoc filters:
+The following data sources support filters:
 
-- Dashboard - Use this special data source to [apply ad hoc filters to data from unsupported data sources](#filter-any-data-using-the-dashboard-data-source).
+- Dashboard - Use this special data source to [apply filters to data from unsupported data sources](#filter-any-data-using-the-dashboard-data-source).
 - Prometheus
 - Loki
 - InfluxDB
@@ -380,22 +380,22 @@ To preserve the context of the current dashboard:
 - **Variables:** You must enable **Include all variables** to preserve existing selections.
 - **Ordering:** Ensure that **Include all variables** is placed before the specific variable you are defining in the link.
 
-Ad hoc filters on the current dashboard are automatically preserved.
+Filters on the current dashboard are automatically preserved.
 
 Learn more in:
 
 - [Configure data links and actions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-data-links/)
-- [Create dashboard URL variables – Ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/#ad-hoc-filters)
+- [Create dashboard URL variables – Filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard-url-variables/#ad-hoc-filters)
   {{< /admonition >}}
 
 ### Filter any data using the Dashboard data source
 
-In cases where a data source doesn't support the use of ad hoc filters, you can use the Dashboard data source to reference that data, and then filter it in a new panel.
+In cases where a data source doesn't support the use of filters, you can use the Dashboard data source to reference that data, and then filter it in a new panel.
 This allows you to bypass the limitations of the data source in the source panel.
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-dashboard-ds-v12.2.png" max-width="750px" alt="The query section of a panel with the Dashboard data source configured" >}}
 
-To use ad hoc filters on data from an unsupported data source, follow these steps:
+To use filters on data from an unsupported data source, follow these steps:
 
 1. Navigate to the dashboard with the panel with the data you want to filter.
 1. Click **Edit** in top-right corner of the dashboard.
@@ -419,9 +419,9 @@ To use ad hoc filters on data from an unsupported data source, follow these step
 Now you can filter the data from the source panel by way of the Dashboard data source.
 Add as many panels as you need.
 
-### Dashboard drilldown with ad hoc filters
+### Dashboard drilldown with filters
 
-In table and bar chart visualizations, you can apply ad hoc filters directly from the visualization.
+In table and bar chart visualizations, you can apply filters directly from the visualization.
 To quickly apply ad hoc filter variables, follow these steps:
 
 1. To display the filter icons, hover your cursor over the table cell with the value for which you want to filter. In this example, the cell value is `ConfigMap Updated`, which is in the `alertname` column:

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -330,16 +330,14 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 ## Add filters {#add-ad-hoc-filters}
 
 {{< admonition type="note" >}}
-In Grafana v13, we released the filter and group by feature in public preview.
-It renames ad hoc filters and extends them by adding grouping for Prometheus and Loki data sources.
-However, in the dashboard schema, it is still referred to as `"kind": "AdhocVariable"`.
+In Grafana v13, we released the **Filter and group by** feature in public preview.
+It renames the **Filters** variable (formerly ad hoc filter) and extends it by adding grouping for Prometheus and Loki data sources.
+However, in the dashboard schema, it's still referred to as `"kind": "AdhocVariable"`.
 
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
 
-For more information on filter and group by, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
+For more information on **Filter and group by**, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
 {{< /admonition >}}
-
-<!--TODO: -->
 
 _Filters_ are one of the most complex and flexible variable options available.
 Instead of creating a variable for each dimension by which you want to filter, filters automatically create variables (key/value pairs) for all the dimensions returned by your data source query.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -327,7 +327,7 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 <!-- vale Grafana.WordList = NO -->
 <!-- vale Grafana.Spelling = NO -->
 
-## Add filters
+## Add filters {#add-ad-hoc-filters}
 
 {{< admonition type="note" >}}
 In Grafana v13, we released the filter and group by feature in public preview.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -330,13 +330,13 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 ## Add filters {#add-ad-hoc-filters}
 
 {{< admonition type="note" >}}
-In Grafana v13, we released the **Filter and group by** feature in public preview.
+In Grafana v13, we released the **Filter and Group by** feature in public preview.
 It renames the **Filters** variable (formerly ad hoc filter) and extends it by adding grouping for Prometheus and Loki data sources.
 However, in the dashboard schema, it's still referred to as `"kind": "AdhocVariable"`.
 
 To use this feature, enable the `dashboardUnifiedDrilldownControls` feature toggle in your Grafana configuration file.
 
-For more information on **Filter and group by**, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/).
+For more information on the **Filter and Group by** feature, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/#filter-and-group-by).
 {{< /admonition >}}
 
 _Filters_ are one of the most complex and flexible variable options available.

--- a/docs/sources/visualizations/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/bar-chart/index.md
@@ -98,7 +98,7 @@ In bar charts, you can apply filters directly from the visualization.
 
 To display the filter button, hover your cursor over the bar that has the value for which you want to filter and click the bar:
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-bar-v12.2.png" max-width="300px" alt="The ad hoc filter button in a bar chart tooltip">}}
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-bar-v12.2.png" max-width="300px" alt="The filter button in a bar chart tooltip">}}
 
 For more information about applying filters this way, refer to [Dashboard drilldown with filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
 

--- a/docs/sources/visualizations/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/bar-chart/index.md
@@ -100,9 +100,7 @@ To display the filter button, hover your cursor over the bar that has the value 
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-bar-v12.2.png" max-width="300px" alt="The filter button in a bar chart tooltip">}}
 
-For more information about applying filters this way, refer to [Dashboard drilldown with filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
-
-<!-- TODO: Confirm this link works -->
+For more information about applying filters this way, refer to [Dashboard drilldown with filters](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
 
 <!-- vale Grafana.Spelling = YES -->
 <!-- vale Grafana.WordList = YES -->

--- a/docs/sources/visualizations/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/bar-chart/index.md
@@ -92,15 +92,17 @@ We recommend that you only use one dataset in a bar chart because using multiple
 <!-- vale Grafana.WordList = NO -->
 <!-- vale Grafana.Spelling = NO -->
 
-## Apply ad hoc filters from the bar chart
+## Apply filters from the bar chart
 
-In bar charts, you can apply ad hoc filters directly from the visualization.
+In bar charts, you can apply filters directly from the visualization.
 
 To display the filter button, hover your cursor over the bar that has the value for which you want to filter and click the bar:
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-adhoc-filter-icon-bar-v12.2.png" max-width="300px" alt="The ad hoc filter button in a bar chart tooltip">}}
 
-For more information about applying ad hoc filters this way, refer to [Dashboard drilldown with ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-ad-hoc-filters).
+For more information about applying filters this way, refer to [Dashboard drilldown with filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
+
+<!-- TODO: Confirm this link works -->
 
 <!-- vale Grafana.Spelling = YES -->
 <!-- vale Grafana.WordList = YES -->

--- a/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
@@ -178,15 +178,16 @@ To remove the filter, click the blue filter icon and then click **Clear filter**
 <!-- vale Grafana.WordList = NO -->
 <!-- vale Grafana.Spelling = NO -->
 
-### Apply ad hoc filters from the table
+### Apply filters from the table
 
-In tables, you can apply ad hoc filters directly from the visualization with one click.
+In tables, you can apply filters directly from the visualization with one click.
 
 To display the filter icons, hover your cursor over the cell that has the value for which you want to filter:
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-table-adhoc-filter-v12.2.png" max-width="500px" alt="Table with ad hoc filter icon displayed on a cell" >}}
 
-For more information about applying ad hoc filters this way, refer to [Dashboard drilldown with ad hoc filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-ad-hoc-filters).
+For more information about applying filters this way, refer to [Dashboard drilldown with filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
+<!-- TODO: Confirm this link works -->
 
 <!-- vale Grafana.Spelling = YES -->
 <!-- vale Grafana.WordList = YES -->

--- a/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
@@ -184,7 +184,7 @@ In tables, you can apply filters directly from the visualization with one click.
 
 To display the filter icons, hover your cursor over the cell that has the value for which you want to filter:
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-table-adhoc-filter-v12.2.png" max-width="500px" alt="Table with ad hoc filter icon displayed on a cell" >}}
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-table-adhoc-filter-v12.2.png" max-width="500px" alt="Table with filter icon displayed on a cell" >}}
 
 For more information about applying filters this way, refer to [Dashboard drilldown with filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
 <!-- TODO: Confirm this link works -->

--- a/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
@@ -186,8 +186,7 @@ To display the filter icons, hover your cursor over the cell that has the value 
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-table-adhoc-filter-v12.2.png" max-width="500px" alt="Table with filter icon displayed on a cell" >}}
 
-For more information about applying filters this way, refer to [Dashboard drilldown with filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
-<!-- TODO: Confirm this link works -->
+For more information about applying filters this way, refer to [Dashboard drilldown with filters](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/variables/add-template-variables/#dashboard-drilldown-with-filters).
 
 <!-- vale Grafana.Spelling = YES -->
 <!-- vale Grafana.WordList = YES -->


### PR DESCRIPTION
Replaces "ad hoc filters" with "filters" in several places
Updates notes to address this change and the new Filter and group by in public preview