### PR TITLE
annotations: update batch annotation permission check

### DIFF
--- a/pkg/registry/apps/annotation/authz.go
+++ b/pkg/registry/apps/annotation/authz.go
@@ -32,42 +32,11 @@ func canAccessAnnotation(ctx context.Context, accessClient authtypes.AccessClien
 	if anno == nil {
 		return false, apierrors.NewBadRequest("annotation must not be nil")
 	}
-
-	authInfo, ok := authtypes.AuthInfoFrom(ctx)
-	if !ok {
-		return false, apierrors.NewUnauthorized("no identity found for request")
-	}
-
-	var checkReq authtypes.CheckRequest
-
-	if anno.Spec.DashboardUID == nil || *anno.Spec.DashboardUID == "" {
-		// Org-level annotation: scope is annotations:type:organization.
-		checkReq = authtypes.CheckRequest{
-			Verb:      verb,
-			Group:     "annotation.grafana.app",
-			Resource:  "annotations",
-			Namespace: namespace,
-			Name:      "organization",
-		}
-	} else {
-		// Dashboard annotation: use dashboards/annotations subresource,
-		// which maps to annotation actions scoped to dashboards:uid:<dashboardUID>.
-		checkReq = authtypes.CheckRequest{
-			Verb:        verb,
-			Group:       "dashboard.grafana.app",
-			Resource:    "dashboards",
-			Subresource: "annotations",
-			Namespace:   namespace,
-			Name:        *anno.Spec.DashboardUID,
-		}
-	}
-
-	resp, err := accessClient.Check(ctx, authInfo, checkReq, "")
+	allowed, err := canAccessAnnotations(ctx, accessClient, namespace, []annotationV0.Annotation{*anno}, verb)
 	if err != nil {
-		return false, fmt.Errorf("authz check failed: %w", err)
+		return false, err
 	}
-
-	return resp.Allowed, nil
+	return allowed[0], nil
 }
 
 // canAccessAnnotations checks permissions for a batch of annotations,
@@ -94,7 +63,8 @@ func canAccessAnnotations(ctx context.Context, accessClient authtypes.AccessClie
 			item.Name = "organization"
 		} else {
 			item.Group = "dashboard.grafana.app"
-			item.Resource = "annotations"
+			item.Resource = "dashboards"
+			item.Subresource = "annotations"
 			item.Name = *anno.Spec.DashboardUID
 		}
 

--- a/pkg/registry/apps/annotation/authz_test.go
+++ b/pkg/registry/apps/annotation/authz_test.go
@@ -36,11 +36,12 @@ func (c *fakeAccessClient) BatchCheck(_ context.Context, _ authtypes.AuthInfo, r
 	for _, item := range req.Checks {
 		results[item.CorrelationID] = authtypes.BatchCheckResult{
 			Allowed: c.fn(authtypes.CheckRequest{
-				Verb:      item.Verb,
-				Group:     item.Group,
-				Resource:  item.Resource,
-				Namespace: req.Namespace,
-				Name:      item.Name,
+				Verb:        item.Verb,
+				Group:       item.Group,
+				Resource:    item.Resource,
+				Subresource: item.Subresource,
+				Namespace:   req.Namespace,
+				Name:        item.Name,
 			}),
 		}
 	}
@@ -147,7 +148,8 @@ func TestCanAccessAnnotations(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, captured, 1)
 		assert.Equal(t, "dashboard.grafana.app", captured[0].Group)
-		assert.Equal(t, "annotations", captured[0].Resource)
+		assert.Equal(t, "dashboards", captured[0].Resource)
+		assert.Equal(t, "annotations", captured[0].Subresource)
 		assert.Equal(t, dashUID, captured[0].Name)
 		assert.Equal(t, ns, captured[0].Namespace)
 		assert.Equal(t, utils.VerbList, captured[0].Verb)


### PR DESCRIPTION
This PR is a follow-up to https://github.com/grafana/grafana/pull/118377 where dashboard-level annotation permissions were changed to be a subresource of dashboards instead of a top-level resource. The PR changed the single `canAccessAnnotation` function, but did not update the `canAccessAnnotations` function that does a batch check of permissions.

This PR updates the `canAccessAnnotations` function to reflect the new permission scheme where `annotations` is a subresource of `dashboards` and also updates the singular `canAccessAnnotation` function to be a thin wrapper around `canAccessAnnotations` so that we have a single source-of-truth for permission logic.