### PR TITLE
Provisioning: Make unstructure conversion generic in integration tests

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -842,7 +842,7 @@ func (h *ProvisioningTestHelper) WaitForResourceQuotaLimit(t *testing.T, repoNam
 			return
 		}
 
-		repo := UnstructuredToRepository(t, repoObj)
+		repo := MustFromUnstructured[provisioning.Repository](t, repoObj)
 		assert.Equal(collect, expectedLimit, repo.Status.Quota.MaxResourcesPerRepository,
 			"repository quota limit not yet updated by controller")
 	}, WaitTimeoutDefault, WaitIntervalDefault, "Status.Quota.MaxResourcesPerRepository should be %d", expectedLimit)
@@ -858,7 +858,7 @@ func (h *ProvisioningTestHelper) WaitForQuotaReconciliation(t *testing.T, repoNa
 			return
 		}
 
-		repo := UnstructuredToRepository(t, repoObj)
+		repo := MustFromUnstructured[provisioning.Repository](t, repoObj)
 		condition := FindCondition(repo.Status.Conditions, provisioning.ConditionTypeResourceQuota)
 		if !assert.NotNil(collect, condition, "Quota condition not found") {
 			return
@@ -877,7 +877,7 @@ func (h *ProvisioningTestHelper) WaitForConditionReason(t *testing.T, repoName s
 			return
 		}
 
-		repo := UnstructuredToRepository(t, repoObj)
+		repo := MustFromUnstructured[provisioning.Repository](t, repoObj)
 		condition := FindCondition(repo.Status.Conditions, conditionType)
 		if !assert.NotNil(collect, condition, "%s condition not found", conditionType) {
 			return
@@ -1332,37 +1332,38 @@ func AsJSON(obj any) []byte {
 	return jj
 }
 
-func UnstructuredToRepository(t *testing.T, obj *unstructured.Unstructured) *provisioning.Repository {
-	bytes, err := obj.MarshalJSON()
-	require.NoError(t, err)
-
-	repo := &provisioning.Repository{}
-	err = json.Unmarshal(bytes, repo)
-	require.NoError(t, err)
-
-	return repo
+// ToUnstructured converts a typed K8s object to an unstructured representation
+// using the canonical DefaultUnstructuredConverter.
+func ToUnstructured[T any](obj *T) (*unstructured.Unstructured, error) {
+	raw, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: raw}, nil
 }
 
-func RepositoryToUnstructured(t *testing.T, obj *provisioning.Repository) *unstructured.Unstructured {
-	bytes, err := json.Marshal(obj)
-	require.NoError(t, err)
-
-	res := &unstructured.Unstructured{}
-	err = res.UnmarshalJSON(bytes)
-	require.NoError(t, err)
-
-	return res
+// FromUnstructured converts an unstructured object to a typed K8s object
+// using the canonical DefaultUnstructuredConverter.
+func FromUnstructured[T any](obj *unstructured.Unstructured) (*T, error) {
+	result := new(T)
+	err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, result)
+	return result, err
 }
 
-func UnstructuredToConnection(t *testing.T, obj *unstructured.Unstructured) *provisioning.Connection {
-	bytes, err := obj.MarshalJSON()
+// MustToUnstructured is a test-fatal wrapper around ToUnstructured.
+func MustToUnstructured[T any](t *testing.T, obj *T) *unstructured.Unstructured {
+	t.Helper()
+	result, err := ToUnstructured(obj)
 	require.NoError(t, err)
+	return result
+}
 
-	c := &provisioning.Connection{}
-	err = json.Unmarshal(bytes, c)
+// MustFromUnstructured is a test-fatal wrapper around FromUnstructured.
+func MustFromUnstructured[T any](t *testing.T, obj *unstructured.Unstructured) *T {
+	t.Helper()
+	result, err := FromUnstructured[T](obj)
 	require.NoError(t, err)
-
-	return c
+	return result
 }
 
 // ParseTestResults extracts TestResults from an API response k8sruntime.Object.
@@ -2870,38 +2871,6 @@ func GetRepositoryClientV1Beta1(helper *apis.K8sTestHelper) *apis.K8sResourceCli
 			Resource: "repositories",
 		},
 	})
