### PR TITLE
Dashboards: Extend DashboardPageError for provisioning preview errors

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -106,19 +106,18 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   }, [route, slug, type, uid]);
 
   if (!dashboard) {
-    let errorElement;
-    if (loadError) {
-      errorElement = <DashboardPageError error={loadError} type={type} />;
-    }
-
-    return (
-      errorElement || (
-        <Page navId="dashboards/browse" layout={PageLayoutType.Canvas} data-testid={'dashboard-scene-page'}>
-          <Box paddingY={4} display="flex" direction="column" alignItems="center">
-            {isLoading && <PageLoader />}
-          </Box>
-        </Page>
-      )
+    return loadError ? (
+      <DashboardPageError
+        error={loadError}
+        type={type}
+        isProvisioned={route.routeName === DashboardRoutes.Provisioning}
+      />
+    ) : (
+      <Page navId="dashboards/browse" layout={PageLayoutType.Canvas} data-testid={'dashboard-scene-page'}>
+        <Box paddingY={4} display="flex" direction="column" alignItems="center">
+          {isLoading && <PageLoader />}
+        </Box>
+      </Page>
     );
   }
 

--- a/public/app/features/dashboard/containers/DashboardPageError.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageError.tsx
@@ -1,13 +1,43 @@
 import { PageLayoutType } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Alert, Box } from '@grafana/ui';
+import { Alert, Box, EmptyState, Text, TextLink } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
 import { getMessageFromError, getStatusFromError } from 'app/core/utils/errors';
 
-export function DashboardPageError({ error, type }: { error: unknown; type?: string }) {
-  const status = getStatusFromError(error);
+interface DashboardPageErrorProps {
+  error: unknown;
+  type?: string;
+  isProvisioned?: boolean;
+}
+
+export function DashboardPageError({ error, type, isProvisioned }: DashboardPageErrorProps) {
   const message = getMessageFromError(error);
+
+  if (isProvisioned) {
+    return (
+      <Page
+        navId="dashboards/browse"
+        pageNav={{ text: t('dashboard.dashboard-page-error.provisioning-title', 'Dashboard preview') }}
+      >
+        <Page.Contents>
+          <EmptyState
+            variant="not-found"
+            message={t('dashboard.dashboard-page-error.provisioning-message', 'Dashboard preview could not be loaded')}
+          >
+            <Text element="p" color="secondary">
+              {message}
+            </Text>
+            <TextLink href="/dashboards">
+              {t('dashboard.dashboard-page-error.back-to-dashboards', 'Back to dashboards')}
+            </TextLink>
+          </EmptyState>
+        </Page.Contents>
+      </Page>
+    );
+  }
+
+  const status = getStatusFromError(error);
   const entity = type === 'snapshot' ? 'Snapshot' : 'Dashboard';
 
   return (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5471,6 +5471,9 @@
       "cancel-loading-dashboard": "Cancel loading dashboard"
     },
     "dashboard-page-error": {
+      "back-to-dashboards": "Back to dashboards",
+      "provisioning-message": "Dashboard preview could not be loaded",
+      "provisioning-title": "Dashboard preview",
       "text": {
         "not-found": "Not found"
       }


### PR DESCRIPTION
**What is this feature?**

When a provisioned dashboard preview fails to load (e.g. backend returns 400 for an unmanaged dashboard conflict), the error page now shows a "Dashboard preview" title, a clear "Dashboard preview could not be loaded" message with the backend error details, and a "Back to dashboards" link — instead of the generic "Not found" header with a "Failed to load dashboard" alert.

**Why do we need this feature?**

The generic error page gave no indication that the user was on a provisioning preview route and provided no actionable context about what went wrong. Users had no way to distinguish a preview failure from a normal dashboard load failure.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1060

**Special notes for your reviewer:**
<img width="1289" height="747" alt="Screenshot 2026-04-14 at 18 08 35" src="https://github.com/user-attachments/assets/cfbe189c-7d47-44bc-b210-b2e9f330ed95" />

