### PR TITLE
chore(grafana-ui): replace lodash sampleSize with native alternative

### DIFF
--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -1,5 +1,5 @@
 import { type Property } from 'csstype';
-import { clone, sampleSize } from 'lodash';
+import { clone } from 'lodash';
 import memoize from 'micro-memoize';
 import { type HeaderGroup, type Row } from 'react-table';
 import tinycolor from 'tinycolor2';
@@ -751,12 +751,11 @@ export function guessLongestField(fieldConfig: FieldConfigSource, data: DataFram
       // the mean length
       else {
         for (const field of stringFields) {
-          // This could result in duplicate values but
-          // that should be fairly unlikely. This could potentially
-          // be improved using a Set datastructure but
-          // going to leave that one as an exercise for
-          // the reader to contemplate and possibly code
-          const vals = sampleSize(field.values, SAMPLE_SIZE);
+          const indices = new Set<number>();
+          while (indices.size < SAMPLE_SIZE) {
+            indices.add(Math.floor(Math.random() * field.values.length));
+          }
+          const vals = [...indices].map((i) => field.values[i]);
           const meanLength = (vals[0]?.length + vals[1]?.length + vals[2]?.length) / 3;
 
           if (meanLength > longestLength) {


### PR DESCRIPTION
## chore(grafana-ui): replace lodash `sampleSize` with native alternative

### What
Removes the `sampleSize` import from `lodash` in `packages/grafana-ui/src/components/Table/utils.ts`.

### Changes
- **`sampleSize`** → `Set<number>` based random index selection. Picks `SAMPLE_SIZE` (3) unique random indices from the array and maps them to values. For arrays with 30+ elements (the only code path that reaches this logic), collisions are rare and resolved by the `Set`.

### Testing
- All 13 Table test suites pass (430 tests)
- ESLint clean