### PR TITLE
Suggestions: Downsample preview cards with LTTB

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
@@ -4,14 +4,16 @@ import { type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
 
 import { type GrafanaTheme2, type PanelData, type PanelPluginVisualizationSuggestion } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { type GraphFieldConfig, StackingMode } from '@grafana/schema';
 import { Tooltip, useStyles2 } from '@grafana/ui';
+import { LTTB_THRESHOLD, lttbPreviewData } from 'app/plugins/panel/timeseries/utils';
 
 import { PanelRenderer } from '../PanelRenderer';
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   data: PanelData;
   width: number;
-  suggestion: PanelPluginVisualizationSuggestion;
+  suggestion: PanelPluginVisualizationSuggestion<{}, GraphFieldConfig>;
   isSelected?: boolean;
 }
 
@@ -47,6 +49,14 @@ export function VisualizationSuggestionCard({ data, suggestion, width, className
     const maxSeries = cardOptions.maxSeries;
     const maxRows = cardOptions.maxRows;
     let previewData = maxSeries ? { ...data, series: data.series.slice(0, maxSeries) } : data;
+
+    const stackingMode = suggestion.fieldConfig?.defaults?.custom?.stacking?.mode;
+    const isStacked = stackingMode && stackingMode !== StackingMode.None;
+
+    const lttbTarget = maxRows ?? LTTB_THRESHOLD;
+    if (!isStacked && previewData.series.some((frame) => frame.length > lttbTarget)) {
+      previewData = lttbPreviewData(previewData, lttbTarget);
+    }
 
     if (maxRows && previewData.series.some((frame) => frame.length > maxRows)) {
       previewData = {

--- a/public/app/plugins/panel/timeseries/presets.ts
+++ b/public/app/plugins/panel/timeseries/presets.ts
@@ -58,7 +58,7 @@ function makePreset(
       },
       overrides: fieldConfig.overrides,
     },
-    cardOptions: { previewModifier, maxRows },
+    cardOptions: { previewModifier, maxRows, maxSeries: MAX_PREVIEW_SERIES },
   };
 }
 
@@ -247,6 +247,7 @@ const FC_MULTI_STACKED_BARS: FieldConfigSource<Partial<GraphFieldConfig>> = {
 
 const FEW_POINTS_THRESHOLD = 80;
 const MAX_PREVIEW_BAR_ROWS = 30;
+const MAX_PREVIEW_SERIES = 8;
 
 export const timeseriesPresetsSupplier: VisualizationPresetsSupplier<Options, GraphFieldConfig> = ({ dataSummary }) => {
   if (

--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -1,4 +1,4 @@
-import { createTheme, FieldType, createDataFrame, toDataFrame } from '@grafana/data';
+import { createTheme, FieldType, createDataFrame, toDataFrame, type PanelData } from '@grafana/data';
 import { TooltipDisplayMode } from '@grafana/schema';
 import { LineInterpolation } from '@grafana/ui';
 
@@ -8,6 +8,8 @@ import {
   getGroupedFilters,
   getTimezones,
   isTooltipScrollable,
+  LTTB_THRESHOLD,
+  lttbPreviewData,
   prepareGraphableFields,
   setClassicPaletteIdxs,
 } from './utils';
@@ -399,5 +401,124 @@ describe('prepareGraphableFields with xNumFieldIdx', () => {
     const frames = prepareGraphableFields([df], createTheme(), undefined, 1);
     expect(frames).not.toBeNull();
     expect(frames![0].fields[0].name).toBe('x');
+  });
+});
+
+describe('lttbPreviewData', () => {
+  const makeFrame = (length: number, extraFields?: Array<{ name: string; type: FieldType; values: unknown[] }>) => {
+    return createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [...Array(length).keys()] },
+        { name: 'value', type: FieldType.number, values: [...Array(length).keys()] },
+        ...(extraFields ?? []),
+      ],
+    });
+  };
+
+  it('returns frames unchanged when below the threshold', () => {
+    const result = lttbPreviewData({ series: [makeFrame(3)] } as PanelData);
+
+    expect(result.series[0].length).toBe(3);
+    expect(result.series[0].fields[0].values).toEqual([0, 1, 2]);
+  });
+
+  it('returns frames unchanged when there is no time field', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'a', type: FieldType.number, values: [1, 2, 3] },
+        { name: 'b', type: FieldType.number, values: [4, 5, 6] },
+      ],
+    });
+    const result = lttbPreviewData({ series: [frame] } as PanelData);
+
+    expect(result.series[0].length).toBe(3);
+  });
+
+  it('returns frames unchanged when there is no numeric field', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+        { name: 'label', type: FieldType.string, values: ['a', 'b', 'c'] },
+      ],
+    });
+    const result = lttbPreviewData({ series: [frame] } as PanelData);
+
+    expect(result.series[0].length).toBe(3);
+  });
+
+  it('downsamples frames exceeding the threshold to LTTB_THRESHOLD points', () => {
+    const result = lttbPreviewData({ series: [makeFrame(1000)] } as PanelData);
+
+    expect(result.series[0].length).toBe(LTTB_THRESHOLD);
+    expect(result.series[0].fields[0].values).toHaveLength(LTTB_THRESHOLD);
+    expect(result.series[0].fields[1].values).toHaveLength(LTTB_THRESHOLD);
+  });
+
+  it('always preserves the first and last data points', () => {
+    const result = lttbPreviewData({ series: [makeFrame(1000)] } as PanelData);
+
+    const outTimes = result.series[0].fields[0].values;
+    expect(outTimes[0]).toBe(0);
+    expect(outTimes[outTimes.length - 1]).toBe(999);
+  });
+
+  it('processes each frame independently', () => {
+    const result = lttbPreviewData({ series: [makeFrame(3), makeFrame(500)] } as PanelData);
+
+    expect(result.series[0].length).toBe(3);
+    expect(result.series[1].length).toBe(LTTB_THRESHOLD);
+  });
+
+  it('does not mutate the original data', () => {
+    const frame = makeFrame(500);
+    const data = { series: [frame] } as PanelData;
+    lttbPreviewData(data);
+
+    expect(data.series[0].fields[0].values).toHaveLength(500);
+    expect(data.series[0].length).toBe(500);
+  });
+
+  it('downsamples to a custom threshold when provided', () => {
+    const result = lttbPreviewData({ series: [makeFrame(100)] } as PanelData, 30);
+
+    expect(result.series[0].length).toBe(30);
+    expect(result.series[0].fields[0].values).toHaveLength(30);
+    expect(result.series[0].fields[1].values).toHaveLength(30);
+
+    const outTimes = result.series[0].fields[0].values;
+    expect(outTimes[0]).toBe(0);
+    expect(outTimes[outTimes.length - 1]).toBe(99);
+  });
+
+  it('skips frames at or below the custom threshold', () => {
+    const result = lttbPreviewData({ series: [makeFrame(30)] } as PanelData, 30);
+
+    expect(result.series[0].length).toBe(30);
+    expect(result.series[0].fields[0].values).toEqual([...Array(30).keys()]);
+  });
+
+  it('clears interval on the time field to prevent gaps', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [...Array(500).keys()], config: { interval: 10000 } },
+        { name: 'value', type: FieldType.number, values: [...Array(500).keys()] },
+      ],
+    });
+    const result = lttbPreviewData({ series: [frame] } as PanelData);
+
+    const timeField = result.series[0].fields[0];
+    expect(timeField.config.interval).toBeUndefined();
+  });
+
+  it('does not modify config on frames below the threshold', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [...Array(3).keys()], config: { interval: 10000 } },
+        { name: 'value', type: FieldType.number, values: [...Array(3).keys()] },
+      ],
+    });
+    const result = lttbPreviewData({ series: [frame] } as PanelData);
+
+    expect(result.series[0].fields[0].config.interval).toBe(10000);
   });
 });


### PR DESCRIPTION
This PR brings back the lttb downsampling removed in https://github.com/grafana/grafana/pull/121604

Fixes https://github.com/grafana/grafana/issues/121606







Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
