### PR TITLE
Alerting: Disable alertingListViewV2PreviewToggle by default, remove OSS edition gate

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1112,7 +1112,7 @@ export interface FeatureToggles {
   pluginsAutoUpdate?: boolean;
   /**
   * Enables the alerting list view v2 preview toggle
-  * @default true
+  * @default false
   */
   alertingListViewV2PreviewToggle?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1904,7 +1904,7 @@ var (
 			Generate:    Generate{LegacyFrontend: true},
 			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaAlertingSquad,
-			Expression:  "true",
+			Expression:  "false",
 		},
 		{
 			Name:        "alertRuleUseFiredAtForStartsAt",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -434,10 +434,10 @@
     {
       "metadata": {
         "name": "alertingListViewV2PreviewToggle",
-        "resourceVersion": "1775152842792",
+        "resourceVersion": "1776254526995",
         "creationTimestamp": "2025-04-22T08:50:34Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-02 18:00:42.792501 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-04-15 12:02:06.995878 +0000 UTC"
         }
       },
       "spec": {
@@ -445,7 +445,7 @@
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
-        "expression": "true"
+        "expression": "false"
       }
     },
     {

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
@@ -1,8 +1,6 @@
 import { render, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { config } from '@grafana/runtime';
-
 import { mockLocalStorage } from '../mocks';
 import { getPreviewToggle, setPreviewToggle } from '../previewToggles';
 

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.test.tsx
@@ -1,7 +1,6 @@
 import { render, testWithFeatureToggles, waitFor, within } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { GrafanaEdition } from '@grafana/data/internal';
 import { config } from '@grafana/runtime';
 
 import { mockLocalStorage } from '../mocks';
@@ -58,19 +57,21 @@ describe('RuleListPageTitle', () => {
     expect(ui.revertButton.query()).not.toBeInTheDocument();
   });
 
-  it('should not show toggle button on non-OSS editions even when flag is enabled', () => {
-    config.buildInfo.edition = GrafanaEdition.Enterprise;
-    renderRuleListPageTitle();
-    expect(ui.useNewExperienceButton.query()).not.toBeInTheDocument();
-    expect(ui.revertButton.query()).not.toBeInTheDocument();
+  describe('when alertingListViewV2PreviewToggle is enabled', () => {
+    testWithFeatureToggles({ enable: ['alertingListViewV2PreviewToggle', 'alertingListViewV2'] });
+
+    beforeEach(() => {
+      setPreviewToggle('alertingListViewV2', true);
+    });
+
+    it('should show the revert toggle button', () => {
+      renderRuleListPageTitle();
+      expect(ui.revertButton.get()).toBeInTheDocument();
+    });
   });
 
   describe('when on OLD view (alertingListViewV2PreviewToggle enabled, alertingListViewV2 disabled)', () => {
     testWithFeatureToggles({ enable: ['alertingListViewV2PreviewToggle'] });
-
-    beforeEach(() => {
-      config.buildInfo.edition = GrafanaEdition.OpenSource;
-    });
 
     it('should show "Use new experience" button', () => {
       renderRuleListPageTitle();
@@ -96,7 +97,6 @@ describe('RuleListPageTitle', () => {
     testWithFeatureToggles({ enable: ['alertingListViewV2PreviewToggle', 'alertingListViewV2'] });
 
     beforeEach(() => {
-      config.buildInfo.edition = GrafanaEdition.OpenSource;
       setPreviewToggle('alertingListViewV2', true);
     });
 

--- a/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx
@@ -11,13 +11,12 @@ import {
 } from '../Analytics';
 import { shouldUseAlertingListViewV2 } from '../featureToggles';
 import { setPreviewToggle } from '../previewToggles';
-import { isOpenSourceEdition } from '../utils/misc';
 import { ALERTING_PATHS } from '../utils/navigation';
 
 import { RevertToOldExperienceModal } from './AlertsActivityOptOutModal';
 
 export function RuleListPageTitle({ title }: { title: string }) {
-  const shouldShowV2Toggle = (config.featureToggles.alertingListViewV2PreviewToggle ?? false) && isOpenSourceEdition();
+  const shouldShowV2Toggle = config.featureToggles.alertingListViewV2PreviewToggle ?? false;
   const listViewV2Enabled = shouldUseAlertingListViewV2();
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);


### PR DESCRIPTION
**What is this feature?**

Changes the default for the `alertingListViewV2PreviewToggle` feature flag from `true` to `false`, and removes the `isOpenSourceEdition()` guard from the rule list page title toggle button.

**Why do we need this feature?**

Previously, the toggle button ("Revert to previous experience" / "Use new experience") was shown by default to all OSS users and hidden from all non-OSS (Cloud) users — regardless of what the feature flag was set to. This caused two problems:

1. Cloud users on paid plans who had `alertingListViewV2PreviewToggle` explicitly enabled via MTFF still never saw the button, because `isOpenSourceEdition()` blocked it unconditionally.
2. OSS users always saw the button by default, with no way to turn it off globally.

The new approach: `alertingListViewV2PreviewToggle` defaults to `false` everywhere. OSS users who want to opt out of v2 can set `alertingListViewV2 = false` in `custom.ini`. Cloud users on eligible paid plans get the toggle button via MTFF enabling `alertingListViewV2PreviewToggle` for their plan.

**Who is this feature for?**

- Cloud users on paid plans (who need the opt-out toggle)
- OSS operators (who can now configure `alertingListViewV2` directly)

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The `alertingListViewV2` flag remains `true` by default — v2 is still on for everyone. Only the opt-out toggle button visibility changes.
- Generated files (`toggles_gen.json`, `featureToggles.gen.ts`) were updated via `make gen-feature-toggles`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.