### PR TITLE
Docs: Add missing panel menu items and added time settings section

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
@@ -66,14 +66,16 @@ If an option is only available in view mode or edit mode, that's indicated:
   - **Data**: Open the **Inspect** drawer in the **Data** tab.
   - **Query**: Open the **Inspect** drawer in the **Query** tab.
   - **Panel JSON**: Open the **Inspect** drawer in the **JSON** tab.
+- **Time settings**: Opens the **Panel time settings** drawer where you can set panel-specific time options. Public preview. For more information, refer to [Panel time settings](#panel-time-settings).
 - **Assistant**: View mode only. Access Grafana Assistant help options. This option is only available on Grafana Cloud.
+- **Metrics drilldown**: Open the panel in the **Drilldown > Metrics** feature for further exploration. For more information, refer to [Metrics drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/simplified-exploration/metrics/).
 - **Extensions**: View mode only. Access other actions provided by installed applications, such as declaring an incident. This option is only available in view mode and only appears if you have app plugins installed that contribute an [extension](https://grafana.com/developers/plugin-tools/key-concepts/ui-extensions) to the panel menu.
 - **More**: Access other panel actions.
   - **Duplicate**: Edit mode only. Make a copy of the panel. Duplicated panels query data separately from the original panel. You can use the special `Dashboard` data source to [share the same query results across panels](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/share-query/) instead.
   - **Copy**: Copy the panel to the clipboard.
   - **New library panel**: Edit mode only. Create a panel that can be imported into other dashboards.
   - **New alert rule**: Open the alert rule configuration page in **Alerting**, where you can [create a Grafana-managed alert](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#create-alerts-from-panels) based on the panel queries.
-  - **Hide legend**: Hide the panel legend.
+  - **Hide/Show legend**: Hide or show the panel legend.
   - **Get help**: Send a snapshot or panel data to Grafana Labs Technical Support.
 - **Remove**: Edit mode only. Remove the panel from the dashboard.
 
@@ -84,7 +86,7 @@ Grafana has a number of keyboard shortcuts available specifically for panels. Pr
 By hovering over a panel with the mouse you can use some shortcuts that will target that panel.
 
 - `e`: Toggle panel edit view
-- `v`: Toggle panel fullscreen view
+- `v`: Toggle panel full screen view
 - `pu`: Share link
 - `pe`: Share embed
 - `ps`: Share snapshot
@@ -93,6 +95,19 @@ By hovering over a panel with the mouse you can use some shortcuts that will tar
 - `i`: Inspect
 - `pl`: Hide or show legend
 - `pr`: Remove Panel
+
+## Panel time settings
+
+{{< docs/public-preview product="Panel time settings" featureFlag="`panelTimeSettings`" >}}
+
+You can configure the following settings to control the time range for a panel:
+
+| Option | Description |
+| --- | --- |
+| Panel time range | Overrides the dashboard time range. Use one of the preset values or enter a custom value like `5m` or `2h`. |
+| Time shift | Adds a time shift relative to the dashboard or panel time range. Use one of the preset values or enter a custom value like `5m` or `2h`. |
+| Time comparison | <p>Compare data between two time ranges.</p><p>To try out this feature, enable the `timeComparison` feature toggle.</p> |
+| Hide panel time range | Don't show the panel time range in the panel header. |
 
 ## Pan and zoom panel time range
 

--- a/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-overview/index.md
@@ -102,12 +102,12 @@ By hovering over a panel with the mouse you can use some shortcuts that will tar
 
 You can configure the following settings to control the time range for a panel:
 
-| Option | Description |
-| --- | --- |
-| Panel time range | Overrides the dashboard time range. Use one of the preset values or enter a custom value like `5m` or `2h`. |
-| Time shift | Adds a time shift relative to the dashboard or panel time range. Use one of the preset values or enter a custom value like `5m` or `2h`. |
-| Time comparison | <p>Compare data between two time ranges.</p><p>To try out this feature, enable the `timeComparison` feature toggle.</p> |
-| Hide panel time range | Don't show the panel time range in the panel header. |
+| Option                | Description                                                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Panel time range      | Overrides the dashboard time range. Use one of the preset values or enter a custom value like `5m` or `2h`.                              |
+| Time shift            | Adds a time shift relative to the dashboard or panel time range. Use one of the preset values or enter a custom value like `5m` or `2h`. |
+| Time comparison       | <p>Compare data between two time ranges.</p><p>To try out this feature, enable the `timeComparison` feature toggle.</p>                  |
+| Hide panel time range | Don't show the panel time range in the panel header.                                                                                     |
 
 ## Pan and zoom panel time range
 


### PR DESCRIPTION
Adds **Time settings** and **Metrics drilldown** to panel menu options.
Adds new section detailing Time settings on the same page.