### PR TITLE
Unified Storage: Allow Terraform manager identity transitions

### DIFF
--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -66,12 +66,27 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
-	if hasOld && (managerNew.Kind != managerOld.Kind || managerNew.Identity != managerOld.Identity) {
+	//
+	// Exception: For Terraform managers, only the kind matters. The identity
+	// changes based on provider version (e.g., "Terraform/crossTF000" or
+	// "terraform-provider-grafana/crossplane" to version-specific IDs), so we
+	// allow identity transitions as long as both old and new are Terraform.
+	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
 			Code:    http.StatusForbidden,
 			Reason:  metav1.StatusReasonForbidden,
-			Message: "Cannot change resource manager; remove the existing manager first, then add the new one",
+			Message: "Cannot change resource manager kind; remove the existing manager first, then add the new one",
+		}}
+	}
+
+	// For non-Terraform managers, identity changes are also blocked
+	if hasOld && managerNew.Kind != utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
+		return &apierrors.StatusError{ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusForbidden,
+			Reason:  metav1.StatusReasonForbidden,
+			Message: "Cannot change resource manager identity; remove the existing manager first, then add the new one",
 		}}
 	}
 

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -27,10 +27,12 @@ import (
 
 var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
 
-// isLegacyTerraformID checks if a Terraform manager identity uses legacy placeholder values
-// like "crossTF000" or "crossplane" that were used before version-specific IDs.
+// isLegacyTerraformID checks if a Terraform manager identity uses the legacy User-Agent
+// based format (e.g., "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane").
+// New format uses simple IDs like "grafana-terraform-provider" or "my-terraform-provider".
 func isLegacyTerraformID(identity string) bool {
-	return strings.Contains(identity, "crossTF000") || strings.Contains(identity, "crossplane")
+	// Legacy IDs are User-Agent strings containing "Terraform/" and the terraform.io URL
+	return strings.Contains(identity, "Terraform/") && strings.Contains(identity, "+https://www.terraform.io")
 }
 
 func checkManagerPropertiesOnDelete(auth authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error {
@@ -74,10 +76,10 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
 	//
-	// Exception: For Terraform managers, the identity is derived from the HTTP
-	// User-Agent and changes with provider versions. We allow identity transitions
-	// to support provider upgrades, but prevent reverting to legacy placeholder IDs
-	// like "crossTF000" or "crossplane" once migrated to version-specific IDs.
+	// Exception: For Terraform managers, we allow one-way migration from legacy
+	// User-Agent based IDs (e.g., "Terraform/... terraform-provider-grafana/...")
+	// to simple custom IDs (e.g., "grafana-terraform-provider"). Once migrated,
+	// reverting back to User-Agent format is blocked.
 	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -27,9 +27,9 @@ import (
 
 var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
 
-// isLegacyTerraformID checks if a Terraform manager identity uses the legacy User-Agent
-// based format (e.g., "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane").
-// New format uses simple IDs like "grafana-terraform-provider" or "my-terraform-provider".
+// isManagerIDBasedOnUserAgent checks if a Terraform manager identity is derived from
+// the HTTP User-Agent header (e.g., "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0").
+// Modern approach uses simple custom IDs like "grafana-terraform-provider" or "my-terraform-provider".
 //
 // HACK: This is a workaround to allow migration from User-Agent based manager IDs to stable custom IDs.
 // The Terraform provider historically used the HTTP User-Agent header as the manager identity, which:
@@ -44,7 +44,7 @@ var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a
 //
 // Reference: https://github.com/grafana/terraform-provider-grafana/blob/main/pkg/provider/framework_provider.go#L307
 // Format: "Terraform/{version} (+https://www.terraform.io) terraform-provider-{name}/{version}"
-func isLegacyTerraformID(identity string) bool {
+func isManagerIDBasedOnUserAgent(identity string) bool {
 	// Detect User-Agent strings from Terraform providers
 	return strings.Contains(identity, "Terraform/") &&
 		strings.Contains(identity, "+https://www.terraform.io") &&
@@ -92,8 +92,8 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
 	//
-	// HACK: Terraform gets special treatment - see isLegacyTerraformID() for details.
-	// We allow one-way migration from User-Agent based IDs to simple custom IDs.
+	// HACK: Terraform gets special treatment - see isManagerIDBasedOnUserAgent() for details.
+	// We allow one-way migration from User-Agent based IDs to stable custom IDs.
 	// This fixes the original mistake of using HTTP User-Agent as a manager identifier.
 	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
@@ -114,18 +114,18 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 		}}
 	}
 
-	// For Terraform managers, prevent reverting from new format back to legacy IDs
+	// For Terraform managers, prevent reverting from custom IDs back to User-Agent based IDs
 	if hasOld && managerNew.Kind == utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
-		oldIsLegacy := isLegacyTerraformID(managerOld.Identity)
-		newIsLegacy := isLegacyTerraformID(managerNew.Identity)
+		oldIsUserAgent := isManagerIDBasedOnUserAgent(managerOld.Identity)
+		newIsUserAgent := isManagerIDBasedOnUserAgent(managerNew.Identity)
 
-		// Block: new format → legacy format (reverting)
-		if !oldIsLegacy && newIsLegacy {
+		// Block: custom ID → User-Agent (reverting to unstable format)
+		if !oldIsUserAgent && newIsUserAgent {
 			return &apierrors.StatusError{ErrStatus: metav1.Status{
 				Status:  metav1.StatusFailure,
 				Code:    http.StatusForbidden,
 				Reason:  metav1.StatusReasonForbidden,
-				Message: "Cannot revert to legacy Terraform manager ID; use version-specific IDs",
+				Message: "Cannot revert to User-Agent based Terraform manager ID; use stable custom IDs",
 			}}
 		}
 	}

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -30,9 +30,25 @@ var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a
 // isLegacyTerraformID checks if a Terraform manager identity uses the legacy User-Agent
 // based format (e.g., "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane").
 // New format uses simple IDs like "grafana-terraform-provider" or "my-terraform-provider".
+//
+// HACK: This is a workaround to allow migration from User-Agent based manager IDs to stable custom IDs.
+// The Terraform provider historically used the HTTP User-Agent header as the manager identity, which:
+//   - Changes with every Terraform/provider version update
+//   - Was never intended to be a stable identifier
+//   - Cannot be customized by users
+//
+// This function enables one-way migration to user-defined stable IDs by detecting the User-Agent
+// format and blocking reversion back to it. This special-casing for Terraform violates the general
+// principle that manager identities should be immutable, but is necessary to fix the original
+// design mistake of using User-Agent as an identifier.
+//
+// Reference: https://github.com/grafana/terraform-provider-grafana/blob/main/pkg/provider/framework_provider.go#L307
+// Format: "Terraform/{version} (+https://www.terraform.io) terraform-provider-{name}/{version}"
 func isLegacyTerraformID(identity string) bool {
-	// Legacy IDs are User-Agent strings containing "Terraform/" and the terraform.io URL
-	return strings.Contains(identity, "Terraform/") && strings.Contains(identity, "+https://www.terraform.io")
+	// Detect User-Agent strings from Terraform providers
+	return strings.Contains(identity, "Terraform/") &&
+		strings.Contains(identity, "+https://www.terraform.io") &&
+		strings.Contains(identity, "terraform-provider-")
 }
 
 func checkManagerPropertiesOnDelete(auth authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error {
@@ -76,10 +92,9 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
 	//
-	// Exception: For Terraform managers, we allow one-way migration from legacy
-	// User-Agent based IDs (e.g., "Terraform/... terraform-provider-grafana/...")
-	// to simple custom IDs (e.g., "grafana-terraform-provider"). Once migrated,
-	// reverting back to User-Agent format is blocked.
+	// HACK: Terraform gets special treatment - see isLegacyTerraformID() for details.
+	// We allow one-way migration from User-Agent based IDs to simple custom IDs.
+	// This fixes the original mistake of using HTTP User-Agent as a manager identifier.
 	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -94,12 +94,8 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 		return nil
 	}
 
-	// Changing the owner (kind or identity) is not allowed.
-	// Remove the old manager first, then add the new one.
-	//
-	// HACK: Terraform gets special treatment - see isTerraformUserAgentID() for details.
-	// We allow one-way migration from User-Agent based IDs to stable custom IDs.
-	// This fixes the original mistake of using HTTP User-Agent as a manager identifier.
+	// Changing the manager kind is not allowed.
+	// Remove the old manager first, then add a new one with a different kind.
 	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
@@ -109,7 +105,8 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 		}}
 	}
 
-	// For non-Terraform managers, identity changes are also blocked
+	// For non-Terraform managers, identity changes are also blocked.
+	// Remove the old manager first, then add a new one with a different identity.
 	if hasOld && managerNew.Kind != utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
@@ -119,7 +116,12 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 		}}
 	}
 
