### PR TITLE
Zanzana: ListObjects path when folder batch checks exceed threshold

### DIFF
--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -249,14 +249,164 @@ func (s *Server) runGroupResourcePhase(
 	return len(checks), nil
 }
 
-// --- Dedup batcher: groups identical OpenFGA folder checks so each unique
-// (relation, folder, context) tuple is only checked once. ---
+// folderCheckEntry is one OpenFGA folder tuple check (relation + folder object + context).
+type folderCheckEntry struct {
+	correlationID string
+	relation      string
+	folderIdent   string
+	groupResource string
+	resource      common.ResourceInfo
+}
 
+func collectFolderPermissionChecks(items map[string]*batchCheckItem) []folderCheckEntry {
+	var entries []folderCheckEntry
+	for _, item := range items {
+		if item.resolved || !item.resource.IsGeneric() {
+			continue
+		}
+		folderIdent := item.resource.FolderIdent()
+		if folderIdent == "" {
+			continue
+		}
+		if !isFolderPermissionBasedResource(item.resource.GroupResource()) {
+			continue
+		}
+		relation := common.FolderPermissionRelation(item.relation)
+		entries = append(entries, folderCheckEntry{
+			correlationID: item.correlationID,
+			relation:      relation,
+			folderIdent:   folderIdent,
+			groupResource: item.resource.GroupResource(),
+			resource:      item.resource,
+		})
+	}
+	return entries
+}
+
+func collectFolderSubresourceChecks(items map[string]*batchCheckItem) []folderCheckEntry {
+	var entries []folderCheckEntry
+	for _, item := range items {
+		if item.resolved || !item.resource.IsGeneric() {
+			continue
+		}
+		folderIdent := item.resource.FolderIdent()
+		if folderIdent == "" {
+			continue
+		}
+		folderRelation := common.SubresourceRelation(item.relation)
+		if !common.IsSubresourceRelation(folderRelation) {
+			continue
+		}
+		for _, relation := range expandedSubresourcePermissionRelations(folderRelation) {
+			entries = append(entries, folderCheckEntry{
+				correlationID: item.correlationID,
+				relation:      relation,
+				folderIdent:   folderIdent,
+				groupResource: item.resource.GroupResource(),
+				resource:      item.resource,
+			})
+		}
+	}
+	return entries
+}
+
+// folderDedupKey identifies a unique OpenFGA folder check after deduplication.
 type folderDedupKey struct {
 	relation      string
 	folderIdent   string
 	groupResource string
 }
+
+func uniqueFolderCheckCount(entries []folderCheckEntry) int {
+	if len(entries) == 0 {
+		return 0
+	}
+	seen := make(map[folderDedupKey]struct{}, len(entries))
+	for _, e := range entries {
+		seen[folderDedupKey{relation: e.relation, folderIdent: e.folderIdent, groupResource: e.groupResource}] = struct{}{}
+	}
+	return len(seen)
+}
+
+// resolveFolderChecks runs folder permission or subresource checks, using BatchCheck when the
+// number of unique folder tuples is small and ListObjects when it exceeds FolderCheckBatchThreshold.
+func (s *Server) resolveFolderChecks(
+	ctx context.Context,
+	store *zanzana.StoreInfo,
+	subject string,
+	items map[string]*batchCheckItem,
+	entries []folderCheckEntry,
+	contextuals *openfgav1.ContextualTupleKeys,
+) (int, error) {
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	if uniqueFolderCheckCount(entries) > s.getFolderCheckBatchThreshold() {
+		return s.resolveFolderChecksByList(ctx, store, subject, items, entries, contextuals)
+	}
+	return s.resolveFolderChecksByBatch(ctx, store, subject, items, entries, contextuals)
+}
+
+func (s *Server) getFolderCheckBatchThreshold() int {
+	if s.cfg.FolderCheckBatchThreshold > 0 {
+		return s.cfg.FolderCheckBatchThreshold
+	}
+	return 20
+}
+
+func (s *Server) resolveFolderChecksByList(
+	ctx context.Context,
+	store *zanzana.StoreInfo,
+	subject string,
+	items map[string]*batchCheckItem,
+	entries []folderCheckEntry,
+	contextuals *openfgav1.ContextualTupleKeys,
+) (int, error) {
+	type listGroupKey struct {
+		relation      string
+		groupResource string
+	}
+	groups := make(map[listGroupKey][]folderCheckEntry)
+	for _, e := range entries {
+		k := listGroupKey{relation: e.relation, groupResource: e.groupResource}
+		groups[k] = append(groups[k], e)
+	}
+
+	unique := uniqueFolderCheckCount(entries)
+
+	for key, groupEntries := range groups {
+		sample := groupEntries[0]
+		allowed := make(map[string]bool)
+		if err := s.collectAllowedObjects(ctx, allowed, &openfgav1.ListObjectsRequest{
+			StoreId:              store.ID,
+			AuthorizationModelId: store.ModelID,
+			Type:                 common.TypeFolder,
+			Relation:             key.relation,
+			User:                 subject,
+			Context:              sample.resource.Context(),
+			ContextualTuples:     contextuals,
+		}); err != nil {
+			return unique, err
+		}
+		for _, e := range groupEntries {
+			if !allowed[e.folderIdent] {
+				continue
+			}
+			item := items[e.correlationID]
+			if item.allowed {
+				continue
+			}
+			item.allowed = true
+			item.resolved = true
+			item.err = ""
+		}
+	}
+
+	return unique, nil
+}
+
+// --- Dedup batcher (BatchCheck path): groups identical OpenFGA folder checks so each unique
+// (relation, folder, context) tuple is only checked once. ---
 
 type dedupGroup struct {
 	check          *openfgav1.BatchCheckItem
@@ -333,41 +483,25 @@ func (b *dedupBatcher) resolve(results map[string]*openfgav1.BatchCheckSingleRes
 	}
 }
 
