### PR TITLE
Dashboard: Ability to repeat by section variables

### DIFF
--- a/devenv/dev-dashboards/section-variables/section-variables.json
+++ b/devenv/dev-dashboards/section-variables/section-variables.json
@@ -5,7 +5,7 @@
     "name": "section-level-variables-dev"
   },
   "spec": {
-    "title": "Section-Level Variables — Test Dashboard",
+    "title": "Section-Level Variables \u2014 Test Dashboard",
     "description": "Covers all variable types, layouts, shadowing, repeating, and edge cases for section-level variables (requires dashboardSectionVariables feature toggle).",
     "cursorSync": "Off",
     "preload": false,
@@ -20,11 +20,31 @@
       "autoRefresh": "",
       "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
       "quickRanges": [
-        { "display": "Last 5 minutes", "from": "now-5m", "to": "now" },
-        { "display": "Last 1 hour", "from": "now-1h", "to": "now" },
-        { "display": "Last 6 hours", "from": "now-6h", "to": "now" },
-        { "display": "Last 24 hours", "from": "now-24h", "to": "now" },
-        { "display": "Last 7 days", "from": "now-7d", "to": "now" }
+        {
+          "display": "Last 5 minutes",
+          "from": "now-5m",
+          "to": "now"
+        },
+        {
+          "display": "Last 1 hour",
+          "from": "now-1h",
+          "to": "now"
+        },
+        {
+          "display": "Last 6 hours",
+          "from": "now-6h",
+          "to": "now"
+        },
+        {
+          "display": "Last 24 hours",
+          "from": "now-24h",
+          "to": "now"
+        },
+        {
+          "display": "Last 7 days",
+          "from": "now-7d",
+          "to": "now"
+        }
       ],
       "hideTimepicker": false,
       "weekStart": "monday",
@@ -36,9 +56,12 @@
         "spec": {
           "name": "global_env",
           "label": "Global Env",
-          "description": "Dashboard-level env variable — used to test shadowing by section vars",
+          "description": "Dashboard-level env variable \u2014 used to test shadowing by section vars",
           "query": "global-dev,global-staging,global-prod",
-          "current": { "text": "global-dev", "value": "global-dev" },
+          "current": {
+            "text": "global-dev",
+            "value": "global-dev"
+          },
           "options": [],
           "multi": false,
           "includeAll": false,
@@ -54,7 +77,10 @@
           "label": "Repeat Variable",
           "description": "Multi-value variable used for row and tab repeat",
           "query": "alpha,beta,gamma",
-          "current": { "text": ["alpha", "beta", "gamma"], "value": ["alpha", "beta", "gamma"] },
+          "current": {
+            "text": ["alpha", "beta", "gamma"],
+            "value": ["alpha", "beta", "gamma"]
+          },
           "options": [],
           "multi": true,
           "includeAll": true,
@@ -104,10 +130,23 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -119,7 +158,14 @@
           "title": "Variable Values",
           "description": "",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -129,7 +175,10 @@
                 "mode": "markdown",
                 "content": "| Type | Name | Value |\n|---|---|---|\n| Custom | `sec_custom` | $sec_custom |\n| Textbox | `sec_textbox` | $sec_textbox |\n| Constant | `sec_constant` | $sec_constant |\n| Interval | `sec_interval` | $sec_interval |\n| Datasource | `sec_datasource` | $sec_datasource |\n| Switch | `sec_switch` | $sec_switch |\n| Query | `sec_query` | $sec_query |\n| Ad Hoc | `sec_adhoc` | (filter bar) |\n| Group By | `sec_groupby` | (group bar) |"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
@@ -141,7 +190,14 @@
           "title": "Inside shadowing row: global_env=$global_env",
           "description": "Section var named global_env overrides the dashboard-level one. Expected: section-override",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -151,7 +207,10 @@
                 "mode": "markdown",
                 "content": "## Shadowing Test\n\n`global_env` inside this row = **$global_env**\n\nExpected: `section-override` (not the dashboard-level value)"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
@@ -160,7 +219,7 @@
         "kind": "Panel",
         "spec": {
           "id": 20,
-          "title": "Repeated row ($repeat_var) — sec_var=$repeated_sec",
+          "title": "Repeated row ($repeat_var) \u2014 sec_var=$repeated_sec",
           "description": "",
           "links": [],
           "data": {
@@ -176,7 +235,10 @@
                       "kind": "DataQuery",
                       "version": "v0",
                       "group": "grafana-testdata-datasource",
-                      "spec": { "scenarioId": "random_walk", "alias": "$repeat_var — $repeated_sec" }
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "$repeat_var \u2014 $repeated_sec"
+                      }
                     }
                   }
                 }
@@ -191,10 +253,23 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -219,7 +294,10 @@
                       "kind": "DataQuery",
                       "version": "v0",
                       "group": "grafana-testdata-datasource",
-                      "spec": { "scenarioId": "random_walk", "alias": "collapsed_var=$collapsed_var" }
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "collapsed_var=$collapsed_var"
+                      }
                     }
                   }
                 }
@@ -234,10 +312,23 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -262,7 +353,10 @@
                       "kind": "DataQuery",
                       "version": "v0",
                       "group": "grafana-testdata-datasource",
-                      "spec": { "scenarioId": "random_walk", "alias": "row=$nested_row_var tab=$nested_tab_var" }
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "row=$nested_row_var tab=$nested_tab_var"
+                      }
                     }
                   }
                 }
@@ -277,10 +371,23 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -292,7 +399,14 @@
           "title": "Tab inherits row_var=$nested_row_var",
           "description": "",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -302,7 +416,10 @@
                 "mode": "markdown",
                 "content": "This tab has **no section vars** of its own.\n\nIt inherits `nested_row_var` = **$nested_row_var** from the parent row via ancestry walk."
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
@@ -327,7 +444,10 @@
                       "kind": "DataQuery",
                       "version": "v0",
                       "group": "grafana-testdata-datasource",
-                      "spec": { "scenarioId": "random_walk", "alias": "hidden=$edge_hidden multi=$edge_multi" }
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "hidden=$edge_hidden multi=$edge_multi"
+                      }
                     }
                   }
                 }
