### PR TITLE
Dashboards: Fix dashboard crash when field override has unknown matcher id

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -447,6 +447,35 @@ describe('applyFieldOverrides', () => {
     expect(config.decimals).toEqual(1);
   });
 
+  it('should skip overrides with unknown matcher ids', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const data = applyFieldOverrides({
+      data: [f0],
+      fieldConfig: {
+        defaults: {},
+        overrides: [
+          {
+            matcher: { id: 'byReg' as FieldMatcherID, options: '.*' },
+            properties: [{ id: 'decimals', value: 5 }],
+          },
+          {
+            matcher: { id: FieldMatcherID.numeric },
+            properties: [{ id: 'decimals', value: 1 }],
+          },
+        ],
+      },
+      replaceVariables: (value) => value,
+      theme: createTheme(),
+      fieldConfigRegistry: customFieldRegistry,
+    });
+
+    expect(data).toHaveLength(1);
+    expect(data[0].fields[1].config.decimals).toEqual(1);
+
+    warnSpy.mockRestore();
+  });
+
   it('displayName should be able to reference itself', () => {
     const data = applyFieldOverrides({
       data: [f0], // the frame

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -121,13 +121,17 @@ export function applyFieldOverrides(
       if ((rule.matcher.scope ?? 'series') !== scope) {
         continue;
       }
-      const info = fieldMatchers.get(rule.matcher.id);
-      if (info) {
-        override.push({
-          match: info.get(rule.matcher.options),
-          properties: rule.properties,
-        });
+      const info = fieldMatchers.getIfExists(rule.matcher.id);
+
+      if (!info) {
+        console.warn(`Unknown field matcher id: "${rule.matcher.id}", skipping override rule`);
+        continue;
       }
+
+      override.push({
+        match: info.get(rule.matcher.options),
+        properties: rule.properties,
+      });
     }
   }
 


### PR DESCRIPTION
**What is this feature?**

Gracefully skip field override rules that reference an unknown matcher id instead of throwing an error that crashes the dashboard.

Fixes #120648