### PR TITLE
Provisioning: finalizer outcomes, retries, and repository deletion SLO metrics

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -21,6 +21,29 @@ import (
 	metricutils "github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 )
 
+// FinalizerError wraps errors from finalizer processing
+type FinalizerError struct {
+	FinalizerType string
+	Err           error
+}
+
+func (e *FinalizerError) Error() string {
+	return fmt.Sprintf("finalizer %s failed: %v", e.FinalizerType, e.Err)
+}
+
+func (e *FinalizerError) Unwrap() error {
+	return e.Err
+}
+
+// orderedRepositoryFinalizers returns the order in which repository finalizers run.
+func orderedRepositoryFinalizers() []string {
+	return []string{
+		repository.CleanFinalizer,
+		repository.ReleaseOrphanResourcesFinalizer,
+		repository.RemoveOrphanResourcesFinalizer,
+	}
+}
+
 type finalizer struct {
 	lister        resources.ResourceLister
 	clientFactory resources.ClientFactory
@@ -35,12 +58,7 @@ func (f *finalizer) process(ctx context.Context,
 	logger := logging.FromContext(ctx)
 	logger.Info("process finalizers", "finalizers", finalizers)
 
-	orderedFinalizers := [3]string{
-		repository.CleanFinalizer,
-		repository.ReleaseOrphanResourcesFinalizer,
-		repository.RemoveOrphanResourcesFinalizer}
-
-	for _, finalizer := range orderedFinalizers {
+	for _, finalizer := range orderedRepositoryFinalizers() {
 		if !slices.Contains(finalizers, finalizer) {
 			continue
 		}
@@ -86,7 +104,10 @@ func (f *finalizer) process(ctx context.Context,
 		f.metrics.RecordFinalizer(finalizer, outcome, count, time.Since(start).Seconds())
 
 		if err != nil {
-			return err
+			return &FinalizerError{
+				FinalizerType: finalizer,
+				Err:           err,
+			}
 		}
 	}
 	return nil

--- a/pkg/registry/apis/provisioning/controller/metrics.go
+++ b/pkg/registry/apis/provisioning/controller/metrics.go
@@ -12,13 +12,14 @@ type finalizerMetrics struct {
 	registry                prometheus.Registerer
 	finalizerProcessedTotal *prometheus.CounterVec
 	finalizerDuration       *prometheus.HistogramVec
+	finalizerRetries        *prometheus.CounterVec
 }
 
 func registerFinalizerMetrics(registry prometheus.Registerer) finalizerMetrics {
 	finalizerProcessedTotal := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "grafana_provisioning_finalizers_processed_total",
-			Help: "Total number of finalizers processed",
+			Help: "Per-finalizer outcomes: success is recorded once all configured finalizers finish for a repository delete; error on terminal reconcile failure for that finalizer step",
 		},
 		[]string{"finalizer_type", "outcome"},
 	)
@@ -34,18 +35,81 @@ func registerFinalizerMetrics(registry prometheus.Registerer) finalizerMetrics {
 	)
 	registry.MustRegister(finalizerDuration)
 
+	finalizerRetries := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grafana_provisioning_finalizers_retries_total",
+			Help: "Total number of finalizer retries",
+		},
+		[]string{"finalizer_type"},
+	)
+	registry.MustRegister(finalizerRetries)
+
 	return finalizerMetrics{
 		registry:                registry,
 		finalizerProcessedTotal: finalizerProcessedTotal,
 		finalizerDuration:       finalizerDuration,
+		finalizerRetries:        finalizerRetries,
 	}
 }
 
 func (m *finalizerMetrics) RecordFinalizer(finalizerType string, outcome string, resourceCountChanged int, duration float64) {
-	m.finalizerProcessedTotal.WithLabelValues(finalizerType, outcome).Inc()
 	if outcome == utils.SuccessOutcome {
 		m.finalizerDuration.WithLabelValues(finalizerType, utils.GetResourceCountBucket(resourceCountChanged)).Observe(duration)
 	}
+}
+
+func (m *finalizerMetrics) RecordRetry(finalizerType string) {
+	m.finalizerRetries.WithLabelValues(finalizerType).Inc()
+}
+
+func (m *finalizerMetrics) RecordFinalOutcome(finalizerType string, outcome string) {
+	m.finalizerProcessedTotal.WithLabelValues(finalizerType, outcome).Inc()
+}
+
+type repositoryDeletionMetrics struct {
+	total    *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+}
+
+func registerRepositoryDeletionMetrics(registry prometheus.Registerer) *repositoryDeletionMetrics {
+	total := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grafana_provisioning_repository_deletion_total",
+			Help: "Repository delete reconcile outcomes (from DeletionTimestamp until finalizers cleared or no-op delete path completes)",
+		},
+		[]string{"outcome"},
+	)
+	registry.MustRegister(total)
+
+	duration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "grafana_provisioning_repository_deletion_duration_seconds",
+			Help:    "Wall time from metadata.deletionTimestamp until delete reconcile succeeds (finalizers removed or none present)",
+			Buckets: []float64{1, 5, 10, 30, 60, 120, 300, 600, 1800},
+		},
+		[]string{"repository_type"},
+	)
+	registry.MustRegister(duration)
+
+	return &repositoryDeletionMetrics{
+		total:    total,
+		duration: duration,
+	}
+}
+
+func (m *repositoryDeletionMetrics) RecordSuccess(repositoryType string, elapsedSeconds float64) {
+	if m == nil {
+		return
+	}
+	m.total.WithLabelValues(utils.SuccessOutcome).Inc()
+	m.duration.WithLabelValues(repositoryType).Observe(elapsedSeconds)
+}
+
+func (m *repositoryDeletionMetrics) RecordError() {
+	if m == nil {
+		return
+	}
+	m.total.WithLabelValues(utils.ErrorOutcome).Inc()
 }
 
 //go:generate mockery --name=HealthMetricsRecorder --structname=MockHealthMetricsRecorder --inpackage --filename metrics_mock.go --with-expecter

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -30,6 +31,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	metricutils "github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -78,11 +80,12 @@ type RepositoryController struct {
 	minSyncInterval time.Duration
 	drainTimeout    time.Duration
 
