### PR TITLE
Add note about reserved SQL keywords in column names

### DIFF
--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -74,6 +74,11 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.CharExpr:
 		return
 
+    // Column names that match reserved SQL keywords (for example: plan,
+    // group, order, select) may still cause parse errors before reaching
+    // this allowlist logic. Users should alias or rename such columns in
+    // their query.
+
 	case sqlparser.ColIdent, *sqlparser.ColName, sqlparser.Columns, sqlparser.ColumnType:
 		return
 


### PR DESCRIPTION
**What is this feature?**

Adds a code comment in `pkg/expr/sql/parser_allow.go` explaining that column names matching reserved SQL keywords such as `plan`, `group`, `order`, and `select` may still fail during parsing before reaching the allowlist logic.

**Why do we need this feature?**

Users can encounter syntax errors when using reserved SQL keywords as column names, even though column identifiers are otherwise allowed. This comment documents that behavior for future maintainers and helps explain why the parser can still fail before `allowedNode()` is reached.

**Who is this feature for?**

Grafana maintainers and contributors working on SQL Expressions parsing behavior.

**Which issue(s) does this PR fix?**:

Fixes #106573 

**Special notes for your reviewer:**

Please check that:

* [x] It works as expected from a user's perspective.
* [ ] If this is a pre-GA feature, it is behind a feature toggle.
* [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
