### PR TITLE
chore: add cache keys to consumers of getCachedPromise

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
@@ -69,9 +69,13 @@ export async function uninstallPluginMeta(pluginId: string): Promise<void> {
 }
 
 export function initPluginMetas(): Promise<PluginMetasResponse> {
-  return getCachedPromise(loadPluginMetas, { defaultValue: { items: [] } });
+  return getCachedPromise(loadPluginMetas, { cacheKey: 'loadPluginMetas', defaultValue: { items: [] } });
 }
 
 export function refetchPluginMetas(): Promise<PluginMetasResponse> {
-  return getCachedPromise(loadPluginMetas, { defaultValue: { items: [] }, invalidate: true });
+  return getCachedPromise(loadPluginMetas, {
+    cacheKey: 'loadPluginMetas',
+    defaultValue: { items: [] },
+    invalidate: true,
+  });
 }

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -102,6 +102,7 @@ function cachePromiseWithCallback<T>({ key, promise, onError }: CachePromiseWith
  * it returns the cached promise. Otherwise, it executes the promise function and caches the result.
  * It also provides options for handling errors, including returning a defaultValue value or invoking a custom error handler.
  * If neither defaultValue nor onError is provided, errors will propagate as usual.
+ * In minified production builds, function names may be mangled. In this case, a cacheKey should be provided to ensure proper caching behavior.
  *
  * @template T - The type of the resolved promise value
  * @param promise - Function that returns the promise to be cached

--- a/public/app/features/plugins/extensions/registry/setup.ts
+++ b/public/app/features/plugins/extensions/registry/setup.ts
@@ -85,5 +85,8 @@ async function initPluginExtensionRegistries(): Promise<PluginExtensionRegistrie
  * @returns Promise resolving to the plugin extension registries
  */
 export async function getPluginExtensionRegistries(): Promise<PluginExtensionRegistries> {
-  return getCachedPromise(initPluginExtensionRegistries, { defaultValue: initRegistries([]) });
+  return getCachedPromise(initPluginExtensionRegistries, {
+    cacheKey: 'initPluginExtensionRegistries',
+    defaultValue: initRegistries([]),
+  });
 }


### PR DESCRIPTION
**What is this feature?**

This pull request improves the caching behavior for plugin metadata and extension registries by explicitly specifying cache keys when using the `getCachedPromise` utility. This makes the caching more robust, especially in production builds where function names may be mangled.

The million 💵 question is, should the `cacheKey` be mandatory so we don't get any strange behavior in production builds?

**Why do we need this feature?**

To prevent cache collisions in production builds

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