-// --- Phase implementations using dedupBatcher ---
-
-// runFolderPermissionPhase checks folder permission inheritance (e.g. can_get on a folder
-// grants access to all dashboards in that folder). Identical folder checks are deduplicated.
-func (s *Server) runFolderPermissionPhase(
+func (s *Server) resolveFolderChecksByBatch(
 	ctx context.Context,
 	store *zanzana.StoreInfo,
 	subject string,
 	items map[string]*batchCheckItem,
+	entries []folderCheckEntry,
 	contextuals *openfgav1.ContextualTupleKeys,
 ) (int, error) {
 	batcher := newDedupBatcher()
-
-	for _, item := range items {
-		if item.resolved || !item.resource.IsGeneric() {
-			continue
-		}
-		folderIdent := item.resource.FolderIdent()
-		if folderIdent == "" {
-			continue
-		}
-		if !isFolderPermissionBasedResource(item.resource.GroupResource()) {
-			continue
-		}
-
-		relation := common.FolderPermissionRelation(item.relation)
-		key := folderDedupKey{relation: relation, folderIdent: folderIdent, groupResource: item.resource.GroupResource()}
-		batcher.add(key, item.correlationID, &openfgav1.BatchCheckItem{
+	for _, e := range entries {
+		key := folderDedupKey{relation: e.relation, folderIdent: e.folderIdent, groupResource: e.groupResource}
+		batcher.add(key, e.correlationID, &openfgav1.BatchCheckItem{
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     subject,
-				Relation: relation,
-				Object:   folderIdent,
+				Relation: e.relation,
+				Object:   e.folderIdent,
 			},
 			ContextualTuples: contextuals,
-			Context:          item.resource.Context(),
+			Context:          e.resource.Context(),
 		})
 	}
 
@@ -385,6 +519,19 @@ func (s *Server) runFolderPermissionPhase(
 	return len(checks), nil
 }
 
+// runFolderPermissionPhase checks folder permission inheritance (e.g. can_get on a folder
+// grants access to all dashboards in that folder). Identical folder checks are deduplicated.
+func (s *Server) runFolderPermissionPhase(
+	ctx context.Context,
+	store *zanzana.StoreInfo,
+	subject string,
+	items map[string]*batchCheckItem,
+	contextuals *openfgav1.ContextualTupleKeys,
+) (int, error) {
+	entries := collectFolderPermissionChecks(items)
+	return s.resolveFolderChecks(ctx, store, subject, items, entries, contextuals)
+}
+
 // runFolderSubresourcePhase checks folder subresource access (e.g. folder_get, folder_set_edit).
 // Each item may expand into multiple relations; identical checks are deduplicated, and an item
 // is allowed if ANY of its expanded checks returns allowed.
@@ -395,47 +542,8 @@ func (s *Server) runFolderSubresourcePhase(
 	items map[string]*batchCheckItem,
 	contextuals *openfgav1.ContextualTupleKeys,
 ) (int, error) {
-	batcher := newDedupBatcher()
-
-	for _, item := range items {
-		if item.resolved || !item.resource.IsGeneric() {
-			continue
-		}
-		folderIdent := item.resource.FolderIdent()
-		if folderIdent == "" {
-			continue
-		}
-		folderRelation := common.SubresourceRelation(item.relation)
-		if !common.IsSubresourceRelation(folderRelation) {
-			continue
-		}
-
-		for _, relation := range expandedSubresourcePermissionRelations(folderRelation) {
-			key := folderDedupKey{relation: relation, folderIdent: folderIdent, groupResource: item.resource.GroupResource()}
-			batcher.add(key, item.correlationID, &openfgav1.BatchCheckItem{
-				TupleKey: &openfgav1.CheckRequestTupleKey{
-					User:     subject,
-					Relation: relation,
-					Object:   folderIdent,
-				},
-				ContextualTuples: contextuals,
-				Context:          item.resource.Context(),
-			})
-		}
-	}
-
-	checks := batcher.checks()
-	if len(checks) == 0 {
-		return 0, nil
-	}
-
-	results, err := s.doBatchCheck(ctx, store, checks)
-	if err != nil {
-		return len(checks), err
-	}
-
-	batcher.resolve(results, items)
-	return len(checks), nil
+	entries := collectFolderSubresourceChecks(items)
+	return s.resolveFolderChecks(ctx, store, subject, items, entries, contextuals)
 }
 
 func expandedSubresourcePermissionRelations(relation string) []string {

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -517,3 +517,75 @@ func TestIntegrationServerBatchCheck_SubBatching(t *testing.T) {
 		assert.True(t, res.GetResults()["f3-b"].GetAllowed())
 	})
 }
+
+func TestIntegrationServerBatchCheck_FolderCheckListPath(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	server := setupOpenFGAServer(t)
+	setup(t, server)
+
+	// Force ListObjects resolution for folder phases (threshold applies to unique folder checks).
+	server.cfg.FolderCheckBatchThreshold = 1
+
+	newBatchReq := func(subject string, items []*authzv1.BatchCheckItem) *authzv1.BatchCheckRequest {
+		return &authzv1.BatchCheckRequest{
+			Namespace: namespace,
+			Subject:   subject,
+			Checks:    items,
+		}
+	}
+
+	newItem := func(correlationID, verb, group, resource, subresource, folder, name string) *authzv1.BatchCheckItem {
+		return &authzv1.BatchCheckItem{
+			CorrelationId: correlationID,
+			Verb:          verb,
+			Group:         group,
+			Resource:      resource,
+			Subresource:   subresource,
+			Name:          name,
+			Folder:        folder,
+		}
+	}
+
+	t.Run("phase 2: folder permission via list path matches batch path", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"),
+			newItem("check2", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"),
+			newItem("check3", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "3"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:4", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 3)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.True(t, res.GetResults()["check2"].GetAllowed())
+		assert.False(t, res.GetResults()["check3"].GetAllowed())
+	})
+
+	t.Run("phase 2: inherited folder hierarchy via list path", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"),
+			newItem("check2", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"),
+			newItem("check3", utils.VerbGet, folderGroup, folderResource, "", "4", "12"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:8", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 3)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.True(t, res.GetResults()["check2"].GetAllowed())
+		assert.False(t, res.GetResults()["check3"].GetAllowed())
+	})
+
+	t.Run("phase 3: folder subresource set_edit via list path", func(t *testing.T) {
+		items := []*authzv1.BatchCheckItem{
+			newItem("check1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "100"),
+			newItem("check2", utils.VerbUpdate, dashboardGroup, dashboardResource, "", "1", "100"),
+			newItem("check3", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "200"),
+		}
+		res, err := server.BatchCheck(newContextWithNamespace(), newBatchReq("user:5", items))
+		require.NoError(t, err)
+		require.Len(t, res.GetResults(), 3)
+		assert.True(t, res.GetResults()["check1"].GetAllowed())
+		assert.True(t, res.GetResults()["check2"].GetAllowed())
+		assert.False(t, res.GetResults()["check3"].GetAllowed())
+	})
+}

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -206,6 +206,8 @@ func (s *Server) listGeneric(ctx context.Context, subject, relation string, reso
 	}, nil
 }
 
+// listObjects resolves ListObjects via OpenFGA's StreamedListObjects RPC (see streamedListObjects),
+// aggregating all streamed objects. That avoids unary ListObjects max-result truncation for large sets.
 func (s *Server) listObjects(ctx context.Context, req *openfgav1.ListObjectsRequest) (*openfgav1.ListObjectsResponse, error) {
 	fn := s.streamedListObjects
 
@@ -250,12 +252,7 @@ func (s *Server) streamedListObjects(ctx context.Context, req *openfgav1.ListObj
 	ctx, span := s.tracer.Start(ctx, "server.streamedListObjects")
 	defer span.End()
 
-	deadline := s.cfg.ListObjectsDeadline
-	if deadline <= 0 {
-		deadline = 3 * time.Second
-	}
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, deadline-time.Second)
+	ctx, cancel := s.withListObjectsClientDeadline(ctx)
 	defer cancel()
 
 	r := &openfgav1.StreamedListObjectsRequest{
@@ -292,6 +289,30 @@ func (s *Server) streamedListObjects(ctx context.Context, req *openfgav1.ListObj
 	return &openfgav1.ListObjectsResponse{
 		Objects: objects,
 	}, nil
+}
+
+// withListObjectsClientDeadline returns a context that expires slightly before cfg.ListObjectsDeadline
+// (the OpenFGA server-side stream deadline). That lets the client cancel first and avoids racing the
+// server/stream deadline. For server deadlines under 1s, uses a small margin instead of deadline-1s.
+func (s *Server) withListObjectsClientDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline := s.cfg.ListObjectsDeadline
+	if deadline <= 0 {
+		deadline = 3 * time.Second
+	}
+	client := deadline - time.Second
+	if client > 0 {
+		return context.WithTimeout(ctx, client)
+	}
+	// deadline <= 1s: leave a margin under the server deadline without extending the budget.
+	if deadline > time.Millisecond {
+		client = deadline - time.Millisecond
+	} else {
+		client = deadline / 2
+	}
+	if client <= 0 {
+		client = deadline
+	}
+	return context.WithTimeout(ctx, client)
 }
 
 func getRequestHash(req *openfgav1.ListObjectsRequest) (string, error) {

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -187,11 +187,6 @@ func TestIntegrationServerListStreaming(t *testing.T) {
 
 	server := setupOpenFGAServer(t)
 	setup(t, server)
-	server.cfg.UseStreamedListObjects = true
-
-	t.Cleanup(func() {
-		server.cfg.UseStreamedListObjects = false
-	})
 
 	newList := func(subject, group, resource, subresource string) *authzv1.ListRequest {
 		return &authzv1.ListRequest{

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -127,9 +127,6 @@ type ZanzanaServerSettings struct {
 	ListObjectsMaxResults uint32
 	// Deadline for the ListObjects() query. Default is 3 seconds.
 	ListObjectsDeadline time.Duration
-	// Use streamed version of list objects.
-	// Returns full list of objects, but takes more time.
-	UseStreamedListObjects bool
 	// URL for fetching signing keys.
 	SigningKeysURL string
 	// Allow insecure connections to the server for development purposes.
@@ -335,7 +332,6 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zs.OpenFGAHttpAddr = serverSec.Key("http_addr").MustString("")
 	zs.ListObjectsDeadline = serverSec.Key("list_objects_deadline").MustDuration(3 * time.Second)
 	zs.ListObjectsMaxResults = uint32(serverSec.Key("list_objects_max_results").MustUint(1000))
-	zs.UseStreamedListObjects = serverSec.Key("use_streamed_list_objects").MustBool(false)
 	zs.SigningKeysURL = serverSec.Key("signing_keys_url").MustString("")
 	zs.AllowInsecure = serverSec.Key("allow_insecure").MustBool(false)
 	zs.ReadPageSize = int32(serverSec.Key("read_page_size").MustInt(defaultReadPageSize))

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -136,6 +136,9 @@ type ZanzanaServerSettings struct {
 	AllowInsecure bool
 	// Page size for Read queries in reconciler. Default is 100.
 	ReadPageSize int32
+	// Max unique folder checks per batch-check phase before switching from OpenFGA BatchCheck
+	// to ListObjects. Reduces graph exploration when many distinct folders are checked. Default 20.
+	FolderCheckBatchThreshold int
 }
 
 type OpenFgaServerSettings struct {
@@ -336,6 +339,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zs.SigningKeysURL = serverSec.Key("signing_keys_url").MustString("")
 	zs.AllowInsecure = serverSec.Key("allow_insecure").MustBool(false)
 	zs.ReadPageSize = int32(serverSec.Key("read_page_size").MustInt(defaultReadPageSize))
+	zs.FolderCheckBatchThreshold = serverSec.Key("folder_check_batch_threshold").MustInt(20)
 
 	// Cache settings
 	zs.CacheSettings.CheckCacheLimit = uint32(serverSec.Key("check_cache_limit").MustUint(10000))


### PR DESCRIPTION
## What

When a `BatchCheck` request involves many unique folder tuples, the per-folder `BatchCheck` path can be expensive (e.g. high memory use when parent chains are evaluated concurrently). This change switches to a `ListObjects`-based path above a configurable threshold so we list folders the subject can access and resolve by membership instead.

## How

- New `[zanzana.server]` setting: `folder_check_batch_threshold` (default **20**), compared against the count of **unique** folder checks (relation + folder + group resource) in each of the folder permission and folder subresource phases.
- Below or at the threshold: existing deduplicated `BatchCheck` behavior.
- Above the threshold: one `ListObjects` per `(relation, group resource)` group, then set membership against requested folder idents.

## Tests

- Integration test `TestIntegrationServerBatchCheck_FolderCheckListPath` forces the list path (`FolderCheckBatchThreshold = 1`) and asserts the same outcomes as existing scenarios (user:4, user:8, user:5).