### PR TITLE
chore: update teams and team group sync codeowners to iam-identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -197,7 +197,7 @@
 /pkg/services/star/ @grafana/grafana-search-and-storage
 /pkg/services/stats/ @grafana/grafana-backend-group
 /pkg/services/tag/ @grafana/grafana-search-and-storage
-/pkg/services/team/ @grafana/access-squad
+/pkg/services/team/ @grafana/identity-squad
 /pkg/services/temp_user/ @grafana/grafana-backend-group
 /pkg/services/updatemanager/ @grafana/grafana-backend-group
 /pkg/services/user/ @grafana/access-squad
@@ -997,7 +997,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/features/browse-dashboards/ @grafana/grafana-frontend-navigation
 /public/app/features/search/ @grafana/grafana-frontend-navigation
 /public/app/features/serviceaccounts/ @grafana/identity-squad
-/public/app/features/teams/ @grafana/access-squad
+/public/app/features/teams/ @grafana/identity-squad
 /public/app/features/templating/ @grafana/dashboards-squad
 /public/app/features/theme-playground/ @grafana/grafana-frontend-platform
 /public/app/features/trails/ @grafana/observability-metrics


### PR DESCRIPTION
Updates CODEOWNERS for \`/pkg/services/team/\` and \`/public/app/features/teams/\` from \`@grafana/access-squad\` to \`@grafana/identity-squad\`.