### PR TITLE
unified-storage: convert RVs to appropriate format in StorageBackend

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -805,12 +805,12 @@ func (s *Storage) validateMinimumResourceVersion(minimumResourceVersion string, 
 	// RVs may be in either snowflake or microsecond format depending
 	// on which backend produced them.
 	rvMin := int64(minimumRV)
-	if resource.IsSnowflake(rvMin) {
-		rvMin = rvmanager.RVFromSnowflake(rvMin)
+	if !resource.IsSnowflake(rvMin) {
+		rvMin = rvmanager.SnowflakeFromRV(rvMin)
 	}
 	rvActual := int64(actualRevision)
-	if resource.IsSnowflake(rvActual) {
-		rvActual = rvmanager.RVFromSnowflake(rvActual)
+	if !resource.IsSnowflake(rvActual) {
+		rvActual = rvmanager.SnowflakeFromRV(rvActual)
 	}
 
 	// Enforce the storage.Interface guarantee that the resource version of the returned data

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -42,6 +42,7 @@ import (
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager"
 )
 
 const (
@@ -800,9 +801,21 @@ func (s *Storage) validateMinimumResourceVersion(minimumResourceVersion string, 
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 
+	// Normalize both to microsecond format for cross-format comparison.
+	// RVs may be in either snowflake or microsecond format depending
+	// on which backend produced them.
+	rvMin := int64(minimumRV)
+	if resource.IsSnowflake(rvMin) {
+		rvMin = rvmanager.RVFromSnowflake(rvMin)
+	}
+	rvActual := int64(actualRevision)
+	if resource.IsSnowflake(rvActual) {
+		rvActual = rvmanager.RVFromSnowflake(rvActual)
+	}
+
 	// Enforce the storage.Interface guarantee that the resource version of the returned data
 	// "will be at least 'resourceVersion'".
-	if minimumRV > actualRevision {
+	if rvMin > rvActual {
 		return storage.NewTooLargeResourceVersionError(minimumRV, actualRevision, 0)
 	}
 	return nil

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -858,7 +858,7 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 	// In compatibility mode, the previous RV, when available, is saved as a microsecond
 	// timestamp, as is done in the SQL backend.
 	previousRV := event.PreviousRV
-	if event.PreviousRV > 0 && isSnowflake(event.PreviousRV) {
+	if event.PreviousRV > 0 && IsSnowflake(event.PreviousRV) {
 		previousRV = rvmanager.RVFromSnowflake(event.PreviousRV)
 	}
 
@@ -1022,9 +1022,9 @@ func (d *dataStore) syncLegacyResourceFromHistory(ctx context.Context, execer db
 	return nil
 }
 
-// isSnowflake returns whether the argument passed is a snowflake ID (new) or a microsecond timestamp (old).
+// IsSnowflake returns whether the argument passed is a snowflake ID (new) or a microsecond timestamp (old).
 // Snowflake IDs always have 19 digits. A 19-digit microsecond timestamp (10^18 µs) would correspond
 // to year ~33658, so any number with fewer than 19 digits is unambiguously a legacy microsecond timestamp.
-func isSnowflake(rv int64) bool {
+func IsSnowflake(rv int64) bool {
 	return rv >= 1e18
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1008,7 +1008,7 @@ func (s *server) update(ctx context.Context, user claims.AuthInfo, req *resource
 		return rsp, nil
 	}
 
-	event, e := s.newEvent(ctx, user, req.Key, req.ResourceVersion, req.Value, latest.Value)
+	event, e := s.newEvent(ctx, user, req.Key, normalizeRV(req.ResourceVersion), req.Value, latest.Value)
 	if e != nil {
 		rsp.Error = e
 		return rsp, nil
@@ -1092,7 +1092,7 @@ func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resource
 	event := WriteEvent{
 		Key:        req.Key,
 		Type:       resourcepb.WatchEvent_DELETED,
-		PreviousRV: req.ResourceVersion,
+		PreviousRV: normalizeRV(req.ResourceVersion),
 		GUID:       uuid.New().String(),
 	}
 	marker := &unstructured.Unstructured{}
@@ -1163,6 +1163,7 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 }
 
 func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb.ReadRequest) (*resourcepb.ReadResponse, error) {
+	req.ResourceVersion = normalizeRV(req.ResourceVersion)
 	rsp := s.backend.ReadResource(ctx, req)
 	if rsp.Error != nil && rsp.Error.Code == http.StatusNotFound {
 		return &resourcepb.ReadResponse{Error: rsp.Error}, nil
@@ -1219,6 +1220,8 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 			return &resourcepb.ListResponse{Error: NewBadRequestError("history and trash must be requested as source")}, nil
 		}
 	}
+
+	req.ResourceVersion = normalizeRV(req.ResourceVersion)
 
 	// Fast path for getting single value in a list
 	if rsp := s.tryFieldSelector(ctx, req); rsp != nil {
@@ -1939,8 +1942,20 @@ func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
 // Unix timestamps (SQL backend).
 func resourceVersionTime(rv int64) time.Time {
 	micro := rv
-	if isSnowflake(rv) {
+	if IsSnowflake(rv) {
 		micro = rvmanager.RVFromSnowflake(rv)
 	}
 	return time.UnixMicro(micro)
+}
+
+// normalizeRV converts a snowflake RV to microsecond format if needed.
+// This ensures that RVs arriving at the server layer are in the canonical
+// microsecond format used by the SQL backend. No-op for values ≤ 0.
+//
+// TODO: remove when compatibility with SQL backend is no longer needed.
+func normalizeRV(rv int64) int64 {
+	if rv > 0 && IsSnowflake(rv) {
+		return rvmanager.RVFromSnowflake(rv)
+	}
+	return rv
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1944,4 +1944,3 @@ func resourceVersionTime(rv int64) time.Time {
 	}
 	return time.UnixMicro(micro)
 }
-

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1008,7 +1008,7 @@ func (s *server) update(ctx context.Context, user claims.AuthInfo, req *resource
 		return rsp, nil
 	}
 
-	event, e := s.newEvent(ctx, user, req.Key, normalizeRV(req.ResourceVersion), req.Value, latest.Value)
+	event, e := s.newEvent(ctx, user, req.Key, req.ResourceVersion, req.Value, latest.Value)
 	if e != nil {
 		rsp.Error = e
 		return rsp, nil
@@ -1092,7 +1092,7 @@ func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resource
 	event := WriteEvent{
 		Key:        req.Key,
 		Type:       resourcepb.WatchEvent_DELETED,
-		PreviousRV: normalizeRV(req.ResourceVersion),
+		PreviousRV: req.ResourceVersion,
 		GUID:       uuid.New().String(),
 	}
 	marker := &unstructured.Unstructured{}
@@ -1163,7 +1163,6 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 }
 
 func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb.ReadRequest) (*resourcepb.ReadResponse, error) {
-	req.ResourceVersion = normalizeRV(req.ResourceVersion)
 	rsp := s.backend.ReadResource(ctx, req)
 	if rsp.Error != nil && rsp.Error.Code == http.StatusNotFound {
 		return &resourcepb.ReadResponse{Error: rsp.Error}, nil
@@ -1220,8 +1219,6 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 			return &resourcepb.ListResponse{Error: NewBadRequestError("history and trash must be requested as source")}, nil
 		}
 	}
-
-	req.ResourceVersion = normalizeRV(req.ResourceVersion)
 
 	// Fast path for getting single value in a list
 	if rsp := s.tryFieldSelector(ctx, req); rsp != nil {
@@ -1948,14 +1945,3 @@ func resourceVersionTime(rv int64) time.Time {
 	return time.UnixMicro(micro)
 }
 
-// normalizeRV converts a snowflake RV to microsecond format if needed.
-// This ensures that RVs arriving at the server layer are in the canonical
-// microsecond format used by the SQL backend. No-op for values ≤ 0.
-//
-// TODO: remove when compatibility with SQL backend is no longer needed.
-func normalizeRV(rv int64) int64 {
-	if rv > 0 && IsSnowflake(rv) {
-		return rvmanager.RVFromSnowflake(rv)
-	}
-	return rv
-}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1476,6 +1476,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		return 0, err
 	}
 	key := req.Options.Key
+	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
 	// Parse continue token if provided
 	lastSeenRV := int64(0)
 	if req.NextPageToken != "" {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -659,10 +659,22 @@ func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName 
 		cutoffTimestamp = time.Now().Add(-b.garbageCollection.DashboardsMaxAge).UnixMicro()
 	}
 
-	if !isSnowflake(cutoffTimestamp) {
+	if !IsSnowflake(cutoffTimestamp) {
 		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
 	}
 	return cutoffTimestamp
+}
+
+// toSnowflakeRV converts a microsecond RV to snowflake format if needed.
+// This ensures the KV backend is compatible with both RV formats during the
+// backend transition period.
+//
+// TODO: remove when compatibility with SQL backend is no longer needed.
+func toSnowflakeRV(rv int64) int64 {
+	if rv > 0 && !IsSnowflake(rv) {
+		return rvmanager.SnowflakeFromRV(rv)
+	}
+	return rv
 }
 
 func conflictError(event WriteEvent, message string) error {
@@ -679,11 +691,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		return 0, apierrors.NewBadRequest(err.Error())
 	}
 
-	// If an RV was passed in the old (microsecond) format, convert it to snowflake.
-	// TODO: remove this once the KV backend has been deployed everywhere.
-	if event.PreviousRV > 0 && !isSnowflake(event.PreviousRV) {
-		event.PreviousRV = rvmanager.SnowflakeFromRV(event.PreviousRV)
-	}
+	event.PreviousRV = toSnowflakeRV(event.PreviousRV)
 
 	rv := k.snowflake.Generate().Int64()
 
@@ -921,6 +929,8 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 		return &BackendReadResponse{Error: &resourcepb.ErrorResult{Code: http.StatusBadRequest, Message: "missing key"}}
 	}
 
+	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
+
 	namespace := req.Key.Namespace
 
 	// If a specific resource version is requested, validate that it's not too high
@@ -997,6 +1007,8 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 		return 0, fmt.Errorf("missing options or key in ListRequest")
 	}
 
+	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
+
 	// Parse continue token if provided
 	listOptions := ListRequestOptions{
 		Key: ListRequestKey{
@@ -1021,7 +1033,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 			listOptions.ContinueNamespace = token.Namespace
 		}
 		listOptions.ContinueName = token.Name
-		listOptions.ResourceVersion = token.ResourceVersion
+		listOptions.ResourceVersion = toSnowflakeRV(token.ResourceVersion)
 	}
 
 	// We set the listRV to the last event resource version.
@@ -1266,6 +1278,8 @@ func (k *kvStorageBackend) ListModifiedSince(ctx context.Context, key Namespaced
 		}
 	}
 
+	sinceRv = toSnowflakeRV(sinceRv)
+
 	latestEvent, err := k.eventStore.LastEventKey(ctx)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -1469,7 +1483,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		if err != nil {
 			return 0, fmt.Errorf("invalid continue token: %w", err)
 		}
-		lastSeenRV = token.ResourceVersion
+		lastSeenRV = toSnowflakeRV(token.ResourceVersion)
 	}
 
 	// Generate a new resource version for the list

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -1128,7 +1128,7 @@ func (b *backend) listAtRevision(ctx context.Context, req *resourcepb.ListReques
 		if err != nil {
 			return 0, fmt.Errorf("get continue token (%q): %w", req.NextPageToken, err)
 		}
-		iter.listRV = continueToken.ResourceVersion
+		iter.listRV = toMicrosecondRV(continueToken.ResourceVersion)
 		iter.offset = continueToken.StartOffset
 
 		if req.ResourceVersion != 0 && req.ResourceVersion != iter.listRV {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -1000,6 +1000,7 @@ func (b *backend) ListHistory(ctx context.Context, req *resourcepb.ListRequest, 
 	ctx, span := tracer.Start(ctx, "sql.backend.ListHistory")
 	defer span.End()
 
+	req.ResourceVersion = toMicrosecondRV(req.ResourceVersion)
 	return b.getHistory(ctx, req, cb)
 }
 

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -683,6 +683,16 @@ func (b *backend) GetResourceStats(ctx context.Context, nsr resource.NamespacedR
 	return res, err
 }
 
+// toMicrosecondRV converts a snowflake RV to microsecond format if needed.
+// This ensures that RVs arriving at the SQL backend are in the native
+// microsecond format. No-op for values ≤ 0 or values already in microsecond format.
+func toMicrosecondRV(rv int64) int64 {
+	if rv > 0 && resource.IsSnowflake(rv) {
+		return rvmanager.RVFromSnowflake(rv)
+	}
+	return rv
+}
+
 func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (int64, error) {
 	if b.disableStorageServices {
 		return 0, fmt.Errorf("storage backend is not enabled")
@@ -690,6 +700,7 @@ func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (in
 	if err := event.Validate(); err != nil {
 		return 0, apierrors.NewBadRequest(err.Error())
 	}
+	event.PreviousRV = toMicrosecondRV(event.PreviousRV)
 
 	_, span := tracer.Start(ctx, "sql.backend.WriteEvent")
 	defer span.End()
@@ -930,6 +941,8 @@ func (b *backend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest)
 	_, span := tracer.Start(ctx, "sql.backend.ReadResource")
 	defer span.End()
 
+	req.ResourceVersion = toMicrosecondRV(req.ResourceVersion)
+
 	// TODO: validate key ?
 
 	if req.ResourceVersion > 0 {
@@ -962,6 +975,8 @@ func (b *backend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest)
 func (b *backend) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
 	ctx, span := tracer.Start(ctx, "sql.backend.ListIterator")
 	defer span.End()
+
+	req.ResourceVersion = toMicrosecondRV(req.ResourceVersion)
 
 	if err := resource.MigrateListRequestVersionMatch(req, b.log); err != nil {
 		return 0, err
@@ -1035,6 +1050,8 @@ func (b *backend) listLatest(ctx context.Context, req *resourcepb.ListRequest, c
 // ListModifiedSince will return all resources that have changed since the given resource version.
 // If a resource has changes, only the latest change will be returned.
 func (b *backend) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64, _ *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
+	sinceRv = toMicrosecondRV(sinceRv)
+
 	// We don't use an explicit transaction for fetching LatestRV and subsequent fetching of resources.
 	// To guarantee that we don't include events with RV > LatestRV, we include the check in SQL query.
 

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -85,6 +85,7 @@ func RunSQLStorageBackendCompatibilityTest(t *testing.T, newSqlBackend NewBacken
 		{"bulk import large counter CRUD", runTestBulkImportLargeCounterCRUD},
 		{"last import time cross backend", runTestLastImportTimeCrossBackend},
 		{"cluster scoped resources compatibility", runTestClusterScopedResources},
+		{"cross backend rv list compatibility", runTestCrossBackendRVListCompatibility},
 	}
 
 	for _, tc := range cases {
@@ -2670,5 +2671,65 @@ func runSearchCompatibilityScenario(t *testing.T, cfg searchCompatibilityTestCon
 		verifySearchServerResults(t, searchServer, cfg.namespace, "Updated", 2, []string{
 			alphaName(1), betaName(1),
 		})
+	})
+}
+
+// runTestCrossBackendRVListCompatibility verifies that a ResourceVersion obtained
+// from one backend can be used to list resources from the other backend. Listing
+// at the same RV should produce the same snapshot. This exercises cross-format RV handling
+// (microsecond ↔ snowflake).
+func runTestCrossBackendRVListCompatibility(t *testing.T, sqlBackend, kvBackend resource.StorageBackend, nsPrefix string, _ sqldb.DB) {
+	ctx := newIntegrationTestContext(t)
+
+	sqlServer := createStorageServer(t, sqlBackend)
+	kvServer := createStorageServer(t, kvBackend)
+
+	// testCrossBackendList creates resources via backend A, lists from A to
+	// capture a point-in-time RV, then lists from backend B using that RV.
+	// The results must match.
+	testCrossBackendList := func(t *testing.T, serverA, serverB resource.ResourceServer, isSnowflakeRV bool, ns string) {
+		// Create resources via backend A.
+		for i := 1; i <= 2; i++ {
+			createPlaylistResource(t, serverA, ctx, PlaylistResourceOptions{
+				Name:       fmt.Sprintf("res-%d", i),
+				Namespace:  ns,
+				UID:        fmt.Sprintf("uid-%d", i),
+				Generation: 1,
+				Title:      fmt.Sprintf("Playlist %d", i),
+			})
+		}
+
+		listOpts := &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "playlists",
+			Namespace: ns,
+		}}
+
+		// List from backend A to capture its RV.
+		listA, err := serverA.List(ctx, &resourcepb.ListRequest{Options: listOpts})
+		require.NoError(t, err)
+		require.Nil(t, listA.Error)
+		require.Len(t, listA.Items, 2)
+		rvFromA := listA.ResourceVersion
+		require.Greater(t, rvFromA, int64(0))
+
+		require.Equal(t, isSnowflakeRV, resource.IsSnowflake(rvFromA))
+
+		// List from backend B using backend A's RV — should return the same resources.
+		listB, err := serverB.List(ctx, &resourcepb.ListRequest{
+			ResourceVersion: rvFromA,
+			Options:         listOpts,
+		})
+		require.NoError(t, err)
+		require.Nil(t, listB.Error)
+		require.Len(t, listB.Items, 2, "listing with cross-backend RV should return the same resources")
+	}
+
+	t.Run("SQL to KV", func(t *testing.T) {
+		testCrossBackendList(t, sqlServer, kvServer, false, nsPrefix+"-rv-sql2kv")
+	})
+
+	t.Run("KV to SQL", func(t *testing.T) {
+		testCrossBackendList(t, kvServer, sqlServer, true, nsPrefix+"-rv-kv2sql")
 	})
 }

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -2675,20 +2675,29 @@ func runSearchCompatibilityScenario(t *testing.T, cfg searchCompatibilityTestCon
 }
 
 // runTestCrossBackendRVListCompatibility verifies that a ResourceVersion obtained
-// from one backend can be used to list resources from the other backend. Listing
-// at the same RV should produce the same snapshot. This exercises cross-format RV handling
-// (microsecond ↔ snowflake).
+// from one backend can be used to list a point-in-time snapshot from the other
+// backend. This exercises cross-format RV handling (microsecond ↔ snowflake).
 func runTestCrossBackendRVListCompatibility(t *testing.T, sqlBackend, kvBackend resource.StorageBackend, nsPrefix string, _ sqldb.DB) {
 	ctx := newIntegrationTestContext(t)
 
 	sqlServer := createStorageServer(t, sqlBackend)
 	kvServer := createStorageServer(t, kvBackend)
 
-	// testCrossBackendList creates resources via backend A, lists from A to
-	// capture a point-in-time RV, then lists from backend B using that RV.
-	// The results must match.
-	testCrossBackendList := func(t *testing.T, serverA, serverB resource.ResourceServer, isSnowflakeRV bool, ns string) {
-		// Create resources via backend A.
+	// testCrossBackendList creates resources via backend A, captures a
+	// point-in-time RV, creates more resources, then lists from backend B
+	// using A's RV. Backend B must return only the resources that existed at
+	// A's RV — not the ones created afterward. This catches missing RV
+	// format conversions: without conversion, a snowflake RV (very large)
+	// passed to the SQL backend would match all rows via `<= RV`, and a
+	// microsecond RV (very small) passed to the KV backend would match none.
+	testCrossBackendList := func(t *testing.T, serverA, serverB resource.ResourceServer, expectSnowflakeRV bool, ns string) {
+		listOpts := &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "playlists",
+			Namespace: ns,
+		}}
+
+		// Create 2 resources via backend A.
 		for i := 1; i <= 2; i++ {
 			createPlaylistResource(t, serverA, ctx, PlaylistResourceOptions{
 				Name:       fmt.Sprintf("res-%d", i),
@@ -2699,30 +2708,41 @@ func runTestCrossBackendRVListCompatibility(t *testing.T, sqlBackend, kvBackend 
 			})
 		}
 
-		listOpts := &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
-			Group:     "playlist.grafana.app",
-			Resource:  "playlists",
-			Namespace: ns,
-		}}
-
-		// List from backend A to capture its RV.
+		// List from backend A to capture a point-in-time RV.
 		listA, err := serverA.List(ctx, &resourcepb.ListRequest{Options: listOpts})
 		require.NoError(t, err)
 		require.Nil(t, listA.Error)
 		require.Len(t, listA.Items, 2)
 		rvFromA := listA.ResourceVersion
 		require.Greater(t, rvFromA, int64(0))
+		require.Equal(t, expectSnowflakeRV, resource.IsSnowflake(rvFromA), "RV format should match the producing backend")
 
-		require.Equal(t, isSnowflakeRV, resource.IsSnowflake(rvFromA))
+		// Create 2 more resources after the captured RV.
+		for i := 3; i <= 4; i++ {
+			createPlaylistResource(t, serverA, ctx, PlaylistResourceOptions{
+				Name:       fmt.Sprintf("res-%d", i),
+				Namespace:  ns,
+				UID:        fmt.Sprintf("uid-%d", i),
+				Generation: 1,
+				Title:      fmt.Sprintf("Playlist %d", i),
+			})
+		}
 
-		// List from backend B using backend A's RV — should return the same resources.
+		// Sanity: listing latest from A should return all 4 items.
+		listAll, err := serverA.List(ctx, &resourcepb.ListRequest{Options: listOpts})
+		require.NoError(t, err)
+		require.Nil(t, listAll.Error)
+		require.Len(t, listAll.Items, 4)
+
+		// List from backend B at A's RV — must return exactly the 2
+		// resources that existed at that point, not all 4.
 		listB, err := serverB.List(ctx, &resourcepb.ListRequest{
 			ResourceVersion: rvFromA,
 			Options:         listOpts,
 		})
 		require.NoError(t, err)
 		require.Nil(t, listB.Error)
-		require.Len(t, listB.Items, 2, "listing with cross-backend RV should return the same resources")
+		require.Len(t, listB.Items, 2, "listing with cross-backend RV should return only the resources that existed at that RV")
 	}
 
 	t.Run("SQL to KV", func(t *testing.T) {


### PR DESCRIPTION
This PR makes each backend (SQL and KV) update RVs received by the client before further processing. During the transition period between backends, we can't assume a particular format. The KV handling of unix microsecond RVs can be removed once compatibility is no longer needed.