### PR TITLE
Search: disable bleve _all composite field to reduce index size

### DIFF
--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -289,6 +289,14 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		},
 		Query:  searchQuery,
 		Fields: []string{resource.SEARCH_FIELD_TITLE, fieldEmail, fieldLogin, fieldLastSeenAt, fieldRole},
+		// The query is a wildcard (*...*), so only Name is used from each
+		// QueryField to specify which fields to search in (Type and Boost
+		// are ignored for wildcard queries).
+		QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{
+			{Name: resource.SEARCH_FIELD_TITLE},
+			{Name: fieldEmail},
+			{Name: fieldLogin},
+		},
 		Limit:  int64(limit),
 		Page:   int64(page),
 		Offset: int64(offset),

--- a/pkg/storage/unified/proto/search.proto
+++ b/pkg/storage/unified/proto/search.proto
@@ -128,7 +128,11 @@ message ResourceSearchRequest {
 
   int64 permission = 12;
 
-  // Optionally specify which fields are included in the query
+  // Optionally specify which fields are included in the query.
+  // For non-wildcard queries, type and boost control how each field is searched.
+  // For wildcard queries (containing '*'), only the field name is used;
+  // type and boost are ignored because bleve wildcards don't support analyzers
+  // or meaningful relevance scoring.
   repeated QueryField query_fields = 13;
 
   // Sort values for SearchAfter pagination.

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -361,6 +361,7 @@ const (
 	SEARCH_FIELD_SOURCE_TIME        = "source.timestampMillis"
 	SEARCH_FIELD_SCORE              = "_score"            // the match score
 	SEARCH_FIELD_EXPLAIN            = "_explain"          // score explanation as JSON object
+	SEARCH_FIELD_ALL_FIELDS         = "_all_columns"      // sentinel: return all known columns in search results (deliberately distinct from bleve's "_all" composite field)
 	SEARCH_SELECTABLE_FIELDS_PREFIX = "selectableFields." // Prefix for searching selectable fields.
 )
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1091,22 +1091,15 @@ func (b *bleveIndex) Search(
 		return response, nil
 	}
 
-	// Show all fields when nothing is selected
+	// Show all fields when nothing is selected.
+	// Individual field names tell bleve which stored values to load.
+	// The sentinel triggers hitsToTable to use the curated allFields column list.
 	if len(searchrequest.Fields) < 1 && req.Limit > 0 {
 		f, err := b.index.Fields()
 		if err != nil {
 			return nil, err
 		}
-		if len(f) > 0 {
-			searchrequest.Fields = f
-		} else {
-			searchrequest.Fields = []string{
-				resource.SEARCH_FIELD_TITLE,
-				resource.SEARCH_FIELD_FOLDER,
-				resource.SEARCH_FIELD_SOURCE_PATH,
-				resource.SEARCH_FIELD_MANAGED_BY,
-			}
-		}
+		searchrequest.Fields = append(f, resource.SEARCH_FIELD_ALL_FIELDS)
 	}
 	stats.AddRequestConversionTime(time.Since(conversionStarts))
 
@@ -1286,6 +1279,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		if strings.Contains(req.Query, "*") {
 			// wildcard query is expensive - should be used with caution
 			wildcard := bleve.NewWildcardQuery(req.Query)
+			wildcard.SetField(resource.SEARCH_FIELD_TITLE)
 			queries = append(queries, wildcard)
 		} else {
 			// When using a
@@ -1743,7 +1737,9 @@ func newQuery(key string, value string, prefix string) query.Query {
 	}
 	if strings.Contains(value, "*") {
 		// wildcard query is expensive - should be used with caution
-		return bleve.NewWildcardQuery(value)
+		q := bleve.NewWildcardQuery(value)
+		q.SetField(prefix + key)
+		return q
 	}
 	delimiter, ok := hasTerms(value)
 	if slices.Contains(termFields, key) && ok {
@@ -1805,7 +1801,7 @@ func (b *bleveIndex) hitsToTable(ctx context.Context, selectFields []string, hit
 
 	fields := []*resourcepb.ResourceTableColumnDefinition{}
 	for _, name := range selectFields {
-		if name == "_all" {
+		if name == resource.SEARCH_FIELD_ALL_FIELDS {
 			fields = b.allFields
 			break
 		}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1294,6 +1294,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 				// IAM user search wraps queries as "*<query>*" — older clients
 				// may not set QueryFields, so we include email/login here for
 				// backward compatibility during the deployment gap.
+				// TODO: remove email and login fields once IAM only sends requests with QueryFields.
 				addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_TITLE)
 				addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_PREFIX+"email")
 				addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_PREFIX+"login")

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1291,9 +1291,17 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 				}
 				queries = append(queries, disjoin)
 			} else {
-				wildcard := bleve.NewWildcardQuery(req.Query)
-				wildcard.SetField(resource.SEARCH_FIELD_TITLE)
-				queries = append(queries, wildcard)
+				// Default: search both title (standard-analyzed, word tokens)
+				// and title_phrase (keyword-analyzed, full lowered title).
+				// title handles prefix wildcards like "hell*" (matches word "hello").
+				// title_phrase handles full-title wildcards like "*grafana dev overview*"
+				// sent by the legacy dashboard search service.
+				wTitle := bleve.NewWildcardQuery(req.Query)
+				wTitle.SetField(resource.SEARCH_FIELD_TITLE)
+				wPhrase := bleve.NewWildcardQuery(req.Query)
+				wPhrase.SetField(resource.SEARCH_FIELD_TITLE_PHRASE)
+
+				queries = append(queries, bleve.NewDisjunctionQuery(wTitle, wPhrase))
 			}
 		} else {
 			// When using a

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1277,10 +1277,24 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 
 	if len(req.Query) > 1 {
 		if strings.Contains(req.Query, "*") {
-			// wildcard query is expensive - should be used with caution
-			wildcard := bleve.NewWildcardQuery(req.Query)
-			wildcard.SetField(resource.SEARCH_FIELD_TITLE)
-			queries = append(queries, wildcard)
+			// Wildcard query is expensive, should be used with caution.
+			// When QueryFields is set, search across each named field (only Name is
+			// used; Type and Boost are ignored because bleve wildcards don't support
+			// analyzers or meaningful relevance scoring).
+			// When QueryFields is empty, default to title.
+			if len(req.QueryFields) > 0 {
+				disjoin := bleve.NewDisjunctionQuery()
+				for _, field := range req.QueryFields {
+					wq := bleve.NewWildcardQuery(req.Query)
+					wq.SetField(field.Name)
+					disjoin.AddQuery(wq)
+				}
+				queries = append(queries, disjoin)
+			} else {
+				wildcard := bleve.NewWildcardQuery(req.Query)
+				wildcard.SetField(resource.SEARCH_FIELD_TITLE)
+				queries = append(queries, wildcard)
+			}
 		} else {
 			// When using a
 			searchrequest.Fields = append(searchrequest.Fields, resource.SEARCH_FIELD_SCORE)

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1281,28 +1281,24 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 			// When QueryFields is set, search across each named field (only Name is
 			// used; Type and Boost are ignored because bleve wildcards don't support
 			// analyzers or meaningful relevance scoring).
-			// When QueryFields is empty, default to title.
+			// When QueryFields is empty, default to title + IAM identity fields
+			// (email, login) for backward compatibility with older clients that
+			// don't set QueryFields.
+			disjoin := bleve.NewDisjunctionQuery()
 			if len(req.QueryFields) > 0 {
-				disjoin := bleve.NewDisjunctionQuery()
 				for _, field := range req.QueryFields {
-					wq := bleve.NewWildcardQuery(req.Query)
-					wq.SetField(field.Name)
-					disjoin.AddQuery(wq)
+					addWildcardQueries(disjoin, req.Query, field.Name)
 				}
-				queries = append(queries, disjoin)
 			} else {
-				// Default: search both title (standard-analyzed, word tokens)
-				// and title_phrase (keyword-analyzed, full lowered title).
-				// title handles prefix wildcards like "hell*" (matches word "hello").
-				// title_phrase handles full-title wildcards like "*grafana dev overview*"
-				// sent by the legacy dashboard search service.
-				wTitle := bleve.NewWildcardQuery(req.Query)
-				wTitle.SetField(resource.SEARCH_FIELD_TITLE)
-				wPhrase := bleve.NewWildcardQuery(req.Query)
-				wPhrase.SetField(resource.SEARCH_FIELD_TITLE_PHRASE)
-
-				queries = append(queries, bleve.NewDisjunctionQuery(wTitle, wPhrase))
+				// Default: search title and IAM identity fields (email, login).
+				// IAM user search wraps queries as "*<query>*" — older clients
+				// may not set QueryFields, so we include email/login here for
+				// backward compatibility during the deployment gap.
+				addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_TITLE)
+				addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_PREFIX+"email")
+				addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_PREFIX+"login")
 			}
