### PR TITLE
Dashboards:  copy-paste a row or tab from one dashboard to another dashboards

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -7,6 +7,7 @@ import {
 import { getLayoutType } from 'app/features/dashboard/utils/tracking';
 
 import { TabItem } from '../scene/layout-tabs/TabItem';
+import { pasteRowTo, pasteTabTo } from '../scene/layouts-shared/addNew';
 import { getRepeatCloneSourceKey } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDefaultVizPanel, getLayoutForObject, getDashboardSceneFor } from '../utils/utils';
@@ -411,6 +412,18 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     }
 
     DashboardInteractions.trackPastePanelClick(source, getLayoutType(target), 'click');
+  }
+
+  public pasteRow(targetElement?: SceneObject) {
+    const dashboard = getDashboardSceneFor(this);
+    const layout = targetElement ? (getLayoutForObject(targetElement) ?? dashboard.getLayout()) : dashboard.getLayout();
+    pasteRowTo(layout);
+  }
+
+  public pasteTab(targetElement?: SceneObject) {
+    const dashboard = getDashboardSceneFor(this);
+    const layout = targetElement ? (getLayoutForObject(targetElement) ?? dashboard.getLayout()) : dashboard.getLayout();
+    pasteTabTo(layout);
   }
 }
 

--- a/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.tsx
@@ -20,7 +20,7 @@ export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
   const { hasCopiedPanel, hasCopiedRow, hasCopiedTab } = useClipboardState();
 
   // TODO this type check here is hacky and should be replaced with a more generic solid solution
-  const canPaste = element instanceof RowItem || element instanceof TabItem ? element : undefined;
+  const pasteTarget = element instanceof RowItem || element instanceof TabItem ? element : undefined;
   const onCopy = element.onCopy?.bind(element);
   const onDuplicate = element.onDuplicate?.bind(element);
   const onDelete = element.onDelete?.bind(element);
@@ -53,7 +53,7 @@ export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
                     onClick={onDuplicate}
                   />
                 ) : null}
