### PR TITLE
Alerting: Add alerting.rulesAPIV2 feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1740,5 +1740,5 @@ export interface FeatureToggles {
   * Enables the new Rules API v2 UI with evaluation chains and groupless rule creation
   * @default false
   */
-  alertingRulesAPIV2?: boolean;
+  ['alerting.rulesAPIV2']?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1736,4 +1736,9 @@ export interface FeatureToggles {
   * @default false
   */
   clickHouseConfigValidation?: boolean;
+  /**
+  * Enables the new Rules API v2 UI with evaluation chains and groupless rule creation
+  * @default false
+  */
+  alertingRulesAPIV2?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3045,6 +3045,15 @@ var (
 			Expression:  "false",
 			Generate:    Generate{Go: true, React: true},
 		},
+		{
+			Name:         "alertingRulesAPIV2",
+			Description:  "Enables the new Rules API v2 UI with evaluation chains and groupless rule creation",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3046,7 +3046,7 @@ var (
 			Generate:    Generate{Go: true, React: true},
 		},
 		{
-			Name:         "alertingRulesAPIV2",
+			Name:         "alerting.rulesAPIV2",
 			Description:  "Enables the new Rules API v2 UI with evaluation chains and groupless rule creation",
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaAlertingSquad,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -355,4 +355,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-04,grafana.newPreferencesPage,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-04-14,datasource.useNewCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-04-17,reporting.anyPageReporting,experimental,@grafana/sharing-squad,false,false,false
-2026-04-14,alertingRulesAPIV2,experimental,@grafana/alerting-squad,false,false,false
+2026-04-14,alerting.rulesAPIV2,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -355,3 +355,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-04,grafana.newPreferencesPage,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-04-14,datasource.useNewCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-04-17,reporting.anyPageReporting,experimental,@grafana/sharing-squad,false,false,false
+2026-04-14,alertingRulesAPIV2,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -957,4 +957,8 @@ const (
 	// FlagReportingAnyPageReporting
 	// Enables reporting for any page in Grafana
 	FlagReportingAnyPageReporting = "reporting.anyPageReporting"
+
+	// FlagAlertingRulesAPIV2
+	// Enables the new Rules API v2 UI with evaluation chains and groupless rule creation
+	FlagAlertingRulesAPIV2 = "alertingRulesAPIV2"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -960,5 +960,5 @@ const (
 
 	// FlagAlertingRulesAPIV2
 	// Enables the new Rules API v2 UI with evaluation chains and groupless rule creation
-	FlagAlertingRulesAPIV2 = "alertingRulesAPIV2"
+	FlagAlertingRulesAPIV2 = "alerting.rulesAPIV2"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -720,6 +720,20 @@
     },
     {
       "metadata": {
+        "name": "alertingRulesAPIV2",
+        "resourceVersion": "1776190542259",
+        "creationTimestamp": "2026-04-14T18:15:42Z"
+      },
+      "spec": {
+        "description": "Enables the new Rules API v2 UI with evaluation chains and groupless rule creation",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingSaveStateCompressed",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-01-27T17:47:33Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -131,6 +131,20 @@
     },
     {
       "metadata": {
+        "name": "alerting.rulesAPIV2",
+        "resourceVersion": "1776193652999",
+        "creationTimestamp": "2026-04-14T19:07:32Z"
+      },
+      "spec": {
+        "description": "Enables the new Rules API v2 UI with evaluation chains and groupless rule creation",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingAIAnalyzeCentralStateHistory",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-07-16T16:42:42Z"
@@ -722,7 +736,8 @@
       "metadata": {
         "name": "alertingRulesAPIV2",
         "resourceVersion": "1776190542259",
-        "creationTimestamp": "2026-04-14T18:15:42Z"
+        "creationTimestamp": "2026-04-14T18:15:42Z",
+        "deletionTimestamp": "2026-04-14T19:07:32Z"
       },
       "spec": {
         "description": "Enables the new Rules API v2 UI with evaluation chains and groupless rule creation",


### PR DESCRIPTION
**What is this feature?**

This PR adds a feature flag to be used to gate the frontend changes related to the RulesAPI UI changes

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1511