### PR TITLE
ShareButton: fixed share button in the regular bar button style

### DIFF
--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareDashboardButton.tsx
@@ -48,7 +48,7 @@ export const ShareDashboardButton = ({ dashboard }: ToolbarActionProps) => {
       arrowLabel={t('dashboard.toolbar.new.share.arrow', 'Share')}
       arrowTestId={newShareButtonSelector.arrowMenu}
       dashboard={dashboard}
-      variant={!dashboard.state.isEditing ? 'primary' : 'canvas'}
+      variant="canvas"
       loading={loading}
     />
   );

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareButton.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareButton.tsx
@@ -1,12 +1,10 @@
-import { css } from '@emotion/css';
 import { useCallback, useState } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
-import { Button, ButtonGroup, Dropdown, useStyles2 } from '@grafana/ui';
+import { ButtonGroup, Dropdown, ToolbarButton } from '@grafana/ui';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { DashboardInteractions } from '../../utils/interactions';
@@ -17,7 +15,6 @@ import { buildShareUrl } from './utils';
 const newShareButtonSelector = e2eSelectors.pages.Dashboard.DashNav.newShareButton;
 
 export default function ShareButton({ dashboard, panel }: { dashboard: DashboardScene; panel?: VizPanel }) {
-  const styles = useStyles2(getStyles);
   const [isOpen, setIsOpen] = useState(false);
 
   const [{ loading }, buildUrl] = useAsyncFn(async () => {
@@ -36,33 +33,22 @@ export default function ShareButton({ dashboard, panel }: { dashboard: Dashboard
   const MenuActions = () => <ShareMenu dashboard={dashboard} />;
 
   return (
-    <ButtonGroup data-testid={newShareButtonSelector.container} className={styles.container}>
-      <Button
+    <ButtonGroup data-testid={newShareButtonSelector.container}>
+      <ToolbarButton
         data-testid={newShareButtonSelector.shareLink}
-        size="sm"
         tooltip={t('share-dashboard.share-button-tooltip', 'Copy link')}
-        onClick={buildUrl}
-        icon={loading ? 'spinner' : undefined}
-        disabled={loading}
+        onClick={loading ? undefined : buildUrl}
+        icon={loading ? 'spinner' : 'share-alt'}
       >
         <Trans i18nKey="share-dashboard.share-button">Share</Trans>
-      </Button>
+      </ToolbarButton>
       <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={onMenuClick}>
-        <Button
+        <ToolbarButton
           aria-label={t('dashboard-scene.share-button.aria-label-sharedropdownmenu', 'Toggle share menu')}
           data-testid={newShareButtonSelector.arrowMenu}
-          size="sm"
           icon={isOpen ? 'angle-up' : 'angle-down'}
         />
       </Dropdown>
     </ButtonGroup>
   );
-}
-
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    container: css({
-      gap: 1,
-    }),
-  };
 }

--- a/public/app/features/dashboard/components/DashNav/ShareButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/ShareButton.tsx
@@ -1,7 +1,7 @@
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
-import { Button } from '@grafana/ui';
+import { ToolbarButton } from '@grafana/ui';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
@@ -9,16 +9,16 @@ import { shareDashboardType } from '../ShareModal/utils';
 
 export const ShareButton = ({ dashboard }: { dashboard: DashboardModel }) => {
   return (
-    <Button
+    <ToolbarButton
+      tooltip={t('dashboard.toolbar.share', 'Share dashboard')}
+      icon="share-alt"
       data-testid={e2eSelectors.pages.Dashboard.DashNav.shareButton}
-      variant="primary"
-      size="sm"
       onClick={() => {
         DashboardInteractions.toolbarShareClick();
         locationService.partial({ shareView: shareDashboardType.link });
       }}
     >
       <Trans i18nKey="dashboard.toolbar.share-button">Share</Trans>
-    </Button>
+    </ToolbarButton>
   );
 };


### PR DESCRIPTION

Fixes #122398 

**Special notes for your reviewer:**

The PR is updated according to the issue Description .


Previous : 

<img width="139" height="60" alt="Screenshot_15-Apr_04-24-25_27321" src="https://github.com/user-attachments/assets/23fa1132-b506-4d51-a730-afcf58d9d70c" />

After change : 

<img width="231" height="50" alt="Screenshot_15-Apr_04-28-55_24078" src="https://github.com/user-attachments/assets/f35886c8-ac73-4ef7-b9dd-5d86c4cde4f6" />



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
