### PR TITLE
Provisioning: Auto-sync dashboard filename from title in save form

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -230,7 +230,8 @@ describe('SaveProvisionedDashboardForm', () => {
 
     await user.type(titleInput, 'New Dashboard');
     await user.type(descriptionInput, 'New Description');
-    // Use a filename distinct from the default path to keep dirtyFields.path true
+
+    await user.clear(filenameInput);
     await user.type(filenameInput, 'custom-filename.json');
     await user.type(commentInput, 'Initial commit');
 
@@ -351,6 +352,8 @@ describe('SaveProvisionedDashboardForm', () => {
 
     await user.type(titleInput, 'New Dashboard');
     await user.type(descriptionInput, 'New Description');
+
+    await user.clear(filenameInput);
     await user.type(filenameInput, 'error-dashboard.json');
     await user.type(commentInput, 'Error commit');
 
@@ -511,12 +514,22 @@ describe('SaveProvisionedDashboardForm', () => {
         },
       });
 
+      const titleInput = screen.getByRole('textbox', { name: /title/i });
       const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+
+      // First verify auto-sync is working
+      await user.type(titleInput, 'First Title');
+      await waitFor(() => {
+        expect(filenameInput).toHaveValue('first-title.json');
+      });
+
+      // Manually edit the filename to stop auto-sync
       await user.clear(filenameInput);
       await user.type(filenameInput, 'custom-name.json');
 
-      const titleInput = screen.getByRole('textbox', { name: /title/i });
-      await user.type(titleInput, 'Some New Title');
+      // Change the title again — filename should NOT update
+      await user.clear(titleInput);
+      await user.type(titleInput, 'Second Title');
 
       await waitFor(() => {
         expect(filenameInput).toHaveValue('custom-name.json');

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -230,7 +230,8 @@ describe('SaveProvisionedDashboardForm', () => {
 
     await user.type(titleInput, 'New Dashboard');
     await user.type(descriptionInput, 'New Description');
-    await user.type(filenameInput, 'test-dashboard.json');
+    // Use a filename distinct from the default path to keep dirtyFields.path true
+    await user.type(filenameInput, 'custom-filename.json');
     await user.type(commentInput, 'Initial commit');
 
     const submitButton = screen.getByRole('button', { name: /save/i });
@@ -241,7 +242,7 @@ describe('SaveProvisionedDashboardForm', () => {
     });
 
     const request = requireCapturedRequest(capturedRequest);
-    expect(request.url.pathname).toContain('/repositories/test-repo/files/test-dashboard.json');
+    expect(request.url.pathname).toContain('/repositories/test-repo/files/custom-filename.json');
     expect(request.url.searchParams.get('ref')).toBe('dashboard/2023-01-01-abcde');
     expect(request.url.searchParams.get('message')).toBe('Initial commit');
     expect(request.body).toEqual(newDashboard);
@@ -444,6 +445,122 @@ describe('SaveProvisionedDashboardForm', () => {
 
     await waitFor(() => {
       expect(saveButton).toBeEnabled();
+    });
+  });
+
+  describe('title-to-filename auto-sync', () => {
+    it('should auto-update filename when the title changes for a new dashboard', async () => {
+      const { user } = setup({
+        defaultValues: {
+          ref: 'dashboard/2023-01-01-abcde',
+          path: 'new-dashboard-2023-01-01-abcde.json',
+          repo: 'test-repo',
+          comment: '',
+          folder: { uid: 'folder-uid', title: '' },
+          title: '',
+          description: '',
+          workflow: 'write',
+        },
+      });
+
+      const titleInput = screen.getByRole('textbox', { name: /title/i });
+      await user.type(titleInput, 'My Cool Dashboard');
+
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      await waitFor(() => {
+        expect(filenameInput).toHaveValue('my-cool-dashboard.json');
+      });
+    });
+
+    it('should keep directory in folder picker when auto-syncing filename', async () => {
+      const { user } = setup({
+        defaultValues: {
+          ref: 'dashboard/2023-01-01-abcde',
+          path: 'dashboards/new-dashboard-2023-01-01-abcde.json',
+          repo: 'test-repo',
+          comment: '',
+          folder: { uid: 'folder-uid', title: '' },
+          title: '',
+          description: '',
+          workflow: 'write',
+        },
+      });
+
+      const titleInput = screen.getByRole('textbox', { name: /title/i });
+      await user.type(titleInput, 'My Cool Dashboard');
+
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      const folderCombobox = screen.getByRole('combobox', { name: /folder/i });
+      await waitFor(() => {
+        expect(filenameInput).toHaveValue('my-cool-dashboard.json');
+        expect(folderCombobox).toHaveValue('dashboards');
+      });
+    });
+
+    it('should stop auto-syncing once the user manually edits the filename', async () => {
+      const { user } = setup({
+        defaultValues: {
+          ref: 'dashboard/2023-01-01-abcde',
+          path: 'new-dashboard-2023-01-01-abcde.json',
+          repo: 'test-repo',
+          comment: '',
+          folder: { uid: 'folder-uid', title: '' },
+          title: '',
+          description: '',
+          workflow: 'write',
+        },
+      });
+
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      await user.clear(filenameInput);
+      await user.type(filenameInput, 'custom-name.json');
+
+      const titleInput = screen.getByRole('textbox', { name: /title/i });
+      await user.type(titleInput, 'Some New Title');
+
+      await waitFor(() => {
+        expect(filenameInput).toHaveValue('custom-name.json');
+      });
+    });
+
+    it('should not auto-sync for special-character-only titles', async () => {
+      const { user } = setup({
+        defaultValues: {
+          ref: 'dashboard/2023-01-01-abcde',
+          path: 'new-dashboard-2023-01-01-abcde.json',
+          repo: 'test-repo',
+          comment: '',
+          folder: { uid: 'folder-uid', title: '' },
+          title: '',
+          description: '',
+          workflow: 'write',
+        },
+      });
+
+      const titleInput = screen.getByRole('textbox', { name: /title/i });
+      await user.type(titleInput, '!!!');
+
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      expect(filenameInput).toHaveValue('new-dashboard-2023-01-01-abcde.json');
+    });
+
+    it('should not auto-sync for existing dashboards', async () => {
+      setup({
+        isNew: false,
+        defaultValues: {
+          ref: 'dashboard/2023-01-01-abcde',
+          path: 'existing-dashboard.json',
+          repo: 'test-repo',
+          comment: '',
+          folder: { uid: 'folder-uid', title: '' },
+          title: 'Existing Dashboard',
+          description: '',
+          workflow: 'write',
+        },
+      });
+
+      const pathInput = screen.getByRole('textbox', { name: /path/i });
+      expect(pathInput).toHaveValue('existing-dashboard.json');
     });
   });
 

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -225,7 +225,6 @@ describe('SaveProvisionedDashboardForm', () => {
 
     await user.clear(titleInput);
     await user.clear(descriptionInput);
-    await user.clear(filenameInput);
     await user.clear(commentInput);
 
     await user.type(titleInput, 'New Dashboard');
@@ -347,7 +346,6 @@ describe('SaveProvisionedDashboardForm', () => {
 
     await user.clear(titleInput);
     await user.clear(descriptionInput);
-    await user.clear(filenameInput);
     await user.clear(commentInput);
 
     await user.type(titleInput, 'New Dashboard');

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -81,11 +81,10 @@ export function SaveProvisionedDashboardForm({
     reset(defaultValues);
   }, [defaultValues, reset]);
 
-  // Auto-sync filename from title for new dashboards.
+  // Sync filename from title for new dashboards.
   // dirtyFields.path is false when only setValue() has updated the path (shouldDirty defaults to false),
   // and becomes true when the user manually types in the filename input (Controller onChange marks it dirty).
   // This lets us stop auto-syncing once the user has intentionally customised the filename.
-  // We use getValues() instead of watching path to avoid re-triggering when setValue updates it.
   useEffect(() => {
     if (!isNew || dirtyFields.path) {
       return;

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -30,6 +30,7 @@ import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 import { getProvisionedRequestError } from '../utils/errors';
 import { getProvisionedMeta } from '../utils/getProvisionedMeta';
+import { joinPath, slugifyForFilename, splitPath } from '../utils/path';
 
 import { type SaveProvisionedDashboardProps } from './SaveProvisionedDashboard';
 
@@ -65,17 +66,37 @@ export function SaveProvisionedDashboardForm({
     control,
     reset,
     register,
+    setValue,
+    getValues,
     formState: { dirtyFields },
   } = methods;
   // button enabled if form comment is dirty or dashboard state is dirty or raw JSON was provided from editor
   const rawDashboardJSON = dashboard.getRawJsonFromEditor();
   const isDirtyState = Boolean(dirtyFields.comment) || isDirty || Boolean(rawDashboardJSON);
   const [workflow, ref, path] = watch(['workflow', 'ref', 'path']);
+  const title = watch('title');
 
   // Update the form if default values change
   useEffect(() => {
     reset(defaultValues);
   }, [defaultValues, reset]);
+
+  // Auto-sync filename from title for new dashboards.
+  // dirtyFields.path is false when only setValue() has updated the path (shouldDirty defaults to false),
+  // and becomes true when the user manually types in the filename input (Controller onChange marks it dirty).
+  // This lets us stop auto-syncing once the user has intentionally customised the filename.
+  // We use getValues() instead of watching path to avoid re-triggering when setValue updates it.
+  useEffect(() => {
+    if (!isNew || dirtyFields.path) {
+      return;
+    }
+    const slugified = slugifyForFilename(title);
+    if (slugified) {
+      const currentPath = getValues('path');
+      const { directory } = splitPath(currentPath);
+      setValue('path', joinPath(directory, `${slugified}.json`));
+    }
+  }, [title, isNew, dirtyFields.path, setValue, getValues]);
 
   const showError = (error: unknown) => {
     setError(

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -173,7 +173,9 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
                       id="folder-path"
                       value={dir}
                       onChange={(option) => {
-                        onChange(joinPath(option?.value ?? '', file));
+                        // setValue (not onChange) so folder picks don't dirty the path field,
+                        // preserving title→filename auto-sync until the filename is edited.
+                        setValue('path', joinPath(option?.value ?? '', file));
                       }}
                       options={folderOptions}
                       loading={isFoldersLoading}

--- a/public/app/features/provisioning/components/utils/path.test.ts
+++ b/public/app/features/provisioning/components/utils/path.test.ts
@@ -1,4 +1,4 @@
-import { ensureFolderPathTrailingSlash, generatePath, joinPath, splitPath } from './path';
+import { ensureFolderPathTrailingSlash, generatePath, joinPath, slugifyForFilename, splitPath } from './path';
 
 describe('generatePath', () => {
   const timestamp = '2023-05-15-abcde';
@@ -129,6 +129,40 @@ describe('joinPath', () => {
 
   it('should handle both empty', () => {
     expect(joinPath('', '')).toBe('');
+  });
+});
+
+describe('slugifyForFilename', () => {
+  it('should convert a simple title to a slug', () => {
+    expect(slugifyForFilename('My Cool Dashboard')).toBe('my-cool-dashboard');
+  });
+
+  it('should handle special characters', () => {
+    expect(slugifyForFilename('CPU Usage (%) — Host')).toBe('cpu-usage-host');
+  });
+
+  it('should collapse multiple spaces into a single dash', () => {
+    expect(slugifyForFilename('a    b')).toBe('a-b');
+  });
+
+  it('should strip leading and trailing dashes', () => {
+    expect(slugifyForFilename('  hello  ')).toBe('hello');
+  });
+
+  it('should return empty string for title with only special characters', () => {
+    expect(slugifyForFilename('!!!')).toBe('');
+  });
+
+  it('should return empty string for empty title', () => {
+    expect(slugifyForFilename('')).toBe('');
+  });
+
+  it('should handle underscores (kept as word characters)', () => {
+    expect(slugifyForFilename('my_dashboard')).toBe('my_dashboard');
+  });
+
+  it('should handle numeric titles', () => {
+    expect(slugifyForFilename('123 Test')).toBe('123-test');
   });
 });
 

--- a/public/app/features/provisioning/components/utils/path.ts
+++ b/public/app/features/provisioning/components/utils/path.ts
@@ -1,3 +1,5 @@
+import kbn from 'app/core/utils/kbn';
+
 /**
  * Parameters for generating a dashboard path
  */
@@ -55,6 +57,15 @@ export function joinPath(directory: string, filename: string): string {
   const cleanDir = directory.replace(/\/+$/, '');
   const cleanFile = filename.replace(/^\/+/, '');
   return cleanDir ? `${cleanDir}/${cleanFile}` : cleanFile;
+}
+
+/**
+ * Converts a dashboard title into a filesystem-safe filename slug.
+ * Delegates to kbn.slugifyForUrl and strips leading/trailing dashes
+ * that slugifyForUrl can leave behind (e.g. titles starting with special chars).
+ */
+export function slugifyForFilename(title: string): string {
+  return kbn.slugifyForUrl(title).replace(/^-+|-+$/g, '');
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

- When saving dashboard in git sync folder, auto update the dashboard filename from the title.


**Why do we need this feature?**

Currently when user saving a new dashboard, filename is always auto generated as `new-dashboard-{}.json` and user can ends up with many similar file names. 

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113308

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
