### PR TITLE
fix: use xz compression in deb packages

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -109,7 +109,7 @@ fpm \
   --license="${FPM_LICENSE:-AGPLv3}" \
   --name="${DEB_PACKAGE_NAME}" \
   --deb-no-default-config-files \
-  --deb-compression zst \
+  --deb-compression xz \
   .
 
 echo "created dist/${FILENAME}"


### PR DESCRIPTION
We changed it to use zst but debian by default doesn't have zstd installed so it doesn't know how to decompress the deb.

xz is much slower but what can you do. best in this case to not break things.