-	// For Terraform managers, prevent reverting from custom IDs back to User-Agent based IDs
+	// HACK: Terraform managers get special treatment for identity changes.
+	// See isTerraformUserAgentID() for full explanation of why this exists.
+	//
+	// We allow one-way migration from deprecated User-Agent based IDs to stable custom IDs,
+	// but prevent reverting back to User-Agent format. This fixes the original design mistake
+	// of using HTTP User-Agent as a manager identifier.
 	if hasOld && managerNew.Kind == utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
 		oldIsUserAgent := isTerraformUserAgentID(managerOld.Identity)
 		newIsUserAgent := isTerraformUserAgentID(managerNew.Identity)

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
-	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +25,14 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
+var (
+	errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
+
+	// terraformUserAgentPattern matches the User-Agent based manager ID format used by Terraform providers.
+	// Format: "Terraform/{version} (+https://www.terraform.io) terraform-provider-{name}/{version}"
+	// Example: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0"
+	terraformUserAgentPattern = regexp.MustCompile(`^Terraform/[^ ]+ \(\+https://www\.terraform\.io\) terraform-provider-[^/]+/.+$`)
+)
 
 // isTerraformUserAgentID checks if a Terraform manager identity uses the
 // DEPRECATED User-Agent based format (e.g., "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0").
