### PR TITLE
IAM: revert noise from TestIntegrationTeamBindings

### DIFF
--- a/pkg/tests/apis/iam/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/team_binding_integration_test.go
@@ -3,10 +3,8 @@ package identity
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,7 +35,6 @@ func TestIntegrationTeamBindings(t *testing.T) {
 					AppModeProduction:      false,
 					DisableAnonymous:       true,
 					RBACSingleOrganization: true,
-					EnableLog:              true,
 					APIServerStorageType:   "unified",
 					UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 						"teambindings.iam.grafana.app": {
@@ -50,7 +47,6 @@ func TestIntegrationTeamBindings(t *testing.T) {
 						featuremgmt.FlagKubernetesUsersApi,
 					},
 				},
-				CustomHTTPClient: &http.Client{Timeout: 60 * time.Second},
 			})
 
 			ctx := context.Background()


### PR DESCRIPTION
Removes `EnableLog: true` and the custom HTTP client timeout added in grafana/grafana#121751. Neither change addressed the root cause of the flaky failure and `EnableLog` produces excessive log output that makes CI runs hard to read.

The `CustomHTTPClient` infrastructure added to `helper.go` in #121751 is left in place as it is generally useful.

The test remains skipped pending a proper fix.