### PR TITLE
Docs: Add limit option for series items in legend docs

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/configure-legend/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-legend/index.md
@@ -129,7 +129,7 @@ If you set the legend placement to **Right**, the **Width** option becomes avail
 ### Limit
 
 Limit how many series items are shown by default.
-When the series count exceeds the limit, click the **Show all** link to see the full list of series.
+When the series count exceeds the limit, click the link to show all items to see the full list of series.
 
 Legend limits are supported for the following visualizations: time series, bar chart, bar gauge, candlestick, histogram, pie chart, state timeline, status history, trend, and XY chart.
 

--- a/docs/sources/visualizations/panels-visualizations/configure-legend/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-legend/index.md
@@ -126,6 +126,10 @@ Set where on the visualization a legend is displayed. Choose from:
 
 If you set the legend placement to **Right**, the **Width** option becomes available. Leave the field empty to allow Grafana to automatically set the legend width or enter a value in the field.
 
+### Limit
+
+Limit how many series items are shown by default. The rest become expandable using a Show all link.
+
 ### Values
 
 You can add more context to a visualization by adding series data values or [calculations](ref:calculations) to a legend. You can add as many values as you'd like. After you apply your changes, you can scroll the legend to see all values.

--- a/docs/sources/visualizations/panels-visualizations/configure-legend/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-legend/index.md
@@ -128,7 +128,10 @@ If you set the legend placement to **Right**, the **Width** option becomes avail
 
 ### Limit
 
-Limit how many series items are shown by default. The rest become expandable using a Show all link.
+Limit how many series items are shown by default.
+When the series count exceeds the limit, click the **Show all** link to see the full list of series.
+
+Legend limits are supported for the following visualizations: time series, bar chart, bar gauge, candlestick, histogram, pie chart, state timeline, status history, trend, and XY chart.
 
 ### Values
 


### PR DESCRIPTION
Added a new section to limit the number of series items shown in the legend.
This page was missed in the other doc updates for this feature.

