### PR TITLE
feat(grafana-runtime): add `lazyWithChunkRetry` utility for graceful …

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -7,6 +7,7 @@ export * from './services';
 export * from './config';
 export * from './analytics/types';
 export { loadPluginCss, type PluginCssOptions, setPluginImportUtils, getPluginImportUtils } from './utils/plugin';
+export { lazyWithChunkRetry } from './utils/lazyWithChunkRetry';
 export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView } from './analytics/utils';
 export { featureEnabled } from './utils/licensing';
 export {

--- a/packages/grafana-runtime/src/utils/lazyWithChunkRetry.test.ts
+++ b/packages/grafana-runtime/src/utils/lazyWithChunkRetry.test.ts
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import React, { Suspense } from 'react';
+
+import { lazyWithChunkRetry } from './lazyWithChunkRetry';
+
+describe('lazyWithChunkRetry', () => {
+  let reloadMock: jest.Mock;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadMock = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadMock },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('renders component on successful load', async () => {
+    const TestComp = () => React.createElement('div', null, 'loaded');
+    const Lazy = lazyWithChunkRetry(() => Promise.resolve({ default: TestComp }));
+
+    render(
+      React.createElement(
+        Suspense,
+        { fallback: React.createElement('div', null, 'loading') },
+        React.createElement(Lazy)
+      )
+    );
+
+    expect(await screen.findByText('loaded')).toBeInTheDocument();
+  });
+
+  it('clears reload flag after successful load', async () => {
+    sessionStorage.setItem('grafana-chunk-reload', 'true');
+    const TestComp = () => React.createElement('div', null, 'loaded');
+    const Lazy = lazyWithChunkRetry(() => Promise.resolve({ default: TestComp }));
+
+    render(
+      React.createElement(
+        Suspense,
+        { fallback: React.createElement('div', null, 'loading') },
+        React.createElement(Lazy)
+      )
+    );
+
+    expect(await screen.findByText('loaded')).toBeInTheDocument();
+    expect(sessionStorage.getItem('grafana-chunk-reload')).toBeNull();
+  });
+
+  it('reloads page on ChunkLoadError', async () => {
+    const error = new Error('Loading chunk 578 failed');
+    error.name = 'ChunkLoadError';
+
+    // Spy on React.lazy to capture the wrapped factory
+    const lazySpy = jest.spyOn(React, 'lazy');
+    lazyWithChunkRetry(() => Promise.reject(error));
+
+    const wrappedFactory = lazySpy.mock.calls[0][0];
+    // The factory returns a never-resolving promise after triggering reload
+    wrappedFactory();
+
+    // Wait for the microtask (catch handler) to execute
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem('grafana-chunk-reload')).toBe('true');
+    lazySpy.mockRestore();
+  });
+
+  it('does not reload if already reloaded in this session', async () => {
+    sessionStorage.setItem('grafana-chunk-reload', 'true');
+    const error = new Error('Loading chunk 578 failed');
+    error.name = 'ChunkLoadError';
+
+    const lazySpy = jest.spyOn(React, 'lazy');
+    lazyWithChunkRetry(() => Promise.reject(error));
+
+    const wrappedFactory = lazySpy.mock.calls[0][0];
+
+    await expect(wrappedFactory()).rejects.toThrow('Loading chunk 578 failed');
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('grafana-chunk-reload')).toBeNull();
+    lazySpy.mockRestore();
+  });
+
+  it('rethrows non-ChunkLoadError errors', async () => {
+    const error = new Error('Network error');
+
+    const lazySpy = jest.spyOn(React, 'lazy');
+    lazyWithChunkRetry(() => Promise.reject(error));
+
+    const wrappedFactory = lazySpy.mock.calls[0][0];
+
+    await expect(wrappedFactory()).rejects.toThrow('Network error');
+    expect(reloadMock).not.toHaveBeenCalled();
+    lazySpy.mockRestore();
+  });
+});

--- a/packages/grafana-runtime/src/utils/lazyWithChunkRetry.ts
+++ b/packages/grafana-runtime/src/utils/lazyWithChunkRetry.ts
@@ -1,0 +1,35 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+
+const CHUNK_RELOAD_KEY = 'grafana-chunk-reload';
+
+/**
+ * Wraps React.lazy with a ChunkLoadError handler that performs a one-time
+ * page reload when a chunk fails to load (e.g. after a plugin upgrade where
+ * the browser has cached stale chunk references).
+ *
+ * Uses sessionStorage to prevent infinite reload loops.
+ *
+ * @public
+ */
+export function lazyWithChunkRetry<T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>
+): LazyExoticComponent<T> {
+  return lazy(() =>
+    factory()
+      .then((module) => {
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+        return module;
+      })
+      .catch((error) => {
+        if (error?.name === 'ChunkLoadError' && !sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+          sessionStorage.setItem(CHUNK_RELOAD_KEY, 'true');
+          window.location.reload();
+          // Keep the promise pending; page reload is imminent
+          return new Promise<never>(() => {});
+        }
+
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+        throw error;
+      })
+  );
+}


### PR DESCRIPTION
**What is this feature?**

Adds `lazyWithChunkRetry` to `@grafana/runtime` - a drop-in replacement for `React.lazy` that catches `ChunkLoadError` and does a one-time page reload, using `sessionStorage` to prevent infinite loops.

**Why do we need this feature?**

When a plugin is hot-upgraded, the browser can serve a stale `module.js` that references old chunk filenames. Those chunks no longer exist → 404 → `ChunkLoadError`. This utility gives every plugin a simple way to recover gracefully without requiring users to hard-refresh.

**Who is this feature for?**

Plugin authors who use code splitting (`React.lazy` / dynamic `import()`).

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/support-escalations/issues/21765

**Special notes for your reviewer:**

One new file (`lazyWithChunkRetry.ts`) + tests + export. The companion backend fix (setting `no-cache` on `module.js`) is in a separate PR — together they prevent the error and recover from it if it still happens.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.