### PR TITLE
Dashboards: Stop pointer event propagation on panel GroupBy action

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByAction.tsx
@@ -108,6 +108,8 @@ export function PanelGroupByAction({ groupByVariable, adhocGroupByVariable, quer
         openPopover();
         ev.stopPropagation();
       }}
+      onPointerDown={(ev) => ev.stopPropagation()}
+      onPointerUp={(ev) => ev.stopPropagation()}
     >
       <Trans i18nKey="panel-group-by.button">Group by</Trans>
       <Icon name="angle-down" />

--- a/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByActionPopover.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-actions/PanelGroupByAction/PanelGroupByActionPopover.tsx
@@ -103,7 +103,12 @@ export function PanelGroupByActionPopover({
     <ClickOutsideWrapper onClick={onCancel} useCapture={true}>
       {/* This is just blocking click events from bubbeling and should not have a keyboard interaction. */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-      <div className={styles.menuContainer} onClick={(ev) => ev.stopPropagation()}>
+      <div
+        className={styles.menuContainer}
+        onClick={(ev) => ev.stopPropagation()}
+        onPointerDown={(ev) => ev.stopPropagation()}
+        onPointerUp={(ev) => ev.stopPropagation()}
+      >
         <Stack direction="column">
           <div className={styles.searchContainer}>
             <FilterInput


### PR DESCRIPTION
**What is this feature?**

Stops `pointerdown` and `pointerup` event propagation on the panel GroupBy button and its popover, preventing the panel edit pane from opening when interacting with the `GroupBy` dropdown.


Fixes #122573