### PR TITLE
[release-11.6.15] Chore(deps): Upgrade handlebars to >= 4.7.9

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18884,11 +18884,11 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:^4.7.7":
-  version: 4.7.7
-  resolution: "handlebars@npm:4.7.7"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
-    neo-async: "npm:^2.6.0"
+    neo-async: "npm:^2.6.2"
     source-map: "npm:^0.6.1"
     uglify-js: "npm:^3.1.4"
     wordwrap: "npm:^1.0.0"
@@ -18897,7 +18897,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10/617b1e689b7577734abc74564bdb8cdaddf8fd48ce72afdb489f426e9c60a7d6ee2a2707c023720c4059070128243c948bded8f2716e4543378033e3971b85ea
+  checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
   languageName: node
   linkType: hard
 
@@ -23605,7 +23605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.6.0, neo-async@npm:^2.6.2":
+"neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10/1a7948fea86f2b33ec766bc899c88796a51ba76a4afc9026764aedc6e7cde692a09067031e4a1bf6db4f978ccd99e7f5b6c03fe47ad9865c3d4f99050d67e002


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `handlebars` to fix a known CVE
- Fixed version: >= 4.7.9 (was 4.7.7, now 4.7.9)
- Method: `yarn up -R handlebars`
- Parent dependency: `lerna` → `conventional-changelog-writer` → `handlebars`

## Test plan
- [ ] CI passes
- [ ] `yarn why handlebars --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)