### PR TITLE
Provisioning: List resources should return correct api version

### DIFF
--- a/pkg/apiserver/registry/generic/versioned_store.go
+++ b/pkg/apiserver/registry/generic/versioned_store.go
@@ -1,0 +1,48 @@
+package generic
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
+)
+
+// VersionedStore wraps a registry.Store and overrides List to re-stamp each
+// item's GroupVersionKind so it matches the API version being served. This is
+// needed when the same Go types are registered under multiple API versions.
+type VersionedStore struct {
+	*registry.Store
+	targetGV schema.GroupVersion
+}
+
+// NewVersionedStore creates a VersionedStore that re-stamps list items to
+// match targetGV. Use this when the underlying store may return items whose
+// GVK differs from the API version being served (shared-type multi-version
+// pattern).
+func NewVersionedStore(store *registry.Store, targetGV schema.GroupVersion) *VersionedStore {
+	return &VersionedStore{Store: store, targetGV: targetGV}
+}
+
+func (v *VersionedStore) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	obj, err := v.Store.List(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := meta.ExtractList(obj)
+	if err != nil {
+		return obj, nil
+	}
+
+	for _, item := range items {
+		gvk := item.GetObjectKind().GroupVersionKind()
+		if gvk.Group == v.targetGV.Group && gvk.Version != v.targetGV.Version {
+			item.GetObjectKind().SetGroupVersionKind(v.targetGV.WithKind(gvk.Kind))
+		}
+	}
+
+	return obj, nil
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -704,7 +704,6 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	}
 
 	repositoryStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, repositoryStorage)
-	b.repoStore = repositoryStorage
 	b.repoLister = repository.NewStorageLister(repositoryStorage)
 
 	// Create admission handler and register mutators/validators
@@ -757,24 +756,25 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 		return fmt.Errorf("failed to create connection storage: %w", err)
 	}
 	connectionStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, connectionsStore)
-	b.connectionStore = connectionsStore
 
 	// When serving a non-storage version (e.g. v1beta1), wrap the CRUD stores
 	// so that List re-stamps each item's apiVersion to match the served version.
-	var repoStorage rest.Storage = repositoryStorage
-	var connStorage rest.Storage = connectionsStore
-	var jobStorage rest.Storage = jobStore
+	// See grafanaregistry.VersionedStore for details on why this is necessary.
 	if b.gv.Version != provisioning.VERSION {
-		repoStorage = grafanaregistry.NewVersionedStore(repositoryStorage, b.gv)
-		connStorage = grafanaregistry.NewVersionedStore(connectionsStore, b.gv)
-		jobStorage = grafanaregistry.NewVersionedStore(jobStore, b.gv)
+		storage[provisioning.RepositoryResourceInfo.StoragePath()] = grafanaregistry.NewVersionedStore(repositoryStorage, b.gv)
+		storage[provisioning.ConnectionResourceInfo.StoragePath()] = grafanaregistry.NewVersionedStore(connectionsStore, b.gv)
+		storage[provisioning.JobResourceInfo.StoragePath()] = grafanaregistry.NewVersionedStore(jobStore, b.gv)
+		b.repoStore = grafanaregistry.NewVersionedStore(repositoryStorage, b.gv)
+		b.connectionStore = grafanaregistry.NewVersionedStore(connectionsStore, b.gv)
+	} else {
+		storage[provisioning.RepositoryResourceInfo.StoragePath()] = repositoryStorage
+		storage[provisioning.ConnectionResourceInfo.StoragePath()] = connectionsStore
+		storage[provisioning.JobResourceInfo.StoragePath()] = jobStore
+		b.repoStore = repositoryStorage
+		b.connectionStore = connectionsStore
 	}
-
-	storage[provisioning.JobResourceInfo.StoragePath()] = jobStorage
-	storage[provisioning.RepositoryResourceInfo.StoragePath()] = repoStorage
 	storage[provisioning.RepositoryResourceInfo.StoragePath("status")] = repositoryStatusStorage
 
-	storage[provisioning.ConnectionResourceInfo.StoragePath()] = connStorage
 	storage[provisioning.ConnectionResourceInfo.StoragePath("status")] = connectionStatusStorage
 	storage[provisioning.ConnectionResourceInfo.StoragePath("repositories")] = NewConnectionRepositoriesConnector(b)
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -759,11 +759,22 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	connectionStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, connectionsStore)
 	b.connectionStore = connectionsStore
 
-	storage[provisioning.JobResourceInfo.StoragePath()] = jobStore
-	storage[provisioning.RepositoryResourceInfo.StoragePath()] = repositoryStorage
+	// When serving a non-storage version (e.g. v1beta1), wrap the CRUD stores
+	// so that List re-stamps each item's apiVersion to match the served version.
+	var repoStorage rest.Storage = repositoryStorage
+	var connStorage rest.Storage = connectionsStore
+	var jobStorage rest.Storage = jobStore
+	if b.gv.Version != provisioning.VERSION {
+		repoStorage = grafanaregistry.NewVersionedStore(repositoryStorage, b.gv)
+		connStorage = grafanaregistry.NewVersionedStore(connectionsStore, b.gv)
+		jobStorage = grafanaregistry.NewVersionedStore(jobStore, b.gv)
+	}
+
+	storage[provisioning.JobResourceInfo.StoragePath()] = jobStorage
+	storage[provisioning.RepositoryResourceInfo.StoragePath()] = repoStorage
 	storage[provisioning.RepositoryResourceInfo.StoragePath("status")] = repositoryStatusStorage
 
-	storage[provisioning.ConnectionResourceInfo.StoragePath()] = connectionsStore
+	storage[provisioning.ConnectionResourceInfo.StoragePath()] = connStorage
 	storage[provisioning.ConnectionResourceInfo.StoragePath("status")] = connectionStatusStorage
 	storage[provisioning.ConnectionResourceInfo.StoragePath("repositories")] = NewConnectionRepositoriesConnector(b)
 

--- a/pkg/tests/apis/provisioning/apiversion/helper_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/helper_test.go
@@ -1,0 +1,17 @@
+package apiversion
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+var env = common.NewDefaultSharedEnv()
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	return common.SharedHelper(t, env)
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -3,6 +3,7 @@ package apiversion
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,6 @@ const (
 	v1beta1APIVersion  = "provisioning.grafana.app/v1beta1"
 )
 
-// repositoryBody returns a JSON-marshalable map for creating a local Repository.
 func repositoryBody(name, apiVersion, provisioningPath string) map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": apiVersion,
@@ -43,429 +43,188 @@ func repositoryBody(name, apiVersion, provisioningPath string) map[string]interf
 	}
 }
 
