### PR TITLE
unified-storage: add metric for conflict errors in KV backend

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -54,16 +54,18 @@ type dataStore struct {
 	kv            KV
 	cache         *gocache.Cache
 	legacyDialect sqltemplate.Dialect // TODO: remove when backwards compatibility is no longer needed.
+	metrics       *kvBackendMetrics
 }
 
 type dataImportBatchWriter interface {
 	InsertDataImportBatch(ctx context.Context, rows []kvpkg.DataImportRow) error
 }
 
-func newDataStore(kv KV) *dataStore {
+func newDataStore(kv KV, metrics *kvBackendMetrics) *dataStore {
 	ds := &dataStore{
-		kv:    kv,
-		cache: gocache.New(time.Hour, 10*time.Minute), // 1 hour expiration, 10 minute cleanup
+		kv:      kv,
+		cache:   gocache.New(time.Hour, 10*time.Minute), // 1 hour expiration, 10 minute cleanup
+		metrics: metrics,
 	}
 
 	if sqlkv, ok := kv.(*kvpkg.SqlKV); ok {
@@ -898,6 +900,7 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 				// This can only happen if a concurrent write was attempted: the validation in
 				// WriteEvent guarantees that we return early when the resource already exists
 				// before entering the transaction.
+				d.metrics.recordConflict(event)
 				return conflictError(event, "concurrent create attempts detected")
 			}
 			return fmt.Errorf("compatibility layer: failed to insert to resource: %w", err)
@@ -918,7 +921,10 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 		if err != nil {
 			return fmt.Errorf("compatibility layer: failed to update resource: %w", err)
 		}
-		if err := checkLegacyCASConflict(res, event, key); err != nil {
+		if isConflict, err := checkLegacyCASConflict(res, event, key); err != nil {
+			if isConflict {
+				d.metrics.recordConflict(event)
+			}
 			return err
 		}
 	case DataActionDeleted:
@@ -934,7 +940,10 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 		if err != nil {
 			return fmt.Errorf("compatibility layer: failed to delete from resource: %w", err)
 		}
-		if err := checkLegacyCASConflict(res, event, key); err != nil {
+		if isConflict, err := checkLegacyCASConflict(res, event, key); err != nil {
+			if isConflict {
+				d.metrics.recordConflict(event)
+			}
 			return err
 		}
 	}
@@ -942,19 +951,19 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 	return nil
 }
 
-func checkLegacyCASConflict(res db.Result, event WriteEvent, key DataKey) error {
+func checkLegacyCASConflict(res db.Result, event WriteEvent, key DataKey) (bool, error) {
 	rows, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("compatibility layer: failed to verify optimistic lock result: %w", err)
+		return false, fmt.Errorf("compatibility layer: failed to verify optimistic lock result: %w", err)
 	}
 	if rows == 1 {
-		return nil
+		return false, nil
 	}
 	if rows > 1 {
-		return fmt.Errorf("compatibility layer: unexpected rows affected: %d", rows)
+		return false, fmt.Errorf("compatibility layer: unexpected rows affected: %d", rows)
 	}
 
-	return conflictError(event, "requested RV does not match current RV")
+	return true, conflictError(event, "requested RV does not match current RV")
 }
 
 func isRowAlreadyExistsError(err error) bool {

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -54,7 +54,7 @@ func setupSqlKV(t *testing.T) kv.KV {
 }
 
 func setupTestDataStore(t *testing.T) *dataStore {
-	return newDataStore(setupBadgerKV(t))
+	return newDataStore(setupBadgerKV(t), nil)
 }
 
 func TestNewDataStore(t *testing.T) {
@@ -63,7 +63,7 @@ func TestNewDataStore(t *testing.T) {
 }
 
 func setupTestDataStoreSqlKv(t *testing.T) *dataStore {
-	return newDataStore(setupSqlKV(t))
+	return newDataStore(setupSqlKV(t), nil)
 }
 
 func TestDataKey_String(t *testing.T) {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,8 +71,9 @@ type kvStorageBackend struct {
 	garbageCollection       GarbageCollectionConfig
 	lastImportStore         *lastImportStore
 	lastImportTimeMaxAge    time.Duration
-	//tracer        trace.Tracer
-	//reg           prometheus.Registerer
+	//tracer  trace.Tracer
+	//reg     prometheus.Registerer
+	metrics *kvBackendMetrics
 
 	watchOpts WatchOptions
 
@@ -92,6 +94,27 @@ type kvStorageBackend struct {
 
 	// cancel stops all background goroutines owned by the backend.
 	cancel context.CancelFunc
+}
+
+type kvBackendMetrics struct {
+	ConflictErrors *prometheus.CounterVec
+}
+
+func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
+	return &kvBackendMetrics{
+		ConflictErrors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "storage_server",
+			Name:      "optimistic_lock_conflicts_total",
+			Help:      "Total number of optimistic lock conflict errors in the KV storage backend",
+		}, []string{"resource", "action"}),
+	}
+}
+
+func (m *kvBackendMetrics) recordConflict(event WriteEvent) {
+	if m == nil {
+		return
+	}
+	m.ConflictErrors.WithLabelValues(event.Key.Resource, event.Type.String()).Inc()
 }
 
 var _ KVBackend = &kvStorageBackend{}
@@ -187,10 +210,12 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		garbageCollection.BatchWait = defaultGarbageCollectionBatchWait
 	}
 
+	metrics := newKVBackendMetrics(opts.Reg)
+
 	backend := &kvStorageBackend{
 		kv:                      kv,
 		bulkLock:                NewBulkLock(),
-		dataStore:               newDataStore(kv),
+		dataStore:               newDataStore(kv, metrics),
 		eventStore:              eventStore,
 		notifier:                newNotifier(eventStore, notifierOptions{log: logger, useChannelNotifier: opts.UseChannelNotifier}),
 		watchOpts:               opts.WatchOptions.normalize(),
@@ -207,6 +232,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 		disablePruner:           opts.DisablePruner,
 		dashboardVersionsToKeep: opts.DashboardVersionsToKeep,
 		cancel:                  cancel,
+		metrics:                 metrics,
 	}
 	err = backend.initPruner(ctx)
 	if err != nil {
@@ -708,6 +734,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		if err != nil {
 			if errors.Is(err, ErrNotFound) {
 				// Resource doesn't exist, but PreviousRV was provided
+				k.metrics.recordConflict(event)
 				return 0, conflictError(event, "resource not found")
 			}
 			return 0, fmt.Errorf("failed to fetch latest resource: %w", err)
@@ -715,6 +742,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 
 		// Verify the current RV matches the PreviousRV
 		if latestKey.ResourceVersion != event.PreviousRV {
+			k.metrics.recordConflict(event)
 			return 0, conflictError(event, "requested RV does not match current RV")
 		}
 	}
@@ -824,12 +852,14 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		if latestKey.ResourceVersion != dataKey.ResourceVersion {
 			// Delete the data we just wrote since it's not the latest
 			_ = k.dataStore.Delete(ctx, dataKey)
+			k.metrics.recordConflict(event)
 			return 0, conflictError(event, "concurrent modification detected")
 		}
 
 		if !rvmanager.IsRvEqual(prevKey.ResourceVersion, event.PreviousRV) {
 			// Another concurrent write happened between our read and write
 			_ = k.dataStore.Delete(ctx, dataKey)
+			k.metrics.recordConflict(event)
 			return 0, conflictError(event, "resource was modified concurrently")
 		}
 	} else if event.Type == resourcepb.WatchEvent_ADDED {
@@ -850,6 +880,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		if latestKey.ResourceVersion != dataKey.ResourceVersion {
 			// Delete the data we just wrote since it's not the latest
 			_ = k.dataStore.Delete(ctx, dataKey)
+			k.metrics.recordConflict(event)
 			return 0, conflictError(event, "concurrent create detected")
 		}
 
@@ -857,6 +888,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		if prevKey.Action == DataActionCreated {
 			// Another concurrent create happened - delete our write and return error
 			_ = k.dataStore.Delete(ctx, dataKey)
+			k.metrics.recordConflict(event)
 			return 0, conflictError(event, "concurrent create attempts detected")
 		}
 	}

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -80,7 +80,7 @@ func (f *failOnceBatchDeleteKV) Batch(ctx context.Context, section string, ops [
 func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore, *PendingDeleteStore) {
 	t.Helper()
 	kv := setupBadgerKV(t)
-	ds := newDataStore(kv)
+	ds := newDataStore(kv, nil)
 	pds := newPendingDeleteStore(kv)
 	cfg := TenantDeleterConfig{
 		DryRun:   dryRun,
@@ -314,7 +314,7 @@ func TestRunDeletionPass_IdempotentAfterPartialFailure(t *testing.T) {
 	realKV := setupBadgerKV(t)
 	faultyKV := &failOnceBatchDeleteKV{KV: realKV, failOnCall: 2}
 
-	ds := newDataStore(faultyKV)
+	ds := newDataStore(faultyKV, nil)
 	pds := newPendingDeleteStore(realKV)
 	cfg := TenantDeleterConfig{
 		DryRun:   false,
@@ -484,7 +484,7 @@ func TestRunDeletionPass_DeletesExpiredForceRecord(t *testing.T) {
 // GCOM returns HTTP 200 with status "deleted".
 func TestRunDeletionPass_AllowsWhenGcomReturnsDeletedStatus(t *testing.T) {
 	kv := setupBadgerKV(t)
-	ds := newDataStore(kv)
+	ds := newDataStore(kv, nil)
 	pds := newPendingDeleteStore(kv)
 	td := NewTenantDeleter(ds, pds, TenantDeleterConfig{
 		DryRun:   false,
@@ -523,7 +523,7 @@ func TestRunDeletionPass_AllowsWhenGcomReturnsDeletedStatus(t *testing.T) {
 // not removed while GCOM still returns the stack instance.
 func TestRunDeletionPass_SkipsWhenGcomInstanceStillExists(t *testing.T) {
 	kv := setupBadgerKV(t)
-	ds := newDataStore(kv)
+	ds := newDataStore(kv, nil)
 	pds := newPendingDeleteStore(kv)
 	td := NewTenantDeleter(ds, pds, TenantDeleterConfig{
 		DryRun:   false,
@@ -562,7 +562,7 @@ func TestRunDeletionPass_SkipsWhenGcomInstanceStillExists(t *testing.T) {
 // does not delete local data (fail-safe on outage or permission errors).
 func TestRunDeletionPass_SkipsWhenGcomCheckFails(t *testing.T) {
 	kv := setupBadgerKV(t)
-	ds := newDataStore(kv)
+	ds := newDataStore(kv, nil)
 	pds := newPendingDeleteStore(kv)
 	td := NewTenantDeleter(ds, pds, TenantDeleterConfig{
 		DryRun:   false,
@@ -601,7 +601,7 @@ func TestRunDeletionPass_SkipsWhenGcomCheckFails(t *testing.T) {
 // do not call GCOM and do not delete local data.
 func TestRunDeletionPass_SkipsWhenNamespaceHasNoStackID(t *testing.T) {
 	kv := setupBadgerKV(t)
-	ds := newDataStore(kv)
+	ds := newDataStore(kv, nil)
 	pds := newPendingDeleteStore(kv)
 	called := false
 	td := NewTenantDeleter(ds, pds, TenantDeleterConfig{

--- a/pkg/storage/unified/resource/tenant_watcher_test.go
+++ b/pkg/storage/unified/resource/tenant_watcher_test.go
@@ -166,7 +166,7 @@ func TestTenantClearPendingDelete(t *testing.T) {
 
 func TestTenantResourceLabelling(t *testing.T) {
 	t.Run("adds pending-delete label to all tenant resources", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		collector := &writeEventCollector{}
 		tw := &TenantWatcher{
 			log:                log.NewNopLogger(),
@@ -201,7 +201,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("removes pending-delete label when tenant is restored", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		collector := &writeEventCollector{}
 		tw := &TenantWatcher{
 			log:                log.NewNopLogger(),
@@ -240,7 +240,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("record exists with LabelingComplete=false when labelling fails", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		failingWriter := func(_ context.Context, _ *WriteEvent) (int64, error) {
 			return 0, fmt.Errorf("simulated write failure")
 		}
@@ -263,7 +263,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("does not delete record if unlabelling fails", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		failingWriter := func(_ context.Context, _ *WriteEvent) (int64, error) {
 			return 0, fmt.Errorf("simulated write failure")
 		}
@@ -294,7 +294,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("skips resources that already have the correct label state", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		collector := &writeEventCollector{}
 		tw := &TenantWatcher{
 			log:                log.NewNopLogger(),
@@ -314,7 +314,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("conflict error during labelling succeeds when latest version already has label", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 
 		// Save the resource at RV 100 without the label (this is what the stale dataKey will read).
 		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
@@ -345,7 +345,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("conflict error during labelling fails when latest version does not have label", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 
 		// Save the resource at RV 100 without the label.
 		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
@@ -378,7 +378,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("retry succeeds after transient conflict", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
 
 		callCount := 0
@@ -411,7 +411,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("context cancellation stops retry on conflict", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
 
 		ctx, cancel := context.WithCancel(t.Context())
@@ -442,7 +442,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("partial labelling failure followed by tenant unmark cleans up orphaned labels", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		collector := &writeEventCollector{}
 
 		// Two resources: the writer will fail on the second one.
@@ -494,7 +494,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("incomplete record is retried on next event", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 
 		saveTestResource(t, ds, "tenant-1", "apps", "dashboards", "dash1", 100, nil)
 
@@ -530,7 +530,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 	})
 
 	t.Run("force record prevents unlabelling during clear", func(t *testing.T) {
-		ds := newDataStore(setupBadgerKV(t))
+		ds := newDataStore(setupBadgerKV(t), nil)
 		collector := &writeEventCollector{}
 		tw := &TenantWatcher{
 			log:                log.NewNopLogger(),
@@ -578,7 +578,7 @@ func TestTenantResourceLabelling(t *testing.T) {
 
 func newTestTenantWatcher(t *testing.T) *TenantWatcher {
 	t.Helper()
-	ds := newDataStore(setupBadgerKV(t))
+	ds := newDataStore(setupBadgerKV(t), nil)
 	return &TenantWatcher{
 		log:                log.NewNopLogger(),
 		pendingDeleteStore: newPendingDeleteStore(ds.kv),


### PR DESCRIPTION
This will allow us to monitor how/if these errors happen in busier environments as we deploy the KV backend with optimistic locking.