### PR TITLE
Logs Table NG: Column width persistence support

### DIFF
--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -33,7 +33,7 @@ export function ExploreLogsTable(props: {
   width: number;
   height: number;
   onOptionsChange: (options: Options) => void;
-  onFieldConfigChange: (config: FieldConfigSource) => void;
+  onFieldConfigChange?: (config: FieldConfigSource) => void;
   onChangeTimeRange: (range: AbsoluteTimeRange) => void;
   onClickFilterLabel: ((key: string, value: string, frame?: DataFrame) => void) | undefined;
   onClickFilterOutLabel: ((key: string, value: string, frame?: DataFrame) => void) | undefined;
@@ -46,6 +46,7 @@ export function ExploreLogsTable(props: {
   const frames = useMemo(() => props?.data.series ?? [], [props.data.series]);
   const frame = useMemo(() => frames[props.externalOptions.frameIndex], [frames, props.externalOptions.frameIndex]);
   const [wrapText, setWrapText] = useState(store.getBool(`${SETTING_KEY_ROOT}.wrapText`, false));
+  const [columnWidths, setColumnWidths] = useState<ColumnWidth[]>(getColumnWidthsFromStorage());
 
   const onCellFilterAdded = useCallback(
     (filter: AdHocFilterItem) => {
@@ -105,6 +106,26 @@ export function ExploreLogsTable(props: {
     [props.buildLinkToLogLine, props.externalOptions, selectedLogInfo?.id, wrapText]
   );
 
+  const handleFieldConfigChange = useCallback((config: FieldConfigSource) => {
+    const widthOverrides = config.overrides
+      .filter((override) => override.matcher.id === 'byName')
+      .filter((override) =>
+        override.properties.some((property) => property.id === 'custom.width' && property.value > 0)
+      )
+      .map((override) => {
+        const field = override.matcher.options;
+        const width = override.properties.find(
+          (property) => property.id === 'custom.width' && property.value > 0
+        )?.value;
+        return {
+          field,
+          width,
+        };
+      });
+    store.set(`${SETTING_KEY_ROOT}.explore.columnWidths`, JSON.stringify(widthOverrides));
+    setColumnWidths(getColumnWidthsFromStorage());
+  }, []);
+
   const fieldConfig = useMemo(
     () => ({
       defaults: {
@@ -112,9 +133,20 @@ export function ExploreLogsTable(props: {
           filterable: true,
         },
       },
-      overrides: [],
+      overrides: columnWidths.map((columnWidth) => ({
+        matcher: {
+          id: 'byName',
+          options: columnWidth.field,
+        },
+        properties: [
+          {
+            id: 'custom.width',
+            value: columnWidth.width,
+          },
+        ],
+      })),
     }),
-    []
+    [columnWidths]
   );
 
   return (
@@ -139,10 +171,30 @@ export function ExploreLogsTable(props: {
         title={''}
         eventBus={props.eventBus}
         onOptionsChange={onOptionsChange}
-        onFieldConfigChange={props.onFieldConfigChange}
+        onFieldConfigChange={handleFieldConfigChange}
         replaceVariables={getTemplateSrv().replace}
         onChangeTimeRange={props.onChangeTimeRange}
       />
     </PanelContextProvider>
   );
+}
+
+type ColumnWidth = { field: string; width: number };
+
+function getColumnWidthsFromStorage() {
+  const stored = store.getObject(`${SETTING_KEY_ROOT}.explore.columnWidths`);
+
+  let columnWidths = Array.isArray(stored)
+    ? stored.filter(
+        (columnWidth: unknown): columnWidth is ColumnWidth =>
+          typeof columnWidth === 'object' &&
+          columnWidth !== null &&
+          'field' in columnWidth &&
+          'width' in columnWidth &&
+          typeof columnWidth.width === 'number' &&
+          typeof columnWidth.field === 'string'
+      )
+    : [];
+
+  return columnWidths;
 }

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -734,6 +734,61 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     [logsVolumeData?.data, logsVolumeEnabled, sortOrderChanged]
   );
 
+  const onTableOptionsChange = useCallback(
+    (options: Options) => {
+      if (options.displayedFields && !shallowCompare(options.displayedFields, displayedFields)) {
+        setDisplayedFields(options.displayedFields);
+      }
+      if (options.sortOrder && options.sortOrder !== logsSortOrder) {
+        onChangeLogsSortOrder(options.sortOrder);
+      }
+      if (options.fieldSelectorWidth !== undefined && options.fieldSelectorWidth !== fieldSelectorWidth) {
+        store.set(LOGS_TABLE_SETTING_KEYS.fieldSelectorWidth, options.fieldSelectorWidth);
+        setFieldSelectorWidth(options.fieldSelectorWidth);
+      }
+      if (
+        options.sortBy &&
+        !compareArrayValues(
+          options?.sortBy ?? [],
+          tableSortBy ?? [],
+          (a, b) => a.displayName === b.displayName && a.desc === b.desc
+        )
+      ) {
+        handleSetTableSortBy(options.sortBy);
+      }
+
+      if (options.frameIndex !== tableFrameIndex) {
+        const refId = props?.logsFrames?.[options.frameIndex]?.refId;
+        if (refId) {
+          updatePanelState({ refId });
+        }
+      }
+    },
+    [
+      displayedFields,
+      fieldSelectorWidth,
+      handleSetTableSortBy,
+      logsSortOrder,
+      onChangeLogsSortOrder,
+      props?.logsFrames,
+      tableFrameIndex,
+      tableSortBy,
+      updatePanelState,
+    ]
+  );
+
+  const tableOptions = useMemo(
+    () => ({
+      sortOrder: logsSortOrder,
+      sortBy: tableSortBy,
+      displayedFields: displayedFields,
+      permalinkedLogId: props.panelState?.logs?.id,
+      frameIndex: tableFrameIndex,
+      fieldSelectorWidth: fieldSelectorWidth,
+    }),
+    [displayedFields, fieldSelectorWidth, logsSortOrder, props.panelState?.logs?.id, tableFrameIndex, tableSortBy]
+  );
+
   const onDisplayedSeriesChanged = useCallback((levels: string[]) => {
     if (visibilityChangedRef.current) {
       visibilityChangedRef.current = false;
@@ -861,47 +916,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
               data={panelData}
               timeZone={timeZone}
               buildLinkToLogLine={onTablePermalinkClick}
-              externalOptions={{
-                sortOrder: logsSortOrder,
-                sortBy: tableSortBy,
-                displayedFields: displayedFields,
-                permalinkedLogId: props.panelState?.logs?.id,
-                frameIndex: tableFrameIndex,
-                fieldSelectorWidth: fieldSelectorWidth,
-              }}
+              externalOptions={tableOptions}
               width={width}
               height={tableHeight}
               onClickFilterLabel={onClickFilterLabel}
               onClickFilterOutLabel={onClickFilterOutLabel}
-              onOptionsChange={(options: Options) => {
-                if (options.displayedFields && !shallowCompare(options.displayedFields, displayedFields)) {
-                  setDisplayedFields(options.displayedFields);
-                }
-                if (options.sortOrder && options.sortOrder !== logsSortOrder) {
-                  onChangeLogsSortOrder(options.sortOrder);
-                }
-                if (options.fieldSelectorWidth !== undefined && options.fieldSelectorWidth !== fieldSelectorWidth) {
-                  store.set(LOGS_TABLE_SETTING_KEYS.fieldSelectorWidth, options.fieldSelectorWidth);
-                  setFieldSelectorWidth(options.fieldSelectorWidth);
-                }
-                if (
-                  options.sortBy &&
-                  !compareArrayValues(
-                    options?.sortBy ?? [],
-                    tableSortBy ?? [],
-                    (a, b) => a.displayName === b.displayName && a.desc === b.desc
-                  )
-                ) {
-                  handleSetTableSortBy(options.sortBy);
-                }
-
-                if (options.frameIndex !== tableFrameIndex) {
-                  const refId = props?.logsFrames?.[options.frameIndex]?.refId;
-                  if (refId) {
-                    updatePanelState({ refId });
-                  }
-                }
-              }}
+              onOptionsChange={onTableOptionsChange}
               onFieldConfigChange={function (config: FieldConfigSource): void {
                 // @todo save field overrides somewhere (e.g. column widths)
               }}

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -16,7 +16,6 @@ import {
   type EventBus,
   type ExploreLogsPanelState,
   type ExplorePanelsState,
-  type FieldConfigSource,
   type GrafanaTheme2,
   LoadingState,
   type LogLevel,
@@ -922,9 +921,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
               onClickFilterLabel={onClickFilterLabel}
               onClickFilterOutLabel={onClickFilterOutLabel}
               onOptionsChange={onTableOptionsChange}
-              onFieldConfigChange={function (config: FieldConfigSource): void {
-                // @todo save field overrides somewhere (e.g. column widths)
-              }}
               onChangeTimeRange={onChangeTime}
             />
           )}

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { DataFrameType, FieldType, toDataFrame } from '@grafana/data';
+import { DataFrameType, FieldMatcherID, FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
+import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 
@@ -31,6 +32,11 @@ const testLogsDataFrame = [
 
 describe('useExtractFields', () => {
   beforeAll(() => {
+    try {
+      standardEditorsRegistry.setInit(getAllOptionEditors);
+    } catch {
+      // already initialized in this Jest worker
+    }
     mockTransformationsRegistry([extractFieldsTransformer]);
   });
 
@@ -52,6 +58,29 @@ describe('useExtractFields', () => {
       expect(result.current.extractedFrame?.fields[2].name).toBe('labels');
       expect(result.current.extractedFrame?.fields[3].name).toBe('service');
       expect(result.current.extractedFrame?.fields[4].name).toBe('level');
+    });
+  });
+
+  test('applies field override custom.width to extracted label columns', async () => {
+    const { result } = renderHook(() =>
+      useExtractFields({
+        rawTableFrame: testLogsDataFrame[0],
+        timeZone: 'utc',
+        fieldConfig: {
+          defaults: {},
+          overrides: [
+            {
+              matcher: { id: FieldMatcherID.byName, options: 'service' },
+              properties: [{ id: 'custom.width', value: 89 }],
+            },
+          ],
+        },
+      })
+    );
+
+    await waitFor(() => {
+      const service = result.current.extractedFrame?.fields.find((f) => f.name === 'service');
+      expect(service?.config.custom?.width).toBe(89);
     });
   });
 });

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -42,10 +42,14 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
     };
 
     extractFields()
-      .then((data) => {
+      .then(async (data) => {
+        // Use the panel plugin registry so `custom.width` and other table custom keys resolve
+        // (see setDynamicConfigValue). Dynamic import avoids a require cycle with module.tsx.
+        const { plugin: logsTablePlugin } = await import('../module');
         const extractedFrames = applyFieldOverrides({
           data,
           fieldConfig,
+          fieldConfigRegistry: logsTablePlugin.fieldConfigRegistry,
           replaceVariables: replaceVariables ?? getTemplateSrv().replace.bind(getTemplateSrv()),
           theme,
           timeZone,

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -14,6 +14,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
 import { replaceVariables } from '@grafana-plugins/loki/querybuilder/parsingUtils';
 
+import { getLogsTableFieldConfigRegistry } from '../logsTableFieldConfig';
 import { extractLogsFieldsTransform } from '../transforms/extractLogsFieldsTransform';
 
 interface Props {
@@ -42,14 +43,11 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
     };
 
     extractFields()
-      .then(async (data) => {
-        // Use the panel plugin registry so `custom.width` and other table custom keys resolve
-        // (see setDynamicConfigValue). Dynamic import avoids a require cycle with module.tsx.
-        const { plugin: logsTablePlugin } = await import('../module');
+      .then((data) => {
         const extractedFrames = applyFieldOverrides({
           data,
           fieldConfig,
-          fieldConfigRegistry: logsTablePlugin.fieldConfigRegistry,
+          fieldConfigRegistry: getLogsTableFieldConfigRegistry(),
           replaceVariables: replaceVariables ?? getTemplateSrv().replace.bind(getTemplateSrv()),
           theme,
           timeZone,

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -1,10 +1,10 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { type DataFrame, DataFrameType, FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
-import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 // Internal package imports, but not exposed to end users, how do we expect plugin developers to test anything that contains a transform?
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { TableCellDisplayMode } from '@grafana/ui';
+import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, parseLogsFrame } from 'app/features/logs/logsFrame';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { type DataFrame, DataFrameType, FieldType, toDataFrame } from '@grafana/data';
+import { type DataFrame, DataFrameType, FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
+import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 // Internal package imports, but not exposed to end users, how do we expect plugin developers to test anything that contains a transform?
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { TableCellDisplayMode } from '@grafana/ui';
@@ -36,6 +37,11 @@ const testLogsFrame = parseLogsFrame(testLogsDataFrame[0]);
 
 describe('useOrganizeFields', () => {
   beforeAll(() => {
+    try {
+      standardEditorsRegistry.setInit(getAllOptionEditors);
+    } catch {
+      // already initialized in this Jest worker
+    }
     mockTransformationsRegistry([organizeFieldsTransformer, extractFieldsTransformer]);
   });
 

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
@@ -130,10 +131,8 @@ const organizeFields = async (
 
     for (const [fieldIndex, field] of frame.fields.entries()) {
       const isFirstField = (!isLevelFirstField && fieldIndex === 0) || (isLevelFirstField && fieldIndex === 1);
-      const baseConfig = {
-        ...fieldConfig.defaults,
-        ...field.config,
-      };
+      // Deep-merge so panel defaults (e.g. custom.filterable) survive when the field already has custom.* from applyFieldOverrides.
+      const baseConfig = merge({}, fieldConfig.defaults, field.config);
 
       const levelEnhancements = getLogLevelColumnEnhancements(field, levelFieldName, baseConfig);
 

--- a/public/app/plugins/panel/logstable/logsTableFieldConfig.ts
+++ b/public/app/plugins/panel/logstable/logsTableFieldConfig.ts
@@ -1,0 +1,40 @@
+import {
+  createFieldConfigRegistry,
+  FieldConfigProperty,
+  type FieldConfigOptionsRegistry,
+  type SetFieldConfigOptionsArgs,
+} from '@grafana/data';
+import { addTableCustomConfig } from 'app/features/panel/table/addTableCustomConfig';
+
+import { type FieldConfig as TableFieldConfig } from '../table/panelcfg.gen';
+
+/**
+ * Shared field config for the Logs Table panel. Used by module.tsx (`useFieldConfig`)
+ * and by useExtractFields (`applyFieldOverrides`) so overrides like `custom.width` resolve
+ * without importing `module.tsx` (avoids cycle: module → LogsTable → useExtractFields).
+ */
+export const logsTablePanelFieldConfig: SetFieldConfigOptionsArgs<TableFieldConfig> = {
+  standardOptions: {
+    [FieldConfigProperty.Actions]: {
+      hideFromDefaults: false,
+    },
+  },
+  useCustomConfig: (builder) => {
+    addTableCustomConfig(builder, {
+      filters: true,
+      wrapHeaderText: true,
+      hideFields: true,
+    });
+  },
+};
+
+let fieldConfigRegistry: FieldConfigOptionsRegistry | undefined;
+
+/**
+ * Lazily builds the same registry shape as {@link logsTablePanelFieldConfig} so Jest can
+ * call `standardEditorsRegistry.setInit` before this runs (addTableCustomConfig needs it).
+ */
+export function getLogsTableFieldConfigRegistry(): FieldConfigOptionsRegistry {
+  fieldConfigRegistry ??= createFieldConfigRegistry(logsTablePanelFieldConfig, 'Logs Table');
+  return fieldConfigRegistry;
+}

--- a/public/app/plugins/panel/logstable/module.tsx
+++ b/public/app/plugins/panel/logstable/module.tsx
@@ -1,29 +1,16 @@
-import { FieldConfigProperty, PanelPlugin } from '@grafana/data';
+import { PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { addTableCustomConfig } from 'app/features/panel/table/addTableCustomConfig';
 import { addTableCustomPanelOptions } from 'app/features/panel/table/addTableCustomPanelOptions';
 
 import { type FieldConfig as TableFieldConfig, type Options as TableOptions } from '../table/panelcfg.gen';
 
 import { LogsTable } from './LogsTable';
+import { logsTablePanelFieldConfig } from './logsTableFieldConfig';
 import { defaultOptions, type Options } from './panelcfg.gen';
 import { logstableSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(LogsTable)
-  .useFieldConfig({
-    standardOptions: {
-      [FieldConfigProperty.Actions]: {
-        hideFromDefaults: false,
-      },
-    },
-    useCustomConfig: (builder) => {
-      addTableCustomConfig(builder, {
-        filters: true,
-        wrapHeaderText: true,
-        hideFields: true,
-      });
-    },
-  })
+  .useFieldConfig(logsTablePanelFieldConfig)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
     const logsTableCategory = [t('logstable.category-table', 'Logs Table')];


### PR DESCRIPTION
This PR adds persistence of column width persistence for Explore and Dashboards.

Explore:

https://github.com/user-attachments/assets/130bbd0f-bad0-4602-a08f-01aa813296cf

Dashboards:

https://github.com/user-attachments/assets/edda4cd6-65a8-43cb-ad98-3456c12c0b5f



