### PR TITLE
RBAC: Reject `*` resource name in resource permissions writes

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -186,10 +186,7 @@ func (m *MappersRegistry) ParseScope(scope, datasourceType string) (*groupResour
 		return nil, fmt.Errorf("%w: %s", errUnknownGroupResource, parts[0])
 	}
 
-	group := gr.Group
-	if parts[2] != "*" || datasourceType != "" {
-		group = resolveGroup(group, datasourceType)
-	}
+	group := resolveGroup(gr.Group, datasourceType)
 
 	return &groupResourceName{Group: group, Resource: gr.Resource, Name: parts[2]}, nil
 }
@@ -286,10 +283,7 @@ func (m *MappersRegistry) ParseScopeCtx(ctx context.Context, ns types.NamespaceI
 	}
 
 	entry := m.entries[gr]
-	group := gr.Group
-	if parts[2] != "*" || datasourceType != "" {
-		group = resolveGroup(group, datasourceType)
-	}
+	group := resolveGroup(gr.Group, datasourceType)
 
 	name := parts[2]
 	if isIDScoped(entry.mapper) && store != nil {

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -325,21 +325,6 @@ func TestMappersRegistry_Wildcard_ParseScope(t *testing.T) {
 	assert.Equal(t, "loki.datasource.grafana.app", grn.Group)
 	assert.Equal(t, "datasources", grn.Resource)
 	assert.Equal(t, "ds1", grn.Name)
-
-	t.Run("wildcard scope identifier preserves wildcard group", func(t *testing.T) {
-		grn, err := m.ParseScope("datasources:uid:*", "")
-		require.NoError(t, err)
-		assert.Equal(t, "*.datasource.grafana.app", grn.Group)
-		assert.Equal(t, "datasources", grn.Resource)
-		assert.Equal(t, "*", grn.Name)
-	})
-
-	t.Run("wildcard scope identifier resolves group when type is provided", func(t *testing.T) {
-		grn, err := m.ParseScope("datasources:uid:*", "loki")
-		require.NoError(t, err)
-		assert.Equal(t, "loki.datasource.grafana.app", grn.Group)
-		assert.Equal(t, "*", grn.Name)
-	})
 }
 
 func TestMappersRegistry_MultipleWildcards(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/validate.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate.go
@@ -24,6 +24,10 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource permission name: %s", err))
 	}
 
+	if grn.Name == "*" {
+		return apierrors.NewBadRequest(`resource name "*" is not valid: resource permissions must target a specific resource`)
+	}
+
 	// Validate that the group/resource/name in the name matches the spec
 	if grn.Group != v0ResourcePerm.Spec.Resource.ApiGroup ||
 		grn.Resource != v0ResourcePerm.Spec.Resource.Resource ||
@@ -57,6 +61,10 @@ func ValidateDeleteInput(ctx context.Context, name string, mappers *MappersRegis
 	grn, err := splitResourceName(name)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource permission name: %s", err))
+	}
+
+	if grn.Name == "*" {
+		return apierrors.NewBadRequest(`resource name "*" is not valid: resource permissions must target a specific resource`)
 	}
 
 	// Check that the group/resource is registered and enabled

--- a/pkg/registry/apis/iam/resourcepermission/validate_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate_test.go
@@ -43,6 +43,29 @@ func TestValidateOnCreate(t *testing.T) {
 			want: errInvalidName,
 		},
 		{
+			name: "wildcard resource name - should fail",
+			obj: &iamv0alpha1.ResourcePermission{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "folder.grafana.app-folders-*",
+				},
+				Spec: iamv0alpha1.ResourcePermissionSpec{
+					Resource: iamv0alpha1.ResourcePermissionspecResource{
+						ApiGroup: "folder.grafana.app",
+						Resource: "folders",
+						Name:     "*",
+					},
+					Permissions: []iamv0alpha1.ResourcePermissionspecPermission{
+						{
+							Kind: iamv0alpha1.ResourcePermissionSpecPermissionKindBasicRole,
+							Name: "Editor",
+							Verb: "edit",
+						},
+					},
+				},
+			},
+			want: errInvalidSpec,
+		},
+		{
 			name: "mismatched name and spec - should fail",
 			obj: &iamv0alpha1.ResourcePermission{
 				ObjectMeta: v1.ObjectMeta{
@@ -179,6 +202,11 @@ func TestValidateDeleteInput(t *testing.T) {
 			name:    "invalid name - should fail",
 			objName: "some-invalid-name",
 			want:    errInvalidName,
+		},
+		{
+			name:    "wildcard resource name - should fail",
+			objName: "folder.grafana.app-folders-*",
+			want:    errInvalidSpec,
 		},
 		{
 			name:    "enabled group/resource (folder) - should pass",

--- a/pkg/services/accesscontrol/resourcepermissions/error.go
+++ b/pkg/services/accesscontrol/resourcepermissions/error.go
@@ -5,11 +5,11 @@ import (
 )
 
 const (
-	invalidPermissionMessage  = `Permission [{{ .Public.permission }}] is invalid for this resource type`
-	invalidAssignmentMessage  = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
-	invalidParamMessage       = `Param [{{ .Public.param }}] is invalid`
-	invalidRequestBody        = `Request body is invalid: {{ .Public.reason }}`
-	invalidResourceIDMessage  = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
+	invalidPermissionMessage = `Permission [{{ .Public.permission }}] is invalid for this resource type`
+	invalidAssignmentMessage = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
+	invalidParamMessage      = `Param [{{ .Public.param }}] is invalid`
+	invalidRequestBody       = `Request body is invalid: {{ .Public.reason }}`
+	invalidResourceIDMessage = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
 )
 
 var (

--- a/pkg/services/accesscontrol/resourcepermissions/error.go
+++ b/pkg/services/accesscontrol/resourcepermissions/error.go
@@ -5,10 +5,11 @@ import (
 )
 
 const (
-	invalidPermissionMessage = `Permission [{{ .Public.permission }}] is invalid for this resource type`
-	invalidAssignmentMessage = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
-	invalidParamMessage      = `Param [{{ .Public.param }}] is invalid`
-	invalidRequestBody       = `Request body is invalid: {{ .Public.reason }}`
+	invalidPermissionMessage  = `Permission [{{ .Public.permission }}] is invalid for this resource type`
+	invalidAssignmentMessage  = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
+	invalidParamMessage       = `Param [{{ .Public.param }}] is invalid`
+	invalidRequestBody        = `Request body is invalid: {{ .Public.reason }}`
+	invalidResourceIDMessage  = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
 )
 
 var (
@@ -20,6 +21,8 @@ var (
 				MustTemplate(invalidPermissionMessage, errutil.WithPublic(invalidPermissionMessage))
 	ErrInvalidAssignment = errutil.BadRequest("resourcePermissions.invalidAssignment").
 				MustTemplate(invalidAssignmentMessage, errutil.WithPublic(invalidAssignmentMessage))
+	ErrInvalidResourceID = errutil.BadRequest("resourcePermissions.invalidResourceID").
+				MustTemplate(invalidResourceIDMessage, errutil.WithPublic(invalidResourceIDMessage))
 )
 
 func ErrInvalidParamData(param string, err error) errutil.TemplateData {
@@ -51,6 +54,14 @@ func ErrInvalidAssignmentData(assignment string) errutil.TemplateData {
 	return errutil.TemplateData{
 		Public: map[string]any{
 			"assignment": assignment,
+		},
+	}
+}
+
+func ErrInvalidResourceIDData(resourceID string) errutil.TemplateData {
+	return errutil.TemplateData{
+		Public: map[string]any{
+			"resourceID": resourceID,
 		},
 	}
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -425,6 +425,10 @@ func (s *Service) validateResource(ctx context.Context, orgID int64, resourceID 
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.validateResource")
 	defer span.End()
 
+	if resourceID == "*" {
+		return ErrInvalidResourceID.Build(ErrInvalidResourceIDData(resourceID))
+	}
+
 	if s.options.ResourceValidator != nil {
 		return s.options.ResourceValidator(ctx, orgID, resourceID)
 	}


### PR DESCRIPTION
**What**

Resource permissions are designed to grant access to a specific resource instance — a folder, a dashboard, a datasource — identified by UID. A scope like `folders:uid:*` is not a valid resource permission target; it's a fixed-role/RBAC pattern that exists to grant broad access across all resources of a type.

Despite this, neither write path had an explicit guard against `*` as the resource name:

- The legacy `resourcepermissions.Service` relied on per-resource `ResourceValidator` callbacks.
- The new K8s `ResourcePermission` API had no check either.
- `ParseScope` in the mapper worked around the problem defensively, preserving the wildcard group (`*.datasource.grafana.app`) when `parts[2] == "*"` — code introduced in #122356 to handle a case that should not exist at write time.

**Changes**

- **`resourcepermissions/service.go`**: `validateResource` now rejects `resourceID == "*"` with a `400 Bad Request` before delegating to any per-resource validator. This closes the gap for all resource types uniformly.
- **`resourcepermissions/error.go`**: new `ErrInvalidResourceID` error type and template data helper.
- **`resourcepermission/validate.go`**: `ValidateCreateAndUpdateInput` and `ValidateDeleteInput` both reject `grn.Name == "*"` immediately after parsing the object name.
- **`resourcepermission/mapper.go`**: removed the `parts[2] != "*"` conditional in `ParseScope` and `ParseScopeCtx`. Since `*` is now rejected on write, it should never reach these functions from live data. The group is now always resolved unconditionally via `resolveGroup`.
- **Tests** updated accordingly: wildcard-name `ParseScope` tests removed; new `"wildcard resource name - should fail"` cases added to `TestValidateOnCreate` and `TestValidateDeleteInput`.