### PR TITLE
Alerting: re-enable lazy-config notification policies test

### DIFF
--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -437,7 +437,7 @@ describe('Non-Grafana alertmanagers', () => {
     ]);
   });
 
-  it.skip('Shows an empty config when config returns an error and the AM supports lazy config initialization', async () => {
+  it('Shows an empty config when config returns an error and the AM supports lazy config initialization', async () => {
     makeAllAlertmanagerConfigFetchFail(getErrorResponse('alertmanager storage object not found'));
     setAlertmanagerStatus(dataSources.mimir.uid, someCloudAlertManagerStatus);
     renderNotificationPolicies(dataSources.mimir.name);

--- a/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute.ts
@@ -56,6 +56,7 @@ const {
 } = routingTreeApi;
 
 const { useGetAlertmanagerConfigurationQuery } = alertmanagerApi;
+const EMPTY_AM_CONFIG_ROUTE: Route = {};
 
 // WeakMap-based caches for stable Route object references. Using WeakMap rather than a
 // fixed-size LRU (micro-memoize's default) avoids cache eviction when multiple external
@@ -101,11 +102,11 @@ export const useNotificationPolicyRoute = (
     selectFromResult: (result) => {
       return {
         ...result,
-        currentData: result.currentData?.alertmanager_config?.route
-          ? parseAmConfigRoute(result.currentData.alertmanager_config.route)
+        currentData: result.currentData?.alertmanager_config
+          ? parseAmConfigRoute(result.currentData.alertmanager_config.route ?? EMPTY_AM_CONFIG_ROUTE)
           : undefined,
-        data: result.data?.alertmanager_config?.route
-          ? parseAmConfigRoute(result.data.alertmanager_config.route)
+        data: result.data?.alertmanager_config
+          ? parseAmConfigRoute(result.data.alertmanager_config.route ?? EMPTY_AM_CONFIG_ROUTE)
           : undefined,
       };
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR re-enables a skipped `NotificationPoliciesPage` test and fixes the lazy-config-init empty-config path for external Alertmanagers.

**Why do we need this feature?**

When config fetch returns `alertmanager storage object not found`, we fall back to an empty config for lazy-config-init-capable Alertmanagers. This change makes sure that state does not expose edit/add actions before a route exists.
  
**Who is this feature for?**

Users of external Alertmanagers such as Mimir that support lazy config initialization.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Tested with:

- `yarn jest --no-watch public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx -t "Shows an empty config when config returns an error and the AM supports lazy config initialization"`
- `yarn jest --no-watch public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx`

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
