### PR TITLE
FS: Add dev SMTP server for testing email flows

### DIFF
--- a/devenv/frontend-service/Tiltfile
+++ b/devenv/frontend-service/Tiltfile
@@ -125,6 +125,7 @@ dc_resource("tempo", labels=["observability"])
 dc_resource("postgres", labels=["misc"])
 dc_resource("tempo-init", labels=["misc"])
 dc_resource("goff", labels=["misc"])
+dc_resource("maildev", labels=["misc"])
 
 # paths in tilt files are confusing....
 # - if tilt is dealing with the path, it is relative to the Tiltfile

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
       OTEL_SERVICE_NAME: grafana-api
       GF_TRACING_OPENTELEMETRY_OTLP_ADDRESS: 'alloy:4317'
       GF_TRACING_OPENTELEMETRY_OTLP_PROPAGATION: jaeger,w3c
+      GF_SMTP_ENABLED: true
+      GF_SMTP_HOST: maildev:1025
     # ports are set dynamically in the Tiltfile (derived from PORT)
     labels:
       - 'alloy.logs=true'
@@ -153,6 +155,11 @@ services:
     depends_on:
       tempo-init:
         condition: service_completed_successfully
+
+  maildev:
+    image: maildev/maildev:2.2.1@sha256:180ef51f65eefebb0e7122d8308813c1fd7bff164bc440ce5a3c2feee167a810
+    ports:
+      - '1080:1080'
 
 configs:
   goff_config:


### PR DESCRIPTION
**What is this feature?**

Adds a dev SMTP server with a web interface for local development

<img width="1241" height="887" alt="Screenshot 2026-04-15 at 10 52 04 am" src="https://github.com/user-attachments/assets/1dbf6166-0232-4357-8e65-7a724bc6540b" />


**Why do we need this feature?**

For testing email flows locally

**Who is this feature for?**

Grafana developers!