### PR TITLE
Git Sync: Strip BOMs when releasing resource ownership

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -19,6 +18,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	metricutils "github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 type finalizer struct {
@@ -243,16 +243,26 @@ func (f *finalizer) releaseResources(
 			"resource", item.Resource,
 		)
 
-		patchAnnotations, err := resources.GetReleasePatch(item)
+		obj, err := client.Get(ctx, item.Name, v1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("get patched annotations: %w", err)
+			return fmt.Errorf("get resource to release ownership: %w", err)
 		}
 
-		_, err = client.Patch(
-			ctx, item.Name, types.JSONPatchType, patchAnnotations, v1.PatchOptions{},
-		)
+		stripped, ok := util.StripBOMFromInterface(obj.Object).(map[string]any)
+		if !ok {
+			return fmt.Errorf("unexpected type after BOM stripping")
+		}
+		obj.Object = stripped
+
+		annotations := obj.GetAnnotations()
+		for _, key := range resources.ReleaseAnnotationKeys(item) {
+			delete(annotations, key)
+		}
+		obj.SetAnnotations(annotations)
+
+		_, err = client.Update(ctx, obj, v1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("patch resource to release ownership: %w", err)
+			return fmt.Errorf("update resource to release ownership: %w", err)
 		}
 		return nil
 	}

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -34,6 +34,8 @@ var (
 type mockDynamicClient struct {
 	deleteFunc func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
 	patchFunc  func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
+	getFunc    func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	updateFunc func(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
 }
 
 func (m mockDynamicClient) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -41,7 +43,10 @@ func (m mockDynamicClient) Create(ctx context.Context, obj *unstructured.Unstruc
 }
 
 func (m mockDynamicClient) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
-	panic("not needed for testing")
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, obj, options, subresources...)
+	}
+	return obj, nil
 }
 
 func (m mockDynamicClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
@@ -60,7 +65,12 @@ func (m mockDynamicClient) DeleteCollection(ctx context.Context, options metav1.
 }
 
 func (m mockDynamicClient) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
-	panic("not needed for testing")
+	if m.getFunc != nil {
+		return m.getFunc(ctx, name, options, subresources...)
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": name, "annotations": map[string]any{}},
+	}}, nil
 }
 
 func (m mockDynamicClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
@@ -163,11 +173,7 @@ func TestFinalizer_process(t *testing.T) {
 			clientFactory: func() resources.ClientFactory {
 				clientFactory := resources.NewMockClientFactory(t)
 				clients := resources.NewMockResourceClients(t)
-				client := &mockDynamicClient{
-					patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
-						return &unstructured.Unstructured{}, nil
-					},
-				}
+				client := &mockDynamicClient{}
 
 				clientFactory.
 					On("Clients", mock.Anything, "default").
@@ -438,7 +444,7 @@ func TestFinalizer_process(t *testing.T) {
 				clientFactory := resources.NewMockClientFactory(t)
 				clients := resources.NewMockResourceClients(t)
 				client := &mockDynamicClient{
-					patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+					getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
 						return nil, assert.AnError
 					},
 				}
@@ -714,11 +720,13 @@ func TestReleaseExistingItems_FoldersBeforeResources(t *testing.T) {
 	clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
 
 	client := &mockDynamicClient{
-		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+		getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
 			mu.Lock()
 			order = append(order, name)
 			mu.Unlock()
-			return nil, nil
+			return &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{"name": name, "annotations": map[string]any{}},
+			}}, nil
 		},
 	}
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
@@ -765,7 +773,7 @@ func TestReleaseExistingItems_ResourcesConcurrent(t *testing.T) {
 	clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
 
 	client := &mockDynamicClient{
-		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+		getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
 			current := atomic.AddInt64(&concurrentCount, 1)
 			defer atomic.AddInt64(&concurrentCount, -1)
 			mu.Lock()
@@ -774,7 +782,9 @@ func TestReleaseExistingItems_ResourcesConcurrent(t *testing.T) {
 			}
 			mu.Unlock()
 			time.Sleep(1 * time.Second)
-			return nil, nil
+			return &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{"name": name, "annotations": map[string]any{}},
+			}}, nil
 		},
 	}
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)

