### PR TITLE
UI: Fix overlap for UsersIndicator UserIcons

### DIFF
--- a/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
+++ b/packages/grafana-ui/src/components/UsersIndicator/UsersIndicator.tsx
@@ -62,7 +62,7 @@ const getStyles = (theme: GrafanaTheme2, limit: number) => {
       marginLeft: theme.spacing(1),
       isolation: 'isolate',
 
-      '& > button': {
+      '& > *': {
         marginLeft: theme.spacing(-1), // Overlay the elements a bit on top of each other
 
         // Ensure overlaying user icons are stacked correctly with z-index on each element


### PR DESCRIPTION
**What is this feature?**

Fixes the overlapping style of the `UserIcon`s in `UsersIndicator`.

| | |
|-|-|
| [Latest](https://developers.grafana.com/ui/latest/index.html?path=/story/iconography-usersindicator--with-many-users) | <img width="1620" height="668" alt="image" src="https://github.com/user-attachments/assets/f1a82e0e-ea83-4912-80f4-c70002cc2cd7" /> |
| [Canary](https://developers.grafana.com/ui/canary/index.html?path=/story/iconography-usersindicator--with-many-users) | <img width="1620" height="668" alt="image" src="https://github.com/user-attachments/assets/d5a4a080-6668-4ba3-9d6b-72f4196a0220" /> |
| [PR](https://storage.googleapis.com/grafana-storybook-previews/pr_122575_MattIPv4-fix-users-indicator-o/index.html?path=/story/iconography-usersindicator--with-many-users) | <img width="1620" height="668" alt="image" src="https://github.com/user-attachments/assets/fb0ef449-cebd-4851-bde5-9f7c4357b8f0" /> |

**Why do we need this feature?**

#120284 switched the underlying element for `UserIcon` to be a `div` in some situations, while the styling in `UsersIndicator` that applies the overlap assumed it would always be a `button`.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
