### PR TITLE
Add new feature flag for rollout of datasource CRUD APIs

### DIFF
--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -39,7 +39,7 @@ func (hs *HTTPServer) getK8sDataSourceByUIDHandler() web.Handler {
 	// datasourcesRerouteLegacyCRUDAPIs requires these flags to be enabled
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if !hs.Features.IsEnabledGlobally(featuremgmt.FlagQueryService) ||
-		!hs.Features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections) {
+		!hs.Features.IsEnabledGlobally(featuremgmt.FlagDatasourceUseNewCRUDAPIs) {
 		return routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
 			return response.Error(http.StatusInternalServerError,
 				"datasourcesRerouteLegacyCRUDAPIs requires queryService and queryServiceWithConnections feature flags",

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -182,7 +182,7 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 				Features: featuremgmt.WithFeatures(
 					featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs,
 					featuremgmt.FlagQueryService,
-					featuremgmt.FlagQueryServiceWithConnections,
+					featuremgmt.FlagDatasourceUseNewCRUDAPIs,
 					featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint,
 				),
 				dsConnectionClient:   &mockConnectionClient{result: tt.connectionResult, err: tt.connectionErr},

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -67,7 +67,7 @@ func RegisterAPIService(
 	pluginSources sources.Registry,
 ) (*DataSourceAPIBuilder, error) {
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if !features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections) {
+	if !features.IsEnabledGlobally(featuremgmt.FlagDatasourceUseNewCRUDAPIs) {
 		return nil, nil
 	}
 
@@ -106,7 +106,7 @@ func RegisterAPIService(
 			//nolint:staticcheck // not yet migrated to OpenFeature
 			DataSourceAPIBuilderConfig{
 				LoadQueryTypes:         features.IsEnabledGlobally(featuremgmt.FlagDatasourcesQueryTypes),
-				UseDualWriter:          features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections),
+				UseDualWriter:          features.IsEnabledGlobally(featuremgmt.FlagDatasourceUseNewCRUDAPIs),
 				EnableResourceEndpoint: features.IsEnabledGlobally(featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint),
 				EnableHealthEndpoint:   features.IsEnabledGlobally(featuremgmt.FlagDatasourcesApiServerEnableHealthEndpoint),
 			},

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3029,6 +3029,14 @@ var (
 			Owner:       grafanaFrontendPlatformSquad,
 			Expression:  "false",
 		},
+		{
+			Name:        "datasource.useNewCRUDAPIs",
+			Description: "Use the new datasource API groups for datasource CRUD requests, backend flag",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{Go: true},
+			Owner:       grafanaDatasourcesCoreServicesSquad,
+			Expression:  "false",
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -353,3 +353,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-13,influxDBConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false
 2026-04-09,clickHouseConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false
 2026-04-04,grafana.newPreferencesPage,experimental,@grafana/grafana-frontend-platform,false,false,true
+2026-04-14,datasource.useNewCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -949,4 +949,8 @@ const (
 	// FlagClickHouseConfigValidation
 	// Enables validation on the ClickHouse data source configuration page
 	FlagClickHouseConfigValidation = "clickHouseConfigValidation"
+
+	// FlagDatasourceUseNewCRUDAPIs
+	// Use the new datasource API groups for datasource CRUD requests, backend flag
+	FlagDatasourceUseNewCRUDAPIs = "datasource.useNewCRUDAPIs"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1675,6 +1675,19 @@
     },
     {
       "metadata": {
+        "name": "datasource.useNewCRUDAPIs",
+        "resourceVersion": "1776199197997",
+        "creationTimestamp": "2026-04-14T20:39:57Z"
+      },
+      "spec": {
+        "description": "Use the new datasource API groups for datasource CRUD requests, backend flag",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-datasources-core-services",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "datasourceAPIServers",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2024-09-19T08:28:27Z"

--- a/pkg/storage/unified/migrations/testcases/datasources.go
+++ b/pkg/storage/unified/migrations/testcases/datasources.go
@@ -30,7 +30,7 @@ func (tc *datasourcesTestCase) Name() string {
 
 func (tc *datasourcesTestCase) FeatureToggles() []string {
 	return []string{
-		featuremgmt.FlagQueryServiceWithConnections, // required for CRUD
+		featuremgmt.FlagDatasourceUseNewCRUDAPIs, // required for CRUD
 	}
 }
 

--- a/pkg/tests/api/datasources/datasource_get_by_uid_test.go
+++ b/pkg/tests/api/datasources/datasource_get_by_uid_test.go
@@ -45,6 +45,7 @@ func getTestModes() []testMode {
 			"datasourcesRerouteLegacyCRUDAPIs",
 			"queryService",                // need query.grafana.app API group
 			"queryServiceWithConnections", // need query.grafana.app connections subresource
+			"datasource.useNewCRUDAPIs",
 		}},
 	}
 }

--- a/pkg/tests/apis/datasource/resources_test.go
+++ b/pkg/tests/apis/datasource/resources_test.go
@@ -35,7 +35,7 @@ func setup(t *testing.T) *apis.K8sTestHelper {
 		DisableAnonymous: true,
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,       // Required to start the datasource api servers
-			featuremgmt.FlagQueryServiceWithConnections,                // enables CRUD endpoints
+			featuremgmt.FlagDatasourceUseNewCRUDAPIs,                   // enables CRUD endpoints
 			featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint, // enables resource endpoint
 		},
 	})

--- a/pkg/tests/apis/datasource/testdata_test.go
+++ b/pkg/tests/apis/datasource/testdata_test.go
@@ -43,7 +43,7 @@ func TestIntegrationTestDatasource(t *testing.T) {
 		DisableAnonymous: true,
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,       // Required to start the datasource api servers
-			featuremgmt.FlagQueryServiceWithConnections,                // enables CRUD endpoints
+			featuremgmt.FlagDatasourceUseNewCRUDAPIs,                   // enables CRUD endpoints
 			featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint, // enables resource endpoint
 			featuremgmt.FlagDatasourcesApiServerEnableHealthEndpoint,   // enables health endpoint
 		},
@@ -234,7 +234,7 @@ func TestIntegrationTestDatasource(t *testing.T) {
 		  { "refId": "A",
 				"scenarioId": "csv_content",
 				"csvContent": "f1,f2,f3\n1,\"two\",false"
-			},{ 
+			},{
 			  "refId": "B",
 				"scenarioId": "csv_content",
 				"csvContent": "f1,f2,f3\n1,\"two\",false"

--- a/pkg/tests/apis/openapi_test.go
+++ b/pkg/tests/apis/openapi_test.go
@@ -32,6 +32,7 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 			featuremgmt.FlagGrafanaAdvisor,
 			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, // library panels in v0
 			featuremgmt.FlagQueryServiceWithConnections,
+			featuremgmt.FlagDatasourceUseNewCRUDAPIs,
 			featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint,
 			// featuremgmt.FlagDatasourcesQueryTypes,
 			featuremgmt.FlagDatasourcesLoadOpenAPI,


### PR DESCRIPTION
This PR adds `FlagDatasourceUseNewCRUDAPIs` and uses it for the backend rollout of new CRUD APIs for datasources.

Previously we were using `FlagQueryServiceWithConnections`, but this caused coupling withe rollout of the query service and caching.