### PR TITLE
Provisioning: add PR comment if resources metadata is removed

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -61,6 +63,10 @@ type fileChangeInfo struct {
 	// URL where we can see a preview of this particular change
 	PreviewURL           string
 	PreviewScreenshotURL string
+
+	// HasRemovedMetadata is true when the original file contains metadata
+	// fields (namespace, labels, annotations) that will be removed when parsing the resource.
+	HasRemovedMetadata bool
 }
 
 type evaluator struct {
@@ -136,6 +142,19 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 	if err != nil {
 		info.Error = err.Error()
 		return info
+	}
+
+	if change.Action == repository.FileActionUpdated {
+		// Detect metadata stripped by resource parser.
+		// Read the file from the default branch (empty ref) and compare its
+		// metadata against the PR-branch parsed version.
+		baseFileInfo, baseErr := repo.Read(ctx, change.Path, "")
+		if baseErr == nil && baseFileInfo != nil {
+			baseObj, _, _, parseErr := resources.ParseFileResource(ctx, baseFileInfo)
+			if parseErr == nil && baseObj != nil {
+				info.HasRemovedMetadata = hasRemovedMetadata(baseObj, info.Parsed.Obj)
+			}
+		}
 	}
 
 	// Find a name within the file
@@ -227,4 +246,30 @@ func renderScreenshotFromGrafanaURL(ctx context.Context,
 	}
 	outcome = utils.SuccessOutcome
 	return base.JoinPath(snap).String(), nil
+}
+
+// hasRemovedMetadata returns true if the original object (from the file)
+// contains metadata fields (namespace, labels, annotations) that are absent
+// or different in the parsed object (post-Parse).
+func hasRemovedMetadata(original, parsed *unstructured.Unstructured) bool {
+	if original.GetNamespace() != "" && parsed.GetNamespace() != original.GetNamespace() {
+		return true
+	}
+	if len(original.GetLabels()) > 0 && hasMissingKeys(original.GetLabels(), parsed.GetLabels()) {
+		return true
+	}
+	if len(original.GetAnnotations()) > 0 && hasMissingKeys(original.GetAnnotations(), parsed.GetAnnotations()) {
+		return true
+	}
+	return false
+}
+
+// hasMissingKeys returns true if any key in original is absent from parsed.
+func hasMissingKeys(original, parsed map[string]string) bool {
+	for k := range original {
+		if _, exists := parsed[k]; !exists {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -54,6 +54,7 @@ func TestCalculateChanges(t *testing.T) {
 
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -127,6 +128,7 @@ func TestCalculateChanges(t *testing.T) {
 
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -198,6 +200,7 @@ func TestCalculateChanges(t *testing.T) {
 
 				progress.On("SetMessage", mock.Anything, mock.Anything).Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -323,6 +326,7 @@ func TestCalculateChanges(t *testing.T) {
 					Data: []byte("invalid json"),
 				}
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				parser.On("Parse", mock.Anything, finfo).Return(nil, fmt.Errorf("parse error"))
 			},
 			changes: []repository.VersionedFileChange{{
@@ -374,6 +378,7 @@ func TestCalculateChanges(t *testing.T) {
 				meta, _ := utils.MetaAccessor(obj)
 
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				parsed := &resources.ParsedResource{
 					Info: finfo,
 					Repo: provisioning.ResourceRepositoryInfo{
@@ -444,6 +449,7 @@ func TestCalculateChanges(t *testing.T) {
 				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -517,6 +523,7 @@ func TestCalculateChanges(t *testing.T) {
 				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -626,6 +633,7 @@ func TestCalculateChanges(t *testing.T) {
 
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -698,6 +706,7 @@ func TestCalculateChanges(t *testing.T) {
 				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(false)
 				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -767,6 +776,7 @@ func TestCalculateChanges(t *testing.T) {
 
 				progress.On("SetMessage", mock.Anything, "process path/to/file with spaces.json").Return()
 				reader.On("Read", mock.Anything, "path/to/file with spaces.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file with spaces.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
 				reader.On("Config").Return(&provisioning.Repository{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
@@ -985,4 +995,155 @@ func TestRenderScreenshotFromGrafanaURL(t *testing.T) {
 			require.Equal(t, tt.wantSnap, got)
 		})
 	}
+}
+
+func TestHasStrippedMetadata(t *testing.T) {
+	t.Run("original has extra metadata, parsed has only name", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":        "my-dash",
+				"namespace":   "default",
+				"labels":      map[string]any{"team": "platform"},
+				"annotations": map[string]any{"custom/note": "important"},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash"},
+		}}
+		require.True(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("original and parsed have same metadata", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash"},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash"},
+		}}
+		require.False(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("original has labels, parsed lost them", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":   "my-dash",
+				"labels": map[string]any{"team": "platform"},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash"},
+		}}
+		require.True(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("original has empty labels, not counted", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":        "my-dash",
+				"labels":      map[string]any{},
+				"annotations": map[string]any{},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash"},
+		}}
+		require.False(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("parsed has more annotations than original, not stripped", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":        "my-dash",
+				"annotations": map[string]any{"custom/note": "important"},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name": "my-dash",
+				"annotations": map[string]any{
+					"custom/note":         "important",
+					"grafana.app/managed": "repo",
+				},
+			},
+		}}
+		require.False(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("original annotation key removed by parser", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":        "my-dash",
+				"annotations": map[string]any{"custom/note": "important", "old/key": "value"},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":        "my-dash",
+				"annotations": map[string]any{"custom/note": "important"},
+			},
+		}}
+		require.True(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("namespace changed by parser", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash", "namespace": "custom-ns"},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash", "namespace": "default"},
+		}}
+		require.True(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("namespace same in both, not stripped", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash", "namespace": "default"},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash", "namespace": "default"},
+		}}
+		require.False(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("empty namespace in original is not counted", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash", "namespace": ""},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-dash"},
+		}}
+		require.False(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("label value changed but key still present, not stripped", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":   "my-dash",
+				"labels": map[string]any{"team": "platform"},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":   "my-dash",
+				"labels": map[string]any{"team": "other"},
+			},
+		}}
+		require.False(t, hasRemovedMetadata(original, parsed))
+	})
+
+	t.Run("label key removed by parser", func(t *testing.T) {
+		original := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":   "my-dash",
+				"labels": map[string]any{"team": "platform", "env": "prod"},
+			},
+		}}
+		parsed := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name":   "my-dash",
+				"labels": map[string]any{"team": "platform"},
+			},
+		}}
+		require.True(t, hasRemovedMetadata(original, parsed))
+	})
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -17,6 +17,7 @@ type commenter struct {
 	templateRenderInfo       *template.Template
 	templateFooter           *template.Template
 	templateValidationErrors *template.Template
+	templateMetadataNotice   *template.Template
 	showImageRendererNote    bool
 }
 
