### PR TITLE
[release-12.2.9] Chore(deps): Upgrade lodash-es to >= 4.18.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22560,9 +22560,9 @@ __metadata:
   linkType: hard
 
 "lodash-es@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10/03f39878ea1e42b3199bd3f478150ab723f93cc8730ad86fec1f2804f4a07c6e30deaac73cad53a88e9c3db33348bb8ceeb274552390e7a75d7849021c02df43
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10/8bfad225ef09ef42b04283cdaf7830efcc2ba29ae41b56501c74422155ee1ccaa1f0f6e8319def3451a1fe54dec501c8e4bee622bae2b2d98ac993731e0a5cce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `lodash-es` to fix CVE-2026-4800
- Fixed version: >= 4.18.0
- Method: `yarn up -R lodash-es`

## Test plan
- [ ] CI passes
- [ ] `yarn why lodash-es --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)