### PR TITLE
Provisioning: Track eventual finalizer success after retries

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -21,6 +21,20 @@ import (
 	metricutils "github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 )
 
+// FinalizerError wraps errors from finalizer processing
+type FinalizerError struct {
+	FinalizerType string
+	Err           error
+}
+
+func (e *FinalizerError) Error() string {
+	return fmt.Sprintf("finalizer %s failed: %v", e.FinalizerType, e.Err)
+}
+
+func (e *FinalizerError) Unwrap() error {
+	return e.Err
+}
+
 type finalizer struct {
 	lister        resources.ResourceLister
 	clientFactory resources.ClientFactory
@@ -86,7 +100,10 @@ func (f *finalizer) process(ctx context.Context,
 		f.metrics.RecordFinalizer(finalizer, outcome, count, time.Since(start).Seconds())
 
 		if err != nil {
-			return err
+			return &FinalizerError{
+				FinalizerType: finalizer,
+				Err:           err,
+			}
 		}
 	}
 	return nil

--- a/pkg/registry/apis/provisioning/controller/metrics.go
+++ b/pkg/registry/apis/provisioning/controller/metrics.go
@@ -12,6 +12,7 @@ type finalizerMetrics struct {
 	registry                prometheus.Registerer
 	finalizerProcessedTotal *prometheus.CounterVec
 	finalizerDuration       *prometheus.HistogramVec
+	finalizerRetries        *prometheus.CounterVec
 }
 
 func registerFinalizerMetrics(registry prometheus.Registerer) finalizerMetrics {
@@ -34,18 +35,35 @@ func registerFinalizerMetrics(registry prometheus.Registerer) finalizerMetrics {
 	)
 	registry.MustRegister(finalizerDuration)
 
+	finalizerRetries := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grafana_provisioning_finalizers_retries_total",
+			Help: "Total number of finalizer retries",
+		},
+		[]string{"finalizer_type"},
+	)
+	registry.MustRegister(finalizerRetries)
+
 	return finalizerMetrics{
 		registry:                registry,
 		finalizerProcessedTotal: finalizerProcessedTotal,
 		finalizerDuration:       finalizerDuration,
+		finalizerRetries:        finalizerRetries,
 	}
 }
 
 func (m *finalizerMetrics) RecordFinalizer(finalizerType string, outcome string, resourceCountChanged int, duration float64) {
-	m.finalizerProcessedTotal.WithLabelValues(finalizerType, outcome).Inc()
 	if outcome == utils.SuccessOutcome {
 		m.finalizerDuration.WithLabelValues(finalizerType, utils.GetResourceCountBucket(resourceCountChanged)).Observe(duration)
 	}
+}
+
+func (m *finalizerMetrics) RecordRetry(finalizerType string) {
+	m.finalizerRetries.WithLabelValues(finalizerType).Inc()
+}
+
+func (m *finalizerMetrics) RecordFinalOutcome(finalizerType string, outcome string) {
+	m.finalizerProcessedTotal.WithLabelValues(finalizerType, outcome).Inc()
 }
 
 //go:generate mockery --name=HealthMetricsRecorder --structname=MockHealthMetricsRecorder --inpackage --filename metrics_mock.go --with-expecter

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	metricutils "github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -248,6 +249,7 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 
 	err := rc.processFn(item)
 	if err == nil {
+		rc.recordFinalOutcome(nil)
 		rc.queue.Forget(item)
 		return true
 	}
@@ -258,22 +260,49 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 
 	if item.attempts >= maxAttempts {
 		logger.Error("RepositoryController failed too many times")
+		rc.recordFinalOutcome(err)
 		rc.queue.Forget(item)
 		return true
 	}
 
 	if !apierrors.IsServiceUnavailable(err) {
 		logger.Info("RepositoryController will not retry")
+		rc.recordFinalOutcome(err)
 		rc.queue.Forget(item)
 		return true
 	} else {
 		logger.Info("RepositoryController will retry as service is unavailable")
+		rc.recordRetry(err)
 	}
 
 	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", item, err))
 	rc.queue.AddRateLimited(item)
 
 	return true
