### PR TITLE
Tempo: Fix grammar in streaming info box

### DIFF
--- a/public/app/plugins/datasource/tempo/configuration/StreamingSection.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/StreamingSection.tsx
@@ -33,7 +33,7 @@ export const StreamingSection = ({ options, onOptionsChange }: Props) => {
       }
     >
       <Alert severity="info" title="Streaming and self-managed Tempo instances">
-        If your Tempo instance is behind a load balancer or proxy that does not supporting gRPC or HTTP2, streaming will
+        If your Tempo instance is behind a load balancer or proxy that does not support gRPC or HTTP2, streaming will
         probably not work and should be disabled.
       </Alert>
       <InlineFieldRow>


### PR DESCRIPTION
## Summary
- Fix grammatical error in Tempo streaming configuration: "does not supporting" → "does not support"
- File: `public/app/plugins/datasource/tempo/configuration/StreamingSection.tsx`

## Test plan
- [x] Verify the info box text reads correctly in the Tempo data source streaming settings

<img width="938" height="364" alt="image" src="https://github.com/user-attachments/assets/4040e4cc-9d16-4d78-b0b6-302090a4ded4" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)