### PR TITLE
Docs: Added docs/shared shortcode

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -84,7 +84,7 @@ To create a dashboard, follow these steps:
 
    {{< figure src="/media/docs/grafana/dashboards/screenshot-empty-dashboard-v13.0.png" max-width="750px" alt="Empty dashboard with sidebar open" >}}
 
-{{ < /shared >}}
+{{< /shared >}}
 
 1. On the new panel, select one of the following options:
    - **Configure visualization**: Opens panel edit mode with the default data source for your instance preselected. Configure a query and set panel and visualization options.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -74,11 +74,17 @@ Each panel needs at least one query to display a visualization.
 
 To create a dashboard, follow these steps:
 
+{{< docs/list >}}
+
+{{< docs/shared id="create-dashboard" >}}
+
 1. Click **Dashboards** in the main menu.
 1. Click **New** and select **New Dashboard**.
 1. Click the **Add new element** icon (blue plus sign) and click or drag a panel onto the dashboard.
 
    {{< figure src="/media/docs/grafana/dashboards/screenshot-empty-dashboard-v13.0.png" max-width="750px" alt="Empty dashboard with sidebar open" >}}
+
+{{ < /docs/shared >}}
 
 1. On the new panel, select one of the following options:
    - **Configure visualization**: Opens panel edit mode with the default data source for your instance preselected. Configure a query and set panel and visualization options.
@@ -137,6 +143,8 @@ To create a dashboard, follow these steps:
 1. Select a folder, if applicable.
 1. Click **Save**
 1. Click **Exit edit**.
+
+{{< /docs/list >}}
 
 ## Dashboard edit
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -76,7 +76,7 @@ To create a dashboard, follow these steps:
 
 {{< docs/list >}}
 
-{{< docs/shared id="create-dashboard" >}}
+{{< shared id="create-dashboard" >}}
 
 1. Click **Dashboards** in the main menu.
 1. Click **New** and select **New Dashboard**.
@@ -84,7 +84,7 @@ To create a dashboard, follow these steps:
 
    {{< figure src="/media/docs/grafana/dashboards/screenshot-empty-dashboard-v13.0.png" max-width="750px" alt="Empty dashboard with sidebar open" >}}
 
-{{ < /docs/shared >}}
+{{ < /shared >}}
 
 1. On the new panel, select one of the following options:
    - **Configure visualization**: Opens panel edit mode with the default data source for your instance preselected. Configure a query and set panel and visualization options.


### PR DESCRIPTION
Added docs/shared shortcode for use in learning path.
This was removed from the docs on `main` and the path was pointed to `latest` docs instead of `next` while dynamic dashboards was in public preview. See PR https://github.com/grafana/website/pull/28644.
Now it needs to be added back on `main` but just for use in the **Visualize JSON data** learning path because the **Visualize CSV data** path has had interactivity added.