@@ -27,6 +28,7 @@ func NewCommenter(showImageRendererNote bool) Commenter {
 		templateRenderInfo:       template.Must(template.New("setup").Parse(commentTemplateMissingImageRenderer)),
 		templateFooter:           template.Must(template.New("footer").Parse(commentTemplateFooter)),
 		templateValidationErrors: template.Must(template.New("errors").Parse(commentTemplateValidationErrors)),
+		templateMetadataNotice:   template.Must(template.New("metadata").Parse(commentTemplateMetadataNotice)),
 		showImageRendererNote:    showImageRendererNote,
 	}
 }
@@ -62,6 +64,12 @@ func (c *commenter) generateComment(_ context.Context, info changeInfo) (string,
 			if err := c.templateValidationErrors.Execute(&buf, &info); err != nil {
 				return "", fmt.Errorf("unable to execute validation errors template: %w", err)
 			}
+		}
+	}
+
+	if info.HasRemovedMetadataChanges() {
+		if err := c.templateMetadataNotice.Execute(&buf, &info); err != nil {
+			return "", fmt.Errorf("unable to execute metadata notice template: %w", err)
 		}
 	}
 
@@ -146,6 +154,11 @@ const commentTemplateValidationErrors = `
 {{- end}}{{ end}}
 `
 
+// TODO(ferruvich): let's discuss this text with the team
+const commentTemplateMetadataNotice = `
+
+> **Note:** Some metadata fields (such as ` + "`namespace`" + `, ` + "`labels`" + `, or ` + "`annotations`" + `) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.`
+
 const commentTemplateMissingImageRenderer = `
 
 NOTE: To enable dashboard previews in pull requests, refer to the [image rendering setup documentation](https://grafana.com/docs/grafana/latest/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering).`
@@ -197,6 +210,15 @@ func (f *fileChangeInfo) TruncatedError() string {
 func (c *changeInfo) HasErrors() bool {
 	for i := range c.Changes {
 		if c.Changes[i].Error != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *changeInfo) HasRemovedMetadataChanges() bool {
+	for i := range c.Changes {
+		if c.Changes[i].HasRemovedMetadata {
 			return true
 		}
 	}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -155,6 +155,55 @@ func TestGenerateComment(t *testing.T) {
 				},
 			},
 		}},
