### PR TITLE
fix(prometheus): fetch labels onBlur instead of onChange for limit input

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -14,6 +14,7 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+  const [localSeriesLimit, setLocalSeriesLimit] = useState(String(seriesLimit));
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -51,12 +52,13 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setLocalSeriesLimit(e.currentTarget.value)}
+            onBlur={() => setSeriesLimit(parseInt(localSeriesLimit.trim(), 10))}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={localSeriesLimit}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>


### PR DESCRIPTION
The series limit input in the Prometheus metrics browser fires a label fetch on every keystroke. Added local state to buffer the input value and only propagate it (triggering the fetch) on blur.

Fixes #120727