### PR TITLE
feat: auto-refresh $__file{} database credentials on auth error

### DIFF
--- a/pkg/services/sqlstore/auth_error.go
+++ b/pkg/services/sqlstore/auth_error.go
@@ -1,0 +1,36 @@
+package sqlstore
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+)
+
+// IsAuthError reports whether err is a database authentication failure.
+// It checks for driver-native error types first, then falls back to string
+// matching for wrapped errors. Returns false for nil.
+func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Postgres: check pq.Error codes
+	// 28P01 = invalid_password, 28000 = invalid_authorization_specification
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "28P01" || pqErr.Code == "28000"
+	}
+
+	// MySQL: check MySQLError number 1045 = ER_ACCESS_DENIED_ERROR
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == 1045
+	}
+
+	// Fallback: string matching for wrapped/opaque errors
+	msg := err.Error()
+	return strings.Contains(msg, "password authentication failed") ||
+		strings.Contains(msg, "Access denied for user")
+}

--- a/pkg/services/sqlstore/auth_error_test.go
+++ b/pkg/services/sqlstore/auth_error_test.go
@@ -1,0 +1,52 @@
+package sqlstore
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAuthError_PostgresAuthFailed(t *testing.T) {
+	err := &pq.Error{Code: "28P01"}
+	assert.True(t, IsAuthError(err), "pq 28P01 should be auth error")
+}
+
+func TestIsAuthError_PostgresInvalidAuth(t *testing.T) {
+	err := &pq.Error{Code: "28000"}
+	assert.True(t, IsAuthError(err), "pq 28000 should be auth error")
+}
+
+func TestIsAuthError_MySQLAccessDenied(t *testing.T) {
+	err := &mysql.MySQLError{Number: 1045}
+	assert.True(t, IsAuthError(err), "mysql 1045 should be auth error")
+}
+
+func TestIsAuthError_WrappedPostgresString(t *testing.T) {
+	inner := fmt.Errorf("password authentication failed for user \"grafana\"")
+	wrapped := fmt.Errorf("db connect: %w", inner)
+	assert.True(t, IsAuthError(wrapped), "wrapped password authentication failed should be auth error")
+}
+
+func TestIsAuthError_WrappedMySQLString(t *testing.T) {
+	inner := fmt.Errorf("Access denied for user 'grafana'@'localhost'")
+	wrapped := fmt.Errorf("db connect: %w", inner)
+	assert.True(t, IsAuthError(wrapped), "wrapped Access denied should be auth error")
+}
+
+func TestIsAuthError_NotAnAuthError(t *testing.T) {
+	err := errors.New("connection refused")
+	assert.False(t, IsAuthError(err), "connection refused should not be auth error")
+}
+
+func TestIsAuthError_NilError(t *testing.T) {
+	assert.False(t, IsAuthError(nil), "nil should not be auth error")
+}
+
+func TestIsAuthError_MySQLOtherError(t *testing.T) {
+	err := &mysql.MySQLError{Number: 1054} // unknown column
+	assert.False(t, IsAuthError(err), "mysql 1054 should not be auth error")
+}

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -23,6 +23,9 @@ type DatabaseConfig struct {
 	Name                        string
 	User                        string
 	Pwd                         string
+	// PwdFilePath is the file path from which Pwd was read via $__file{}.
+	// Empty when password was not sourced from a file.
+	PwdFilePath                 string
 	Path                        string
 	SslMode                     string
 	SSLSNI                      string
@@ -50,6 +53,35 @@ type DatabaseConfig struct {
 	TransactionRetries int
 }
 
+// RefreshPassword re-reads Pwd from PwdFilePath. Returns true if the password
+// changed. No-op (returns false, nil) when PwdFilePath is empty.
+func (dbCfg *DatabaseConfig) RefreshPassword() (bool, error) {
+	if dbCfg.PwdFilePath == "" {
+		return false, nil
+	}
+
+	// nolint:gosec
+	data, err := os.ReadFile(dbCfg.PwdFilePath)
+	if err != nil {
+		return false, fmt.Errorf("re-reading password file %q: %w", dbCfg.PwdFilePath, err)
+	}
+
+	newPwd := strings.TrimSpace(string(data))
+	if newPwd == dbCfg.Pwd {
+		return false, nil
+	}
+
+	dbCfg.Pwd = newPwd
+	return true, nil
+}
+
+// RebuildConnectionString clears the cached ConnectionString and rebuilds it
+// from the current field values. Must be called after RefreshPassword updates Pwd.
+func (dbCfg *DatabaseConfig) RebuildConnectionString(cfg *setting.Cfg, features featuremgmt.FeatureToggles) error {
+	dbCfg.ConnectionString = ""
+	return dbCfg.buildConnectionString(cfg, features)
+}
+
 func NewDatabaseConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles) (*DatabaseConfig, error) {
 	if cfg == nil {
 		return nil, errors.New("cfg cannot be nil")
@@ -58,6 +90,13 @@ func NewDatabaseConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles) (*
 	dbCfg := &DatabaseConfig{}
 	if err := dbCfg.readConfig(cfg); err != nil {
 		return nil, err
+	}
+
+	// Propagate $__file{} path for the password so we can re-read it on rotation.
+	if cfg.FileExpansions != nil {
+		if dbSection, ok := cfg.FileExpansions["database"]; ok {
+			dbCfg.PwdFilePath = dbSection["password"]
+		}
 	}
 
 	if err := dbCfg.buildConnectionString(cfg, features); err != nil {

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"errors"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,4 +214,58 @@ func TestBuildConnectionStringPostgres(t *testing.T) {
 			assert.Equal(t, tc.expectedConnStr, tc.dbCfg.ConnectionString)
 		})
 	}
+}
+
+func TestRefreshPassword_DetectsChange(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "pwd_*")
+	require.NoError(t, err)
+	_, err = f.WriteString("initial_password")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	dbCfg := &DatabaseConfig{
+		Pwd:         "initial_password",
+		PwdFilePath: f.Name(),
+	}
+
+	changed, err := dbCfg.RefreshPassword()
+	require.NoError(t, err)
+	assert.False(t, changed, "password has not changed, so changed should be false")
+
+	// Now rotate the secret
+	require.NoError(t, os.WriteFile(f.Name(), []byte("new_password"), 0o600))
+
+	changed, err = dbCfg.RefreshPassword()
+	require.NoError(t, err)
+	assert.True(t, changed, "password changed, so changed should be true")
+	assert.Equal(t, "new_password", dbCfg.Pwd)
+}
+
+func TestRefreshPassword_NoPwdFilePath(t *testing.T) {
+	dbCfg := &DatabaseConfig{
+		Pwd:         "static_password",
+		PwdFilePath: "",
+	}
+
+	changed, err := dbCfg.RefreshPassword()
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, "static_password", dbCfg.Pwd)
+}
+
+func TestRebuildConnectionString_ClearsAndRebuildsPostgres(t *testing.T) {
+	dbCfg := &DatabaseConfig{
+		Type:             migrator.Postgres,
+		User:             "grafana",
+		Pwd:              "newpassword",
+		Host:             "127.0.0.1:5432",
+		Name:             "grafana_test",
+		SslMode:          "disable",
+		ConnectionString: "old_stale_connection_string",
+	}
+
+	err := dbCfg.RebuildConnectionString(&setting.Cfg{}, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, "old_stale_connection_string", dbCfg.ConnectionString)
+	assert.Contains(t, dbCfg.ConnectionString, "newpassword")
 }

