### PR TITLE
XYChart: Add unit tests for XYChartTooltip, scatter.ts, and XYChartPanel

### DIFF
--- a/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
@@ -1,0 +1,252 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { createDataFrame, createTheme, FieldType, getDisplayProcessor, type Field } from '@grafana/data';
+import { LegendDisplayMode, SortOrder, TooltipDisplayMode, VisibilityMode } from '@grafana/schema';
+
+import { getPanelProps } from '../test-utils';
+
+import { XYChartPanel2 } from './XYChartPanel';
+import { type Options, PointShape, SeriesMapping } from './panelcfg.gen';
+import { type XYSeries } from './types2';
+
+const mockPrepData = jest.fn(() => [
+  null,
+  [
+    [1, 2],
+    [10, 20],
+    [5, 5],
+    ['#ff0000', '#ff0000'],
+  ],
+]);
+const mockBuilder = {};
+
+jest.mock('./scatter', () => ({
+  prepConfig: jest.fn(() => ({
+    builder: mockBuilder,
+    prepData: mockPrepData,
+    warn: null,
+  })),
+}));
+
+jest.mock('./utils', () => ({
+  prepSeries: jest.fn(() => []),
+}));
+
+/*
+ * Why mock @grafana/ui components:
+ * - UPlotChart needs a real uPlot + canvas (no DOM in Jest)
+ * - VizLayout uses a render-prop that needs real dimensions
+ * - Stubbing them lets us test what gets rendered and what props are passed
+ */
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    useStyles2: () => ({ legend: '' }),
+    useTheme2: () => actual.createTheme?.() ?? {},
+    usePanelContext: () => ({ canExecuteActions: () => false }),
+    UPlotChart: ({ children }: { children?: ReactNode }) => <div data-testid="uplot-chart">{children}</div>,
+    VizLayout: Object.assign(
+      ({ children, legend }: { children: unknown; legend: ReactNode }) => (
+        <div data-testid="viz-layout">
+          {legend}
+          {typeof children === 'function' ? children(100, 100) : children}
+        </div>
+      ),
+      {
+        Legend: ({ children }: { children: ReactNode }) => <div data-testid="viz-layout-legend">{children}</div>,
+      }
+    ),
+    VizLegend: (props: { items?: Array<{ label: string; color: string }> }) => (
+      <div data-testid="viz-legend">
+        {props.items?.map((item, i) => (
+          <span key={i} data-testid={`legend-item-${i}`} data-color={item.color}>
+            {item.label}
+          </span>
+        ))}
+      </div>
+    ),
+    TooltipPlugin2: (_props: Record<string, unknown>) => <div data-testid="tooltip-plugin" />,
+    TooltipDisplayMode: actual.TooltipDisplayMode,
+  };
+});
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  PanelDataErrorView: (props: { message?: string }) => <div data-testid="error-view">{props.message}</div>,
+}));
+
+const theme = createTheme();
+
+function makeField(opts: {
+  name: string;
+  values: number[];
+  displayName?: string;
+  hideFromLegend?: boolean;
+  hideFromViz?: boolean;
+}): Field {
+  const { name, values, displayName, hideFromLegend = false, hideFromViz = false } = opts;
+
+  const field = createDataFrame({
+    fields: [
+      {
+        name,
+        type: FieldType.number,
+        values,
+        config: {
+          custom: {
+            hideFrom: { legend: hideFromLegend, viz: hideFromViz },
+          },
+        },
+      },
+    ],
+  }).fields[0];
+
+  field.display = getDisplayProcessor({ field, theme });
+
+  if (displayName) {
+    field.state = { ...field.state, displayName };
+  }
+  if (hideFromViz) {
+    field.state = { ...field.state, hideFrom: { viz: true } };
+  }
+
+  return field;
+}
+
+function makeSeries(overrides?: Partial<XYSeries>): XYSeries {
+  return {
+    showPoints: VisibilityMode.Always,
+    pointShape: PointShape.Circle,
+    pointStrokeWidth: 1,
+    fillOpacity: 50,
+    showLine: false,
+    lineWidth: 1,
+    lineStyle: { fill: 'solid' },
+    name: { value: 'Series A' },
+    x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
+    y: { field: makeField({ name: 'y', values: [10, 20, 30] }) },
+    color: { fixed: '#ff0000' },
+    size: { fixed: 5 },
+    _rest: [],
+    ...overrides,
+  };
+}
+
+const defaultOptions: Options = {
+  mapping: SeriesMapping.Auto,
+  series: [],
+  legend: {
+    showLegend: true,
+    placement: 'bottom',
+    displayMode: LegendDisplayMode.List,
+    calcs: [],
+  },
+  tooltip: {
+    mode: TooltipDisplayMode.Single,
+    sort: SortOrder.None,
+  },
+};
+
+function renderPanel(optionOverrides?: Partial<Options>, seriesOverride?: XYSeries[]) {
+  const { prepSeries } = require('./utils');
+  prepSeries.mockReturnValue(seriesOverride ?? [makeSeries()]);
+
+  const props = getPanelProps<Options>({ ...defaultOptions, ...optionOverrides });
+
+  return render(<XYChartPanel2 {...props} />);
+}
+
+describe('XYChartPanel2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { prepConfig } = require('./scatter');
+    prepConfig.mockReturnValue({
+      builder: mockBuilder,
+      prepData: mockPrepData,
+      warn: null,
+    });
+  });
+
+  it('renders error view when prepConfig returns warn', () => {
+    const { prepConfig } = require('./scatter');
+    prepConfig.mockReturnValue({ builder: null, prepData: () => [], warn: 'No data' });
+
+    renderPanel();
+    expect(screen.getByTestId('error-view')).toBeVisible();
+    expect(screen.getByText('No data')).toBeVisible();
+  });
+
+  it('renders error view when builder is null', () => {
+    const { prepConfig } = require('./scatter');
+    prepConfig.mockReturnValue({ builder: null, prepData: () => [null], warn: null });
+
+    renderPanel();
+    expect(screen.getByTestId('error-view')).toBeVisible();
+  });
+
+  it('renders UPlotChart when series and config are valid', () => {
+    renderPanel();
+    expect(screen.getByTestId('uplot-chart')).toBeVisible();
+    expect(screen.queryByTestId('error-view')).toBeNull();
+  });
+
+  it('does not render tooltip when mode is None', () => {
+    renderPanel({ tooltip: { mode: TooltipDisplayMode.None, sort: SortOrder.None } });
+    expect(screen.queryByTestId('tooltip-plugin')).toBeNull();
+  });
+
+  it('renders tooltip when mode is not None', () => {
+    renderPanel({ tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.None } });
+    expect(screen.getByTestId('tooltip-plugin')).toBeVisible();
+  });
+
+  describe('legend', () => {
+    it('does not render legend when showLegend is false', () => {
+      renderPanel({
+        legend: { showLegend: false, placement: 'bottom', displayMode: LegendDisplayMode.List, calcs: [] },
+      });
+      expect(screen.queryByTestId('viz-legend')).toBeNull();
+    });
+
+    it('builds legend items with correct labels and colors', () => {
+      const series1 = makeSeries({
+        name: { value: 'cpu' },
+        color: { fixed: '#ff0000' },
+        y: { field: makeField({ name: 'y1', values: [10], displayName: 'cpu usage' }) },
+      });
+      const series2 = makeSeries({
+        name: { value: 'mem' },
+        color: { fixed: '#00ff00' },
+        y: { field: makeField({ name: 'y2', values: [20], displayName: 'mem usage' }) },
+      });
+
+      renderPanel(undefined, [series1, series2]);
+
+      expect(screen.getByText('cpu')).toBeVisible();
+      expect(screen.getByText('mem')).toBeVisible();
+
+      const item0 = screen.getByTestId('legend-item-0');
+      const item1 = screen.getByTestId('legend-item-1');
+      expect(item0.dataset.color).toBeTruthy();
+      expect(item1.dataset.color).toBeTruthy();
+    });
+
+    it('excludes series with hideFrom.legend true', () => {
+      const visibleSeries = makeSeries({
+        name: { value: 'visible' },
+        y: { field: makeField({ name: 'y1', values: [10] }) },
+      });
+      const hiddenSeries = makeSeries({
+        name: { value: 'hidden' },
+        y: { field: makeField({ name: 'y2', values: [20], hideFromLegend: true }) },
+      });
+
+      renderPanel(undefined, [visibleSeries, hiddenSeries]);
+
+      expect(screen.getByText('visible')).toBeVisible();
+      expect(screen.queryByText('hidden')).toBeNull();
+    });
+  });
+});

