### PR TITLE
CLI: Fix reset-admin-password failing on PostgreSQL due to boolean = integer comparison

### DIFF
--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -110,7 +110,8 @@ type adminFilter struct{}
 
 func (f *adminFilter) WhereCondition() *user.WhereCondition {
 	return &user.WhereCondition{
-		Condition: "is_admin = 1",
+		Condition: "is_admin = ?",
+		Params:    true,
 	}
 }
 

--- a/pkg/cmd/grafana-cli/commands/reset_password_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 )
 
+func TestAdminFilterWhereCondition(t *testing.T) {
+	// "is_admin = 1" is invalid on PostgreSQL where is_admin is a boolean column.
+	// Condition must use a placeholder with Params: true.
+	f := &adminFilter{}
+	wc := f.WhereCondition()
+	require.NotNil(t, wc)
+	require.Contains(t, wc.Condition, "?", "condition must use a parameter placeholder, not a hardcoded integer")
+	require.Equal(t, true, wc.Params)
+}
+
 func TestResetPassword(t *testing.T) {
 	tests := map[string]struct {
 		UserID    int64


### PR DESCRIPTION
## Summary

- Replace hardcoded `is_admin = 1` with parameterized `is_admin = ?` + `Params: true` in `adminFilter.WhereCondition()`
- xorm now emits the correct boolean literal per dialect instead of an integer

**Before:** `reset-admin-password` fails on PostgreSQL with `pq: operator does not exist: boolean = integer`

**After:** command succeeds on all supported databases (SQLite, MySQL, PostgreSQL)

## Which issue(s) does this PR fix?

Fixes #122206
Related: #106241

## Special notes for your reviewer:

The same parameterized pattern is already used elsewhere in the codebase (e.g. `sess.Where("is_admin=?", true)` in `userimpl/store.go:440`). This PR brings `adminFilter` in line with that convention.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
