### PR TITLE
[release-13.0.1] Provisioning: Include dashboard validation errors in pull request comments

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -147,7 +147,6 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 	err = info.Parsed.DryRun(ctx)
 	if err != nil {
 		info.Error = err.Error()
-		return info
 	}
 
 	// Dashboards get special handling

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -402,8 +402,10 @@ func TestCalculateChanges(t *testing.T) {
 						Path:   "path/to/file.json",
 						Ref:    "ref",
 					},
-					Error: "no client configured",
-					Title: "hello world",
+					Error:      "no client configured",
+					Title:      "hello world",
+					GrafanaURL: "http://host/d/the-uid/hello-world",
+					PreviewURL: "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
 					Parsed: &resources.ParsedResource{
 						Info: &repository.FileInfo{
 							Path: "path/to/file.json",

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -4,26 +4,30 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"path/filepath"
 	"strings"
+	"text/template"
 )
 
+const maxErrorLength = 256
+
 type commenter struct {
-	templateDashboard     *template.Template
-	templateTable         *template.Template
-	templateRenderInfo    *template.Template
-	templateFooter        *template.Template
-	showImageRendererNote bool
+	templateDashboard        *template.Template
+	templateTable            *template.Template
+	templateRenderInfo       *template.Template
+	templateFooter           *template.Template
+	templateValidationErrors *template.Template
+	showImageRendererNote    bool
 }
 
 func NewCommenter(showImageRendererNote bool) Commenter {
 	return &commenter{
-		templateDashboard:     template.Must(template.New("dashboard").Parse(commentTemplateSingleDashboard)),
-		templateTable:         template.Must(template.New("table").Parse(commentTemplateTable)),
-		templateRenderInfo:    template.Must(template.New("setup").Parse(commentTemplateMissingImageRenderer)),
-		templateFooter:        template.Must(template.New("footer").Parse(commentTemplateFooter)),
-		showImageRendererNote: showImageRendererNote,
+		templateDashboard:        template.Must(template.New("dashboard").Parse(commentTemplateSingleDashboard)),
+		templateTable:            template.Must(template.New("table").Parse(commentTemplateTable)),
+		templateRenderInfo:       template.Must(template.New("setup").Parse(commentTemplateMissingImageRenderer)),
+		templateFooter:           template.Must(template.New("footer").Parse(commentTemplateFooter)),
+		templateValidationErrors: template.Must(template.New("errors").Parse(commentTemplateValidationErrors)),
+		showImageRendererNote:    showImageRendererNote,
 	}
 }
 
@@ -47,12 +51,17 @@ func (c *commenter) generateComment(_ context.Context, info changeInfo) (string,
 	if len(info.Changes) == 0 {
 		buf.WriteString("Grafana didn't find any changes in this pull request.")
 	} else if len(info.Changes) == 1 && info.Changes[0].Parsed.GVK.Kind == dashboardKind {
-		if err := c.templateDashboard.Execute(&buf, info.Changes[0]); err != nil {
+		if err := c.templateDashboard.Execute(&buf, &info.Changes[0]); err != nil {
 			return "", fmt.Errorf("unable to execute template: %w", err)
 		}
 	} else {
-		if err := c.templateTable.Execute(&buf, info); err != nil {
+		if err := c.templateTable.Execute(&buf, &info); err != nil {
 			return "", fmt.Errorf("unable to execute template: %w", err)
+		}
+		if info.HasErrors() {
+			if err := c.templateValidationErrors.Execute(&buf, &info); err != nil {
+				return "", fmt.Errorf("unable to execute validation errors template: %w", err)
+			}
 		}
 	}
 
@@ -66,10 +75,14 @@ func (c *commenter) generateComment(_ context.Context, info changeInfo) (string,
 		return "", fmt.Errorf("unable to execute footer template: %w", err)
 	}
 
-	return strings.TrimSpace(buf.String()), nil
+	result := strings.TrimSpace(buf.String())
+	for strings.Contains(result, "\n\n\n") {
+		result = strings.ReplaceAll(result, "\n\n\n", "\n\n")
+	}
+	return result, nil
 }
 
-const commentTemplateSingleDashboard = `Hey there! 🎉
+const commentTemplateSingleDashboard = `Hey there! 👋
 Grafana spotted some changes to your dashboard.
 {{- if and .GrafanaScreenshotURL .PreviewScreenshotURL}}
 
@@ -95,20 +108,43 @@ See the [original]({{.GrafanaURL}}) of {{.Title}}.
 {{- else if .PreviewURL}}
 
 See the [preview]({{.PreviewURL}}) of {{.Parsed.Info.Path}}.
-{{- end}}`
+{{- end}}{{ if .Error}}
 
-const commentTemplateTable = `Hey there! 🎉
-Grafana spotted some changes.
+> ⚠️ **Validation failed:** {{.TruncatedError}}
+{{- end}}
+`
 
-| Action | Kind | Resource | Preview |
-|--------|------|----------|---------|
+const commentTemplateTable = `Hey there! 👋
+{{- if .HasErrors}}
+Grafana spotted {{.TotalChanges}} changes ({{.ErrorCount}} with issues).
+{{- else}}
+Grafana spotted {{.TotalChanges}} changes.
+{{- end}}
+
+| Action | Kind | Resource | Preview | Status |
+|--------|------|----------|---------|--------|
 {{- range .Changes}}
-| {{.Parsed.Action}} | {{.Kind}} | {{.ExistingLink}} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} |
+| {{.Parsed.Action}} | {{.Kind}} | {{.ExistingLink}} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
 {{- end -}}
 {{- if .SkippedFiles}}
 
 and {{ .SkippedFiles }} more files.
+{{- end}}
+{{- if not .HasErrors}}
+
+All resources passed validation. ✅
 {{- end}}`
+
+const commentTemplateValidationErrors = `
+
+### ⚠️ Validation Issues
+
+| File | Error |
+|------|-------|
+{{- range .Changes}}{{ if .Error}}
+| ` + "`{{.Change.Path}}`" + ` | {{.TruncatedError}} |
+{{- end}}{{ end}}
+`
 
 const commentTemplateMissingImageRenderer = `
 
@@ -137,4 +173,46 @@ func (f *fileChangeInfo) ExistingLink() string {
 		return fmt.Sprintf("[%s](%s)", f.Title, f.GrafanaURL)
 	}
 	return f.Title
+}
+
+func (f *fileChangeInfo) StatusIcon() string {
+	if f.Error != "" {
+		return "⚠️"
+	}
+	return "✅"
+}
+
+// TruncatedError returns a sanitized, length-limited error suitable for a
+// pullrequest comment.
+func (f *fileChangeInfo) TruncatedError() string {
+	msg := strings.ReplaceAll(f.Error, "\n", " ")
+	msg = strings.ReplaceAll(msg, "\r", "")
+	msg = strings.ReplaceAll(msg, "|", "\\|")
+	if len(msg) > maxErrorLength {
+		return msg[:maxErrorLength] + "…"
+	}
+	return msg
+}
+
+func (c *changeInfo) HasErrors() bool {
+	for i := range c.Changes {
+		if c.Changes[i].Error != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *changeInfo) TotalChanges() int {
+	return len(c.Changes)
+}
+
+func (c *changeInfo) ErrorCount() int {
+	n := 0
+	for i := range c.Changes {
+		if c.Changes[i].Error != "" {
+			n++
+		}
+	}
+	return n
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -138,6 +138,69 @@ func TestGenerateComment(t *testing.T) {
 				},
 			},
 		}},
