### PR TITLE
grafana-mixin: Add cluster label to recording rule and alert

### DIFF
--- a/grafana-mixin/alerts/alerts.libsonnet
+++ b/grafana-mixin/alerts/alerts.libsonnet
@@ -20,7 +20,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: '{{ $labels.namespace }}/{{ $labels.job }}/{{ $labels.handler }} is experiencing {{ $value | humanize }}% errors',
+              message: '{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.job }}/{{ $labels.handler }} is experiencing {{ $value | humanize }}% errors',
             },
             'for': '5m',
           },

--- a/grafana-mixin/rules/rules.libsonnet
+++ b/grafana-mixin/rules/rules.libsonnet
@@ -7,7 +7,7 @@
           {
             record: 'namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m',
             expr: |||
-              sum by (namespace, job, handler, status_code) (rate(grafana_http_request_duration_seconds_count[5m]))
+              sum by (cluster, namespace, job, handler, status_code) (rate(grafana_http_request_duration_seconds_count[5m]))
             |||,
           },
         ],


### PR DESCRIPTION
**What is this feature?**

Add the `cluster` label to the `sum by` clause in the grafana-mixin recording rule (`rules/rules.libsonnet`) and include `{{ $labels.cluster }}` in the `GrafanaRequestsFailing` alert message annotation (`alerts/alerts.libsonnet`).

**Why do we need this feature?**

In multi-cluster environments, the recording rule `namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m` drops the `cluster` label during aggregation. This means alerts like `GrafanaRequestsFailing` cannot identify which cluster is affected, making them significantly less useful for incident response.

**Who is this feature for?**

Operators running Grafana in multi-cluster Kubernetes environments who rely on the grafana-mixin alerts for monitoring.

**Which issue(s) does this PR fix?**:

Fixes #122721

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