--- a/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
@@ -8,7 +8,9 @@ import { getPanelProps } from '../test-utils';
 
 import { XYChartPanel2 } from './XYChartPanel';
 import { type Options, PointShape, SeriesMapping } from './panelcfg.gen';
+import { prepConfig } from './scatter';
 import { type XYSeries } from './types2';
+import { prepSeries } from './utils';
 
 const mockPrepData = jest.fn(() => [
   null,
@@ -32,6 +34,9 @@ jest.mock('./scatter', () => ({
 jest.mock('./utils', () => ({
   prepSeries: jest.fn(() => []),
 }));
+
+const prepConfigMock = prepConfig as jest.Mock;
+const prepSeriesMock = prepSeries as jest.Mock;
 
 /*
  * Why mock @grafana/ui components:
@@ -150,8 +155,7 @@ const defaultOptions: Options = {
 };
 
 function renderPanel(optionOverrides?: Partial<Options>, seriesOverride?: XYSeries[]) {
-  const { prepSeries } = require('./utils');
-  prepSeries.mockReturnValue(seriesOverride ?? [makeSeries()]);
+  prepSeriesMock.mockReturnValue(seriesOverride ?? [makeSeries()]);
 
   const props = getPanelProps<Options>({ ...defaultOptions, ...optionOverrides });
 
@@ -161,8 +165,7 @@ function renderPanel(optionOverrides?: Partial<Options>, seriesOverride?: XYSeri
 describe('XYChartPanel2', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    const { prepConfig } = require('./scatter');
-    prepConfig.mockReturnValue({
+    prepConfigMock.mockReturnValue({
       builder: mockBuilder,
       prepData: mockPrepData,
       warn: null,
@@ -170,8 +173,7 @@ describe('XYChartPanel2', () => {
   });
 
   it('renders error view when prepConfig returns warn', () => {
-    const { prepConfig } = require('./scatter');
-    prepConfig.mockReturnValue({ builder: null, prepData: () => [], warn: 'No data' });
+    prepConfigMock.mockReturnValue({ builder: null, prepData: () => [], warn: 'No data' });
 
     renderPanel();
     expect(screen.getByTestId('error-view')).toBeVisible();
@@ -179,8 +181,7 @@ describe('XYChartPanel2', () => {
   });
 
   it('renders error view when builder is null', () => {
-    const { prepConfig } = require('./scatter');
-    prepConfig.mockReturnValue({ builder: null, prepData: () => [null], warn: null });
+    prepConfigMock.mockReturnValue({ builder: null, prepData: () => [null], warn: null });
 
     renderPanel();
     expect(screen.getByTestId('error-view')).toBeVisible();

--- a/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
@@ -211,7 +211,7 @@ describe('XYChartPanel2', () => {
       expect(screen.queryByTestId('viz-legend')).toBeNull();
     });
 
-    it('builds legend items with correct labels and colors', () => {
+    it('builds legend items with correct labels', () => {
       const series1 = makeSeries({
         name: { value: 'cpu' },
         color: { fixed: '#ff0000' },
@@ -227,11 +227,6 @@ describe('XYChartPanel2', () => {
 
       expect(screen.getByText('cpu')).toBeVisible();
       expect(screen.getByText('mem')).toBeVisible();
-
-      const item0 = screen.getByTestId('legend-item-0');
-      const item1 = screen.getByTestId('legend-item-1');
-      expect(item0.dataset.color).toBeTruthy();
-      expect(item1.dataset.color).toBeTruthy();
     });
 
     it('excludes series with hideFrom.legend true', () => {

--- a/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.test.tsx
@@ -109,7 +109,7 @@ function makeField(opts: {
     field.state = { ...field.state, displayName };
   }
   if (hideFromViz) {
-    field.state = { ...field.state, hideFrom: { viz: true } };
+    field.state = { ...field.state, hideFrom: { viz: true, legend: false, tooltip: false } };
   }
 
   return field;

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -299,36 +299,38 @@ describe('XYChartTooltip', () => {
       expect(screen.getByText('y')).toBeVisible();
     });
 
-    it('calls getFieldActions when canExecuteActions is true and pinned', () => {
-      const mockGetFieldActions = getFieldActions as jest.Mock;
-      mockGetFieldActions.mockClear();
+    describe('getFieldActions', () => {
+      it('calls getFieldActions when canExecuteActions is true and pinned', () => {
+        const mockGetFieldActions = getFieldActions as jest.Mock;
+        mockGetFieldActions.mockClear();
 
-      const series = makeSeries();
-      const yField = series.y.field;
-      // Build a frame that holds the exact yField reference so .includes() matches
-      const frame = { fields: [yField], length: yField.values.length };
+        const series = makeSeries();
+        const yField = series.y.field;
+        // Build a frame that holds the exact yField reference so .includes() matches
+        const frame = { fields: [yField], length: yField.values.length };
 
-      renderTooltip({
-        isPinned: true,
-        canExecuteActions: true,
-        data: [frame] as DataFrame[],
-        xySeries: [series],
+        renderTooltip({
+          isPinned: true,
+          canExecuteActions: true,
+          data: [frame] as DataFrame[],
+          xySeries: [series],
+        });
+
+        expect(mockGetFieldActions).toHaveBeenCalledWith(
+          expect.objectContaining({ fields: expect.arrayContaining([yField]) }),
+          yField,
+          expect.any(Function),
+          0,
+          'xychart'
+        );
       });
 
-      expect(mockGetFieldActions).toHaveBeenCalledWith(
-        expect.objectContaining({ fields: expect.arrayContaining([yField]) }),
-        yField,
-        expect.any(Function),
-        0,
-        'xychart'
-      );
-    });
-
-    it('does not call getFieldActions when canExecuteActions is false', () => {
-      const mockGetFieldActions = getFieldActions as jest.Mock;
-      mockGetFieldActions.mockClear();
-      renderTooltip({ isPinned: true, canExecuteActions: false });
-      expect(mockGetFieldActions).not.toHaveBeenCalled();
+      it('does not call getFieldActions when canExecuteActions is false', () => {
+        const mockGetFieldActions = getFieldActions as jest.Mock;
+        mockGetFieldActions.mockClear();
+        renderTooltip({ isPinned: true, canExecuteActions: false });
+        expect(mockGetFieldActions).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -205,7 +205,6 @@ describe('XYChartTooltip', () => {
         y: { field: makeField({ name: 'y', values: [10], displayName: 'cpu' }) },
       });
       renderTooltip({ xySeries: [series] });
-      // "cpu" appears in header (series name) and content (label preserved because name === label)
       expect(screen.getAllByText('cpu')).toHaveLength(2);
     });
 
@@ -215,7 +214,6 @@ describe('XYChartTooltip', () => {
         y: { field: makeField({ name: 'y', values: [10], displayName: 'usage' }) },
       });
       renderTooltip({ xySeries: [series] });
-      // "usage" has no space and does not contain "cpu", so no stripping
       expect(screen.getByText('usage')).toBeVisible();
     });
   });
@@ -286,7 +284,6 @@ describe('XYChartTooltip', () => {
     ])('renders footer when %s', (_label, overrides) => {
       renderTooltip(overrides);
       const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
-      // header + content + footer
       expect(wrapper.children).toHaveLength(3);
       expect(screen.getByText('Series A')).toBeVisible();
       expect(screen.getByText('x')).toBeVisible();
@@ -296,7 +293,6 @@ describe('XYChartTooltip', () => {
     it('does not render footer when not pinned and no oneClick links', () => {
       renderTooltip({ isPinned: false, dataLinks: [] });
       const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
-      // header + content only
       expect(wrapper.children).toHaveLength(2);
       expect(screen.getByText('Series A')).toBeVisible();
       expect(screen.getByText('x')).toBeVisible();

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -272,8 +272,6 @@ describe('XYChartTooltip', () => {
       const series = makeSeries({ color: { field: colorField } });
       renderTooltip({ xySeries: [series] });
       const indicator = getHeaderColorIndicator();
-      // Can't assert exact rgba string — colorManipulator output format varies across environments
-      expect(indicator.style.backgroundColor).not.toBe('#ff0000');
       expect(indicator.style.backgroundColor).toContain('0.5');
     });
   });

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -230,10 +230,10 @@ describe('XYChartTooltip', () => {
     ])(`${hideFromTooltip ? 'hides' : 'shows'} %s field`, (_slot, fieldName, overrides) => {
       const series = makeSeries(overrides);
       renderTooltip({ xySeries: [series] });
-      if(hideFromTooltip){
+      if (hideFromTooltip) {
         expect(screen.queryByText(fieldName)).toBeNull();
-      }else{
-        expect(screen.queryByText(fieldName)).toBeVisible()
+      } else {
+        expect(screen.queryByText(fieldName)).toBeVisible();
       }
     });
   });

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -1,0 +1,331 @@
+import { render, screen } from '@testing-library/react';
+
+import {
+  createDataFrame,
+  createTheme,
+  FieldType,
+  getDisplayProcessor,
+  type DataFrame,
+  type DisplayValue,
+  type Field,
+  type LinkModel,
+} from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { VisibilityMode } from '@grafana/schema';
+
+import { getFieldActions } from '../status-history/utils';
+
+import { XYChartTooltip, type Props } from './XYChartTooltip';
+import { PointShape } from './panelcfg.gen';
+import { type XYSeries } from './types2';
+
+jest.mock('../status-history/utils', () => ({
+  getFieldActions: jest.fn(() => []),
+}));
+
+const theme = createTheme();
+
+function makeField(opts: {
+  name: string;
+  values: number[];
+  hideFromTooltip?: boolean;
+  displayName?: string;
+  customConfig?: Record<string, unknown>;
+}): Field {
+  const { name, values, hideFromTooltip = false, displayName, customConfig = {} } = opts;
+
+  const field = createDataFrame({
+    fields: [
+      {
+        name,
+        type: FieldType.number,
+        values,
+        config: {
+          custom: {
+            hideFrom: { tooltip: hideFromTooltip },
+            ...customConfig,
+          },
+        },
+      },
+    ],
+  }).fields[0];
+
+  field.display = getDisplayProcessor({ field, theme });
+
+  if (displayName) {
+    field.state = { ...field.state, displayName };
+  }
+
+  return field;
+}
+
+function makeSeries(overrides?: Partial<XYSeries>): XYSeries {
+  return {
+    showPoints: VisibilityMode.Auto,
+    pointShape: PointShape.Circle,
+    pointStrokeWidth: 1,
+    fillOpacity: 50,
+    showLine: false,
+    lineWidth: 1,
+    lineStyle: { fill: 'solid' },
+    name: { value: 'Series A' },
+    x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
+    y: { field: makeField({ name: 'y', values: [10, 20, 30] }) },
+    color: {},
+    size: {},
+    _rest: [],
+    ...overrides,
+  };
+}
+
+function renderTooltip(overrides?: Partial<Props>) {
+  const series = overrides?.xySeries?.[0] ?? makeSeries();
+  const yField = series.y.field;
+  const frame = createDataFrame({ fields: [yField] });
+
+  const defaultProps: Props = {
+    dataIdxs: [0],
+    seriesIdx: 1,
+    isPinned: false,
+    dismiss: jest.fn(),
+    data: [frame],
+    xySeries: [series],
+    replaceVariables: jest.fn((v: string) => v),
+    dataLinks: [],
+  };
+
+  return render(<XYChartTooltip {...defaultProps} {...overrides} />);
+}
+
+describe('XYChartTooltip', () => {
+  it('renders with series name in header', () => {
+    renderTooltip();
+    expect(screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper)).toBeVisible();
+    expect(screen.getByText('Series A')).toBeVisible();
+  });
+
+  describe('content fields', () => {
+    it('shows x and y field values', () => {
+      renderTooltip();
+      expect(screen.getByText('x')).toBeVisible();
+      expect(screen.getByText('1')).toBeVisible();
+      expect(screen.getByText('y')).toBeVisible();
+      expect(screen.getByText('10')).toBeVisible();
+    });
+
+    it('shows size field when mapped', () => {
+      const series = makeSeries({
+        size: { field: makeField({ name: 'radius', values: [5, 10, 15] }) },
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getByText('radius')).toBeVisible();
+      expect(screen.getByText('5')).toBeVisible();
+    });
+
+    it('shows color field when mapped', () => {
+      const series = makeSeries({
+        color: { field: makeField({ name: 'temp', values: [100, 200, 300] }) },
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getByText('temp')).toBeVisible();
+      expect(screen.getByText('100')).toBeVisible();
+    });
+
+    it('shows rest fields', () => {
+      const series = makeSeries({
+        _rest: [makeField({ name: 'host', values: [42] }), makeField({ name: 'region', values: [7] })],
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getByText('host')).toBeVisible();
+      expect(screen.getByText('42')).toBeVisible();
+      expect(screen.getByText('region')).toBeVisible();
+      expect(screen.getByText('7')).toBeVisible();
+    });
+
+    it('renders content items in order: x, y, size, color, rest', () => {
+      const series = makeSeries({
+        size: { field: makeField({ name: 'sz', values: [5] }) },
+        color: { field: makeField({ name: 'clr', values: [99] }) },
+        _rest: [makeField({ name: 'extra', values: [1] })],
+      });
+      renderTooltip({ xySeries: [series] });
+
+      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      const allText = wrapper.textContent ?? '';
+      const positions = ['x', 'y', 'sz', 'clr', 'extra'].map((label) => allText.indexOf(label));
+      for (let i = 1; i < positions.length; i++) {
+        expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+      }
+    });
+  });
+
+  describe('field deduplication', () => {
+    it('skips size field when same reference as x', () => {
+      const sharedField = makeField({ name: 'shared', values: [1, 2, 3] });
+      const series = makeSeries({
+        x: { field: sharedField },
+        size: { field: sharedField },
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getAllByText('shared')).toHaveLength(1);
+    });
+
+    it('skips color field when same reference as y', () => {
+      const sharedField = makeField({ name: 'shared', values: [10, 20, 30] });
+      const series = makeSeries({
+        y: { field: sharedField },
+        color: { field: sharedField },
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getAllByText('shared')).toHaveLength(1);
+    });
+  });
+
+  describe('field display names', () => {
+    it('uses displayName from field state when available', () => {
+      const series = makeSeries({
+        x: { field: makeField({ name: 'x', values: [1], displayName: 'X Axis' }) },
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getByText('X Axis')).toBeVisible();
+    });
+
+    it('strips series name from compound field label', () => {
+      const series = makeSeries({
+        name: { value: 'cpu' },
+        y: { field: makeField({ name: 'y', values: [10], displayName: 'cpu usage' }) },
+      });
+      renderTooltip({ xySeries: [series] });
+      expect(screen.getByText('usage')).toBeVisible();
+    });
+
+    it('preserves label when it equals series name exactly', () => {
+      const series = makeSeries({
+        name: { value: 'cpu' },
+        y: { field: makeField({ name: 'y', values: [10], displayName: 'cpu' }) },
+      });
+      renderTooltip({ xySeries: [series] });
+      // "cpu" appears in header (series name) and content (label preserved because name === label)
+      expect(screen.getAllByText('cpu').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('preserves label when field name has no spaces', () => {
+      const series = makeSeries({
+        name: { value: 'cpu' },
+        y: { field: makeField({ name: 'y', values: [10], displayName: 'usage' }) },
+      });
+      renderTooltip({ xySeries: [series] });
+      // "usage" has no space and does not contain "cpu", so no stripping
+      expect(screen.getByText('usage')).toBeVisible();
+    });
+  });
+
+  describe('hideFrom.tooltip', () => {
+    it.each<[string, string, Partial<XYSeries>]>([
+      ['x', 'x', { x: { field: makeField({ name: 'x', values: [1], hideFromTooltip: true }) } }],
+      ['y', 'y', { y: { field: makeField({ name: 'y', values: [10], hideFromTooltip: true }) } }],
+      ['size', 'radius', { size: { field: makeField({ name: 'radius', values: [5], hideFromTooltip: true }) } }],
+      ['color', 'temp', { color: { field: makeField({ name: 'temp', values: [100], hideFromTooltip: true }) } }],
+      ['rest', 'extra', { _rest: [makeField({ name: 'extra', values: [99], hideFromTooltip: true })] }],
+    ])('hides %s field', (_slot, fieldName, overrides) => {
+      const series = makeSeries(overrides);
+      renderTooltip({ xySeries: [series] });
+      expect(screen.queryByText(fieldName)).toBeNull();
+    });
+  });
+
+  describe('color', () => {
+    function getHeaderColorIndicator(): HTMLElement {
+      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      const header = wrapper.children[0];
+      // VizTooltipColorIndicator renders a div with inline backgroundColor — no testid available
+      return header.querySelector('[style*="background-color"]') as HTMLElement;
+    }
+
+    it('uses color from color field display value', () => {
+      const colorField = makeField({ name: 'temp', values: [100] });
+      colorField.display = (v: unknown): DisplayValue => ({ text: `${v}`, numeric: Number(v), color: '#ff0000' });
+      const series = makeSeries({ color: { field: colorField } });
+      renderTooltip({ xySeries: [series] });
+      expect(getHeaderColorIndicator()).toHaveStyle({ backgroundColor: '#ff0000' });
+    });
+
+    it('uses fixed color when no color field', () => {
+      const series = makeSeries({ color: { fixed: '#00ff00' } });
+      renderTooltip({ xySeries: [series] });
+      expect(getHeaderColorIndicator()).toHaveStyle({ backgroundColor: '#00ff00' });
+    });
+
+    it('falls back to #fff when no color field or fixed', () => {
+      const series = makeSeries({ color: {} });
+      renderTooltip({ xySeries: [series] });
+      expect(getHeaderColorIndicator()).toHaveStyle({ backgroundColor: '#fff' });
+    });
+
+    it('applies fillOpacity as alpha to color', () => {
+      const colorField = makeField({ name: 'temp', values: [100], customConfig: { fillOpacity: 50 } });
+      colorField.display = (v: unknown): DisplayValue => ({ text: `${v}`, numeric: Number(v), color: '#ff0000' });
+      const series = makeSeries({ color: { field: colorField } });
+      renderTooltip({ xySeries: [series] });
+      const indicator = getHeaderColorIndicator();
+      // Can't assert exact rgba string — colorManipulator output format varies across environments
+      expect(indicator.style.backgroundColor).not.toBe('#ff0000');
+      expect(indicator.style.backgroundColor).toContain('0.5');
+    });
+  });
+
+  describe('footer', () => {
+    it('renders footer when isPinned', () => {
+      renderTooltip({ isPinned: true });
+      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      expect(wrapper.children).toHaveLength(3);
+    });
+
+    it('renders footer when dataLink has oneClick', () => {
+      renderTooltip({
+        isPinned: false,
+        dataLinks: [{ href: 'http://example.com', title: 'Link', oneClick: true } as LinkModel],
+      });
+      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      expect(wrapper.children).toHaveLength(3);
+    });
+
+    it('does not render footer when not pinned and no oneClick links', () => {
+      renderTooltip({ isPinned: false, dataLinks: [] });
+      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      expect(wrapper.children).toHaveLength(2);
+    });
+
+    it('calls getFieldActions when canExecuteActions is true and pinned', () => {
+      const mockGetFieldActions = getFieldActions as jest.Mock;
+      mockGetFieldActions.mockClear();
+
+      const series = makeSeries();
+      const yField = series.y.field;
+      // Build a frame that holds the exact yField reference so .includes() matches
+      const frame = { fields: [yField], length: yField.values.length };
+
+      renderTooltip({
+        isPinned: true,
+        canExecuteActions: true,
+        data: [frame] as DataFrame[],
+        xySeries: [series],
+      });
+
+      expect(mockGetFieldActions).toHaveBeenCalledWith(
+        expect.objectContaining({ fields: expect.arrayContaining([yField]) }),
+        yField,
+        expect.any(Function),
+        0,
+        'xychart'
+      );
+    });
+
+    it('does not call getFieldActions when canExecuteActions is false', () => {
+      const mockGetFieldActions = getFieldActions as jest.Mock;
+      mockGetFieldActions.mockClear();
+      renderTooltip({ isPinned: true, canExecuteActions: false });
+      expect(mockGetFieldActions).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -220,17 +220,21 @@ describe('XYChartTooltip', () => {
     });
   });
 
-  describe('hideFrom.tooltip', () => {
+  describe.each([true, false])('hideFrom.tooltip: %s', (hideFromTooltip) => {
     it.each<[string, string, Partial<XYSeries>]>([
-      ['x', 'x', { x: { field: makeField({ name: 'x', values: [1], hideFromTooltip: true }) } }],
-      ['y', 'y', { y: { field: makeField({ name: 'y', values: [10], hideFromTooltip: true }) } }],
-      ['size', 'radius', { size: { field: makeField({ name: 'radius', values: [5], hideFromTooltip: true }) } }],
-      ['color', 'temp', { color: { field: makeField({ name: 'temp', values: [100], hideFromTooltip: true }) } }],
-      ['rest', 'extra', { _rest: [makeField({ name: 'extra', values: [99], hideFromTooltip: true })] }],
-    ])('hides %s field', (_slot, fieldName, overrides) => {
+      ['x', 'x', { x: { field: makeField({ name: 'x', values: [1], hideFromTooltip }) } }],
+      ['y', 'y', { y: { field: makeField({ name: 'y', values: [10], hideFromTooltip }) } }],
+      ['size', 'radius', { size: { field: makeField({ name: 'radius', values: [5], hideFromTooltip }) } }],
+      ['color', 'temp', { color: { field: makeField({ name: 'temp', values: [100], hideFromTooltip }) } }],
+      ['rest', 'extra', { _rest: [makeField({ name: 'extra', values: [99], hideFromTooltip })] }],
+    ])(`${hideFromTooltip ? 'hides' : 'shows'} %s field`, (_slot, fieldName, overrides) => {
       const series = makeSeries(overrides);
       renderTooltip({ xySeries: [series] });
-      expect(screen.queryByText(fieldName)).toBeNull();
+      if(hideFromTooltip){
+        expect(screen.queryByText(fieldName)).toBeNull();
+      }else{
+        expect(screen.queryByText(fieldName)).toBeVisible()
+      }
     });
   });
 

--- a/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartTooltip.test.tsx
@@ -206,7 +206,7 @@ describe('XYChartTooltip', () => {
       });
       renderTooltip({ xySeries: [series] });
       // "cpu" appears in header (series name) and content (label preserved because name === label)
-      expect(screen.getAllByText('cpu').length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByText('cpu')).toHaveLength(2);
     });
 
     it('preserves label when field name has no spaces', () => {
@@ -277,25 +277,30 @@ describe('XYChartTooltip', () => {
   });
 
   describe('footer', () => {
-    it('renders footer when isPinned', () => {
-      renderTooltip({ isPinned: true });
+    it.each<[string, Partial<Props>]>([
+      ['isPinned', { isPinned: true }],
+      [
+        'dataLink has oneClick',
+        { isPinned: false, dataLinks: [{ href: 'http://example.com', title: 'Link', oneClick: true } as LinkModel] },
+      ],
+    ])('renders footer when %s', (_label, overrides) => {
+      renderTooltip(overrides);
       const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      // header + content + footer
       expect(wrapper.children).toHaveLength(3);
-    });
-
-    it('renders footer when dataLink has oneClick', () => {
-      renderTooltip({
-        isPinned: false,
-        dataLinks: [{ href: 'http://example.com', title: 'Link', oneClick: true } as LinkModel],
-      });
-      const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
-      expect(wrapper.children).toHaveLength(3);
+      expect(screen.getByText('Series A')).toBeVisible();
+      expect(screen.getByText('x')).toBeVisible();
+      expect(screen.getByText('y')).toBeVisible();
     });
 
     it('does not render footer when not pinned and no oneClick links', () => {
       renderTooltip({ isPinned: false, dataLinks: [] });
       const wrapper = screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+      // header + content only
       expect(wrapper.children).toHaveLength(2);
+      expect(screen.getByText('Series A')).toBeVisible();
+      expect(screen.getByText('x')).toBeVisible();
+      expect(screen.getByText('y')).toBeVisible();
     });
 
     it('calls getFieldActions when canExecuteActions is true and pinned', () => {

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -33,13 +33,6 @@ jest.mock('@grafana/ui', () => ({
 
 const theme = createTheme();
 
-/*
- * Why makeField has defaults and a two-level merge:
- * - prepConfig accesses custom.pointSize, axisLabel, axisPlacement directly
- * - config.custom is shallow-merged so caller overrides win
- * - Top-level keys (unit, thresholds, mappings, color) spread separately
- *   so they don't overwrite the custom defaults
- */
 function makeField(opts: {
   name: string;
   values: number[];

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -97,7 +97,7 @@ describe('prepConfig', () => {
   it('returns null builder and warn when xySeries is empty', () => {
     const result = prepConfig([], theme);
     expect(result.builder).toBeNull();
-    expect(result.warn).toEqual("No data")
+    expect(result.warn).toEqual('No data');
   });
 
   it('returns non-null builder when series provided', () => {
@@ -184,8 +184,8 @@ describe('prepData', () => {
     // series2 val=100: pct=1, diam=√100=10
     const diams1 = data[1]![2] as number[];
     const diams2 = data[2]![2] as number[];
-    expect(diams1[0]).toEqual(2)
-    expect(diams2[1]).toEqual(10)
+    expect(diams1[0]).toEqual(2);
+    expect(diams2[1]).toEqual(10);
   });
 });
 

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -95,7 +95,7 @@ describe('prepConfig', () => {
   it('returns null builder and warn when xySeries is empty', () => {
     const result = prepConfig([], theme);
     expect(result.builder).toBeNull();
-    expect(result.warn).toBeTruthy();
+    expect(result.warn).toEqual("No data")
   });
 
   it('returns non-null builder when series provided', () => {

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -100,13 +100,9 @@ describe('prepConfig', () => {
     expect(result.warn).toEqual('No data');
   });
 
-  it('returns non-null builder when series provided', () => {
+  it('returns non-null builder and null warn when series provided', () => {
     const result = prepConfig([makeSeries()], theme);
     expect(result.builder).not.toBeNull();
-  });
-
-  it('returns null warn when series provided', () => {
-    const result = prepConfig([makeSeries()], theme);
     expect(result.warn).toBeNull();
   });
 });

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -48,6 +48,8 @@ function makeField(opts: {
 }): Field {
   const { name, values, type = FieldType.number, config = {} } = opts;
 
+  const { custom, ...rest } = config;
+
   const field = createDataFrame({
     fields: [
       {
@@ -59,9 +61,9 @@ function makeField(opts: {
             pointSize: { fixed: 5, min: 1, max: 10 },
             axisLabel: '',
             axisPlacement: 'auto',
-            ...((config.custom as Record<string, unknown>) ?? {}),
+            ...(custom as Record<string, unknown>),
           },
-          ...Object.fromEntries(Object.entries(config).filter(([k]) => k !== 'custom')),
+          ...rest,
         },
       },
     ],

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -13,6 +13,12 @@ import { PointShape } from './panelcfg.gen';
 import { prepConfig } from './scatter';
 import { type XYSeries } from './types2';
 
+/*
+ * Why mock UPlotConfigBuilder:
+ * - Real one needs a uPlot instance + canvas context (no DOM in Jest)
+ * - Stubbing its methods lets prepConfig run through setup without crashing
+ * - We only care about the returned prepData closure, not the builder itself
+ */
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual('@grafana/ui'),
   UPlotConfigBuilder: jest.fn().mockImplementation(() => ({
@@ -27,6 +33,13 @@ jest.mock('@grafana/ui', () => ({
 
 const theme = createTheme();
 
+/*
+ * Why makeField has defaults and a two-level merge:
+ * - prepConfig accesses custom.pointSize, axisLabel, axisPlacement directly
+ * - config.custom is shallow-merged so caller overrides win
+ * - Top-level keys (unit, thresholds, mappings, color) spread separately
+ *   so they don't overwrite the custom defaults
+ */
 function makeField(opts: {
   name: string;
   values: number[];
@@ -97,7 +110,7 @@ describe('prepConfig', () => {
 });
 
 describe('prepData', () => {
-  it('returns faceted data with null first element', () => {
+  it('returns data array with null first element (uPlot convention)', () => {
     const series = makeSeries();
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
@@ -114,7 +127,7 @@ describe('prepData', () => {
     expect(entry[1]).toEqual([10, 20, 30]);
   });
 
-  it('uses fixed size when no size field mapped', () => {
+  it('fills all diameters with the fixed value when no size field is mapped', () => {
     const series = makeSeries({ size: { fixed: 7 } });
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
@@ -122,7 +135,7 @@ describe('prepData', () => {
     expect(entry[2]).toEqual([7, 7, 7]);
   });
 
-  it('fills fixed color when no color field mapped', () => {
+  it('fills all color entries with the fixed value when no color field is mapped', () => {
     const series = makeSeries({ color: { fixed: '#00ff00' } });
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
@@ -130,7 +143,7 @@ describe('prepData', () => {
     expect(entry[3]).toEqual(['#00ff00', '#00ff00', '#00ff00']);
   });
 
-  it('computes quadratic size scaling when size field mapped', () => {
+  it('scales diameters by area (not linearly) when a size field is mapped', () => {
     const sizeField = makeField({ name: 'sz', values: [0, 50, 100] });
     const series = makeSeries({
       size: { field: sizeField, min: 2, max: 10, fixed: 5 },
@@ -148,7 +161,7 @@ describe('prepData', () => {
     expect(diams[2]).toBeCloseTo(10, 5);
   });
 
-  it('size scaling uses global min/max across multiple series', () => {
+  it('normalizes diameters against the global min/max when multiple series share a size field', () => {
     const series1 = makeSeries({
       x: { field: makeField({ name: 'x', values: [1, 2] }) },
       y: { field: makeField({ name: 'y', values: [10, 20], config: { unit: 'y' } }) },
@@ -175,7 +188,7 @@ describe('prepData', () => {
 });
 
 describe('fieldValueColors via prepConfig', () => {
-  it('does not throw with threshold-based color field', () => {
+  it('processes a color field with absolute thresholds without error', () => {
     const colorField = makeField({
       name: 'temp',
       values: [10, 50, 90],
@@ -204,7 +217,7 @@ describe('fieldValueColors via prepConfig', () => {
     expect(data[1]).toHaveLength(4);
   });
 
-  it('does not throw with value mapping color field', () => {
+  it('processes a color field with value-to-text mappings without error', () => {
     const colorField = makeField({
       name: 'status',
       values: [1, 2, 3],

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -7,7 +7,7 @@ import {
   ThresholdsMode,
   type Field,
 } from '@grafana/data';
-import { FieldColorModeId, VisibilityMode } from '@grafana/schema';
+import { AxisPlacement, FieldColorModeId, VisibilityMode } from '@grafana/schema';
 
 import { PointShape } from './panelcfg.gen';
 import { prepConfig } from './scatter';
@@ -53,7 +53,7 @@ function makeField(opts: {
           custom: {
             pointSize: { fixed: 5, min: 1, max: 10 },
             axisLabel: '',
-            axisPlacement: 'auto',
+            axisPlacement: AxisPlacement.Auto,
             ...(custom as Record<string, unknown>),
           },
           ...rest,
@@ -178,8 +178,8 @@ describe('prepData', () => {
   });
 });
 
-describe('fieldValueColors via prepConfig', () => {
-  it('processes a color field with absolute thresholds without error', () => {
+describe('color field compilation', () => {
+  it('compiles absolute threshold color config without throwing', () => {
     const colorField = makeField({
       name: 'temp',
       values: [10, 50, 90],
@@ -215,7 +215,7 @@ describe('fieldValueColors via prepConfig', () => {
     ]);
   });
 
-  it('processes a color field with value-to-text mappings without error', () => {
+  it('compiles value-to-text mapping color config without throwing', () => {
     const colorField = makeField({
       name: 'status',
       values: [1, 2, 3],

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -211,8 +211,15 @@ describe('fieldValueColors via prepConfig', () => {
 
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
-    expect(data).toHaveLength(2);
-    expect(data[1]).toHaveLength(4);
+    expect(data).toEqual([
+      null,
+      [
+        [1, 2, 3],
+        [10, 20, 30],
+        [5, 5, 5],
+        ['#ff0000', '#ff0000', '#ff0000'],
+      ],
+    ]);
   });
 
   it('processes a color field with value-to-text mappings without error', () => {
@@ -241,7 +248,14 @@ describe('fieldValueColors via prepConfig', () => {
 
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
-    expect(data).toHaveLength(2);
-    expect(data[1]).toHaveLength(4);
+    expect(data).toEqual([
+      null,
+      [
+        [1, 2, 3],
+        [10, 20, 30],
+        [5, 5, 5],
+        ['#ff0000', '#ff0000', '#ff0000'],
+      ],
+    ]);
   });
 });

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -182,8 +182,8 @@ describe('prepData', () => {
     // series2 val=100: pct=1, diam=√100=10
     const diams1 = data[1]![2] as number[];
     const diams2 = data[2]![2] as number[];
-    expect(diams1[0]).toBeCloseTo(2, 5);
-    expect(diams2[1]).toBeCloseTo(10, 5);
+    expect(diams1[0]).toEqual(2)
+    expect(diams2[1]).toEqual(10)
   });
 });
 

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -1,0 +1,236 @@
+import {
+  createDataFrame,
+  createTheme,
+  FieldType,
+  getDisplayProcessor,
+  MappingType,
+  ThresholdsMode,
+  type Field,
+} from '@grafana/data';
+import { FieldColorModeId, VisibilityMode } from '@grafana/schema';
+
+import { PointShape } from './panelcfg.gen';
+import { prepConfig } from './scatter';
+import { type XYSeries } from './types2';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  UPlotConfigBuilder: jest.fn().mockImplementation(() => ({
+    addScale: jest.fn(),
+    addAxis: jest.fn(),
+    addSeries: jest.fn(),
+    setCursor: jest.fn(),
+    addHook: jest.fn(),
+    setMode: jest.fn(),
+  })),
+}));
+
+const theme = createTheme();
+
+function makeField(opts: {
+  name: string;
+  values: number[];
+  type?: FieldType;
+  config?: Record<string, unknown>;
+}): Field {
+  const { name, values, type = FieldType.number, config = {} } = opts;
+
+  const field = createDataFrame({
+    fields: [
+      {
+        name,
+        type,
+        values,
+        config: {
+          custom: {
+            pointSize: { fixed: 5, min: 1, max: 10 },
+            axisLabel: '',
+            axisPlacement: 'auto',
+            ...((config.custom as Record<string, unknown>) ?? {}),
+          },
+          ...Object.fromEntries(Object.entries(config).filter(([k]) => k !== 'custom')),
+        },
+      },
+    ],
+  }).fields[0];
+
+  field.display = getDisplayProcessor({ field, theme });
+
+  return field;
+}
+
+function makeSeries(overrides?: Partial<XYSeries>): XYSeries {
+  return {
+    showPoints: VisibilityMode.Always,
+    pointShape: PointShape.Circle,
+    pointStrokeWidth: 1,
+    fillOpacity: 50,
+    showLine: false,
+    lineWidth: 1,
+    lineStyle: { fill: 'solid' },
+    name: { value: 'Series A' },
+    x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
+    y: { field: makeField({ name: 'y', values: [10, 20, 30], config: { unit: 'y' } }) },
+    color: { fixed: '#ff0000' },
+    size: { fixed: 5 },
+    _rest: [],
+    ...overrides,
+  };
+}
+
+describe('prepConfig', () => {
+  it('returns null builder and warn when xySeries is empty', () => {
+    const result = prepConfig([], theme);
+    expect(result.builder).toBeNull();
+    expect(result.warn).toBeTruthy();
+  });
+
+  it('returns non-null builder when series provided', () => {
+    const result = prepConfig([makeSeries()], theme);
+    expect(result.builder).not.toBeNull();
+  });
+
+  it('returns null warn when series provided', () => {
+    const result = prepConfig([makeSeries()], theme);
+    expect(result.warn).toBeNull();
+  });
+});
+
+describe('prepData', () => {
+  it('returns faceted data with null first element', () => {
+    const series = makeSeries();
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    expect(data[0]).toBeNull();
+  });
+
+  it('each series entry has [xValues, yValues, diameters, colors] shape', () => {
+    const series = makeSeries();
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    const entry = data[1] as unknown[][];
+    expect(entry).toHaveLength(4);
+    expect(entry[0]).toEqual([1, 2, 3]);
+    expect(entry[1]).toEqual([10, 20, 30]);
+  });
+
+  it('uses fixed size when no size field mapped', () => {
+    const series = makeSeries({ size: { fixed: 7 } });
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    const entry = data[1] as unknown[][];
+    expect(entry[2]).toEqual([7, 7, 7]);
+  });
+
+  it('fills fixed color when no color field mapped', () => {
+    const series = makeSeries({ color: { fixed: '#00ff00' } });
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    const entry = data[1] as unknown[][];
+    expect(entry[3]).toEqual(['#00ff00', '#00ff00', '#00ff00']);
+  });
+
+  it('computes quadratic size scaling when size field mapped', () => {
+    const sizeField = makeField({ name: 'sz', values: [0, 50, 100] });
+    const series = makeSeries({
+      size: { field: sizeField, min: 2, max: 10, fixed: 5 },
+    });
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    const diams = data[1]![2] as number[];
+
+    // Math: min=0, max=100, minPx=2²=4, maxPx=10²=100, pxRange=96
+    // val=0:   pct=0,   area=4+0*96=4,     diam=√4=2
+    // val=50:  pct=0.5, area=4+0.5*96=52,  diam=√52≈7.211
+    // val=100: pct=1,   area=4+1*96=100,   diam=√100=10
+    expect(diams[0]).toBeCloseTo(2, 5);
+    expect(diams[1]).toBeCloseTo(Math.sqrt(52), 5);
+    expect(diams[2]).toBeCloseTo(10, 5);
+  });
+
+  it('size scaling uses global min/max across multiple series', () => {
+    const series1 = makeSeries({
+      x: { field: makeField({ name: 'x', values: [1, 2] }) },
+      y: { field: makeField({ name: 'y', values: [10, 20], config: { unit: 'y' } }) },
+      size: { field: makeField({ name: 'sz', values: [0, 50] }), min: 2, max: 10, fixed: 5 },
+    });
+    const series2 = makeSeries({
+      name: { value: 'Series B' },
+      x: { field: makeField({ name: 'x', values: [3, 4] }) },
+      y: { field: makeField({ name: 'y', values: [30, 40], config: { unit: 'y' } }) },
+      size: { field: makeField({ name: 'sz', values: [50, 100] }), min: 2, max: 10, fixed: 5 },
+    });
+    const allSeries = [series1, series2];
+    const { prepData } = prepConfig(allSeries, theme);
+    const data = prepData!(allSeries);
+
+    // Global range: min=0, max=100 (across both series)
+    // series1 val=0: pct=0, diam=√4=2
+    // series2 val=100: pct=1, diam=√100=10
+    const diams1 = data[1]![2] as number[];
+    const diams2 = data[2]![2] as number[];
+    expect(diams1[0]).toBeCloseTo(2, 5);
+    expect(diams2[1]).toBeCloseTo(10, 5);
+  });
+});
+
+describe('fieldValueColors via prepConfig', () => {
+  it('does not throw with threshold-based color field', () => {
+    const colorField = makeField({
+      name: 'temp',
+      values: [10, 50, 90],
+      config: {
+        color: { mode: FieldColorModeId.Thresholds },
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [
+            { value: -Infinity, color: 'green' },
+            { value: 30, color: 'yellow' },
+            { value: 70, color: 'red' },
+          ],
+        },
+      },
+    });
+
+    const series = makeSeries({
+      color: { field: colorField, fixed: '#ff0000' },
+      x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
+      y: { field: makeField({ name: 'y', values: [10, 20, 30], config: { unit: 'y' } }) },
+    });
+
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    expect(data).toHaveLength(2);
+    expect(data[1]).toHaveLength(4);
+  });
+
+  it('does not throw with value mapping color field', () => {
+    const colorField = makeField({
+      name: 'status',
+      values: [1, 2, 3],
+      config: {
+        mappings: [
+          {
+            type: MappingType.ValueToText,
+            options: {
+              '1': { text: 'low', color: 'green' },
+              '2': { text: 'med', color: 'yellow' },
+              '3': { text: 'high', color: 'red' },
+            },
+          },
+        ],
+      },
+    });
+
+    const series = makeSeries({
+      color: { field: colorField, fixed: '#ff0000' },
+      x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
+      y: { field: makeField({ name: 'y', values: [10, 20, 30], config: { unit: 'y' } }) },
+    });
+
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    expect(data).toHaveLength(2);
+    expect(data[1]).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary

Unit tests for three previously-uncovered files in the xychart panel plugin.

**49 new tests** (54 total), plugin-wide statement coverage **28% → 50%**.

---

### XYChartTooltip.tsx (31 tests, 0% → 100%)

**Content**
- Renders x, y, size, color, and rest fields with correct labels and values
- Verifies content item ordering

**Deduplication**
- Skips size/color fields when same reference as x/y

**Display names**
- Uses displayName, strips series name from compound labels
- Preserves label on exact match or no spaces

**Visibility**
- Parametric test: hidden and visible states for all field slots

**Color indicator**
- Verifies backgroundColor for field display, fixed fallback, #fff default, fillOpacity alpha

**Footer**
- Parametric test: renders when isPinned or oneClick dataLink; omitted otherwise
- Gates getFieldActions on canExecuteActions

---

### scatter.ts (10 tests, 27% → 49%)

**prepConfig**
- Error state for empty series
- Valid builder and null warn for non-empty series

**prepData**
- Fixed size/color fill
- Area-based diameter scaling
- Global min/max normalization across multiple series

**Color field compilation**
- Compiles absolute threshold and value-to-text mapping configs without throwing

---

### XYChartPanel.tsx (8 tests, 0% → 88%)

**Error states**
- Renders error view when prepConfig returns warn or null builder

**Rendering**
- Renders UPlotChart when valid
- Hides tooltip when mode is None

**Legend**
- Hides when showLegend is false
- Builds items with correct labels
- Excludes series with hideFrom.legend

---

## Test plan
- [ ] `yarn jest public/app/plugins/panel/xychart/ --no-watch --watchAll=false` — 54 tests pass
- [ ] `yarn typecheck` — passes
- [ ] No production code changes — test-only PR