@@ -45,10 +52,8 @@ var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a
 // Reference: https://github.com/grafana/terraform-provider-grafana/blob/main/pkg/provider/framework_provider.go#L307
 // Format: "Terraform/{version} (+https://www.terraform.io) terraform-provider-{name}/{version}"
 func isTerraformUserAgentID(identity string) bool {
-	// Detect User-Agent strings from Terraform providers
-	return strings.Contains(identity, "Terraform/") &&
-		strings.Contains(identity, "+https://www.terraform.io") &&
-		strings.Contains(identity, "terraform-provider-")
+	// Use regex to precisely validate the User-Agent format structure
+	return terraformUserAgentPattern.MatchString(identity)
 }
 
 func checkManagerPropertiesOnDelete(auth authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error {

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -27,9 +27,9 @@ import (
 
 var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
 
-// isManagerIDBasedOnUserAgent checks if a Terraform manager identity is derived from
-// the HTTP User-Agent header (e.g., "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0").
-// Modern approach uses simple custom IDs like "grafana-terraform-provider" or "my-terraform-provider".
+// isDeprecatedUserAgentBasedManagerID checks if a Terraform manager identity uses the
+// DEPRECATED User-Agent based format (e.g., "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0").
+// Modern approach uses stable custom IDs like "grafana-terraform-provider" or "my-terraform-provider".
 //
 // HACK: This is a workaround to allow migration from User-Agent based manager IDs to stable custom IDs.
 // The Terraform provider historically used the HTTP User-Agent header as the manager identity, which:
@@ -44,7 +44,7 @@ var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a
 //
 // Reference: https://github.com/grafana/terraform-provider-grafana/blob/main/pkg/provider/framework_provider.go#L307
 // Format: "Terraform/{version} (+https://www.terraform.io) terraform-provider-{name}/{version}"
-func isManagerIDBasedOnUserAgent(identity string) bool {
+func isDeprecatedUserAgentBasedManagerID(identity string) bool {
 	// Detect User-Agent strings from Terraform providers
 	return strings.Contains(identity, "Terraform/") &&
 		strings.Contains(identity, "+https://www.terraform.io") &&
@@ -92,7 +92,7 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
 	//
-	// HACK: Terraform gets special treatment - see isManagerIDBasedOnUserAgent() for details.
+	// HACK: Terraform gets special treatment - see isDeprecatedUserAgentBasedManagerID() for details.
 	// We allow one-way migration from User-Agent based IDs to stable custom IDs.
 	// This fixes the original mistake of using HTTP User-Agent as a manager identifier.
 	if hasOld && managerNew.Kind != managerOld.Kind {
@@ -116,8 +116,8 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 
 	// For Terraform managers, prevent reverting from custom IDs back to User-Agent based IDs
 	if hasOld && managerNew.Kind == utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
-		oldIsUserAgent := isManagerIDBasedOnUserAgent(managerOld.Identity)
-		newIsUserAgent := isManagerIDBasedOnUserAgent(managerNew.Identity)
+		oldIsUserAgent := isDeprecatedUserAgentBasedManagerID(managerOld.Identity)
+		newIsUserAgent := isDeprecatedUserAgentBasedManagerID(managerNew.Identity)
 
 		// Block: custom ID → User-Agent (reverting to unstable format)
 		if !oldIsUserAgent && newIsUserAgent {

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -68,9 +68,9 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Remove the old manager first, then add the new one.
 	//
 	// Exception: For Terraform managers, only the kind matters. The identity
-	// changes based on provider version (e.g., "Terraform/crossTF000" or
-	// "terraform-provider-grafana/crossplane" to version-specific IDs), so we
-	// allow identity transitions as long as both old and new are Terraform.
+	// is derived from the HTTP User-Agent and changes with provider versions
+	// (e.g., "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane"),
+	// so we allow identity transitions as long as both old and new are Terraform.
 	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -119,20 +119,30 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// HACK: Terraform managers get special treatment for identity changes.
 	// See isTerraformUserAgentID() for full explanation of why this exists.
 	//
-	// We allow one-way migration from deprecated User-Agent based IDs to stable custom IDs,
-	// but prevent reverting back to User-Agent format. This fixes the original design mistake
-	// of using HTTP User-Agent as a manager identifier.
+	// We allow one-way migration from deprecated User-Agent based IDs to stable custom IDs.
+	// Once migrated to a custom ID, that identity is locked (cannot be changed).
+	// User-Agent IDs can still be updated to other User-Agent IDs (for version updates).
 	if hasOld && managerNew.Kind == utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
 		oldIsUserAgent := isTerraformUserAgentID(managerOld.Identity)
 		newIsUserAgent := isTerraformUserAgentID(managerNew.Identity)
 
-		// Block: custom ID → User-Agent (reverting to unstable format)
+		// Block: custom ID → User-Agent (reverting to deprecated format)
 		if !oldIsUserAgent && newIsUserAgent {
 			return &apierrors.StatusError{ErrStatus: metav1.Status{
 				Status:  metav1.StatusFailure,
 				Code:    http.StatusForbidden,
 				Reason:  metav1.StatusReasonForbidden,
-				Message: "Cannot revert to User-Agent based Terraform manager ID; use stable custom IDs",
+				Message: "Cannot change Terraform manager ID back to User-Agent format; stable custom IDs are immutable",
+			}}
+		}
+
+		// Block: custom ID → different custom ID (identity is locked after migration)
+		if !oldIsUserAgent && !newIsUserAgent {
+			return &apierrors.StatusError{ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusForbidden,
+				Reason:  metav1.StatusReasonForbidden,
+				Message: "Cannot change Terraform manager ID; stable custom IDs are immutable",
 			}}
 		}
 	}

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,12 @@ import (
 )
 
 var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
+
+// isLegacyTerraformID checks if a Terraform manager identity uses legacy placeholder values
+// like "crossTF000" or "crossplane" that were used before version-specific IDs.
+func isLegacyTerraformID(identity string) bool {
+	return strings.Contains(identity, "crossTF000") || strings.Contains(identity, "crossplane")
+}
 
 func checkManagerPropertiesOnDelete(auth authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error {
 	return enforceManagerProperties(auth, obj)
@@ -67,10 +74,10 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
 	//
-	// Exception: For Terraform managers, only the kind matters. The identity
-	// is derived from the HTTP User-Agent and changes with provider versions
-	// (e.g., "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane"),
-	// so we allow identity transitions as long as both old and new are Terraform.
+	// Exception: For Terraform managers, the identity is derived from the HTTP
+	// User-Agent and changes with provider versions. We allow identity transitions
+	// to support provider upgrades, but prevent reverting to legacy placeholder IDs
+	// like "crossTF000" or "crossplane" once migrated to version-specific IDs.
 	if hasOld && managerNew.Kind != managerOld.Kind {
 		return &apierrors.StatusError{ErrStatus: metav1.Status{
 			Status:  metav1.StatusFailure,
@@ -88,6 +95,22 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 			Reason:  metav1.StatusReasonForbidden,
 			Message: "Cannot change resource manager identity; remove the existing manager first, then add the new one",
 		}}
+	}
+
+	// For Terraform managers, prevent reverting from new format back to legacy IDs
+	if hasOld && managerNew.Kind == utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
+		oldIsLegacy := isLegacyTerraformID(managerOld.Identity)
+		newIsLegacy := isLegacyTerraformID(managerNew.Identity)
+
+		// Block: new format → legacy format (reverting)
+		if !oldIsLegacy && newIsLegacy {
+			return &apierrors.StatusError{ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusForbidden,
+				Reason:  metav1.StatusReasonForbidden,
+				Message: "Cannot revert to legacy Terraform manager ID; use version-specific IDs",
+			}}
+		}
 	}
 
 	// Adding a manager or updating flags on the same owner.

--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -27,7 +27,7 @@ import (
 
 var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a repository")
 
-// isDeprecatedUserAgentBasedManagerID checks if a Terraform manager identity uses the
+// isTerraformUserAgentID checks if a Terraform manager identity uses the
 // DEPRECATED User-Agent based format (e.g., "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0").
 // Modern approach uses stable custom IDs like "grafana-terraform-provider" or "my-terraform-provider".
 //
@@ -44,7 +44,7 @@ var errResourceIsManagedInRepository = fmt.Errorf("this resource is managed by a
 //
 // Reference: https://github.com/grafana/terraform-provider-grafana/blob/main/pkg/provider/framework_provider.go#L307
 // Format: "Terraform/{version} (+https://www.terraform.io) terraform-provider-{name}/{version}"
-func isDeprecatedUserAgentBasedManagerID(identity string) bool {
+func isTerraformUserAgentID(identity string) bool {
 	// Detect User-Agent strings from Terraform providers
 	return strings.Contains(identity, "Terraform/") &&
 		strings.Contains(identity, "+https://www.terraform.io") &&
@@ -92,7 +92,7 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 	// Changing the owner (kind or identity) is not allowed.
 	// Remove the old manager first, then add the new one.
 	//
-	// HACK: Terraform gets special treatment - see isDeprecatedUserAgentBasedManagerID() for details.
+	// HACK: Terraform gets special treatment - see isTerraformUserAgentID() for details.
 	// We allow one-way migration from User-Agent based IDs to stable custom IDs.
 	// This fixes the original mistake of using HTTP User-Agent as a manager identifier.
 	if hasOld && managerNew.Kind != managerOld.Kind {
@@ -116,8 +116,8 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 
 	// For Terraform managers, prevent reverting from custom IDs back to User-Agent based IDs
 	if hasOld && managerNew.Kind == utils.ManagerKindTerraform && managerNew.Identity != managerOld.Identity {
-		oldIsUserAgent := isDeprecatedUserAgentBasedManagerID(managerOld.Identity)
-		newIsUserAgent := isDeprecatedUserAgentBasedManagerID(managerNew.Identity)
+		oldIsUserAgent := isTerraformUserAgentID(managerOld.Identity)
+		newIsUserAgent := isTerraformUserAgentID(managerNew.Identity)
 
 		// Block: custom ID → User-Agent (reverting to unstable format)
 		if !oldIsUserAgent && newIsUserAgent {

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -189,6 +189,50 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
+			name: "terraform manager identity can change (provider version updates)",
+			auth: user,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "terraform-provider-grafana/v3.0.0",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000",
+					},
+				},
+			},
+		},
+		{
+			name: "terraform manager identity change from legacy crossplane ID",
+			auth: user,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "terraform-provider-grafana/v4.0.0",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "terraform-provider-grafana/crossplane",
+					},
+				},
+			},
+		},
+		{
 			name: "audience includes provisioning group",
 			auth: &serviceauthn.Identity{
 				Type: authtypes.TypeAccessPolicy,

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -211,8 +211,9 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform: new (simple ID) → new (different simple ID) allowed",
+			name: "terraform: new (simple ID) → new (different simple ID) blocked",
 			auth: user,
+			err:  "Cannot change Terraform manager ID; stable custom IDs are immutable",
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,
@@ -257,7 +258,7 @@ func TestManagedAuthorizer(t *testing.T) {
 		{
 			name: "terraform: new (simple ID) → legacy (User-Agent) blocked (no reverting)",
 			auth: user,
-			err:  "Cannot revert to User-Agent based Terraform manager ID",
+			err:  "Cannot change Terraform manager ID back to User-Agent format",
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -189,14 +189,14 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform: legacy → new format allowed (migration)",
+			name: "terraform: legacy (User-Agent) → new (simple ID) allowed (migration)",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
+						utils.AnnoKeyManagerIdentity: "grafana-terraform-provider",
 					},
 				},
 			},
@@ -211,14 +211,14 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform: new → new format allowed (version updates)",
+			name: "terraform: new (simple ID) → new (different simple ID) allowed",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.1.0",
+						utils.AnnoKeyManagerIdentity: "my-terraform-provider-v2",
 					},
 				},
 			},
@@ -227,20 +227,20 @@ func TestManagedAuthorizer(t *testing.T) {
 					Generation: 1,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
+						utils.AnnoKeyManagerIdentity: "my-terraform-provider",
 					},
 				},
 			},
 		},
 		{
-			name: "terraform: legacy → legacy allowed",
+			name: "terraform: legacy (User-Agent) → legacy (different User-Agent) allowed",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane-v2",
+						utils.AnnoKeyManagerIdentity: "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0",
 					},
 				},
 			},