+			queries = append(queries, disjoin)
 		} else {
 			// When using a
 			searchrequest.Fields = append(searchrequest.Fields, resource.SEARCH_FIELD_SCORE)
@@ -1750,6 +1746,22 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 	return nil, resource.NewBadRequestError(
 		fmt.Sprintf("unsupported query operation (%s %s %v)", req.Key, req.Operator, req.Values),
 	)
+}
+
+// addWildcardQueries adds wildcard queries for the given field to the disjunction.
+// When the field is "title", it adds queries for both "title" (standard-analyzed,
+// matches word-level wildcards like "hell*") and "title_phrase" (keyword-analyzed,
+// matches full-phrase wildcards like "*grafana dev overview*").
+func addWildcardQueries(disjoin *query.DisjunctionQuery, pattern string, field string) {
+	wq := bleve.NewWildcardQuery(pattern)
+	wq.SetField(field)
+	disjoin.AddQuery(wq)
+
+	if field == resource.SEARCH_FIELD_TITLE {
+		wPhrase := bleve.NewWildcardQuery(pattern)
+		wPhrase.SetField(resource.SEARCH_FIELD_TITLE_PHRASE)
+		disjoin.AddQuery(wPhrase)
+	}
 }
 
 // newQuery will create a query that will match the value or the tokens of the value

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -78,7 +78,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 		Store:              true,
 		Index:              true,
 		IncludeTermVectors: false,