-}
-
-// ToUnstructuredConnection converts a Connection to an unstructured object
-func ToUnstructuredConnection(obj *provisioning.Connection) (*unstructured.Unstructured, error) {
-	unstructuredObj, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		return nil, err
-	}
-	return &unstructured.Unstructured{Object: unstructuredObj}, nil
-}
-
-// FromUnstructuredToConnection converts an unstructured object to a Connection
-func FromUnstructuredToConnection(obj *unstructured.Unstructured) (*provisioning.Connection, error) {
-	conn := &provisioning.Connection{}
-	err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, conn)
-	return conn, err
-}
-
-// ToUnstructuredRepository converts a Repository to an unstructured object
-func ToUnstructuredRepository(obj *provisioning.Repository) (*unstructured.Unstructured, error) {
-	unstructuredObj, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		return nil, err
-	}
-	return &unstructured.Unstructured{Object: unstructuredObj}, nil
-}
-
-// FromUnstructuredToRepository converts an unstructured object to a Repository
-func FromUnstructuredToRepository(obj *unstructured.Unstructured) (*provisioning.Repository, error) {
-	repo := &provisioning.Repository{}
-	err := k8sruntime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, repo)
-	return repo, err
 }
 
 // NewDefaultSharedEnv creates a SharedEnv with default options for provisioning tests

--- a/pkg/tests/apis/provisioning/connection/github_branch_protection_test.go
+++ b/pkg/tests/apis/provisioning/connection/github_branch_protection_test.go
@@ -732,7 +732,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		// Convert to repository (verify structure is valid)
-		_ = common.UnstructuredToRepository(t, obj.(*unstructured.Unstructured))
+		_ = common.MustFromUnstructured[provisioning.Repository](t, obj.(*unstructured.Unstructured))
 
 		// Wait for health check to run and mark repository as unhealthy
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -741,7 +741,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 				return
 			}
 
-			repo := common.UnstructuredToRepository(t, repoStatus)
+			repo := common.MustFromUnstructured[provisioning.Repository](t, repoStatus)
 
 			// Log the actual health status for debugging
 			t.Logf("Health status: Healthy=%v, Error=%q", repo.Status.Health.Healthy, repo.Status.Health.Error)
@@ -833,7 +833,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		// Convert to repository (verify structure is valid)
-		_ = common.UnstructuredToRepository(t, obj.(*unstructured.Unstructured))
+		_ = common.MustFromUnstructured[provisioning.Repository](t, obj.(*unstructured.Unstructured))
 
 		// Wait for health check to run and mark repository as unhealthy
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -842,7 +842,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 				return
 			}
 
-			repo := common.UnstructuredToRepository(t, repoStatus)
+			repo := common.MustFromUnstructured[provisioning.Repository](t, repoStatus)
 
 			// Log the actual health status for debugging
 			t.Logf("Health status: Healthy=%v, Error=%q", repo.Status.Health.Healthy, repo.Status.Health.Error)
@@ -933,7 +933,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		// Convert to repository (verify structure is valid)
-		_ = common.UnstructuredToRepository(t, obj.(*unstructured.Unstructured))
+		_ = common.MustFromUnstructured[provisioning.Repository](t, obj.(*unstructured.Unstructured))
 
 		// Wait for health check to run, then verify no branch protection errors
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -942,7 +942,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 				return
 			}
 
-			repo := common.UnstructuredToRepository(t, repoStatus)
+			repo := common.MustFromUnstructured[provisioning.Repository](t, repoStatus)
 
 			// Log the actual health status for debugging
 			t.Logf("Health status: Healthy=%v, Error=%q", repo.Status.Health.Healthy, repo.Status.Health.Error)

--- a/pkg/tests/apis/provisioning/connection/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/connection/pending_delete_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -57,7 +58,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteLabel_SkipsReconciliatio
 		if err != nil {
 			return
 		}
-		conn := common.UnstructuredToConnection(t, obj)
+		conn := common.MustFromUnstructured[provisioning.Connection](t, obj)
 		assert.Equal(collect, conn.Generation, conn.Status.ObservedGeneration,
 			"generation and observedGeneration should match after initial reconciliation")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
