### PR TITLE
 Provisioning: Fix folder rename failing when cached UID is stale

### DIFF
--- a/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.test.tsx
+++ b/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.test.tsx
@@ -181,8 +181,8 @@ describe('RenameProvisionedFolderForm', () => {
       expect(request.url.pathname).toContain('/repositories/test-repo/files/');
       expect(request.url.searchParams.get('ref')).toBe('my-branch');
       expect(request.url.searchParams.get('message')).toBe('Rename folder');
+      // No metadata.name — omitting the ID lets the backend preserve the existing UID from the repo.
       expect(request.body).toEqual({
-        metadata: { name: 'folder-uid' },
         spec: { title: 'Test Folder' },
       });
     });
@@ -246,8 +246,8 @@ describe('RenameProvisionedFolderForm', () => {
       const request = requireCapturedRequest(capturedRequest);
       // Path stays the same — only the title in the body changes
       expect(request.url.pathname).toContain('folders/test-folder/');
+      // No metadata.name — omitting the ID lets the backend preserve the existing UID from the repo.
       expect(request.body).toEqual({
-        metadata: { name: 'folder-uid' },
         spec: { title: 'New Folder Name' },
       });
     });

--- a/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.tsx
@@ -128,7 +128,6 @@ function FormContent({ initialValues, folder, repository, canPushToConfiguredBra
       ref: branchRef,
       message: comment || t('browse-dashboards.rename-provisioned-folder-form.commit', 'Rename folder'),
       body: {
-        metadata: { name: folder.uid },
         spec: { title },
       },
     });


### PR DESCRIPTION
**What is this feature?**

- Remove `metadata: { name: folder.uid }` from the `replaceFile` PUT body in `RenameProvisionedFolderForm.tsx`
- Update two test expectations in `RenameProvisionedFolderForm.test.tsx` to expect body without `metadata.name`

**Why do we need this feature?**

- `RenameProvisionedFolderForm` sends `metadata.name` set to the browse-dashboards `FolderDTO.uid`, which can lag behind the actual UID in git after fix-folder-metadata jobs, branch merges, or other repo-first updates
- The backend (`WriteFolderMetadataUpdate`) compares the submitted `metadata.name` against `_folder.json` and returns a **400 "folder ID change is not allowed"** when they differ
- When `metadata.name` is omitted (empty), the backend already skips the ID check and preserves the existing UID from the repo — this is the correct behavior for a title-only rename

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1071

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