-func createRepoViaREST(t *testing.T, helper *common.ProvisioningTestHelper, name, version string) {
-	t.Helper()
-	body := repositoryBody(name, "provisioning.grafana.app/"+version, helper.ProvisioningPath)
-	bodyBytes, err := json.Marshal(body)
-	require.NoError(t, err)
-
-	result := helper.AdminREST.Post().
-		AbsPath("/apis/provisioning.grafana.app/"+version+"/namespaces/default/repositories").
-		Body(bodyBytes).
-		SetHeader("Content-Type", "application/json").
-		Do(context.Background())
-	require.NoError(t, result.Error(), "creating repository %q via %s", name, version)
+func connectionBody(name, apiVersion string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       "Connection",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"title": "Version Test Connection - " + name,
+			"type":  "github",
+			"github": map[string]interface{}{
+				"appID":          "123456",
+				"installationID": "789012",
+			},
+		},
+		"secure": map[string]interface{}{
+			"privateKey": map[string]interface{}{
+				"create": common.TestGithubPrivateKeyBase64(),
+			},
+		},
+	}
 }
 
-func getRepoViaREST(t *testing.T, helper *common.ProvisioningTestHelper, name, version string) map[string]interface{} {
-	t.Helper()
-	result := helper.AdminREST.Get().
-		AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories/" + name).
-		Do(context.Background())
-	require.NoError(t, result.Error(), "getting repository %q via %s", name, version)
-
-	raw, err := result.Raw()
-	require.NoError(t, err)
-
-	var obj map[string]interface{}
-	require.NoError(t, json.Unmarshal(raw, &obj))
-	return obj
-}
-
-func listReposViaREST(t *testing.T, helper *common.ProvisioningTestHelper, version string) map[string]interface{} {
-	t.Helper()
-	result := helper.AdminREST.Get().
-		AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories").
-		Do(context.Background())
-	require.NoError(t, result.Error(), "listing repositories via %s", version)
-
-	raw, err := result.Raw()
-	require.NoError(t, err)
-
-	var obj map[string]interface{}
-	require.NoError(t, json.Unmarshal(raw, &obj))
-	return obj
-}
-
-// TestIntegrationRepositoryVersionConsistency verifies that the provisioning API
-// server returns the correct apiVersion in responses depending on which version
-// endpoint the request was made against. This is the primary diagnostic test for
-// the shared-Go-type multi-version serialization issue.
-func TestIntegrationRepositoryVersionConsistency(t *testing.T) {
+// TestIntegrationVersionConsistency verifies that the provisioning API returns
+// the correct apiVersion in responses matching the endpoint version, regardless
+// of which version was used for creation. Covers GET, LIST, CREATE, UPDATE, and
+// DELETE across both Repository and Connection resources.
+func TestIntegrationVersionConsistency(t *testing.T) {
 	helper := sharedHelper(t)
 
-	t.Run("GET via v1beta1 returns v1beta1 apiVersion", func(t *testing.T) {
-		const repoName = "version-get-v1beta1"
-		createRepoViaREST(t, helper, repoName, "v1beta1")
+	type resourceDef struct {
+		resource string
+		body     func(name, apiVersion string) map[string]interface{}
+	}
 
-		raw := getRepoViaREST(t, helper, repoName, "v1beta1")
+	resources := []resourceDef{
+		{
+			resource: "repositories",
+			body: func(name, apiVersion string) map[string]interface{} {
+				return repositoryBody(name, apiVersion, helper.ProvisioningPath)
+			},
+		},
+		{
+			resource: "connections",
+			body:     connectionBody,
+		},
+	}
 
-		apiVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, apiVersion,
-			"GET via v1beta1 endpoint must return v1beta1 apiVersion, got %q", apiVersion)
+	versionCombos := []struct {
+		name            string
+		createVersion   string
+		queryVersion    string
+		expectedVersion string
+	}{
+		{"same v1beta1", "v1beta1", "v1beta1", v1beta1APIVersion},
+		{"same v0alpha1", "v0alpha1", "v0alpha1", v0alpha1APIVersion},
+		{"create v0alpha1 query v1beta1", "v0alpha1", "v1beta1", v1beta1APIVersion},
+		{"create v1beta1 query v0alpha1", "v1beta1", "v0alpha1", v0alpha1APIVersion},
+	}
 
-		kind, _ := raw["kind"].(string)
-		assert.Equal(t, "Repository", kind)
-	})
+	t.Run("GET returns endpoint version", func(t *testing.T) {
+		for _, res := range resources {
+			t.Run(res.resource, func(t *testing.T) {
+				for i, tc := range versionCombos {
+					t.Run(tc.name, func(t *testing.T) {
+						name := fmt.Sprintf("ver-get-%s-%d", res.resource[:4], i)
+						body := res.body(name, "provisioning.grafana.app/"+tc.createVersion)
+						helper.RESTDo(t, "POST", tc.createVersion, res.resource, body)
 
-	t.Run("GET via v0alpha1 returns v0alpha1 apiVersion", func(t *testing.T) {
-		const repoName = "version-get-v0alpha1"
-		createRepoViaREST(t, helper, repoName, "v0alpha1")
-
-		raw := getRepoViaREST(t, helper, repoName, "v0alpha1")
-
-		apiVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v0alpha1APIVersion, apiVersion,
-			"GET via v0alpha1 endpoint must return v0alpha1 apiVersion, got %q", apiVersion)
-	})
-
-	// The cross-version test: create via v0alpha1, read via v1beta1.
-	// The response version MUST match the endpoint version, not the creation version.
-	t.Run("create via v0alpha1, GET via v1beta1 returns v1beta1", func(t *testing.T) {
-		const repoName = "version-cross-get"
-		createRepoViaREST(t, helper, repoName, "v0alpha1")
-
-		raw := getRepoViaREST(t, helper, repoName, "v1beta1")
-
-		apiVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, apiVersion,
-			"GET via v1beta1 must return v1beta1 even when created via v0alpha1, got %q", apiVersion)
-	})
-
-	t.Run("create via v1beta1, GET via v0alpha1 returns v0alpha1", func(t *testing.T) {
-		const repoName = "version-cross-get-rev"
-		createRepoViaREST(t, helper, repoName, "v1beta1")
-
-		raw := getRepoViaREST(t, helper, repoName, "v0alpha1")
-
-		apiVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v0alpha1APIVersion, apiVersion,
-			"GET via v0alpha1 must return v0alpha1 even when created via v1beta1, got %q", apiVersion)
-	})
-
-	t.Run("LIST via v1beta1 returns v1beta1 for list and all items", func(t *testing.T) {
-		const repoName = "version-list-v1beta1"
-		createRepoViaREST(t, helper, repoName, "v0alpha1")
-
-		raw := listReposViaREST(t, helper, "v1beta1")
-
-		listAPIVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, listAPIVersion,
-			"LIST response apiVersion must be v1beta1, got %q", listAPIVersion)
-
-		items, _ := raw["items"].([]interface{})
-		require.GreaterOrEqual(t, len(items), 1, "list should contain at least one item")
-
-		for i, item := range items {
-			obj, ok := item.(map[string]interface{})
-			require.True(t, ok, "item %d should be a map", i)
-			itemAPIVersion, _ := obj["apiVersion"].(string)
-			itemName := "(unknown)"
-			if md, ok := obj["metadata"].(map[string]interface{}); ok {
-				if n, ok := md["name"].(string); ok {
-					itemName = n
+						obj := helper.RESTDo(t, "GET", tc.queryVersion, res.resource+"/"+name)
+						assert.Equal(t, tc.expectedVersion, obj["apiVersion"])
+					})
 				}
-			}
-			assert.Equal(t, v1beta1APIVersion, itemAPIVersion,
-				"LIST item %d (%s) must have v1beta1 apiVersion, got %q", i, itemName, itemAPIVersion)
+			})
 		}
 	})
 
-	t.Run("LIST via v0alpha1 returns v0alpha1 for list and all items", func(t *testing.T) {
-		const repoName = "version-list-v0alpha1"
-		createRepoViaREST(t, helper, repoName, "v1beta1")
+	t.Run("LIST returns endpoint version for list and all items", func(t *testing.T) {
+		for _, res := range resources {
+			t.Run(res.resource, func(t *testing.T) {
+				for _, version := range []string{"v0alpha1", "v1beta1"} {
+					t.Run(version, func(t *testing.T) {
+						expected := "provisioning.grafana.app/" + version
+						obj := helper.RESTDo(t, "GET", version, res.resource)
+						assert.Equal(t, expected, obj["apiVersion"])
 
-		raw := listReposViaREST(t, helper, "v0alpha1")
-
-		listAPIVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v0alpha1APIVersion, listAPIVersion,
-			"LIST response apiVersion must be v0alpha1, got %q", listAPIVersion)
-
-		items, _ := raw["items"].([]interface{})
-		require.GreaterOrEqual(t, len(items), 1, "list should contain at least one item")
-
-		for i, item := range items {
-			obj, ok := item.(map[string]interface{})
-			require.True(t, ok, "item %d should be a map", i)
-			itemAPIVersion, _ := obj["apiVersion"].(string)
-			itemName := "(unknown)"
-			if md, ok := obj["metadata"].(map[string]interface{}); ok {
-				if n, ok := md["name"].(string); ok {
-					itemName = n
+						items, _ := obj["items"].([]interface{})
+						require.GreaterOrEqual(t, len(items), 1, "list should contain at least one item")
+						for i, item := range items {
+							itemObj, ok := item.(map[string]interface{})
+							require.True(t, ok, "item %d should be a map", i)
+							assert.Equal(t, expected, itemObj["apiVersion"], "item %d", i)
+						}
+					})
 				}
-			}
-			assert.Equal(t, v0alpha1APIVersion, itemAPIVersion,
-				"LIST item %d (%s) must have v0alpha1 apiVersion, got %q", i, itemName, itemAPIVersion)
+			})
 		}
 	})
 
-	// Test CREATE response: the version in the response to a POST must match
-	// the endpoint version, not whatever gvks[0] happens to be.
-	t.Run("CREATE response via v1beta1 has v1beta1 apiVersion", func(t *testing.T) {
-		const repoName = "version-create-resp-v1beta1"
-		body := repositoryBody(repoName, v1beta1APIVersion, helper.ProvisioningPath)
-		bodyBytes, err := json.Marshal(body)
-		require.NoError(t, err)
-
-		result := helper.AdminREST.Post().
-			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories").
-			Body(bodyBytes).
-			SetHeader("Content-Type", "application/json").
-			Do(context.Background())
-		require.NoError(t, result.Error())
-
-		raw, err := result.Raw()
-		require.NoError(t, err)
-
-		var obj map[string]interface{}
-		require.NoError(t, json.Unmarshal(raw, &obj))
-
-		apiVersion, _ := obj["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, apiVersion,
-			"CREATE response via v1beta1 must have v1beta1 apiVersion, got %q", apiVersion)
+	t.Run("CREATE response returns endpoint version", func(t *testing.T) {
+		for _, version := range []string{"v0alpha1", "v1beta1"} {
+			t.Run(version, func(t *testing.T) {
+				expected := "provisioning.grafana.app/" + version
+				name := "ver-create-" + version
+				body := repositoryBody(name, expected, helper.ProvisioningPath)
+				obj := helper.RESTDo(t, "POST", version, "repositories", body)
+				assert.Equal(t, expected, obj["apiVersion"])
+			})
+		}
 	})
 
-	t.Run("CREATE response via v0alpha1 has v0alpha1 apiVersion", func(t *testing.T) {
-		const repoName = "version-create-resp-v0alpha1"
-		body := repositoryBody(repoName, v0alpha1APIVersion, helper.ProvisioningPath)
-		bodyBytes, err := json.Marshal(body)
-		require.NoError(t, err)
+	t.Run("UPDATE response returns endpoint version", func(t *testing.T) {
+		for _, version := range []string{"v0alpha1", "v1beta1"} {
+			t.Run(version, func(t *testing.T) {
+				expected := "provisioning.grafana.app/" + version
+				name := "ver-update-" + version
+				body := repositoryBody(name, expected, helper.ProvisioningPath)
+				helper.RESTDo(t, "POST", version, "repositories", body)
 
-		result := helper.AdminREST.Post().
-			AbsPath("/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories").
-			Body(bodyBytes).
-			SetHeader("Content-Type", "application/json").
-			Do(context.Background())
-		require.NoError(t, result.Error())
+				current := helper.RESTDo(t, "GET", version, "repositories/"+name)
+				require.NoError(t, unstructured.SetNestedField(current, "Updated Title", "spec", "title"))
 
-		raw, err := result.Raw()
-		require.NoError(t, err)
-
-		var obj map[string]interface{}
-		require.NoError(t, json.Unmarshal(raw, &obj))
-
-		apiVersion, _ := obj["apiVersion"].(string)
-		assert.Equal(t, v0alpha1APIVersion, apiVersion,
-			"CREATE response via v0alpha1 must have v0alpha1 apiVersion, got %q", apiVersion)
+				obj := helper.RESTDo(t, "PUT", version, "repositories/"+name, current)
+				assert.Equal(t, expected, obj["apiVersion"])
+			})
+		}
 	})
 
-	// Test UPDATE response: PUT to v1beta1 endpoint must reflect v1beta1.
-	t.Run("UPDATE response via v1beta1 has v1beta1 apiVersion", func(t *testing.T) {
-		const repoName = "version-update-resp"
-		createRepoViaREST(t, helper, repoName, "v1beta1")
+	t.Run("DELETE response returns endpoint version", func(t *testing.T) {
+		for _, version := range []string{"v0alpha1", "v1beta1"} {
+			t.Run(version, func(t *testing.T) {
+				expected := "provisioning.grafana.app/" + version
+				name := "ver-delete-" + version
+				body := repositoryBody(name, expected, helper.ProvisioningPath)
+				helper.RESTDo(t, "POST", version, "repositories", body)
 
-		result := helper.AdminREST.Get().
-			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
-			Do(context.Background())
-		require.NoError(t, result.Error())
-
-		var current unstructured.Unstructured
-		require.NoError(t, result.Into(&current))
-
-		// Modify the title
-		require.NoError(t, unstructured.SetNestedField(current.Object, "Updated Title", "spec", "title"))
-
-		updatedBytes, err := json.Marshal(current.Object)
-		require.NoError(t, err)
-
-		updateResult := helper.AdminREST.Put().
-			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/"+repoName).
-			Body(updatedBytes).
-			SetHeader("Content-Type", "application/json").
-			Do(context.Background())
-		require.NoError(t, updateResult.Error())
-
-		raw, err := updateResult.Raw()
-		require.NoError(t, err)
-
-		var obj map[string]interface{}
-		require.NoError(t, json.Unmarshal(raw, &obj))
-
-		apiVersion, _ := obj["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, apiVersion,
-			"UPDATE response via v1beta1 must have v1beta1 apiVersion, got %q", apiVersion)
-	})
-
-	// Test DELETE response via v1beta1.
-	t.Run("DELETE response via v1beta1 has v1beta1 apiVersion", func(t *testing.T) {
-		const repoName = "version-delete-resp"
-		createRepoViaREST(t, helper, repoName, "v1beta1")
-
-		result := helper.AdminREST.Delete().
-			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
-			Do(context.Background())
-		require.NoError(t, result.Error())
-
-		raw, err := result.Raw()
-		require.NoError(t, err)
-
-		var obj map[string]interface{}
-		require.NoError(t, json.Unmarshal(raw, &obj))
-
-		apiVersion, _ := obj["apiVersion"].(string)
-		kind, _ := obj["kind"].(string)
-		// DELETE may return a Status object or the deleted Repository.
-		// If it's the Repository, the apiVersion must be v1beta1.
-		if kind == "Repository" {
-			assert.Equal(t, v1beta1APIVersion, apiVersion,
-				"DELETE response (Repository) via v1beta1 must have v1beta1 apiVersion, got %q", apiVersion)
+				obj := helper.RESTDo(t, "DELETE", version, "repositories/"+name)
+				if kind, _ := obj["kind"].(string); kind == "Repository" {
+					assert.Equal(t, expected, obj["apiVersion"])
+				}
+			})
 		}
 	})
 }
 
-// TestIntegrationRepositoryVersionInDynamicClient verifies version consistency
+// TestIntegrationDynamicClientVersionConsistency verifies version consistency
 // when using the typed dynamic client (schema.GroupVersionResource with v1beta1).
-// This catches issues in the K8s client-go / discovery layer.
-func TestIntegrationRepositoryVersionInDynamicClient(t *testing.T) {
+func TestIntegrationDynamicClientVersionConsistency(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()
-
 	repoClient := common.GetRepositoryClientV1Beta1(helper.K8sTestHelper)
 
-	t.Run("create and get via dynamic v1beta1 client", func(t *testing.T) {
+	t.Run("create and get", func(t *testing.T) {
 		repo := &unstructured.Unstructured{
 			Object: repositoryBody("dyn-v1beta1-repo", v1beta1APIVersion, helper.ProvisioningPath),
 		}
 
 		created, err := repoClient.Resource.Create(ctx, repo, metav1.CreateOptions{})
 		require.NoError(t, err)
-
-		assert.Equal(t, v1beta1APIVersion, created.GetAPIVersion(),
-			"dynamic client CREATE response must have v1beta1 apiVersion, got %q", created.GetAPIVersion())
+		assert.Equal(t, v1beta1APIVersion, created.GetAPIVersion())
 
 		fetched, err := repoClient.Resource.Get(ctx, "dyn-v1beta1-repo", metav1.GetOptions{})
 		require.NoError(t, err)
-
-		assert.Equal(t, v1beta1APIVersion, fetched.GetAPIVersion(),
-			"dynamic client GET response must have v1beta1 apiVersion, got %q", fetched.GetAPIVersion())
+		assert.Equal(t, v1beta1APIVersion, fetched.GetAPIVersion())
 	})
 
-	t.Run("list via dynamic v1beta1 client", func(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
 		list, err := repoClient.Resource.List(ctx, metav1.ListOptions{})
 		require.NoError(t, err)
-
-		assert.Equal(t, v1beta1APIVersion, list.GetAPIVersion(),
-			"dynamic client LIST apiVersion must be v1beta1, got %q", list.GetAPIVersion())
+		assert.Equal(t, v1beta1APIVersion, list.GetAPIVersion())
 
 		for i, item := range list.Items {
 			assert.Equal(t, v1beta1APIVersion, item.GetAPIVersion(),
-				"dynamic client LIST item %d (%s) must have v1beta1, got %q",
-				i, item.GetName(), item.GetAPIVersion())
-		}
-	})
-}
-
-// TestIntegrationConnectionVersionConsistency performs the same version check
-// on the Connection resource (same shared-type pattern as Repository).
-func TestIntegrationConnectionVersionConsistency(t *testing.T) {
-	helper := sharedHelper(t)
-
-	connectionBody := func(name, apiVersion string) map[string]interface{} {
-		return map[string]interface{}{
-			"apiVersion": apiVersion,
-			"kind":       "Connection",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": "default",
-			},
-			"spec": map[string]interface{}{
-				"title": "Version Test Connection - " + name,
-				"type":  "github",
-				"github": map[string]interface{}{
-					"appID":          "123456",
-					"installationID": "789012",
-				},
-			},
-			"secure": map[string]interface{}{
-				"privateKey": map[string]interface{}{
-					"create": common.TestGithubPrivateKeyBase64(),
-				},
-			},
-		}
-	}
-
-	createConnection := func(t *testing.T, name, version string) {
-		t.Helper()
-		body := connectionBody(name, "provisioning.grafana.app/"+version)
-		bodyBytes, err := json.Marshal(body)
-		require.NoError(t, err)
-
-		result := helper.AdminREST.Post().
-			AbsPath("/apis/provisioning.grafana.app/"+version+"/namespaces/default/connections").
-			Body(bodyBytes).
-			SetHeader("Content-Type", "application/json").
-			Do(context.Background())
-		require.NoError(t, result.Error(), "creating connection %q via %s", name, version)
-	}
-
-	getConnection := func(t *testing.T, name, version string) map[string]interface{} {
-		t.Helper()
-		result := helper.AdminREST.Get().
-			AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/connections/" + name).
-			Do(context.Background())
-		require.NoError(t, result.Error(), "getting connection %q via %s", name, version)
-
-		raw, err := result.Raw()
-		require.NoError(t, err)
-
-		var obj map[string]interface{}
-		require.NoError(t, json.Unmarshal(raw, &obj))
-		return obj
-	}
-
-	t.Run("GET connection via v1beta1 returns v1beta1 apiVersion", func(t *testing.T) {
-		const name = "conn-version-v1beta1"
-		createConnection(t, name, "v1beta1")
-
-		raw := getConnection(t, name, "v1beta1")
-		apiVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, apiVersion,
-			"GET connection via v1beta1 must return v1beta1, got %q", apiVersion)
-	})
-
-	t.Run("create connection via v0alpha1, GET via v1beta1 returns v1beta1", func(t *testing.T) {
-		const name = "conn-version-cross"
-		createConnection(t, name, "v0alpha1")
-
-		raw := getConnection(t, name, "v1beta1")
-		apiVersion, _ := raw["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, apiVersion,
-			"GET connection via v1beta1 must return v1beta1 even when created via v0alpha1, got %q", apiVersion)
-	})
-
-	t.Run("LIST connections via v1beta1 returns v1beta1 for all items", func(t *testing.T) {
-		const name = "conn-version-list"
-		createConnection(t, name, "v0alpha1")
-
-		result := helper.AdminREST.Get().
-			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/connections").
-			Do(context.Background())
-		require.NoError(t, result.Error())
-
-		raw, err := result.Raw()
-		require.NoError(t, err)
-
-		var obj map[string]interface{}
-		require.NoError(t, json.Unmarshal(raw, &obj))
-
-		listAPIVersion, _ := obj["apiVersion"].(string)
-		assert.Equal(t, v1beta1APIVersion, listAPIVersion,
-			"LIST connections apiVersion must be v1beta1, got %q", listAPIVersion)
-
-		items, _ := obj["items"].([]interface{})
-		for i, item := range items {
-			itemObj, ok := item.(map[string]interface{})
-			require.True(t, ok, "item %d should be a map", i)
-			itemAPIVersion, _ := itemObj["apiVersion"].(string)
-			assert.Equal(t, v1beta1APIVersion, itemAPIVersion,
-				"LIST connections item %d must have v1beta1, got %q", i, itemAPIVersion)
+				"item %d (%s)", i, item.GetName())
 		}
 	})
 }
 
 // TestIntegrationAPIGroupDiscoveryVersions checks that the provisioning API
 // group advertises both v0alpha1 and v1beta1, and that v1beta1 resource
-// endpoints actually exist and return correctly versioned content.
+// endpoints exist with the expected resources.
 func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()
@@ -484,11 +243,11 @@ func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
 		for _, v := range group.Versions {
 			versions[v.Version] = true
 		}
-		assert.True(t, versions["v0alpha1"], "v0alpha1 should be listed in API group versions")
-		assert.True(t, versions["v1beta1"], "v1beta1 should be listed in API group versions")
+		assert.True(t, versions["v0alpha1"], "v0alpha1 should be listed")
+		assert.True(t, versions["v1beta1"], "v1beta1 should be listed")
 	})
 
-	t.Run("v1beta1 resource list endpoint returns v1beta1 resources", func(t *testing.T) {
+	t.Run("v1beta1 resource list contains expected resources", func(t *testing.T) {
 		result := helper.AdminREST.Get().
 			AbsPath("/apis/provisioning.grafana.app/v1beta1").
 			Do(ctx)
@@ -500,97 +259,13 @@ func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
 		var resourceList metav1.APIResourceList
 		require.NoError(t, json.Unmarshal(raw, &resourceList))
 
-		assert.Equal(t, "provisioning.grafana.app/v1beta1", resourceList.GroupVersion,
-			"resource list groupVersion must be v1beta1, got %q", resourceList.GroupVersion)
+		assert.Equal(t, v1beta1APIVersion, resourceList.GroupVersion)
 
 		resourceNames := make(map[string]bool)
 		for _, r := range resourceList.APIResources {
 			resourceNames[r.Name] = true
 		}
-		assert.True(t, resourceNames["repositories"], "repositories should be in v1beta1 resources")
-		assert.True(t, resourceNames["connections"], "connections should be in v1beta1 resources")
+		assert.True(t, resourceNames["repositories"], "repositories should be in v1beta1")
+		assert.True(t, resourceNames["connections"], "connections should be in v1beta1")
 	})
-}
-
-// TestIntegrationRawHTTPVersionDiagnostic provides detailed diagnostic output
-// for debugging the version mismatch. It logs the full raw JSON response so
-// that when the test fails, the output gives immediate visibility into what
-// the server is actually returning.
-func TestIntegrationRawHTTPVersionDiagnostic(t *testing.T) {
-	helper := sharedHelper(t)
-	ctx := context.Background()
-
-	const repoName = "diag-raw-version"
-	createRepoViaREST(t, helper, repoName, "v0alpha1")
-
-	for _, version := range []string{"v0alpha1", "v1beta1"} {
-		t.Run("raw GET /"+version+"/"+repoName, func(t *testing.T) {
-			result := helper.AdminREST.Get().
-				AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories/" + repoName).
-				Do(ctx)
-			require.NoError(t, result.Error())
-
-			raw, err := result.Raw()
-			require.NoError(t, err)
-
-			var obj map[string]interface{}
-			require.NoError(t, json.Unmarshal(raw, &obj))
-
-			apiVersion, _ := obj["apiVersion"].(string)
-			kind, _ := obj["kind"].(string)
-
-			t.Logf("Endpoint version: %s", version)
-			t.Logf("Response apiVersion: %s", apiVersion)
-			t.Logf("Response kind: %s", kind)
-			t.Logf("Full response (first 2048 bytes):\n%s", truncate(string(raw), 2048))
-
-			expected := "provisioning.grafana.app/" + version
-			assert.Equal(t, expected, apiVersion,
-				"GET via %s must return %s, got %q", version, expected, apiVersion)
-		})
-	}
-
-	for _, version := range []string{"v0alpha1", "v1beta1"} {
-		t.Run("raw LIST /"+version, func(t *testing.T) {
-			result := helper.AdminREST.Get().
-				AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories").
-				Do(ctx)
-			require.NoError(t, result.Error())
-
-			raw, err := result.Raw()
-			require.NoError(t, err)
-
-			var obj map[string]interface{}
-			require.NoError(t, json.Unmarshal(raw, &obj))
-
-			apiVersion, _ := obj["apiVersion"].(string)
-
-			t.Logf("LIST endpoint version: %s", version)
-			t.Logf("LIST response apiVersion: %s", apiVersion)
-
-			items, _ := obj["items"].([]interface{})
-			for i, item := range items {
-				itemObj, _ := item.(map[string]interface{})
-				itemVersion, _ := itemObj["apiVersion"].(string)
-				itemName := "(unknown)"
-				if md, ok := itemObj["metadata"].(map[string]interface{}); ok {
-					if n, ok := md["name"].(string); ok {
-						itemName = n
-					}
-				}
-				t.Logf("  item[%d] name=%s apiVersion=%s", i, itemName, itemVersion)
-			}
-
-			expected := "provisioning.grafana.app/" + version
-			assert.Equal(t, expected, apiVersion,
-				"LIST via %s must return %s, got %q", version, expected, apiVersion)
-		})
-	}
-}
-
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "... (truncated)"
 }

--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -1,0 +1,596 @@
+package apiversion
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+const (
+	v0alpha1APIVersion = "provisioning.grafana.app/v0alpha1"
+	v1beta1APIVersion  = "provisioning.grafana.app/v1beta1"
+)
+
+// repositoryBody returns a JSON-marshalable map for creating a local Repository.
+func repositoryBody(name, apiVersion, provisioningPath string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       "Repository",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"title": "API Version Test - " + name,
+			"type":  "local",
+			"local": map[string]interface{}{
+				"path": provisioningPath,
+			},
+			"workflows": []string{"write"},
+			"sync": map[string]interface{}{
+				"enabled":         false,
+				"target":          "folder",
+				"intervalSeconds": 60,
+			},
+		},
+	}
+}
+
+func createRepoViaREST(t *testing.T, helper *common.ProvisioningTestHelper, name, version string) {
+	t.Helper()
+	body := repositoryBody(name, "provisioning.grafana.app/"+version, helper.ProvisioningPath)
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	result := helper.AdminREST.Post().
+		AbsPath("/apis/provisioning.grafana.app/"+version+"/namespaces/default/repositories").
+		Body(bodyBytes).
+		SetHeader("Content-Type", "application/json").
+		Do(context.Background())
+	require.NoError(t, result.Error(), "creating repository %q via %s", name, version)
+}
+
+func getRepoViaREST(t *testing.T, helper *common.ProvisioningTestHelper, name, version string) map[string]interface{} {
+	t.Helper()
+	result := helper.AdminREST.Get().
+		AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories/" + name).
+		Do(context.Background())
+	require.NoError(t, result.Error(), "getting repository %q via %s", name, version)
+
+	raw, err := result.Raw()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	return obj
+}
+
+func listReposViaREST(t *testing.T, helper *common.ProvisioningTestHelper, version string) map[string]interface{} {
+	t.Helper()
+	result := helper.AdminREST.Get().
+		AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories").
+		Do(context.Background())
+	require.NoError(t, result.Error(), "listing repositories via %s", version)
+
+	raw, err := result.Raw()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	return obj
+}
+
+// TestIntegrationRepositoryVersionConsistency verifies that the provisioning API
+// server returns the correct apiVersion in responses depending on which version
+// endpoint the request was made against. This is the primary diagnostic test for
+// the shared-Go-type multi-version serialization issue.
+func TestIntegrationRepositoryVersionConsistency(t *testing.T) {
+	helper := sharedHelper(t)
+
+	t.Run("GET via v1beta1 returns v1beta1 apiVersion", func(t *testing.T) {
+		const repoName = "version-get-v1beta1"
+		createRepoViaREST(t, helper, repoName, "v1beta1")
+
+		raw := getRepoViaREST(t, helper, repoName, "v1beta1")
+
+		apiVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, apiVersion,
+			"GET via v1beta1 endpoint must return v1beta1 apiVersion, got %q", apiVersion)
+
+		kind, _ := raw["kind"].(string)
+		assert.Equal(t, "Repository", kind)
+	})
+
+	t.Run("GET via v0alpha1 returns v0alpha1 apiVersion", func(t *testing.T) {
+		const repoName = "version-get-v0alpha1"
+		createRepoViaREST(t, helper, repoName, "v0alpha1")
+
+		raw := getRepoViaREST(t, helper, repoName, "v0alpha1")
+
+		apiVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v0alpha1APIVersion, apiVersion,
+			"GET via v0alpha1 endpoint must return v0alpha1 apiVersion, got %q", apiVersion)
+	})
+
+	// The cross-version test: create via v0alpha1, read via v1beta1.
+	// The response version MUST match the endpoint version, not the creation version.
+	t.Run("create via v0alpha1, GET via v1beta1 returns v1beta1", func(t *testing.T) {
+		const repoName = "version-cross-get"
+		createRepoViaREST(t, helper, repoName, "v0alpha1")
+
+		raw := getRepoViaREST(t, helper, repoName, "v1beta1")
+
+		apiVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, apiVersion,
+			"GET via v1beta1 must return v1beta1 even when created via v0alpha1, got %q", apiVersion)
+	})
+
+	t.Run("create via v1beta1, GET via v0alpha1 returns v0alpha1", func(t *testing.T) {
+		const repoName = "version-cross-get-rev"
+		createRepoViaREST(t, helper, repoName, "v1beta1")
+
+		raw := getRepoViaREST(t, helper, repoName, "v0alpha1")
+
+		apiVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v0alpha1APIVersion, apiVersion,
+			"GET via v0alpha1 must return v0alpha1 even when created via v1beta1, got %q", apiVersion)
+	})
+
+	t.Run("LIST via v1beta1 returns v1beta1 for list and all items", func(t *testing.T) {
+		const repoName = "version-list-v1beta1"
+		createRepoViaREST(t, helper, repoName, "v0alpha1")
+
+		raw := listReposViaREST(t, helper, "v1beta1")
+
+		listAPIVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, listAPIVersion,
+			"LIST response apiVersion must be v1beta1, got %q", listAPIVersion)
+
+		items, _ := raw["items"].([]interface{})
+		require.GreaterOrEqual(t, len(items), 1, "list should contain at least one item")
+
+		for i, item := range items {
+			obj, ok := item.(map[string]interface{})
+			require.True(t, ok, "item %d should be a map", i)
+			itemAPIVersion, _ := obj["apiVersion"].(string)
+			itemName := "(unknown)"
+			if md, ok := obj["metadata"].(map[string]interface{}); ok {
+				if n, ok := md["name"].(string); ok {
+					itemName = n
+				}
+			}
+			assert.Equal(t, v1beta1APIVersion, itemAPIVersion,
+				"LIST item %d (%s) must have v1beta1 apiVersion, got %q", i, itemName, itemAPIVersion)
+		}
+	})
+
+	t.Run("LIST via v0alpha1 returns v0alpha1 for list and all items", func(t *testing.T) {
+		const repoName = "version-list-v0alpha1"
+		createRepoViaREST(t, helper, repoName, "v1beta1")
+
+		raw := listReposViaREST(t, helper, "v0alpha1")
+
+		listAPIVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v0alpha1APIVersion, listAPIVersion,
+			"LIST response apiVersion must be v0alpha1, got %q", listAPIVersion)
+
+		items, _ := raw["items"].([]interface{})
+		require.GreaterOrEqual(t, len(items), 1, "list should contain at least one item")
+
+		for i, item := range items {
+			obj, ok := item.(map[string]interface{})
+			require.True(t, ok, "item %d should be a map", i)
+			itemAPIVersion, _ := obj["apiVersion"].(string)
+			itemName := "(unknown)"
+			if md, ok := obj["metadata"].(map[string]interface{}); ok {
+				if n, ok := md["name"].(string); ok {
+					itemName = n
+				}
+			}
+			assert.Equal(t, v0alpha1APIVersion, itemAPIVersion,
+				"LIST item %d (%s) must have v0alpha1 apiVersion, got %q", i, itemName, itemAPIVersion)
+		}
+	})
+
+	// Test CREATE response: the version in the response to a POST must match
+	// the endpoint version, not whatever gvks[0] happens to be.
+	t.Run("CREATE response via v1beta1 has v1beta1 apiVersion", func(t *testing.T) {
+		const repoName = "version-create-resp-v1beta1"
+		body := repositoryBody(repoName, v1beta1APIVersion, helper.ProvisioningPath)
+		bodyBytes, err := json.Marshal(body)
+		require.NoError(t, err)
+
+		result := helper.AdminREST.Post().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories").
+			Body(bodyBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(context.Background())
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &obj))
+
+		apiVersion, _ := obj["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, apiVersion,
+			"CREATE response via v1beta1 must have v1beta1 apiVersion, got %q", apiVersion)
+	})
+
+	t.Run("CREATE response via v0alpha1 has v0alpha1 apiVersion", func(t *testing.T) {
+		const repoName = "version-create-resp-v0alpha1"
+		body := repositoryBody(repoName, v0alpha1APIVersion, helper.ProvisioningPath)
+		bodyBytes, err := json.Marshal(body)
+		require.NoError(t, err)
+
+		result := helper.AdminREST.Post().
+			AbsPath("/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories").
+			Body(bodyBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(context.Background())
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &obj))
+
+		apiVersion, _ := obj["apiVersion"].(string)
+		assert.Equal(t, v0alpha1APIVersion, apiVersion,
+			"CREATE response via v0alpha1 must have v0alpha1 apiVersion, got %q", apiVersion)
+	})
+
+	// Test UPDATE response: PUT to v1beta1 endpoint must reflect v1beta1.
+	t.Run("UPDATE response via v1beta1 has v1beta1 apiVersion", func(t *testing.T) {
+		const repoName = "version-update-resp"
+		createRepoViaREST(t, helper, repoName, "v1beta1")
+
+		result := helper.AdminREST.Get().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
+			Do(context.Background())
+		require.NoError(t, result.Error())
+
+		var current unstructured.Unstructured
+		require.NoError(t, result.Into(&current))
+
+		// Modify the title
+		require.NoError(t, unstructured.SetNestedField(current.Object, "Updated Title", "spec", "title"))
+
+		updatedBytes, err := json.Marshal(current.Object)
+		require.NoError(t, err)
+
+		updateResult := helper.AdminREST.Put().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/"+repoName).
+			Body(updatedBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(context.Background())
+		require.NoError(t, updateResult.Error())
+
+		raw, err := updateResult.Raw()
+		require.NoError(t, err)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &obj))
+
+		apiVersion, _ := obj["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, apiVersion,
+			"UPDATE response via v1beta1 must have v1beta1 apiVersion, got %q", apiVersion)
+	})
+
+	// Test DELETE response via v1beta1.
+	t.Run("DELETE response via v1beta1 has v1beta1 apiVersion", func(t *testing.T) {
+		const repoName = "version-delete-resp"
+		createRepoViaREST(t, helper, repoName, "v1beta1")
+
+		result := helper.AdminREST.Delete().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
+			Do(context.Background())
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &obj))
+
+		apiVersion, _ := obj["apiVersion"].(string)
+		kind, _ := obj["kind"].(string)
+		// DELETE may return a Status object or the deleted Repository.
+		// If it's the Repository, the apiVersion must be v1beta1.
+		if kind == "Repository" {
+			assert.Equal(t, v1beta1APIVersion, apiVersion,
+				"DELETE response (Repository) via v1beta1 must have v1beta1 apiVersion, got %q", apiVersion)
+		}
+	})
+}
+
+// TestIntegrationRepositoryVersionInDynamicClient verifies version consistency
+// when using the typed dynamic client (schema.GroupVersionResource with v1beta1).
+// This catches issues in the K8s client-go / discovery layer.
+func TestIntegrationRepositoryVersionInDynamicClient(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	repoClient := common.GetRepositoryClientV1Beta1(helper.K8sTestHelper)
+
+	t.Run("create and get via dynamic v1beta1 client", func(t *testing.T) {
+		repo := &unstructured.Unstructured{
+			Object: repositoryBody("dyn-v1beta1-repo", v1beta1APIVersion, helper.ProvisioningPath),
+		}
+
+		created, err := repoClient.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, v1beta1APIVersion, created.GetAPIVersion(),
+			"dynamic client CREATE response must have v1beta1 apiVersion, got %q", created.GetAPIVersion())
+
+		fetched, err := repoClient.Resource.Get(ctx, "dyn-v1beta1-repo", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, v1beta1APIVersion, fetched.GetAPIVersion(),
+			"dynamic client GET response must have v1beta1 apiVersion, got %q", fetched.GetAPIVersion())
+	})
+
+	t.Run("list via dynamic v1beta1 client", func(t *testing.T) {
+		list, err := repoClient.Resource.List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, v1beta1APIVersion, list.GetAPIVersion(),
+			"dynamic client LIST apiVersion must be v1beta1, got %q", list.GetAPIVersion())
+
+		for i, item := range list.Items {
+			assert.Equal(t, v1beta1APIVersion, item.GetAPIVersion(),
+				"dynamic client LIST item %d (%s) must have v1beta1, got %q",
+				i, item.GetName(), item.GetAPIVersion())
+		}
+	})
+}
+
+// TestIntegrationConnectionVersionConsistency performs the same version check
+// on the Connection resource (same shared-type pattern as Repository).
+func TestIntegrationConnectionVersionConsistency(t *testing.T) {
+	helper := sharedHelper(t)
+
+	connectionBody := func(name, apiVersion string) map[string]interface{} {
+		return map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       "Connection",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"title": "Version Test Connection - " + name,
+				"type":  "github",
+				"github": map[string]interface{}{
+					"appID":          "123456",
+					"installationID": "789012",
+				},
+			},
+			"secure": map[string]interface{}{
+				"privateKey": map[string]interface{}{
+					"create": common.TestGithubPrivateKeyBase64(),
+				},
+			},
+		}
+	}
+
+	createConnection := func(t *testing.T, name, version string) {
+		t.Helper()
+		body := connectionBody(name, "provisioning.grafana.app/"+version)
+		bodyBytes, err := json.Marshal(body)
+		require.NoError(t, err)
+
+		result := helper.AdminREST.Post().
+			AbsPath("/apis/provisioning.grafana.app/"+version+"/namespaces/default/connections").
+			Body(bodyBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(context.Background())
+		require.NoError(t, result.Error(), "creating connection %q via %s", name, version)
+	}
+
+	getConnection := func(t *testing.T, name, version string) map[string]interface{} {
+		t.Helper()
+		result := helper.AdminREST.Get().
+			AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/connections/" + name).
+			Do(context.Background())
+		require.NoError(t, result.Error(), "getting connection %q via %s", name, version)
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &obj))
+		return obj
+	}
+
+	t.Run("GET connection via v1beta1 returns v1beta1 apiVersion", func(t *testing.T) {
+		const name = "conn-version-v1beta1"
+		createConnection(t, name, "v1beta1")
+
+		raw := getConnection(t, name, "v1beta1")
+		apiVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, apiVersion,
+			"GET connection via v1beta1 must return v1beta1, got %q", apiVersion)
+	})
+
+	t.Run("create connection via v0alpha1, GET via v1beta1 returns v1beta1", func(t *testing.T) {
+		const name = "conn-version-cross"
+		createConnection(t, name, "v0alpha1")
+
+		raw := getConnection(t, name, "v1beta1")
+		apiVersion, _ := raw["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, apiVersion,
+			"GET connection via v1beta1 must return v1beta1 even when created via v0alpha1, got %q", apiVersion)
+	})
+
+	t.Run("LIST connections via v1beta1 returns v1beta1 for all items", func(t *testing.T) {
+		const name = "conn-version-list"
+		createConnection(t, name, "v0alpha1")
+
+		result := helper.AdminREST.Get().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/connections").
+			Do(context.Background())
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &obj))
+
+		listAPIVersion, _ := obj["apiVersion"].(string)
+		assert.Equal(t, v1beta1APIVersion, listAPIVersion,
+			"LIST connections apiVersion must be v1beta1, got %q", listAPIVersion)
+
+		items, _ := obj["items"].([]interface{})
+		for i, item := range items {
+			itemObj, ok := item.(map[string]interface{})
+			require.True(t, ok, "item %d should be a map", i)
+			itemAPIVersion, _ := itemObj["apiVersion"].(string)
+			assert.Equal(t, v1beta1APIVersion, itemAPIVersion,
+				"LIST connections item %d must have v1beta1, got %q", i, itemAPIVersion)
+		}
+	})
+}
+
+// TestIntegrationAPIGroupDiscoveryVersions checks that the provisioning API
+// group advertises both v0alpha1 and v1beta1, and that v1beta1 resource
+// endpoints actually exist and return correctly versioned content.
+func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	t.Run("API group lists both versions", func(t *testing.T) {
+		result := helper.AdminREST.Get().AbsPath("/apis/provisioning.grafana.app").Do(ctx)
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var group metav1.APIGroup
+		require.NoError(t, json.Unmarshal(raw, &group))
+
+		versions := make(map[string]bool)
+		for _, v := range group.Versions {
+			versions[v.Version] = true
+		}
+		assert.True(t, versions["v0alpha1"], "v0alpha1 should be listed in API group versions")
+		assert.True(t, versions["v1beta1"], "v1beta1 should be listed in API group versions")
+	})
+
+	t.Run("v1beta1 resource list endpoint returns v1beta1 resources", func(t *testing.T) {
+		result := helper.AdminREST.Get().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1").
+			Do(ctx)
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var resourceList metav1.APIResourceList
+		require.NoError(t, json.Unmarshal(raw, &resourceList))
+
+		assert.Equal(t, "provisioning.grafana.app/v1beta1", resourceList.GroupVersion,
+			"resource list groupVersion must be v1beta1, got %q", resourceList.GroupVersion)
+
+		resourceNames := make(map[string]bool)
+		for _, r := range resourceList.APIResources {
+			resourceNames[r.Name] = true
+		}
+		assert.True(t, resourceNames["repositories"], "repositories should be in v1beta1 resources")
+		assert.True(t, resourceNames["connections"], "connections should be in v1beta1 resources")
+	})
+}
+
+// TestIntegrationRawHTTPVersionDiagnostic provides detailed diagnostic output
+// for debugging the version mismatch. It logs the full raw JSON response so
+// that when the test fails, the output gives immediate visibility into what
+// the server is actually returning.
+func TestIntegrationRawHTTPVersionDiagnostic(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	const repoName = "diag-raw-version"
+	createRepoViaREST(t, helper, repoName, "v0alpha1")
+
+	for _, version := range []string{"v0alpha1", "v1beta1"} {
+		t.Run("raw GET /"+version+"/"+repoName, func(t *testing.T) {
+			result := helper.AdminREST.Get().
+				AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories/" + repoName).
+				Do(ctx)
+			require.NoError(t, result.Error())
+
+			raw, err := result.Raw()
+			require.NoError(t, err)
+
+			var obj map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &obj))
+
+			apiVersion, _ := obj["apiVersion"].(string)
+			kind, _ := obj["kind"].(string)
+
+			t.Logf("Endpoint version: %s", version)
+			t.Logf("Response apiVersion: %s", apiVersion)
+			t.Logf("Response kind: %s", kind)
+			t.Logf("Full response (first 2048 bytes):\n%s", truncate(string(raw), 2048))
+
+			expected := "provisioning.grafana.app/" + version
+			assert.Equal(t, expected, apiVersion,
+				"GET via %s must return %s, got %q", version, expected, apiVersion)
+		})
+	}
+
+	for _, version := range []string{"v0alpha1", "v1beta1"} {
+		t.Run("raw LIST /"+version, func(t *testing.T) {
+			result := helper.AdminREST.Get().
+				AbsPath("/apis/provisioning.grafana.app/" + version + "/namespaces/default/repositories").
+				Do(ctx)
+			require.NoError(t, result.Error())
+
+			raw, err := result.Raw()
+			require.NoError(t, err)
+
+			var obj map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &obj))
+
+			apiVersion, _ := obj["apiVersion"].(string)
+
+			t.Logf("LIST endpoint version: %s", version)
+			t.Logf("LIST response apiVersion: %s", apiVersion)
+
+			items, _ := obj["items"].([]interface{})
+			for i, item := range items {
+				itemObj, _ := item.(map[string]interface{})
+				itemVersion, _ := itemObj["apiVersion"].(string)
+				itemName := "(unknown)"
+				if md, ok := itemObj["metadata"].(map[string]interface{}); ok {
+					if n, ok := md["name"].(string); ok {
+						itemName = n
+					}
+				}
+				t.Logf("  item[%d] name=%s apiVersion=%s", i, itemName, itemVersion)
+			}
+
+			expected := "provisioning.grafana.app/" + version
+			assert.Equal(t, expected, apiVersion,
+				"LIST via %s must return %s, got %q", version, expected, apiVersion)
+		})
+	}
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "... (truncated)"
+}

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -2922,6 +2922,35 @@ func SharedHelper(t *testing.T, env *SharedEnv) *ProvisioningTestHelper {
 	return helper
 }
 
