### PR TITLE
Zanzana: merge legacy and Zanzana permissions for access-control user endpoints

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -724,10 +724,10 @@ export interface FeatureToggles {
   */
   zanzanaNoLegacyClient?: boolean;
   /**
-  * Search users permissions using Zanzana.
+  * Merge Zanzana permissions into legacy RBAC for access-control API endpoints.
   * @default false
   */
-  zanzanaSearchUsersPermissions?: boolean;
+  zanzanaMergeUserPermissions?: boolean;
   /**
   * Enables reload of dashboards on scopes, time range and variables changes
   * @default false

--- a/pkg/services/accesscontrol/api/api.go
+++ b/pkg/services/accesscontrol/api/api.go
@@ -42,7 +42,7 @@ func NewAccessControlAPI(
 	}
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features != nil && features.IsEnabledGlobally(featuremgmt.FlagZanzanaSearchUsersPermissions) && zanzanaClient != nil {
+	if features != nil && features.IsEnabledGlobally(featuremgmt.FlagZanzanaMergeUserPermissions) && zanzanaClient != nil {
 		api.zanzanaResolver = newZanzanaPermissionResolver(zanzanaClient, userSvc)
 	}
 
@@ -78,6 +78,15 @@ func (api *AccessControlAPI) getUserActions(c *contextmodel.ReqContext) response
 		return response.JSON(http.StatusInternalServerError, err)
 	}
 
+	if api.zanzanaResolver != nil {
+		zanzanaPerms, zErr := api.zanzanaResolver.resolveCurrentUserPermissions(ctx, c.SignedInUser)
+		if zErr == nil {
+			permissions = mergeUserPermissions(permissions, zanzanaPerms)
+		} else {
+			logger.Warn("could not get zanzana user actions, using legacy only", "error", zErr)
+		}
+	}
+
 	return response.JSON(http.StatusOK, ac.BuildPermissionsMap(permissions))
 }
 
@@ -90,6 +99,15 @@ func (api *AccessControlAPI) getUserPermissions(c *contextmodel.ReqContext) resp
 	permissions, err := api.Service.GetUserPermissions(ctx, c.SignedInUser, ac.Options{ReloadCache: reloadCache})
 	if err != nil {
 		return response.JSON(http.StatusInternalServerError, err)
+	}
+
+	if api.zanzanaResolver != nil {
+		zanzanaPerms, zErr := api.zanzanaResolver.resolveCurrentUserPermissions(ctx, c.SignedInUser)
+		if zErr == nil {
+			permissions = mergeUserPermissions(permissions, zanzanaPerms)
+		} else {
+			logger.Warn("could not get zanzana user permissions, using legacy only", "error", zErr)
+		}
 	}
 
 	return response.JSON(http.StatusOK, ac.GroupScopesByActionContext(ctx, permissions))
@@ -194,6 +212,23 @@ func mergePermissions(a, b map[int64][]ac.Permission) map[int64][]ac.Permission 
 	}
 
 	return result
+}
+
+// mergeUserPermissions unions permissions from legacy RBAC and Zanzana for a single user,
+// deduplicating by action+scope.
+func mergeUserPermissions(legacy, zanzana []ac.Permission) []ac.Permission {
+	seen := make(map[string]struct{}, len(legacy))
+	for _, p := range legacy {
+		seen[p.Action+"|"+p.Scope] = struct{}{}
+	}
+	for _, p := range zanzana {
+		key := p.Action + "|" + p.Scope
+		if _, ok := seen[key]; !ok {
+			legacy = append(legacy, p)
+			seen[key] = struct{}{}
+		}
+	}
+	return legacy
 }
 
 func (api *AccessControlAPI) ComputeUserID(ctx context.Context, typedID string) (int64, error) {

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -443,7 +443,7 @@ func TestAccessControlAPI_searchUsersPermissions_MergesLegacyAndZanzana(t *testi
 	zClient := &fakeZanzanaClient{
 		listResp: &authzv1.ListResponse{Items: []string{"zanzana"}},
 	}
-	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaSearchUsersPermissions)
+	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaMergeUserPermissions)
 	api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc, features, zClient)
 	api.RegisterAPIEndpoints()
 
@@ -478,7 +478,7 @@ func TestAccessControlAPI_searchUsersPermissions_UsesLegacyWhenZanzanaFails(t *t
 	zClient := &fakeZanzanaClient{
 		listErr: errors.New("zanzana unavailable"),
 	}
-	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaSearchUsersPermissions)
+	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaMergeUserPermissions)
 	api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, mockUserSvc, features, zClient)
 	api.RegisterAPIEndpoints()
 
@@ -498,4 +498,142 @@ func TestAccessControlAPI_searchUsersPermissions_UsesLegacyWhenZanzanaFails(t *t
 	require.Equal(t, map[int64]map[string][]string{
 		2: {"dashboards:read": {"dashboards:uid:legacy"}},
 	}, output)
+}
+
+func TestMergeUserPermissions(t *testing.T) {
+	tests := []struct {
+		name     string
+		legacy   []ac.Permission
+		zanzana  []ac.Permission
+		expected []ac.Permission
+	}{
+		{
+			name:     "dedup identical action and scope",
+			legacy:   []ac.Permission{{Action: "a", Scope: "s"}},
+			zanzana:  []ac.Permission{{Action: "a", Scope: "s"}},
+			expected: []ac.Permission{{Action: "a", Scope: "s"}},
+		},
+		{
+			name:     "union different scopes for same action",
+			legacy:   []ac.Permission{{Action: "a", Scope: "s1"}},
+			zanzana:  []ac.Permission{{Action: "a", Scope: "s2"}},
+			expected: []ac.Permission{{Action: "a", Scope: "s1"}, {Action: "a", Scope: "s2"}},
+		},
+		{
+			name:     "zanzana only adds new permissions",
+			legacy:   []ac.Permission{{Action: "teams:read", Scope: "teams:*"}},
+			zanzana:  []ac.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:x"}},
+			expected: []ac.Permission{{Action: "teams:read", Scope: "teams:*"}, {Action: "dashboards:read", Scope: "dashboards:uid:x"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacy := append([]ac.Permission(nil), tt.legacy...)
+			got := mergeUserPermissions(legacy, tt.zanzana)
+			sortPermissions(got)
+			expected := append([]ac.Permission(nil), tt.expected...)
+			sortPermissions(expected)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+func TestAPI_getUserActions_MergesLegacyAndZanzana(t *testing.T) {
+	acSvc := actest.FakeService{
+		ExpectedPermissions: []ac.Permission{
+			{Action: datasources.ActionRead, Scope: datasources.ScopeAll},
+		},
+	}
+	zClient := &fakeZanzanaClient{
+		listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+	}
+	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaMergeUserPermissions)
+	api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{}, features, zClient)
+	api.RegisterAPIEndpoints()
+
+	server := webtest.NewServer(t, api.RouteRegister)
+	req := server.NewGetRequest("/api/access-control/user/actions")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID:       1,
+		UserID:      1,
+		UserUID:     "user_test_uid",
+		Permissions: map[int64]map[string][]string{},
+	})
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var output util.DynMap
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+	require.True(t, output[datasources.ActionRead].(bool))
+	require.Contains(t, output, "dashboards:read")
+}
+
+func TestAPI_getUserActions_UsesLegacyWhenZanzanaFails(t *testing.T) {
+	acSvc := actest.FakeService{
+		ExpectedPermissions: []ac.Permission{
+			{Action: datasources.ActionRead, Scope: datasources.ScopeAll},
+		},
+	}
+	zClient := &fakeZanzanaClient{
+		listErr: errors.New("zanzana unavailable"),
+	}
+	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaMergeUserPermissions)
+	api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{}, features, zClient)
+	api.RegisterAPIEndpoints()
+
+	server := webtest.NewServer(t, api.RouteRegister)
+	req := server.NewGetRequest("/api/access-control/user/actions")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID:       1,
+		UserID:      1,
+		UserUID:     "user_test_uid",
+		Permissions: map[int64]map[string][]string{},
+	})
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var output util.DynMap
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+	require.Equal(t, util.DynMap{datasources.ActionRead: true}, output)
+}
+
+func TestAPI_getUserPermissions_MergesLegacyAndZanzana(t *testing.T) {
+	acSvc := actest.FakeService{
+		ExpectedPermissions: []ac.Permission{
+			{Action: datasources.ActionRead, Scope: datasources.ScopeAll},
+		},
+	}
+	zClient := &fakeZanzanaClient{
+		listResp: &authzv1.ListResponse{Items: []string{"zanzana-dash"}},
+	}
+	features := featuremgmt.WithFeatures(featuremgmt.FlagZanzanaMergeUserPermissions)
+	api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, &usertest.FakeUserService{}, features, zClient)
+	api.RegisterAPIEndpoints()
+
+	server := webtest.NewServer(t, api.RouteRegister)
+	req := server.NewGetRequest("/api/access-control/user/permissions")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID:       1,
+		UserID:      1,
+		UserUID:     "user_test_uid",
+		Permissions: map[int64]map[string][]string{},
+	})
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var output util.DynMap
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&output))
+	require.Contains(t, output, datasources.ActionRead)
+	require.Contains(t, output, "dashboards:read")
+
+	dsScopes, ok := output[datasources.ActionRead].([]any)
+	require.True(t, ok)
+	require.Contains(t, dsScopes, datasources.ScopeAll)
 }

--- a/pkg/services/accesscontrol/api/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/api/zanzana_resolver.go
@@ -31,6 +31,13 @@ func newZanzanaPermissionResolver(client zanzana.Client, userSvc user.Service) *
 	}
 }
 
+// resolveCurrentUserPermissions lists Zanzana-supported permissions for the signed-in identity.
+func (r *zanzanaPermissionResolver) resolveCurrentUserPermissions(ctx context.Context, usr identity.Requester) ([]ac.Permission, error) {
+	subject := usr.GetUID()
+	namespace := claims.OrgNamespaceFormatter(usr.GetOrgID())
+	return r.listAllWithPrefix(ctx, namespace, subject, "", "")
+}
+
 // searchUsersPermissions searches for users' permissions using Zanzana
 func (r *zanzanaPermissionResolver) searchUsersPermissions(ctx context.Context, signedInUser identity.Requester, orgID int64, options ac.SearchOptions) (map[int64][]ac.Permission, error) {
 	// If we have a specific user ID, search for that user

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1243,8 +1243,8 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:         "zanzanaSearchUsersPermissions",
-			Description:  "Search users permissions using Zanzana.",
+			Name:         "zanzanaMergeUserPermissions",
+			Description:  "Merge Zanzana permissions into legacy RBAC for access-control API endpoints.",
 			Stage:        FeatureStageExperimental,
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -144,7 +144,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-06-13,authZGRPCServer,experimental,@grafana/identity-access-team,false,false,false
 2024-06-19,zanzana,experimental,@grafana/identity-access-team,false,false,false
 2025-10-21,zanzanaNoLegacyClient,experimental,@grafana/identity-access-team,false,false,false
-2026-03-25,zanzanaSearchUsersPermissions,experimental,@grafana/identity-access-team,false,false,false
+2026-04-13,zanzanaMergeUserPermissions,experimental,@grafana/identity-access-team,false,false,false
 2024-10-25,reloadDashboardsOnParamsChange,experimental,@grafana/dashboards-squad,false,false,false
 2024-11-06,enableScopesInMetricsExplore,experimental,@grafana/dashboards-squad,false,false,false
 2024-06-27,cloudWatchRoundUpEndTime,GA,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -411,9 +411,9 @@ const (
 	// Use openFGA as main authorization engine and disable legacy RBAC clietn.
 	FlagZanzanaNoLegacyClient = "zanzanaNoLegacyClient"
 
-	// FlagZanzanaSearchUsersPermissions
-	// Search users permissions using Zanzana.
-	FlagZanzanaSearchUsersPermissions = "zanzanaSearchUsersPermissions"
+	// FlagZanzanaMergeUserPermissions
+	// Merge Zanzana permissions into legacy RBAC for access-control API endpoints.
+	FlagZanzanaMergeUserPermissions = "zanzanaMergeUserPermissions"
 
 	// FlagReloadDashboardsOnParamsChange
 	// Enables reload of dashboards on scopes, time range and variables changes

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5777,6 +5777,20 @@
     },
     {
       "metadata": {
+        "name": "zanzanaMergeUserPermissions",
+        "resourceVersion": "1776107616688",
+        "creationTimestamp": "2026-04-13T19:13:36Z"
+      },
+      "spec": {
+        "description": "Merge Zanzana permissions into legacy RBAC for access-control API endpoints.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "zanzanaNoLegacyClient",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-10-21T14:03:17Z"
@@ -5794,6 +5808,7 @@
         "name": "zanzanaSearchUsersPermissions",
         "resourceVersion": "1776076870099",
         "creationTimestamp": "2026-03-25T09:17:53Z",
+        "deletionTimestamp": "2026-04-13T19:13:36Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2026-04-13 10:41:10.099738 +0000 UTC"
         }


### PR DESCRIPTION
## Summary

Merges Zanzana permissions with legacy RBAC for:
- `GET /api/access-control/user/actions`
- `GET /api/access-control/user/permissions`
- `GET /api/access-control/users/permissions/search` (existing merge path, renamed flag)

Renames feature flag `zanzanaSearchUsersPermissions` to `zanzanaMergeUserPermissions`.