### PR TITLE
chore(grafana-ui): replace lodash isEqual with fast-deep-equal

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -94,6 +94,7 @@
     "d3": "7.9.0",
     "date-fns": "4.1.0",
     "downshift": "^9.0.6",
+    "fast-deep-equal": "^3.1.3",
     "hoist-non-react-statics": "3.3.2",
     "i18next": "^25.0.0",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/packages/grafana-ui/src/components/Select/ValueContainer.tsx
+++ b/packages/grafana-ui/src/components/Select/ValueContainer.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { isEqual } from 'lodash';
+import deepEqual from 'fast-deep-equal';
 import { Component, createRef, type ReactNode } from 'react';
 import { type ValueContainerProps as BaseValueContainerProps, type GroupBase } from 'react-select';
 
@@ -27,7 +27,7 @@ class UnthemedValueContainer<Option, isMulti extends boolean, Group extends Grou
       this.ref.current &&
       this.props.selectProps.autoWidth &&
       !this.props.selectProps.maxVisibleValues &&
-      !isEqual(prevProps.selectProps.value, this.props.selectProps.value)
+      !deepEqual(prevProps.selectProps.value, this.props.selectProps.value)
     ) {
       // Reset in order to measure the new width
       this.ref.current.style.minWidth = '0px';

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { isEqual } from 'lodash';
+import deepEqual from 'fast-deep-equal';
 import { createRef, PureComponent } from 'react';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
@@ -87,7 +87,7 @@ export class Typeahead extends PureComponent<Props, State> {
       this.listRef.current.scrollToItem(this.state.typeaheadIndex);
     }
 
-    if (isEqual(prevProps.groupedItems, this.props.groupedItems) === false) {
+    if (!deepEqual(prevProps.groupedItems, this.props.groupedItems)) {
       const allItems = flattenGroupItems(this.props.groupedItems);
       const longestLabel = calculateLongestLabel(allItems);
       const { listWidth, listHeight, itemHeight } = calculateListSizes(this.context, allItems, longestLabel);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4119,6 +4119,7 @@ __metadata:
     downshift: "npm:^9.0.6"
     esbuild: "npm:0.25.8"
     expose-loader: "npm:5.0.1"
+    fast-deep-equal: "npm:^3.1.3"
     fs-extra: "npm:^11.2.0"
     hoist-non-react-statics: "npm:3.3.2"
     i18next: "npm:^25.0.0"


### PR DESCRIPTION
## What

Replace `lodash.isEqual` with `fast-deep-equal` in `ValueContainer.tsx` and `Typeahead.tsx`.

## Why

Part of the ongoing effort to remove lodash dependencies from `@grafana/ui`.

### Why `fast-deep-equal`?

- **Already used in the project** — `@grafana/i18n` already depends on it, so this adds no new dependency to the monorepo
- **Drop-in replacement** — same signature as `lodash.isEqual`: `deepEqual(a, b) => boolean`
- **Smaller** — ~500 bytes vs ~16KB for `lodash.isEqual`
- **Faster** — 3x faster than `lodash.isEqual` in benchmarks

## Changes

- Removed `import { isEqual } from 'lodash'` from `ValueContainer.tsx` and `Typeahead.tsx`
- Added `import deepEqual from 'fast-deep-equal'` in both files
- Added `fast-deep-equal` as a dependency of `@grafana/ui`

## Test

All existing tests pass:
- Select: 2 suites, 31 tests
- Typeahead: 3 suites, 8 tests