@@ -342,10 +462,23 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -357,7 +490,14 @@
           "title": "Sibling A: shared_name=$shared_name",
           "description": "",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -365,9 +505,12 @@
             "spec": {
               "options": {
                 "mode": "markdown",
-                "content": "**Row A** — `shared_name` = **$shared_name**\n\nExpected: `from-sibling-A`"
+                "content": "**Row A** \u2014 `shared_name` = **$shared_name**\n\nExpected: `from-sibling-A`"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
@@ -379,7 +522,14 @@
           "title": "Sibling B: shared_name=$shared_name",
           "description": "",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -387,14 +537,16 @@
             "spec": {
               "options": {
                 "mode": "markdown",
-                "content": "**Row B** — `shared_name` = **$shared_name**\n\nExpected: `from-sibling-B`"
+                "content": "**Row B** \u2014 `shared_name` = **$shared_name**\n\nExpected: `from-sibling-B`"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
       },
-
       "tab_all_types_panel": {
         "kind": "Panel",
         "spec": {
@@ -415,7 +567,10 @@
                       "kind": "DataQuery",
                       "version": "v0",
                       "group": "grafana-testdata-datasource",
-                      "spec": { "scenarioId": "random_walk", "alias": "custom=$tab_custom interval=$tab_interval" }
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "custom=$tab_custom interval=$tab_interval"
+                      }
                     }
                   }
                 }
@@ -430,10 +585,23 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -445,7 +613,14 @@
           "title": "Tab Variable Values",
           "description": "",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -455,7 +630,10 @@
                 "mode": "markdown",
                 "content": "| Type | Name | Value |\n|---|---|---|\n| Custom | `tab_custom` | $tab_custom |\n| Textbox | `tab_textbox` | $tab_textbox |\n| Interval | `tab_interval` | $tab_interval |\n| Switch | `tab_switch` | $tab_switch |\n| Query | `tab_query` | $tab_query |\n| Datasource | `tab_datasource` | $tab_datasource |"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
@@ -467,7 +645,14 @@
           "title": "Tab shadowing: global_env=$global_env",
           "description": "Tab-level var overrides dashboard-level global_env",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -477,7 +662,10 @@
                 "mode": "markdown",
                 "content": "## Tab Shadowing Test\n\n`global_env` = **$global_env**\n\nExpected: `tab-override` (not dashboard-level value)"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
             }
           }
         }
@@ -486,10 +674,17 @@
         "kind": "Panel",
         "spec": {
           "id": 103,
-          "title": "Tab without vars — global_env=$global_env",
+          "title": "Tab without vars \u2014 global_env=$global_env",
           "description": "",
           "links": [],
-          "data": { "kind": "QueryGroup", "spec": { "queries": [], "transformations": [], "queryOptions": {} } },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
           "vizConfig": {
             "kind": "VizConfig",
             "group": "text",
@@ -499,7 +694,128 @@
                 "mode": "markdown",
                 "content": "This tab has **no section variables**.\n\n`global_env` = **$global_env** (should show dashboard-level value)\n\n`tab_custom` should **not** resolve here: $tab_custom"
               },
-              "fieldConfig": { "defaults": {}, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "sec_var_repeat_panel": {
+        "kind": "Panel",
+        "spec": {
+          "id": 70,
+          "title": "Tab repeat=$tab_repeat_driver, Row var=$row_in_repeated",
+          "description": "Row repeated by parent tab's section variable (tab_repeat_driver). Also has its own section var (row_in_repeated).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "refId": "A",
+                    "hidden": false,
+                    "query": {
+                      "kind": "DataQuery",
+                      "version": "v0",
+                      "group": "grafana-testdata-datasource",
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "region=$tab_repeat_driver replica=$row_in_repeated"
+                      }
+                    }
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "",
+            "spec": {
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "ancestor_row_repeat_panel": {
+        "kind": "Panel",
+        "spec": {
+          "id": 71,
+          "title": "Ancestor row var=$nested_row_var",
+          "description": "Row nested inside a tab inside another row, repeated by grandparent row's section variable (nested_row_var).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "refId": "A",
+                    "hidden": false,
+                    "query": {
+                      "kind": "DataQuery",
+                      "version": "v0",
+                      "group": "grafana-testdata-datasource",
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "ancestor_row=$nested_row_var"
+                      }
+                    }
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "",
+            "spec": {
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
@@ -508,7 +824,7 @@
         "kind": "Panel",
         "spec": {
           "id": 104,
-          "title": "Repeated tab ($repeat_var) — tab_sec=$tab_repeated_sec",
+          "title": "Repeated tab ($repeat_var) \u2014 tab_sec=$tab_repeated_sec",
           "description": "",
           "links": [],
           "data": {
@@ -524,7 +840,10 @@
                       "kind": "DataQuery",
                       "version": "v0",
                       "group": "grafana-testdata-datasource",
-                      "spec": { "scenarioId": "random_walk", "alias": "$repeat_var — $tab_repeated_sec" }
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "$repeat_var \u2014 $tab_repeated_sec"
+                      }
                     }
                   }
                 }
@@ -539,16 +858,87 @@
             "version": "",
             "spec": {
               "options": {
-                "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-                "tooltip": { "mode": "single" }
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
               },
-              "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] }
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel_repeat_by_sec_var": {
+        "kind": "Panel",
+        "spec": {
+          "id": 72,
+          "title": "Panel repeated by section var: $sec_panel_repeat_source",
+          "description": "This panel repeats by sec_panel_repeat_source, a multi-value section variable on the parent row. Tests DashboardGridItem.performRepeat with ancestor-walked section variables.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "refId": "A",
+                    "hidden": false,
+                    "query": {
+                      "kind": "DataQuery",
+                      "version": "v0",
+                      "group": "grafana-testdata-datasource",
+                      "spec": {
+                        "scenarioId": "random_walk",
+                        "alias": "service=$sec_panel_repeat_source"
+                      }
+                    }
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "",
+            "spec": {
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "single"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  }
+                },
+                "overrides": []
+              }
             }
           }
         }
       }
     },
-
     "layout": {
       "kind": "TabsLayout",
       "spec": {
@@ -557,6 +947,28 @@
             "kind": "TabsLayoutTab",
             "spec": {
               "title": "Row-Scoped Variables",
+              "variables": [
+                {
+                  "kind": "CustomVariable",
+                  "spec": {
+                    "name": "tab_repeat_driver",
+                    "label": "Tab Repeat Driver",
+                    "description": "Multi-value variable on the tab, used to repeat a child row by ancestor section variable",
+                    "query": "east,west,central",
+                    "current": {
+                      "text": ["east", "west", "central"],
+                      "value": ["east", "west", "central"]
+                    },
+                    "options": [],
+                    "multi": true,
+                    "includeAll": true,
+                    "allValue": "",
+                    "hide": "dontHide",
+                    "skipUrlSync": false,
+                    "allowCustomValue": false
+                  }
+                }
+              ],
               "layout": {
                 "kind": "RowsLayout",
                 "spec": {
@@ -577,7 +989,10 @@
                                   "y": 0,
                                   "width": 16,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "all_types_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "all_types_panel"
+                                  }
                                 }
                               },
                               {
@@ -587,7 +1002,10 @@
                                   "y": 0,
                                   "width": 8,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "all_types_info" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "all_types_info"
+                                  }
                                 }
                               }
                             ]
