### PR TITLE
SplashContent: Update Assistant URL to use window location origin

### DIFF
--- a/public/app/core/components/SplashScreenModal/splashContent.ts
+++ b/public/app/core/components/SplashScreenModal/splashContent.ts
@@ -54,7 +54,7 @@ export function getSplashScreenConfig(): SplashScreenConfig {
         ],
         cta: {
           text: t('splash-screen.assistant.cta', 'Show me'),
-          url: `https://grafana.com/grafana/plugins/grafana-assistant-app/?${UTM}`,
+          url: `${window.location.origin}/plugins/grafana-assistant-app/?${UTM}`,
         },
         heroImageUrl: assistantHeroImage,
       },


### PR DESCRIPTION
**What is this feature?**

Changes the URL to be in-grafana.