### PR TITLE
Provisioning: nil parsed result in errors while creating comments

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -119,8 +119,7 @@ var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind
 
 func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
 	if change.Action == repository.FileActionDeleted {
-		// TODO: read the old and verify
-		return fileChangeInfo{Change: change, Error: "delete feedback not yet implemented"}
+		return e.evaluateDeletedFile(ctx, repo, baseURL, change, parser)
 	}
 
 	info := fileChangeInfo{Change: change}
@@ -189,6 +188,38 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 					info.Error = err.Error()
 				}
 			}
+		}
+	}
+
+	return info
+}
+
+// evaluateDeletedFile is best-effort: it tries to read and parse the file at
+// the previous ref to extract metadata (kind, title, GrafanaURL)
+func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Reader, baseURL string, change repository.VersionedFileChange, parser resources.Parser) fileChangeInfo {
+	info := fileChangeInfo{Change: change}
+
+	fileInfo, err := repo.Read(ctx, change.Path, change.PreviousRef)
+	if err != nil {
+		return info
+	}
+
+	info.Parsed, err = parser.Parse(ctx, fileInfo)
+	if err != nil {
+		return info
+	}
+
+	obj := info.Parsed.Obj
+	info.Title = info.Parsed.Meta.FindTitle(obj.GetName())
+
+	if info.Parsed.GVK.Kind == dashboardKind {
+		urlBuilder, err := url.Parse(baseURL)
+		if err != nil {
+			return info
+		}
+		if info.Parsed.Existing != nil {
+			grafanaURL := urlBuilder.JoinPath("d", obj.GetName(), slugify.Slugify(info.Title))
+			info.GrafanaURL = grafanaURL.String()
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -566,7 +566,72 @@ func TestCalculateChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "deleted file",
+			name: "deleted file reads from previous ref",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "base-ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+				})
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "base-ref").Return(finfo, nil)
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:      obj,
+					Existing: obj,
+					Meta:     meta,
+				}, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action:      repository.FileActionDeleted,
+				Path:        "path/to/file.json",
+				Ref:         "ref",
+				PreviousRef: "base-ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action:      repository.FileActionDeleted,
+						Path:        "path/to/file.json",
+						Ref:         "ref",
+						PreviousRef: "base-ref",
+					},
+					Title:      "hello world",
+					GrafanaURL: "http://host/d/the-uid/hello-world",
+				}},
+			},
+		},
+		{
+			name: "deleted file with read error degrades gracefully",
 			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
@@ -577,20 +642,53 @@ func TestCalculateChanges(t *testing.T) {
 				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
 				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "base-ref").Return(nil, fmt.Errorf("file not found"))
 			},
 			changes: []repository.VersionedFileChange{{
-				Action: repository.FileActionDeleted,
-				Path:   "path/to/file.json",
-				Ref:    "ref",
+				Action:      repository.FileActionDeleted,
+				Path:        "path/to/file.json",
+				Ref:         "ref",
+				PreviousRef: "base-ref",
 			}},
 			expectedInfo: changeInfo{
 				Changes: []fileChangeInfo{{
 					Change: repository.VersionedFileChange{
-						Action: repository.FileActionDeleted,
-						Path:   "path/to/file.json",
-						Ref:    "ref",
+						Action:      repository.FileActionDeleted,
+						Path:        "path/to/file.json",
+						Ref:         "ref",
+						PreviousRef: "base-ref",
 					},
-					Error: "delete feedback not yet implemented",
+				}},
+			},
+		},
+		{
+			name: "deleted file with empty previous ref degrades gracefully",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+				})
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Return(nil, fmt.Errorf("ref not found"))
+			},
+			changes: []repository.VersionedFileChange{{
+				Action:      repository.FileActionDeleted,
+				Path:        "path/to/file.json",
+				Ref:         "ref",
+				PreviousRef: "",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action:      repository.FileActionDeleted,
+						Path:        "path/to/file.json",
+						Ref:         "ref",
+						PreviousRef: "",
+					},
 				}},
 			},
 		},

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -45,12 +45,12 @@ func (c *commenter) Comment(ctx context.Context, prRepo PullRequestRepo, pr int,
 }
 
 func (c *commenter) generateComment(_ context.Context, info changeInfo) (string, error) {
-	// TODO: should we comment even if there are no changes?
 	var buf bytes.Buffer
 
+	// TODO: should we comment even if there are no changes?
 	if len(info.Changes) == 0 {
 		buf.WriteString("Grafana didn't find any changes in this pull request.")
-	} else if len(info.Changes) == 1 && info.Changes[0].Parsed.GVK.Kind == dashboardKind {
+	} else if len(info.Changes) == 1 && info.Changes[0].Parsed != nil && info.Changes[0].Parsed.GVK.Kind == dashboardKind {
 		if err := c.templateDashboard.Execute(&buf, &info.Changes[0]); err != nil {
 			return "", fmt.Errorf("unable to execute template: %w", err)
 		}
@@ -124,7 +124,7 @@ Grafana spotted {{.TotalChanges}} changes.
 | Action | Kind | Resource | Preview | Status |
 |--------|------|----------|---------|--------|
 {{- range .Changes}}
-| {{.Parsed.Action}} | {{.Kind}} | {{.ExistingLink}} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
+| {{.Action}} | {{.Kind}} | {{.ExistingLink}} | {{ if .PreviewURL}}[preview]({{.PreviewURL}}){{ end }} | {{.StatusIcon}} |
 {{- end -}}
 {{- if .SkippedFiles}}
 
@@ -154,6 +154,13 @@ const commentTemplateFooter = `
 
 ---
 _Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}}){{- if .RepositoryTitle}} · Repository: **{{.RepositoryTitle}}** (` + "`" + `{{.RepositoryName}}` + "`" + `){{- end}}_`
+
+func (f *fileChangeInfo) Action() string {
+	if f.Parsed != nil {
+		return string(f.Parsed.Action)
+	}
+	return string(f.Change.Action)
+}
 
 // TODO: does this have some value?
 func (f *fileChangeInfo) Kind() string {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -220,9 +220,14 @@ func TestGenerateComment(t *testing.T) {
 	}
 }
 
-func TestGenerateComment_NilParsedInTableTemplate(t *testing.T) {
+func TestGenerateComment_NilParsedDeletedInTableTemplate(t *testing.T) {
 	repo := NewMockPullRequestRepo(t)
-	repo.On("CommentPullRequest", context.Background(), 1, mock.Anything).Return(nil)
+
+	var capturedComment string
+	repo.On("CommentPullRequest", context.Background(), 1, mock.MatchedBy(func(comment string) bool {
+		capturedComment = comment
+		return true
+	})).Return(nil)
 
 	info := changeInfo{
 		GrafanaBaseURL: "http://host/",
@@ -243,7 +248,6 @@ func TestGenerateComment_NilParsedInTableTemplate(t *testing.T) {
 					Action: repository.FileActionDeleted,
 					Path:   "deleted-file.json",
 				},
-				Error: "delete feedback not yet implemented",
 			},
 		},
 	}
@@ -251,11 +255,19 @@ func TestGenerateComment_NilParsedInTableTemplate(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
+	require.Contains(t, capturedComment, "2 changes")
+	require.Contains(t, capturedComment, "deleted")
+	require.Contains(t, capturedComment, ".json")
 }
 
 func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
 	repo := NewMockPullRequestRepo(t)
-	repo.On("CommentPullRequest", context.Background(), 1, mock.Anything).Return(nil)
+
+	var capturedComment string
+	repo.On("CommentPullRequest", context.Background(), 1, mock.MatchedBy(func(comment string) bool {
+		capturedComment = comment
+		return true
+	})).Return(nil)
 
 	info := changeInfo{
 		GrafanaBaseURL: "http://host/",
@@ -273,6 +285,51 @@ func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
 	commenter := NewCommenter(false)
 	err := commenter.Comment(context.Background(), repo, 1, info)
 	require.NoError(t, err)
+	require.Contains(t, capturedComment, "1 changes")
+	require.Contains(t, capturedComment, "created")
+}
+
+func TestGenerateComment_ParseFailureErrorSurfaced(t *testing.T) {
+	repo := NewMockPullRequestRepo(t)
+
+	var capturedComment string
+	repo.On("CommentPullRequest", context.Background(), 1, mock.MatchedBy(func(comment string) bool {
+		capturedComment = comment
+		return true
+	})).Return(nil)
+
+	info := changeInfo{
+		GrafanaBaseURL: "http://host/",
+		Changes: []fileChangeInfo{
+			{
+				Parsed: &resources.ParsedResource{
+					Info: &repository.FileInfo{
+						Path: "valid.json",
+					},
+					Action: v0alpha1.ResourceActionCreate,
+					GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+				},
+				Title:      "Valid Dashboard",
+				PreviewURL: "http://grafana/admin/preview",
+			},
+			{
+				Change: repository.VersionedFileChange{
+					Action: repository.FileActionCreated,
+					Path:   "broken.json",
+				},
+				Error: "unable to parse resource",
+			},
+		},
+	}
+
+	commenter := NewCommenter(false)
+	err := commenter.Comment(context.Background(), repo, 1, info)
+	require.NoError(t, err)
+	require.Contains(t, capturedComment, "2 changes")
+	require.Contains(t, capturedComment, "1 with issues")
+	require.Contains(t, capturedComment, "Validation Issues")
+	require.Contains(t, capturedComment, "broken.json")
+	require.Contains(t, capturedComment, "unable to parse resource")
 }
 
 func TestCommenter_ShowImageRendererNote(t *testing.T) {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -220,6 +220,61 @@ func TestGenerateComment(t *testing.T) {
 	}
 }
 
+func TestGenerateComment_NilParsedInTableTemplate(t *testing.T) {
+	repo := NewMockPullRequestRepo(t)
+	repo.On("CommentPullRequest", context.Background(), 1, mock.Anything).Return(nil)
+
+	info := changeInfo{
+		GrafanaBaseURL: "http://host/",
+		Changes: []fileChangeInfo{
+			{
+				Parsed: &resources.ParsedResource{
+					Info: &repository.FileInfo{
+						Path: "valid.json",
+					},
+					Action: v0alpha1.ResourceActionCreate,
+					GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+				},
+				Title:      "Valid Dashboard",
+				PreviewURL: "http://grafana/admin/preview",
+			},
+			{
+				Change: repository.VersionedFileChange{
+					Action: repository.FileActionDeleted,
+					Path:   "deleted-file.json",
+				},
+				Error: "delete feedback not yet implemented",
+			},
+		},
+	}
+
+	commenter := NewCommenter(false)
+	err := commenter.Comment(context.Background(), repo, 1, info)
+	require.NoError(t, err)
+}
+
+func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
+	repo := NewMockPullRequestRepo(t)
+	repo.On("CommentPullRequest", context.Background(), 1, mock.Anything).Return(nil)
+
+	info := changeInfo{
+		GrafanaBaseURL: "http://host/",
+		Changes: []fileChangeInfo{
+			{
+				Change: repository.VersionedFileChange{
+					Action: repository.FileActionCreated,
+					Path:   "unparseable-file.json",
+				},
+				Error: "parse error",
+			},
+		},
+	}
+
+	commenter := NewCommenter(false)
+	err := commenter.Comment(context.Background(), repo, 1, info)
+	require.NoError(t, err)
+}
+
 func TestCommenter_ShowImageRendererNote(t *testing.T) {
 	t.Run("note appears when showImageRendererNote is true", func(t *testing.T) {
 		repo := NewMockPullRequestRepo(t)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Provisioning PR comment may fail if the parsed resource is nil. This can happen when:

* Deleted files — early return without parsing
* File read failure — returns before parser.Parse is called
* Parse failure — parser.Parse returns nil, err, so assignment never succeeds

This PR makes updates the behavior so:

* Deleted files still contain relevant information instead of just a generic "not handled" error.
* Failures to read and parsed files are handled gracefully in the template (Parsed nil protection).

**Why do we need this feature?**

This solve a bug that caused errors in the webhook job. Fix is needed.

**Who is this feature for?**

Provisioning feature customers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1058

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