@@ -600,7 +1018,10 @@
                               "name": "sec_custom",
                               "label": "Custom",
                               "query": "web,api,worker,scheduler",
-                              "current": { "text": "web", "value": "web" },
+                              "current": {
+                                "text": "web",
+                                "value": "web"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -615,7 +1036,10 @@
                               "name": "sec_textbox",
                               "label": "Textbox",
                               "query": "hello-world",
-                              "current": { "text": "hello-world", "value": "hello-world" },
+                              "current": {
+                                "text": "hello-world",
+                                "value": "hello-world"
+                              },
                               "hide": "dontHide",
                               "skipUrlSync": false
                             }
@@ -626,7 +1050,10 @@
                               "name": "sec_constant",
                               "label": "Constant",
                               "query": "v2.5.0-beta",
-                              "current": { "text": "v2.5.0-beta", "value": "v2.5.0-beta" },
+                              "current": {
+                                "text": "v2.5.0-beta",
+                                "value": "v2.5.0-beta"
+                              },
                               "hide": "dontHide",
                               "skipUrlSync": true
                             }
@@ -637,14 +1064,36 @@
                               "name": "sec_interval",
                               "label": "Interval",
                               "query": "10s,30s,1m,5m,15m,1h",
-                              "current": { "text": "1m", "value": "1m" },
+                              "current": {
+                                "text": "1m",
+                                "value": "1m"
+                              },
                               "options": [
-                                { "text": "10s", "value": "10s" },
-                                { "text": "30s", "value": "30s" },
-                                { "text": "1m", "value": "1m", "selected": true },
-                                { "text": "5m", "value": "5m" },
-                                { "text": "15m", "value": "15m" },
-                                { "text": "1h", "value": "1h" }
+                                {
+                                  "text": "10s",
+                                  "value": "10s"
+                                },
+                                {
+                                  "text": "30s",
+                                  "value": "30s"
+                                },
+                                {
+                                  "text": "1m",
+                                  "value": "1m",
+                                  "selected": true
+                                },
+                                {
+                                  "text": "5m",
+                                  "value": "5m"
+                                },
+                                {
+                                  "text": "15m",
+                                  "value": "15m"
+                                },
+                                {
+                                  "text": "1h",
+                                  "value": "1h"
+                                }
                               ],
                               "auto": false,
                               "auto_count": 10,
@@ -662,7 +1111,10 @@
                               "pluginId": "grafana-testdata-datasource",
                               "regex": "",
                               "refresh": "onDashboardLoad",
-                              "current": { "text": "", "value": "" },
+                              "current": {
+                                "text": "",
+                                "value": ""
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -700,7 +1152,10 @@
                               "regex": "",
                               "sort": "alphabeticalAsc",
                               "refresh": "onDashboardLoad",
-                              "current": { "text": "us-east-1", "value": "us-east-1" },
+                              "current": {
+                                "text": "us-east-1",
+                                "value": "us-east-1"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -729,7 +1184,10 @@
                             "spec": {
                               "name": "sec_groupby",
                               "label": "Group By",
-                              "current": { "text": "", "value": "" },
+                              "current": {
+                                "text": "",
+                                "value": ""
+                              },
                               "options": [],
                               "multi": true,
                               "hide": "dontHide",
@@ -742,7 +1200,7 @@
                     {
                       "kind": "RowsLayoutRow",
                       "spec": {
-                        "title": "2. Shadowing — section overrides global_env",
+                        "title": "2. Shadowing \u2014 section overrides global_env",
                         "collapse": false,
                         "layout": {
                           "kind": "GridLayout",
@@ -755,7 +1213,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 6,
-                                  "element": { "kind": "ElementReference", "name": "shadow_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "shadow_panel"
+                                  }
                                 }
                               }
                             ]
@@ -768,7 +1229,10 @@
                               "name": "global_env",
                               "label": "Shadowed Env",
                               "query": "section-override,section-alt",
-                              "current": { "text": "section-override", "value": "section-override" },
+                              "current": {
+                                "text": "section-override",
+                                "value": "section-override"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -785,7 +1249,10 @@
                       "spec": {
                         "title": "3. Repeated Row ($repeat_var) with section var",
                         "collapse": false,
-                        "repeat": { "mode": "variable", "value": "repeat_var" },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "repeat_var"
+                        },
                         "layout": {
                           "kind": "GridLayout",
                           "spec": {
@@ -797,7 +1264,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "repeat_row_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "repeat_row_panel"
+                                  }
                                 }
                               }
                             ]
@@ -810,7 +1280,10 @@
                               "name": "repeated_sec",
                               "label": "Repeated Section Var",
                               "query": "hot,warm,cold",
-                              "current": { "text": "hot", "value": "hot" },
+                              "current": {
+                                "text": "hot",
+                                "value": "hot"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -838,7 +1311,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "collapsed_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "collapsed_panel"
+                                  }
                                 }
                               }
                             ]
@@ -851,7 +1327,10 @@
                               "name": "collapsed_var",
                               "label": "Collapsed Row Var",
                               "query": "expand-me,to-see-me",
