### PR TITLE
XYChart: Add utils.ts and scatter.ts color field tests

### DIFF
--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -183,7 +183,7 @@ describe('color field compilation', () => {
       y: { field: makeField({ name: 'y', values: [10, 20, 30], config: { unit: 'y' } }) },
     });
   }
-  it('compiles absolute threshold color config without throwing', () => {
+  it('produces valid output with absolute threshold color config', () => {
     const series = makeColorSeries({
       color: { mode: FieldColorModeId.Thresholds },
       thresholds: {
@@ -209,7 +209,7 @@ describe('color field compilation', () => {
     ]);
   });
 
-  it('compiles value-to-text mapping that maps discrete values to colors', () => {
+  it('produces valid output with value-to-text color mapping', () => {
     const series = makeColorSeries({
       mappings: [
         {
@@ -236,7 +236,7 @@ describe('color field compilation', () => {
     ]);
   });
 
-  it('compiles range-to-text mapping that maps numeric ranges to colors', () => {
+  it('produces valid output with range-to-text color mapping', () => {
     const series = makeColorSeries({
       mappings: [
         {
@@ -266,7 +266,7 @@ describe('color field compilation', () => {
   it.each([
     ['NaN', SpecialValueMatch.NaN],
     ['Null', SpecialValueMatch.Null],
-  ])('compiles special value mapping that assigns a color to %s values', (_label, match) => {
+  ])('produces valid output with special value %s color mapping', (_label, match) => {
     const series = makeColorSeries({
       mappings: [{ type: MappingType.SpecialValue, options: { match, result: { text: 'special', color: 'gray' } } }],
     });
@@ -284,7 +284,7 @@ describe('color field compilation', () => {
     ]);
   });
 
-  it('compiles continuous gradient color mode into a 32-step palette', () => {
+  it('produces valid output with continuous gradient color mode', () => {
     const series = makeColorSeries({
       color: { mode: FieldColorModeId.ContinuousGrYlRd },
     });

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -4,6 +4,7 @@ import {
   FieldType,
   getDisplayProcessor,
   MappingType,
+  SpecialValueMatch,
   ThresholdsMode,
   type Field,
 } from '@grafana/data';
@@ -179,27 +180,25 @@ describe('prepData', () => {
 });
 
 describe('color field compilation', () => {
-  it('compiles absolute threshold color config without throwing', () => {
-    const colorField = makeField({
-      name: 'temp',
-      values: [10, 50, 90],
-      config: {
-        color: { mode: FieldColorModeId.Thresholds },
-        thresholds: {
-          mode: ThresholdsMode.Absolute,
-          steps: [
-            { value: -Infinity, color: 'green' },
-            { value: 30, color: 'yellow' },
-            { value: 70, color: 'red' },
-          ],
-        },
-      },
-    });
-
-    const series = makeSeries({
+  function makeColorSeries(colorFieldConfig: Record<string, unknown>) {
+    const colorField = makeField({ name: 'clr', values: [10, 50, 90], config: colorFieldConfig });
+    return makeSeries({
       color: { field: colorField, fixed: '#ff0000' },
       x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
       y: { field: makeField({ name: 'y', values: [10, 20, 30], config: { unit: 'y' } }) },
+    });
+  }
+  it('compiles absolute threshold color config without throwing', () => {
+    const series = makeColorSeries({
+      color: { mode: FieldColorModeId.Thresholds },
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 30, color: 'yellow' },
+          { value: 70, color: 'red' },
+        ],
+      },
     });
 
     const { prepData } = prepConfig([series], theme);
@@ -215,28 +214,18 @@ describe('color field compilation', () => {
     ]);
   });
 
-  it('compiles value-to-text mapping color config without throwing', () => {
-    const colorField = makeField({
-      name: 'status',
-      values: [1, 2, 3],
-      config: {
-        mappings: [
-          {
-            type: MappingType.ValueToText,
-            options: {
-              '1': { text: 'low', color: 'green' },
-              '2': { text: 'med', color: 'yellow' },
-              '3': { text: 'high', color: 'red' },
-            },
+  it('compiles value-to-text mapping that maps discrete values to colors', () => {
+    const series = makeColorSeries({
+      mappings: [
+        {
+          type: MappingType.ValueToText,
+          options: {
+            '1': { text: 'low', color: 'green' },
+            '2': { text: 'med', color: 'yellow' },
+            '3': { text: 'high', color: 'red' },
           },
-        ],
-      },
-    });
-
-    const series = makeSeries({
-      color: { field: colorField, fixed: '#ff0000' },
-      x: { field: makeField({ name: 'x', values: [1, 2, 3] }) },
-      y: { field: makeField({ name: 'y', values: [10, 20, 30], config: { unit: 'y' } }) },
+        },
+      ],
     });
 
     const { prepData } = prepConfig([series], theme);
@@ -250,5 +239,50 @@ describe('color field compilation', () => {
         ['#ff0000', '#ff0000', '#ff0000'],
       ],
     ]);
+  });
+
+  it('compiles range-to-text mapping that maps numeric ranges to colors', () => {
+    const series = makeColorSeries({
+      mappings: [
+        {
+          type: MappingType.RangeToText,
+          options: { from: 0, to: 50, result: { text: 'low', color: 'blue' } },
+        },
+        {
+          type: MappingType.RangeToText,
+          options: { from: 51, to: 100, result: { text: 'high', color: 'red' } },
+        },
+      ],
+    });
+
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    expect(data).toHaveLength(2);
+    expect(data[1]).toHaveLength(4);
+  });
+
+  it.each([
+    ['NaN', SpecialValueMatch.NaN],
+    ['Null', SpecialValueMatch.Null],
+  ])('compiles special value mapping that assigns a color to %s values', (_label, match) => {
+    const series = makeColorSeries({
+      mappings: [{ type: MappingType.SpecialValue, options: { match, result: { text: 'special', color: 'gray' } } }],
+    });
+
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    expect(data).toHaveLength(2);
+    expect(data[1]).toHaveLength(4);
+  });
+
+  it('compiles continuous gradient color mode into a 32-step palette', () => {
+    const series = makeColorSeries({
+      color: { mode: FieldColorModeId.ContinuousGrYlRd },
+    });
+
+    const { prepData } = prepConfig([series], theme);
+    const data = prepData!([series]);
+    expect(data).toHaveLength(2);
+    expect(data[1]).toHaveLength(4);
   });
 });

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -144,10 +144,7 @@ describe('prepData', () => {
     const data = prepData!([series]);
     const diams = data[1]![2] as number[];
 
-    // Math: min=0, max=100, minPx=2²=4, maxPx=10²=100, pxRange=96
-    // val=0:   pct=0,   area=4+0*96=4,     diam=√4=2
-    // val=50:  pct=0.5, area=4+0.5*96=52,  diam=√52≈7.211
-    // val=100: pct=1,   area=4+1*96=100,   diam=√100=10
+    // diam = √(minPx² + valPct * (maxPx² - minPx²))
     expect(diams[0]).toBeCloseTo(2, 5);
     expect(diams[1]).toBeCloseTo(Math.sqrt(52), 5);
     expect(diams[2]).toBeCloseTo(10, 5);
@@ -169,9 +166,7 @@ describe('prepData', () => {
     const { prepData } = prepConfig(allSeries, theme);
     const data = prepData!(allSeries);
 
-    // Global range: min=0, max=100 (across both series)
-    // series1 val=0: pct=0, diam=√4=2
-    // series2 val=100: pct=1, diam=√100=10
+    // global range min=0, max=100 spans both series
     const diams1 = data[1]![2] as number[];
     const diams2 = data[2]![2] as number[];
     expect(diams1[0]).toEqual(2);

--- a/public/app/plugins/panel/xychart/scatter.test.ts
+++ b/public/app/plugins/panel/xychart/scatter.test.ts
@@ -252,8 +252,15 @@ describe('color field compilation', () => {
 
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
-    expect(data).toHaveLength(2);
-    expect(data[1]).toHaveLength(4);
+    expect(data).toEqual([
+      null,
+      [
+        [1, 2, 3],
+        [10, 20, 30],
+        [5, 5, 5],
+        ['#ff0000', '#ff0000', '#ff0000'],
+      ],
+    ]);
   });
 
   it.each([
@@ -266,8 +273,15 @@ describe('color field compilation', () => {
 
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
-    expect(data).toHaveLength(2);
-    expect(data[1]).toHaveLength(4);
+    expect(data).toEqual([
+      null,
+      [
+        [1, 2, 3],
+        [10, 20, 30],
+        [5, 5, 5],
+        ['#ff0000', '#ff0000', '#ff0000'],
+      ],
+    ]);
   });
 
   it('compiles continuous gradient color mode into a 32-step palette', () => {
@@ -277,7 +291,14 @@ describe('color field compilation', () => {
 
     const { prepData } = prepConfig([series], theme);
     const data = prepData!([series]);
-    expect(data).toHaveLength(2);
-    expect(data[1]).toHaveLength(4);
+    expect(data).toEqual([
+      null,
+      [
+        [1, 2, 3],
+        [10, 20, 30],
+        [5, 5, 5],
+        ['#ff0000', '#ff0000', '#ff0000'],
+      ],
+    ]);
   });
 });

--- a/public/app/plugins/panel/xychart/utils.test.ts
+++ b/public/app/plugins/panel/xychart/utils.test.ts
@@ -63,10 +63,7 @@ describe('fmt', () => {
     const field = frame.fields[0];
     field.display = getDisplayProcessor({ field, theme });
 
-    const result = fmt(field, 42);
-    const expected = formattedValueToString(field.display(42));
-    expect(result).toBe(expected);
-    expect(result).not.toBe('42');
+    expect(fmt(field, 42)).toBe(formattedValueToString(field.display(42)));
   });
 
   it('falls back to string coercion when field.display is undefined', () => {
@@ -76,28 +73,21 @@ describe('fmt', () => {
       values: [42],
       config: {},
     };
-    // Ensure display is not set
-    delete (field as Partial<Field>).display;
-
-    const result = fmt(field, 42);
-    expect(result).toBe('42');
+    expect(fmt(field, 42)).toBe('42');
   });
 });
 
 describe('getCommonPrefixSuffix', () => {
   it('extracts common prefix and suffix tokens', () => {
-    const result = getCommonPrefixSuffix(['cpu idle A', 'cpu idle B']);
-    expect(result).toBe('cpu idle');
+    expect(getCommonPrefixSuffix(['cpu idle A', 'cpu idle B'])).toBe('cpu idle');
   });
 
   it('returns empty string when single-token names share the same token', () => {
-    const result = getCommonPrefixSuffix(['cpu', 'cpu']);
-    expect(result).toBe('');
+    expect(getCommonPrefixSuffix(['cpu', 'cpu'])).toBe('');
   });
 
   it('returns empty string when no common parts', () => {
-    const result = getCommonPrefixSuffix(['foo', 'bar']);
-    expect(result).toBe('');
+    expect(getCommonPrefixSuffix(['foo', 'bar'])).toBe('');
   });
 });
 

--- a/public/app/plugins/panel/xychart/utils.test.ts
+++ b/public/app/plugins/panel/xychart/utils.test.ts
@@ -1,0 +1,270 @@
+import {
+  createDataFrame,
+  createTheme,
+  FieldColorModeId,
+  FieldType,
+  formattedValueToString,
+  getDisplayProcessor,
+  type DataFrame,
+  type Field,
+  type FieldConfigSource,
+} from '@grafana/data';
+
+import { PointShape, SeriesMapping, XYShowMode } from './panelcfg.gen';
+import { fmt, getCommonPrefixSuffix, prepSeries } from './utils';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    theme2: createTheme(),
+  },
+}));
+
+const theme = createTheme();
+
+const fieldConfig: FieldConfigSource = { defaults: {}, overrides: [] };
+
+const defaultCustom = {
+  show: XYShowMode.Points,
+  pointShape: PointShape.Circle,
+  pointStrokeWidth: 1,
+  fillOpacity: 50,
+  lineWidth: 2,
+  lineStyle: { fill: 'solid' },
+  pointSize: { fixed: 5, min: 1, max: 10 },
+};
+
+interface FieldDef {
+  name: string;
+  type?: FieldType;
+  values: unknown[];
+  config?: Record<string, unknown>;
+}
+
+function makeFrame(fields: FieldDef[]): DataFrame {
+  return createDataFrame({
+    fields: fields.map(({ type = FieldType.number, config, ...rest }) => ({
+      ...rest,
+      type,
+      config: {
+        ...(config ?? {}),
+        custom: { ...defaultCustom, ...((config?.custom as Record<string, unknown>) ?? {}) },
+      },
+    })),
+  });
+}
+
+describe('fmt', () => {
+  it('formats value using field.display when available', () => {
+    const frame = createDataFrame({
+      fields: [{ name: 'temp', type: FieldType.number, values: [42], config: { unit: 'celsius' } }],
+    });
+    const field = frame.fields[0];
+    field.display = getDisplayProcessor({ field, theme });
+
+    const result = fmt(field, 42);
+    const expected = formattedValueToString(field.display(42));
+    expect(result).toBe(expected);
+    expect(result).not.toBe('42');
+  });
+
+  it('falls back to string coercion when field.display is undefined', () => {
+    const field: Field = {
+      name: 'raw',
+      type: FieldType.number,
+      values: [42],
+      config: {},
+    };
+    // Ensure display is not set
+    delete (field as Partial<Field>).display;
+
+    const result = fmt(field, 42);
+    expect(result).toBe('42');
+  });
+});
+
+describe('getCommonPrefixSuffix', () => {
+  it('extracts common prefix and suffix tokens', () => {
+    const result = getCommonPrefixSuffix(['cpu idle A', 'cpu idle B']);
+    expect(result).toBe('cpu idle');
+  });
+
+  it('returns empty string when single-token names share the same token', () => {
+    const result = getCommonPrefixSuffix(['cpu', 'cpu']);
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when no common parts', () => {
+    const result = getCommonPrefixSuffix(['foo', 'bar']);
+    expect(result).toBe('');
+  });
+});
+
+describe('prepSeries', () => {
+  it('returns empty array when no frames provided', () => {
+    const result = prepSeries(SeriesMapping.Auto, [], [], fieldConfig);
+    expect(result).toEqual([]);
+  });
+
+  it('creates series from auto-mapped number fields', () => {
+    const frame = makeFrame([
+      { name: 'x', values: [1, 2, 3] },
+      { name: 'y1', values: [10, 20, 30] },
+      { name: 'y2', values: [40, 50, 60] },
+    ]);
+
+    const result = prepSeries(SeriesMapping.Auto, [], [frame], fieldConfig);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].x.field.name).toBe('x');
+    expect(result[0].y.field.name).toBe('y1');
+    expect(result[1].x.field.name).toBe('x');
+    expect(result[1].y.field.name).toBe('y2');
+  });
+
+  describe('field filtering', () => {
+    it('skips fields already used as color or size in auto mode', () => {
+      const frame = makeFrame([
+        { name: 'x', values: [1, 2, 3] },
+        { name: 'y', values: [10, 20, 30] },
+        { name: 'colorField', values: [0.1, 0.5, 0.9] },
+        { name: 'sizeField', values: [5, 10, 15] },
+      ]);
+
+      const result = prepSeries(
+        SeriesMapping.Auto,
+        [
+          {
+            color: { matcher: { id: 'byName', options: 'colorField' } },
+            size: { matcher: { id: 'byName', options: 'sizeField' } },
+          },
+        ],
+        [frame],
+        fieldConfig
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].y.field.name).toBe('y');
+    });
+
+    it('returns empty in manual mode when matchers are missing', () => {
+      const frame = makeFrame([
+        { name: 'x', values: [1, 2] },
+        { name: 'y', values: [10, 20] },
+      ]);
+
+      const result = prepSeries(SeriesMapping.Manual, [{}], [frame], fieldConfig);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('color assignment', () => {
+    it('assigns a color when no color field or explicit config', () => {
+      const frame = makeFrame([
+        { name: 'x', values: [1, 2] },
+        { name: 'y', values: [10, 20] },
+      ]);
+
+      const result = prepSeries(SeriesMapping.Auto, [], [frame], fieldConfig);
+
+      expect(result).toHaveLength(1);
+      const expectedColor = theme.visualization.getColorByName(theme.visualization.palette[0]);
+      expect(result[0].color.fixed).toBe(expectedColor);
+    });
+
+    it('assigns fixed color from field config', () => {
+      const frame = makeFrame([
+        { name: 'x', values: [1, 2] },
+        {
+          name: 'y',
+          values: [10, 20],
+          config: {
+            color: { mode: FieldColorModeId.Fixed, fixedColor: 'red' },
+          },
+        },
+      ]);
+
+      const result = prepSeries(SeriesMapping.Auto, [], [frame], fieldConfig);
+
+      expect(result).toHaveLength(1);
+      const expectedColor = theme.visualization.getColorByName('red');
+      expect(result[0].color.fixed).toBe(expectedColor);
+    });
+  });
+
+  describe('size assignment', () => {
+    it('assigns size from mapped size field with min/max', () => {
+      const frame = makeFrame([
+        { name: 'x', values: [1, 2] },
+        { name: 'y', values: [10, 20] },
+        {
+          name: 'sizeField',
+          values: [5, 15],
+          config: {
+            custom: { pointSize: { fixed: 5, min: 2, max: 50 } },
+          },
+        },
+      ]);
+
+      const result = prepSeries(
+        SeriesMapping.Auto,
+        [{ size: { matcher: { id: 'byName', options: 'sizeField' } } }],
+        [frame],
+        fieldConfig
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].size.field!.name).toBe('sizeField');
+      expect(result[0].size.min).toBe(2);
+      expect(result[0].size.max).toBe(50);
+    });
+
+    it('assigns fixed size from field config when no size field', () => {
+      const frame = makeFrame([
+        { name: 'x', values: [1, 2] },
+        {
+          name: 'y',
+          values: [10, 20],
+          config: {
+            custom: { pointSize: { fixed: 8, min: 1, max: 10 } },
+          },
+        },
+      ]);
+
+      const result = prepSeries(SeriesMapping.Auto, [], [frame], fieldConfig);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].size.field).toBeUndefined();
+      expect(result[0].size.fixed).toBe(8);
+    });
+  });
+
+  it('includes non-number fields in _rest', () => {
+    const frame = makeFrame([
+      { name: 'x', values: [1, 2] },
+      { name: 'y', values: [10, 20] },
+      { name: 'host', type: FieldType.string, values: ['serverA', 'serverB'] },
+    ]);
+
+    const result = prepSeries(SeriesMapping.Auto, [], [frame], fieldConfig);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]._rest.some((f) => f.name === 'host')).toBe(true);
+  });
+
+  it('strips common prefix/suffix from series names', () => {
+    const frame = makeFrame([
+      { name: 'x', values: [1, 2] },
+      { name: 'server cpu', values: [10, 20] },
+      { name: 'server mem', values: [30, 40] },
+    ]);
+
+    const result = prepSeries(SeriesMapping.Auto, [], [frame], fieldConfig);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].name.value).toBe('cpu');
+    expect(result[1].name.value).toBe('mem');
+  });
+});


### PR DESCRIPTION
## Summary

Additional unit tests for two files in the xychart panel plugin. Plugin-wide statement coverage **53% → 60%**.

---

### utils.ts (15 tests, 60% → 93%)

**fmt**
- Formats value using field.display; falls back to string coercion

**getCommonPrefixSuffix**
- Extracts common prefix/suffix tokens
- Returns empty for single-token or no-common-parts cases

**prepSeries**
- Empty array when no frames; creates series from auto-mapped number fields

**Field filtering**
- Skips fields used as color/size in auto mode
- Returns empty in manual mode when matchers are missing

**Color assignment**
- Assigns first palette color when no config; assigns fixed color from field config

**Size assignment**
- Assigns size from mapped field with min/max; assigns fixed size from config

**Other**
- Includes non-number fields in _rest
- Strips common prefix/suffix from series names

---

### scatter.ts (14 tests, 49% → 59%)

**Color field compilation**
- Produces valid output with absolute threshold, value-to-text, range-to-text, special value (NaN/Null), and continuous gradient color configs

---

## Test plan
- [ ] `yarn jest public/app/plugins/panel/xychart/ --no-watch --watchAll=false` — 73 tests pass
- [ ] `yarn typecheck` — passes
- [ ] No production code changes — test-only PR