@@ -66,7 +67,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteLabel_SkipsReconciliatio
 	obj, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 	require.NoError(t, err)
 
-	initialConn := common.UnstructuredToConnection(t, obj)
+	initialConn := common.MustFromUnstructured[provisioning.Connection](t, obj)
 	require.Equal(t, initialConn.Generation, initialConn.Status.ObservedGeneration,
 		"generation and observedGeneration should match after initial reconciliation")
 
@@ -97,7 +98,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteLabel_SkipsReconciliatio
 		if err != nil {
 			return false
 		}
-		conn := common.UnstructuredToConnection(t, obj)
+		conn := common.MustFromUnstructured[provisioning.Connection](t, obj)
 		return conn.Status.ObservedGeneration >= newGeneration
 	}, 10*time.Second, 200*time.Millisecond,
 		"ObservedGeneration must not advance while the pending-delete label is set (reconciliation should be skipped)")
@@ -122,7 +123,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteLabel_SkipsReconciliatio
 		if err != nil {
 			return
 		}
-		conn := common.UnstructuredToConnection(t, obj)
+		conn := common.MustFromUnstructured[provisioning.Connection](t, obj)
 		assert.GreaterOrEqual(collect, conn.Status.ObservedGeneration, newGeneration,
 			"connection should be reconciled after label removal")
 		assert.True(collect, conn.Status.Health.Healthy,

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -36,7 +36,7 @@ func TestIntegrationHealth(t *testing.T) {
 	// Verify the health status before calling the endpoint
 	repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 	require.NoError(t, err)
-	originalRepo := common.UnstructuredToRepository(t, repoObj)
+	originalRepo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 	require.True(t, originalRepo.Status.Health.Healthy, "repository should be marked healthy")
 	require.Empty(t, originalRepo.Status.Health.Error, "should be empty")
 	require.Empty(t, originalRepo.Status.Health.Message, "should not have messages")
@@ -170,7 +170,7 @@ func TestIntegrationHealth(t *testing.T) {
 		// Verify repository health status after update
 		repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 		require.NoError(t, err)
-		afterTest := common.UnstructuredToRepository(t, repoObj)
+		afterTest := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		require.True(t, afterTest.Status.Health.Healthy, "repository should be marked healthy")
 		require.Empty(t, afterTest.Status.Health.Error, "should be empty")
 		require.Empty(t, afterTest.Status.Health.Message, "should not have messages")
@@ -197,7 +197,7 @@ func TestIntegrationHealth(t *testing.T) {
 		// Get the repository status before the test
 		repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 		require.NoError(t, err)
-		beforeTest := common.UnstructuredToRepository(t, repoObj)
+		beforeTest := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		t.Logf("Before test - Healthy: %v, Checked: %d", beforeTest.Status.Health.Healthy, beforeTest.Status.Health.Checked)
 
 		// Call the test endpoint
@@ -223,7 +223,7 @@ func TestIntegrationHealth(t *testing.T) {
 		// Verify repository health status after test - timestamp should change
 		repoObj, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 		require.NoError(t, err)
-		afterTest := common.UnstructuredToRepository(t, repoObj)
+		afterTest := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		t.Logf("After test - Healthy: %v, Checked: %d", afterTest.Status.Health.Healthy, afterTest.Status.Health.Checked)
 
 		// For unhealthy repositories, the timestamp should change as the health check will be triggered
@@ -255,7 +255,7 @@ func TestIntegrationHealth(t *testing.T) {
 		// Verify repository health status is now healthy again
 		repoObj, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 		require.NoError(t, err)
-		finalRepo := common.UnstructuredToRepository(t, repoObj)
+		finalRepo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		t.Logf("After recreating directory - Healthy: %v, Checked: %d", finalRepo.Status.Health.Healthy, finalRepo.Status.Health.Checked)
 		require.True(t, finalRepo.Status.Health.Healthy, "repository should be healthy again after recreating directory")
 		require.Empty(t, finalRepo.Status.Health.Error, "should have no error after recreating directory")

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -82,7 +82,7 @@ func waitForUnhealthyWithNamespaceQuota(t *testing.T, helper *common.Provisionin
 		if !assert.NoError(collect, err) {
 			return
 		}
-		repo := common.UnstructuredToRepository(t, repoObj)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		assert.False(collect, repo.Status.Health.Healthy, "repo %s should be unhealthy", repoName)
 		cond := common.FindCondition(repo.Status.Conditions, provisioning.ConditionTypeNamespaceQuota)
 		if !assert.NotNil(collect, cond, "NamespaceQuota condition not found on %s", repoName) {
@@ -102,7 +102,7 @@ func waitForHealthyWithNamespaceQuota(t *testing.T, helper *common.ProvisioningT
 		if !assert.NoError(collect, err) {
 			return
 		}
-		repo := common.UnstructuredToRepository(t, repoObj)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		assert.True(collect, repo.Status.Health.Healthy, "repo %s should be healthy", repoName)
 		cond := common.FindCondition(repo.Status.Conditions, provisioning.ConditionTypeNamespaceQuota)
 		if !assert.NotNil(collect, cond, "NamespaceQuota condition not found on %s", repoName) {
@@ -158,7 +158,7 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 		if !assert.NoError(c, err) {
 			return
 		}
-		connObj := common.UnstructuredToConnection(t, obj)
+		connObj := common.MustFromUnstructured[provisioning.Connection](t, obj)
 		assert.NotEqual(c, int64(0), connObj.Status.ObservedGeneration,
 			"connection should be reconciled at least once")
 		assert.False(c, connObj.Secure.Token.IsZero(),
@@ -208,7 +208,7 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 			if !assert.NoError(c, err) {
 				return
 			}
-			r := common.UnstructuredToRepository(t, obj)
+			r := common.MustFromUnstructured[provisioning.Repository](t, obj)
 			assert.False(c, r.Secure.Token.IsZero(),
 				"repo %s should have a token after initial reconciliation", name)
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault,
@@ -262,7 +262,7 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 		if !assert.NoError(c, err) {
 			return
 		}
-		r := common.UnstructuredToRepository(t, obj)
+		r := common.MustFromUnstructured[provisioning.Repository](t, obj)
 
 		// Repository must still be blocked by the namespace quota.
 		cond := common.FindCondition(r.Status.Conditions, provisioning.ConditionTypeNamespaceQuota)

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -141,7 +141,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Verify the repo is over quota using the quotas package
 		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
-		typedRepo := common.UnstructuredToRepository(t, repoObj)
+		typedRepo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		require.True(t, quotas.IsQuotaExceeded(typedRepo.Status.Conditions), "quota should be exceeded")
 
 		// Now add a 3rd dashboard - this should be blocked by quota on the next full sync

--- a/pkg/tests/apis/provisioning/repository/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/repository/pending_delete_test.go
@@ -35,7 +35,7 @@ func TestIntegrationProvisioning_PendingDeleteLabel_SkipsReconciliation(t *testi
 	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 	require.NoError(t, err)
 
-	initialRepo := common.UnstructuredToRepository(t, repoObj)
+	initialRepo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 	require.Equal(t, initialRepo.Generation, initialRepo.Status.ObservedGeneration,
 		"generation and observedGeneration should match after initial sync")
 
@@ -70,7 +70,7 @@ func TestIntegrationProvisioning_PendingDeleteLabel_SkipsReconciliation(t *testi
 		if err != nil {
 			return false
 		}
-		repo := common.UnstructuredToRepository(t, obj)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		return repo.Status.ObservedGeneration >= newGeneration
 	}, 10*time.Second, 200*time.Millisecond,
 		"ObservedGeneration must not advance while the pending-delete label is set (reconciliation should be skipped)")
@@ -95,7 +95,7 @@ func TestIntegrationProvisioning_PendingDeleteLabel_SkipsReconciliation(t *testi
 		if err != nil {
 			return
 		}
-		repo := common.UnstructuredToRepository(t, obj)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		assert.Equal(collect, provisioning.JobStateSuccess, repo.Status.Sync.State,
 			"repository should reach success sync state after label removal")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault,

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -96,8 +96,8 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 			}
 
 			// Marshal as real objects to ",omitempty" values are tested properly
-			expectedRepo := common.UnstructuredToRepository(t, input)
-			returnedRepo := common.UnstructuredToRepository(t, output)
+			expectedRepo := common.MustFromUnstructured[provisioning.Repository](t, input)
+			returnedRepo := common.MustFromUnstructured[provisioning.Repository](t, output)
 			require.Equal(t, expectedRepo.Spec, returnedRepo.Spec)
 
 			// A viewer should be able to read the repository
@@ -117,7 +117,7 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 			require.True(t, ok, "expecting unstructured object")
 
 			// Verify viewer gets the same repository data
-			viewerRepo := common.UnstructuredToRepository(t, viewerUnstruct)
+			viewerRepo := common.MustFromUnstructured[provisioning.Repository](t, viewerUnstruct)
 			require.Equal(t, expectedRepo.Spec, viewerRepo.Spec, "viewer should see same repository spec")
 
 			// Viewer can see file listing
@@ -629,7 +629,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		created, err := helper.Repositories.Resource.Create(ctx, r, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		createdRepo := common.UnstructuredToRepository(t, created)
+		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
 		require.Equal(t, int64(10), createdRepo.Spec.Sync.IntervalSeconds, "interval should be updated with default value")
 	})
 
@@ -646,7 +646,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		require.NoError(t, err, "repository creation should succeed")
 
 		// Verify finalizers were automatically added by the mutator
-		createdRepo := common.UnstructuredToRepository(t, created)
+		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
 		require.NotEmpty(t, createdRepo.Finalizers, "finalizers should be automatically added")
 		require.Contains(t, createdRepo.Finalizers, repository.RemoveOrphanResourcesFinalizer, "should contain RemoveOrphanResourcesFinalizer")
 		require.Contains(t, createdRepo.Finalizers, repository.CleanFinalizer, "should contain CleanFinalizer")
@@ -662,7 +662,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		created, err := helper.Repositories.Resource.Create(ctx, r, metav1.CreateOptions{})
 		require.NoError(t, err, "repository creation should succeed")
 
-		createdRepo := common.UnstructuredToRepository(t, created)
+		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
 		require.NotEmpty(t, createdRepo.Finalizers, "finalizers should be present after creation")
 		require.Contains(t, createdRepo.Finalizers, repository.RemoveOrphanResourcesFinalizer, "should contain RemoveOrphanResourcesFinalizer")
 		require.Contains(t, createdRepo.Finalizers, repository.CleanFinalizer, "should contain CleanFinalizer")
@@ -677,7 +677,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			require.NoError(collect, err, "repository update should succeed")
 
 			// Verify finalizers were re-added by the mutator
-			updatedRepo := common.UnstructuredToRepository(t, updated)
+			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, updated)
 			require.NotEmpty(collect, updatedRepo.Finalizers, "finalizers should be re-added after update")
 			require.Contains(collect, updatedRepo.Finalizers, repository.RemoveOrphanResourcesFinalizer, "should contain RemoveOrphanResourcesFinalizer")
 			require.Contains(collect, updatedRepo.Finalizers, repository.CleanFinalizer, "should contain CleanFinalizer")
@@ -867,7 +867,7 @@ func TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook(t *testing.T) {
 		repoObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
 		require.NoError(t, err, "failed to get repository")
 
-		repo := common.UnstructuredToRepository(t, repoObj)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		require.Empty(t, repo.Spec.Workflows, "repository should have no workflows (read-only)")
 		require.Nil(t, repo.Status.Webhook, "read-only repository should not have a webhook")
 	})
@@ -909,7 +909,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 		created, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
 		require.NoError(t, err, "should create repository with webhook config")
 
-		createdRepo := common.UnstructuredToRepository(t, created)
+		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
 		require.NotNil(t, createdRepo.Spec.Webhook, "webhook config should be persisted")
 		require.Equal(t, "https://grafana.example.com", createdRepo.Spec.Webhook.BaseURL, "trailing slash should be trimmed by mutator")
 	})
@@ -946,7 +946,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 		created, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
 		require.NoError(t, err, "should accept HTTP webhook base URL")
 
-		createdRepo := common.UnstructuredToRepository(t, created)
+		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
 		require.NotNil(t, createdRepo.Spec.Webhook)
 		require.Equal(t, "http://internal-proxy.example.com", createdRepo.Spec.Webhook.BaseURL, "trailing slash should be trimmed by mutator")
 	})
@@ -955,7 +955,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 		obj, err := helper.Repositories.Resource.Get(ctx, "repo-with-webhook", metav1.GetOptions{})
 		require.NoError(t, err, "should read back repository")
 
-		repo := common.UnstructuredToRepository(t, obj)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		require.NotNil(t, repo.Spec.Webhook, "webhook config should be present on read")
 		require.Equal(t, "https://grafana.example.com", repo.Spec.Webhook.BaseURL)
 	})
@@ -965,14 +965,14 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 			obj, err := helper.Repositories.Resource.Get(ctx, "repo-with-webhook", metav1.GetOptions{})
 			require.NoError(t, err)
 
-			repo := common.UnstructuredToRepository(t, obj)
+			repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 			repo.Spec.Webhook.BaseURL = "https://new-proxy.example.com/"
-			updated := common.RepositoryToUnstructured(t, repo)
+			updated := common.MustToUnstructured(t, repo)
 
 			result, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
 			require.NoError(collect, err, "should update webhook base URL")
 
-			updatedRepo := common.UnstructuredToRepository(t, result)
+			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
 			require.NotNil(collect, updatedRepo.Spec.Webhook)
 			assert.Equal(collect, "https://new-proxy.example.com", updatedRepo.Spec.Webhook.BaseURL, "trailing slash should be trimmed by mutator")
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
@@ -983,14 +983,14 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 			obj, err := helper.Repositories.Resource.Get(ctx, "repo-with-webhook", metav1.GetOptions{})
 			require.NoError(t, err)
 
-			repo := common.UnstructuredToRepository(t, obj)
+			repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 			repo.Spec.Webhook = nil
-			updated := common.RepositoryToUnstructured(t, repo)
+			updated := common.MustToUnstructured(t, repo)
 
 			result, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
 			require.NoError(collect, err, "should clear webhook config")
 
-			updatedRepo := common.UnstructuredToRepository(t, result)
+			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
 			assert.Nil(collect, updatedRepo.Spec.Webhook, "webhook config should be nil after removal")
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	})
@@ -1819,7 +1819,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		c, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
 		require.NoError(collectT, err, "can list values")
