### PR TITLE
Prometheus: Remove PCRE (?i) regex flag from metrics modal search

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.test.tsx
@@ -224,7 +224,7 @@ describe('MetricsModalContext', () => {
       expect(mockLanguageProvider.queryLabelValues).toHaveBeenCalledWith(
         defaultTimeRange,
         '__name__',
-        '{__name__=~"(?i).*test.*"}'
+        '{__name__=~".*test.*"}'
       );
       expect(result.current.filteredMetricsData).toHaveLength(1);
     });

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -148,9 +148,9 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
 
           setIsLoading(true);
 
-          const queryString = regexifyLabelValuesQueryString(metricText);
+          const queryString = regexifyLabelValuesQueryString(metricText.toLowerCase());
           const filterArray = queryLabels ? formatPrometheusLabelFilters(queryLabels) : [];
-          const match = `{__name__=~"(?i).*${queryString}"${filterArray ? filterArray.join('') : ''}}`;
+          const match = `{__name__=~".*${queryString}"${filterArray ? filterArray.join('') : ''}}`;
 
           const results = await languageProvider.queryLabelValues(timeRange, METRIC_LABEL, match);
 


### PR DESCRIPTION
**What is this feature?**

Removes the Perl-style `(?i)` inline regex flag from the metrics browser's backend search query. The search input is lowercased before constructing the regex, preserving case-insensitive matching behavior for the vast majority of metric names (which are lowercase by convention).

**Why do we need this feature?**

The `(?i)` inline flag is a PCRE (Perl Compatible Regular Expressions) syntax that is not supported by all Prometheus-compatible backends. Specifically, Google Managed Prometheus (GMP) translates Prometheus API calls to Cloud Monitoring API calls using `monitoring.regex.full_match()`, which uses a restricted RE2 regex syntax that rejects inline flags like `(?i)`.

This causes the entire metrics browser search to fail with:
```
fetching metric schemas from schema service failed: generic::invalid_argument:
Illegal function invocation in monitoring.regex.full_match("(?i)...");
failed to parse regular expression in vicinity of "(?i"; invalid perl operator: (?i
```

**Who is this feature for?**

Users of the Prometheus metrics browser modal who have datasources backed by Google Managed Prometheus (GMP) or any other Prometheus-compatible backend that uses RE2 regex without support for inline flags.

**Which issue(s) does this PR fix?**:

Fixes #122475

**Special notes for your reviewer:**

- The `(?i)` flag was used to make metric name search case-insensitive. Since Prometheus metric names are lowercase by convention, lowercasing the search input (`metricText.toLowerCase()`) before regex construction achieves the same practical effect while being compatible with all regex engines.
- The `fuzzySearch()` that runs on the results after the backend query already handles case-insensitive reordering client-side.
- The change is limited to `MetricsModalContext.tsx` in `@grafana/prometheus` — no other search paths are affected.
- All 55 existing tests in the metrics-modal test suite pass.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.