### PR TITLE
Pyroscope: Update metricsFromProfiles and profilesExemplars feature flags stages

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -109,6 +109,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `newPanelPadding`                 | Increases panel padding globally                                                                       |
 | `panelTimeSettings`               | Enables a new panel time settings drawer                                                               |
 | `transformationsEmptyPlaceholder` | Show transformation quick-start cards in empty transformations state                                   |
+| `profilesExemplars`               | Enables profiles exemplars support in profiles drilldown                                               |
 | `splashScreen`                    | Enables the splash screen modal for introducing new Grafana features on first session                  |
 
 ## Development feature toggles

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1869,7 +1869,7 @@ var (
 		{
 			Name:        "metricsFromProfiles",
 			Description: "Enables creating metrics from profiles and storing them as recording rules",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePrivatePreview,
 			Owner:       grafanaObservabilityTracesAndProfilingSquad,
 			Generate:    Generate{LegacyFrontend: true},
 			Expression:  "false",
@@ -2563,7 +2563,7 @@ var (
 		{
 			Name:        "profilesExemplars",
 			Description: "Enables profiles exemplars support in profiles drilldown",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaObservabilityTracesAndProfilingSquad,
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 			Expression:  "false",


### PR DESCRIPTION

**What is this feature?**

Updating `metricsFromProfiles` feature to private preview and `profilesExemplars` to public preview.
