### PR TITLE
Dashboards: Prevent query variable editor modal from closing on outside click

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -177,6 +177,8 @@ export function ModalEditor({ variable }: { variable: QueryVariable }) {
         title={t('dashboard.edit-pane.variable.query-options.modal-title', 'Query Variable')}
         isOpen={isOpen}
         onDismiss={() => setIsOpen(false)}
+        closeOnBackdropClick={false}
+        closeOnEscape={false}
       >
         <Editor variable={variable} />
         <Modal.ButtonRow>


### PR DESCRIPTION
## What

Adds `closeOnBackdropClick={false}` and `closeOnEscape={false}` to the query variable editor modal.

## Why

Clicking outside the modal dismisses it. The custom variable editor modals already had this protection - the query variable editor was the one missing it.

## How to test

1. Open a dashboard in edit mode
2. Open the variables settings pane
3. Click to edit a query variable (the modal opens)
4. Click outside the modal
5. **Before:** modal closes, edits lost
6. **After:** modal stays open, close via X button or Cancel