+}
+
+func (rc *RepositoryController) recordRetry(err error) {
+	var finalizerErr *FinalizerError
+	if errors.As(err, &finalizerErr) {
+		f, ok := rc.finalizer.(*finalizer)
+		if ok {
+			f.metrics.RecordRetry(finalizerErr.FinalizerType)
+		}
+	}
+}
+
+func (rc *RepositoryController) recordFinalOutcome(err error) {
+	var finalizerErr *FinalizerError
+	if errors.As(err, &finalizerErr) {
+		outcome := metricutils.SuccessOutcome
+		if err != nil {
+			outcome = metricutils.ErrorOutcome
+		}
+		f, ok := rc.finalizer.(*finalizer)
+		if ok {
+			f.metrics.RecordFinalOutcome(finalizerErr.FinalizerType, outcome)
+		}
+	}
 }
 
 func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provisioning.Repository) error {


### PR DESCRIPTION
## What

This PR modifies how provisioning finalizer metrics are recorded to track **eventual success rate** (after all retries) instead of **per-attempt success rate**.

## Why

### Current Problem

The existing `grafana_provisioning_finalizers_processed_total` metric records every attempt at finalizer execution, which causes successful retries to be double-counted in failure scenarios:

**Example scenario:**
- 100 finalizers run
- 10 fail initially with `ServiceUnavailable`
- Those 10 retry and succeed
- **Metric records:** 10 errors + 100 successes
- **SLO shows:** 100/110 = **90.9% success rate** ❌

This incorrectly penalizes the SLO for transient failures that are successfully recovered through retries.

### Desired Behavior

The SLO should measure **eventual success** - what users actually experience:

**Same scenario with fix:**
- 100 finalizers run
- 10 fail initially, retry, and succeed
- **Metric records:** 100 successes (final outcomes only)
- **SLO shows:** 100/100 = **100% success rate** ✅

## How

### Metric Recording Strategy

1. **Move outcome recording to controller level**
   - Previously: Recorded at finalizer execution in `finalizers.go:86`
   - Now: Recorded at controller retry logic in `repository.go:processNextWorkItem()`
   
2. **Record only when retries are exhausted:**
   - ✅ Success on first attempt → record success
   - ✅ Success after retry → record success
   - ❌ Failure after max attempts → record error
   - ❌ Non-retryable error → record error
   - ⏭️  Will retry (ServiceUnavailable) → don't record yet

3. **Add retry visibility metric**
   - New: `grafana_provisioning_finalizers_retries_total{finalizer_type}`
   - Increments each time we queue a finalizer for retry
   - Preserves observability into retry behavior

### Code Changes

**`finalizers.go`:**
- Add `FinalizerError` type to wrap errors with finalizer context
- Propagates finalizer type to controller for proper metric labeling

**`metrics.go`:**
- Split `RecordFinalizer()` - now only records duration
- Add `RecordFinalOutcome()` - records to existing `_processed_total` metric
- Add `RecordRetry()` - records to new `_retries_total` metric

**`repository.go`:**
- Add `recordFinalOutcome()` helper - extracts finalizer info from error
- Add `recordRetry()` helper - tracks retry attempts
- Call these at appropriate points in `processNextWorkItem()`

## Metrics Impact

### Existing Metrics

✅ **`grafana_provisioning_finalizers_processed_total{finalizer_type, outcome}`**
- **Behavior changed:** Now records final outcome only (after retries)
- **Breaking:** Existing dashboards showing "attempts per second" will show lower values
- **SLO impact:** Will now correctly show ~100% for successfully-retried operations

✅ **`grafana_provisioning_finalizers_duration_seconds{finalizer_type, resource_count_bucket}`**
- **No change:** Still records duration only on success

### New Metrics

🆕 **`grafana_provisioning_finalizers_retries_total{finalizer_type}`**
- Tracks number of retry attempts
- Use `rate(grafana_provisioning_finalizers_retries_total[5m])` to monitor retry rate
- Helps identify transient issues vs persistent failures

## Testing

- [ ] Unit tests pass
- [ ] Integration test: Verify metrics in dev environment
  - Trigger finalizer with ServiceUnavailable error
  - Verify retry succeeds
  - Check `_processed_total` shows 1 success (not 1 error + 1 success)
  - Check `_retries_total` increments by 1

## Rollout Plan

1. Deploy to dev/ops → new metrics populate
2. Wait ~1 hour for metric collection
3. Verify SLO dashboard shows improved success rate
4. Deploy to production
5. (Optional) Update deployment_tools SLO description to clarify "eventual success"

## Related

- SLO definition: `deployment_tools/terraform/ancillary/grafana-slo-app/gops_slos/GrafanaGitSyncControllers.tf.json:283-375`
- Dashboard: https://ops.grafana-ops.net/goto/af08hy05v4mwwa

---

/cc @grafana/grafana-app-platform-squad