+// RESTDo performs a REST request against the provisioning API and returns the
+// response as an unstructured map. The subpath is appended to
+// /apis/provisioning.grafana.app/<version>/namespaces/<namespace>/.
+func (h *ProvisioningTestHelper) RESTDo(t *testing.T, method, version, subpath string, body ...map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	ns := h.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	absPath := fmt.Sprintf("/apis/provisioning.grafana.app/%s/namespaces/%s/%s", version, ns, subpath)
+
+	req := h.AdminREST.Verb(method).AbsPath(absPath)
+	if len(body) > 0 && body[0] != nil {
+		bodyBytes, err := json.Marshal(body[0])
+		require.NoError(t, err)
+		req = req.Body(bodyBytes).SetHeader("Content-Type", "application/json")
+	}
+
+	result := req.Do(context.Background())
+	require.NoError(t, result.Error())
+
+	raw, err := result.Raw()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	return obj
+}
+
 // LabelPendingDelete is the label key written by the tenant watcher to mark
 // resources whose namespace is pending deletion.
 const LabelPendingDelete = "cloud.grafana.com/pending-delete"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As a result of using a go type alias for two different API versions (v0alpha1 and v1beta1), k8s machinery is not able to return the correct version on LIST operations (it work wells for individual item operations, though). The result is that the list itself is properly versioned, but the objects in the list pick the first version registered for the shared go type:

```
{
  "kind": "RepositoryList",
  "apiVersion": "provisioning.grafana.app/v1beta1",
  "metadata": {
    "resourceVersion": "1776155089026743"
  },
  "items": [
    {
      "kind": "Repository",
      "apiVersion": "provisioning.grafana.app/v0alpha1", <--------
      "metadata": {
```

This PR aims to create a wrapper over the list operation that corrects that. It's been tested that the solution works:

```
{
  "kind": "RepositoryList",
  "apiVersion": "provisioning.grafana.app/v1beta1",
  "metadata": {
    "resourceVersion": "1776240441839983"
  },
  "items": [
    {
      "kind": "Repository",
      "apiVersion": "provisioning.grafana.app/v1beta1", <----------
      "metadata": {
```

**Why do we need this feature?**

Without it, the LIST APIs for provisioning v1beta1 return an incorrect api version. This can break clients expectations and prevent them from working with the updated API.

**Who is this feature for?**

Anyone using v1beta1 provisioning apis.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/1034

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
