### PR TITLE
[release-12.3.7] Chore(deps): Upgrade node-forge to >= 1.4.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24816,9 +24816,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 10/d70fd769768e646eda73343d4d4105ccb6869315d975905a22117431c04ae5b6df6c488e34ed275b1a66b50195a09b84b5c8aeca3b8605c20605fcb8e9f109d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `node-forge` to fix CVE-2026-33896 (CVSS 9.1 — basicConstraints bypass in certificate chain verification)
- Fixed version: >= 1.4.0
- Method: `yarn up -R node-forge`

## Test plan
- [ ] CI passes
- [ ] `yarn why node-forge --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)