@@ -255,7 +255,7 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform: new → legacy blocked (no reverting)",
+			name: "terraform: new (simple ID) → legacy (User-Agent) blocked (no reverting)",
 			auth: user,
 			err:  "Cannot revert to legacy Terraform manager ID",
 			obj: &dashboard.Dashboard{
@@ -263,7 +263,7 @@ func TestManagedAuthorizer(t *testing.T) {
 					Generation: 2,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane",
+						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
 					},
 				},
 			},
@@ -272,7 +272,7 @@ func TestManagedAuthorizer(t *testing.T) {
 					Generation: 1,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
+						utils.AnnoKeyManagerIdentity: "grafana-terraform-provider",
 					},
 				},
 			},

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -257,7 +257,7 @@ func TestManagedAuthorizer(t *testing.T) {
 		{
 			name: "terraform: new (simple ID) → legacy (User-Agent) blocked (no reverting)",
 			auth: user,
-			err:  "Cannot revert to legacy Terraform manager ID",
+			err:  "Cannot revert to User-Agent based Terraform manager ID",
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -189,14 +189,14 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform manager identity can change (provider version updates)",
+			name: "terraform manager identity can change (user-agent based ID)",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "terraform-provider-grafana/v3.0.0",
+						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
 					},
 				},
 			},
