### PR TITLE
Alerting: Fix threshold value reset when changing condition type

### DIFF
--- a/public/app/features/expressions/components/__snapshots__/hysteresis.test.ts.snap
+++ b/public/app/features/expressions/components/__snapshots__/hysteresis.test.ts.snap
@@ -72,7 +72,7 @@ exports[`thresholdReducer should update Threshold Type, and unloadEvaluator para
     {
       "evaluator": {
         "params": [
-          0,
+          10,
         ],
         "type": "lt",
       },
@@ -89,7 +89,7 @@ exports[`thresholdReducer should update Threshold Type, and unloadEvaluator para
       "type": "query",
       "unloadEvaluator": {
         "params": [
-          0,
+          10,
         ],
         "type": "gt",
       },

--- a/public/app/features/expressions/components/hysteresis.test.ts
+++ b/public/app/features/expressions/components/hysteresis.test.ts
@@ -159,7 +159,120 @@ describe('thresholdReducer', () => {
     expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsBelow);
     expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsAbove);
     expect(onError).toHaveBeenCalledWith(undefined);
-    expect(newState.conditions[0].unloadEvaluator?.params[0]).toEqual(0);
+    // single → single: preserves the existing param value from thresholdCondition (params[0] = 10)
+    expect(newState.conditions[0].unloadEvaluator?.params[0]).toEqual(10);
+  });
+
+  it('single → single: preserves existing threshold value', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsAbove, params: [42] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(
+      initialState,
+      updateThresholdType({ evalFunction: EvalFunction.IsBelow, onError })
+    );
+
+    expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsBelow);
+    expect(newState.conditions[0].evaluator.params).toEqual([42]);
+  });
+
+  it('single → single: normalises stale 2-element params array to 1 element', () => {
+    // Older rules may have been saved with params: [10, 0] from a prior range type.
+    // Switching between single-value types should collapse it to a single-element array.
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsAbove, params: [10, 0] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(
+      initialState,
+      updateThresholdType({ evalFunction: EvalFunction.IsBelow, onError })
+    );
+
+    expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsBelow);
+    expect(newState.conditions[0].evaluator.params).toEqual([10]);
+  });
+
+  it('range → single: resets params to [0]', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsWithinRange, params: [10, 20] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(
+      initialState,
+      updateThresholdType({ evalFunction: EvalFunction.IsAbove, onError })
+    );
+
+    expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsAbove);
+    expect(newState.conditions[0].evaluator.params).toEqual([0]);
+  });
+
+  it('single → range: resets params to [0, 0]', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsAbove, params: [42] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(
+      initialState,
+      updateThresholdType({ evalFunction: EvalFunction.IsWithinRange, onError })
+    );
+
+    expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsWithinRange);
+    expect(newState.conditions[0].evaluator.params).toEqual([0, 0]);
+  });
+
+  it('range → range: preserves existing params', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsWithinRange, params: [10, 20] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(
+      initialState,
+      updateThresholdType({ evalFunction: EvalFunction.IsOutsideRange, onError })
+    );
+
+    expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsOutsideRange);
+    expect(newState.conditions[0].evaluator.params).toEqual([10, 20]);
   });
   it('Should update unlooadEvaluator when checking hysteresis', () => {
     const initialState: ThresholdExpressionQuery = {

--- a/public/app/features/expressions/components/thresholdReducer.ts
+++ b/public/app/features/expressions/components/thresholdReducer.ts
@@ -3,6 +3,7 @@ import { createAction, createReducer } from '@reduxjs/toolkit';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
 import { type ClassicCondition, ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
+import { isRangeEvaluator } from '../utils/expressionTypes';
 
 export const updateRefId = createAction<string | undefined>('thresold/updateRefId');
 export const updateThresholdType = createAction<{
@@ -30,11 +31,24 @@ export const thresholdReducer = createReducer<ThresholdExpressionQuery>(
       const typeInPayload = action.payload.evalFunction;
       const onError = action.payload.onError;
 
+      // Determine arity change before overwriting the type.
+      // Only reset params when crossing the single ↔ range boundary:
+      //   single → range : reset to [0, 0]  (need two params)
+      //   range  → single: reset to [0]     (drop second param; fixes stale [from, to] array)
+      //   single → single: preserve existing value (fixes value silently resetting to 0)
+      //   range  → range : preserve existing values
+      const previouslyRange = isRangeEvaluator(state.conditions[0].evaluator.type);
+      const nowRange = isRangeEvaluator(typeInPayload);
+      if (previouslyRange !== nowRange) {
+        state.conditions[0].evaluator.params = nowRange ? [0, 0] : [0];
+      } else if (!nowRange) {
+        // Ensure single-value types always carry exactly one param element.
+        // Older rules may have been saved with a 2-element array from a prior range type.
+        state.conditions[0].evaluator.params = [state.conditions[0].evaluator.params[0] ?? 0];
+      }
+
       //set new type in evaluator
       state.conditions[0].evaluator.type = typeInPayload;
-
-      //reset params
-      state.conditions[0].evaluator.params = [0];
 
       // check if hysteresis is checked
       const hsyteresisIsChecked = Boolean(state.conditions[0].unloadEvaluator);


### PR DESCRIPTION
**What is this feature?**

Fixes a bug in the Threshold expression editor (advanced mode) where changing the condition type (e.g. "Is Above" → "Is Below") silently resets the threshold value to 0.

**Why do we need this feature?**

When a user edits a threshold condition type, `evaluator.params` was being unconditionally reset to `[0]` on every type change, discarding the user's configured value with no indication — the value is lost on save.

The reset was introduced by PR #111645 to fix stale 2-element `params` arrays left over from range-type conditions causing duplicate values in YAML/Terraform export. That fix was correct for `range ↔ single` transitions but overcorrected by applying the reset to all transitions, including `single → single`.

The new logic is arity-aware:
- **single → single**: preserve `params[0]`, normalise to exactly 1 element (also cleans up stale `[value, 0]` arrays from older rules — the original issue from #111645 remains fixed)
- **range → single**: reset to `[0]`
- **single → range**: reset to `[0, 0]`
- **range → range**: preserve existing params

**Who is this feature for?**

Alerting users editing Grafana-managed alert rules with threshold expressions.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

The snapshot update in `hysteresis.test.ts.snap` is intentional — `params` now correctly shows `[10]` (value preserved, normalised to 1 element) instead of `[0]`.