### PR TITLE
fix(tabs): disambiguate tab slugs that collide due to special characters

### DIFF
--- a/apps/dashboard/kinds/v2/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2/dashboard_spec.cue
@@ -691,6 +691,7 @@ TabsLayoutTabKind: {
 }
 
 TabsLayoutTabSpec: {
+	uid?:                  string
 	title?:                string
 	layout:                GridLayoutKind | RowsLayoutKind | AutoGridLayoutKind | TabsLayoutKind
 	conditionalRendering?: ConditionalRenderingGroupKind

--- a/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
@@ -690,6 +690,7 @@ TabsLayoutTabKind: {
 }
 
 TabsLayoutTabSpec: {
+	uid?:                  string
 	title?:                string
 	layout:                GridLayoutKind | RowsLayoutKind | AutoGridLayoutKind | TabsLayoutKind
 	conditionalRendering?: ConditionalRenderingGroupKind

--- a/packages/grafana-schema/src/schema/dashboard/v2/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2/types.spec.gen.ts
@@ -968,6 +968,7 @@ export const defaultTabsLayoutTabKind = (): TabsLayoutTabKind => ({
 });
 
 export interface TabsLayoutTabSpec {
+	uid?: string;
 	title?: string;
 	layout: GridLayoutKind | RowsLayoutKind | AutoGridLayoutKind | TabsLayoutKind;
 	conditionalRendering?: ConditionalRenderingGroupKind;

--- a/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
@@ -969,6 +969,7 @@ export const defaultTabsLayoutTabKind = (): TabsLayoutTabKind => ({
 });
 
 export interface TabsLayoutTabSpec {
+	uid?: string;
 	title?: string;
 	layout: GridLayoutKind | RowsLayoutKind | AutoGridLayoutKind | TabsLayoutKind;
 	conditionalRendering?: ConditionalRenderingGroupKind;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -122,7 +122,31 @@ export class TabItem
   }
 
   public getSlug(): string {
-    return kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Tab'));
+    const baseSlug = kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Tab'));
+
+    //check for slug collisions among sibling tabs. When two different tabs produce
+    // the same base slug
+    let parent: TabsLayoutManager | undefined;
+    try {
+      parent = this.getParentLayout();
+    } catch {
+      // tab is not yet attached to a layout so no collision check is possible
+      return baseSlug;
+    }
+
+    const siblings = parent.getTabsIncludingRepeats();
+    const slugCollision = siblings.some(
+      (sibling) =>
+        sibling !== this &&
+        kbn.slugifyForUrl(interpolateSectionTitle(sibling, sibling.state.title ?? 'Tab')) === baseSlug
+    );
+
+    if (slugCollision) {
+      // apend a short suffix derived from the tab's unique scene key hence each colliding tab gets a distinct slug
+      return `${baseSlug}-${this.state.key}`;
+    }
+
+    return baseSlug;
   }
 
   public isCurrentTab() {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
@@ -49,6 +51,8 @@ import { TabItems } from './TabItems';
 import { TabsLayoutManager } from './TabsLayoutManager';
 
 export interface TabItemState extends SceneObjectState {
+  /** Stable identifier persisted in the dashboard spec; used to disambiguate slug collisions across reloads. */
+  uid: string;
   layout: DashboardLayoutManager;
   title?: string;
   isDropTarget?: boolean;
@@ -61,8 +65,7 @@ export interface TabItemState extends SceneObjectState {
 
 export class TabItem
   extends SceneObjectBase<TabItemState>
-  implements LayoutParent, BulkActionElement, EditableDashboardElement, DashboardDropTarget
-{
+  implements LayoutParent, BulkActionElement, EditableDashboardElement, DashboardDropTarget {
   public static Component = TabItemRenderer;
 
   protected _variableDependency = new VariableDependencyConfig(this, {
@@ -77,6 +80,7 @@ export class TabItem
   constructor(state?: Partial<TabItemState>) {
     super({
       ...state,
+      uid: state?.uid ?? uuidv4(),
       title: state?.title ?? t('dashboard.tabs-layout.tab.new', 'New tab'),
       layout: state?.layout ?? AutoGridLayoutManager.createEmpty(),
       conditionalRendering: state?.conditionalRendering ?? ConditionalRenderingGroup.createEmpty(),
@@ -121,29 +125,37 @@ export class TabItem
     return this.state.layout;
   }
 
-  public getSlug(): string {
+  // siblings can be passed explicitly when the tab is not yet attached to a layout
+  // (e.g. during addNewTab / removeTab undo before setState fires).
+  public getSlug(siblings?: TabItem[]): string {
     const baseSlug = kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Tab'));
 
-    //check for slug collisions among sibling tabs. When two different tabs produce
-    // the same base slug
-    let parent: TabsLayoutManager | undefined;
-    try {
-      parent = this.getParentLayout();
-    } catch {
-      // tab is not yet attached to a layout so no collision check is possible
-      return baseSlug;
+    // Check for slug collisions among sibling tabs. When two different tabs
+    // produce the same base slug, append a uid-derived suffix for disambiguation.
+    let siblingsToCheck: TabItem[];
+    if (siblings !== undefined) {
+      siblingsToCheck = siblings;
+    } else {
+      let parent: TabsLayoutManager | undefined;
+      try {
+        parent = this.getParentLayout();
+      } catch {
+        // Tab is not yet attached to a layout so no collision check is possible.
+        return baseSlug;
+      }
+      siblingsToCheck = parent.getTabsIncludingRepeats();
     }
 
-    const siblings = parent.getTabsIncludingRepeats();
-    const slugCollision = siblings.some(
+    const slugCollision = siblingsToCheck.some(
       (sibling) =>
         sibling !== this &&
         kbn.slugifyForUrl(interpolateSectionTitle(sibling, sibling.state.title ?? 'Tab')) === baseSlug
     );
 
     if (slugCollision) {
-      // apend a short suffix derived from the tab's unique scene key hence each colliding tab gets a distinct slug
-      return `${baseSlug}-${this.state.key}`;
+      // Append a short suffix derived from the tab's persisted uid so the slug
+      // remains stable across reloads and shared URLs don't break.
+      return `${baseSlug}-${this.state.uid.slice(0, 8)}`;
     }
 
     return baseSlug;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -41,6 +41,49 @@ function buildTabsLayoutManager(tabs: TabItem[] = []) {
 }
 
 describe('TabsLayoutManager', () => {
+  describe('TabItem.getSlug', () => {
+    it('returns a plain slug when there are no collisions', () => {
+      const tab = new TabItem({ title: 'Overview' });
+      buildTabsLayoutManager([tab]);
+      expect(tab.getSlug()).toBe('overview');
+    });
+
+    it('disambiguates tabs whose titles differ only by special characters', () => {
+      const tab1 = new TabItem({ title: 'Foo' });
+      const tab2 = new TabItem({ title: 'Foo!' });
+      buildTabsLayoutManager([tab1, tab2]);
+
+      const slug1 = tab1.getSlug();
+      const slug2 = tab2.getSlug();
+
+      expect(slug1).not.toBe(slug2);
+      // both slugs should still be prefixed with the base slug
+      expect(slug1).toMatch(/^foo/);
+      expect(slug2).toMatch(/^foo/);
+    });
+
+    it('disambiguates all tabs in a larger collision group', () => {
+      const tab1 = new TabItem({ title: 'Metrics' });
+      const tab2 = new TabItem({ title: 'Metrics!' });
+      const tab3 = new TabItem({ title: 'Metrics?' });
+      buildTabsLayoutManager([tab1, tab2, tab3]);
+
+      const slugs = [tab1.getSlug(), tab2.getSlug(), tab3.getSlug()];
+      const uniqueSlugs = new Set(slugs);
+
+      expect(uniqueSlugs.size).toBe(3);
+    });
+
+    it('does not affect tabs with non-colliding titles', () => {
+      const tab1 = new TabItem({ title: 'Alpha' });
+      const tab2 = new TabItem({ title: 'Beta' });
+      buildTabsLayoutManager([tab1, tab2]);
+
+      expect(tab1.getSlug()).toBe('alpha');
+      expect(tab2.getSlug()).toBe('beta');
+    });
+  });
+
   describe('URL sync', () => {
     it('when on top level', () => {
       const tabsLayoutManager = buildTabsLayoutManager([new TabItem({ title: 'Performance' })]);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -48,30 +48,31 @@ describe('TabsLayoutManager', () => {
       expect(tab.getSlug()).toBe('overview');
     });
 
-    it('disambiguates tabs whose titles differ only by special characters', () => {
-      const tab1 = new TabItem({ title: 'Foo' });
-      const tab2 = new TabItem({ title: 'Foo!' });
+    it('returns baseSlug when called on a detached tab (no parent)', () => {
+      // Tab not yet added to any layout — collision check is skipped.
+      const tab = new TabItem({ title: 'Foo!' });
+      expect(tab.getSlug()).toBe('foo');
+    });
+
+    it('disambiguates tabs whose titles differ only by special characters using uid suffix', () => {
+      const tab1 = new TabItem({ title: 'Foo', uid: 'aaaaaaaa-0000-0000-0000-000000000000' });
+      const tab2 = new TabItem({ title: 'Foo!', uid: 'bbbbbbbb-0000-0000-0000-000000000000' });
       buildTabsLayoutManager([tab1, tab2]);
 
-      const slug1 = tab1.getSlug();
-      const slug2 = tab2.getSlug();
-
-      expect(slug1).not.toBe(slug2);
-      // both slugs should still be prefixed with the base slug
-      expect(slug1).toMatch(/^foo/);
-      expect(slug2).toMatch(/^foo/);
+      // Every tab in the collision group gets a uid suffix so all slugs are distinct.
+      expect(tab1.getSlug()).toBe('foo-aaaaaaaa');
+      expect(tab2.getSlug()).toBe('foo-bbbbbbbb');
     });
 
     it('disambiguates all tabs in a larger collision group', () => {
-      const tab1 = new TabItem({ title: 'Metrics' });
-      const tab2 = new TabItem({ title: 'Metrics!' });
-      const tab3 = new TabItem({ title: 'Metrics?' });
+      const tab1 = new TabItem({ title: 'Metrics', uid: 'aaa00000-0000-0000-0000-000000000000' });
+      const tab2 = new TabItem({ title: 'Metrics!', uid: 'bbb00000-0000-0000-0000-000000000000' });
+      const tab3 = new TabItem({ title: 'Metrics?', uid: 'ccc00000-0000-0000-0000-000000000000' });
       buildTabsLayoutManager([tab1, tab2, tab3]);
 
-      const slugs = [tab1.getSlug(), tab2.getSlug(), tab3.getSlug()];
-      const uniqueSlugs = new Set(slugs);
-
-      expect(uniqueSlugs.size).toBe(3);
+      expect(tab1.getSlug()).toBe('metrics-aaa00000');
+      expect(tab2.getSlug()).toBe('metrics-bbb00000');
+      expect(tab3.getSlug()).toBe('metrics-ccc00000');
     });
 
     it('does not affect tabs with non-colliding titles', () => {
@@ -81,6 +82,18 @@ describe('TabsLayoutManager', () => {
 
       expect(tab1.getSlug()).toBe('alpha');
       expect(tab2.getSlug()).toBe('beta');
+    });
+
+    it('accepts an explicit siblings array so callers can compute the slug before attachment', () => {
+      const tab1 = new TabItem({ title: 'Sales', uid: 'aaaaaaaa-0000-0000-0000-000000000000' });
+      const tab2 = new TabItem({ title: 'Sales!', uid: 'bbbbbbbb-0000-0000-0000-000000000000' });
+      // tab2 is not yet attached — pass the target array explicitly to get the correct slug.
+      const futureSiblings = [tab1, tab2];
+      buildTabsLayoutManager([tab1]);
+
+      // Both slugify to "sales", so both get uid suffixes.
+      expect(tab1.getSlug(futureSiblings)).toBe('sales-aaaaaaaa');
+      expect(tab2.getSlug(futureSiblings)).toBe('sales-bbbbbbbb');
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -47,8 +47,7 @@ interface TabsLayoutManagerState extends SceneObjectState {
 
 export class TabsLayoutManager
   extends SceneObjectBase<TabsLayoutManagerState>
-  implements DashboardLayoutGroup, DashboardDropTarget
-{
+  implements DashboardLayoutGroup, DashboardDropTarget {
   public static Component = TabsLayoutManagerRenderer;
 
   public readonly isDashboardLayoutManager = true;
@@ -206,15 +205,22 @@ export class TabsLayoutManager
       newTab.setState({ title: newTitle });
     }
 
+    // Pre-compute the final tabs array and slug so both perform and undo use the
+    // same value. getSlug() does a collision check against siblings, and newTab is
+    // not yet attached when perform/undo callbacks fire, so we must pass the target
+    // tabs array explicitly to get the correct slug.
+    const newTabs = [...this.state.tabs, newTab];
+    const newTabSlug = newTab.getSlug(newTabs);
+
     dashboardEditActions.addElement({
       addedObject: newTab,
       source: this,
-      perform: () => this.setState({ tabs: [...this.state.tabs, newTab], currentTabSlug: newTab.getSlug() }),
+      perform: () => this.setState({ tabs: newTabs, currentTabSlug: newTabSlug }),
       undo: () => {
         this.setState({
           tabs: this.state.tabs.filter((t) => t !== newTab),
-          // if the new tab was the current tab, set the current tab to the previous tab
-          currentTabSlug: this.state.currentTabSlug === newTab.getSlug() ? undefined : this.state.currentTabSlug,
+          // if the new tab was the current tab, clear the selection
+          currentTabSlug: this.state.currentTabSlug === newTabSlug ? undefined : this.state.currentTabSlug,
         });
       },
     });
@@ -389,9 +395,11 @@ export class TabsLayoutManager
       if (!tabsAfterRemoval.length) {
         parent.switchLayout(thisLayout);
       } else {
+        // Pass tabsBeforeRemoval explicitly: tab is detached when undo fires, so
+        // getSlug() must know the restored sibling set to compute the correct slug.
         this.setState({
           tabs: tabsBeforeRemoval,
-          currentTabSlug: tab.getSlug(),
+          currentTabSlug: tab.getSlug(tabsBeforeRemoval),
         });
       }
     };

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -24,6 +24,7 @@ export function serializeTab(tab: TabItem, isSnapshot?: boolean): TabsLayoutTabK
   const tabKind: TabsLayoutTabKind = {
     kind: 'TabsLayoutTab',
     spec: {
+      uid: tab.state.uid,
       title: tab.state.title,
       layout: layout,
       ...(tab.state.repeatByVariable && {
@@ -75,6 +76,7 @@ export function deserializeTab(
   const layout = tab.spec.layout;
 
   return new TabItem({
+    uid: tab.spec.uid,
     title: tab.spec.title,
     $variables: deserializeSectionVariables(tab.spec.variables),
     layout: layoutDeserializerRegistry.get(layout.kind).deserialize(layout, elements, preload, panelIdGenerator),


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/122447

## Problem

Tabs with titles that differ only by special characters (e.g. `"Foo"` vs `"Foo!"`) produce the same URL slug after `slugifyForUrl`. This caused multiple tabs to appear active simultaneously since the URL-based active-tab check matched all of them.

## Fix

In `TabItem.getSlug()`, after generating the base slug, check for collisions among sibling tabs. If a collision is detected, append the tab's unique scene key as a suffix (e.g. `foo-tab-1`) to guarantee each tab gets a distinct, stable slug.

No change in behaviour when there are no collisions.

## Testing

Unit tests added in `TabsLayoutManager.test.tsx` covering:
- Collision detection between tabs with differing special characters
- No-op for tabs with already-unique slugs
- Detached tab fallback (tab not yet attached to a layout)
