### PR TITLE
QueryCaching: Add querycaching.enableConnectionsClient feature flag

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2988,6 +2988,14 @@ var (
 			Generate:    Generate{Go: true},
 		},
 		{
+			Name:        "querycaching.enableConnectionsClient",
+			Description: "Use connections client instead of storage to resolve datasource plugin ID in query caching",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaOperatorExperienceSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:         "compiledBootScript",
 			Description:  "Boots the frontend using the boot.js script built from TS instead of the embedded boot script",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -348,6 +348,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-02,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
 2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-04-10,querycaching.redirectToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,false,false
+2026-04-13,querycaching.enableConnectionsClient,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-04-02,compiledBootScript,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-02-13,influxDBConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false
 2026-04-09,clickHouseConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -934,6 +934,10 @@ const (
 	// Redirect caching service cache config reads from legacy storage to K8s API
 	FlagQuerycachingRedirectToK8SApi = "querycaching.redirectToK8SApi"
 
+	// FlagQuerycachingEnableConnectionsClient
+	// Use connections client instead of storage to resolve datasource plugin ID in query caching
+	FlagQuerycachingEnableConnectionsClient = "querycaching.enableConnectionsClient"
+
 	// FlagCompiledBootScript
 	// Boots the frontend using the boot.js script built from TS instead of the embedded boot script
 	FlagCompiledBootScript = "compiledBootScript"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4615,6 +4615,19 @@
     },
     {
       "metadata": {
+        "name": "querycaching.enableConnectionsClient",
+        "resourceVersion": "1776093426820",
+        "creationTimestamp": "2026-04-13T15:17:06Z"
+      },
+      "spec": {
+        "description": "Use connections client instead of storage to resolve datasource plugin ID in query caching",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "querycaching.handlersReadFromK8SApi",
         "resourceVersion": "1775842665327",
         "creationTimestamp": "2026-04-10T17:37:45Z",


### PR DESCRIPTION
## Summary

- Adds a new `querycaching.enableConnectionsClient` feature flag (experimental, default off)
- Allows query caching to independently control whether datasource plugin IDs are resolved via the connections client or legacy storage
- Decouples this behavior from the broader `queryServiceWithConnections` flag since it is currently not reliable

A companion enterprise PR will update `caching/api/api_k8_handler.go` to use this new flag.

## Which issue(s) does this PR fix?

- Fixes # https://github.com/grafana/support-escalations/issues/21730

## Special notes for your reviewer

OSS-only change — adds the feature flag definition and generated code. The enterprise usage is in a separate PR.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>