-		IncludeInAll:       true,
+		IncludeInAll:       false,
 		DocValues:          false,
 	})
 
@@ -125,7 +125,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 		Store:              true,
 		Index:              true,
 		IncludeTermVectors: false,
-		IncludeInAll:       true,
+		IncludeInAll:       false,
 	})
 	manager.AddFieldMappingsAt("id", &mapping.FieldMapping{
 		Name:               "id",
@@ -134,7 +134,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 		Store:              true,
 		Index:              true,
 		IncludeTermVectors: false,
-		IncludeInAll:       true,
+		IncludeInAll:       false,
 	})
 
 	source := bleve.NewDocumentStaticMapping()
@@ -145,7 +145,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 		Store:              true,
 		Index:              true,
 		IncludeTermVectors: false,
-		IncludeInAll:       true,
+		IncludeInAll:       false,
 	})
 	source.AddFieldMappingsAt("checksum", &mapping.FieldMapping{
 		Name:               "checksum",
@@ -154,7 +154,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 		Store:              true,
 		Index:              true,
 		IncludeTermVectors: false,
-		IncludeInAll:       true,
+		IncludeInAll:       false,
 	})
 	source.AddFieldMappingsAt("timestampMillis", mapping.NewNumericFieldMapping())
 
@@ -196,6 +196,13 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	}
 
 	mapper.AddSubDocumentMapping(strings.TrimSuffix(resource.SEARCH_FIELD_PREFIX, "."), fieldMapper)