--- a/pkg/registry/apis/provisioning/jobs/releaseresources/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/releaseresources/worker.go
@@ -10,7 +10,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -18,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // Worker handles the releaseResources job action.
@@ -145,18 +145,19 @@ func (w *Worker) releaseItem(ctx context.Context, clients resources.ResourceClie
 		return nil
 	}
 
-	patchBytes, err := resources.GetReleasePatch(item)
-	if err != nil {
-		result.WithError(fmt.Errorf("build release patch for %s/%s: %w", item.Resource, item.Name, err))
-		progress.Record(ctx, result.Build())
-		if tooMany := progress.TooManyErrors(); tooMany != nil {
-			return tooMany
+	releaseCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	obj, err := res.Get(releaseCtx, item.Name, v1.GetOptions{})
+	if err == nil {
+		if stripped, ok := util.StripBOMFromInterface(obj.Object).(map[string]any); ok {
+			obj.Object = stripped
 		}
-		return nil
+		annotations := obj.GetAnnotations()
+		for _, key := range resources.ReleaseAnnotationKeys(item) {
+			delete(annotations, key)
+		}
+		obj.SetAnnotations(annotations)
+		_, err = res.Update(releaseCtx, obj, v1.UpdateOptions{})
 	}
-
-	patchCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	_, err = res.Patch(patchCtx, item.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
 	cancel()
 
 	if err != nil {

--- a/pkg/registry/apis/provisioning/jobs/releaseresources/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/releaseresources/worker_test.go
@@ -25,15 +25,15 @@ import (
 var _ dynamic.ResourceInterface = (*fakeDynamicClient)(nil)
 
 type fakeDynamicClient struct {
-	patchCalls []string
-	patchErr   error
+	getCalls []string
+	getErr   error
 }
 
 func (f *fakeDynamicClient) Create(context.Context, *unstructured.Unstructured, metav1.CreateOptions, ...string) (*unstructured.Unstructured, error) {
 	panic("unexpected")
 }
-func (f *fakeDynamicClient) Update(context.Context, *unstructured.Unstructured, metav1.UpdateOptions, ...string) (*unstructured.Unstructured, error) {
-	panic("unexpected")
+func (f *fakeDynamicClient) Update(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+	return obj, nil
 }
 func (f *fakeDynamicClient) UpdateStatus(context.Context, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {
 	panic("unexpected")
@@ -44,8 +44,14 @@ func (f *fakeDynamicClient) Delete(context.Context, string, metav1.DeleteOptions
 func (f *fakeDynamicClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
 	panic("unexpected")
 }
-func (f *fakeDynamicClient) Get(context.Context, string, metav1.GetOptions, ...string) (*unstructured.Unstructured, error) {
-	panic("unexpected")
+func (f *fakeDynamicClient) Get(_ context.Context, name string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+	f.getCalls = append(f.getCalls, name)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": name, "annotations": map[string]any{}},
+	}}, nil
 }
 func (f *fakeDynamicClient) List(context.Context, metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	panic("unexpected")
@@ -53,12 +59,8 @@ func (f *fakeDynamicClient) List(context.Context, metav1.ListOptions) (*unstruct
 func (f *fakeDynamicClient) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
 	panic("unexpected")
 }
-func (f *fakeDynamicClient) Patch(_ context.Context, name string, _ types.PatchType, _ []byte, _ metav1.PatchOptions, _ ...string) (*unstructured.Unstructured, error) {
-	f.patchCalls = append(f.patchCalls, name)
-	if f.patchErr != nil {
-		return nil, f.patchErr
-	}
-	return &unstructured.Unstructured{}, nil
+func (f *fakeDynamicClient) Patch(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("unexpected")
 }
 func (f *fakeDynamicClient) Apply(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions, ...string) (*unstructured.Unstructured, error) {
 	panic("unexpected")
@@ -128,7 +130,7 @@ func TestWorker_Process(t *testing.T) {
 
 	err := w.Process(ctx, nil, job, progress)
 	require.NoError(t, err)
-	require.Equal(t, []string{"dash-1", "dash-2"}, fakeClient.patchCalls)
+	require.Equal(t, []string{"dash-1", "dash-2"}, fakeClient.getCalls)
 }
 
 func TestWorker_Process_EmptyResourceList(t *testing.T) {
@@ -206,7 +208,7 @@ func TestWorker_Process_NotFoundResourceSkipped(t *testing.T) {
 	mockClients := resources.NewMockResourceClients(t)
 
 	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "dash-1")
-	fakeClient := &fakeDynamicClient{patchErr: notFoundErr}
+	fakeClient := &fakeDynamicClient{getErr: notFoundErr}
 
 	w := NewWorker(lister, clientFactory, 1)
 

--- a/pkg/registry/apis/provisioning/resources/cleanup.go
+++ b/pkg/registry/apis/provisioning/resources/cleanup.go
@@ -38,6 +38,19 @@ func GetReleasePatch(item *provisioning.ResourceListItem) ([]byte, error) {
 	return json.Marshal(ops)
 }
 
+// ReleaseAnnotationKeys returns the annotation keys that should be removed
+// when releasing a resource from repository ownership.
+func ReleaseAnnotationKeys(item *provisioning.ResourceListItem) []string {
+	keys := []string{utils.AnnoKeyManagerKind, utils.AnnoKeyManagerIdentity}
+	if item.Path != "" {
+		keys = append(keys, utils.AnnoKeySourcePath)
+	}
+	if item.Hash != "" {
+		keys = append(keys, utils.AnnoKeySourceChecksum)
+	}
+	return keys
+}
+
 // EscapePatchString escapes a string for use in a JSON Pointer (RFC 6901)
 // by replacing ~ with ~0 and / with ~1.
 func EscapePatchString(s string) string {

--- a/pkg/registry/apis/provisioning/resources/cleanup_test.go
+++ b/pkg/registry/apis/provisioning/resources/cleanup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 func TestEscapePatchString(t *testing.T) {
@@ -329,4 +330,28 @@ func TestSplitItems_NoFolders(t *testing.T) {
 	folderItems, resourceItems := SplitItems(items)
 	assert.Empty(t, folderItems)
 	require.Len(t, resourceItems, 1)
+}
+
+func TestReleaseAnnotationKeys(t *testing.T) {
+	t.Run("minimal item returns only manager keys", func(t *testing.T) {
+		keys := ReleaseAnnotationKeys(&provisioning.ResourceListItem{Name: "d"})
+		assert.Equal(t, []string{utils.AnnoKeyManagerKind, utils.AnnoKeyManagerIdentity}, keys)
+	})
+
+	t.Run("item with path includes sourcePath", func(t *testing.T) {
+		keys := ReleaseAnnotationKeys(&provisioning.ResourceListItem{Name: "d", Path: "a.json"})
+		assert.Contains(t, keys, utils.AnnoKeySourcePath)
+		assert.NotContains(t, keys, utils.AnnoKeySourceChecksum)
+	})
+
+	t.Run("item with hash includes sourceChecksum", func(t *testing.T) {
+		keys := ReleaseAnnotationKeys(&provisioning.ResourceListItem{Name: "d", Hash: "abc"})
+		assert.Contains(t, keys, utils.AnnoKeySourceChecksum)
+		assert.NotContains(t, keys, utils.AnnoKeySourcePath)
+	})
+
+	t.Run("item with both path and hash includes all four keys", func(t *testing.T) {
+		keys := ReleaseAnnotationKeys(&provisioning.ResourceListItem{Name: "d", Path: "a.json", Hash: "abc"})
+		assert.Len(t, keys, 4)
+	})
 }


### PR DESCRIPTION
Fixes the case where the finalizer cannot patch the dashboard due to BOM characters

Results in this error message:
```
2026-04-14 21:53:26.760 error t=2026-04-14T21:53:26.760359862Z level=error caller=logger.go:234 time=2026-04-14T21:53:26.760348045Z msg="RepositoryController failed to process key" logger=provisioning-repository-controller work_key=<namespace>/<repo> namespace=<namespace> repository=<repo> error="process finalizers: release resources: processing item: patch resource to release ownership: Dashboard.dashboard.grafana.app \"<uid>\" is invalid: []: Invalid value: illegal byte order mark" attempts=1 
```