### PR TITLE
Dashboards: Fix collapse/expand all rows keyboard shortcuts

### DIFF
--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -255,6 +255,14 @@ describe('setupKeyboardShortcuts', () => {
       expect(vBinding).toBeDefined();
       expect(drBinding).toBeDefined();
     });
+
+    it('should setup collapse/expand all rows shortcuts when cannot edit', () => {
+      const collapseBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 'd shift+c');
+      const expandBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 'd shift+e');
+
+      expect(collapseBinding).toBeDefined();
+      expect(expandBinding).toBeDefined();
+    });
   });
 
   describe('time range zoom shortcuts with feature toggle', () => {

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -20,6 +20,7 @@ import { DashboardScene } from './DashboardScene';
 import { onRemovePanel, toggleVizPanelLegend } from './PanelMenuBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 import { RowsLayoutManager } from './layout-rows/RowsLayoutManager';
+import { TabsLayoutManager } from './layout-tabs/TabsLayoutManager';
 
 export function setupKeyboardShortcuts(scene: DashboardScene) {
   const keybindings = new KeybindingSet();
@@ -270,30 +271,29 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
       }),
     });
 
-    // collapse all rows
-    keybindings.addBinding({
-      key: 'd shift+c',
-      onTrigger: () => {
-        if (scene.state.body instanceof DefaultGridLayoutManager) {
-          scene.state.body.collapseAllRows();
-        } else if (scene.state.body instanceof RowsLayoutManager) {
-          scene.state.body.collapseAllRows();
-        }
-      },
-    });
-
-    // expand all rows
-    keybindings.addBinding({
-      key: 'd shift+e',
-      onTrigger: () => {
-        if (scene.state.body instanceof DefaultGridLayoutManager) {
-          scene.state.body.expandAllRows();
-        } else if (scene.state.body instanceof RowsLayoutManager) {
-          scene.state.body.expandAllRows();
-        }
-      },
-    });
   }
+
+  // collapse all rows
+  keybindings.addBinding({
+    key: 'd shift+c',
+    onTrigger: () => {
+      const layout = getRowCollapseTarget(scene);
+      if (layout) {
+        layout.collapseAllRows();
+      }
+    },
+  });
+
+  // expand all rows
+  keybindings.addBinding({
+    key: 'd shift+e',
+    onTrigger: () => {
+      const layout = getRowCollapseTarget(scene);
+      if (layout) {
+        layout.expandAllRows();
+      }
+    },
+  });
 
   // toggle all panel legends (TODO)
   // toggle all exemplars (TODO)
@@ -302,6 +302,23 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     keybindings.removeAll();
     panelAttentionSubscription.unsubscribe();
   };
+}
+
+function getRowCollapseTarget(scene: DashboardScene): DefaultGridLayoutManager | RowsLayoutManager | undefined {
+  const body = scene.state.body;
+
+  if (body instanceof DefaultGridLayoutManager || body instanceof RowsLayoutManager) {
+    return body;
+  }
+
+  if (body instanceof TabsLayoutManager) {
+    const tabLayout = body.getCurrentTab()?.getLayout();
+    if (tabLayout instanceof DefaultGridLayoutManager || tabLayout instanceof RowsLayoutManager) {
+      return tabLayout;
+    }
+  }
+
+  return undefined;
 }
 
 function handleZoom(scene: DashboardScene, scale: number) {

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -270,7 +270,6 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
         }
       }),
     });
-
   }
 
   // collapse all rows


### PR DESCRIPTION
## What

Fixes the `d Shift+C` (collapse all rows) and `d Shift+E` (expand all rows) keyboard shortcuts which were broken for read-only users and on tabbed dashboards.

## Why

Two issues:

1. **Permission gate regression.** Both bindings were inside the `if (canEdit)` block, so they never registered for users without edit permissions. Collapsing/expanding rows is a view-mode operation - it doesn't mutate the dashboard. The legacy `keybindingSrv.ts` had no such gate.

2. **Missing TabsLayoutManager support.** The handlers only checked `instanceof DefaultGridLayoutManager` and `instanceof RowsLayoutManager`. On tabbed dashboards the body is a `TabsLayoutManager`, so the checks silently failed. Added `getRowCollapseTarget()` that delegates to the current tab's inner layout.

Fixes #100622

## How to test

1. Open a dashboard with rows (either `DefaultGridLayoutManager` or `RowsLayoutManager`)
2. Verify `d` then `Shift+C` collapses all rows
3. Verify `d` then `Shift+E` expands all rows
4. Switch to a viewer role (or open as a user without edit permissions) and verify the shortcuts still work
5. Open a tabbed dashboard with rows inside a tab and verify the shortcuts work on the current tab's rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)