+
+	// Disable bleve's internal "_all" composite field. By default bleve merges
+	// terms from all fields with IncludeInAll:true into a synthetic "_all"
+	// field. We never query it (all searches target explicit fields). Disabling
+	// it significantly reduces index size (see mapping/index.go:366-371 in
+	// blevesearch/bleve).
+	mapper.AddSubDocumentMapping("_all", bleve.NewDocumentDisabledMapping())
 
 	selectableFieldsMapper := bleve.NewDocumentStaticMapping()
 	for _, field := range selectableFields {

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -200,8 +200,8 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	// Disable bleve's internal "_all" composite field. By default bleve merges
 	// terms from all fields with IncludeInAll:true into a synthetic "_all"
 	// field. We never query it (all searches target explicit fields). Disabling
-	// it significantly reduces index size (see mapping/index.go:366-371 in
-	// blevesearch/bleve).
+	// it significantly reduces index size.
+	// https://github.com/blevesearch/bleve/blob/v2.5.7/mapping/index.go#L366-L371
 	mapper.AddSubDocumentMapping("_all", bleve.NewDocumentDisabledMapping())
 
 	selectableFieldsMapper := bleve.NewDocumentStaticMapping()

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -51,4 +51,5 @@ func TestDocumentMapping(t *testing.T) {
 	fmt.Printf("DOC: fields %d\n", len(doc.Fields))
 	fmt.Printf("DOC: size %d\n", doc.Size())
 	require.Equal(t, 21, len(doc.Fields))
+	require.False(t, doc.HasComposite(), "_all composite field should be disabled")
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -339,6 +339,31 @@ func TestWildcardQuery(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("Hell*"), []string{"name1"})
 	})
 
+	t.Run("wildcard query with QueryFields searches specified fields", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Hello World",
+			"name2": "Goodbye Moon",
+		})
+
+		req := newTestQuery("hell*")
+		req.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{
+			{Name: resource.SEARCH_FIELD_TITLE},
+		}
+		res, err := index.Search(context.Background(), nil, req, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), res.TotalHits)
+
+		// QueryFields pointing at a non-matching field should return no results
+		req2 := newTestQuery("hell*")
+		req2.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{
+			{Name: resource.SEARCH_FIELD_FOLDER},
+		}
+		res2, err := index.Search(context.Background(), nil, req2, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), res2.TotalHits)
+	})
+
 	t.Run("wildcard query matches multiple documents", func(t *testing.T) {
 		index := newTestDashboardsIndex(t, threshold, 2, noop)
 		indexDocumentsWithTitles(t, index, key, map[string]string{

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -391,6 +391,50 @@ func TestWildcardQuery(t *testing.T) {
 		// Partial multi-word match
 		checkSearchQuery(t, index, newTestQuery("*dev overview*"), []string{"name1"})
 	})
+
+	t.Run("default wildcard searches email and login fields", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+					RV: 1, Name: "user1", Title: "First User",
+					Key:    &resourcepb.ResourceKey{Name: "user1", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+					Fields: map[string]any{"email": "uniquemail", "login": "firstlogin"},
+				}},
+				{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+					RV: 1, Name: "user2", Title: "Second User",
+					Key:    &resourcepb.ResourceKey{Name: "user2", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+					Fields: map[string]any{"email": "othermail", "login": "secondlogin"},
+				}},
+			},
+		}))
+
+		// Default wildcard (no QueryFields) should match email field.
+		// Values are distinct from titles to prove field matching works.
+		// Note: simple tokens because the test index uses the standard
+		// analyzer for dynamic fields (production uses keyword).
+		checkSearchQuery(t, index, newTestQuery("*uniquemail*"), []string{"user1"})
+		// Default wildcard should match login field
+		checkSearchQuery(t, index, newTestQuery("*secondlogin*"), []string{"user2"})
+	})
+
+	t.Run("QueryFields with title also searches title_phrase", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Grafana Dev Overview",
+			"name2": "Production Alerts",
+		})
+
+		// When QueryFields includes title, multi-word wildcards should still
+		// work because title is auto-expanded to title + title_phrase.
+		req := newTestQuery("*grafana dev overview*")
+		req.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{
+			{Name: resource.SEARCH_FIELD_TITLE},
+		}
+		res, err := index.Search(context.Background(), nil, req, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), res.TotalHits)
+	})
 }
 
 func TestScoringHierarchy(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -376,6 +376,21 @@ func TestWildcardQuery(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(2), res.TotalHits)
 	})