-		conn := common.UnstructuredToConnection(t, c)
+		conn := common.MustFromUnstructured[provisioning.Connection](t, c)
 		require.NotEqual(collectT, 0, conn.Status.ObservedGeneration, "resource should be reconciled at least once")
 		require.Equal(collectT, conn.Status.ObservedGeneration, conn.Generation, "resource should be reconciled")
 		// Token should be there
@@ -1857,7 +1857,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
 		require.NoError(collectT, err, "can get repository")
-		r := common.UnstructuredToRepository(t, repo)
+		r := common.MustFromUnstructured[provisioning.Repository](t, repo)
 		require.NotEqual(collectT, 0, r.Status.ObservedGeneration, "resource should be reconciled at least once")
 		require.Equal(collectT, r.Status.ObservedGeneration, r.Generation, "resource should be reconciled")
 		// Token should be there
@@ -1884,7 +1884,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	for attempt := range maxStatusRetries {
 		repoUnstructured, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
 		require.NoError(t, err, "can get repository")
-		firstReconciledRepo = common.UnstructuredToRepository(t, repoUnstructured)
+		firstReconciledRepo = common.MustFromUnstructured[provisioning.Repository](t, repoUnstructured)
 
 		now := time.Now()
 		firstReconciledRepo.Status.ObservedGeneration = firstReconciledRepo.Generation
@@ -1914,7 +1914,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 				Reason:             provisioning.ReasonAvailable,
 			},
 		}
