### PR TITLE
Docs: Adjust weight of G13 upgrade guide to fix ordering

### DIFF
--- a/docs/sources/upgrade-guide/upgrade-v13.0/index.md
+++ b/docs/sources/upgrade-guide/upgrade-v13.0/index.md
@@ -8,7 +8,7 @@ keywords:
   - '13.0'
 title: Upgrade to Grafana v13.0
 menuTitle: Upgrade to v13.0
-weight: 496
+weight: 495
 ---
 
 # Upgrade to Grafana v13.0


### PR DESCRIPTION
**What is this feature?**

Fixes the weight of the g13 upgrade guide to fix how it's displayed in the left-hand nav

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]To have correct ordering of content

**Who is this feature for?**

All Grafana documentation users