+
+	t.Run("multi-word wildcard matches via title_phrase", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Grafana Dev Overview",
+			"name2": "Production Alerts",
+		})
+
+		// Legacy dashboard search wraps queries as "*<lowered title>*".
+		// Multi-word wildcards can't match word tokens in the standard-analyzed
+		// title field, but DO match the keyword-analyzed title_phrase field.
+		checkSearchQuery(t, index, newTestQuery("*grafana dev overview*"), []string{"name1"})
+		// Partial multi-word match
+		checkSearchQuery(t, index, newTestQuery("*dev overview*"), []string{"name1"})
+	})
 }
 
 func TestScoringHierarchy(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -319,6 +319,40 @@ func TestTitleNgramFieldSearch(t *testing.T) {
 	})
 }
 
+func TestWildcardQuery(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	t.Run("wildcard query matches title", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Hello World",
+			"name2": "Goodbye Moon",
+		})
+
+		checkSearchQuery(t, index, newTestQuery("hell*"), []string{"name1"})
+		// title field also has a keyword mapping that preserves original case,
+		// so capitalized wildcards also match
+		checkSearchQuery(t, index, newTestQuery("Hell*"), []string{"name1"})
+	})
+
+	t.Run("wildcard query matches multiple documents", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Dashboard One",
+			"name2": "Dashboard Two",
+			"name3": "Alert Rules",
+		})
+
+		res, err := index.Search(context.Background(), nil, newTestQuery("dashboard*"), nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), res.TotalHits)
+	})
+}
+
 func TestScoringHierarchy(t *testing.T) {
 	key := resource.NamespacedResource{
 		Namespace: "default",

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -393,29 +393,35 @@ func TestWildcardQuery(t *testing.T) {
 	})
 
 	t.Run("default wildcard searches email and login fields", func(t *testing.T) {
-		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		// Use an index with keyword-analyzed email/login fields (matching
+		// production IAM config) so wildcards match full email addresses.
+		index := newTestIndexWithFields(t, key, []*resourcepb.ResourceTableColumnDefinition{
+			{Name: "email", Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: &resourcepb.ResourceTableColumnDefinition_Properties{Filterable: true}},
+			{Name: "login", Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: &resourcepb.ResourceTableColumnDefinition_Properties{Filterable: true}},
+		})
 		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
 					RV: 1, Name: "user1", Title: "First User",
 					Key:    &resourcepb.ResourceKey{Name: "user1", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
-					Fields: map[string]any{"email": "uniquemail", "login": "firstlogin"},
+					Fields: map[string]any{"email": "uniquemail@grafana.com", "login": "firstlogin"},
 				}},
 				{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
 					RV: 1, Name: "user2", Title: "Second User",
 					Key:    &resourcepb.ResourceKey{Name: "user2", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
-					Fields: map[string]any{"email": "othermail", "login": "secondlogin"},
+					Fields: map[string]any{"email": "othermail@grafana.com", "login": "secondlogin"},
 				}},
 			},
 		}))
 
-		// Default wildcard (no QueryFields) should match email field.
-		// Values are distinct from titles to prove field matching works.
-		// Note: simple tokens because the test index uses the standard
-		// analyzer for dynamic fields (production uses keyword).
-		checkSearchQuery(t, index, newTestQuery("*uniquemail*"), []string{"user1"})
+		// Default wildcard (no QueryFields) should match email field
+		checkSearchQuery(t, index, newTestQuery("*uniquemail@grafana.com*"), []string{"user1"})
 		// Default wildcard should match login field
 		checkSearchQuery(t, index, newTestQuery("*secondlogin*"), []string{"user2"})
+		// Wildcard matching domain across both users (order is non-deterministic)
+		res, err := index.Search(context.Background(), nil, newTestQuery("*grafana.com*"), nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), res.TotalHits)
 	})
 
 	t.Run("QueryFields with title also searches title_phrase", func(t *testing.T) {
@@ -627,6 +633,25 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 	}, size, info.Fields, "test", writer, nil, false, time.Time{})
 	require.NoError(t, err)
 
