### PR TITLE
Dashboard: Add conditionalRendering support to mutation API

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
@@ -8,6 +8,8 @@
 
 import { type z } from 'zod';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
@@ -93,6 +95,18 @@ export const addPanelCommand: MutationCommand<AddPanelPayload> = {
               gridItem.setState(updates);
             }
           }
+        }
+      }
+
+      if (layoutItem?.spec?.conditionalRendering) {
+        if (isAutoGrid) {
+          const gridItem = vizPanel.parent;
+          if (gridItem instanceof AutoGridItem) {
+            const group = ConditionalRenderingGroup.deserialize(layoutItem.spec.conditionalRendering);
+            gridItem.setState({ conditionalRendering: group });
+          }
+        } else {
+          warnings.push('conditionalRendering ignored: show/hide rules are only supported with Auto grid layout.');
         }
       }
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/addRow.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addRow.ts
@@ -8,6 +8,7 @@
 
 import { type z } from 'zod';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
@@ -54,6 +55,9 @@ export const addRowCommand: MutationCommand<AddRowPayload> = {
           hideHeader: row.spec.hideHeader,
           fillScreen: row.spec.fillScreen,
           repeatByVariable: row.spec.repeat?.value,
+          conditionalRendering: row.spec.conditionalRendering
+            ? ConditionalRenderingGroup.deserialize(row.spec.conditionalRendering)
+            : undefined,
         });
 
         const currentRows = [...rowsManager.state.rows];
@@ -77,6 +81,9 @@ export const addRowCommand: MutationCommand<AddRowPayload> = {
           hideHeader: row.spec.hideHeader,
           fillScreen: row.spec.fillScreen,
           repeatByVariable: row.spec.repeat?.value,
+          conditionalRendering: row.spec.conditionalRendering
+            ? ConditionalRenderingGroup.deserialize(row.spec.conditionalRendering)
+            : undefined,
         });
 
         rowsManager = new RowsLayoutManager({ rows: [newRow] });

--- a/public/app/features/dashboard-scene/mutation-api/commands/addTab.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addTab.ts
@@ -8,6 +8,7 @@
 
 import { type z } from 'zod';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';
@@ -51,6 +52,9 @@ export const addTabCommand: MutationCommand<AddTabPayload> = {
           layout: DefaultGridLayoutManager.fromVizPanels([]),
           title: tab.spec.title,
           repeatByVariable: tab.spec.repeat?.value,
+          conditionalRendering: tab.spec.conditionalRendering
+            ? ConditionalRenderingGroup.deserialize(tab.spec.conditionalRendering)
+            : undefined,
         });
 
         const currentTabs = [...tabsManager.state.tabs];
@@ -71,6 +75,9 @@ export const addTabCommand: MutationCommand<AddTabPayload> = {
           layout: targetLayout,
           title: tab.spec.title,
           repeatByVariable: tab.spec.repeat?.value,
+          conditionalRendering: tab.spec.conditionalRendering
+            ? ConditionalRenderingGroup.deserialize(tab.spec.conditionalRendering)
+            : undefined,
         });
 
         tabsManager = new TabsLayoutManager({ tabs: [newTab] });

--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -269,6 +269,45 @@ describe('Layout mutation commands', () => {
       const body = scene.state.body as unknown as RowsLayoutManager;
       expect(body.state.rows.map((r) => r.state.title)).toEqual(['First', 'Second', 'Third']);
     });