-		updatedRepo := common.RepositoryToUnstructured(t, firstReconciledRepo)
+		updatedRepo := common.MustToUnstructured(t, firstReconciledRepo)
 		// This should also trigger a reconciliation loop
 		_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedRepo, metav1.UpdateOptions{})
 		if err == nil {
@@ -1929,7 +1929,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
 		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
 		require.NoError(collectT, err, "can get repository")
-		r := common.UnstructuredToRepository(t, repo)
+		r := common.MustFromUnstructured[provisioning.Repository](t, repo)
 		// Token should be there
 		require.False(collectT, r.Secure.Token.IsZero())
 		// and different from the previous one

--- a/pkg/tests/apis/provisioning/v1beta1/connection_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/connection_test.go
@@ -55,7 +55,7 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	created, err := client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
@@ -63,7 +63,7 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 	require.NotNil(t, created)
 
 	// Verify the created object
-	createdConn, err := common.FromUnstructuredToConnection(created)
+	createdConn, err := common.FromUnstructured[provisioning.Connection](created)
 	require.NoError(t, err)
 	require.NotEmpty(t, createdConn.UID)
 	require.Equal(t, connection.Name, createdConn.Name)
@@ -118,14 +118,14 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	created, err := client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	createdConn, err := common.FromUnstructuredToConnection(created)
+	createdConn, err := common.FromUnstructured[provisioning.Connection](created)
 	require.NoError(t, err)
 	require.Equal(t, provisioning.GitlabConnectionType, createdConn.Spec.Type)
 	require.Equal(t, "gitlab-client-123", createdConn.Spec.Gitlab.ClientID)
@@ -173,14 +173,14 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	created, err := client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	createdConn, err := common.FromUnstructuredToConnection(created)
+	createdConn, err := common.FromUnstructured[provisioning.Connection](created)
 	require.NoError(t, err)
 	require.Equal(t, provisioning.BitbucketConnectionType, createdConn.Spec.Type)
 	require.Equal(t, "bitbucket-client-456", createdConn.Spec.Bitbucket.ClientID)
@@ -229,7 +229,7 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
@@ -240,7 +240,7 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 
-	retrievedConn, err := common.FromUnstructuredToConnection(retrieved)
+	retrievedConn, err := common.FromUnstructured[provisioning.Connection](retrieved)
 	require.NoError(t, err)
 	require.Equal(t, "test-get-connection", retrievedConn.Name)
 	require.Equal(t, namespace, retrievedConn.Namespace)
@@ -290,7 +290,7 @@ func TestIntegrationV1Beta1Connection_List(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
@@ -356,7 +356,7 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
@@ -366,27 +366,27 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	current, err := client.Resource.Get(ctx, "test-update-connection", metav1.GetOptions{})
 	require.NoError(t, err)
 
-	currentConn, err := common.FromUnstructuredToConnection(current)
+	currentConn, err := common.FromUnstructured[provisioning.Connection](current)
 	require.NoError(t, err)
 
 	// Update the AppID
 	currentConn.Spec.GitHub.AppID = "999999"
 
-	unstructuredObj, err = common.ToUnstructuredConnection(currentConn)
+	unstructuredObj, err = common.ToUnstructured(currentConn)
 	require.NoError(t, err)
 
 	updated, err := client.Resource.Update(ctx, unstructuredObj, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, updated)
 
-	updatedConn, err := common.FromUnstructuredToConnection(updated)
+	updatedConn, err := common.FromUnstructured[provisioning.Connection](updated)
 	require.NoError(t, err)
 	require.Equal(t, "999999", updatedConn.Spec.GitHub.AppID)
 
 	// Verify the update persisted
 	retrieved, err := client.Resource.Get(ctx, "test-update-connection", metav1.GetOptions{})
 	require.NoError(t, err)
-	retrievedConn, err := common.FromUnstructuredToConnection(retrieved)
+	retrievedConn, err := common.FromUnstructured[provisioning.Connection](retrieved)
 	require.NoError(t, err)
 	require.Equal(t, "999999", retrievedConn.Spec.GitHub.AppID)
 
@@ -434,7 +434,7 @@ func TestIntegrationV1Beta1Connection_Delete(t *testing.T) {
 		},
 	}
 
-	unstructuredObj, err := common.ToUnstructuredConnection(connection)
+	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
 	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In provisioning integration tests, use a generic conversion method for unstructured resources, avoiding the need to have one per resource type.

**Why do we need this feature?**

This is part of an ongoing effort to simplify the integration test helpers.

**Who is this feature for?**

Provisioning feature devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/956

**Special notes for your reviewer:**

Please check that:
- [ x] It works as expected from a user's perspective.
- [ x] If this is a pre-GA feature, it is behind a feature toggle.
- [ x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
