### PR TITLE
CI: Stabilize the pr-checks.yml workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,11 @@
 name: PR Checks
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: pr-checks-${{ github.event.number }}-new
+  cancel-in-progress: true
 
 permissions:
   statuses: write


### PR DESCRIPTION
I got sick of seeing the changelog check not update after I labeled it with "no-changelog". Turns out, it's becuase: "By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened"

There's also no point in continuing this if a new event is received so cancel-in-progress will make everything behave nicer and prevent race conditions.