@@ -205,20 +205,20 @@ func TestManagedAuthorizer(t *testing.T) {
 					Generation: 1,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000",
+						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane",
 					},
 				},
 			},
 		},
 		{
-			name: "terraform manager identity change from legacy crossplane ID",
+			name: "terraform manager identity transitions work across any versions",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
 					Generation: 2,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "terraform-provider-grafana/v4.0.0",
+						utils.AnnoKeyManagerIdentity: "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.1.0",
 					},
 				},
 			},
@@ -227,7 +227,7 @@ func TestManagedAuthorizer(t *testing.T) {
 					Generation: 1,
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
-						utils.AnnoKeyManagerIdentity: "terraform-provider-grafana/crossplane",
+						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
 					},
 				},
 			},

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -189,7 +189,7 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform manager identity can change (user-agent based ID)",
+			name: "terraform: legacy → new format allowed (migration)",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
@@ -211,7 +211,7 @@ func TestManagedAuthorizer(t *testing.T) {
 			},
 		},
 		{
-			name: "terraform manager identity transitions work across any versions",
+			name: "terraform: new → new format allowed (version updates)",
 			auth: user,
 			obj: &dashboard.Dashboard{
 				ObjectMeta: v1.ObjectMeta{
@@ -219,6 +219,51 @@ func TestManagedAuthorizer(t *testing.T) {
 					Annotations: map[string]string{
 						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
 						utils.AnnoKeyManagerIdentity: "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.1.0",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
+					},
+				},
+			},
+		},
+		{
+			name: "terraform: legacy → legacy allowed",
+			auth: user,
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane-v2",
+					},
+				},
+			},
+			old: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 1,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane",
+					},
+				},
+			},
+		},
+		{
+			name: "terraform: new → legacy blocked (no reverting)",
+			auth: user,
+			err:  "Cannot revert to legacy Terraform manager ID",
+			obj: &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Generation: 2,
+					Annotations: map[string]string{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/crossTF000 (+https://www.terraform.io) terraform-provider-grafana/crossplane",
 					},
 				},
 			},

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -715,6 +715,169 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 	})
 }
 
