### PR TITLE
Dashboard: DashboardCodePane width refactoring and fixes  

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -127,7 +127,8 @@ export function useSidebar({
           return prevWidth;
         }
 
-        return clamp(prevWidth + diff, 100, 500);
+        const maxWidth = Math.max(window.innerWidth * 0.5, 500);
+        return clamp(prevWidth + diff, 100, maxWidth);
       });
     },
     [hasOpenPane, setCompact, setPaneWidth, compact]

--- a/public/app/features/dashboard-scene/edit-pane/DashboardCodePane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardCodePane.tsx
@@ -18,6 +18,7 @@ export interface DashboardCodePaneProps {
 
 export class DashboardCodePane extends SceneObjectBase {
   public static Component = DashboardCodePaneRenderer;
+  public minWidth = 700;
 
   public getId() {
     return 'code' as const;

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -230,27 +230,18 @@ function useSidebarPaneMinWidth(openPane: DashboardSidebarPane | undefined, side
   const previousPaneRef = useRef<DashboardSidebarPane | undefined>(undefined);
 
   useEffect(() => {
-    const openPaneMinWidth = openPane?.minWidth;
-
     previousPaneRef.current = openPane;
 
-    if (openPaneMinWidth && sidebarContext.paneWidth < openPaneMinWidth) {
+    if (openPane?.minWidth && sidebarContext.paneWidth < openPane.minWidth) {
       originalPaneWidthRef.current = sidebarContext.paneWidth;
-      const diff = openPaneMinWidth - sidebarContext.paneWidth;
-      console.log('Resizing sidebar to meet min width requirement', {
-        openPaneMinWidth,
-        currentWidth: sidebarContext.paneWidth,
-        diff,
-      });
+      const diff = openPane.minWidth - sidebarContext.paneWidth;
       sidebarContext.onResize(diff);
-    } else if (!openPaneMinWidth && originalPaneWidthRef.current !== null) {
+    }
+
+    // If we are switching to a different openPane without minWidth
+    if (openPane && !openPane.minWidth && originalPaneWidthRef.current !== null) {
       const diff = originalPaneWidthRef.current - sidebarContext.paneWidth;
       sidebarContext.onResize(diff);
-      console.log('Restoring original sidebar width', {
-        originalWidth: originalPaneWidthRef.current,
-        currentWidth: sidebarContext.paneWidth,
-        diff,
-      });
       originalPaneWidthRef.current = null;
     }
   }, [openPane, sidebarContext]);

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -6,7 +6,14 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, useChromeHeaderHeight } from '@grafana/runtime';
 import { type VizPanel, useSceneObjectState } from '@grafana/scenes';
-import { ElementSelectionContext, useSidebar, useStyles2, useTheme2, Sidebar } from '@grafana/ui';
+import {
+  ElementSelectionContext,
+  useSidebar,
+  useStyles2,
+  useTheme2,
+  Sidebar,
+  type SidebarContextValue,
+} from '@grafana/ui';
 import NativeScrollbar, { DivScrollElement } from 'app/core/components/NativeScrollbar';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -26,7 +33,7 @@ import { StarButton } from '../scene/new-toolbar/actions/StarButton';
 import { dynamicDashNavActions } from '../utils/registerDynamicDashNavAction';
 
 import { DashboardEditPaneRenderer } from './DashboardEditPaneRenderer';
-import { type DashboardSidebarPaneName } from './types';
+import { type DashboardSidebarPane } from './types';
 
 interface Props {
   dashboard: DashboardScene;
@@ -119,10 +126,6 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     []
   );
 
-  const CODE_PANE_MIN_WIDTH = 700;
-  const originalPaneWidthRef = useRef<number | null>(null);
-  const previousPaneRef = useRef<DashboardSidebarPaneName | undefined>(undefined);
-
   // Selection is only needed in edit mode — the assistant popover is triggered
   // exclusively via the sparkle button, not through the selection system.
   useEffect(() => {
@@ -145,25 +148,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     defaultIsHidden: isEditing ? false : isMobile,
   });
 
-  useEffect(() => {
-    const wasCodePane = previousPaneRef.current === 'code';
-    const isCodePane = openPane?.getId() === 'code';
-    previousPaneRef.current = openPane?.getId();
-
-    if (isCodePane && !wasCodePane) {
-      // Opening code pane - store original width and expand if needed
-      if (sidebarContext.paneWidth < CODE_PANE_MIN_WIDTH) {
-        originalPaneWidthRef.current = sidebarContext.paneWidth;
-        const diff = CODE_PANE_MIN_WIDTH - sidebarContext.paneWidth;
-        sidebarContext.onResize(diff);
-      }
-    } else if (wasCodePane && !isCodePane && originalPaneWidthRef.current !== null) {
-      // Leaving code pane - restore original width
-      const diff = originalPaneWidthRef.current - sidebarContext.paneWidth;
-      sidebarContext.onResize(diff);
-      originalPaneWidthRef.current = null;
-    }
-  }, [openPane, sidebarContext]);
+  useSidebarPaneMinWidth(openPane, sidebarContext);
 
   /**
    * Sync docked state to editPane state
@@ -238,6 +223,37 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
       </div>
     </AssistantPopoverContext.Provider>
   );
+}
+
+function useSidebarPaneMinWidth(openPane: DashboardSidebarPane | undefined, sidebarContext: SidebarContextValue) {
+  const originalPaneWidthRef = useRef<number | null>(null);
+  const previousPaneRef = useRef<DashboardSidebarPane | undefined>(undefined);
+
+  useEffect(() => {
+    const openPaneMinWidth = openPane?.minWidth;
+
+    previousPaneRef.current = openPane;
+
+    if (openPaneMinWidth && sidebarContext.paneWidth < openPaneMinWidth) {
+      originalPaneWidthRef.current = sidebarContext.paneWidth;
+      const diff = openPaneMinWidth - sidebarContext.paneWidth;
+      console.log('Resizing sidebar to meet min width requirement', {
+        openPaneMinWidth,
+        currentWidth: sidebarContext.paneWidth,
+        diff,
+      });
+      sidebarContext.onResize(diff);
+    } else if (!openPaneMinWidth && originalPaneWidthRef.current !== null) {
+      const diff = originalPaneWidthRef.current - sidebarContext.paneWidth;
+      sidebarContext.onResize(diff);
+      console.log('Restoring original sidebar width', {
+        originalWidth: originalPaneWidthRef.current,
+        currentWidth: sidebarContext.paneWidth,
+        diff,
+      });
+      originalPaneWidthRef.current = null;
+    }
+  }, [openPane, sidebarContext]);
 }
 
 function useUpdateAppChromeActions(dashboard: DashboardScene) {

--- a/public/app/features/dashboard-scene/edit-pane/types.ts
+++ b/public/app/features/dashboard-scene/edit-pane/types.ts
@@ -15,4 +15,8 @@ export type DashboardSidebarPaneName = 'element' | 'outline' | 'filters' | 'add'
 
 export interface DashboardSidebarPane extends SceneObject {
   getId(): DashboardSidebarPaneName;
+  /**
+   * Some panes like code editor require a wider pane
+   */
+  minWidth?: number;
 }


### PR DESCRIPTION
builds on https://github.com/grafana/grafana/pull/122003  


* Refactor code side pane width logic  (now uses interface) and moved logic to hook
* Fixes issue of closing code pane and then selecting element (or outline) that used the code pane width instead of the previously set user width 
* Fixes issue of actually setting the desired 700 width (useSidebar pane onResize clamped it to max 500) 
* Now max sidebar width is based on window width (50%) 