### PR TITLE
Cli: Fix bug with reset-admin-password command when using PostgreSQL

### DIFF
--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -110,7 +110,8 @@ type adminFilter struct{}
 
 func (f *adminFilter) WhereCondition() *user.WhereCondition {
 	return &user.WhereCondition{
-		Condition: "is_admin = 1",
+		Condition: "is_admin = ?",
+		Params:    true,
 	}
 }
 


### PR DESCRIPTION
Fixes #122206

## What

The `reset-admin-password` CLI command fails on PostgreSQL because the admin filter uses `is_admin = 1`, but PostgreSQL's `is_admin` column is boolean and rejects integer comparison.

## Why

PostgreSQL enforces strict type checking — `boolean = integer` is not valid SQL. MySQL/SQLite implicitly cast integers to booleans, masking the bug.

## How

Use a parameterized query `is_admin = ?` with `true` as the bound parameter, matching the pattern used elsewhere in the codebase (e.g., `store.go:440`).