### PR TITLE
fix(connections): show section to users with plugin children, not only datasource admins

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -164,7 +164,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/connections/datasources", authorize(datasources.ConfigurationPageAccess), hs.Index)
 	r.Get("/connections/datasources/new", authorize(datasources.NewPageAccess), hs.Index)
 	r.Get("/connections/datasources/edit/*", authorize(datasources.EditPageAccess), hs.Index)
-	r.Get("/connections", authorize(datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/connections", reqSignedIn, hs.Index)
 	r.Get("/connections/add-new-connection", authorize(datasources.ConfigurationPageAccess), hs.Index)
 	// Plugin details pages
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -220,6 +220,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	hs.HooksService.RunIndexDataHooks(&data, c)
 
 	data.NavTree.RemoveEmptyAdminSections()
+	data.NavTree.RemoveEmptyConnectionsSection()
 	data.NavTree.Sort()
 
 	return &data, nil

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -149,6 +149,16 @@ func (root *NavTreeRoot) RemoveEmptyAdminSections() {
 	}
 }
 
+// RemoveEmptyConnectionsSection removes the Connections section if it has no children.
+// The section is always added to the nav tree so that plugin pages can be attached via
+// addAppLinks; this method prunes it when no children were ultimately registered.
+// Must be called AFTER all hooks have had a chance to add their nav items.
+func (root *NavTreeRoot) RemoveEmptyConnectionsSection() {
+	if sec := root.FindById("connections"); sec != nil && len(sec.Children) == 0 {
+		root.RemoveSectionByID("connections")
+	}
+}
+
 func (root *NavTreeRoot) MarshalJSON() ([]byte, error) {
 	return json.Marshal(root.Children)
 }

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -376,6 +376,104 @@ func TestAddAppLinks(t *testing.T) {
 	})
 }
 
+func TestBuildDataConnectionsNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
+
+	t.Run("core items (add-new-connection, datasources) are added when user has ConfigurationPageAccess", func(t *testing.T) {
+		service := ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: accesscontrolmock.New().WithPermissions([]ac.Permission{{Action: datasources.ActionCreate, Scope: "*"}}),
+			features:      featuremgmt.WithFeatures(),
+		}
+
+		section := service.buildDataConnectionsNavLink(reqCtx)
+		require.NotNil(t, section)
+		require.Len(t, section.Children, 2)
+		require.Equal(t, "connections-add-new-connection", section.Children[0].Id)
+		require.Equal(t, "connections-datasources", section.Children[1].Id)
+	})
+
+	t.Run("section is returned with no core children when user lacks ConfigurationPageAccess", func(t *testing.T) {
+		service := ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: accesscontrolmock.New().WithPermissions([]ac.Permission{}),
+			features:      featuremgmt.WithFeatures(),
+		}
+
+		section := service.buildDataConnectionsNavLink(reqCtx)
+		require.NotNil(t, section, "section must always be returned so plugins can attach children")
+		require.Empty(t, section.Children)
+	})
+
+	t.Run("plugin pages under the connections section are visible to users without ConfigurationPageAccess", func(t *testing.T) {
+		pluginApp := pluginstore.Plugin{
+			JSONData: plugins.JSONData{
+				ID:   "grafana-collector-app",
+				Name: "Collector",
+				Type: plugins.TypeApp,
+				Includes: []*plugins.Includes{
+					{
+						Name:     "Collector",
+						Path:     "/a/grafana-collector-app",
+						Type:     "page",
+						AddToNav: false,
+					},
+				},
+			},
+		}
+		pluginSettings := pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
+			pluginApp.ID: {ID: 0, OrgID: 1, PluginID: pluginApp.ID, PluginVersion: "1.0.0", Enabled: true},
+		}}
+		service := ServiceImpl{
+			cfg: setting.NewCfg(),
+			accessControl: accesscontrolmock.New().WithPermissions([]ac.Permission{
+				{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"},
+			}),
+			pluginSettings: &pluginSettings,
+			features:       featuremgmt.WithFeatures(),
+			pluginStore: &pluginstore.FakePluginStore{
+				PluginList: []pluginstore.Plugin{pluginApp},
+			},
+		}
+		service.navigationAppPathConfig = map[string]NavigationAppConfig{
+			"/a/grafana-collector-app": {SectionID: "connections"},
+		}
+
+		treeRoot := navtree.NavTreeRoot{}
+		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx))
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		connectionsNode := treeRoot.FindById("connections")
+		require.NotNil(t, connectionsNode)
+		require.Len(t, connectionsNode.Children, 1)
+		require.Equal(t, "standalone-plugin-page-/a/grafana-collector-app", connectionsNode.Children[0].Id)
+	})
+
+	t.Run("RemoveEmptyConnectionsSection removes the section when it has no children", func(t *testing.T) {
+		service := ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: accesscontrolmock.New().WithPermissions([]ac.Permission{}),
+			features:      featuremgmt.WithFeatures(),
+			pluginStore:   &pluginstore.FakePluginStore{},
+			pluginSettings: &pluginsettings.FakePluginSettings{
+				Plugins: map[string]*pluginsettings.DTO{},
+			},
+		}
+
+		treeRoot := navtree.NavTreeRoot{}
+		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx))
+		require.NotNil(t, treeRoot.FindById("connections"), "section should exist before app links are applied")
+
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		treeRoot.RemoveEmptyConnectionsSection()
+		require.Nil(t, treeRoot.FindById("connections"), "empty section should be pruned")
+	})
+}
+
 func TestReadingNavigationSettings(t *testing.T) {
 	t.Run("Should include defaults", func(t *testing.T) {
 		service := ServiceImpl{

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -161,9 +161,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		}
 	}
 
-	if connectionsSection := s.buildDataConnectionsNavLink(c); connectionsSection != nil {
-		treeRoot.AddSection(connectionsSection)
-	}
+	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
 	orgAdminNode, err := s.getAdminNode(c)
 
@@ -618,12 +616,11 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 	hasAccess := ac.HasAccess(s.accessControl, c)
 
 	var children []*navtree.NavLink
-	var navLink *navtree.NavLink
 
 	baseUrl := s.cfg.AppSubURL + "/connections"
 
 	if hasAccess(datasources.ConfigurationPageAccess) {
-		// Add new connection
+		// Add new connection — requires create/write permissions
 		children = append(children, &navtree.NavLink{
 			Id:       "connections-add-new-connection",
 			Text:     "Add new connection",
@@ -633,7 +630,7 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 			Keywords: []string{"csv", "graphite", "json", "loki", "prometheus", "sql", "tempo"},
 		})
 
-		// Data sources
+		// Data sources — also requires write permissions to be useful
 		children = append(children, &navtree.NavLink{
 			Id:       "connections-datasources",
 			Text:     "Data sources",
@@ -643,18 +640,17 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		})
 	}
 
-	if len(children) > 0 {
-		// Connections (main)
-		navLink = &navtree.NavLink{
-			Text:       "Connections",
-			Icon:       "adjust-circle",
-			Id:         "connections",
-			Url:        baseUrl,
-			Children:   children,
-			SortWeight: navtree.WeightDataConnections,
-		}
-
-		return navLink
+	// Always return the section so that plugin pages registered under the
+	// "connections" section ID (via addAppLinks) can be attached regardless
+	// of the user's datasource permissions. The section is pruned after all
+	// app links are processed if it still has no children (see
+	// NavTreeRoot.RemoveEmptyConnectionsSection called in setIndexViewData).
+	return &navtree.NavLink{
+		Text:       "Connections",
+		Icon:       "adjust-circle",
+		Id:         "connections",
+		Url:        baseUrl,
+		Children:   children,
+		SortWeight: navtree.WeightDataConnections,
 	}
-	return nil
 }


### PR DESCRIPTION
## Summary

Fixes an access gap where the Connections section was invisible to users who lacked `datasources:write/create` permissions, even when they had access to plugins (e.g. Collector, PDC) registered under that section.

## Root cause

`buildDataConnectionsNavLink` returned `nil` when the user lacked `ConfigurationPageAccess`. Since `addAppLinks` attaches plugin pages by looking up the existing `"connections"` section in the tree, a missing section meant plugin children were never attached — and viewers saw no Connections entry in the left nav at all.

## Changes

**`pkg/services/navtree/navtreeimpl/navtree.go`**
- `buildDataConnectionsNavLink` now always returns the Connections section node. Core items (`add-new-connection`, `datasources`) remain gated by `ConfigurationPageAccess` — these pages require write permissions. The always-present section allows `addAppLinks` to attach plugin children regardless of datasource permissions.

**`pkg/services/navtree/models.go`**
- Added `RemoveEmptyConnectionsSection` — prunes the Connections section if it still has no children after all app links and enterprise hooks have run (mirrors the `RemoveEmptyAdminSections` pattern).

**`pkg/api/index.go`**
- Calls `RemoveEmptyConnectionsSection` alongside `RemoveEmptyAdminSections` in `setIndexViewData`.

**`pkg/api/api.go`**
- `/connections` landing page route relaxed from `authorize(datasources.ConfigurationPageAccess)` to `reqSignedIn`. The page derives its cards from the nav tree (grafana/grafana#122017), so authorization is fully delegated to the nav tree and each sub-page's own route guard. Sub-page routes (`/connections/datasources`, `/connections/add-new-connection`, etc.) are unchanged.

**`pkg/services/navtree/navtreeimpl/applinks_test.go`**
- Four new tests covering:
  - Admin sees core items (add-new-connection, datasources)
  - Viewer gets an empty section (no core items)
  - Viewer with a plugin registered under connections sees the section with that plugin's child
  - `RemoveEmptyConnectionsSection` prunes the section when no children are registered

## Before / After

| User | Before | After |
|------|--------|-------|
| Admin/Editor with datasource write | Connections section visible | Connections section visible ✓ |
| Viewer with plugin (e.g. Collector) | No Connections section | Connections section with plugin cards ✓ |
| Viewer with no applicable plugins | No Connections section | No Connections section (pruned) ✓ |

## Test plan

- [x] `go test ./pkg/services/navtree/... -count=1` — all tests pass
- [ ] Verify viewer on a Cloud instance with Collector enabled sees the Connections section with Collector card
- [ ] Verify viewer on an OSS instance (no plugins under connections) does not see the Connections section
- [ ] Verify admin still sees all core cards (Add new connection, Data sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)