+	return index
+}
+
+// newTestIndexWithFields creates a test index with custom searchable fields
+// (e.g. keyword-analyzed email/login for IAM-like tests).
+func newTestIndexWithFields(t testing.TB, key resource.NamespacedResource, columns []*resourcepb.ResourceTableColumnDefinition) resource.ResourceIndex {
+	backend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: threshold,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
+	fields, err := resource.NewSearchableDocumentFields(columns)
+	require.NoError(t, err)
+
+	index, err := backend.BuildIndex(ctx, key, 2, fields, "test", noop, nil, false, time.Time{})
+	require.NoError(t, err)
 	return index
 }
 


### PR DESCRIPTION
## Summary

- Disable bleve's internal `_all` composite field — we never query it (all searches target explicit fields like `title`, `title_phrase`, `title_ngram`), and it significantly increases index size
- Route wildcard queries to explicit fields instead of implicitly searching `_all`
- Support multi-field wildcard queries via `QueryFields` (used by IAM user search for email/login)
- Use `title` + `title_phrase` disjunction for default wildcard queries to handle both word-level and full-phrase matching
- Default wildcard also searches `fields.email` and `fields.login` for backward compatibility with older IAM clients during the deployment gap
- When `QueryFields` includes `title`, auto-expand to `title` + `title_phrase` so callers don't need to know about the internal field split
- Introduce `SEARCH_FIELD_ALL_FIELDS` sentinel (`_all_columns`) to decouple the "return all columns" API convention from bleve's `_all` composite field

Ref: grafana/search-and-storage-team#743
Parent: grafana/search-and-storage-team#737

## Details

Bleve's `_all` field merges terms from all indexed fields with `IncludeInAll: true` into a single composite field. In a 10K-document index, `_all` was the single largest field (~35% of the zap file). Analysis of the search code confirmed no queries target it — the only exception was wildcard queries (created without `SetField()`), which are now explicitly routed to specific fields.

Disabling `_all` is done via `AddSubDocumentMapping("_all", bleve.NewDocumentDisabledMapping())`. This is the supported mechanism — bleve explicitly checks for it in [`MapDocument()`](https://github.com/blevesearch/bleve/blob/v2.5.7/mapping/index.go#L366-L371).

### Wildcard query changes

When `_all` was the implicit search field, unscoped wildcard queries matched against all indexed terms. With `_all` disabled, wildcards need explicit field routing. This is handled by `addWildcardQueries()` which also auto-expands `title` to include `title_phrase` (keyword-analyzed full title), so multi-word wildcards work transparently:

- **Default (no `QueryFields`)**: searches a disjunction of `title` + `title_phrase` + `fields.email` + `fields.login`. The title fields handle both word-level wildcards like `hell*` and full-phrase wildcards like `*grafana dev overview*` (used by the legacy dashboard search service). The email/login fields provide backward compatibility for older IAM clients that don't yet set `QueryFields`.
- **With `QueryFields`**: creates a disjunction of wildcard queries across all named fields. When a field is `title`, it auto-expands to `title` + `title_phrase`. Only `Name` is used from each `QueryField` — `Type` and `Boost` are ignored since bleve wildcards don't support analyzers or relevance scoring.

### Sentinel change

When `_all` was disabled, `b.index.Fields()` no longer returned `"_all"` as a field name. This broke a side-effect where `hitsToTable` used `"_all"` in the field list to trigger the "return all known columns" convention. Fixed by introducing an explicit `SEARCH_FIELD_ALL_FIELDS` sentinel (`_all_columns`), cleanly separating the two concepts.

## Test plan

- [x] `go test ./pkg/storage/unified/search/...` — 138 tests pass
- [x] `TestIntegrationSearchDevDashboards` — integration tests pass, no snapshot changes
- [x] `TestWildcardQuery` — wildcard search against title, title_phrase, email/login fields, QueryFields with auto-expansion
- [x] `TestDocumentMapping` verifies `_all` composite field is no longer created
- [x] `TestIntegrationUserSearch/search_by_email` — verifies IAM wildcard search across email/login fields
- [x] `TestIntegrationUpdatingProvisionionedDashboards` — verifies legacy dashboard multi-word wildcard search
