### PR TITLE
QuickAdd: Update import dashboard icon

### DIFF
--- a/public/app/core/components/AppChrome/QuickAdd/utils.ts
+++ b/public/app/core/components/AppChrome/QuickAdd/utils.ts
@@ -10,7 +10,7 @@ export interface CreateActionGroup {
 export const ITEM_ICONS: Record<string, IconName> = {
   'dashboards/new': 'plus',
   'browse-template-dashboard': 'grid',
-  'dashboards/import': 'cloud-download',
+  'dashboards/import': 'import',
   alert: 'plus',
   folder: 'folder',
 };


### PR DESCRIPTION
**What is this feature?**

Update import dashboard icon. 
<img width="250" height="52" alt="image" src="https://github.com/user-attachments/assets/14a17a41-4111-4a91-ba54-71ee19c0df90" />
