### PR TITLE
IAM: diagnostic logs for TestIntegrationTeamBindings flaky failure

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -806,6 +806,9 @@ func (s *Service) getUserTeams(ctx context.Context, ns types.NamespaceInfo, user
 }
 
 func (s *Service) getUserBasicRole(ctx context.Context, ns types.NamespaceInfo, userIdentifiers *store.UserIdentifiers) (store.BasicRole, error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		s.logger.Warn("getUserBasicRole: context already cancelled on entry", "err", ctxErr)
+	}
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.getUserBasicRole")
 	defer span.End()
 

--- a/pkg/tests/apis/iam/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/team_binding_integration_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestIntegrationTeamBindings(t *testing.T) {
-	t.Skip("flaky: context cancelled on basic roles fetch during Delete authz check — see https://github.com/grafana/grafana/pull/121625")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	// TODO: Add rest.Mode5 when it's supported
@@ -164,7 +163,9 @@ func doTeamBindingCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHel
 		require.Equal(t, createdUID, actual.Name)
 
 		// Delete the team binding
+		deleteStart := time.Now()
 		err = teamBindingClient.Resource.Delete(ctx, createdUID, metav1.DeleteOptions{})
+		t.Logf("[diag] DELETE duration=%v err=%v", time.Since(deleteStart), err)
 		require.NoError(t, err)
 
 		// Verify the team binding is deleted


### PR DESCRIPTION
**What is this feature?**

Diagnostic instrumentation to determine the root cause of the flaky `TestIntegrationTeamBindings` failure.

**Why do we need this feature?**

The test has been flaky since grafana/grafana#98607 introduced a singleflight in `getUserPermissions`. Two hypotheses exist for the failure:

1. Something in the request path got slower, pushing execution past the K8s apiserver's internal `timeoutHandler` deadline
2. The context is cancelled during goroutine scheduling (before any user code runs), and the singleflight cascades that single cancellation to all ~25 concurrent waiters

The previous fix (#121751, 60s HTTP client timeout) addressed the wrong layer — the cancellation comes from the server-side K8s timeout, not the HTTP client. A prior CI log showed DELETE returning 500 in 1.33ms, suggesting the context was dead before any work started.

**What changed:**

- Removed `t.Skip` so the test runs in CI again
- Added `t.Logf` around the DELETE call to record round-trip duration on failure
- Added `s.logger.Warn` in `getUserBasicRole` to log if the context is already cancelled on entry

**What the logs will tell us:**

| Observation | Implication |
|---|---|
| DELETE duration <5ms + "context already cancelled on entry" | Scheduler delay — context killed before work started, no slow operation to find |
| DELETE duration 100ms+ + ctx not yet cancelled | Something in the path is genuinely slow — pprof investigation makes sense |

**Special notes for your reviewer:**

This is a diagnostic-only PR — no behaviour change. The logs will be removed once the root cause is confirmed and the real fix is applied.

See also: #121625, #121751