### PR TITLE
Pyroscope: Include profile ID and absolute times in assistant context

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.test.ts
@@ -119,8 +119,8 @@ describe('enrichDataFrameWithAssistantContentMapper', () => {
       expect(mockCreateAssistantContextItem).toHaveBeenCalledWith('structured', {
         title: 'Analyze Flame Graph',
         data: {
-          start: request.range.from.valueOf(),
-          end: request.range.to.valueOf(),
+          start: request.range.from.toISOString(),
+          end: request.range.to.toISOString(),
           profile_type_id: 'cpu',
           label_selector: '{service="test"}',
           operation: 'execute',
@@ -326,8 +326,65 @@ describe('enrichDataFrameWithAssistantContentMapper', () => {
       expect(mockCreateAssistantContextItem).toHaveBeenCalledWith('structured', {
         title: 'Analyze Flame Graph',
         data: {
-          start: fromTime.valueOf(),
-          end: toTime.valueOf(),
+          start: fromTime.toISOString(),
+          end: toTime.toISOString(),
+          profile_type_id: 'cpu',
+          label_selector: '{service="test"}',
+          operation: 'execute',
+        },
+      });
+    });
+
+    it('should include profile_id when profileIdSelector is set', () => {
+      const request = createMockRequest([
+        {
+          refId: 'A0',
+          profileTypeId: 'cpu',
+          labelSelector: '{service="test"}',
+          profileIdSelector: ['7c9e6679-7425-40de-944b-e07fc1f90ae7'],
+        },
+      ]);
+
+      const dataFrame = createMockDataFrame('A0', 'flamegraph');
+      const response = createMockResponse([dataFrame]);
+
+      const mapper = enrichDataFrameWithAssistantContentMapper(request, 'TestDatasource');
+      mapper(response);
+
+      expect(mockCreateAssistantContextItem).toHaveBeenCalledWith('structured', {
+        title: 'Analyze Flame Graph',
+        data: {
+          start: request.range.from.toISOString(),
+          end: request.range.to.toISOString(),
+          profile_type_id: 'cpu',
+          label_selector: '{service="test"}',
+          operation: 'execute',
+          profile_id: ['7c9e6679-7425-40de-944b-e07fc1f90ae7'],
+        },
+      });
+    });
+
+    it('should not include profile_id when profileIdSelector is empty', () => {
+      const request = createMockRequest([
+        {
+          refId: 'A0',
+          profileTypeId: 'cpu',
+          labelSelector: '{service="test"}',
+          profileIdSelector: [],
+        },
+      ]);
+
+      const dataFrame = createMockDataFrame('A0', 'flamegraph');
+      const response = createMockResponse([dataFrame]);
+
+      const mapper = enrichDataFrameWithAssistantContentMapper(request, 'TestDatasource');
+      mapper(response);
+
+      expect(mockCreateAssistantContextItem).toHaveBeenCalledWith('structured', {
+        title: 'Analyze Flame Graph',
+        data: {
+          start: request.range.from.toISOString(),
+          end: request.range.to.toISOString(),
           profile_type_id: 'cpu',
           label_selector: '{service="test"}',
           operation: 'execute',

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.ts
@@ -164,11 +164,12 @@ export function enrichDataFrameWithAssistantContentMapper(
         createAssistantContextItem('structured', {
           title: 'Analyze Flame Graph',
           data: {
-            start: request.range.from.valueOf(),
-            end: request.range.to.valueOf(),
+            start: request.range.from.toISOString(),
+            end: request.range.to.toISOString(),
             profile_type_id: query.profileTypeId,
             label_selector: query.labelSelector,
             operation: 'execute',
+            ...(query.profileIdSelector?.length ? { profile_id: query.profileIdSelector } : {}),
           },
         }),
       ];


### PR DESCRIPTION
## Summary
- Pass `profileIdSelector` from the query to the assistant context when an exemplar is selected
- Change time format from `.valueOf()` (millisecond numbers) to `.toISOString()` (ISO-8601 strings)

## Why
When a user selects an exemplar in Profiles Drilldown and clicks "Analyze Flamegraph" via the global Grafana Assistant, two things go wrong:

1. **Profile ID not passed**: The selected exemplar's `profileIdSelector` is available on the query (set by Profiles Drilldown) but not included in the assistant context. The assistant queries the full aggregated flamegraph instead of the specific profile.

2. **Wrong time range**: The assistant's `parseTimeRange()` [expects](https://github.com/grafana/grafana-assistant-app/blob/fa187e535f6330b9a738f36b02fc2ac4609c8c51/api/internal/agent/tools/pyroscope/handlers.go#L666) ISO-8601 strings (`time.Parse(time.RFC3339, ...)`). Millisecond numbers from `.valueOf()` fail to parse, causing a silent fallback to `now - 1h`. The assistant analyzes a different time range than what the user sees.

## Related
- Part of [pyroscope-squad#745](https://github.com/grafana/pyroscope-squad/issues/745)