### PR TITLE
Dashboard: Fix restore erroring  with API version mismatch

### DIFF
--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -97,9 +97,6 @@ export function isV2DashboardCommand(
   return isDashboardV2Spec(cmd.dashboard);
 }
 
-/**
- * Build a clean create payload from a deleted dashboard resource.
- */
 export function buildRestorePayload<T>(dashboard: Resource<T>): ResourceForCreate<T> {
   return {
     metadata: {

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -2,7 +2,7 @@ import { config, locationService } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Status, type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { isRecord } from 'app/core/utils/isRecord';
-import { type Resource } from 'app/features/apiserver/types';
+import { AnnoKeyGrantPermissions, type Resource, type ResourceForCreate } from 'app/features/apiserver/types';
 import { type DashboardDataDTO } from 'app/types/dashboard';
 
 import { type SaveDashboardCommand } from '../components/SaveDashboard/types';
@@ -95,6 +95,23 @@ export function isV2DashboardCommand(
   cmd: SaveDashboardCommand<Dashboard | DashboardV2Spec>
 ): cmd is SaveDashboardCommand<DashboardV2Spec> {
   return isDashboardV2Spec(cmd.dashboard);
+}
+
+/**
+ * Build a clean create payload from a deleted dashboard resource.
+ */
+export function buildRestorePayload<T>(dashboard: Resource<T>): ResourceForCreate<T> {
+  return {
+    metadata: {
+      ...dashboard.metadata,
+      resourceVersion: '',
+      annotations: {
+        ...dashboard.metadata.annotations,
+        [AnnoKeyGrantPermissions]: 'default',
+      },
+    },
+    spec: dashboard.spec,
+  };
 }
 
 /**

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -3,6 +3,7 @@ import * as folderHooks from 'app/api/clients/folder/v1beta1/hooks';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
   AnnoKeyFolder,
+  AnnoKeyGrantPermissions,
   AnnoKeyManagerAllowsEdits,
   AnnoKeyManagerKind,
   AnnoKeyMessage,
@@ -617,45 +618,26 @@ describe('v1 dashboard API', () => {
   });
 
   describe('restoreDashboard', () => {
-    it('should reset resource version and return created dashboard', async () => {
+    it('should send only metadata and spec, without apiVersion, kind, or status', async () => {
       const dashboardToRestore = {
         ...mockDashboardDto,
         metadata: {
           ...mockDashboardDto.metadata,
           resourceVersion: '123456',
         },
+        status: { conversion: { failed: false, storedVersion: 'v0alpha1' } },
       };
 
       const api = new K8sDashboardAPI();
       const result = await api.restoreDashboard(dashboardToRestore);
 
-      expect(dashboardToRestore.metadata.resourceVersion).toBe('');
-      expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v1beta1/'),
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            resourceVersion: '',
-          }),
-        }),
-        expect.anything()
-      );
+      const payload = mockPost.mock.calls[0][1];
+      expect(payload).not.toHaveProperty('apiVersion');
+      expect(payload).not.toHaveProperty('kind');
+      expect(payload).not.toHaveProperty('status');
+      expect(payload.metadata.resourceVersion).toBe('');
+      expect(payload).toHaveProperty('spec');
       expect(result).toEqual(saveDashboardResponse);
-    });
-
-    it('should handle dashboard with empty resource version', async () => {
-      const dashboardToRestore = {
-        ...mockDashboardDto,
-        metadata: {
-          ...mockDashboardDto.metadata,
-          resourceVersion: '',
-        },
-      };
-
-      const api = new K8sDashboardAPI();
-      await api.restoreDashboard(dashboardToRestore);
-
-      expect(dashboardToRestore.metadata.resourceVersion).toBe('');
-      expect(mockPost).toHaveBeenCalled();
     });
 
     it('should preserve dashboard folder metadata', async () => {
@@ -673,16 +655,12 @@ describe('v1 dashboard API', () => {
       const api = new K8sDashboardAPI();
       await api.restoreDashboard(dashboardToRestore);
 
-      expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v1beta1/'),
+      const payload = mockPost.mock.calls[0][1];
+      expect(payload.metadata.annotations).toEqual(
         expect.objectContaining({
-          metadata: expect.objectContaining({
-            annotations: expect.objectContaining({
-              [AnnoKeyFolder]: 'randomFolderUid',
-            }),
-          }),
-        }),
-        expect.anything()
+          [AnnoKeyFolder]: 'randomFolderUid',
+          [AnnoKeyGrantPermissions]: 'default',
+        })
       );
     });
   });

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -36,7 +36,7 @@ import {
   type ListDashboardHistoryOptions,
   type ListDeletedDashboardsOptions,
 } from './types';
-import { isV2StoredVersion } from './utils';
+import { buildRestorePayload, isV2StoredVersion } from './utils';
 
 export function getK8sV1DashboardApiConfig() {
   return {
@@ -307,17 +307,6 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
   }
 
   restoreDashboard(dashboard: Resource<DashboardDataDTO>) {
-    // reset the resource version to create a new resource
-    return this.client.create({
-      metadata: {
-        ...dashboard.metadata,
-        resourceVersion: '',
-        annotations: {
-          ...dashboard.metadata.annotations,
-          [AnnoKeyGrantPermissions]: 'default',
-        },
-      },
-      spec: dashboard.spec,
-    });
+    return this.client.create(buildRestorePayload(dashboard));
   }
 }

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -308,11 +308,16 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
 
   restoreDashboard(dashboard: Resource<DashboardDataDTO>) {
     // reset the resource version to create a new resource
-    dashboard.metadata.resourceVersion = '';
-    dashboard.metadata.annotations = {
-      ...dashboard.metadata.annotations,
-      [AnnoKeyGrantPermissions]: 'default',
-    };
-    return this.client.create(dashboard);
+    return this.client.create({
+      metadata: {
+        ...dashboard.metadata,
+        resourceVersion: '',
+        annotations: {
+          ...dashboard.metadata.annotations,
+          [AnnoKeyGrantPermissions]: 'default',
+        },
+      },
+      spec: dashboard.spec,
+    });
   }
 }

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -7,6 +7,7 @@ import {
   AnnoKeyFolder,
   AnnoKeyFolderTitle,
   AnnoKeyFolderUrl,
+  AnnoKeyGrantPermissions,
   AnnoKeyMessage,
   AnnoKeySavedFromUI,
   DeprecatedInternalId,
@@ -539,45 +540,26 @@ describe('v2 dashboard API', () => {
   });
 
   describe('restoreDashboard', () => {
-    it('should reset resource version and return created dashboard', async () => {
+    it('should send only metadata and spec, without apiVersion, kind, or status', async () => {
       const dashboardToRestore = {
         ...mockDashboardDto,
         metadata: {
           ...mockDashboardDto.metadata,
           resourceVersion: '123456',
         },
+        status: { conversion: { failed: false, storedVersion: 'v0alpha1' } },
       };
 
       const api = new K8sDashboardV2API();
       const result = await api.restoreDashboard(dashboardToRestore);
 
-      expect(dashboardToRestore.metadata.resourceVersion).toBe('');
-      expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v2/'),
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            resourceVersion: '',
-          }),
-        }),
-        expect.anything()
-      );
+      const payload = mockPost.mock.calls[0][1];
+      expect(payload).not.toHaveProperty('apiVersion');
+      expect(payload).not.toHaveProperty('kind');
+      expect(payload).not.toHaveProperty('status');
+      expect(payload.metadata.resourceVersion).toBe('');
+      expect(payload).toHaveProperty('spec');
       expect(result.metadata.name).toBe('dash-uid');
-    });
-
-    it('should handle dashboard with empty resource version', async () => {
-      const dashboardToRestore = {
-        ...mockDashboardDto,
-        metadata: {
-          ...mockDashboardDto.metadata,
-          resourceVersion: '',
-        },
-      };
-
-      const api = new K8sDashboardV2API();
-      await api.restoreDashboard(dashboardToRestore);
-
-      expect(dashboardToRestore.metadata.resourceVersion).toBe('');
-      expect(mockPost).toHaveBeenCalled();
     });
 
     it('should preserve dashboard folder metadata', async () => {
@@ -595,16 +577,12 @@ describe('v2 dashboard API', () => {
       const api = new K8sDashboardV2API();
       await api.restoreDashboard(dashboardToRestore);
 
-      expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v2/'),
+      const payload = mockPost.mock.calls[0][1];
+      expect(payload.metadata.annotations).toEqual(
         expect.objectContaining({
-          metadata: expect.objectContaining({
-            annotations: expect.objectContaining({
-              [AnnoKeyFolder]: 'randomFolderUid',
-            }),
-          }),
-        }),
-        expect.anything()
+          [AnnoKeyFolder]: 'randomFolderUid',
+          [AnnoKeyGrantPermissions]: 'default',
+        })
       );
     });
   });

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -33,7 +33,7 @@ import {
   type ListDashboardHistoryOptions,
   type ListDeletedDashboardsOptions,
 } from './types';
-import { isV0V1StoredVersion } from './utils';
+import { buildRestorePayload, isV0V1StoredVersion } from './utils';
 
 export function getK8sV2DashboardApiConfig() {
   return {
@@ -253,17 +253,6 @@ export class K8sDashboardV2API
   }
 
   restoreDashboard(dashboard: Resource<DashboardV2Spec>) {
-    // reset the resource version to create a new resource
-    return this.client.create({
-      metadata: {
-        ...dashboard.metadata,
-        resourceVersion: '',
-        annotations: {
-          ...dashboard.metadata.annotations,
-          [AnnoKeyGrantPermissions]: 'default',
-        },
-      },
-      spec: dashboard.spec,
-    });
+    return this.client.create(buildRestorePayload(dashboard));
   }
 }

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -254,11 +254,16 @@ export class K8sDashboardV2API
 
   restoreDashboard(dashboard: Resource<DashboardV2Spec>) {
     // reset the resource version to create a new resource
-    dashboard.metadata.resourceVersion = '';
-    dashboard.metadata.annotations = {
-      ...dashboard.metadata.annotations,
-      [AnnoKeyGrantPermissions]: 'default',
-    };
-    return this.client.create(dashboard);
+    return this.client.create({
+      metadata: {
+        ...dashboard.metadata,
+        resourceVersion: '',
+        annotations: {
+          ...dashboard.metadata.annotations,
+          [AnnoKeyGrantPermissions]: 'default',
+        },
+      },
+      spec: dashboard.spec,
+    });
   }
 }


### PR DESCRIPTION
**What is this feature?**

Fixes the `restoreDashboard` method in both v1 and v2 dashboard api clients to construct a clean create payload with only `metadata` and `spec`, letting the API server infer `apiVersion` and `kind` 

Fixes https://github.com/grafana/grafana/issues/122532