### PR TITLE
Folders: Remove redundant UID validation from folder service Create method

### DIFF
--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -57,10 +57,19 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "reserved name",
+			name: "reserved name - general",
 			folder: &folders.Folder{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "general", // can not name something with general
+					Name: folder.GeneralFolderUID,
+				},
+			},
+			expectedErr: "invalid uid for folder provided",
+		},
+		{
+			name: "reserved name - sharedwithme",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: folder.SharedWithMeFolderUID,
 				},
 			},
 			expectedErr: "invalid uid for folder provided",

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -478,20 +478,11 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		}
 	}
 
-	if cmd.UID == folder.SharedWithMeFolderUID {
-		return nil, folder.ErrBadRequest.Errorf("cannot create folder with UID %s", folder.SharedWithMeFolderUID)
-	}
-
-	trimmedUID := strings.TrimSpace(cmd.UID)
-	if trimmedUID == accesscontrol.GeneralFolderUID {
-		return nil, folder.ErrInvalidUID
-	}
-
 	cmd = &folder.CreateFolderCommand{
 		// TODO: Today, if a UID isn't specified, the dashboard store
 		// generates a new UID. The new folder store will need to do this as
 		// well, but for now we take the UID from the newly created folder.
-		UID:          trimmedUID,
+		UID:          cmd.UID,
 		OrgID:        cmd.OrgID,
 		Title:        cmd.Title,
 		Description:  cmd.Description,

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -377,16 +377,6 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				compareFoldersNormalizeTime(t, f, actualFolder)
 			})
 
-			t.Run("When creating folder should return error if uid is general", func(t *testing.T) {
-				_, err := folderService.Create(ctx, &folder.CreateFolderCommand{
-					OrgID:        orgID,
-					Title:        f.Title,
-					UID:          "general",
-					SignedInUser: usr,
-				})
-				require.ErrorIs(t, err, folder.ErrInvalidUID)
-			})
-
 			t.Run("When updating folder should not return access denied error", func(t *testing.T) {
 				title := "TEST-Folder"
 				req := &folder.UpdateFolderCommand{


### PR DESCRIPTION
The reserved UID checks for **general** and **sharedwithme** were duplicated in the folder service Create method. 

This PR removes them, as they are already enforced at the Folder API Server by **validateOnCreate**. 

Adds a missing test for sharedwithme in validate_test.go and removes the now-stale service-level test.

Related to https://github.com/grafana/search-and-storage-team/issues/748