+		{"single dashboard with stripped metadata", changeInfo{
+			GrafanaBaseURL: "http://host/",
+			Changes: []fileChangeInfo{
+				{
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "dashboard.json",
+						},
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+						Action: v0alpha1.ResourceActionUpdate,
+					},
+					Title:              "My Dashboard",
+					GrafanaURL:         "http://grafana/d/uid",
+					PreviewURL:         "http://grafana/admin/preview",
+					HasRemovedMetadata: true,
+				},
+			},
+		}},
+		{"multiple files with stripped metadata", changeInfo{
+			GrafanaBaseURL:  "http://host/",
+			RepositoryName:  "my-repo",
+			RepositoryTitle: "My Repo",
+			Changes: []fileChangeInfo{
+				{
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "good.json",
+						},
+						Action: v0alpha1.ResourceActionCreate,
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+					},
+					Title:      "Dashboard A",
+					PreviewURL: "http://grafana/admin/preview",
+				},
+				{
+					Parsed: &resources.ParsedResource{
+						Info: &repository.FileInfo{
+							Path: "stripped.json",
+						},
+						Action: v0alpha1.ResourceActionUpdate,
+						GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+					},
+					Title:              "Dashboard B",
+					GrafanaURL:         "http://grafana/d/bbb",
+					PreviewURL:         "http://grafana/admin/preview",
+					HasRemovedMetadata: true,
+				},
+			},
+		}},
 		{"multiple files with errors", changeInfo{
 			GrafanaBaseURL: "http://host/",
 			Changes: []fileChangeInfo{

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -1,0 +1,14 @@
+Hey there! 👋
+Grafana spotted 2 changes.
+
+| Action | Kind | Resource | Preview | Status |
+|--------|------|----------|---------|--------|
+| create | Dashboard | Dashboard A | [preview](http://grafana/admin/preview) | ✅ |
+| update | Dashboard | [Dashboard B](http://grafana/d/bbb) | [preview](http://grafana/admin/preview) | ✅ |
+
+All resources passed validation. ✅
+
+> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format — only `metadata.name` and `spec` are preserved. This is expected behavior and does not affect your dashboards in Grafana.
+
+---
+_Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -8,7 +8,7 @@ Grafana spotted 2 changes.
 
 All resources passed validation. ✅
 
-> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format — only `metadata.name` and `spec` are preserved. This is expected behavior and does not affect your dashboards in Grafana.
+> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
 _Posted by [host](http://host/) · Repository: **My Repo** (`my-repo`)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
@@ -3,7 +3,7 @@ Grafana spotted some changes to your dashboard.
 
 See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of dashboard.json.
 
-> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format — only `metadata.name` and `spec` are preserved. This is expected behavior and does not affect your dashboards in Grafana.
+> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
 _Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/single-dashboard-with-stripped-metadata.md
@@ -1,0 +1,9 @@
+Hey there! 👋
+Grafana spotted some changes to your dashboard.
+
+See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of dashboard.json.
+
+> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format — only `metadata.name` and `spec` are preserved. This is expected behavior and does not affect your dashboards in Grafana.
+
+---
+_Posted by [host](http://host/)_


### PR DESCRIPTION
## Summary

When a user saves a dashboard via the Git Sync writeback flow, the resource parser normalizes files to a minimal format — keeping only `metadata.name` and `spec`. If the file in the repository was originally created by another tool (e.g., grafanactl, manual editing) that preserved extra metadata fields (namespace, labels, annotations), the PR diff shows these fields being removed even though the user only changed a query or panel.

This PR adds a notice to the PR comment explaining that metadata removal is expected behavior from Git Sync's normalization.

Part of https://github.com/grafana/git-ui-sync-project/issues/1065

## What

### Detection (`changes.go`)

- Added `HasRemovedMetadata bool` field to `fileChangeInfo`
- Added `hasStrippedMetadata(original, parsed)` function that compares the base-branch file against the PR-branch parsed version, checking for missing namespace, label keys, or annotation keys
- Added `hasMissingKeys()` helper for map key comparison
- Detection runs only for `FileActionUpdated` changes — reads the base-branch version of the file via `repo.Read(ctx, path, "")` (empty ref resolves to the configured default branch)

### PR comment (`comment.go`)

- Added `commentTemplateMetadataNotice` template with an explanatory note
- Added `HasRemovedMetadataChanges()` method on `changeInfo`
- The notice renders after the main comment body (for both single-dashboard and multi-file formats) when any file has removed metadata

### Example output

For a single dashboard PR where metadata was stripped:

> **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.

## Test plan

- [x] Unit tests for `hasStrippedMetadata`: 11 cases covering all combinations (namespace changed/same/empty, labels removed/added/changed, annotations removed/added, empty maps)
- [x] Golden file tests for PR comment: `single-dashboard-with-stripped-metadata.md`, `multiple-files-with-stripped-metadata.md`
- [x] All existing tests pass unchanged (base-branch read mocked with `.Maybe()`)
- [x] `make gofmt` clean
- [x] `make lint-go-diff` — 0 issues