### PR TITLE
E2E: Fix selector versions

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -82,7 +82,7 @@ export const versionedComponents = {
       '12.4.0': 'data-testid sidebar add new panel',
     },
     configurePanelButton: {
-      '13.0.0': 'data-testid edit pane configure panel button',
+      '13.1.0': 'data-testid edit pane configure panel button',
     },
   },
   EditPaneHeader: {
@@ -663,7 +663,7 @@ export const versionedComponents = {
         [MIN_GRAFANA_VERSION]: 'Panel editor option pane select',
       },
       fieldLabel: {
-        '13.0.0-24085625829': (type: string) => `data-testid ${type} field property editor`,
+        '13.1.0': (type: string) => `data-testid ${type} field property editor`,
         [MIN_GRAFANA_VERSION]: (type: string) => `${type} field property editor`,
       },
       fieldInput: {
@@ -696,23 +696,23 @@ export const versionedComponents = {
 
     // [Geomap] Map controls
     showZoomField: {
-      '13.0.0-24085625829': 'data-testid Map controls Show zoom control field property editor',
+      '13.1.0': 'data-testid Map controls Show zoom control field property editor',
       '10.2.0': 'Map controls Show zoom control field property editor',
     },
     showAttributionField: {
-      '13.0.0-24085625829': 'data-testid Map controls Show attribution field property editor',
+      '13.1.0': 'data-testid Map controls Show attribution field property editor',
       '10.2.0': 'Map controls Show attribution field property editor',
     },
     showScaleField: {
-      '13.0.0-24085625829': 'data-testid Map controls Show scale field property editor',
+      '13.1.0': 'data-testid Map controls Show scale field property editor',
       '10.2.0': 'Map controls Show scale field property editor',
     },
     showMeasureField: {
-      '13.0.0-24085625829': 'data-testid Map controls Show measure tools field property editor',
+      '13.1.0': 'data-testid Map controls Show measure tools field property editor',
       '10.2.0': 'Map controls Show measure tools field property editor',
     },
     showDebugField: {
-      '13.0.0-24085625829': 'data-testid Map controls Show debug field property editor',
+      '13.1.0': 'data-testid Map controls Show debug field property editor',
       '10.2.0': 'Map controls Show debug field property editor',
     },
 
@@ -795,13 +795,13 @@ export const versionedComponents = {
   PanelInspector: {
     Data: {
       content: {
-        '13.0.0-24085625829': 'data-testid Panel inspector Data content',
+        '13.1.0': 'data-testid Panel inspector Data content',
         [MIN_GRAFANA_VERSION]: 'Panel inspector Data content',
       },
     },
     Stats: {
       content: {
-        '13.0.0-24085625829': 'data-testid Panel inspector Stats content',
+        '13.1.0': 'data-testid Panel inspector Stats content',
         [MIN_GRAFANA_VERSION]: 'Panel inspector Stats content',
       },
     },
@@ -813,11 +813,11 @@ export const versionedComponents = {
     },
     Query: {
       content: {
-        '13.0.0-24085625829': 'data-testid Panel inspector Query content',
+        '13.1.0': 'data-testid Panel inspector Query content',
         [MIN_GRAFANA_VERSION]: 'Panel inspector Query content',
       },
       refreshButton: {
-        '13.0.0-24085625829': 'data-testid Panel inspector Query refresh button',
+        '13.1.0': 'data-testid Panel inspector Query refresh button',
         [MIN_GRAFANA_VERSION]: 'Panel inspector Query refresh button',
       },
       jsonObjectKeys: {
@@ -841,11 +841,11 @@ export const versionedComponents = {
   },
   QueryTab: {
     content: {
-      '13.0.0-24085625829': 'data-testid Query editor tab content',
+      '13.1.0': 'data-testid Query editor tab content',
       [MIN_GRAFANA_VERSION]: 'Query editor tab content',
     },
     queryInspectorButton: {
-      '13.0.0-24085625829': 'data-testid Query inspector button',
+      '13.1.0': 'data-testid Query inspector button',
       [MIN_GRAFANA_VERSION]: 'Query inspector button',
     },
     queryHistoryButton: {
@@ -873,7 +873,7 @@ export const versionedComponents = {
   },
   QueryEditorRows: {
     rows: {
-      '13.0.0-24085625829': 'data-testid Query editor row',
+      '13.1.0': 'data-testid Query editor row',
       [MIN_GRAFANA_VERSION]: 'Query editor row',
     },
   },
@@ -882,7 +882,7 @@ export const versionedComponents = {
       '10.4.0': (title: string) => `data-testid ${title}`,
     },
     title: {
-      '13.0.0-24085625829': (refId: string) => `data-testid Query editor row title ${refId}`,
+      '13.1.0': (refId: string) => `data-testid Query editor row title ${refId}`,
       [MIN_GRAFANA_VERSION]: (refId: string) => `Query editor row title ${refId}`,
     },
     container: {
@@ -978,11 +978,11 @@ export const versionedComponents = {
     },
     SpatialOperations: {
       actionLabel: {
-        '13.0.0-24085625829': 'data-testid root Action field property editor',
+        '13.1.0': 'data-testid root Action field property editor',
         '9.1.2': 'root Action field property editor',
       },
       locationLabel: {
-        '13.0.0-24085625829': 'data-testid root Location Mode field property editor',
+        '13.1.0': 'data-testid root Location Mode field property editor',
         '10.2.0': 'root Location Mode field property editor',
       },
       location: {
@@ -994,11 +994,11 @@ export const versionedComponents = {
             '9.1.2': 'Coords location option',
           },
           latitudeFieldLabel: {
-            '13.0.0-24085625829': 'data-testid root Latitude field field property editor',
+            '13.1.0': 'data-testid root Latitude field field property editor',
             '9.1.2': 'root Latitude field field property editor',
           },
           longitudeFieldLabel: {
-            '13.0.0-24085625829': 'data-testid root Longitude field field property editor',
+            '13.1.0': 'data-testid root Longitude field field property editor',
             '9.1.2': 'root Longitude field field property editor',
           },
         },
@@ -1007,7 +1007,7 @@ export const versionedComponents = {
             '9.1.2': 'Geohash location option',
           },
           geohashFieldLabel: {
-            '13.0.0-24085625829': 'data-testid root Geohash field field property editor',
+            '13.1.0': 'data-testid root Geohash field field property editor',
             '9.1.2': 'root Geohash field field property editor',
           },
         },
@@ -1016,11 +1016,11 @@ export const versionedComponents = {
             '9.1.2': 'Lookup location option',
           },
           lookupFieldLabel: {
-            '13.0.0-24085625829': 'data-testid root Lookup field field property editor',
+            '13.1.0': 'data-testid root Lookup field field property editor',
             '9.1.2': 'root Lookup field field property editor',
           },
           gazetteerFieldLabel: {
-            '13.0.0-24085625829': 'data-testid root Gazetteer field property editor',
+            '13.1.0': 'data-testid root Gazetteer field property editor',
             '9.1.2': 'root Gazetteer field property editor',
           },
         },

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -89,7 +89,7 @@ export const versionedPages = {
       [MIN_GRAFANA_VERSION]: '/datasources/new',
     },
     dataSourcePluginsV2: {
-      '13.0.0-24085625829': (pluginName: string) => `data-testid Add new data source ${pluginName}`,
+      '13.1.0': (pluginName: string) => `data-testid Add new data source ${pluginName}`,
       '9.3.1': (pluginName: string) => `Add new data source ${pluginName}`,
       [MIN_GRAFANA_VERSION]: (pluginName: string) => `Data source plugin item ${pluginName}`,
     },
@@ -277,7 +277,7 @@ export const versionedPages = {
     },
     SubMenu: {
       submenu: {
-        '13.0.0-24085625829': 'data-testid Dashboard submenu',
+        '13.1.0': 'data-testid Dashboard submenu',
         [MIN_GRAFANA_VERSION]: 'Dashboard submenu',
       },
       submenuItem: {
@@ -291,7 +291,7 @@ export const versionedPages = {
           `data-testid Dashboard template variables Variable Value DropDown value link text ${item}`,
       },
       submenuItemValueDropDownDropDown: {
-        '13.0.0-24085625829': 'data-testid Variable options',
+        '13.1.0': 'data-testid Variable options',
         [MIN_GRAFANA_VERSION]: 'Variable options',
       },
       submenuItemValueDropDownOptionTexts: {
@@ -324,11 +324,11 @@ export const versionedPages = {
           [MIN_GRAFANA_VERSION]: (item: string) => `Dashboard settings section item ${item}`,
         },
         saveDashBoard: {
-          '13.0.0-24085625829': 'data-testid Dashboard settings aside actions Save button',
+          '13.1.0': 'data-testid Dashboard settings aside actions Save button',
           [MIN_GRAFANA_VERSION]: 'Dashboard settings aside actions Save button',
         },
         saveAsDashBoard: {
-          '13.0.0-24085625829': 'data-testid Dashboard settings aside actions Save As button',
+          '13.1.0': 'data-testid Dashboard settings aside actions Save As button',
           [MIN_GRAFANA_VERSION]: 'Dashboard settings aside actions Save As button',
         },
         title: {
@@ -395,21 +395,19 @@ export const versionedPages = {
             [MIN_GRAFANA_VERSION]: 'data-testid Call to action button Add variable',
           },
           newButton: {
-            '13.0.0-24085625829': 'data-testid Variable editor New variable button',
+            '13.1.0': 'data-testid Variable editor New variable button',
             [MIN_GRAFANA_VERSION]: 'Variable editor New variable button',
           },
           table: {
-            '13.0.0-24085625829': 'data-testid Variable editor Table',
+            '13.1.0': 'data-testid Variable editor Table',
             [MIN_GRAFANA_VERSION]: 'Variable editor Table',
           },
           tableRowNameFields: {
-            '13.0.0-24085625829': (variableName: string) =>
-              `data-testid Variable editor Table Name field ${variableName}`,
+            '13.1.0': (variableName: string) => `data-testid Variable editor Table Name field ${variableName}`,
             [MIN_GRAFANA_VERSION]: (variableName: string) => `Variable editor Table Name field ${variableName}`,
           },
           tableRowDefinitionFields: {
-            '13.0.0-24085625829': (variableName: string) =>
-              `data-testid Variable editor Table Definition field ${variableName}`,
+            '13.1.0': (variableName: string) => `data-testid Variable editor Table Definition field ${variableName}`,
             '10.1.0': (variableName: string) => `Variable editor Table Definition field ${variableName}`,
           },
           tableRowArrowUpButtons: {
@@ -419,13 +417,11 @@ export const versionedPages = {
             [MIN_GRAFANA_VERSION]: (variableName: string) => `Variable editor Table ArrowDown button ${variableName}`,
           },
           tableRowDuplicateButtons: {
-            '13.0.0-24085625829': (variableName: string) =>
-              `data-testid Variable editor Table Duplicate button ${variableName}`,
+            '13.1.0': (variableName: string) => `data-testid Variable editor Table Duplicate button ${variableName}`,
             [MIN_GRAFANA_VERSION]: (variableName: string) => `Variable editor Table Duplicate button ${variableName}`,
           },
           tableRowRemoveButtons: {
-            '13.0.0-24085625829': (variableName: string) =>
-              `data-testid Variable editor Table Remove button ${variableName}`,
+            '13.1.0': (variableName: string) => `data-testid Variable editor Table Remove button ${variableName}`,
             [MIN_GRAFANA_VERSION]: (variableName: string) => `Variable editor Table Remove button ${variableName}`,
           },
         },
@@ -718,15 +714,15 @@ export const versionedPages = {
   },
   SaveDashboardModal: {
     save: {
-      '13.0.0-24085625829': 'data-testid Dashboard settings Save Dashboard Modal Save button',
+      '13.1.0': 'data-testid Dashboard settings Save Dashboard Modal Save button',
       '10.2.0': 'Dashboard settings Save Dashboard Modal Save button',
     },
     saveVariables: {
-      '13.0.0-24085625829': 'data-testid Dashboard settings Save Dashboard Modal Save variables checkbox',
+      '13.1.0': 'data-testid Dashboard settings Save Dashboard Modal Save variables checkbox',
       '10.2.0': 'Dashboard settings Save Dashboard Modal Save variables checkbox',
     },
     saveTimerange: {
-      '13.0.0-24085625829': 'data-testid Dashboard settings Save Dashboard Modal Save timerange checkbox',
+      '13.1.0': 'data-testid Dashboard settings Save Dashboard Modal Save timerange checkbox',
       '10.2.0': 'Dashboard settings Save Dashboard Modal Save timerange checkbox',
     },
     saveRefresh: {
@@ -1088,11 +1084,11 @@ export const versionedPages = {
   },
   PlaylistForm: {
     name: {
-      '13.0.0-24085625829': 'data-testid Playlist name',
+      '13.1.0': 'data-testid Playlist name',
       [MIN_GRAFANA_VERSION]: 'Playlist name',
     },
     interval: {
-      '13.0.0-24085625829': 'data-testid Playlist interval',
+      '13.1.0': 'data-testid Playlist interval',
       [MIN_GRAFANA_VERSION]: 'Playlist interval',
     },
     itemDelete: {


### PR DESCRIPTION
**What is this feature?**

[This PR](https://github.com/grafana/grafana/pull/122312) was merged to main right after the cutoff for 13.1.0, so the selectors got the wrong version. This PR fixes that. 

**Why do we need this feature?**

Fix e2e tests in plugins

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