+		{"single dashboard with error", changeInfo{
+			GrafanaBaseURL: "http://host/",
+			Changes: []fileChangeInfo{
+				{
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "broken.json",
+						},
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+						Action: v0alpha1.ResourceActionCreate,
+					},
+					Title:      "Broken Dashboard",
+					PreviewURL: "http://grafana/admin/preview",
+					Error:      "strict decoding error: unknown field \"spec.invalidField\"",
+				},
+			},
+		}},
+		{"multiple files with errors", changeInfo{
+			GrafanaBaseURL: "http://host/",
+			Changes: []fileChangeInfo{
+				{
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "good.json",
+						},
+						Action: v0alpha1.ResourceActionCreate,
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+					},
+					Title:      "Good Dashboard",
+					PreviewURL: "http://grafana/admin/preview",
+				},
+				{
+					Change: repository.VersionedFileChange{
+						Path: "bad.json",
+					},
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "bad.json",
+						},
+						Action: v0alpha1.ResourceActionUpdate,
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+					},
+					Title:      "Bad Dashboard",
+					GrafanaURL: "http://grafana/d/bad",
+					PreviewURL: "http://grafana/admin/preview",
+					Error:      "admission webhook denied: panel type \"unknown-panel\" is not installed",
+				},
+				{
+					Change: repository.VersionedFileChange{
+						Path: "invalid.yaml",
+					},
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "invalid.yaml",
+						},
+						Action: v0alpha1.ResourceActionCreate,
+						GVK:    schema.GroupVersionKind{Kind: "Playlist"},
+					},
+					Title: "Broken Playlist",
+					Error: "strict decoding error: unknown field \"spec.extra\"",
+				},
+			},
+		}},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			repo := NewMockPullRequestRepo(t)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-errors.md
@@ -1,0 +1,18 @@
+Hey there! 👋
+Grafana spotted 3 changes (2 with issues).
+
+| Action | Kind | Resource | Preview | Status |
+|--------|------|----------|---------|--------|
+| create | Dashboard | Good Dashboard | [preview](http://grafana/admin/preview) | ✅ |
+| update | Dashboard | [Bad Dashboard](http://grafana/d/bad) | [preview](http://grafana/admin/preview) | ⚠️ |
+| create | Playlist | Broken Playlist |  | ⚠️ |
+
+### ⚠️ Validation Issues
+
+| File | Error |
+|------|-------|
+| `bad.json` | admission webhook denied: panel type "unknown-panel" is not installed |
+| `invalid.yaml` | strict decoding error: unknown field "spec.extra" |
+
+---
+_Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -1,13 +1,15 @@
-Hey there! 🎉
-Grafana spotted some changes.
+Hey there! 👋
+Grafana spotted 3 changes.
 
-| Action | Kind | Resource | Preview |
-|--------|------|----------|---------|
-| create | Dashboard | Dash A | [preview](http://grafana/admin/preview) |
-| update | Dashboard | [Dash B](http://grafana/d/bbb) | [preview](http://grafana/admin/preview) |
-| create | Playlist | My Playlist |  |
+| Action | Kind | Resource | Preview | Status |
+|--------|------|----------|---------|--------|
+| create | Dashboard | Dash A | [preview](http://grafana/admin/preview) | ✅ |
+| update | Dashboard | [Dash B](http://grafana/d/bbb) | [preview](http://grafana/admin/preview) | ✅ |
+| create | Playlist | My Playlist |  | ✅ |
 
 and 5 more files.
+
+All resources passed validation. ✅
 
 ---
 _Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
@@ -1,4 +1,4 @@
-Hey there! 🎉
+Hey there! 👋
 Grafana spotted some changes to your dashboard.
 
 ### Preview of file.json

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-error.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-error.md
@@ -1,0 +1,9 @@
+Hey there! 👋
+Grafana spotted some changes to your dashboard.
+
+See the [preview](http://grafana/admin/preview) of broken.json.
+
+> ⚠️ **Validation failed:** strict decoding error: unknown field "spec.invalidField"
+
+---
+_Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
@@ -1,4 +1,4 @@
-Hey there! 🎉
+Hey there! 👋
 Grafana spotted some changes to your dashboard.
 
 See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of file.json.

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
@@ -1,4 +1,4 @@
-Hey there! 🎉
+Hey there! 👋
 Grafana spotted some changes to your dashboard.
 
 ### Side by Side Comparison of file.json


### PR DESCRIPTION
Backport bb41ac0c85d854e32cb19874fb4b3f17163179a8 from #122233

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Improve error handling in webhook pull request comments in two ways:
* Preview url is generated even if resource parse fail, as the preview will contain a visualization of the error.
* PR comments for invalid resources are improved:
  * Resources that have errors are marked with a warning emoji, so they're easy to track.
  * In multiple resources PRs, a summary line is added, containing the successful and failed resources.
  * In single resource PRs, a list of the errors is added.

**Why do we need this feature?**

Provide better user feedback when PRs contains invalid changes.

**Who is this feature for?**

Provisioning customers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1059

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
