### PR TITLE
Add centimeter (cm) unit to length formats

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -1112,6 +1112,11 @@ export const getCategories = (): ValueFormatCategory[] => [
         fn: SIPrefix('m', -1),
       },
       {
+        name: t('grafana-data.valueFormats.categories.length.formats.name-centimeter', 'centimeter (cm)'),
+        id: 'lengthcm',
+        fn: toFixedUnit('cm'),
+      },
+      {
         name: t('grafana-data.valueFormats.categories.length.formats.name-inch', 'inch (in)'),
         id: 'lengthin',
         fn: toFixedUnit('in'),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9765,7 +9765,8 @@
             "name-kilometer": "kilometer (km)",
             "name-meter": "meter (m)",
             "name-mile": "mile (mi)",
-            "name-millimeter": "millimeter (mm)"
+            "name-millimeter": "millimeter (mm)",
+            "name-centimeter": "centimeter (cm)"
           },
           "name": "Length"
         },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9760,13 +9760,13 @@
         },
         "length": {
           "formats": {
+            "name-centimeter": "centimeter (cm)",
             "name-feet": "feet (ft)",
             "name-inch": "inch (in)",
             "name-kilometer": "kilometer (km)",
             "name-meter": "meter (m)",
             "name-mile": "mile (mi)",
-            "name-millimeter": "millimeter (mm)",
-            "name-centimeter": "centimeter (cm)"
+            "name-millimeter": "millimeter (mm)"
           },
           "name": "Length"
         },


### PR DESCRIPTION
This PR adds support for the centimeter (cm) unit in the length value formats.

## Changes
- Added a new format `lengthcm` using `toFixedUnit('cm')`
- Integrated the unit into the existing length category alongside mm, m, km, etc.
- Used translation key `grafana-data.valueFormats.categories.length.formats.name-centimeter` with fallback "centimeter (cm)"

## Why
Currently, Grafana supports millimeter and meter, but does not include centimeter, which is a commonly used unit for values below 1 meter. Adding this improves usability and consistency in unit representation.

## Notes
- Follows existing coding and formatting patterns
- No breaking changes introduced

Closes #122395