### PR TITLE
PanelEditor: Enable Discard button when styles are pasted before opening editor

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -188,6 +188,37 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   }
 
   /**
+   * Detects panel changes that occurred outside of the editor (e.g. styles pasted from dashboard view)
+   * and marks the editor as dirty so the Discard button is enabled.
+   */
+  private _applyPreExistingChanges(panel: VizPanel) {
+    const savedPanel = this._getPanelFromInitialSaveModel(panel);
+    if (!savedPanel) {
+      return;
+    }
+
+    const currentPanel = vizPanelToPanel(panel);
+    if (deepEqual(currentPanel.fieldConfig, savedPanel.fieldConfig)) {
+      return;
+    }
+
+    // Use saved fieldConfig as the baseline so the pre-existing change is reflected as dirty.
+    this._originalSaveModel = { ...currentPanel, fieldConfig: savedPanel.fieldConfig };
+    this.setState({ isDirty: true });
+  }
+
+  private _getPanelFromInitialSaveModel(panel: VizPanel): Panel | undefined {
+    const dashboard = getDashboardSceneFor(this);
+    const initialSaveModel = dashboard.getInitialSaveModel();
+    if (!initialSaveModel || !('panels' in initialSaveModel) || !initialSaveModel.panels) {
+      return undefined;
+    }
+    const panelId = getPanelIdForVizPanel(panel);
+    // Filter out row panels (which have a nested `panels` array) before searching
+    return initialSaveModel.panels.filter((p): p is Panel => !('panels' in p)).find((p) => p.id === panelId);
+  }
+
+  /**
    * Useful for testing to turn on debounce
    */
   public debounceSaveModelDiff = true;
@@ -226,6 +257,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     if (this.state.isInitializing) {
       this.setOriginalState(this.state.panelRef);
       this._setupChangeDetection();
+      this._applyPreExistingChanges(panel);
       this._updateDataPane(plugin);
 
       // Listen for panel plugin changes


### PR DESCRIPTION
## Summary

When `pastePanelStyles()` modifies a panel's `fieldConfig` from the dashboard view (before the panel editor is opened), `setOriginalState` captures the already-pasted state as the baseline. The change detection comparison then sees no diff, leaving the Discard button permanently disabled.

- Adds `_applyPreExistingChanges()`: called once during editor initialization, after `_setupChangeDetection`. It compares the current panel's `fieldConfig` against the saved dashboard model (`getInitialSaveModel()`). If a diff is found, it resets the baseline `fieldConfig` in `_originalSaveModel` to the saved value and sets `isDirty: true`, enabling the Discard button.
- Adds `_getPanelFromInitialSaveModel()`: looks up the panel in the last-saved dashboard model by ID, skipping row panels.
- No change to `setOriginalState`, `onDiscard`, or the change detection subscription.

**Behavior after this fix:**
- Pasted styles remain visible while editing (panel is not silently reverted on open).
- The Discard button is enabled as soon as the editor opens.
- Clicking Discard reverts changes made inside the editor. The paste itself is a pre-editor action tracked by the dashboard-level dirty state.

## Test plan

- [ ] Paste styles on a panel from dashboard view (via the panel actions menu)
- [ ] Open the panel editor for that panel
- [ ] Verify the Discard button is enabled immediately on open
- [ ] Make no changes and click Discard: editor closes, panel retains pasted styles
- [ ] Open editor again, make a change, click Discard: editor change is reverted
- [ ] Existing tests in `PanelEditor.test.ts` pass