### PR TITLE
Dashboards: Fix restore failing with API version mismatch on upgraded instances

### DIFF
--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'app/features/apiserver/types';
 import { type DashboardDataDTO } from 'app/types/dashboard';
 
+import { dashboardAPIVersionResolver } from './DashboardAPIVersionResolver';
 import { type DashboardWithAccessInfo } from './types';
 import { K8sDashboardAPI } from './v1';
 
@@ -126,6 +127,7 @@ jest.mock('app/features/live/dashboard/dashboardWatcher', () => ({
 describe('v1 dashboard API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    dashboardAPIVersionResolver.set({ v1: 'v1', v2: 'v2' });
   });
 
   it('should provide folder annotations', async () => {
@@ -415,7 +417,7 @@ describe('v1 dashboard API', () => {
 
       expect(mockPut).toHaveBeenCalledTimes(1);
       expect(mockPut).toHaveBeenCalledWith(
-        '/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/test-dash',
+        '/apis/dashboard.grafana.app/v1/namespaces/default/dashboards/test-dash',
         expect.objectContaining({
           metadata: expect.objectContaining({
             annotations: expect.objectContaining({
@@ -631,7 +633,7 @@ describe('v1 dashboard API', () => {
 
       expect(dashboardToRestore.metadata.resourceVersion).toBe('');
       expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v1beta1/'),
+        expect.stringContaining('/apis/dashboard.grafana.app/v1/'),
         expect.objectContaining({
           metadata: expect.objectContaining({
             resourceVersion: '',
@@ -674,13 +676,36 @@ describe('v1 dashboard API', () => {
       await api.restoreDashboard(dashboardToRestore);
 
       expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v1beta1/'),
+        expect.stringContaining('/apis/dashboard.grafana.app/v1/'),
         expect.objectContaining({
           metadata: expect.objectContaining({
             annotations: expect.objectContaining({
               [AnnoKeyFolder]: 'randomFolderUid',
             }),
           }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should correct apiVersion when input has stale version', async () => {
+      const dashboardToRestore = {
+        ...mockDashboardDto,
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        metadata: {
+          ...mockDashboardDto.metadata,
+          resourceVersion: '123456',
+        },
+      };
+
+      const api = new K8sDashboardAPI();
+      await api.restoreDashboard(dashboardToRestore);
+
+      expect(dashboardToRestore.apiVersion).toBe('dashboard.grafana.app/v1');
+      expect(mockPost).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/v1/'),
+        expect.objectContaining({
+          apiVersion: 'dashboard.grafana.app/v1',
         }),
         expect.anything()
       );

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -313,6 +313,10 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
       ...dashboard.metadata.annotations,
       [AnnoKeyGrantPermissions]: 'default',
     };
+    // Ensure apiVersion matches the endpoint version to prevent K8s API rejection
+    // when the stored resource has a stale version (e.g. v1beta1)
+    const { group, version } = getK8sV1DashboardApiConfig();
+    dashboard.apiVersion = `${group}/${version}`;
     return this.client.create(dashboard);
   }
 }

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -607,5 +607,28 @@ describe('v2 dashboard API', () => {
         expect.anything()
       );
     });
+
+    it('should correct apiVersion when input has stale version', async () => {
+      const dashboardToRestore = {
+        ...mockDashboardDto,
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        metadata: {
+          ...mockDashboardDto.metadata,
+          resourceVersion: '123456',
+        },
+      };
+
+      const api = new K8sDashboardV2API();
+      await api.restoreDashboard(dashboardToRestore);
+
+      expect(dashboardToRestore.apiVersion).toBe('dashboard.grafana.app/v2');
+      expect(mockPost).toHaveBeenCalledWith(
+        expect.stringContaining('/apis/dashboard.grafana.app/v2/'),
+        expect.objectContaining({
+          apiVersion: 'dashboard.grafana.app/v2',
+        }),
+        expect.anything()
+      );
+    });
   });
 });

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -259,6 +259,10 @@ export class K8sDashboardV2API
       ...dashboard.metadata.annotations,
       [AnnoKeyGrantPermissions]: 'default',
     };
+    // Ensure apiVersion matches the endpoint version to prevent K8s API rejection
+    // when the stored resource has a stale version (e.g. v2beta1)
+    const { group, version } = getK8sV2DashboardApiConfig();
+    dashboard.apiVersion = `${group}/${version}`;
     return this.client.create(dashboard);
   }
 }

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -20,6 +20,7 @@ import { getAPIBaseURL } from 'app/api/utils';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { contextSrv } from 'app/core/services/context_srv';
 import kbn from 'app/core/utils/kbn';
+import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/DashboardAPIVersionResolver';
 import { dispatch } from 'app/store/store';
 
 import { deletedDashboardsCache } from './deletedDashboardsCache';
@@ -366,7 +367,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
     }
 
     if (query.deleted) {
-      uri = `${getAPIBaseURL(DASHBOARD_API_GROUP, 'v1beta1')}/dashboards/?labelSelector=grafana.app/get-trash=true`;
+      uri = `${getAPIBaseURL(DASHBOARD_API_GROUP, dashboardAPIVersionResolver.getV1())}/dashboards/?labelSelector=grafana.app/get-trash=true`;
     }
     return uri;
   }


### PR DESCRIPTION
## What

Fix `restoreDashboard()` in both `v1.ts` and `v2.ts` to set the correct `apiVersion` on the resource body before posting it, and fix the hardcoded `v1beta1` in the deleted-dashboards search URL in `unified.ts`.

## Why

When restoring a deleted dashboard from "Recently deleted", the request fails with:

> the API version in the data (dashboard.grafana.app/v1beta1) does not match the expected API version (dashboard.grafana.app/v1)

Trashed resources retain their original stored `apiVersion` (e.g. `v1beta1`), but `ScopedResourceClient` sends the request to the resolved `/v1/` endpoint. The K8s API server rejects the mismatch with 400.

This affects instances upgraded through v1beta1 → v1 (13.0.0+).

### Changes

- `v1.ts` / `v2.ts`: derive `group` and `version` from the resolved API config and set `dashboard.apiVersion` before calling `this.client.create()`
- `unified.ts`: replace hardcoded `v1beta1` with `dashboardAPIVersionResolver.getV1()`
- Added test coverage for the stale-apiVersion restore path in both `v1.test.ts` and `v2.test.ts`

Fixes #122532