### PR TITLE
Dashboard: Reduce prominence of Share button

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -1112,6 +1112,11 @@ export const getCategories = (): ValueFormatCategory[] => [
         fn: SIPrefix('m', -1),
       },
       {
+        name: t('grafana-data.valueFormats.categories.length.formats.name-centimeter', 'centimeter (cm)'),
+        id: 'lengthcm',
+        fn: toFixedUnit('cm'),
+      },
+      {
         name: t('grafana-data.valueFormats.categories.length.formats.name-inch', 'inch (in)'),
         id: 'lengthin',
         fn: toFixedUnit('in'),

--- a/public/app/features/dashboard/components/DashNav/ShareButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/ShareButton.tsx
@@ -11,7 +11,7 @@ export const ShareButton = ({ dashboard }: { dashboard: DashboardModel }) => {
   return (
     <Button
       data-testid={e2eSelectors.pages.Dashboard.DashNav.shareButton}
-      variant="primary"
+      variant="secondary"
       size="sm"
       onClick={() => {
         DashboardInteractions.toolbarShareClick();

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9765,7 +9765,8 @@
             "name-kilometer": "kilometer (km)",
             "name-meter": "meter (m)",
             "name-mile": "mile (mi)",
-            "name-millimeter": "millimeter (mm)"
+            "name-millimeter": "millimeter (mm)",
+            "name-centimeter": "centimeter (cm)"
           },
           "name": "Length"
         },


### PR DESCRIPTION
## What this change does

This PR reduces the visual prominence of the Share button in the dashboard toolbar by switching its variant from `primary` to `secondary`.

## Why this change is needed

The current primary styling makes the Share button visually dominant, especially in dark mode, which can distract users from the main dashboard content.

Using a secondary variant makes the button less obtrusive while keeping its functionality unchanged.

## Scope

- This change is intentionally minimal
- Only affects the dashboard toolbar Share button
- No changes to functionality or other components

## Related issue

Fixes #122398
