### PR TITLE
Dashboard Controls: Remove performance tracking for lazy-loaded controls

### DIFF
--- a/public/app/features/dashboard-scene/utils/dashboardControls.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.test.ts
@@ -19,13 +19,8 @@ jest.mock('@grafana/runtime', () => {
   return {
     ...actual,
     getDataSourceSrv: jest.fn(),
-    reportInteraction: jest.fn(),
   };
 });
-
-jest.mock('nanoid', () => ({
-  nanoid: jest.fn(() => 'mock-trace-id'),
-}));
 
 jest.mock('../serialization/layoutSerializers/utils', () => ({
   getRuntimePanelDataSource: jest.fn(),

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -1,26 +1,10 @@
-import { nanoid } from 'nanoid';
 import { filter, Observable, scan, share, type Subscriber } from 'rxjs';
 
 import { type DataSourceApi } from '@grafana/data';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-
-type LoadDefaultControlsPhase = 'default_variables' | 'default_links';
-type InvokeAndTrackOptions = { traceId: string; phase: LoadDefaultControlsPhase; datasourceType?: string };
-
-async function invokeAndTrack<T>(action: () => Promise<T>, options: InvokeAndTrackOptions): Promise<T> {
-  const start = performance.now();
-  const result = await action();
-
-  reportInteraction('dashboards_load_default_controls', {
-    ...options,
-    duration_ms: Math.round(performance.now() - start),
-  });
-
-  return result;
-}
 
 export type DefaultControlEvent =
   | { type: 'variables'; data: VariableKind[] }
@@ -33,8 +17,7 @@ function loadDefaultControlsRaw$(refs: DataSourceRef[]): Observable<DefaultContr
       return;
     }
 
-    const traceId = nanoid(8);
-    const promises = refs.map((ref) => loadControlsFromRef(ref, traceId, subscriber));
+    const promises = refs.map((ref) => loadControlsFromRef(ref, subscriber));
 
     Promise.all(promises).then(() => subscriber.complete());
   });
@@ -79,7 +62,7 @@ function sortLinks(a: DashboardLink, b: DashboardLink): number {
   return groupCmp !== 0 ? groupCmp : collator.compare(a.title ?? '', b.title ?? '');
 }
 
-async function loadControlsFromRef(ref: DataSourceRef, traceId: string, subscriber: Subscriber<DefaultControlEvent>) {
+async function loadControlsFromRef(ref: DataSourceRef, subscriber: Subscriber<DefaultControlEvent>) {
   let ds: DataSourceApi;
 
   try {
@@ -89,20 +72,16 @@ async function loadControlsFromRef(ref: DataSourceRef, traceId: string, subscrib
     return;
   }
 
-  await Promise.all([emitDefaultVariables(ds, traceId, subscriber), emitDefaultLinks(ds, traceId, subscriber)]);
+  await Promise.all([emitDefaultVariables(ds, subscriber), emitDefaultLinks(ds, subscriber)]);
 }
 
-async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscriber: Subscriber<DefaultControlEvent>) {
+async function emitDefaultVariables(ds: DataSourceApi, subscriber: Subscriber<DefaultControlEvent>) {
   if (typeof ds.getDefaultVariables !== 'function') {
     return;
   }
 
   try {
-    const variables = await invokeAndTrack(ds.getDefaultVariables.bind(ds), {
-      traceId,
-      phase: 'default_variables',
-      datasourceType: ds.type,
-    });
+    const variables = await ds.getDefaultVariables();
 
     if (variables?.length) {
       const sanitizedType = ds.type.replace(/\W/g, '_');
@@ -123,17 +102,13 @@ async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscrib
   }
 }
 
-async function emitDefaultLinks(ds: DataSourceApi, traceId: string, subscriber: Subscriber<DefaultControlEvent>) {
+async function emitDefaultLinks(ds: DataSourceApi, subscriber: Subscriber<DefaultControlEvent>) {
   if (typeof ds.getDefaultLinks !== 'function') {
     return;
   }
 
   try {
-    const links = await invokeAndTrack(ds.getDefaultLinks.bind(ds), {
-      traceId,
-      phase: 'default_links',
-      datasourceType: ds.type,
-    });
+    const links = await ds.getDefaultLinks();
 
     if (links?.length) {
       subscriber.next({


### PR DESCRIPTION
**What is this feature?**

Removes the `reportInteraction` performance tracking (`dashboards_load_default_controls` event) and `nanoid` trace IDs from the dashboard controls loading code. The `invokeAndTrack` wrapper is removed and datasource methods (`getDefaultVariables`, `getDefaultLinks`) are now called directly.

**Why do we need this feature?**

Dashboard controls were initially loaded synchronously, blocking dashboard rendering. Performance tracking was added to measure that impact (PR #109108). Since PR #119384 introduced lazy loading, controls no longer block rendering, so the tracking generates unnecessary analytics events without providing actionable insights.

**Who is this feature for?**

Internal — reduces noise in our analytics pipeline.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.