### PR TITLE
Dashboard: Skip folder tree build during schema conversion

### DIFF
--- a/pkg/registry/apis/dashboard/datasources.go
+++ b/pkg/registry/apis/dashboard/datasources.go
@@ -127,8 +127,9 @@ func (l *libraryElementIndexProvider) GetLibraryElementInfo(ctx context.Context)
 	page := 1
 	for {
 		result, err := l.libraryElementService.GetAllElements(ctx, user, model.SearchLibraryElementsQuery{
-			PerPage: perPage,
-			Page:    page,
+			PerPage:                perPage,
+			Page:                   page,
+			SkipFolderTreeForAdmin: true,
 		})
 		if err != nil {
 			span.SetAttributes(attribute.String("error", err.Error()))

--- a/pkg/services/libraryelements/cache_test.go
+++ b/pkg/services/libraryelements/cache_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -152,6 +153,99 @@ func TestFolderTreeCache_Unit(t *testing.T) {
 		_, err = cache.get(ctx, user2)
 		require.NoError(t, err)
 		assert.Equal(t, 2, trackingSvc.GetCallCount(), "Different user should trigger a new GetFolders call")
+	})
+}
+
+func TestIntegration_SkipFolderTreeForAdmin(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	createPanels := func(t *testing.T, sc scenarioContext, count int) {
+		t.Helper()
+		for i := 0; i < count; i++ {
+			// nolint:staticcheck
+			command := getCreatePanelCommand(sc.folder.ID, sc.folder.UID, "Panel "+string(rune('A'+i)))
+			sc.reqContext.Req.Body = mockRequestBody(command)
+			resp := sc.service.createHandler(sc.reqContext)
+			require.Equal(t, 200, resp.Status())
+		}
+	}
+
+	replaceWithTrackingFolderSvc := func(sc scenarioContext) *trackingFolderService {
+		trackingSvc := newTrackingFolderService()
+		trackingSvc.ExpectedFolders = []*folder.Folder{sc.folder}
+		trackingSvc.AddFolder(sc.folder)
+		sc.service.folderService = trackingSvc
+		sc.service.treeCache = newFolderTreeCache(trackingSvc)
+		return trackingSvc
+	}
+
+	t.Run("admin with SkipFolderTreeForAdmin skips GetFolders", func(t *testing.T) {
+		sc := setupTestScenario(t)
+		createPanels(t, sc, 3)
+
+		trackingSvc := replaceWithTrackingFolderSvc(sc)
+
+		result, err := sc.service.getAllLibraryElements(context.Background(), sc.reqContext.SignedInUser, model.SearchLibraryElementsQuery{
+			PerPage:                100,
+			Page:                   1,
+			SkipFolderTreeForAdmin: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(result.Elements))
+		assert.Equal(t, 0, trackingSvc.GetCallCount(), "GetFolders should not be called for admin with SkipFolderTreeForAdmin")
+
+		// FolderName should be the default (General) since folder tree was not fetched
+		for _, elem := range result.Elements {
+			assert.Equal(t, "General", elem.Meta.FolderName, "FolderName should default to General when SkipFolderTreeForAdmin is set")
+		}
+	})
+
+	t.Run("admin without SkipFolderTreeForAdmin fetches folder tree", func(t *testing.T) {
+		sc := setupTestScenario(t)
+		createPanels(t, sc, 3)
+
+		trackingSvc := replaceWithTrackingFolderSvc(sc)
+
+		result, err := sc.service.getAllLibraryElements(context.Background(), sc.reqContext.SignedInUser, model.SearchLibraryElementsQuery{
+			PerPage:                100,
+			Page:                   1,
+			SkipFolderTreeForAdmin: false,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(result.Elements))
+		assert.Equal(t, 1, trackingSvc.GetCallCount(), "GetFolders should be called once")
+
+		for _, elem := range result.Elements {
+			assert.Equal(t, sc.folder.Title, elem.Meta.FolderName, "FolderName should be populated")
+		}
+	})
+
+	t.Run("non-admin with SkipFolderTreeForAdmin still fetches folder tree", func(t *testing.T) {
+		sc := setupTestScenario(t)
+		createPanels(t, sc, 3)
+
+		trackingSvc := replaceWithTrackingFolderSvc(sc)
+
+		viewer := &user.SignedInUser{
+			UserID:  sc.user.UserID,
+			UserUID: sc.user.UserUID,
+			OrgID:   sc.user.OrgID,
+			OrgRole: org.RoleViewer,
+			Permissions: map[int64]map[string][]string{
+				sc.user.OrgID: {
+					folder.ActionFoldersRead: {folder.ScopeFoldersAll},
+				},
+			},
+		}
+
+		result, err := sc.service.getAllLibraryElements(context.Background(), viewer, model.SearchLibraryElementsQuery{
+			PerPage:                100,
+			Page:                   1,
+			SkipFolderTreeForAdmin: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(result.Elements))
+		assert.Equal(t, 1, trackingSvc.GetCallCount(), "GetFolders should still be called for non-admin")
 	})
 }
 

--- a/pkg/services/libraryelements/cache_test.go
+++ b/pkg/services/libraryelements/cache_test.go
@@ -194,9 +194,9 @@ func TestIntegration_SkipFolderTreeForAdmin(t *testing.T) {
 		assert.Equal(t, 3, len(result.Elements))
 		assert.Equal(t, 0, trackingSvc.GetCallCount(), "GetFolders should not be called for admin with SkipFolderTreeForAdmin")
 
-		// FolderName should be the default (General) since folder tree was not fetched
+		// FolderName should be empty since folder tree was not fetched
 		for _, elem := range result.Elements {
-			assert.Equal(t, "General", elem.Meta.FolderName, "FolderName should default to General when SkipFolderTreeForAdmin is set")
+			assert.Empty(t, elem.Meta.FolderName, "FolderName should be empty when SkipFolderTreeForAdmin is set")
 		}
 	})
 

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -483,10 +483,11 @@ func (l *LibraryElementService) getAllLibraryElements(c context.Context, signedI
 					continue
 				}
 			}
-			title := dashboards.RootFolderName
+			var title string
 			if needsFolderTree {
-				if t := folderTree.GetTitle(element.FolderUID); t != "" {
-					title = t
+				title = folderTree.GetTitle(element.FolderUID)
+				if title == "" {
+					title = dashboards.RootFolderName
 				}
 			}
 			retDTOs = append(retDTOs, model.LibraryElementDTO{

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -466,10 +466,14 @@ func (l *LibraryElementService) getAllLibraryElements(c context.Context, signedI
 		}
 
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
-		// Get the folder tree filtered by user permissions (cached per user per request)
-		folderTree, err := l.treeCache.get(c, signedInUser)
-		if err != nil {
-			return err
+		needsFolderTree := !query.SkipFolderTreeForAdmin || !signedInUser.HasRole(org.RoleAdmin)
+		var folderTree *folder.FolderTree
+		if needsFolderTree {
+			// Get the folder tree filtered by user permissions (cached per user per request)
+			folderTree, err = l.treeCache.get(c, signedInUser)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Filter elements based on folder access using the tree
@@ -479,9 +483,11 @@ func (l *LibraryElementService) getAllLibraryElements(c context.Context, signedI
 					continue
 				}
 			}
-			title := folderTree.GetTitle(element.FolderUID)
-			if title == "" {
-				title = dashboards.RootFolderName
+			title := dashboards.RootFolderName
+			if needsFolderTree {
+				if t := folderTree.GetTitle(element.FolderUID); t != "" {
+					title = t
+				}
 			}
 			retDTOs = append(retDTOs, model.LibraryElementDTO{
 				ID:          element.ID,

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -205,6 +205,10 @@ type SearchLibraryElementsQuery struct {
 	// Deprecated: use FolderFilterUIDs instead
 	FolderFilter     string
 	FolderFilterUIDs string
+	// SkipFolderTreeForAdmin skips fetching the folder tree when the caller is admin.
+	// Admin can see all folders, so we avoid listing them.
+	// When set, Meta.FolderName will be empty in the results.
+	SkipFolderTreeForAdmin bool
 }
 
 // LibraryElementResponse is a response struct for LibraryElementDTO.


### PR DESCRIPTION
**What is this feature?**

Adds `SkipFolderTreeForAdmin` option to `SearchLibraryElementsQuery` that skips fetching the folder tree when the caller is admin. Used by the dashboard schema conversion path (`libraryElementIndexProvider.GetLibraryElementInfo`).

**Why do we need this feature?**

The dashboard DTO endpoint (`/apis/dashboard.grafana.app/v2beta1/.../dto`) triggers schema version conversion (v0→v2beta1) which calls `GetAllElements()` to resolve library panel repeat options. This internally fetches ALL folders via unified storage (`k8s List` with `limit=100000` → `ListIterator` → `BatchGet` in chunks of 50), causing high latency on large orgs. The conversion already runs as admin (`StaticRequester{OrgRole: RoleAdmin}`) and only needs `elem.UID` and `elem.Model` — folder names and permission filtering are unnecessary.

**Who is this feature for?**

Grafana operators running at scale with many folders, experiencing slow dashboard DTO responses.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.