### PR TITLE
Storage: Fix broadcaster race in removeSubscriber

### DIFF
--- a/pkg/storage/unified/resource/broadcaster.go
+++ b/pkg/storage/unified/resource/broadcaster.go
@@ -304,10 +304,10 @@ func (b *broadcaster[T]) removeSubscriber(recv <-chan T, reason string) {
 		return
 	}
 	sub.overflow = nil
-	close(sub.ch)
 	delete(b.subs, recv)
 	b.metrics.Subscribers.Dec()
 	b.metrics.UnsubscriptionsTotal.WithLabelValues(reason).Inc()
+	close(sub.ch)
 }
 
 // ringBuffer is a fixed-size circular buffer. It is not safe for concurrent


### PR DESCRIPTION
**What is this feature?**

Fixes a race condition in the broadcaster's `removeSubscriber` by moving `close(sub.ch)` after metric updates and map deletion.

**Why do we need this feature?**

`close(sub.ch)` is the signal that unblocks consumers waiting on the channel. When it fired before metrics were updated, consumers could observe stale metric values (e.g. `UnsubscriptionsTotal` still at 0 after shutdown). This caused flaky `TestBroadcaster` failures. Additionally, `close` before `delete` means the stream loop could still find the subscriber in `b.subs` and attempt to send to the closed channel, which panics.

**Who is this feature for?**

Unified storage developers and CI stability (failed here https://github.com/grafana/grafana/actions/runs/24355263714/job/71120474555).

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.