### PR TITLE
Alerting: Fix missing return in RouteGetReceivers

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -192,7 +192,7 @@ func (srv AlertmanagerSrv) RouteGetReceivers(c *contextmodel.ReqContext) respons
 	}
 	statuses, err = srv.receiverAuthz.FilterRead(c.Req.Context(), c.SignedInUser, statuses...)
 	if err != nil {
-		response.ErrOrFallback(http.StatusInternalServerError, "failed to apply permissions to the receivers", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "failed to apply permissions to the receivers", err)
 	}
 	return response.JSON(http.StatusOK, statuses)
 }


### PR DESCRIPTION
We're not returning an error when we fail to apply permissions in `RouteGetReceivers`.