### PR TITLE
fix(plugins): set `Cache-Control: no-cache` on `module.js` to prevent…

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -385,6 +385,8 @@ func (hs *HTTPServer) serveLocalPluginAsset(c *contextmodel.ReqContext, plugin p
 
 	if hs.Cfg.Env == setting.Dev {
 		c.Resp.Header().Set("Cache-Control", "max-age=0, must-revalidate, no-cache")
+	} else if assetPath == "module.js" || assetPath == "module.js.map" {
+		c.Resp.Header().Set("Cache-Control", "no-cache")
 	} else {
 		c.Resp.Header().Set("Cache-Control", "public, max-age=3600")
 	}

--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -354,6 +354,50 @@ func Test_GetPluginAssets(t *testing.T) {
 	})
 }
 
+func Test_GetPluginAssetCacheHeaders(t *testing.T) {
+	pluginID := "test-plugin"
+	tmpDir := t.TempDir()
+
+	for _, name := range []string{"module.js", "module.js.map", "chunk.js"} {
+		err := os.WriteFile(filepath.Join(tmpDir, name), []byte("test content"), 0644)
+		require.NoError(t, err)
+	}
+
+	p := createPlugin(plugins.JSONData{ID: pluginID}, plugins.ClassExternal, plugins.NewLocalFS(tmpDir))
+	pluginRegistry := &pluginfakes.FakePluginRegistry{
+		Store: map[string]*plugins.Plugin{
+			p.ID: p,
+		},
+	}
+
+	tests := []struct {
+		name          string
+		file          string
+		env           string
+		expectedCache string
+	}{
+		{"module.js gets no-cache in production", "module.js", setting.Prod, "no-cache"},
+		{"module.js.map gets no-cache in production", "module.js.map", setting.Prod, "no-cache"},
+		{"other assets get max-age=3600 in production", "chunk.js", setting.Prod, "public, max-age=3600"},
+		{"module.js gets dev cache headers in dev mode", "module.js", setting.Dev, "max-age=0, must-revalidate, no-cache"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.Env = tt.env
+			url := fmt.Sprintf("/public/plugins/%s/%s", pluginID, tt.file)
+			pluginAssetScenario(t, "When calling GET on", url, "/public/plugins/:pluginId/*",
+				cfg, pluginRegistry, func(sc *scenarioContext) {
+					callGetPluginAsset(sc)
+
+					require.Equal(t, 200, sc.resp.Code)
+					require.Equal(t, tt.expectedCache, sc.resp.Header().Get("Cache-Control"))
+				})
+		})
+	}
+}
+
 func TestMakePluginResourceRequest(t *testing.T) {
 	hs := HTTPServer{
 		Cfg:          setting.NewCfg(),


### PR DESCRIPTION
**What is this feature?**

Set `Cache-Control: no-cache` on plugin `module.js` and `module.js.map` responses so the browser always revalidates these entry points with the server. All other plugin assets retain `Cache-Control: public, max-age=3600`.

**Why do we need this feature?**

When a plugin is updated on disk without restarting Grafana, the browser can serve a stale `module.js` from its HTTP cache (up to 1 hour). This stale entry point contains webpack chunk URL mappings from the previous version, causing 404s for chunks that no longer exist and `ChunkLoadError` in the browser. This affects every plugin that uses code splitting (`React.lazy` / dynamic `import()`).

With `no-cache`, the browser must revalidate on every request. `http.ServeContent` already handles conditional requests via `If-Modified-Since` / `Last-Modified`, so unchanged files return `304 Not Modified` — no bandwidth penalty in the common case. When the file has changed (plugin upgrade), the server returns `200` with the new content.

**Who is this feature for?**

All Grafana operators who update plugins without restarting Grafana (hot-upgrade), particularly Kubernetes deployments where plugins are provisioned or updated via init containers / sidecars.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/21765

Related:
- https://github.com/grafana/metrics-drilldown/issues/801
- https://github.com/grafana/metrics-drilldown/issues/1071

**Special notes for your reviewer:**

The change is 2 lines of production code in `pkg/api/plugins.go` (`serveLocalPluginAsset`). Chunk files are unaffected — they already have content hashes in their URLs (`?_cache=[contenthash]`), so aggressive caching remains safe and correct for everything except the entry point.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.