### PR TITLE
Dashboards: Add debug logging to getDashboardThroughK8s for k8s errors

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1760,8 +1760,10 @@ func (dr *DashboardServiceImpl) getDashboardThroughK8s(ctx context.Context, quer
 
 	out, err := dr.k8sclient.GetWithPreferredAPIVersion(ctx, query.UID, query.OrgID, v1.GetOptions{}, query.K8sGetAPIVersion, "")
 	if err != nil && !apierrors.IsNotFound(err) {
+		dr.log.Debug("k8s returned non-404 error for dashboard", "uid", query.UID, "orgID", query.OrgID, "err", err)
 		return nil, err
 	} else if err != nil || out == nil {
+		dr.log.Debug("k8s returned 404 or nil for dashboard", "uid", query.UID, "orgID", query.OrgID, "k8sErr", err)
 		return nil, dashboards.ErrDashboardNotFound
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1759,11 +1759,18 @@ func (dr *DashboardServiceImpl) getDashboardThroughK8s(ctx context.Context, quer
 	}
 
 	out, err := dr.k8sclient.GetWithPreferredAPIVersion(ctx, query.UID, query.OrgID, v1.GetOptions{}, query.K8sGetAPIVersion, "")
+	// Temporary debug logging to diagnose unexpected dashboard lookup failures via the k8s API.
+	// Enable by setting log level for "dashboard-service" to debug.
+	// TODO: remove once the root cause is identified.
 	if err != nil && !apierrors.IsNotFound(err) {
-		dr.log.Debug("k8s returned non-404 error for dashboard", "uid", query.UID, "orgID", query.OrgID, "err", err)
+		if dr.log != nil {
+			dr.log.Debug("k8s returned non-404 error for dashboard", "uid", query.UID, "orgID", query.OrgID, "err", err)
+		}
 		return nil, err
 	} else if err != nil || out == nil {
-		dr.log.Debug("k8s returned 404 or nil for dashboard", "uid", query.UID, "orgID", query.OrgID, "k8sErr", err)
+		if dr.log != nil {
+			dr.log.Debug("k8s returned 404 or nil for dashboard", "uid", query.UID, "orgID", query.OrgID, "k8sErr", err)
+		}
 		return nil, dashboards.ErrDashboardNotFound
 	}
 

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -152,6 +152,7 @@ func setupK8sDashboardTests(service *DashboardServiceImpl) (context.Context, *cl
 func TestGetDashboard(t *testing.T) {
 	service := &DashboardServiceImpl{
 		cfg: setting.NewCfg(),
+		log: log.New("test.logger"),
 	}
 	query := &dashboards.GetDashboardQuery{
 		UID:   "test-uid",

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -152,7 +152,6 @@ func setupK8sDashboardTests(service *DashboardServiceImpl) (context.Context, *cl
 func TestGetDashboard(t *testing.T) {
 	service := &DashboardServiceImpl{
 		cfg: setting.NewCfg(),
-		log: log.New("test.logger"),
 	}
 	query := &dashboards.GetDashboardQuery{
 		UID:   "test-uid",


### PR DESCRIPTION
**What is this feature?**

Adds two `debug`-level log lines to `getDashboardThroughK8s` to surface the raw k8s error before it gets wrapped into `ErrDashboardNotFound`.

**Why do we need this feature?**

When `InheritedScopesSolver` calls `getDashboard` with a service identity context, any k8s error is silently swallowed into a generic "Dashboard not found" message. This makes it impossible to distinguish between a genuine 404, an authorization failure (403), or any other k8s error from the loopback API. This logging is needed to diagnose a customer support escalation where the permissions endpoint returns 500 for dashboards in nested folders.

**Who is this feature for?**

Grafana engineers diagnosing dashboard k8s lookup failures.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Temporary diagnostic logging — two `Debug` lines only, no behaviour change.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.