--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -95,6 +95,11 @@ func (ss *SQLStore) retryOnLocks(ctx context.Context, callback DBTransactionFunc
 		}
 
 		if err != nil {
+			if ss.dbCfg.PwdFilePath != "" && IsAuthError(err) && retry <= 1 {
+				ctxLogger.Info("Database auth error in session callback, attempting credential refresh", "error", err, "retry", retry)
+				ss.attemptCredentialRefresh()
+				return retryer.FuncFailure, nil
+			}
 			return retryer.FuncError, err
 		}
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -53,6 +53,10 @@ type SQLStore struct {
 	tracer                       tracing.Tracer
 	recursiveQueriesAreSupported *bool
 	recursiveQueriesMu           sync.Mutex
+
+	// credential refresh state — only active when dbCfg.PwdFilePath != ""
+	refreshMu       sync.Mutex
+	lastRefreshTime time.Time
 }
 
 func ProvideService(cfg *setting.Cfg,
@@ -371,6 +375,62 @@ func (ss *SQLStore) ensureTransactionIsolationCompatibility(engine *xorm.Engine,
 
 func (ss *SQLStore) GetMigrationLockAttemptTimeout() int {
 	return ss.dbCfg.MigrationLockAttemptTimeout
+}
+
+const credentialRefreshDebounce = 30 * time.Second
+
+// attemptCredentialRefresh re-reads the password file, rebuilds the connection
+// string, and swaps the xorm engine. It is debounced to once per 30 seconds to
+// prevent thundering-herd on repeated auth errors.
+//
+// Guard: only active when dbCfg.PwdFilePath != "".
+func (ss *SQLStore) attemptCredentialRefresh() {
+	if ss.dbCfg.PwdFilePath == "" {
+		return
+	}
+
+	ss.refreshMu.Lock()
+	defer ss.refreshMu.Unlock()
+
+	if time.Since(ss.lastRefreshTime) < credentialRefreshDebounce {
+		return
+	}
+
+	changed, err := ss.dbCfg.RefreshPassword()
+	if err != nil {
+		ss.log.Error("Failed to re-read database password file", "path", ss.dbCfg.PwdFilePath, "error", err)
+		return
+	}
+	if !changed {
+		ss.log.Debug("Database password file unchanged, skipping engine rebuild")
+		ss.lastRefreshTime = time.Now()
+		return
+	}
+
+	if err := ss.dbCfg.RebuildConnectionString(ss.cfg, ss.features); err != nil {
+		ss.log.Error("Failed to rebuild database connection string after password rotation", "error", err)
+		return
+	}
+
+	newEngine, err := xorm.NewEngine(ss.dbCfg.Type, ss.dbCfg.ConnectionString)
+	if err != nil {
+		ss.log.Error("Failed to create new database engine after password rotation", "error", err)
+		return
+	}
+	newEngine.SetMaxOpenConns(ss.dbCfg.MaxOpenConn)
+	newEngine.SetMaxIdleConns(ss.dbCfg.MaxIdleConn)
+	newEngine.SetConnMaxLifetime(time.Second * time.Duration(ss.dbCfg.ConnMaxLifetime))
+
+	oldEngine := ss.engine
+	ss.engine = newEngine
+	ss.lastRefreshTime = time.Now()
+
+	ss.log.Info("Database credentials refreshed after password rotation")
+
+	// Close old engine — in-flight queries finish gracefully.
+	if err := oldEngine.Close(); err != nil {
+		ss.log.Warn("Error closing old database engine after credential refresh", "error", err)
+	}
 }
 
 func (ss *SQLStore) RecursiveQueriesAreSupported() (bool, error) {

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -75,6 +75,17 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 	}
 
 	if err != nil {
+		// On auth error with a file-sourced password, attempt credential refresh
+		// and retry the transaction once.
+		if ss.dbCfg.PwdFilePath != "" && IsAuthError(err) && retry == 0 {
+			ctxLogger.Info("Auth error detected, attempting credential refresh", "error", err)
+			ss.attemptCredentialRefresh()
+			if rollErr := sess.Rollback(); rollErr != nil {
+				ctxLogger.Warn("Rolling back failed session after auth error", "error", rollErr)
+			}
+			return ss.inTransactionWithRetryCtx(ctx, ss.engine, bus, callback, retry+1)
+		}
+
 		if rollErr := sess.Rollback(); rollErr != nil {
 			return fmt.Errorf("rolling back transaction due to error failed: %s: %w", rollErr, err)
 		}

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -34,6 +34,11 @@ func (ss *SQLStore) inTransactionWithRetry(ctx context.Context, fn func(ctx cont
 func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.Engine, bus bus.Bus, callback DBTransactionFunc, retry int) error {
 	sess, isNew, span, err := startSessionOrUseExisting(ctx, engine, true, ss.tracer)
 	if err != nil {
+		if ss.dbCfg.PwdFilePath != "" && IsAuthError(err) && retry == 0 {
+			tsclogger.FromContext(ctx).Info("Database auth error on session start, attempting credential refresh", "error", err)
+			ss.attemptCredentialRefresh()
+			return ss.inTransactionWithRetryCtx(ctx, ss.engine, bus, callback, retry+1)
+		}
 		return err
 	}
 

--- a/pkg/setting/expanders.go
+++ b/pkg/setting/expanders.go
@@ -49,6 +49,30 @@ func GetExpanderRegex() *regexp.Regexp {
 	return regex
 }
 
+// scanFileExpansions scans all INI keys for $__file{...} patterns BEFORE
+// expansion and returns a mapping of section -> key -> file path.
+// This must be called before expandConfig so we capture the raw paths.
+func scanFileExpansions(file *ini.File) map[string]map[string]string {
+	result := make(map[string]map[string]string)
+	fileRegex := regexp.MustCompile(`\$__file\{([^}]+)\}`)
+
+	for _, section := range file.Sections() {
+		for _, key := range section.Keys() {
+			match := fileRegex.FindStringSubmatch(key.Value())
+			if len(match) < 2 {
+				continue
+			}
+			sectionName := section.Name()
+			if result[sectionName] == nil {
+				result[sectionName] = make(map[string]string)
+			}
+			result[sectionName][key.Name()] = match[1]
+		}
+	}
+
+	return result
+}
+
 func expandConfig(file *ini.File) error {
 	sort.Slice(expanders, func(i, j int) bool {
 		return expanders[i].priority < expanders[j].priority

--- a/pkg/setting/expanders_test.go
+++ b/pkg/setting/expanders_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 )
 
 func TestExpandVar_EnvSuccessful(t *testing.T) {
@@ -93,4 +94,72 @@ func TestExpanderRegex(t *testing.T) {
 			assert.Equal(t, expected[i], variable[1:])
 		}
 	}
+}
+
+func TestScanFileExpansions_CapturesDatabasePassword(t *testing.T) {
+	iniContent := `
+[database]
+password = $__file{/run/secrets/db_password}
+user = grafana
+`
+	file, err := ini.Load([]byte(iniContent))
+	require.NoError(t, err)
+
+	result := scanFileExpansions(file)
+
+	require.NotNil(t, result)
+	require.Contains(t, result, "database")
+	require.Contains(t, result["database"], "password")
+	assert.Equal(t, "/run/secrets/db_password", result["database"]["password"])
+}
+
+func TestScanFileExpansions_MultipleKeys(t *testing.T) {
+	iniContent := `
+[database]
+password = $__file{/secrets/db_pwd}
+user = grafana
+
+[auth]
+secret_key = $__file{/secrets/auth_key}
+`
+	file, err := ini.Load([]byte(iniContent))
+	require.NoError(t, err)
+
+	result := scanFileExpansions(file)
+
+	require.Contains(t, result, "database")
+	assert.Equal(t, "/secrets/db_pwd", result["database"]["password"])
+	require.Contains(t, result, "auth")
+	assert.Equal(t, "/secrets/auth_key", result["auth"]["secret_key"])
+}
+
+func TestScanFileExpansions_NoFileExpansions(t *testing.T) {
+	iniContent := `
+[database]
+password = mysecret
+user = grafana
+`
+	file, err := ini.Load([]byte(iniContent))
+	require.NoError(t, err)
+
+	result := scanFileExpansions(file)
+
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestScanFileExpansions_OnlyFileExpansionsRecorded(t *testing.T) {
+	// env expansion should not be recorded, only file
+	iniContent := `
+[database]
+password = $__file{/secrets/db_pwd}
+host = $__env{DB_HOST}
+`
+	file, err := ini.Load([]byte(iniContent))
+	require.NoError(t, err)
+
+	result := scanFileExpansions(file)
+
+	require.Contains(t, result["database"], "password")
+	assert.NotContains(t, result["database"], "host")
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -95,6 +95,11 @@ type Cfg struct {
 	Raw    *ini.File
 	Logger log.Logger
 
+	// FileExpansions tracks which INI keys used $__file{} expansion.
+	// Mapping: section name -> key name -> file path.
+	// Populated before config expansion so callers can re-read files on rotation.
+	FileExpansions map[string]map[string]string
+
 	// for logging purposes
 	configFiles                  []string
 	appliedCommandLineProperties []string
@@ -1234,6 +1239,9 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 
 	// apply command line overrides
 	cfg.applyCommandLineProperties(parsedFile)
+
+	// record $__file{} paths before expansion so they can be re-read on credential rotation
+	cfg.FileExpansions = scanFileExpansions(parsedFile)
 
 	// evaluate config values containing environment variables
 	err = expandConfig(parsedFile)

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -52,6 +52,7 @@ func ProvideResourceDB(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.Trac
 type resourceDBProvider struct {
 	engine          *xorm.Engine
 	cfg             *setting.Cfg
+	dbCfg           *sqlstore.DatabaseConfig
 	log             log.Logger
 	migrateFunc     func(context.Context, *xorm.Engine, *setting.Cfg) error
 	tracer          trace.Tracer
@@ -81,6 +82,7 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		if err != nil {
 			return nil, err
 		}
+		p.dbCfg = dbCfg
 		p.registerMetrics = true
 		p.engine, err = getEngine(dbCfg)
 		return p, err
@@ -142,7 +144,44 @@ func (p *resourceDBProvider) initDB(ctx context.Context) (db.DB, error) {
 	}
 
 	d := NewDB(p.engine.DB().DB, p.engine.Dialect().DriverName())
+
+	// Wrap with refreshableDB when the password is sourced from a file so that
+	// auth errors trigger an automatic credential refresh and retry.
+	if p.dbCfg != nil && p.dbCfg.PwdFilePath != "" {
+		d = newRefreshableDB(d, p.buildRefreshedDB)
+	}
+
 	d = otel.NewInstrumentedDB(d, p.tracer)
 
 	return d, nil
+}
+
+// buildRefreshedDB re-reads the password file, rebuilds the connection string,
+// opens a new *sql.DB and returns it wrapped as db.DB.
+func (p *resourceDBProvider) buildRefreshedDB() (db.DB, error) {
+	changed, err := p.dbCfg.RefreshPassword()
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
+		// Password unchanged; return the current engine's DB (caller will retry).
+		return NewDB(p.engine.DB().DB, p.engine.Dialect().DriverName()), nil
+	}
+
+	if err := p.dbCfg.RebuildConnectionString(p.cfg, nil); err != nil {
+		return nil, err
+	}
+
+	newEngine, err := getEngine(p.dbCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	oldEngine := p.engine
+	p.engine = newEngine
+
+	// Close old engine gracefully.
+	_ = oldEngine.Close()
+
+	return NewDB(p.engine.DB().DB, p.engine.Dialect().DriverName()), nil
 }

--- a/pkg/storage/unified/sql/db/dbimpl/refreshable_db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/refreshable_db.go
@@ -1,0 +1,125 @@
+package dbimpl
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
+)
+
+const refreshableDBDebounce = 30 * time.Second
+
+// refreshFn is a function that returns a fresh db.DB after credential rotation.
+type refreshFn func() (db.DB, error)
+
+// refreshableDB wraps a db.DB and intercepts BeginTx. On authentication errors
+// it calls a caller-provided refresh function to obtain a new inner DB, then
+// retries the operation once.
+//
+// It is only instantiated when PwdFilePath is non-empty, so it has zero impact
+// on SQLite or static-credential deployments.
+type refreshableDB struct {
+	mu              sync.RWMutex
+	inner           db.DB
+	refresh         refreshFn
+	lastRefreshTime time.Time
+	db.WithTxFunc
+}
+
+// newRefreshableDB constructs a refreshableDB wrapping inner.
+func newRefreshableDB(inner db.DB, refresh refreshFn) *refreshableDB {
+	r := &refreshableDB{
+		inner:   inner,
+		refresh: refresh,
+	}
+	r.WithTxFunc = db.NewWithTxFunc(r.BeginTx)
+	return r
+}
+
+// BeginTx delegates to the inner DB. On auth error, calls refresh() and retries once.
+func (r *refreshableDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (db.Tx, error) {
+	r.mu.RLock()
+	inner := r.inner
+	r.mu.RUnlock()
+
+	tx, err := inner.BeginTx(ctx, opts)
+	if err == nil {
+		return tx, nil
+	}
+
+	if !sqlstore.IsAuthError(err) {
+		return nil, err
+	}
+
+	// Auth error — attempt refresh with debounce.
+	r.mu.Lock()
+	if time.Since(r.lastRefreshTime) < refreshableDBDebounce {
+		r.mu.Unlock()
+		// Already refreshed recently; return the original error.
+		return nil, err
+	}
+
+	newDB, refreshErr := r.refresh()
+	if refreshErr != nil {
+		r.mu.Unlock()
+		return nil, err // return original auth error; log is up to caller
+	}
+
+	r.inner = newDB
+	r.lastRefreshTime = time.Now()
+	r.mu.Unlock()
+
+	// Retry with the new inner DB.
+	r.mu.RLock()
+	inner = r.inner
+	r.mu.RUnlock()
+
+	return inner.BeginTx(ctx, opts)
+}
+
+// Forward all other db.DB methods to the current inner DB.
+
+func (r *refreshableDB) ExecContext(ctx context.Context, query string, args ...any) (db.Result, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.ExecContext(ctx, query, args...)
+}
+
+func (r *refreshableDB) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.QueryContext(ctx, query, args...)
+}
+
+func (r *refreshableDB) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.QueryRowContext(ctx, query, args...)
+}
+
+func (r *refreshableDB) PingContext(ctx context.Context) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.PingContext(ctx)
+}
+
+func (r *refreshableDB) Stats() sql.DBStats {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.Stats()
+}
+
+func (r *refreshableDB) DriverName() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.DriverName()
+}
+
+func (r *refreshableDB) SqlDB() *sql.DB {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.inner.SqlDB()
+}

--- a/pkg/storage/unified/sql/db/dbimpl/refreshable_db_test.go
+++ b/pkg/storage/unified/sql/db/dbimpl/refreshable_db_test.go
@@ -1,0 +1,119 @@
+package dbimpl
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// authErrorDB is a test db.DB that always returns an auth error on BeginTx.
+type authErrorDB struct {
+	callCount int
+	authErr   error
+	successDB db.DB
+}
+
+func (d *authErrorDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (db.Tx, error) {
+	d.callCount++
+	if d.callCount == 1 {
+		return nil, d.authErr
+	}
+	return d.successDB.BeginTx(ctx, opts)
+}
+
+func (d *authErrorDB) WithTx(ctx context.Context, opts *sql.TxOptions, f db.TxFunc) error {
+	return errors.New("not implemented")
+}
+
+func (d *authErrorDB) ExecContext(ctx context.Context, query string, args ...any) (db.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *authErrorDB) QueryContext(ctx context.Context, query string, args ...any) (db.Rows, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *authErrorDB) QueryRowContext(ctx context.Context, query string, args ...any) db.Row {
+	return nil
+}
+
+func (d *authErrorDB) PingContext(ctx context.Context) error { return nil }
+
+func (d *authErrorDB) Stats() sql.DBStats { return sql.DBStats{} }
+
+func (d *authErrorDB) DriverName() string { return "postgres" }
+
+func (d *authErrorDB) SqlDB() *sql.DB { return nil }
+
+// mockRefreshFunc is a simple refresh function for testing.
+type mockRefreshFunc struct {
+	callCount int
+	err       error
+	newDB     db.DB
+}
+
+func (m *mockRefreshFunc) refresh() (db.DB, error) {
+	m.callCount++
+	return m.newDB, m.err
+}
+
+func TestRefreshableDB_PassesThroughOnSuccess(t *testing.T) {
+	registerTestSQLDrivers()
+	ctx := testutil.NewDefaultTestContext(t)
+
+	sqlDB, err := sql.Open(driverWithoutIsolationLevelName, "")
+	require.NoError(t, err)
+	inner := NewDB(sqlDB, driverWithoutIsolationLevelName)
+
+	refreshFn := &mockRefreshFunc{newDB: inner}
+	rdb := newRefreshableDB(inner, refreshFn.refresh)
+
+	tx, err := rdb.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	require.NoError(t, tx.Rollback())
+	assert.Equal(t, 0, refreshFn.callCount, "no refresh should occur on success")
+}
+
+func TestRefreshableDB_RefreshesOnAuthError(t *testing.T) {
+	registerTestSQLDrivers()
+	ctx := testutil.NewDefaultTestContext(t)
+
+	sqlDB, err := sql.Open(driverWithoutIsolationLevelName, "")
+	require.NoError(t, err)
+	successDB := NewDB(sqlDB, driverWithoutIsolationLevelName)
+
+	authErr := errors.New("password authentication failed for user")
+	failOnceDB := &authErrorDB{authErr: authErr, successDB: successDB}
+
+	refreshFn := &mockRefreshFunc{newDB: successDB}
+	// For the refresh to swap inner, after refresh the failOnceDB must succeed on 2nd call.
+	rdb := newRefreshableDB(failOnceDB, refreshFn.refresh)
+
+	tx, err := rdb.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	require.NoError(t, tx.Rollback())
+	assert.Equal(t, 1, refreshFn.callCount, "refresh should be called once on auth error")
+}
+
+func TestRefreshableDB_DoesNotRefreshOnNonAuthError(t *testing.T) {
+	ctx := context.Background()
+
+	nonAuthErr := errors.New("connection timeout")
+	failDB := &authErrorDB{authErr: nonAuthErr}
+
+	refreshFn := &mockRefreshFunc{}
+	rdb := newRefreshableDB(failDB, refreshFn.refresh)
+
+	_, err := rdb.BeginTx(ctx, nil)
+	require.Error(t, err)
+	assert.Equal(t, 0, refreshFn.callCount, "no refresh on non-auth error")
+}


### PR DESCRIPTION
## Why

In Kubernetes, the standard pattern for managing database credentials is mounting secrets as volume files and rotating them automatically (e.g., via ExternalSecrets Operator syncing from AWS Secrets Manager, Vault, etc.). Grafana's `$__file{/path}` config expansion was designed for exactly this — reading secrets from files rather than hardcoding them.

However, when the password rotates, Grafana enters an infinite error loop:

```
level=error msg="poller get latest resource version" logger=sql-resource-server err="begin: pq: password authentication failed for user \"grafana\""
```

This happens because `$__file{}` is expanded once at startup, the file path is discarded, and the password is baked into the connection string for the lifetime of the process. Even though Kubernetes updates the mounted file, Grafana never re-reads it. The only recovery is a pod restart.

This makes credential rotation in Kubernetes painful — you need an external controller like Stakater Reloader just to restart Grafana pods when a secret changes. That shouldn't be necessary when Grafana already has the `$__file{}` mechanism.

## What this does

On database authentication errors, Grafana now re-reads the original `$__file{}` path and rebuilds the connection pool — the same retry it was already doing, but with the current password instead of the stale one.

- Tracks `$__file{}` paths in `Cfg.FileExpansions` before config expansion so the original file path is preserved
- Propagates `PwdFilePath` to `DatabaseConfig`; adds `RefreshPassword()` and `RebuildConnectionString()` methods
- Adds `IsAuthError(err error) bool` to classify Postgres (`28P01`/`28000`) and MySQL (`1045`) authentication failures, with string-match fallback for wrapped errors
- Hooks credential refresh into all three DB access paths:
  - `inTransactionWithRetryCtx` — catches auth errors from `startSessionOrUseExisting` (session `Begin()`) and from transaction callbacks
  - `retryOnLocks` / `withDbSession` — catches auth errors in non-transactional query callbacks
  - `refreshableDB` wrapper for the unified storage resource DB — intercepts `BeginTx` auth errors
- 30s debounce on refresh attempts prevents thundering herd

All guard clauses check `PwdFilePath != ""` — zero behavior change for SQLite or static-credential deployments.

## Test plan

- [x] `go test ./pkg/setting/... -run TestScanFileExpansions` — unit tests for `scanFileExpansions`
- [x] `go test ./pkg/services/sqlstore/... -run TestIsAuthError` — unit tests for `IsAuthError`
- [x] `go test ./pkg/services/sqlstore/... -run "TestRefreshPassword|TestRebuildConnectionString"` — credential refresh tests
- [x] `go test ./pkg/storage/unified/sql/db/dbimpl/... -run TestRefreshableDB` — refreshable DB wrapper tests
- [x] `go test ./pkg/setting/... ./pkg/services/sqlstore/... ./pkg/storage/unified/sql/db/dbimpl/...` — all existing tests continue to pass
- [x] Manual end-to-end test (see below)

### Manual test: password rotation with podman postgres

```bash
# 1. Start Postgres with initial password
podman run -d --name grafana-test-pg \
  -e POSTGRES_USER=grafana -e POSTGRES_PASSWORD=initialpass -e POSTGRES_DB=grafana \
  -p 15432:5432 postgres:16-alpine

# 2. Configure Grafana with $__file{} password and short conn_max_lifetime
#    grafana.ini:
#      [database]
#      type = postgres
#      host = 127.0.0.1:15432
#      user = grafana
#      password = $__file{/tmp/grafana-test/dbpass}
#      ssl_mode = disable
#      conn_max_lifetime = 5
echo "initialpass" > /tmp/grafana-test/dbpass

# 3. Build and start Grafana — verify it works
go build -o grafana-server ./pkg/cmd/grafana
./grafana-server server --config grafana.ini
curl -s -u admin:admin http://localhost:13000/api/dashboards/home  # ✅ 200

# 4. Rotate password in Postgres and update the file
podman exec grafana-test-pg psql -U grafana -d grafana \
  -c "ALTER USER grafana PASSWORD 'rotatedpass';"
echo "rotatedpass" > /tmp/grafana-test/dbpass

# 5. Wait for conn_max_lifetime (5s), then hit the API
sleep 6
curl -s -u admin:admin http://localhost:13000/api/dashboards/home  # ✅ 200
```

**Result**: After `conn_max_lifetime` expires and old connections are recycled, Grafana detects the auth error, re-reads the password file, rebuilds the connection pool, and recovers — all without a restart.

**Logs confirm the refresh path**:
```
level=info msg="Database auth error on session start, attempting credential refresh"
    error="pq: password authentication failed for user \"grafana\""
level=info msg="Database credentials refreshed and connection pool reset"
```