-	registry              prometheus.Registerer
-	tracer                tracing.Tracer
-	quotaGetter           quotas.QuotaGetter
-	tokenMetrics          *repositoryTokenMetrics
-	folderMetadataEnabled bool
+	registry                  prometheus.Registerer
+	repositoryDeletionMetrics *repositoryDeletionMetrics
+	tracer                    tracing.Tracer
+	quotaGetter               quotas.QuotaGetter
+	tokenMetrics              *repositoryTokenMetrics
+	folderMetadataEnabled     bool
 }
 
 // NewRepositoryController creates new RepositoryController.
@@ -110,6 +113,7 @@ func NewRepositoryController(
 ) (*RepositoryController, error) {
 	finalizerMetrics := registerFinalizerMetrics(registry)
 	repoTokenMetrics := registerRepositoryTokenMetrics(registry)
+	deletionMetrics := registerRepositoryDeletionMetrics(registry)
 
 	rc := &RepositoryController{
 		client:     provisioningClient,
@@ -132,16 +136,17 @@ func NewRepositoryController(
 			metrics:       &finalizerMetrics,
 			maxWorkers:    parallelOperations,
 		},
-		jobs:                  jobs,
-		logger:                logging.DefaultLogger.With("logger", loggerName),
-		registry:              registry,
-		tracer:                tracer,
-		resyncInterval:        resyncInterval,
-		minSyncInterval:       minSyncInterval,
-		drainTimeout:          drainTimeout,
-		quotaGetter:           quotaGetter,
-		tokenMetrics:          repoTokenMetrics,
-		folderMetadataEnabled: folderMetadataEnabled,
+		jobs:                      jobs,
+		logger:                    logging.DefaultLogger.With("logger", loggerName),
+		registry:                  registry,
+		repositoryDeletionMetrics: deletionMetrics,
+		tracer:                    tracer,
+		resyncInterval:            resyncInterval,
+		minSyncInterval:           minSyncInterval,
+		drainTimeout:              drainTimeout,
+		quotaGetter:               quotaGetter,
+		tokenMetrics:              repoTokenMetrics,
+		folderMetadataEnabled:     folderMetadataEnabled,
 	}
 
 	_, err := repoInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -248,6 +253,7 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 
 	err := rc.processFn(item)
 	if err == nil {
+		rc.recordFinalOutcome(nil)
 		rc.queue.Forget(item)
 		return true
 	}
@@ -258,16 +264,19 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 
 	if item.attempts >= maxAttempts {
 		logger.Error("RepositoryController failed too many times")
+		rc.recordFinalOutcome(err)
 		rc.queue.Forget(item)
 		return true
 	}
 
 	if !apierrors.IsServiceUnavailable(err) {
 		logger.Info("RepositoryController will not retry")
+		rc.recordFinalOutcome(err)
 		rc.queue.Forget(item)
 		return true
 	} else {
 		logger.Info("RepositoryController will retry as service is unavailable")
+		rc.recordRetry(err)
 	}
 
 	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", item, err))
@@ -276,14 +285,80 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
+func (rc *RepositoryController) recordRetry(err error) {
+	var finalizerErr *FinalizerError
+	if errors.As(err, &finalizerErr) {
+		f, ok := rc.finalizer.(*finalizer)
+		if ok {
+			f.metrics.RecordRetry(finalizerErr.FinalizerType)
+		}
+	}
+}
+
+func (rc *RepositoryController) recordFinalOutcome(err error) {
+	var finalizerErr *FinalizerError
+	if errors.As(err, &finalizerErr) {
+		outcome := metricutils.SuccessOutcome
+		if err != nil {
+			outcome = metricutils.ErrorOutcome
+		}
+		f, ok := rc.finalizer.(*finalizer)
+		if ok {
+			f.metrics.RecordFinalOutcome(finalizerErr.FinalizerType, outcome)
+		}
+	}
+}
+
+func repositoryTypeMetricLabel(obj *provisioning.Repository) string {
+	t := string(obj.Spec.Type)
+	if t == "" {
+		return "unknown"
+	}
+	return t
+}
+
+func (rc *RepositoryController) recordRepositoryDeletionMetricsEnabled(obj *provisioning.Repository) bool {
+	return rc.repositoryDeletionMetrics != nil && obj != nil && obj.DeletionTimestamp != nil
+}
+
+func (rc *RepositoryController) recordRepositoryDeletionSucceeded(obj *provisioning.Repository, finalizersAtStart []string) {
+	if !rc.recordRepositoryDeletionMetricsEnabled(obj) {
+		return
+	}
+	elapsed := time.Since(obj.DeletionTimestamp.Time).Seconds()
+	rc.repositoryDeletionMetrics.RecordSuccess(repositoryTypeMetricLabel(obj), elapsed)
+	if len(finalizersAtStart) == 0 {
+		return
+	}
+	f, ok := rc.finalizer.(*finalizer)
+	if !ok {
+		return
+	}
+	for _, name := range orderedRepositoryFinalizers() {
+		if slices.Contains(finalizersAtStart, name) {
+			f.metrics.RecordFinalOutcome(name, metricutils.SuccessOutcome)
+		}
+	}
+}
+
+func (rc *RepositoryController) recordRepositoryDeletionFailed(obj *provisioning.Repository) {
+	if !rc.recordRepositoryDeletionMetricsEnabled(obj) {
+		return
+	}
+	rc.repositoryDeletionMetrics.RecordError()
+}
+
 func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provisioning.Repository) error {
 	logger := logging.FromContext(ctx)
 	logger.Info("handle repository delete")
+
+	finalizersAtStart := slices.Clone(obj.Finalizers)
 
 	// Process any finalizers
 	if len(obj.Finalizers) > 0 {
 		repo, err := rc.repoFactory.Build(ctx, obj)
 		if err != nil {
+			rc.recordRepositoryDeletionFailed(obj)
 			return fmt.Errorf("create repository from configuration: %w", err)
 		}
 
@@ -292,6 +367,7 @@ func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provision
 			if statusErr := rc.updateDeleteStatus(ctx, obj, fmt.Errorf("remove finalizers: %w", err)); statusErr != nil {
 				logger.Error("failed to update repository status after finalizer removal error", "error", statusErr)
 			}
+			rc.recordRepositoryDeletionFailed(obj)
 			return fmt.Errorf("process finalizers: %w", err)
 		}
 
@@ -303,13 +379,14 @@ func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provision
 				FieldManager: "provisioning-controller",
 			})
 		if err != nil {
+			rc.recordRepositoryDeletionFailed(obj)
 			return fmt.Errorf("remove finalizers: %w", err)
 		}