+
+    it('adds a row with conditionalRendering', async () => {
+      const scene = buildRowsScene(['Existing']);
+      const executor = new DashboardMutationClient(scene);
+
+      const result = await executor.execute({
+        type: 'ADD_ROW',
+        payload: {
+          row: {
+            kind: 'RowsLayoutRow',
+            spec: {
+              title: 'Conditional Row',
+              conditionalRendering: {
+                kind: 'ConditionalRenderingGroup',
+                spec: {
+                  visibility: 'hide',
+                  condition: 'or',
+                  items: [
+                    {
+                      kind: 'ConditionalRenderingTimeRangeSize',
+                      spec: { value: '1h' },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          parentPath: '/',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as RowsLayoutManager;
+      const serialized = body.state.rows[1].state.conditionalRendering?.serialize();
+      expect(serialized?.spec.visibility).toBe('hide');
+      expect(serialized?.spec.condition).toBe('or');
+      expect(serialized?.spec.items).toHaveLength(1);
+      expect(serialized?.spec.items[0].kind).toBe('ConditionalRenderingTimeRangeSize');
+    });
   });
 
   describe('REMOVE_ROW', () => {
@@ -348,6 +387,86 @@ describe('Layout mutation commands', () => {
       const body = scene.state.body as unknown as RowsLayoutManager;
       expect(body.state.rows[0].state.collapse).toBe(true);
     });
+
+    it('sets conditionalRendering with a variable condition', async () => {
+      const scene = buildRowsScene(['Row']);
+      const executor = new DashboardMutationClient(scene);
+
+      const result = await executor.execute({
+        type: 'UPDATE_ROW',
+        payload: {
+          path: '/rows/0',
+          spec: {
+            conditionalRendering: {
+              kind: 'ConditionalRenderingGroup',
+              spec: {
+                visibility: 'hide',
+                condition: 'and',
+                items: [
+                  {
+                    kind: 'ConditionalRenderingVariable',
+                    spec: { variable: 'env', operator: 'equals', value: 'prod' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as RowsLayoutManager;
+      const serialized = body.state.rows[0].state.conditionalRendering?.serialize();
+      expect(serialized?.spec.visibility).toBe('hide');
+      expect(serialized?.spec.condition).toBe('and');
+      expect(serialized?.spec.items).toHaveLength(1);
+      expect(serialized?.spec.items[0].kind).toBe('ConditionalRenderingVariable');
+    });
+
+    it('clears conditionalRendering when items is empty', async () => {
+      const scene = buildRowsScene(['Row']);
+      const executor = new DashboardMutationClient(scene);
+
+      await executor.execute({
+        type: 'UPDATE_ROW',
+        payload: {
+          path: '/rows/0',
+          spec: {
+            conditionalRendering: {
+              kind: 'ConditionalRenderingGroup',
+              spec: {
+                visibility: 'show',
+                condition: 'and',
+                items: [
+                  {
+                    kind: 'ConditionalRenderingVariable',
+                    spec: { variable: 'env', operator: 'equals', value: 'prod' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      const result = await executor.execute({
+        type: 'UPDATE_ROW',
+        payload: {
+          path: '/rows/0',
+          spec: {
+            conditionalRendering: {
+              kind: 'ConditionalRenderingGroup',
+              spec: { visibility: 'show', condition: 'and', items: [] },
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as RowsLayoutManager;
+      const serialized = body.state.rows[0].state.conditionalRendering?.serialize();
+      expect(serialized?.spec.items).toHaveLength(0);
+    });
   });
 
   describe('MOVE_ROW', () => {
@@ -421,6 +540,39 @@ describe('Layout mutation commands', () => {
       const body = scene.state.body as unknown as TabsLayoutManager;
       expect(body.state.tabs.map((t) => t.state.title)).toEqual(['First', 'Second', 'Third']);
     });
+
+    it('adds a tab with conditionalRendering', async () => {
+      const scene = buildTabsScene(['Existing']);
+      const executor = new DashboardMutationClient(scene);
+
+      const result = await executor.execute({
+        type: 'ADD_TAB',
+        payload: {
+          tab: {
+            kind: 'TabsLayoutTab',
+            spec: {
+              title: 'Conditional Tab',
+              conditionalRendering: {
+                kind: 'ConditionalRenderingGroup',
+                spec: {
+                  visibility: 'show',
+                  condition: 'and',
+                  items: [{ kind: 'ConditionalRenderingData', spec: { value: false } }],
+                },
+              },
+            },
+          },
+          parentPath: '/',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as TabsLayoutManager;
+      const serialized = body.state.tabs[1].state.conditionalRendering?.serialize();
+      expect(serialized?.spec.visibility).toBe('show');
+      expect(serialized?.spec.items).toHaveLength(1);
+      expect(serialized?.spec.items[0].kind).toBe('ConditionalRenderingData');
+    });
   });
 
   describe('REMOVE_TAB', () => {
@@ -482,6 +634,35 @@ describe('Layout mutation commands', () => {
       expect(result.success).toBe(true);
       const body = scene.state.body as unknown as TabsLayoutManager;
       expect(body.state.tabs[0].state.title).toBe('New Title');
+    });
+
+    it('sets conditionalRendering with a data condition', async () => {
+      const scene = buildTabsScene(['Tab']);
+      const executor = new DashboardMutationClient(scene);
+
+      const result = await executor.execute({
+        type: 'UPDATE_TAB',
+        payload: {
+          path: '/tabs/0',
+          spec: {
+            conditionalRendering: {
+              kind: 'ConditionalRenderingGroup',
+              spec: {
+                visibility: 'show',
+                condition: 'and',
+                items: [{ kind: 'ConditionalRenderingData', spec: { value: true } }],
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as TabsLayoutManager;
+      const serialized = body.state.tabs[0].state.conditionalRendering?.serialize();
+      expect(serialized?.spec.visibility).toBe('show');
+      expect(serialized?.spec.items).toHaveLength(1);
+      expect(serialized?.spec.items[0].kind).toBe('ConditionalRenderingData');
     });
   });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -3,6 +3,8 @@ import { sceneGraph, type VizPanel } from '@grafana/scenes';
 
 import { getUpdatedHoverHeader } from '../../panel-edit/getPanelFrameOptions';
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { type AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
+import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getQueryRunnerFor } from '../../utils/utils';
@@ -78,6 +80,37 @@ function mockSerializer(elementMap: Record<string, number> = {}) {
 
 function buildPanelScene(panels: VizPanel[] = [], elementMap: Record<string, number> = {}): DashboardScene {
   const body = DefaultGridLayoutManager.fromVizPanels(panels);
+  const state: Record<string, unknown> = {
+    uid: 'test-dash',
+    isEditing: false,
+    body,
+  };
+
+  const scene = {
+    state,
+    serializer: mockSerializer(elementMap),
+    canEditDashboard: jest.fn(() => true),
+    onEnterEditMode: jest.fn(() => {
+      state.isEditing = true;
+    }),
+    forceRender: jest.fn(),
+    setState: jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(state, partial);
+    }),
+    updatePanelTitle: jest.fn((panel: VizPanel, title: string) => {
+      panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange) });
+    }),
+    changePanelPlugin: jest.fn(),
+  };
+
+  currentTestScene = scene;
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return scene as unknown as DashboardScene;
+}
+
+function buildAutoGridPanelScene(panels: VizPanel[] = [], elementMap: Record<string, number> = {}): DashboardScene {
+  const body = AutoGridLayoutManager.createFromLayout(DefaultGridLayoutManager.fromVizPanels(panels));
   const state: Record<string, unknown> = {
     uid: 'test-dash',
     isEditing: false,
@@ -695,6 +728,143 @@ describe('Panel mutation commands', () => {
 
       const tr = vizPanel.state.$timeRange as PanelTimeRange;
       expect(tr.state.timeFrom).toBe('1h');
+    });
+
+    it('sets conditionalRendering on an AutoGrid panel', async () => {
+      const scene = buildAutoGridPanelScene();
+      const client = new DashboardMutationClient(scene);
+
+      const elementName = await addPanel(client, 'Conditional Panel');
+
+      const result = await client.execute({
+        type: 'UPDATE_PANEL',
+        payload: {
+          element: { name: elementName },
+          panel: { kind: 'Panel', spec: {} },
+          conditionalRendering: {
+            kind: 'ConditionalRenderingGroup',
+            spec: {
+              visibility: 'hide',
+              condition: 'and',
+              items: [
+                {
+                  kind: 'ConditionalRenderingVariable',
+                  spec: { variable: 'env', operator: 'equals', value: 'prod' },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as AutoGridLayoutManager;
+      const vizPanel = body.getVizPanels()[0];
+      const autoGridItem = vizPanel.parent as AutoGridItem;
+      const serialized = autoGridItem.state.conditionalRendering?.serialize();
+      expect(serialized?.spec.visibility).toBe('hide');
+      expect(serialized?.spec.condition).toBe('and');
+      expect(serialized?.spec.items).toHaveLength(1);
+      expect(serialized?.spec.items[0].kind).toBe('ConditionalRenderingVariable');
+    });
+
+    it('sets conditionalRendering without passing panel', async () => {
+      const scene = buildAutoGridPanelScene();
+      const client = new DashboardMutationClient(scene);
+
+      const elementName = await addPanel(client, 'No Panel Payload');
+
+      const result = await client.execute({
+        type: 'UPDATE_PANEL',
+        payload: {
+          element: { name: elementName },
+          conditionalRendering: {
+            kind: 'ConditionalRenderingGroup',
+            spec: {
+              visibility: 'show',
+              condition: 'and',
+              items: [{ kind: 'ConditionalRenderingData', spec: { value: true } }],
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as AutoGridLayoutManager;
+      const vizPanel = body.getVizPanels()[0];
+      expect(vizPanel.state.title).toBe('No Panel Payload');
+      const autoGridItem = vizPanel.parent as AutoGridItem;
+      const serialized = autoGridItem.state.conditionalRendering?.serialize();
+      expect(serialized?.spec.visibility).toBe('show');
+      expect(serialized?.spec.items).toHaveLength(1);
+    });
+
+    it('rejects conditionalRendering on a GridLayout panel', async () => {
+      const scene = buildPanelScene();
+      const client = new DashboardMutationClient(scene);
+
+      const elementName = await addPanel(client, 'Grid Panel');
+
+      const result = await client.execute({
+        type: 'UPDATE_PANEL',
+        payload: {
+          element: { name: elementName },
+          panel: { kind: 'Panel', spec: {} },
+          conditionalRendering: {
+            kind: 'ConditionalRenderingGroup',
+            spec: {
+              visibility: 'show',
+              condition: 'and',
+              items: [{ kind: 'ConditionalRenderingData', spec: { value: true } }],
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Auto grid layout');
+    });
+
+    it('sets multiple conditions with or logic', async () => {
+      const scene = buildAutoGridPanelScene();
+      const client = new DashboardMutationClient(scene);
+
+      const elementName = await addPanel(client, 'Multi Condition Panel');
+
+      const result = await client.execute({
+        type: 'UPDATE_PANEL',
+        payload: {
+          element: { name: elementName },
+          panel: { kind: 'Panel', spec: {} },
+          conditionalRendering: {
+            kind: 'ConditionalRenderingGroup',
+            spec: {
+              visibility: 'show',
+              condition: 'or',
+              items: [
+                {
+                  kind: 'ConditionalRenderingVariable',
+                  spec: { variable: 'env', operator: 'notEquals', value: 'dev' },
+                },
+                {
+                  kind: 'ConditionalRenderingTimeRangeSize',
+                  spec: { value: '6h' },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const body = scene.state.body as unknown as AutoGridLayoutManager;
+      const vizPanel = body.getVizPanels()[0];
+      const autoGridItem = vizPanel.parent as AutoGridItem;
+      const serialized = autoGridItem.state.conditionalRendering?.serialize();
+      expect(serialized?.spec.condition).toBe('or');
+      expect(serialized?.spec.items).toHaveLength(2);
+      expect(serialized?.spec.items[0].kind).toBe('ConditionalRenderingVariable');
+      expect(serialized?.spec.items[1].kind).toBe('ConditionalRenderingTimeRangeSize');
     });
   });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -462,12 +462,53 @@ export const repeatOptionsSchema = z
   })
   .describe('Repeat options matching v2beta1 RepeatOptions');
 
+const conditionalRenderingVariableKindSchema = z.object({
+  kind: z.literal('ConditionalRenderingVariable'),
+  spec: z.object({
+    variable: z.string().describe('Name of the dashboard template variable'),
+    operator: z.enum(['equals', 'notEquals', 'matches', 'notMatches']),
+    value: z.string().describe('Value to compare against. For matches/notMatches this is a regex.'),
+  }),
+});
+
+const conditionalRenderingDataKindSchema = z.object({
+  kind: z.literal('ConditionalRenderingData'),
+  spec: z.object({
+    value: z.boolean().describe('true = "has data", false = "no data"'),
+  }),
+});
+
+const conditionalRenderingTimeRangeSizeKindSchema = z.object({
+  kind: z.literal('ConditionalRenderingTimeRangeSize'),
+  spec: z.object({
+    value: z.string().describe('Duration threshold (e.g. "5m", "1h", "7d", "6M", "1y")'),
+  }),
+});
+
+export const conditionalRenderingGroupKindSchema = z.object({
+  kind: z.literal('ConditionalRenderingGroup').optional().default('ConditionalRenderingGroup'),
+  spec: z.object({
+    visibility: z.enum(['show', 'hide']).describe('Whether to show or hide the element when conditions match'),
+    condition: z.enum(['and', 'or']).describe('"and" = match all rules; "or" = match any rule'),
+    items: z
+      .array(
+        z.discriminatedUnion('kind', [
+          conditionalRenderingVariableKindSchema,
+          conditionalRenderingDataKindSchema,
+          conditionalRenderingTimeRangeSizeKindSchema,
+        ])
+      )
+      .describe('List of conditions. Pass an empty array to remove all rules.'),
+  }),
+});
+
 export const rowsLayoutRowSpecSchema = z.object({
   title: z.string().optional().describe('Row heading title'),
   collapse: z.boolean().optional().default(false).describe('Whether the row starts collapsed'),
   hideHeader: z.boolean().optional().default(false).describe('Hide the row header'),
   fillScreen: z.boolean().optional().default(false).describe('Row fills viewport height'),
   repeat: rowRepeatOptionsSchema.optional().describe('Repeat row for each value of a variable'),
+  conditionalRendering: conditionalRenderingGroupKindSchema.optional().describe('Show/hide rules for this row'),
 });
 
 export const partialRowSpecSchema = z
@@ -479,12 +520,16 @@ export const partialRowSpecSchema = z
     repeat: rowRepeatOptionsSchema
       .optional()
       .describe('Repeat row for each value of a variable. Omit to leave unchanged.'),
+    conditionalRendering: conditionalRenderingGroupKindSchema
+      .optional()
+      .describe('Show/hide rules for this row. Omit to leave unchanged.'),
   })
   .describe('Fields to update (partial RowsLayoutRowSpec)');
 
 export const tabsLayoutTabSpecSchema = z.object({
   title: z.string().optional().describe('Tab title'),
   repeat: tabRepeatOptionsSchema.optional().describe('Repeat tab for each value of a variable'),
+  conditionalRendering: conditionalRenderingGroupKindSchema.optional().describe('Show/hide rules for this tab'),
 });
 
 export const partialTabSpecSchema = z
@@ -493,6 +538,9 @@ export const partialTabSpecSchema = z
     repeat: tabRepeatOptionsSchema
       .optional()
       .describe('Repeat tab for each value of a variable. Omit to leave unchanged.'),
+    conditionalRendering: conditionalRenderingGroupKindSchema
+      .optional()
+      .describe('Show/hide rules for this tab. Omit to leave unchanged.'),
   })
   .describe('Fields to update (partial TabsLayoutTabSpec)');
 
@@ -826,7 +874,20 @@ export const layoutItemInputSchema = z
         'Layout item type hint. If omitted, automatically determined from the target layout. ' +
           'A warning is emitted if the provided kind does not match the target layout.'
       ),
-    spec: gridLayoutItemKindSchema.shape.spec.omit({ element: true }).partial().optional().default({}),
+    spec: gridLayoutItemKindSchema.shape.spec
+      .omit({ element: true })
+      .extend({
+        conditionalRendering: conditionalRenderingGroupKindSchema
+          .optional()
+          .describe(
+            'Show/hide rules (Auto grid layout only). ' +
+              'On ADD_PANEL, ignored with a warning if the target is not Auto grid. ' +
+              'On UPDATE_PANEL, returns an error.'
+          ),
+      })
+      .partial()
+      .optional()
+      .default({}),
   })
   .describe(
     'Layout item with optional sizing hints. The kind is optional and auto-detected from the target layout. ' +
@@ -860,12 +921,28 @@ export const addPanelPayloadSchema = z.object({
     ),
 });
 
-export const updatePanelPayloadSchema = z.object({
-  element: elementReferenceSchema.describe('Panel to update, identified by element name'),
-  panel: partialPanelKindSchema.describe(
-    'Partial panel update. Only provided fields are applied. Options and fieldConfig are deep-merged.'
-  ),
-});
+export const updatePanelPayloadSchema = z
+  .object({
+    element: elementReferenceSchema.describe('Panel to update, identified by element name'),
+    panel: partialPanelKindSchema
+      .optional()
+      .describe(
+        'Partial panel update. Only provided fields are applied. Options and fieldConfig are deep-merged. ' +
+          'Can be omitted when only setting conditionalRendering.'
+      ),
+    conditionalRendering: conditionalRenderingGroupKindSchema
+      .optional()
+      .describe('Show/hide rules for this panel (Auto grid layout only). Omit to leave unchanged.'),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.panel && data.conditionalRendering === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        message: 'At least one of panel or conditionalRendering must be provided.',
+      });
+    }
+  });
 
 export const removePanelPayloadSchema = z.object({
   elements: z.array(elementReferenceSchema).max(10).describe('Panels to remove, identified by element name'),

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -12,7 +12,9 @@ import { type z } from 'zod';
 
 import { type FieldConfigSource } from '@grafana/data';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { getUpdatedHoverHeader } from '../../panel-edit/getPanelFrameOptions';
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getElements, panelQueryKindToSceneQuery } from '../../serialization/layoutSerializers/utils';
 import { getQueryRunnerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
@@ -80,7 +82,7 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
     try {
       const { element, panel } = payload;
       const elementName = element.name;
-      const spec = panel.spec;
+      const spec = panel?.spec;
 
       const panelId = scene.serializer.getPanelIdForElement(elementName);
       if (panelId === undefined) {
@@ -97,114 +99,128 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
 
       const previousElement = getElements(scene.state.body, scene)[elementName];
 
-      if (spec.title !== undefined) {
-        scene.updatePanelTitle(vizPanel, spec.title);
-      }
+      if (spec) {
+        if (spec.title !== undefined) {
+          scene.updatePanelTitle(vizPanel, spec.title);
+        }
 
-      if (spec.description !== undefined) {
-        vizPanel.onDescriptionChange(spec.description);
-      }
+        if (spec.description !== undefined) {
+          vizPanel.onDescriptionChange(spec.description);
+        }
 
-      if (spec.transparent !== undefined) {
-        vizPanel.setState({ displayMode: spec.transparent ? 'transparent' : 'default' });
-      }
+        if (spec.transparent !== undefined) {
+          vizPanel.setState({ displayMode: spec.transparent ? 'transparent' : 'default' });
+        }
 
-      if (spec.links !== undefined) {
-        const titleItems = vizPanel.state.titleItems;
-        if (Array.isArray(titleItems)) {
-          for (const item of titleItems) {
-            if (hasRawLinks(item)) {
-              item.setState({ rawLinks: spec.links });
-              break;
+        if (spec.links !== undefined) {
+          const titleItems = vizPanel.state.titleItems;
+          if (Array.isArray(titleItems)) {
+            for (const item of titleItems) {
+              if (hasRawLinks(item)) {
+                item.setState({ rawLinks: spec.links });
+                break;
+              }
+            }
+          }
+        }
+
+        const vizConfig = spec.vizConfig;
+        if (vizConfig) {
+          const isPluginChange = vizConfig.group && vizConfig.group !== vizPanel.state.pluginId;
+
+          // Zod parsed types and VizPanel state types don't overlap, so casts are needed.
+          /* eslint-disable @typescript-eslint/consistent-type-assertions */
+          if (isPluginChange) {
+            const newOptions = vizConfig.spec?.options as Record<string, unknown> | undefined;
+            const newFieldConfig = vizConfig.spec?.fieldConfig as FieldConfigSource | undefined;
+            await scene.changePanelPlugin(vizPanel, vizConfig.group!, newOptions, newFieldConfig);
+          } else {
+            if (vizConfig.spec?.options) {
+              const merged = mergeReplacingArrays(
+                (vizPanel.state.options ?? {}) as Record<string, unknown>,
+                vizConfig.spec.options as Record<string, unknown>
+              );
+              vizPanel.onOptionsChange(merged, true);
+            }
+
+            if (vizConfig.spec?.fieldConfig) {
+              const merged = mergeReplacingArrays(
+                vizPanel.state.fieldConfig as unknown as Record<string, unknown>,
+                vizConfig.spec.fieldConfig as unknown as Record<string, unknown>
+              );
+              vizPanel.onFieldConfigChange(merged as unknown as FieldConfigSource, true);
+            }
+          }
+          /* eslint-enable @typescript-eslint/consistent-type-assertions */
+        }
+
+        const dataSpec = spec.data?.spec;
+        if (dataSpec) {
+          const dataPipeline = vizPanel.state.$data;
+          const queryRunner = getQueryRunnerFor(vizPanel);
+          if (dataSpec.queries && queryRunner) {
+            const queries = dataSpec.queries.map((pq: PanelQueryKind) => panelQueryKindToSceneQuery(pq));
+            queryRunner.setState({ queries });
+            queryRunner.runQueries();
+          }
+
+          if (dataSpec.transformations !== undefined && isDataTransformer(dataPipeline)) {
+            const transformations = dataSpec.transformations.map((t: TransformationKind) => ({
+              id: t.group,
+              disabled: t.spec.disabled,
+              filter: t.spec.filter,
+              topic: t.spec.topic,
+              options: t.spec.options,
+            }));
+            dataPipeline.setState({ transformations });
+            dataPipeline.reprocessTransformations();
+          }
+
+          if (dataSpec.queryOptions && queryRunner) {
+            const qo = dataSpec.queryOptions;
+            const runnerUpdate: Record<string, unknown> = {};
+
+            if (qo.maxDataPoints !== undefined) {
+              runnerUpdate.maxDataPoints = qo.maxDataPoints;
+            }
+            if (qo.interval !== undefined) {
+              runnerUpdate.minInterval = qo.interval;
+            }
+            if (qo.cacheTimeout !== undefined) {
+              runnerUpdate.cacheTimeout = qo.cacheTimeout;
+            }
+            if (qo.queryCachingTTL !== undefined) {
+              runnerUpdate.queryCachingTTL = qo.queryCachingTTL;
+            }
+
+            if (Object.keys(runnerUpdate).length > 0) {
+              queryRunner.setState(runnerUpdate);
+            }
+
+            if (qo.timeFrom !== undefined || qo.timeShift !== undefined) {
+              const timeRange = new PanelTimeRange({
+                timeFrom: qo.timeFrom,
+                timeShift: qo.timeShift,
+                hideTimeOverride: qo.hideTimeOverride,
+              });
+              vizPanel.setState({
+                $timeRange: timeRange,
+                hoverHeader: getUpdatedHoverHeader(vizPanel.state.title, timeRange),
+              });
             }
           }
         }
       }
 
-      const vizConfig = spec.vizConfig;
-      if (vizConfig) {
-        const isPluginChange = vizConfig.group && vizConfig.group !== vizPanel.state.pluginId;
-
-        // Zod parsed types and VizPanel state types don't overlap, so casts are needed.
-        /* eslint-disable @typescript-eslint/consistent-type-assertions */
-        if (isPluginChange) {
-          const newOptions = vizConfig.spec?.options as Record<string, unknown> | undefined;
-          const newFieldConfig = vizConfig.spec?.fieldConfig as FieldConfigSource | undefined;
-          await scene.changePanelPlugin(vizPanel, vizConfig.group!, newOptions, newFieldConfig);
+      if (payload.conditionalRendering !== undefined) {
+        const parent = vizPanel.parent;
+        if (parent instanceof AutoGridItem) {
+          const group = ConditionalRenderingGroup.deserialize(payload.conditionalRendering);
+          parent.setState({ conditionalRendering: group });
         } else {
-          if (vizConfig.spec?.options) {
-            const merged = mergeReplacingArrays(
-              (vizPanel.state.options ?? {}) as Record<string, unknown>,
-              vizConfig.spec.options as Record<string, unknown>
-            );
-            vizPanel.onOptionsChange(merged, true);
-          }
-
-          if (vizConfig.spec?.fieldConfig) {
-            const merged = mergeReplacingArrays(
-              vizPanel.state.fieldConfig as unknown as Record<string, unknown>,
-              vizConfig.spec.fieldConfig as unknown as Record<string, unknown>
-            );
-            vizPanel.onFieldConfigChange(merged as unknown as FieldConfigSource, true);
-          }
-        }
-        /* eslint-enable @typescript-eslint/consistent-type-assertions */
-      }
-
-      const dataSpec = spec.data?.spec;
-      if (dataSpec) {
-        const dataPipeline = vizPanel.state.$data;
-        const queryRunner = getQueryRunnerFor(vizPanel);
-        if (dataSpec.queries && queryRunner) {
-          const queries = dataSpec.queries.map((pq: PanelQueryKind) => panelQueryKindToSceneQuery(pq));
-          queryRunner.setState({ queries });
-          queryRunner.runQueries();
-        }
-
-        if (dataSpec.transformations !== undefined && isDataTransformer(dataPipeline)) {
-          const transformations = dataSpec.transformations.map((t: TransformationKind) => ({
-            id: t.group,
-            disabled: t.spec.disabled,
-            filter: t.spec.filter,
-            topic: t.spec.topic,
-            options: t.spec.options,
-          }));
-          dataPipeline.setState({ transformations });
-          dataPipeline.reprocessTransformations();
-        }
-
-        if (dataSpec.queryOptions && queryRunner) {
-          const qo = dataSpec.queryOptions;
-          const runnerUpdate: Record<string, unknown> = {};
-
-          if (qo.maxDataPoints !== undefined) {
-            runnerUpdate.maxDataPoints = qo.maxDataPoints;
-          }
-          if (qo.interval !== undefined) {
-            runnerUpdate.minInterval = qo.interval;
-          }
-          if (qo.cacheTimeout !== undefined) {
-            runnerUpdate.cacheTimeout = qo.cacheTimeout;
-          }
-          if (qo.queryCachingTTL !== undefined) {
-            runnerUpdate.queryCachingTTL = qo.queryCachingTTL;
-          }
-
-          if (Object.keys(runnerUpdate).length > 0) {
-            queryRunner.setState(runnerUpdate);
-          }
-
-          if (qo.timeFrom !== undefined || qo.timeShift !== undefined) {
-            const timeRange = new PanelTimeRange({
-              timeFrom: qo.timeFrom,
-              timeShift: qo.timeShift,
-              hideTimeOverride: qo.hideTimeOverride,
-            });
-            vizPanel.setState({
-              $timeRange: timeRange,
-              hoverHeader: getUpdatedHoverHeader(vizPanel.state.title, timeRange),
-            });
-          }
+          throw new Error(
+            'Show/hide rules are only supported with Auto grid layout. Switch the layout to Auto grid first.'
+          );
         }
       }
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateRow.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateRow.ts
@@ -6,6 +6,7 @@
 
 import { type z } from 'zod';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { RowItem } from '../../scene/layout-rows/RowItem';
 
 import { resolveLayoutPath } from './layoutPathResolver';
@@ -42,6 +43,7 @@ export const updateRowCommand: MutationCommand<UpdateRowPayload> = {
         collapse: row.state.collapse,
         hideHeader: row.state.hideHeader,
         fillScreen: row.state.fillScreen,
+        conditionalRendering: row.state.conditionalRendering?.serialize(),
       };
 
       const updates: Record<string, unknown> = {};
@@ -64,11 +66,17 @@ export const updateRowCommand: MutationCommand<UpdateRowPayload> = {
         row.onChangeRepeat(spec.repeat?.value || undefined);
       }
 
+      if (spec.conditionalRendering !== undefined) {
+        const group = ConditionalRenderingGroup.deserialize(spec.conditionalRendering);
+        row.setState({ conditionalRendering: group });
+      }
+
       const currentSpec = {
         title: row.state.title,
         collapse: row.state.collapse,
         hideHeader: row.state.hideHeader,
         fillScreen: row.state.fillScreen,
+        conditionalRendering: row.state.conditionalRendering?.serialize(),
       };
 
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateTab.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateTab.ts
@@ -6,6 +6,7 @@
 
 import { type z } from 'zod';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 
 import { resolveLayoutPath } from './layoutPathResolver';
@@ -37,7 +38,10 @@ export const updateTabCommand: MutationCommand<UpdateTabPayload> = {
       }
 
       const tab = resolved.item;
-      const previousValue = { title: tab.state.title };
+      const previousValue = {
+        title: tab.state.title,
+        conditionalRendering: tab.state.conditionalRendering?.serialize(),
+      };
 
       const updates: Record<string, unknown> = {};
       if (spec.title !== undefined) {
@@ -50,7 +54,15 @@ export const updateTabCommand: MutationCommand<UpdateTabPayload> = {
         tab.onChangeRepeat(spec.repeat?.value || undefined);
       }
 
-      const currentSpec = { title: tab.state.title };
+      if (spec.conditionalRendering !== undefined) {
+        const group = ConditionalRenderingGroup.deserialize(spec.conditionalRendering);
+        tab.setState({ conditionalRendering: group });
+      }
+
+      const currentSpec = {
+        title: tab.state.title,
+        conditionalRendering: tab.state.conditionalRendering?.serialize(),
+      };
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
- Add `conditionalRendering` (v2beta1 `ConditionalRenderingGroup`) to the Dashboard Mutation API schemas for rows, tabs, and panels.
- Wire deserialization/application in `addRow`, `addTab`, `addPanel`, `updateRow`, `updateTab`, and `updatePanel` commands.
- Panel conditional rendering is supported on Auto grid layout only; DefaultGrid attempts return a clear error (update) or warning (add).
- Comprehensive tests for all paths: add/update with variable, data, and time-range-size conditions; clearing rules; layout rejection.

## Test plan
- [x] `yarn jest --no-watch layoutCommands.test.ts panelCommands.test.ts` — 112 tests pass
- [ ] CI green