-                {canPaste && hasCopiedPanel ? (
+                {pasteTarget && hasCopiedPanel ? (
                   <Menu.Item
                     icon="clipboard-alt"
                     label={t('dashboard.layout.common.paste', 'Paste')}

--- a/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/EditPaneHeader.tsx
@@ -17,7 +17,7 @@ interface EditPaneHeaderProps {
 
 export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
   const elementInfo = element.getEditableElementInfo();
-  const { hasCopiedPanel } = useClipboardState();
+  const { hasCopiedPanel, hasCopiedRow, hasCopiedTab } = useClipboardState();
 
   // TODO this type check here is hacky and should be replaced with a more generic solid solution
   const canPaste = element instanceof RowItem || element instanceof TabItem ? element : undefined;
@@ -59,6 +59,20 @@ export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
                     label={t('dashboard.layout.common.paste', 'Paste')}
                     onClick={() => editPane.pastePanel(editPane.getSelectedObject(), 'editPaneHeader')}
                     data-testid={selectors.components.EditPaneHeader.paste}
+                  />
+                ) : null}
+                {pasteTarget && hasCopiedRow ? (
+                  <Menu.Item
+                    icon="clipboard-alt"
+                    label={t('dashboard.layout.common.paste-row', 'Paste row')}
+                    onClick={() => editPane.pasteRow(pasteTarget)}
+                  />
+                ) : null}
+                {pasteTarget && hasCopiedTab ? (
+                  <Menu.Item
+                    icon="clipboard-alt"
+                    label={t('dashboard.layout.common.paste-tab', 'Paste tab')}
+                    onClick={() => editPane.pasteTab(pasteTarget)}
                   />
                 ) : null}
               </Menu>

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
@@ -31,7 +31,7 @@ export class AddNewEditPane extends SceneObjectBase {
 
 export function AddNewEditPaneRenderer({ model }: SceneComponentProps<AddNewEditPane>) {
   const editPane = sceneGraph.getAncestor(model, DashboardEditPane);
-  const { hasCopiedPanel } = useClipboardState();
+  const { hasCopiedPanel, hasCopiedRow, hasCopiedTab } = useClipboardState();
   const styles = useStyles2(getStyles);
   const dashboardScene = getDashboardSceneFor(model);
   const orchestrator = dashboardScene.state.layoutOrchestrator;
@@ -127,6 +127,38 @@ export function AddNewEditPaneRenderer({ model }: SceneComponentProps<AddNewEdit
         <AddNewSection title={t('dashboard-scene.add-new-edit-pane.group-layouts', 'Group layouts')}>
           <AddRow dashboardScene={dashboardScene} selectedElement={selectedObj} />
           <AddTab dashboardScene={dashboardScene} selectedElement={selectedObj} />
+          {hasCopiedRow && (
+            <AddButton
+              icon="clipboard-alt"
+              tabIndex={0}
+              onClick={() => editPane.pasteRow(selectedObj)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  editPane.pasteRow(selectedObj);
+                }
+              }}
+              aria-label={t('dashboard.canvas-actions.add.paste-row.title', 'Paste row')}
+              label={t('dashboard.canvas-actions.add.paste-row.title', 'Paste row')}
+              tooltip={t('dashboard.canvas-actions.add.paste-row.description', 'Click to paste row from clipboard')}
+            />
+          )}
+          {hasCopiedTab && (
+            <AddButton
+              icon="clipboard-alt"
+              tabIndex={0}
+              onClick={() => editPane.pasteTab(selectedObj)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  editPane.pasteTab(selectedObj);
+                }
+              }}
+              aria-label={t('dashboard.canvas-actions.add.paste-tab.title', 'Paste tab')}
+              label={t('dashboard.canvas-actions.add.paste-tab.title', 'Paste tab')}
+              tooltip={t('dashboard.canvas-actions.add.paste-tab.description', 'Click to paste tab from clipboard')}
+            />
+          )}
         </AddNewSection>
         <AddNewSection title={t('dashboard-scene.dashboard-side-pane-new.dashboard-controls', 'Dashboard controls')}>
           {config.featureToggles.dashboardUnifiedDrilldownControls && <AddFilters dashboardScene={dashboardScene} />}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.test.tsx
@@ -37,6 +37,8 @@ jest.mock('./addNew', () => ({
   ...jest.requireActual('./addNew'),
   addNewRowTo: jest.fn(),
   addNewTabTo: jest.fn(),
+  pasteRowTo: jest.fn(),
+  pasteTabTo: jest.fn(),
 }));
 
 // mock useClipboardState
@@ -44,6 +46,8 @@ jest.mock('./useClipboardState', () => ({
   ...jest.requireActual('./useClipboardState'),
   useClipboardState: () => ({
     hasCopiedPanel: true,
+    hasCopiedRow: true,
+    hasCopiedTab: true,
   }),
 }));
 
@@ -131,6 +135,28 @@ describe('CanvasGridAddActions', () => {
 
       await user.click(await screen.findByTestId(selectors.components.CanvasGridAddActions.pastePanel));
       expect(DashboardInteractions.trackPastePanelClick).toHaveBeenCalled();
+    });
+
+    it('should render the paste row button and call pasteRowTo when clicked', async () => {
+      const { pasteRowTo } = jest.requireMock('./addNew');
+      const scene = buildTestScene();
+      const layoutManager = scene.state.body;
+      const user = userEvent.setup();
+      render(<CanvasGridAddActions layoutManager={layoutManager} />);
+
+      await user.click(await screen.findByTestId(selectors.components.CanvasGridAddActions.pasteRow));
+      expect(pasteRowTo).toHaveBeenCalledWith(layoutManager);
+    });
+
+    it('should render the paste tab button and call pasteTabTo when clicked', async () => {
+      const { pasteTabTo } = jest.requireMock('./addNew');
+      const scene = buildTestScene();
+      const layoutManager = scene.state.body;
+      const user = userEvent.setup();
+      render(<CanvasGridAddActions layoutManager={layoutManager} />);
+
+      await user.click(await screen.findByTestId(selectors.components.CanvasGridAddActions.pasteTab));
+      expect(pasteTabTo).toHaveBeenCalledWith(layoutManager);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -12,7 +12,7 @@ import { getDefaultVizPanel } from '../../utils/utils';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { type DashboardLayoutManager, isDashboardLayoutManager } from '../types/DashboardLayoutManager';
 
-import { addNewRowTo, addNewTabTo } from './addNew';
+import { addNewRowTo, addNewTabTo, pasteRowTo, pasteTabTo } from './addNew';
 import { getLayoutControlsStyles } from './styles';
 import { useClipboardState } from './useClipboardState';
 
@@ -23,7 +23,7 @@ export interface Props {
 export function CanvasGridAddActions({ layoutManager }: Props) {
   const styles = useStyles2(getLayoutControlsStyles);
   const localStyles = useStyles2(getStyles);
-  const { hasCopiedPanel } = useClipboardState();
+  const { hasCopiedPanel, hasCopiedRow, hasCopiedTab } = useClipboardState();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { disableGrouping, disableTabs } = useNestingRestrictions(layoutManager);
 
@@ -110,6 +110,32 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
           }}
         >
           <Trans i18nKey="dashboard.canvas-actions.paste-panel">Paste panel</Trans>
+        </Button>
+      )}
+      {hasCopiedRow && (
+        <Button
+          data-testid={selectors.components.CanvasGridAddActions.pasteRow}
+          variant="secondary"
+          icon="clipboard-alt"
+          size="sm"
+          onClick={() => {
+            pasteRowTo(layoutManager);
+          }}
+        >
+          <Trans i18nKey="dashboard.canvas-actions.paste-row">Paste row</Trans>
+        </Button>
+      )}
+      {hasCopiedTab && !disableTabs && (
+        <Button
+          data-testid={selectors.components.CanvasGridAddActions.pasteTab}
+          variant="secondary"
+          icon="clipboard-alt"
+          size="sm"
+          onClick={() => {
+            pasteTabTo(layoutManager);
+          }}
+        >
+          <Trans i18nKey="dashboard.canvas-actions.paste-tab">Paste tab</Trans>
         </Button>
       )}
     </div>

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -8,7 +8,7 @@ import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
 import { TabItem } from '../layout-tabs/TabItem';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 
-import { addNewRowTo, addNewTabTo } from './addNew';
+import { addNewRowTo, addNewTabTo, pasteRowTo, pasteTabTo } from './addNew';
 
 jest.mock('../../edit-pane/shared', () => ({
   dashboardEditActions: {
@@ -23,6 +23,11 @@ jest.mock('../../edit-pane/shared', () => ({
     }),
   },
   NewObjectAddedToCanvasEvent: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('./paste', () => ({
+  getRowFromClipboard: jest.fn(() => new RowItem({ title: 'Pasted Row' })),
+  getTabFromClipboard: jest.fn(() => new TabItem({ title: 'Pasted Tab' })),
 }));
 
 function buildScene(body: DashboardScene['state']['body']) {
@@ -176,5 +181,90 @@ describe('addNewRowTo', () => {
       expect(innerRows.state.rows[0].state.title).toBe('Row A');
       expect(innerRows.state.rows[1].getLayout().getVizPanels()).toHaveLength(0);
     });
+  });
+});
+
+describe('pasteRowTo', () => {
+  let originalDashboardNewLayouts: boolean | undefined;
+
+  beforeAll(() => {
+    originalDashboardNewLayouts = config.featureToggles.dashboardNewLayouts;
+    config.featureToggles.dashboardNewLayouts = true;
+  });
+
+  afterAll(() => {
+    config.featureToggles.dashboardNewLayouts = originalDashboardNewLayouts;
+  });
+
+  it('should call pasteRow when layout is already a RowsLayoutManager', () => {
+    const rowsLayout = new RowsLayoutManager({
+      rows: [new RowItem({ title: 'Existing Row' })],
+    });
+    buildScene(rowsLayout);
+
+    rowsLayout.pasteRow = jest.fn();
+    pasteRowTo(rowsLayout);
+
+    expect(rowsLayout.pasteRow).toHaveBeenCalled();
+  });
+
+  it('should replace layout with a RowsLayoutManager containing only the pasted row when layout is a plain grid', () => {
+    const grid = DefaultGridLayoutManager.fromVizPanels([]);
+    buildScene(grid);
+
+    pasteRowTo(grid);
+
+    const newBody = (grid.parent as DashboardScene).state.body;
+    expect(newBody).toBeInstanceOf(RowsLayoutManager);
+
+    const rows = (newBody as RowsLayoutManager).state.rows;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].state.title).toBe('Pasted Row');
+  });
+
+  it('should recurse into the current tab when layout is a TabsLayoutManager', () => {
+    const innerGrid = DefaultGridLayoutManager.fromVizPanels([]);
+    const tab = new TabItem({ title: 'Tab 1', layout: innerGrid });
+    const tabsLayout = new TabsLayoutManager({ tabs: [tab] });
+    tabsLayout.setState({ currentTabSlug: tab.getSlug() });
+    buildScene(tabsLayout);
+
+    pasteRowTo(tabsLayout);
+
+    // The tab's inner layout should have been replaced with a RowsLayoutManager
+    const tabLayout = tab.getLayout();
+    expect(tabLayout).toBeInstanceOf(RowsLayoutManager);
+
+    const rows = (tabLayout as RowsLayoutManager).state.rows;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].state.title).toBe('Pasted Row');
+  });
+});
+
+describe('pasteTabTo', () => {
+  it('should call pasteTab when layout is already a TabsLayoutManager', () => {
+    const tabsLayout = new TabsLayoutManager({
+      tabs: [new TabItem({ title: 'Existing Tab' })],
+    });
+    buildScene(tabsLayout);
+
+    tabsLayout.pasteTab = jest.fn();
+    pasteTabTo(tabsLayout);
+
+    expect(tabsLayout.pasteTab).toHaveBeenCalled();
+  });
+
+  it('should replace layout with a TabsLayoutManager containing only the pasted tab when layout is a plain grid', () => {
+    const grid = DefaultGridLayoutManager.fromVizPanels([]);
+    buildScene(grid);
+
+    pasteTabTo(grid);
+
+    const newBody = (grid.parent as DashboardScene).state.body;
+    expect(newBody).toBeInstanceOf(TabsLayoutManager);
+
+    const tabs = (newBody as TabsLayoutManager).state.tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].state.title).toBe('Pasted Tab');
   });
 });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -2,6 +2,7 @@ import { config } from '@grafana/runtime';
 import { type SceneGridRow } from '@grafana/scenes';
 
 import { NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
+import { getDashboardSceneFor } from '../../utils/utils';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { type RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
@@ -9,6 +10,8 @@ import { type TabItem } from '../layout-tabs/TabItem';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
+
+import { getRowFromClipboard, getTabFromClipboard } from './paste';
 
 export function addNewTabTo(layout: DashboardLayoutManager): TabItem {
   const layoutParent = layout.parent!;
@@ -71,4 +74,56 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   layout.publishEvent(new NewObjectAddedToCanvasEvent(row), true);
 
   return row;
+}
+
+export function pasteRowTo(layout: DashboardLayoutManager): void {
+  const scene = getDashboardSceneFor(layout);
+
+  if (layout instanceof RowsLayoutManager) {
+    layout.pasteRow();
+    return;
+  }
+
+  if (layout instanceof TabsLayoutManager) {
+    const currentTab = layout.getCurrentTab();
+    if (!currentTab) {
+      throw new Error('Could not find currently active tab');
+    }
+    pasteRowTo(currentTab.state.layout);
+    return;
+  }
+
+  const layoutParent = layout.parent!;
+  if (!isLayoutParent(layoutParent)) {
+    throw new Error('Parent layout is not a LayoutParent');
+  }
+
+  // Wrap current layout in rows layout, then paste the row
+  const rowsLayout = RowsLayoutManager.createFromLayout(layoutParent.getLayout());
+  layoutParent.switchLayout(rowsLayout);
+
+  const row = getRowFromClipboard(scene);
+  rowsLayout.addNewRow(row);
+}
+
+export function pasteTabTo(layout: DashboardLayoutManager): void {
+  const scene = getDashboardSceneFor(layout);
+
+  if (layout instanceof TabsLayoutManager) {
+    layout.pasteTab();
+    return;
+  }
+
+  const layoutParent = layout.parent!;
+  if (!isLayoutParent(layoutParent)) {
+    throw new Error('Parent layout is not a LayoutParent');
+  }
+
+  // Create new tabs layout and wrap the current layout in the first tab, then paste the new tab
+  const tabsLayout = TabsLayoutManager.createEmpty();
+  tabsLayout.state.tabs[0].setState({ layout: layout.clone() });
+  layoutParent.switchLayout(tabsLayout);
+
+  const tab = getTabFromClipboard(scene);
+  tabsLayout.addNewTab(tab);
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -98,12 +98,11 @@ export function pasteRowTo(layout: DashboardLayoutManager): void {
     throw new Error('Parent layout is not a LayoutParent');
   }
 
-  // Wrap current layout in rows layout, then paste the row
-  const rowsLayout = RowsLayoutManager.createFromLayout(layoutParent.getLayout());
-  layoutParent.switchLayout(rowsLayout);
-
+  // Create a rows layout with only the pasted row (don't wrap existing content into an extra row)
   const row = getRowFromClipboard(scene);
-  rowsLayout.addNewRow(row);
+  const rowsLayout = new RowsLayoutManager({ rows: [row] });
+  layoutParent.switchLayout(rowsLayout);
+  layout.publishEvent(new NewObjectAddedToCanvasEvent(row), true);
 }
 
 export function pasteTabTo(layout: DashboardLayoutManager): void {
@@ -119,11 +118,9 @@ export function pasteTabTo(layout: DashboardLayoutManager): void {
     throw new Error('Parent layout is not a LayoutParent');
   }
 
-  // Create new tabs layout and wrap the current layout in the first tab, then paste the new tab
-  const tabsLayout = TabsLayoutManager.createEmpty();
-  tabsLayout.state.tabs[0].setState({ layout: layout.clone() });
-  layoutParent.switchLayout(tabsLayout);
-
+  // Create a tabs layout with only the pasted tab (don't wrap existing content into an extra tab)
   const tab = getTabFromClipboard(scene);
-  tabsLayout.addNewTab(tab);
+  const tabsLayout = new TabsLayoutManager({ tabs: [tab] });
+  layoutParent.switchLayout(tabsLayout);
+  layout.publishEvent(new NewObjectAddedToCanvasEvent(tab), true);
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5345,6 +5345,14 @@
         "paste": {
           "description": "Click or drag to paste panel",
           "title": "Paste panel"
+        },
+        "paste-row": {
+          "description": "Click to paste row from clipboard",
+          "title": "Paste row"
+        },
+        "paste-tab": {
+          "description": "Click to paste tab from clipboard",
+          "title": "Paste tab"
         }
       },
       "add-panel": "Add panel",
@@ -5976,7 +5984,9 @@
         "delete": "Delete",
         "duplicate": "Duplicate",
         "layout": "Layout",
-        "paste": "Paste"
+        "paste": "Paste",
+        "paste-row": "Paste row",
+        "paste-tab": "Paste tab"
       },
       "continue": "Continue",
       "panel": {


### PR DESCRIPTION

### Description of the change :
1. In the `addNew.ts` : Added  pasteRowTo() / pasteTabTo() routing helpers.
2. In the ` CanvasGridAddActions.tsx` : Added "Paste row" / "Paste tab" buttons on canvas.
3.  ` EditPaneHeader.tsx` : Added paste row/tab items in copy dropdown.
4. ` AddNewEditPane.tsx` : Added paste row/tab buttons in Add sidebar.
5.  ` DashboardEditPane.tsx` : Added pasteRow() /  pasteTab() methods.
6.  `DashboardEditPaneRendere.tsx` : Passed callbacks to sidebar.



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #121749

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/7156aeed-75ed-4ec8-b4a0-f174d0d72d7f



Please check that:
- [x] It works as expected from a user's perspective.