+func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+	dashboardAPIVersion := dashboardV1.DashboardResourceInfo.GroupVersion().String()
+
+	// Create an unmanaged folder for testing
+	unmanagedFolder := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
+			"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+			"metadata": map[string]interface{}{
+				"generateName": "terraform-test-folder-",
+			},
+			"spec": map[string]interface{}{
+				"title": "Terraform Test Folder",
+			},
+		},
+	}
+	createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+	require.NoError(t, err)
+	folderName := createdFolder.GetName()
+
+	t.Run("User-Agent to User-Agent allowed (version updates)", func(t *testing.T) {
+		dashboard := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": dashboardAPIVersion,
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"generateName": "tf-ua-to-ua-",
+					"annotations": map[string]interface{}{
+						"grafana.app/folder":         folderName,
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
+					},
+				},
+				"spec": map[string]interface{}{
+					"title":         "Terraform Dashboard UA to UA",
+					"schemaVersion": 41,
+				},
+			},
+		}
+		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		annotations[utils.AnnoKeyManagerIdentity] = "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0"
+		fresh.SetAnnotations(annotations)
+
+		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.NoError(t, err, "should allow User-Agent to User-Agent transition")
+		require.Equal(t, "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0",
+			updated.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+	})
+
+	t.Run("User-Agent to simple ID allowed (migration)", func(t *testing.T) {
+		dashboard := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": dashboardAPIVersion,
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"generateName": "tf-ua-to-simple-",
+					"annotations": map[string]interface{}{
+						"grafana.app/folder":         folderName,
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0",
+					},
+				},
+				"spec": map[string]interface{}{
+					"title":         "Terraform Dashboard UA to Simple",
+					"schemaVersion": 41,
+				},
+			},
+		}
+		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		annotations[utils.AnnoKeyManagerIdentity] = "my-terraform-provider"
+		fresh.SetAnnotations(annotations)
+
+		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.NoError(t, err, "should allow User-Agent to simple ID transition (migration)")
+		require.Equal(t, "my-terraform-provider", updated.GetAnnotations()[utils.AnnoKeyManagerIdentity])
+	})
+
+	t.Run("simple ID to simple ID blocked (immutable)", func(t *testing.T) {
+		dashboard := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": dashboardAPIVersion,
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"generateName": "tf-simple-to-simple-",
+					"annotations": map[string]interface{}{
+						"grafana.app/folder":         folderName,
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "my-terraform-provider",
+					},
+				},
+				"spec": map[string]interface{}{
+					"title":         "Terraform Dashboard Simple to Simple",
+					"schemaVersion": 41,
+				},
+			},
+		}
+		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		annotations[utils.AnnoKeyManagerIdentity] = "my-terraform-provider-v2"
+		fresh.SetAnnotations(annotations)
+
+		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.Error(t, err, "should block simple ID to simple ID transition")
+		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
+		require.Contains(t, err.Error(), "Cannot change Terraform manager ID")
+		require.Contains(t, err.Error(), "stable custom IDs are immutable")
+	})
+
+	t.Run("simple ID to User-Agent blocked (no reverting)", func(t *testing.T) {
+		dashboard := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": dashboardAPIVersion,
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"generateName": "tf-simple-to-ua-",
+					"annotations": map[string]interface{}{
+						"grafana.app/folder":         folderName,
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "my-terraform-provider",
+					},
+				},
+				"spec": map[string]interface{}{
+					"title":         "Terraform Dashboard Simple to UA",
+					"schemaVersion": 41,
+				},
+			},
+		}
+		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		annotations[utils.AnnoKeyManagerIdentity] = "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0"
+		fresh.SetAnnotations(annotations)
+
+		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.Error(t, err, "should block simple ID to User-Agent transition")
+		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
+		require.Contains(t, err.Error(), "Cannot change Terraform manager ID back to User-Agent format")
+	})
+}
+
 func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()