-                              "current": { "text": "expand-me", "value": "expand-me" },
+                              "current": {
+                                "text": "expand-me",
+                                "value": "expand-me"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -866,7 +1345,7 @@
                     {
                       "kind": "RowsLayoutRow",
                       "spec": {
-                        "title": "5. Nested — Row with Tabs (both levels have vars)",
+                        "title": "5. Nested \u2014 Row with Tabs (both levels have vars)",
                         "collapse": false,
                         "layout": {
                           "kind": "TabsLayout",
@@ -887,7 +1366,10 @@
                                             "y": 0,
                                             "width": 24,
                                             "height": 8,
-                                            "element": { "kind": "ElementReference", "name": "nested_panel" }
+                                            "element": {
+                                              "kind": "ElementReference",
+                                              "name": "nested_panel"
+                                            }
                                           }
                                         }
                                       ]
@@ -900,7 +1382,10 @@
                                         "name": "nested_tab_var",
                                         "label": "Nested Tab Var",
                                         "query": "tab-val-A,tab-val-B,tab-val-C",
-                                        "current": { "text": "tab-val-A", "value": "tab-val-A" },
+                                        "current": {
+                                          "text": "tab-val-A",
+                                          "value": "tab-val-A"
+                                        },
                                         "options": [],
                                         "multi": false,
                                         "includeAll": false,
@@ -927,7 +1412,54 @@
                                             "y": 0,
                                             "width": 24,
                                             "height": 8,
-                                            "element": { "kind": "ElementReference", "name": "nested_inherit_panel" }
+                                            "element": {
+                                              "kind": "ElementReference",
+                                              "name": "nested_inherit_panel"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "TabsLayoutTab",
+                                "spec": {
+                                  "title": "Repeat by Ancestor Row Var ($nested_row_var)",
+                                  "layout": {
+                                    "kind": "RowsLayout",
+                                    "spec": {
+                                      "rows": [
+                                        {
+                                          "kind": "RowsLayoutRow",
+                                          "spec": {
+                                            "title": "Repeated by ancestor nested_row_var ($nested_row_var)",
+                                            "collapse": false,
+                                            "repeat": {
+                                              "mode": "variable",
+                                              "value": "nested_row_var"
+                                            },
+                                            "layout": {
+                                              "kind": "GridLayout",
+                                              "spec": {
+                                                "items": [
+                                                  {
+                                                    "kind": "GridLayoutItem",
+                                                    "spec": {
+                                                      "x": 0,
+                                                      "y": 0,
+                                                      "width": 24,
+                                                      "height": 8,
+                                                      "element": {
+                                                        "kind": "ElementReference",
+                                                        "name": "ancestor_row_repeat_panel"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
                                           }
                                         }
                                       ]
@@ -945,78 +1477,10 @@
                               "name": "nested_row_var",
                               "label": "Nested Row Var",
                               "query": "row-val-X,row-val-Y,row-val-Z",
-                              "current": { "text": "row-val-X", "value": "row-val-X" },
-                              "options": [],
-                              "multi": false,
-                              "includeAll": false,
-                              "hide": "dontHide",
-                              "skipUrlSync": false,
-                              "allowCustomValue": false
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "kind": "RowsLayoutRow",
-                      "spec": {
-                        "title": "6. Edge Cases — Hidden, skipUrlSync, Multi-value",
-                        "collapse": false,
-                        "layout": {
-                          "kind": "GridLayout",
-                          "spec": {
-                            "items": [
-                              {
-                                "kind": "GridLayoutItem",
-                                "spec": {
-                                  "x": 0,
-                                  "y": 0,
-                                  "width": 24,
-                                  "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "edge_panel" }
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "CustomVariable",
-                            "spec": {
-                              "name": "edge_hidden",
-                              "label": "Hidden Var",
-                              "query": "hidden-val-1,hidden-val-2",
-                              "current": { "text": "hidden-val-1", "value": "hidden-val-1" },
-                              "options": [],
-                              "multi": false,
-                              "includeAll": false,
-                              "hide": "hideVariable",
-                              "skipUrlSync": false,
-                              "allowCustomValue": false
-                            }
-                          },
-                          {
-                            "kind": "CustomVariable",
-                            "spec": {
-                              "name": "edge_skipurl",
-                              "label": "Skip URL Sync",
-                              "query": "no-url-1,no-url-2",
-                              "current": { "text": "no-url-1", "value": "no-url-1" },
-                              "options": [],
-                              "multi": false,
-                              "includeAll": false,
-                              "hide": "dontHide",
-                              "skipUrlSync": true,
-                              "allowCustomValue": false
-                            }
-                          },
-                          {
-                            "kind": "CustomVariable",
-                            "spec": {
-                              "name": "edge_multi",
-                              "label": "Multi-Value",
-                              "query": "val-a,val-b,val-c,val-d",
-                              "current": { "text": ["val-a", "val-b"], "value": ["val-a", "val-b"] },
+                              "current": {
+                                "text": ["row-val-X", "row-val-Y", "row-val-Z"],
+                                "value": ["row-val-X", "row-val-Y", "row-val-Z"]
+                              },
                               "options": [],
                               "multi": true,
                               "includeAll": true,
@@ -1032,7 +1496,91 @@
                     {
                       "kind": "RowsLayoutRow",
                       "spec": {
-                        "title": "7a. Sibling Isolation — Row A",
+                        "title": "6. Edge Cases \u2014 Hidden, skipUrlSync, Multi-value",
+                        "collapse": false,
+                        "layout": {
+                          "kind": "GridLayout",
+                          "spec": {
+                            "items": [
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 0,
+                                  "width": 24,
+                                  "height": 8,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "edge_panel"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "variables": [
+                          {
+                            "kind": "CustomVariable",
+                            "spec": {
+                              "name": "edge_hidden",
+                              "label": "Hidden Var",
+                              "query": "hidden-val-1,hidden-val-2",
+                              "current": {
+                                "text": "hidden-val-1",
+                                "value": "hidden-val-1"
+                              },
+                              "options": [],
+                              "multi": false,
+                              "includeAll": false,
+                              "hide": "hideVariable",
+                              "skipUrlSync": false,
+                              "allowCustomValue": false
+                            }
+                          },
+                          {
+                            "kind": "CustomVariable",
+                            "spec": {
+                              "name": "edge_skipurl",
+                              "label": "Skip URL Sync",
+                              "query": "no-url-1,no-url-2",
+                              "current": {
+                                "text": "no-url-1",
+                                "value": "no-url-1"
+                              },
+                              "options": [],
+                              "multi": false,
+                              "includeAll": false,
+                              "hide": "dontHide",
+                              "skipUrlSync": true,
+                              "allowCustomValue": false
+                            }
+                          },
+                          {
+                            "kind": "CustomVariable",
+                            "spec": {
+                              "name": "edge_multi",
+                              "label": "Multi-Value",
+                              "query": "val-a,val-b,val-c,val-d",
+                              "current": {
+                                "text": ["val-a", "val-b"],
+                                "value": ["val-a", "val-b"]
+                              },
+                              "options": [],
+                              "multi": true,
+                              "includeAll": true,
+                              "allValue": "",
+                              "hide": "dontHide",
+                              "skipUrlSync": false,
+                              "allowCustomValue": false
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "7a. Sibling Isolation \u2014 Row A",
                         "collapse": false,
                         "layout": {
                           "kind": "GridLayout",
@@ -1045,7 +1593,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 5,
-                                  "element": { "kind": "ElementReference", "name": "sibling_a_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "sibling_a_panel"
+                                  }
                                 }
                               }
                             ]
@@ -1058,7 +1609,10 @@
                               "name": "shared_name",
                               "label": "Shared Name (A)",
                               "query": "from-sibling-A",
-                              "current": { "text": "from-sibling-A", "value": "from-sibling-A" },
+                              "current": {
+                                "text": "from-sibling-A",
+                                "value": "from-sibling-A"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -1073,7 +1627,7 @@
                     {
                       "kind": "RowsLayoutRow",
                       "spec": {
-                        "title": "7b. Sibling Isolation — Row B",
+                        "title": "7b. Sibling Isolation \u2014 Row B",
                         "collapse": false,
                         "layout": {
                           "kind": "GridLayout",
@@ -1086,7 +1640,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 5,
-                                  "element": { "kind": "ElementReference", "name": "sibling_b_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "sibling_b_panel"
+                                  }
                                 }
                               }
                             ]
@@ -1099,10 +1656,119 @@
                               "name": "shared_name",
                               "label": "Shared Name (B)",
                               "query": "from-sibling-B",
-                              "current": { "text": "from-sibling-B", "value": "from-sibling-B" },
+                              "current": {
+                                "text": "from-sibling-B",
+                                "value": "from-sibling-B"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
+                              "hide": "dontHide",
+                              "skipUrlSync": false,
+                              "allowCustomValue": false
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "8. Repeat Row by Ancestor Section Variable ($tab_repeat_driver)",
+                        "collapse": false,
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "tab_repeat_driver"
+                        },
+                        "layout": {
+                          "kind": "GridLayout",
+                          "spec": {
+                            "items": [
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 0,
+                                  "width": 24,
+                                  "height": 8,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "sec_var_repeat_panel"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "variables": [
+                          {
+                            "kind": "CustomVariable",
+                            "spec": {
+                              "name": "row_in_repeated",
+                              "label": "Row In Repeated",
+                              "query": "primary,replica",
+                              "current": {
+                                "text": "primary",
+                                "value": "primary"
+                              },
+                              "options": [],
+                              "multi": false,
+                              "includeAll": false,
+                              "hide": "dontHide",
+                              "skipUrlSync": false,
+                              "allowCustomValue": false
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "9. Panel Repeat by Section Variable",
+                        "collapse": false,
+                        "layout": {
+                          "kind": "GridLayout",
+                          "spec": {
+                            "items": [
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 0,
+                                  "width": 12,
+                                  "height": 8,
+                                  "repeat": {
+                                    "mode": "variable",
+                                    "value": "sec_panel_repeat_source",
+                                    "direction": "horizontal",
+                                    "maxPerRow": 4
+                                  },
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel_repeat_by_sec_var"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "variables": [
+                          {
+                            "kind": "CustomVariable",
+                            "spec": {
+                              "name": "sec_panel_repeat_source",
+                              "label": "Services (panel repeat source)",
+                              "description": "Multi-value section variable used as the repeat source for panels inside this row",
+                              "query": "auth,gateway,billing,notify,search",
+                              "current": {
+                                "text": ["auth", "gateway", "billing", "notify", "search"],
+                                "value": ["auth", "gateway", "billing", "notify", "search"]
+                              },
+                              "options": [],
+                              "multi": true,
+                              "includeAll": true,
+                              "allValue": "",
                               "hide": "dontHide",
                               "skipUrlSync": false,
                               "allowCustomValue": false
@@ -1116,7 +1782,6 @@
               }
             }
           },
-
           {
             "kind": "TabsLayoutTab",
             "spec": {
@@ -1140,7 +1805,10 @@
                                   "y": 0,
                                   "width": 16,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "tab_all_types_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "tab_all_types_panel"
+                                  }
                                 }
                               },
                               {
@@ -1150,7 +1818,10 @@
                                   "y": 0,
                                   "width": 8,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "tab_all_types_info" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "tab_all_types_info"
+                                  }
                                 }
                               }
                             ]
@@ -1163,7 +1834,10 @@
                               "name": "tab_custom",
                               "label": "Custom",
                               "query": "redis,memcached,postgres,mysql",
-                              "current": { "text": "redis", "value": "redis" },
+                              "current": {
+                                "text": "redis",
+                                "value": "redis"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -1178,7 +1852,10 @@
                               "name": "tab_textbox",
                               "label": "Textbox",
                               "query": "type-here",
-                              "current": { "text": "type-here", "value": "type-here" },
+                              "current": {
+                                "text": "type-here",
+                                "value": "type-here"
+                              },
                               "hide": "dontHide",
                               "skipUrlSync": false
                             }
@@ -1189,13 +1866,32 @@
                               "name": "tab_interval",
                               "label": "Interval",
                               "query": "1s,5s,10s,30s,1m",
-                              "current": { "text": "10s", "value": "10s" },
+                              "current": {
+                                "text": "10s",
+                                "value": "10s"
+                              },
                               "options": [
-                                { "text": "1s", "value": "1s" },
-                                { "text": "5s", "value": "5s" },
-                                { "text": "10s", "value": "10s", "selected": true },
-                                { "text": "30s", "value": "30s" },
-                                { "text": "1m", "value": "1m" }
+                                {
+                                  "text": "1s",
+                                  "value": "1s"
+                                },
+                                {
+                                  "text": "5s",
+                                  "value": "5s"
+                                },
+                                {
+                                  "text": "10s",
+                                  "value": "10s",
+                                  "selected": true
+                                },
+                                {
+                                  "text": "30s",
+                                  "value": "30s"
+                                },
+                                {
+                                  "text": "1m",
+                                  "value": "1m"
+                                }
                               ],
                               "auto": false,
                               "auto_count": 10,
@@ -1234,7 +1930,10 @@
                               "regex": "",
                               "sort": "alphabeticalAsc",
                               "refresh": "onDashboardLoad",
-                              "current": { "text": "svc-auth", "value": "svc-auth" },
+                              "current": {
+                                "text": "svc-auth",
+                                "value": "svc-auth"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -1251,7 +1950,10 @@
                               "pluginId": "grafana-testdata-datasource",
                               "regex": "",
                               "refresh": "onDashboardLoad",
-                              "current": { "text": "", "value": "" },
+                              "current": {
+                                "text": "",
+                                "value": ""
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -1278,7 +1980,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "tab_shadow_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "tab_shadow_panel"
+                                  }
                                 }
                               }
                             ]
@@ -1291,7 +1996,10 @@
                               "name": "global_env",
                               "label": "Tab Shadow",
                               "query": "tab-override,tab-alt",
-                              "current": { "text": "tab-override", "value": "tab-override" },
+                              "current": {
+                                "text": "tab-override",
+                                "value": "tab-override"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,
@@ -1318,7 +2026,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "tab_no_vars_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "tab_no_vars_panel"
+                                  }
                                 }
                               }
                             ]
@@ -1330,7 +2041,10 @@
                       "kind": "TabsLayoutTab",
                       "spec": {
                         "title": "Repeated Tab ($repeat_var)",
-                        "repeat": { "mode": "variable", "value": "repeat_var" },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "repeat_var"
+                        },
                         "layout": {
                           "kind": "GridLayout",
                           "spec": {
@@ -1342,7 +2056,10 @@
                                   "y": 0,
                                   "width": 24,
                                   "height": 8,
-                                  "element": { "kind": "ElementReference", "name": "tab_repeat_panel" }
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "tab_repeat_panel"
+                                  }
                                 }
                               }
                             ]
@@ -1355,7 +2072,10 @@
                               "name": "tab_repeated_sec",
                               "label": "Repeated Tab Var",
                               "query": "ssd,hdd,nvme",
-                              "current": { "text": "ssd", "value": "ssd" },
+                              "current": {
+                                "text": "ssd",
+                                "value": "ssd"
+                              },
                               "options": [],
                               "multi": false,
                               "includeAll": false,

--- a/public/app/features/dashboard-scene/utils/collectAncestorSceneVariables.test.ts
+++ b/public/app/features/dashboard-scene/utils/collectAncestorSceneVariables.test.ts
@@ -1,0 +1,74 @@
+import { CustomVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { RowItem } from '../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
+
+import { collectAncestorSceneVariables } from './collectAncestorSceneVariables';
+
+describe('collectAncestorSceneVariables', () => {
+  it('includes dashboard variables when sceneObject is the scene root (no parent)', () => {
+    const dashVar = new CustomVariable({ name: 'dashVar', query: 'd', value: 'd', text: 'd' });
+    const dashboard = new DashboardScene({
+      $variables: new SceneVariableSet({ variables: [dashVar] }),
+    });
+
+    const merged = collectAncestorSceneVariables(dashboard);
+    expect(merged.map((v) => v.state.name)).toEqual(['dashVar']);
+  });
+
+  it('merges dashboard and section variables with inner scope winning on duplicate names (from grid item)', () => {
+    const dashVar = new CustomVariable({ name: 'dup', query: 'd', value: 'd', text: 'd' });
+    const sectionDup = new CustomVariable({ name: 'dup', query: 's', value: 's', text: 's' });
+    const sectionOnly = new CustomVariable({ name: 'sectionOnly', query: 'x', value: 'x', text: 'x' });
+
+    const panel = new VizPanel({ key: 'p1', pluginId: 'text' });
+    const gridItem = new DashboardGridItem({ body: panel });
+    const row = new RowItem({
+      title: 'R',
+      $variables: new SceneVariableSet({ variables: [sectionDup, sectionOnly] }),
+      layout: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({ children: [gridItem] }),
+      }),
+    });
+    new DashboardScene({
+      $variables: new SceneVariableSet({ variables: [dashVar] }),
+      body: new RowsLayoutManager({ rows: [row] }),
+    });
+
+    const merged = collectAncestorSceneVariables(gridItem);
+    const names = merged.map((v) => v.state.name);
+
+    expect(names).toContain('sectionOnly');
+    expect(names).toContain('dup');
+    const dupInstance = merged.find((v) => v.state.name === 'dup');
+    expect(dupInstance).toBe(sectionDup);
+  });
+
+  it('excludes the starting row section variables (walk starts at parent when present)', () => {
+    const dashVar = new CustomVariable({ name: 'dashVar', query: 'd', value: 'd', text: 'd' });
+    const sectionVar = new CustomVariable({ name: 'sectionVar', query: 's', value: 's', text: 's' });
+
+    const panel = new VizPanel({ key: 'p1', pluginId: 'text' });
+    const gridItem = new DashboardGridItem({ body: panel });
+    const row = new RowItem({
+      title: 'R',
+      $variables: new SceneVariableSet({ variables: [sectionVar] }),
+      layout: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({ children: [gridItem] }),
+      }),
+    });
+    new DashboardScene({
+      $variables: new SceneVariableSet({ variables: [dashVar] }),
+      body: new RowsLayoutManager({ rows: [row] }),
+    });
+
+    const merged = collectAncestorSceneVariables(row);
+    const names = merged.map((v) => v.state.name);
+
+    expect(names).toContain('dashVar');
+    expect(names).not.toContain('sectionVar');
+  });
+});

--- a/public/app/features/dashboard-scene/utils/collectAncestorSceneVariables.test.ts
+++ b/public/app/features/dashboard-scene/utils/collectAncestorSceneVariables.test.ts
@@ -8,6 +8,30 @@ import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 
 import { collectAncestorSceneVariables } from './collectAncestorSceneVariables';
 
+function buildRowFixture({
+  dashboardVariables,
+  sectionVariables,
+}: {
+  dashboardVariables: CustomVariable[];
+  sectionVariables: CustomVariable[];
+}) {
+  const panel = new VizPanel({ key: 'p1', pluginId: 'text' });
+  const gridItem = new DashboardGridItem({ body: panel });
+  const row = new RowItem({
+    title: 'R',
+    $variables: new SceneVariableSet({ variables: sectionVariables }),
+    layout: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({ children: [gridItem] }),
+    }),
+  });
+  new DashboardScene({
+    $variables: new SceneVariableSet({ variables: dashboardVariables }),
+    body: new RowsLayoutManager({ rows: [row] }),
+  });
+
+  return { gridItem, row };
+}
+
 describe('collectAncestorSceneVariables', () => {
   it('includes dashboard variables when sceneObject is the scene root (no parent)', () => {
     const dashVar = new CustomVariable({ name: 'dashVar', query: 'd', value: 'd', text: 'd' });
@@ -24,18 +48,9 @@ describe('collectAncestorSceneVariables', () => {
     const sectionDup = new CustomVariable({ name: 'dup', query: 's', value: 's', text: 's' });
     const sectionOnly = new CustomVariable({ name: 'sectionOnly', query: 'x', value: 'x', text: 'x' });
 
-    const panel = new VizPanel({ key: 'p1', pluginId: 'text' });
-    const gridItem = new DashboardGridItem({ body: panel });
-    const row = new RowItem({
-      title: 'R',
-      $variables: new SceneVariableSet({ variables: [sectionDup, sectionOnly] }),
-      layout: new DefaultGridLayoutManager({
-        grid: new SceneGridLayout({ children: [gridItem] }),
-      }),
-    });
-    new DashboardScene({
-      $variables: new SceneVariableSet({ variables: [dashVar] }),
-      body: new RowsLayoutManager({ rows: [row] }),
+    const { gridItem } = buildRowFixture({
+      dashboardVariables: [dashVar],
+      sectionVariables: [sectionDup, sectionOnly],
     });
 
     const merged = collectAncestorSceneVariables(gridItem);
@@ -51,18 +66,9 @@ describe('collectAncestorSceneVariables', () => {
     const dashVar = new CustomVariable({ name: 'dashVar', query: 'd', value: 'd', text: 'd' });
     const sectionVar = new CustomVariable({ name: 'sectionVar', query: 's', value: 's', text: 's' });
 
-    const panel = new VizPanel({ key: 'p1', pluginId: 'text' });
-    const gridItem = new DashboardGridItem({ body: panel });
-    const row = new RowItem({
-      title: 'R',
-      $variables: new SceneVariableSet({ variables: [sectionVar] }),
-      layout: new DefaultGridLayoutManager({
-        grid: new SceneGridLayout({ children: [gridItem] }),
-      }),
-    });
-    new DashboardScene({
-      $variables: new SceneVariableSet({ variables: [dashVar] }),
-      body: new RowsLayoutManager({ rows: [row] }),
+    const { row } = buildRowFixture({
+      dashboardVariables: [dashVar],
+      sectionVariables: [sectionVar],
     });
 
     const merged = collectAncestorSceneVariables(row);

--- a/public/app/features/dashboard-scene/utils/collectAncestorSceneVariables.ts
+++ b/public/app/features/dashboard-scene/utils/collectAncestorSceneVariables.ts
@@ -1,0 +1,51 @@
+import { type SceneObject, type SceneVariable, SceneVariableSet } from '@grafana/scenes';
+
+/**
+ * Resolves variables visible when editing from `sceneObject` (e.g. repeat options).
+ *
+ * Walk begins at `sceneObject.parent ?? sceneObject` so a row, tab, or grid item never
+ * contributes its own `$variables` — only ancestors (e.g. section above, then dashboard).
+ * When `sceneObject` is the scene root (`DashboardScene`), `parent` is undefined and the
+ * walk starts at the dashboard, including global variables.
+ */
+export function collectAncestorSceneVariables(sceneObject: SceneObject): SceneVariable[] {
+  const result: SceneVariable[] = [];
+  const seenNames = new Set<string>();
+  let current: SceneObject | undefined = sceneObject.parent ?? sceneObject;
+
+  while (current) {
+    if (current.state.$variables instanceof SceneVariableSet) {
+      for (const variable of current.state.$variables.state.variables) {
+        const name = variable.state.name;
+        if (!seenNames.has(name)) {
+          seenNames.add(name);
+          result.push(variable);
+        }
+      }
+    }
+    current = current.parent;
+  }
+
+  return result;
+}
+
+/**
+ * Subscribes to state changes on every `SceneVariableSet` along the same walk as
+ * {@link collectAncestorSceneVariables} so the UI refreshes when variables change.
+ */
+export function subscribeAncestorVariableSets(sceneObject: SceneObject, onChange: () => void): () => void {
+  let current: SceneObject | undefined = sceneObject.parent ?? sceneObject;
+
+  const unsubs: Array<{ unsubscribe: () => void }> = [];
+
+  while (current) {
+    if (current.state.$variables instanceof SceneVariableSet) {
+      unsubs.push(current.state.$variables.subscribeToState(onChange));
+    }
+    current = current.parent;
+  }
+
+  return () => {
+    unsubs.forEach((u) => u.unsubscribe());
+  };
+}

--- a/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.test.tsx
+++ b/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.test.tsx
@@ -32,27 +32,17 @@ async function buildTestScene(variables?: SceneVariable[]) {
   return dashboard;
 }
 
-const Wrapper = ({ scene }: { scene: DashboardScene }) => {
-  const [repeat, setRepeat] = useState<string | undefined>(undefined);
-  return <RepeatRowSelect2 sceneContext={scene} repeat={repeat} onChange={(newRepeat) => setRepeat(newRepeat)} />;
-};
-
-const setup = async (variables?: SceneVariable[]) => {
-  const scene = await buildTestScene(variables);
-
-  return render(<Wrapper scene={scene} />);
-};
-
-const SectionScopeWrapper = ({ sceneContext }: { sceneContext: SceneObject }) => {
+const RepeatRowSelectWrapper = ({ sceneContext }: { sceneContext: SceneObject }) => {
   const [repeat, setRepeat] = useState<string | undefined>(undefined);
   return (
     <RepeatRowSelect2 sceneContext={sceneContext} repeat={repeat} onChange={(newRepeat) => setRepeat(newRepeat)} />
   );
 };
 
-const RowRepeatScopeWrapper = ({ row }: { row: SceneObject }) => {
-  const [repeat, setRepeat] = useState<string | undefined>(undefined);
-  return <RepeatRowSelect2 sceneContext={row} repeat={repeat} onChange={(newRepeat) => setRepeat(newRepeat)} />;
+const setup = async (variables?: SceneVariable[]) => {
+  const scene = await buildTestScene(variables);
+
+  return render(<RepeatRowSelectWrapper sceneContext={scene} />);
 };
 
 describe('RepeatRowSelect2', () => {
@@ -136,7 +126,7 @@ describe('RepeatRowSelect2', () => {
 
     await new Promise((r) => setTimeout(r, 1));
 
-    render(<SectionScopeWrapper sceneContext={gridItem} />);
+    render(<RepeatRowSelectWrapper sceneContext={gridItem} />);
 
     const input = screen.getByRole('combobox');
     expect(input).not.toBeDisabled();
@@ -177,7 +167,7 @@ describe('RepeatRowSelect2', () => {
 
     await new Promise((r) => setTimeout(r, 1));
 
-    render(<RowRepeatScopeWrapper row={row} />);
+    render(<RepeatRowSelectWrapper sceneContext={row} />);
 
     const input = screen.getByRole('combobox');
     expect(input).not.toBeDisabled();

--- a/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.test.tsx
+++ b/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.test.tsx
@@ -2,8 +2,19 @@ import { render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { userEvent } from 'test/test-utils';
 
-import { CustomVariable, type SceneVariable, SceneVariableSet } from '@grafana/scenes';
+import {
+  CustomVariable,
+  type SceneObject,
+  type SceneVariable,
+  SceneGridLayout,
+  SceneVariableSet,
+  VizPanel,
+} from '@grafana/scenes';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+import { DashboardGridItem } from 'app/features/dashboard-scene/scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from 'app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager';
+import { RowItem } from 'app/features/dashboard-scene/scene/layout-rows/RowItem';
+import { RowsLayoutManager } from 'app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager';
 import { activateFullSceneTree } from 'app/features/dashboard-scene/utils/test-utils';
 
 import { RepeatRowSelect2 } from './RepeatRowSelect';
@@ -30,6 +41,18 @@ const setup = async (variables?: SceneVariable[]) => {
   const scene = await buildTestScene(variables);
 
   return render(<Wrapper scene={scene} />);
+};
+
+const SectionScopeWrapper = ({ sceneContext }: { sceneContext: SceneObject }) => {
+  const [repeat, setRepeat] = useState<string | undefined>(undefined);
+  return (
+    <RepeatRowSelect2 sceneContext={sceneContext} repeat={repeat} onChange={(newRepeat) => setRepeat(newRepeat)} />
+  );
+};
+
+const RowRepeatScopeWrapper = ({ row }: { row: SceneObject }) => {
+  const [repeat, setRepeat] = useState<string | undefined>(undefined);
+  return <RepeatRowSelect2 sceneContext={row} repeat={repeat} onChange={(newRepeat) => setRepeat(newRepeat)} />;
 };
 
 describe('RepeatRowSelect2', () => {
@@ -80,5 +103,87 @@ describe('RepeatRowSelect2', () => {
 
     expect(screen.getByRole('combobox')).toHaveProperty('placeholder', 'No template variables found');
     expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('includes section variables when sceneContext is under a RowItem with section SceneVariableSet', async () => {
+    const dashVar = new CustomVariable({
+      name: 'dashVar',
+      query: 'a',
+      value: 'a',
+      text: 'a',
+    });
+    const sectionVar = new CustomVariable({
+      name: 'sectionVar',
+      query: 'b',
+      value: 'b',
+      text: 'b',
+    });
+
+    const panel = new VizPanel({ key: 'panel-1', pluginId: 'text' });
+    const gridItem = new DashboardGridItem({ body: panel });
+    const row = new RowItem({
+      title: 'Row 1',
+      $variables: new SceneVariableSet({ variables: [sectionVar] }),
+      layout: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({ children: [gridItem] }),
+      }),
+    });
+    new DashboardScene({
+      uid: 'section-repeat-test',
+      $variables: new SceneVariableSet({ variables: [dashVar] }),
+      body: new RowsLayoutManager({ rows: [row] }),
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    render(<SectionScopeWrapper sceneContext={gridItem} />);
+
+    const input = screen.getByRole('combobox');
+    expect(input).not.toBeDisabled();
+    await userEvent.click(input);
+
+    expect(await screen.findByText(/sectionVar/)).toBeInTheDocument();
+    expect(screen.getByText(/dashVar/)).toBeInTheDocument();
+  });
+
+  it('excludes the row own section variables for row repeat options (walk starts at parent)', async () => {
+    const dashVar = new CustomVariable({
+      name: 'dashVar',
+      query: 'a',
+      value: 'a',
+      text: 'a',
+    });
+    const sectionVar = new CustomVariable({
+      name: 'sectionVar',
+      query: 'b',
+      value: 'b',
+      text: 'b',
+    });
+
+    const panel = new VizPanel({ key: 'panel-2', pluginId: 'text' });
+    const gridItem = new DashboardGridItem({ body: panel });
+    const row = new RowItem({
+      title: 'Row 1',
+      $variables: new SceneVariableSet({ variables: [sectionVar] }),
+      layout: new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({ children: [gridItem] }),
+      }),
+    });
+    new DashboardScene({
+      uid: 'row-repeat-exclude-own',
+      $variables: new SceneVariableSet({ variables: [dashVar] }),
+      body: new RowsLayoutManager({ rows: [row] }),
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    render(<RowRepeatScopeWrapper row={row} />);
+
+    const input = screen.getByRole('combobox');
+    expect(input).not.toBeDisabled();
+    await userEvent.click(input);
+
+    expect(await screen.findByText(/dashVar/)).toBeInTheDocument();
+    expect(screen.queryByText(/^sectionVar$/)).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.tsx
+++ b/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { LocalValueVariable, type SceneObject, sceneGraph } from '@grafana/scenes';
 import { Combobox, type ComboboxOption, Select } from '@grafana/ui';
+import {
+  collectAncestorSceneVariables,
+  subscribeAncestorVariableSets,
+} from 'app/features/dashboard-scene/utils/collectAncestorSceneVariables';
 import { useSelector } from 'app/types/store';
 
 import { getLastKey, getVariablesByKey } from '../../../variables/state/selectors';
@@ -55,8 +59,18 @@ interface Props2 {
 }
 
 export const RepeatRowSelect2 = ({ sceneContext, repeat, id, onChange }: Props2) => {
-  const sceneVars = useMemo(() => sceneGraph.getVariables(sceneContext.getRoot()), [sceneContext]);
-  const variables = sceneVars.useState().variables;
+  const [ancestorVarsVersion, setAncestorVarsVersion] = useState(0);
+
+  useEffect(() => {
+    return subscribeAncestorVariableSets(sceneContext, () => {
+      setAncestorVarsVersion((v) => v + 1);
+    });
+  }, [sceneContext]);
+
+  const variables = useMemo(() => {
+    void ancestorVarsVersion;
+    return collectAncestorSceneVariables(sceneContext);
+  }, [sceneContext, ancestorVarsVersion]);
 
   const variableOptions = useMemo(() => {
     const options: ComboboxOption[] = variables

--- a/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.tsx
+++ b/public/app/features/dashboard/components/RepeatRowSelect/RepeatRowSelect.tsx
@@ -68,8 +68,9 @@ export const RepeatRowSelect2 = ({ sceneContext, repeat, id, onChange }: Props2)
   }, [sceneContext]);
 
   const variables = useMemo(() => {
-    void ancestorVarsVersion;
     return collectAncestorSceneVariables(sceneContext);
+    // Recompute when any ancestor SceneVariableSet emits (see subscribeAncestorVariableSets).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ancestorVarsVersion is an intentional cache bust
   }, [sceneContext, ancestorVarsVersion]);
 
   const variableOptions = useMemo(() => {


### PR DESCRIPTION
This PR adds the following functionality for section variables:

- **Panel repeat**: The repeat dropdown now lists template variables from the full ancestor chain (dashboard globals plus any section SceneVariableSet above the panel). Panels can be repeated by section variables because they resolve variables for the section they live in.

- **Nested rows:** For row repeat, the list is built from sceneObject.parent ?? sceneObject, so a row does not offer its own section variables as repeat targets, but it still sees ancestors—including a parent row’s section variables. That allows rows inside rows to be repeated using the parent section’s variables.

Please check that:
- [ ] It works as expected from a user's perspective.

