### PR TITLE
Provisioning: add new check for webhook creation in repository controller

### DIFF
--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -649,6 +649,8 @@ func (rc *RepositoryController) process(item *queueItem) error {
 		logger.Info("repository token needs to be generated", "connection", obj.Spec.Connection.Name)
 	case hasQuotaChanged:
 		logger.Info("quota changed", "quota", newQuota)
+	case len(obj.Spec.Workflows) > 0 && (obj.Status.Webhook == nil || obj.Status.Webhook.ID == 0):
+		logger.Info("webhook missing, reconciling")
 	default:
 		logger.Info("skipping as conditions are not met", "status", obj.Status, "generation", obj.Generation, "sync_spec", obj.Spec.Sync)
 		return nil
@@ -804,7 +806,10 @@ func (rc *RepositoryController) process(item *queueItem) error {
 // processHooks handles hook execution with intelligent retry logic
 // Returns hook operations, whether processing should continue, and any error
 func (rc *RepositoryController) processHooks(ctx context.Context, repo repository.Repository, obj *provisioning.Repository) ([]map[string]interface{}, bool, error) {
-	shouldRunHooks := obj.Generation != obj.Status.ObservedGeneration
+	webhookMissing := len(obj.Spec.Workflows) > 0 &&
+		(obj.Status.Webhook == nil || obj.Status.Webhook.ID == 0)
+
+	shouldRunHooks := (obj.Generation != obj.Status.ObservedGeneration) || webhookMissing
 
 	// Skip hooks if status already indicates recent hook failure to avoid infinite retry
 	if shouldRunHooks && rc.healthChecker.HasRecentFailure(obj.Status.Health, provisioning.HealthFailureHook) {

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1120,6 +1120,7 @@ func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testin
 	require.Error(t, result.Error(), "webhook request should be rejected for unhealthy repository")
 	require.Equal(t, http.StatusFailedDependency, statusCode, "should return 424 Failed Dependency for unhealthy repository")
 }
+
 func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes webhook creation not being retried on controller restart. When a repository has workflows configured but no webhook (`Status.Webhook` is nil), the controller now triggers hook execution to create the webhook — even if the spec hasn't changed.

Fixes https://github.com/grafana/git-ui-sync-project/issues/147

## Why

Webhook creation is gated on `obj.Generation != obj.Status.ObservedGeneration` in `processHooks()`. After initial creation, if webhook setup fails (e.g., no public URL at the time) or the controller restarts, the generation hasn't changed, so hooks are never re-executed. The only recovery was for the user to make a spec change — which is not discoverable.

## What

Two changes in `repository.go`:

1. **`processHooks()`**: Extended `shouldRunHooks` to also fire when workflows exist but the webhook is missing:
   ```go
   webhookMissing := len(obj.Spec.Workflows) > 0 &&
       (obj.Status.Webhook == nil || obj.Status.Webhook.ID == 0)
   shouldRunHooks := (obj.Generation != obj.Status.ObservedGeneration) || webhookMissing
   ```

2. **`process()` trigger switch**: Added a case so reconciliation isn't skipped when a missing webhook is the only trigger:
   ```go
   case len(obj.Spec.Workflows) > 0 && (obj.Status.Webhook == nil || obj.Status.Webhook.ID == 0):
       logger.Info("webhook missing, reconciling")
   ```

No new functions or types — the existing `processHooks` → `runHooks` → `OnCreate` chain handles webhook creation, with the existing health check backoff preventing infinite retries.

## Test plan

- [x] All existing controller unit tests pass (no regressions)
- [x] `TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook` — repos without workflows unaffected
- [x] `TestIntegrationProvisioning_WebhookConfig` — existing webhook config tests pass
- [x] `make gofmt` clean
- [x] `make lint-go-diff` — 0 issues