### PR TITLE
Preferences: Fix patch support

### DIFF
--- a/pkg/registry/apis/preferences/legacy/preferences.go
+++ b/pkg/registry/apis/preferences/legacy/preferences.go
@@ -14,12 +14,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	authlib "github.com/grafana/authlib/types"
-
 	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	utilsOrig "github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/preferences/utils"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 )
 
@@ -315,6 +315,7 @@ func asPreferencesResource(ns string, p *preferenceModel) preferences.Preference
 		}
 	}
 
+	obj.UID = gapiutil.CalculateClusterWideUID(&obj)
 	return obj
 }
 

--- a/pkg/registry/apis/preferences/legacy/sql.go
+++ b/pkg/registry/apis/preferences/legacy/sql.go
@@ -195,7 +195,7 @@ func (s *LegacySQL) GetTeams(ctx context.Context, id authlib.AuthInfo, admin boo
 	if !ok {
 		return nil, fmt.Errorf("expected identity.Requester")
 	}
-	req := newTeamsQueryReq(sql, xid.GetOrgID(), id.GetUID(), admin)
+	req := newTeamsQueryReq(sql, xid.GetOrgID(), id.GetIdentifier(), admin)
 
 	q, err := sqltemplate.Execute(sqlTeams, req)
 	if err != nil {

--- a/pkg/registry/apis/preferences/register.go
+++ b/pkg/registry/apis/preferences/register.go
@@ -88,6 +88,15 @@ func (b *APIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 		return err
 	}
 
+	// Required for patch (hub version)
+	scheme.AddKnownTypes(schema.GroupVersion{
+		Group:   gv.Group,
+		Version: runtime.APIVersionInternal,
+	},
+		&preferences.Preferences{},
+		&preferences.PreferencesList{},
+	)
+
 	metav1.AddToGroupVersion(scheme, gv)
 	return scheme.SetVersionPriority(gv)
 }

--- a/pkg/registry/apis/preferences/utils/authorizer.go
+++ b/pkg/registry/apis/preferences/utils/authorizer.go
@@ -91,7 +91,11 @@ func (a *AuthorizeFromName) Authorize(ctx context.Context, attr authorizer.Attri
 		if ok {
 			return authorizer.DecisionAllow, "", nil
 		}
-		return authorizer.DecisionDeny, "you are not a member of the referenced team", nil
+		msg := "you are not an admin of the referenced team"
+		if attr.IsReadOnly() {
+			msg = "you are not a member of the referenced team"
+		}
+		return authorizer.DecisionDeny, msg, nil
 
 	case UnknownResourceOwner:
 		return authorizer.DecisionAllow, "", nil

--- a/pkg/tests/apis/preferences/preferences_test.go
+++ b/pkg/tests/apis/preferences/preferences_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 
 	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1alpha1"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -55,10 +57,17 @@ func TestIntegrationPreferences(t *testing.T) {
 			Method: http.MethodPut,
 			Path:   "/api/user/preferences",
 			Body: []byte(`{
-				"weekStart": "saturday"
+				"weekStart": "tuesday"
 			}`),
 		}, &raw)
 		require.Equal(t, http.StatusOK, legacyResponse.Response.StatusCode, "create preference for user")
+
+		out, err := clientAdmin.Resource.Patch(ctx, "user-"+clientAdmin.Args.User.Identity.GetIdentifier(), types.StrategicMergePatchType, []byte(`{
+			"spec": { "weekStart": "saturday" }
+		}`), metav1.PatchOptions{})
+		require.NoError(t, err)
+		v, _, _ := unstructured.NestedString(out.Object, "spec", "weekStart")
+		require.Equal(t, "saturday", v)
 
 		// http://localhost:3000/api/teams/1/preferences
 		legacyResponse = apis.DoRequest(helper, apis.RequestParams{
@@ -71,6 +80,12 @@ func TestIntegrationPreferences(t *testing.T) {
 			}`),
 		}, &raw)
 		require.Equal(t, http.StatusOK, legacyResponse.Response.StatusCode, "create preference for user")
+
+		// Fetch the same resource over k8s apis
+		out, err = clientAdmin.Resource.Get(ctx, "team-"+helper.Org1.Staff.UID, metav1.GetOptions{})
+		require.NoError(t, err)
+		v, _, _ = unstructured.NestedString(out.Object, "spec", "weekStart")
+		require.Equal(t, "sunday", v)
 
 		// http://localhost:3000/api/org/preferences
 		legacyResponse = apis.DoRequest(helper, apis.RequestParams{


### PR DESCRIPTION
Patch requires a few things we were missing from the legacy implementation:
1. objects must have a UID 🤷🏻 
2. the __internal version must be registered

This also fixes an bug when validating team membership