### PR TITLE
fix: update datasource group for migration

### DIFF
--- a/pkg/registry/apis/datasource/migrator/registrar.go
+++ b/pkg/registry/apis/datasource/migrator/registrar.go
@@ -10,7 +10,7 @@ import (
 // A single "primary" GroupResource is used for config/registration, while the actual
 // MigratorFunc streams each datasource with its per-plugin GroupResource key.
 func DataSourceMigration(dsMigrator DataSourceMigrator) migrations.MigrationDefinition {
-	gr := schema.GroupResource{Group: "*.datasource.grafana.app", Resource: "datasources"}
+	gr := schema.GroupResource{Group: "datasource.grafana.app", Resource: "datasources"}
 
 	return migrations.MigrationDefinition{
 		ID:          "datasource",

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -24,7 +24,7 @@ const (
 	DashboardResource   = "dashboards.dashboard.grafana.app"
 	ShortURLResource    = "shorturls.shorturl.grafana.app"
 	StarsResource       = "stars.collections.grafana.app"
-	DataSourceResources = "datasources.*.datasource.grafana.app" // All datasources
+	DataSourceResources = "datasources.datasource.grafana.app" // All datasources
 )
 
 // MigratedUnifiedResources maps resources to a boolean indicating if migration is enabled by default

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -114,7 +114,7 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 	// TODO... the migrator must be able to dynamically define the groups
 	// The bulk processor will clean up any resources in these groups, and
 	// initialize authorization scoped to this set of resources
-	if len(opts.Resources) == 1 && opts.Resources[0].Group == "*.datasource.grafana.app" {
+	if len(opts.Resources) == 1 && opts.Resources[0].Group == "datasource.grafana.app" {
 		// This should be loaded from the DB, or the plugin scanning
 		plugins := []string{
 			"alertmanager", "azuremonitor", "cloud-monitoring", "cloudwatch", "dashboard", "elasticsearch",

--- a/pkg/storage/unified/migrations/testcases/datasources.go
+++ b/pkg/storage/unified/migrations/testcases/datasources.go
@@ -46,7 +46,7 @@ func (tc *datasourcesTestCase) Resources() []schema.GroupVersionResource {
 			Resource: "datasources",
 		},
 		{
-			Group:    "*.datasource.grafana.app",
+			Group:    "datasource.grafana.app",
 			Version:  "v0alpha1",
 			Resource: "datasources",
 		},


### PR DESCRIPTION
The mt-settings api will not be able to pass in `*` as a config section in the cloud which makes the current dual writer setting for the `datasources` in the `config.ini` impossible.

```bash
➜  hg-dev /instances/mustafatest/config -d "config[unified_storage.datasources.*.datasource.grafana.app][dualWriterMode]=1"
{"code":"Bad Request","traceID":"92b50ba0fba1be055c409be082b5078d","message":"invalid config provided: invalid configuration section name: unified_storage.datasource.*.datasource.grafana.app"}
```

So, I was thinking whether the wildcard is a **must**? I think we can configure the dual writer mode for ALL datasources as below:

```ini
; before
[unified_storage.datasources.*.datasource.grafana.app]
dualWriterMode = 1

; after
[unified_storage.datasources.datasource.grafana.app]
dualWriterMode = 1
```