### PR TITLE
[release-13.0.0] fix: use xz compression in deb packages (#122471)

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -109,7 +109,7 @@ fpm \
   --license="${FPM_LICENSE:-AGPLv3}" \
   --name="${DEB_PACKAGE_NAME}" \
   --deb-no-default-config-files \
-  --deb-compression zst \
+  --deb-compression xz \
   .
 
 echo "created dist/${FILENAME}"


### PR DESCRIPTION
fix: use xz compression in deb packages (#122448)

use xz compression deb

(cherry picked from commit 29a79d446a21bb83703be13c7582539f0b83d68c)