### PR TITLE
Plugins: Include /schema/* in distribution

### DIFF
--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -261,6 +261,7 @@ const config = async (env: Env): Promise<Configuration> => {
           { from: '**/*.html', to: '.', noErrorOnMissing: true, filter: skipFiles }, // Optional
           { from: 'img/**/*', to: '.', noErrorOnMissing: true, filter: skipFiles }, // Optional
           { from: 'libs/**/*', to: '.', noErrorOnMissing: true, filter: skipFiles }, // Optional
+          { from: 'schema/**/*', to: '.', noErrorOnMissing: true, filter: skipFiles }, // Optional
           { from: 'static/**/*', to: '.', noErrorOnMissing: true, filter: skipFiles }, // Optional
         ],
       }),


### PR DESCRIPTION
Extracted from https://github.com/grafana/grafana/pull/110216

This prepares the plugin setup so it now includes the any files in a `/schema/` folder