### PR TITLE
[release-12.4.4] Chore(deps): Upgrade node-forge to >= 1.4.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26430,9 +26430,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1.3.1":
-  version: 1.3.3
-  resolution: "node-forge@npm:1.3.3"
-  checksum: 10/f41c31b9296771a4b8c955d58417471712f54f324603a35f8e6cbac19d5e6eaaf5fd5fd14584dfedecbf46a05438ded6eee60a5f2f0822fc5061aaa073cfc75d
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 10/d70fd769768e646eda73343d4d4105ccb6869315d975905a22117431c04ae5b6df6c488e34ed275b1a66b50195a09b84b5c8aeca3b8605c20605fcb8e9f109d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `node-forge` to fix CVE-2026-33896 (CVSS 9.1 — basicConstraints bypass in certificate chain verification)
- Fixed version: >= 1.4.0
- Method: `yarn up -R node-forge`

## Test plan
- [ ] CI passes
- [ ] `yarn why node-forge --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)