### PR DESCRIPTION
Part of https://github.com/grafana/support-escalations/issues/21520#issuecomment-4251964704

## Summary

Enables one-way migration from legacy User-Agent based Terraform manager IDs to stable custom IDs. Once migrated, the custom ID becomes immutable.

## Problem

Terraform provider historically set manager identity from HTTP User-Agent:
- **Legacy format**: `"Terraform/1.5.0 (+https://www.terraform.io) terraform-provider-grafana/v3.0.0"`
  - Full User-Agent string that changes with every Terraform/provider version
  - Not a stable identifier
  - Cannot be customized by users
  
**Desired new format**: Simple custom IDs like:
- `"grafana-terraform-provider"`
- `"my-terraform-provider"`
- User-defined stable identifiers that never change

Current code blocks ANY identity change, preventing migration from User-Agent to custom IDs.

Reference: https://github.com/grafana/terraform-provider-grafana/blob/main/pkg/provider/framework_provider.go#L307

## Solution

Implement one-way migration to stable custom IDs with immutability guarantee:

| Transition | Example | Allowed? |
|------------|---------|----------|
| User-Agent → User-Agent | v1.5 → v1.6 | ✅ Yes (legacy version updates) |
| User-Agent → Custom ID | User-Agent → `"my-provider"` | ✅ Yes (one-time migration) |
| Custom ID → Custom ID | `"my-provider"` → `"my-provider-v2"` | ❌ **No (immutable)** |
| Custom ID → User-Agent | `"my-provider"` → User-Agent | ❌ No (no reverting) |

