### PR TITLE
[release-12.3.7] Packaging: Fix packaging issues with windows .exe file and Ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,7 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   fi && \
   GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
   mkdir -p "$GF_PATHS_HOME/.aws" && \
-  useradd --system --uid $GF_UID --gid "$GF_GID_NAME" --no-create-home grafana && \
+  useradd --system --uid $GF_UID --gid "$GF_GID_NAME" --create-home grafana && \
   mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
   "$GF_PATHS_PROVISIONING/dashboards" \
   "$GF_PATHS_PROVISIONING/notifiers" \

--- a/Makefile
+++ b/Makefile
@@ -307,9 +307,9 @@ update-workspace: gen-go
 .PHONY: build-go
 build-go: pkg/services/preference/themes_generated.go
 	@echo "compiling backend ($(OS)/$(ARCH))"
-	$(GO_BUILD_ENV) $(GO) build $(GO_BUILD_ARGS) -o ./bin/$(OS)/$(ARCH)/grafana ./pkg/cmd/grafana
-	$(GO_BUILD_ENV) $(GO) build $(GO_BUILD_ARGS) -o ./bin/$(OS)/$(ARCH)/grafana-server ./pkg/cmd/grafana-server
-	$(GO_BUILD_ENV) $(GO) build $(GO_BUILD_ARGS) -o ./bin/$(OS)/$(ARCH)/grafana-cli ./pkg/cmd/grafana-cli
+	$(GO_BUILD_ENV) $(GO) build $(GO_BUILD_ARGS) -o ./bin/$(OS)/$(ARCH)/grafana$(if $(filter windows,$(OS)),.exe) ./pkg/cmd/grafana
+	$(GO_BUILD_ENV) $(GO) build $(GO_BUILD_ARGS) -o ./bin/$(OS)/$(ARCH)/grafana-server$(if $(filter windows,$(OS)),.exe) ./pkg/cmd/grafana-server
+	$(GO_BUILD_ENV) $(GO) build $(GO_BUILD_ARGS) -o ./bin/$(OS)/$(ARCH)/grafana-cli$(if $(filter windows,$(OS)),.exe) ./pkg/cmd/grafana-cli
 	if [ "$(OS)" = "$(GO_HOST_OS)" ] && [ "$(ARCH)" = "$(GO_HOST_ARCH)" ]; then \
 		cp ./bin/$(OS)/$(ARCH)/grafana ./bin/grafana; \
 		cp ./bin/$(OS)/$(ARCH)/grafana-server ./bin/grafana-server; \


### PR DESCRIPTION
Backport f6fcb9311337a58769a3ed0354eb9600de4aa13e from #122650

---

- https://github.com/grafana/grafana/issues/122627
- https://github.com/grafana/grafana/issues/122626

Ubuntu $HOME fix confirmed: 

```
$ docker run --rm -it --entrypoint=bash grafana:13.1.0-local
grafana@6aaa939a39e3:/usr/share/grafana$ echo $HOME && stat $HOME
/home/grafana
  File: /home/grafana
  Size: 54              Blocks: 0          IO Block: 4096   directory
Device: 0,266   Inode: 3689935     Links: 1
Access: (0750/drwxr-x---)  Uid: (  472/ grafana)   Gid: (    0/    root)
Access: 2026-04-15 07:47:55.000000000 +0000
Modify: 2026-04-15 07:47:55.000000000 +0000
Change: 2026-04-15 07:49:06.759897505 +0000
 Birth: 2026-04-15 07:49:06.758518548 +0000
 ```

Windows .exe filename fix:

```
$ make build-go OS=windows ARCH=amd64
compiling backend (windows/amd64)
GOOS=windows GOARCH=amd64  \
        go build -buildvcs=false -trimpath    -ldflags "-X main.version=13.1.0-local -X main.commit=0092f8e5110 -X main.buildBranch=km/fix-release-issues -X main.buildstamp=1776239482  " -o ./bin/windows/amd64/grafana.exe ./pkg/cmd/grafana
```
