### PR TITLE
Draft: Dynamic dashboards: preserve tab/row URL slugs and keep legacy tab URLs working

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -17,7 +17,6 @@ import {
 import { type RowsLayoutRowKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { appEvents } from 'app/core/app_events';
 import { LS_ROW_COPY_KEY } from 'app/core/constants';
-import kbn from 'app/core/utils/kbn';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
@@ -122,7 +121,7 @@ export class RowItem
   }
 
   public getSlug(): string {
-    return kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Row'));
+    return interpolateSectionTitle(this, this.state.title ?? 'Row').replace(/ +/g, '-');
   }
 
   public switchLayout(layout: DashboardLayoutManager) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -17,7 +17,6 @@ import {
 import { type TabsLayoutTabKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { appEvents } from 'app/core/app_events';
 import { LS_TAB_COPY_KEY } from 'app/core/constants';
-import kbn from 'app/core/utils/kbn';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
@@ -122,7 +121,7 @@ export class TabItem
   }
 
   public getSlug(): string {
-    return kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Tab'));
+    return interpolateSectionTitle(this, this.state.title ?? 'Tab').replace(/ +/g, '-');
   }
 
   public isCurrentTab() {


### PR DESCRIPTION
Fix for https://github.com/grafana/grafana/issues/120022 and https://github.com/grafana/grafana/issues/122447

Opted to just replace `-`. The original function lowercased and replaced special characters. 

This will break existing links (for instances with DD enabled), however better sooner than later? 🤷🏻‍♀️

**Tested that tabs and rows upon select + after refresh link correctly for:** 

1. Plus sign: Tab title: e.g. New tab +
Expect: In the address bar, the dtab=... part should contain %2B, not a bare + in the value (a bare + is ambiguous for query parsers).

2. Characters that would break a naive query string
tab titles that include (alone or combined):
  - & (e.g. Sales & Marketing)
  - = (e.g. a=b)
  - hastag (e.g. see # 1)
  - ? (e.g. why?)
  - / (e.g. east/west)

    Expect: In the query string, those characters appear percent-encoded in the value of dtab=... (and if nested, possibly in the param name as well, e.g. parentSlug-dtab).

3. Spaces 
Tab title: Two spaces (double space) vs Two spaces
Expect: Slug reflects your rule (- vs -- if you only replace space runs).

4. Non-ASCII 
Tab title: e.g. 東京 or München
Expect: Longer %-sequences in the URL; after reload, correct tab. Url might contain the exact string, but `window.location.search` should contain encoded url