**For non-Terraform managers**: Continue strict validation (both Kind and Identity must match)

## Implementation

**Modified files:**

`pkg/storage/unified/apistore/managed.go`:
- Split validation: Kind changes blocked for all managers
- Identity changes: Terraform gets special handling, others remain strict
- `isTerraformUserAgentID()`: Regex-based detection of User-Agent format
  - Pattern: `^Terraform/[^ ]+ \(\+https://www\.terraform\.io\) terraform-provider-[^/]+/.+$`
  - Validates exact structure with proper spacing and parentheses
- Block transitions from custom IDs (both to User-Agent and to different custom IDs)
- Marked as HACK with comprehensive documentation explaining why it exists

`pkg/storage/unified/apistore/managed_test.go`:
- Test all four transition scenarios
- Use realistic examples matching actual Terraform provider format
- Verify immutability of custom IDs

## Testing

✅ Unit test coverage:
```
terraform: User-Agent → User-Agent allowed (legacy version updates)
terraform: User-Agent → custom ID allowed (one-time migration)
terraform: custom ID → custom ID blocked (immutable)
terraform: custom ID → User-Agent blocked (no reverting)
```

✅ Non-Terraform managers still enforce strict identity validation  
✅ All existing tests pass

## Why This is a HACK

This special-casing for Terraform violates the principle that manager identities should be immutable. However, it's necessary because:

1. **Original design mistake**: Using HTTP User-Agent as a manager identity
2. **User-Agent is unstable**: Changes with every version, not suitable as an identifier
3. **No user control**: Users can't customize User-Agent based IDs
4. **Migration path needed**: Must allow transition to stable custom IDs
5. **Immutability guarantee**: Once migrated, custom IDs are locked to prevent accidental changes

The hack enables fixing the past mistake while ensuring future stability.

## Backward Compatibility

✅ Fully backward compatible:
- Resources with User-Agent IDs can continue updating between versions
- Resources can migrate to custom IDs when ready
- Once migrated, custom IDs are immutable (prevents accidental changes)
- Non-Terraform managers maintain strict validation
- No breaking changes

## Use Case

Allows Terraform provider to transition users from automatic User-Agent based IDs (which change with every version) to stable, user-defined manager IDs that provide better tracking and control. Once a user chooses their stable ID, it cannot be changed without explicitly removing and re-adding the manager.

## Related

- Previous PR: #120580 - Refactored manager update check to compare only kind and identity
- This PR enables Terraform provider to adopt stable custom manager IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)