+		rc.recordRepositoryDeletionSucceeded(obj, finalizersAtStart)
 		return nil
-	} else {
-		logger.Info("no finalizers to process")
 	}
-
+	logger.Info("no finalizers to process")
+	rc.recordRepositoryDeletionSucceeded(obj, nil)
 	return nil
 }
 

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	metricutils "github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -376,6 +379,127 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func histogramSampleCountForRepoType(t *testing.T, reg prometheus.Gatherer, repoType string) uint64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	var total uint64
+	for _, mf := range mfs {
+		if mf.GetName() != "grafana_provisioning_repository_deletion_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var rt string
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "repository_type" {
+					rt = lp.GetValue()
+				}
+			}
+			if rt == repoType && m.GetHistogram() != nil {
+				total += m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return total
+}
+
+func TestRepositoryController_handleDelete_recordsRepositoryDeletionMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	dm := registerRepositoryDeletionMetrics(reg)
+	dt := metav1.NewTime(time.Now().Add(-30 * time.Second))
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			DeletionTimestamp: &dt,
+			Finalizers:        []string{repository.RemoveOrphanResourcesFinalizer},
+		},
+		Spec: provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	}
+	f := repository.NewMockFactory(t)
+	f.On("Build", context.Background(), mock.Anything).Return(nil, nil).Once()
+
+	fp := NewMockFinalizerProcessor(t)
+	fp.On("process", context.Background(), nil, []string{repository.RemoveOrphanResourcesFinalizer}).Return(nil).Once()
+
+	client := &mockProvisioningV0alpha1Interface{
+		repositoriesFunc: func(string) client.RepositoryInterface {
+			return &mockRepoInterface{
+				patchFunc: func(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*provisioning.Repository, error) {
+					return &provisioning.Repository{}, nil
+				},
+			}
+		},
+	}
+
+	rc := &RepositoryController{
+		repoFactory:               f,
+		finalizer:                 fp,
+		client:                    client,
+		repositoryDeletionMetrics: dm,
+	}
+
+	require.NoError(t, rc.handleDelete(context.Background(), repo))
+	require.Equal(t, float64(1), testutil.ToFloat64(dm.total.WithLabelValues(metricutils.SuccessOutcome)))
+	require.Equal(t, uint64(1), histogramSampleCountForRepoType(t, reg, "github"))
+}
+
+func TestRepositoryController_recordRepositoryDeletionSucceeded_recordsPerFinalizerSuccess(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	fm := registerFinalizerMetrics(reg)
+	dm := registerRepositoryDeletionMetrics(reg)
+	dt := metav1.NewTime(time.Now().Add(-time.Minute))
+	obj := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			DeletionTimestamp: &dt,
+			Finalizers: []string{
+				repository.CleanFinalizer,
+				repository.RemoveOrphanResourcesFinalizer,
+			},
+		},
+		Spec: provisioning.RepositorySpec{Type: provisioning.LocalRepositoryType},
+	}
+	rc := &RepositoryController{
+		finalizer: &finalizer{
+			metrics:    &fm,
+			maxWorkers: 1,
+		},
+		repositoryDeletionMetrics: dm,
+	}
+	finalizersAtStart := []string{
+		repository.CleanFinalizer,
+		repository.RemoveOrphanResourcesFinalizer,
+	}
+	rc.recordRepositoryDeletionSucceeded(obj, finalizersAtStart)
+
+	require.Equal(t, float64(1), testutil.ToFloat64(dm.total.WithLabelValues(metricutils.SuccessOutcome)))
+	require.Equal(t, uint64(1), histogramSampleCountForRepoType(t, reg, "local"))
+	require.Equal(t, float64(1), testutil.ToFloat64(fm.finalizerProcessedTotal.WithLabelValues(repository.CleanFinalizer, metricutils.SuccessOutcome)))
+	require.Equal(t, float64(1), testutil.ToFloat64(fm.finalizerProcessedTotal.WithLabelValues(repository.RemoveOrphanResourcesFinalizer, metricutils.SuccessOutcome)))
+	require.Equal(t, float64(0), testutil.ToFloat64(fm.finalizerProcessedTotal.WithLabelValues(repository.ReleaseOrphanResourcesFinalizer, metricutils.SuccessOutcome)))
+}
+
+func TestRepositoryController_handleDelete_recordsDeletionErrorMetric(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	dm := registerRepositoryDeletionMetrics(reg)
+	dt := metav1.NewTime(time.Now().Add(-time.Second))
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			DeletionTimestamp: &dt,
+			Finalizers:        []string{repository.RemoveOrphanResourcesFinalizer},
+		},
+		Spec: provisioning.RepositorySpec{Type: provisioning.GitHubRepositoryType},
+	}
+	f := repository.NewMockFactory(t)
+	f.On("Build", context.Background(), mock.Anything).Return(nil, assert.AnError).Once()
+
+	rc := &RepositoryController{
+		repoFactory:               f,
+		repositoryDeletionMetrics: dm,
+	}
+
+	require.Error(t, rc.handleDelete(context.Background(), repo))
+	require.Equal(t, float64(1), testutil.ToFloat64(dm.total.WithLabelValues(metricutils.ErrorOutcome)))
 }
 
 func TestShouldUseIncrementalSync(t *testing.T) {


### PR DESCRIPTION
## Summary

This pull request improves provisioning observability for repository finalizers and repository CR deletion.

### Finalizer controller metrics
- Record `grafana_provisioning_finalizers_processed_total` at the controller when a reconcile attempt finishes (including terminal failure after retries), so transient `ServiceUnavailable` retries are not double-counted as separate final outcomes.
- Add `grafana_provisioning_finalizers_retries_total` for visibility into retry volume.
- Keep per-step latency on `grafana_provisioning_finalizers_duration_seconds` on successful steps.

### Repository deletion SLO
- Add `grafana_provisioning_repository_deletion_total` (`outcome`) and `grafana_provisioning_repository_deletion_duration_seconds` (`repository_type`) for time from `metadata.deletionTimestamp` until delete reconcile succeeds.
- On successful delete, emit `grafana_provisioning_finalizers_processed_total` success once per configured finalizer (aligned with completed delete, not per retry).
- Add `pkg/registry/apis/provisioning/SLO_QUERIES.md` with metric scopes and example PromQL.

### Tests
- Extend `repository_test.go` for deletion metrics and per-finalizer success recording.

## How to test
```bash
go test ./pkg/registry/apis/provisioning/controller/... -count=1
```


Made with [Cursor](https://cursor.com)