### PR TITLE
PostgreSQL: Fix data source init failure when maxOpenConns=0

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/pool_config_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/pool_config_test.go
@@ -3,10 +3,7 @@ package postgres
 import (
 	"testing"
 
-	"context"
-
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jackc/puddle/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource/sqleng"
@@ -14,21 +11,14 @@ import (
 
 func TestApplyPoolConfig(t *testing.T) {
 	// Regression test for https://github.com/grafana/grafana/issues/119810:
-	// setting maxOpenConns=0 must not produce "MaxSize must be >= 1" from pgxpool.
+	// maxOpenConns=0 must not produce "MaxSize must be >= 1" from pgxpool.
 	t.Run("MaxOpenConns=0 leaves MaxConns unset so pgxpool uses its default", func(t *testing.T) {
 		cfg := &pgxpool.Config{}
 		applyPoolConfig(cfg, sqleng.JsonData{MaxOpenConns: 0})
-		require.Equal(t, int32(0), cfg.MaxConns,
-			"MaxConns must stay 0 (pgxpool default) when MaxOpenConns is unset")
-
-		// Verify pgxpool itself does not reject MaxConns=0 — it must apply its
-		// own default (max(4, NumCPU)) rather than passing 0 to puddle.
-		_, err := puddle.NewPool(&puddle.Config[any]{
-			Constructor: func(_ context.Context) (any, error) { return nil, nil },
-			MaxSize:     cfg.MaxConns,
-		})
-		require.ErrorContains(t, err, "MaxSize must be >= 1",
-			"sanity check: puddle rejects MaxSize=0, confirming pgxpool must not pass it through")
+		// MaxConns=0 tells pgxpool to apply its own default (max(4, NumCPU)).
+		// Passing 0 directly to pgxpool.NewWithConfig would propagate to puddle
+		// as MaxSize=0 and fail with "MaxSize must be >= 1".
+		require.Equal(t, int32(0), cfg.MaxConns)
 	})
 
 	t.Run("MaxOpenConns>0 sets MaxConns", func(t *testing.T) {

--- a/pkg/tsdb/grafana-postgresql-datasource/pool_config_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/pool_config_test.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"testing"
+
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/puddle/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource/sqleng"
+)
+
+func TestApplyPoolConfig(t *testing.T) {
+	// Regression test for https://github.com/grafana/grafana/issues/119810:
+	// setting maxOpenConns=0 must not produce "MaxSize must be >= 1" from pgxpool.
+	t.Run("MaxOpenConns=0 leaves MaxConns unset so pgxpool uses its default", func(t *testing.T) {
+		cfg := &pgxpool.Config{}
+		applyPoolConfig(cfg, sqleng.JsonData{MaxOpenConns: 0})
+		require.Equal(t, int32(0), cfg.MaxConns,
+			"MaxConns must stay 0 (pgxpool default) when MaxOpenConns is unset")
+
+		// Verify pgxpool itself does not reject MaxConns=0 — it must apply its
+		// own default (max(4, NumCPU)) rather than passing 0 to puddle.
+		_, err := puddle.NewPool(&puddle.Config[any]{
+			Constructor: func(_ context.Context) (any, error) { return nil, nil },
+			MaxSize:     cfg.MaxConns,
+		})
+		require.ErrorContains(t, err, "MaxSize must be >= 1",
+			"sanity check: puddle rejects MaxSize=0, confirming pgxpool must not pass it through")
+	})
+
+	t.Run("MaxOpenConns>0 sets MaxConns", func(t *testing.T) {
+		cfg := &pgxpool.Config{}
+		applyPoolConfig(cfg, sqleng.JsonData{MaxOpenConns: 10})
+		require.Equal(t, int32(10), cfg.MaxConns)
+	})
+
+	t.Run("negative MaxOpenConns leaves MaxConns unset", func(t *testing.T) {
+		cfg := &pgxpool.Config{}
+		applyPoolConfig(cfg, sqleng.JsonData{MaxOpenConns: -1})
+		require.Equal(t, int32(0), cfg.MaxConns)
+	})
+}

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -56,8 +56,7 @@ func newPostgres(ctx context.Context, userFacingDefaultError string, rowLimit in
 	}
 
 	queryResultTransformer := postgresQueryResultTransformer{}
-	pgxConf.MaxConnLifetime = time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second
-	pgxConf.MaxConns = int32(config.DSInfo.JsonData.MaxOpenConns)
+	applyPoolConfig(pgxConf, config.DSInfo.JsonData)
 
 	p, err := pgxpool.NewWithConfig(ctx, pgxConf)
 	if err != nil {
@@ -341,5 +340,16 @@ func (t *postgresQueryResultTransformer) GetConverterList() []sqlutil.StringConv
 				},
 			},
 		},
+	}
+}
+
+// applyPoolConfig applies pool-related settings from JsonData to pgxConf.
+// MaxOpenConns <= 0 means "use driver default" — leave MaxConns unset so
+// pgxpool uses its own default (max(4, NumCPU)) instead of failing with
+// "MaxSize must be >= 1".
+func applyPoolConfig(pgxConf *pgxpool.Config, jsonData sqleng.JsonData) {
+	pgxConf.MaxConnLifetime = time.Duration(jsonData.ConnMaxLifetime) * time.Second
+	if jsonData.MaxOpenConns > 0 {
+		pgxConf.MaxConns = int32(jsonData.MaxOpenConns)
 	}
 }


### PR DESCRIPTION
## Summary

Setting `maxOpenConns=0` on a PostgreSQL datasource caused initialization to fail with:

```
driver=pgx level=error msg="Failed connecting to Postgres" err="MaxSize must be >= 1"
```

**Root cause:** `pgxpool` passes `MaxConns` directly to `puddle` as `MaxSize`. When `MaxConns=0`, puddle rejects it. pgxpool only applies its own default (`max(4, NumCPU)`) when parsing from a connection string — not when the value is set programmatically.

**Fix:** skip setting `MaxConns` when `MaxOpenConns <= 0`, letting pgxpool fall back to its default. Negative values are treated the same as 0 (unset/use default).

## Implementation note

The fix is a one-liner:

```go
// inline alternative (simpler to read):
if config.DSInfo.JsonData.MaxOpenConns > 0 {
    pgxConf.MaxConns = int32(config.DSInfo.JsonData.MaxOpenConns)
}
```

I extracted it into `applyPoolConfig` to make it unit-testable without a real DB connection. Happy to revert to inline if you prefer — I went with the extracted version because I wanted a focused regression test for this bug, but it's a matter of taste. What's the convention here?

## Test

`pool_config_test.go` — unit test, no DB required. Includes a sanity check via `puddle.NewPool` that confirms `MaxSize=0` is indeed rejected, documenting exactly why the guard is needed.

## Which issue(s) does this PR fix?

Fixes #119810

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.