### PR TITLE
InfluxDB: Add config validation to config editor v2

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/ConfigEditor.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Box, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { DatabaseConnectionSection } from './DatabaseConnectionSection';
@@ -10,8 +11,16 @@ import { UrlAndAuthenticationSection } from './UrlAndAuthenticationSection';
 import { CONTAINER_MIN_WIDTH } from './constants';
 import { type Props } from './types';
 
-export const ConfigEditor: React.FC<Props> = ({ onOptionsChange, options }: Props) => {
+export const ConfigEditor: React.FC<Props> = (props: Props) => {
+  const { onOptionsChange, options } = props;
   const styles = useStyles2(getStyles);
+
+  // Only activate validation when the feature toggle is enabled. When disabled,
+  // validation is undefined so no validators are registered and save proceeds
+  // as before.
+  const validationEnabled = config.featureToggles.influxDBConfigValidation;
+  const validation = validationEnabled ? props.validation : undefined;
+
   return (
     <Stack justifyContent="space-between">
       <div className={`${styles.hideOnSmallScreen} ${styles.leftSticky}`}>
@@ -24,8 +33,8 @@ export const ConfigEditor: React.FC<Props> = ({ onOptionsChange, options }: Prop
           <Text variant="bodySmall" color="secondary">
             Fields marked with * are required
           </Text>
-          <UrlAndAuthenticationSection options={options} onOptionsChange={onOptionsChange} />
-          <DatabaseConnectionSection options={options} onOptionsChange={onOptionsChange} />
+          <UrlAndAuthenticationSection options={options} onOptionsChange={onOptionsChange} validation={validation} />
+          <DatabaseConnectionSection options={options} onOptionsChange={onOptionsChange} validation={validation} />
         </Stack>
       </Box>
       <Box width="20%" flex="0 0 20%">

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/DatabaseConnectionSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/DatabaseConnectionSection.tsx
@@ -9,7 +9,7 @@ import { InfluxSQLDBConnection } from './InfluxSQLDBConnection';
 import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH } from './constants';
 import { type Props } from './types';
 
-export const DatabaseConnectionSection = ({ options, onOptionsChange }: Props) => (
+export const DatabaseConnectionSection = ({ options, onOptionsChange, validation }: Props) => (
   <>
     <Box
       borderStyle="solid"
@@ -50,13 +50,13 @@ export const DatabaseConnectionSection = ({ options, onOptionsChange }: Props) =
         )}
         <>
           {options.jsonData.version === InfluxVersion.InfluxQL && (
-            <InfluxInfluxQLDBConnection options={options} onOptionsChange={onOptionsChange} />
+            <InfluxInfluxQLDBConnection options={options} onOptionsChange={onOptionsChange} validation={validation} />
           )}
           {options.jsonData.version === InfluxVersion.Flux && (
-            <InfluxFluxDBConnection options={options} onOptionsChange={onOptionsChange} />
+            <InfluxFluxDBConnection options={options} onOptionsChange={onOptionsChange} validation={validation} />
           )}
           {options.jsonData.version === InfluxVersion.SQL && (
-            <InfluxSQLDBConnection options={options} onOptionsChange={onOptionsChange} />
+            <InfluxSQLDBConnection options={options} onOptionsChange={onOptionsChange} validation={validation} />
           )}
           {options.jsonData.version && (
             <AdvancedDbConnectionSettings options={options} onOptionsChange={onOptionsChange} />

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 
 import { InfluxFluxDBConnection } from './InfluxFluxDBConnection';
-import { createTestProps } from './helpers';
+import { createMockValidation, createTestProps } from './helpers';
 
 describe('InfluxFluxDBConnection', () => {
   const onOptionsChangeMock = jest.fn();
@@ -42,5 +42,42 @@ describe('InfluxFluxDBConnection', () => {
     const orgInput = screen.getByLabelText(/Organization/i);
     fireEvent.change(orgInput, { target: { value: 'NewOrg' } });
     expect(onOptionsChangeMock).toHaveBeenCalled();
+  });
+
+  describe('validation', () => {
+    const emptyProps = createTestProps({
+      options: {
+        jsonData: { organization: '', defaultBucket: '' },
+        secureJsonData: { token: '' },
+        secureJsonFields: { token: false },
+      },
+      mocks: { onOptionsChange: jest.fn() },
+    });
+
+    it('shows inline errors for all required fields when validator is called with empty values', async () => {
+      const validation = createMockValidation();
+      render(<InfluxFluxDBConnection {...emptyProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.getByText('Organization is required')).toBeInTheDocument();
+      expect(screen.getByText('Default bucket is required')).toBeInTheDocument();
+      expect(screen.getByText('Token is required')).toBeInTheDocument();
+    });
+
+    it('shows no errors when all fields are filled', async () => {
+      const validation = createMockValidation();
+      render(<InfluxFluxDBConnection {...defaultProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.queryByText('Organization is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Default bucket is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Token is required')).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceSecureJsonDataOption,
@@ -15,11 +17,76 @@ import { type Props } from './types';
 export const InfluxFluxDBConnection = (props: Props) => {
   const {
     options: { jsonData, secureJsonData, secureJsonFields },
+    validation,
   } = props;
+
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const tokenConfigured = Boolean(secureJsonFields?.token);
+  const tokenEntered = Boolean(secureJsonData?.token);
+
+  useEffect(() => {
+    if (!validation) {
+      return;
+    }
+    if (jsonData.organization) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.organization;
+        return next;
+      });
+      validation.clearError('organization');
+    }
+    if (jsonData.defaultBucket) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.defaultBucket;
+        return next;
+      });
+      validation.clearError('defaultBucket');
+    }
+    if (tokenConfigured || tokenEntered) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.token;
+        return next;
+      });
+      validation.clearError('token');
+    }
+    return validation.registerValidation(() => {
+      const errors: Record<string, string> = {};
+      if (!jsonData.organization) {
+        errors.organization = 'Organization is required';
+      }
+      if (!jsonData.defaultBucket) {
+        errors.defaultBucket = 'Default bucket is required';
+      }
+      if (!tokenConfigured && !tokenEntered) {
+        errors.token = 'Token is required';
+      }
+      setFieldErrors(errors);
+      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
+      if (!errors.organization) {
+        validation.clearError('organization');
+      }
+      if (!errors.defaultBucket) {
+        validation.clearError('defaultBucket');
+      }
+      if (!errors.token) {
+        validation.clearError('token');
+      }
+      return Object.keys(errors).length === 0;
+    });
+  }, [jsonData.organization, jsonData.defaultBucket, tokenConfigured, tokenEntered, validation]);
 
   return (
     <Box width="50%">
-      <Field label="Organization" required noMargin>
+      <Field
+        label="Organization"
+        required
+        noMargin
+        invalid={!!fieldErrors.organization}
+        error={fieldErrors.organization}
+      >
         <Input
           id="organization"
           placeholder="myorg"
@@ -29,7 +96,13 @@ export const InfluxFluxDBConnection = (props: Props) => {
         />
       </Field>
       <Space v={2} />
-      <Field label="Default bucket" required noMargin>
+      <Field
+        label="Default bucket"
+        required
+        noMargin
+        invalid={!!fieldErrors.defaultBucket}
+        error={fieldErrors.defaultBucket}
+      >
         <Input
           id="default-bucket"
           onBlur={trackInfluxDBConfigV2FluxDBDetailsDefaultBucketInputField}
@@ -39,10 +112,10 @@ export const InfluxFluxDBConnection = (props: Props) => {
         />
       </Field>
       <Space v={2} />
-      <Field label="Token" required noMargin>
+      <Field label="Token" required noMargin invalid={!!fieldErrors.token} error={fieldErrors.token}>
         <SecretInput
           id="token"
-          isConfigured={Boolean(secureJsonFields && secureJsonFields.token)}
+          isConfigured={tokenConfigured}
           onBlur={trackInfluxDBConfigV2FluxDBDetailsTokenInputField}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}
           onReset={() => updateDatasourcePluginResetOption(props, 'token')}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
@@ -29,27 +29,15 @@ export const InfluxFluxDBConnection = (props: Props) => {
       return;
     }
     if (jsonData.organization) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.organization;
-        return next;
-      });
+      setFieldErrors(({ organization: _, ...rest }) => rest);
       validation.clearError('organization');
     }
     if (jsonData.defaultBucket) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.defaultBucket;
-        return next;
-      });
+      setFieldErrors(({ defaultBucket: _, ...rest }) => rest);
       validation.clearError('defaultBucket');
     }
     if (tokenConfigured || tokenEntered) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.token;
-        return next;
-      });
+      setFieldErrors(({ token: _, ...rest }) => rest);
       validation.clearError('token');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
@@ -1,3 +1,4 @@
+import { omit } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import {
@@ -29,15 +30,15 @@ export const InfluxFluxDBConnection = (props: Props) => {
       return;
     }
     if (jsonData.organization) {
-      setFieldErrors(({ organization: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'organization'));
       validation.clearError('organization');
     }
     if (jsonData.defaultBucket) {
-      setFieldErrors(({ defaultBucket: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'defaultBucket'));
       validation.clearError('defaultBucket');
     }
     if (tokenConfigured || tokenEntered) {
-      setFieldErrors(({ token: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'token'));
       validation.clearError('token');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxFluxDBConnection.tsx
@@ -31,15 +31,12 @@ export const InfluxFluxDBConnection = (props: Props) => {
     }
     if (jsonData.organization) {
       setFieldErrors((prev) => omit(prev, 'organization'));
-      validation.clearError('organization');
     }
     if (jsonData.defaultBucket) {
       setFieldErrors((prev) => omit(prev, 'defaultBucket'));
-      validation.clearError('defaultBucket');
     }
     if (tokenConfigured || tokenEntered) {
       setFieldErrors((prev) => omit(prev, 'token'));
-      validation.clearError('token');
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
@@ -53,16 +50,6 @@ export const InfluxFluxDBConnection = (props: Props) => {
         errors.token = 'Token is required';
       }
       setFieldErrors(errors);
-      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
-      if (!errors.organization) {
-        validation.clearError('organization');
-      }
-      if (!errors.defaultBucket) {
-        validation.clearError('defaultBucket');
-      }
-      if (!errors.token) {
-        validation.clearError('token');
-      }
       return Object.keys(errors).length === 0;
     });
   }, [jsonData.organization, jsonData.defaultBucket, tokenConfigured, tokenEntered, validation]);

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 
 import { InfluxInfluxQLDBConnection } from './InfluxInfluxQLDBConnection';
-import { createTestProps } from './helpers';
+import { createMockValidation, createTestProps } from './helpers';
 
 describe('InfluxInfluxQLDBConnection', () => {
   const onOptionsChangeMock = jest.fn();
@@ -40,5 +40,43 @@ describe('InfluxInfluxQLDBConnection', () => {
     fireEvent.change(screen.getByLabelText(/User/i), { target: { value: 'newuser' } });
 
     expect(onOptionsChangeMock).toHaveBeenCalled();
+  });
+
+  describe('validation', () => {
+    const emptyProps = createTestProps({
+      options: {
+        user: '',
+        jsonData: { dbName: '' },
+        secureJsonData: { password: '' },
+        secureJsonFields: { password: false },
+      },
+      mocks: { onOptionsChange: jest.fn() },
+    });
+
+    it('shows inline errors for all required fields when validator is called with empty values', async () => {
+      const validation = createMockValidation();
+      render(<InfluxInfluxQLDBConnection {...emptyProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.getByText('Database is required')).toBeInTheDocument();
+      expect(screen.getByText('User is required')).toBeInTheDocument();
+      expect(screen.getByText('Password is required')).toBeInTheDocument();
+    });
+
+    it('shows no errors when all fields are filled', async () => {
+      const validation = createMockValidation();
+      render(<InfluxInfluxQLDBConnection {...defaultProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.queryByText('Database is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('User is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Password is required')).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceOption,
@@ -14,11 +16,68 @@ import {
 import { type Props } from './types';
 
 export const InfluxInfluxQLDBConnection = (props: Props) => {
-  const { options } = props;
+  const { options, validation } = props;
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const passwordConfigured = Boolean(options.secureJsonFields?.password);
+  const passwordEntered = Boolean(options.secureJsonData?.password);
+
+  useEffect(() => {
+    if (!validation) {
+      return;
+    }
+    if (options.jsonData.dbName) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.dbName;
+        return next;
+      });
+      validation.clearError('dbName');
+    }
+    if (options.user) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.user;
+        return next;
+      });
+      validation.clearError('user');
+    }
+    if (passwordConfigured || passwordEntered) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.password;
+        return next;
+      });
+      validation.clearError('password');
+    }
+    return validation.registerValidation(() => {
+      const errors: Record<string, string> = {};
+      if (!options.jsonData.dbName) {
+        errors.dbName = 'Database is required';
+      }
+      if (!options.user) {
+        errors.user = 'User is required';
+      }
+      if (!passwordConfigured && !passwordEntered) {
+        errors.password = 'Password is required';
+      }
+      setFieldErrors(errors);
+      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
+      if (!errors.dbName) {
+        validation.clearError('dbName');
+      }
+      if (!errors.user) {
+        validation.clearError('user');
+      }
+      if (!errors.password) {
+        validation.clearError('password');
+      }
+      return Object.keys(errors).length === 0;
+    });
+  }, [options.jsonData.dbName, options.user, passwordConfigured, passwordEntered, validation]);
 
   return (
     <Box width="50%">
-      <Field label="Database" required noMargin>
+      <Field label="Database" required noMargin invalid={!!fieldErrors.dbName} error={fieldErrors.dbName}>
         <Input
           id="database"
           placeholder="mydb"
@@ -28,7 +87,7 @@ export const InfluxInfluxQLDBConnection = (props: Props) => {
         />
       </Field>
       <Space v={2} />
-      <Field label="User" required noMargin>
+      <Field label="User" required noMargin invalid={!!fieldErrors.user} error={fieldErrors.user}>
         <Input
           id="user"
           placeholder="myuser"
@@ -38,10 +97,10 @@ export const InfluxInfluxQLDBConnection = (props: Props) => {
         />
       </Field>
       <Space v={2} />
-      <Field label="Password" required noMargin>
+      <Field label="Password" required noMargin invalid={!!fieldErrors.password} error={fieldErrors.password}>
         <SecretInput
           id="password"
-          isConfigured={Boolean(options.secureJsonFields && options.secureJsonFields.password)}
+          isConfigured={passwordConfigured}
           value={options.secureJsonData?.password || ''}
           onReset={() => updateDatasourcePluginResetOption(props, 'password')}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'password')}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
@@ -26,27 +26,15 @@ export const InfluxInfluxQLDBConnection = (props: Props) => {
       return;
     }
     if (options.jsonData.dbName) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.dbName;
-        return next;
-      });
+      setFieldErrors(({ dbName: _, ...rest }) => rest);
       validation.clearError('dbName');
     }
     if (options.user) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.user;
-        return next;
-      });
+      setFieldErrors(({ user: _, ...rest }) => rest);
       validation.clearError('user');
     }
     if (passwordConfigured || passwordEntered) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.password;
-        return next;
-      });
+      setFieldErrors(({ password: _, ...rest }) => rest);
       validation.clearError('password');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
@@ -1,3 +1,4 @@
+import { omit } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import {
@@ -26,15 +27,15 @@ export const InfluxInfluxQLDBConnection = (props: Props) => {
       return;
     }
     if (options.jsonData.dbName) {
-      setFieldErrors(({ dbName: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'dbName'));
       validation.clearError('dbName');
     }
     if (options.user) {
-      setFieldErrors(({ user: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'user'));
       validation.clearError('user');
     }
     if (passwordConfigured || passwordEntered) {
-      setFieldErrors(({ password: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'password'));
       validation.clearError('password');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxInfluxQLDBConnection.tsx
@@ -28,15 +28,12 @@ export const InfluxInfluxQLDBConnection = (props: Props) => {
     }
     if (options.jsonData.dbName) {
       setFieldErrors((prev) => omit(prev, 'dbName'));
-      validation.clearError('dbName');
     }
     if (options.user) {
       setFieldErrors((prev) => omit(prev, 'user'));
-      validation.clearError('user');
     }
     if (passwordConfigured || passwordEntered) {
       setFieldErrors((prev) => omit(prev, 'password'));
-      validation.clearError('password');
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
@@ -50,16 +47,6 @@ export const InfluxInfluxQLDBConnection = (props: Props) => {
         errors.password = 'Password is required';
       }
       setFieldErrors(errors);
-      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
-      if (!errors.dbName) {
-        validation.clearError('dbName');
-      }
-      if (!errors.user) {
-        validation.clearError('user');
-      }
-      if (!errors.password) {
-        validation.clearError('password');
-      }
       return Object.keys(errors).length === 0;
     });
   }, [options.jsonData.dbName, options.user, passwordConfigured, passwordEntered, validation]);

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 
 import { InfluxSQLDBConnection } from './InfluxSQLDBConnection';
-import { createTestProps } from './helpers';
+import { createMockValidation, createTestProps } from './helpers';
 
 describe('InfluxSQLDBConnection', () => {
   const onOptionsChangeMock = jest.fn();
@@ -35,5 +35,40 @@ describe('InfluxSQLDBConnection', () => {
     render(<InfluxSQLDBConnection {...defaultProps} />);
     fireEvent.change(screen.getByLabelText(/Database/i), { target: { value: 'newdb' } });
     expect(onOptionsChangeMock).toHaveBeenCalled();
+  });
+
+  describe('validation', () => {
+    const emptyProps = createTestProps({
+      options: {
+        jsonData: { dbName: '' },
+        secureJsonData: { token: '' },
+        secureJsonFields: { token: false },
+      },
+      mocks: { onOptionsChange: jest.fn() },
+    });
+
+    it('shows inline errors for all required fields when validator is called with empty values', async () => {
+      const validation = createMockValidation();
+      render(<InfluxSQLDBConnection {...emptyProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.getByText('Database is required')).toBeInTheDocument();
+      expect(screen.getByText('Token is required')).toBeInTheDocument();
+    });
+
+    it('shows no errors when all fields are filled', async () => {
+      const validation = createMockValidation();
+      render(<InfluxSQLDBConnection {...defaultProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.queryByText('Database is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Token is required')).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceSecureJsonDataOption,
@@ -12,12 +14,55 @@ import {
 import { type Props } from './types';
 
 export const InfluxSQLDBConnection = (props: Props) => {
-  const { options } = props;
+  const { options, validation } = props;
   const { secureJsonData, secureJsonFields } = options;
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const tokenConfigured = Boolean(secureJsonFields?.token);
+  const tokenEntered = Boolean(secureJsonData?.token);
+
+  useEffect(() => {
+    if (!validation) {
+      return;
+    }
+    if (options.jsonData.dbName) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.dbName;
+        return next;
+      });
+      validation.clearError('dbName');
+    }
+    if (tokenConfigured || tokenEntered) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.token;
+        return next;
+      });
+      validation.clearError('token');
+    }
+    return validation.registerValidation(() => {
+      const errors: Record<string, string> = {};
+      if (!options.jsonData.dbName) {
+        errors.dbName = 'Database is required';
+      }
+      if (!tokenConfigured && !tokenEntered) {
+        errors.token = 'Token is required';
+      }
+      setFieldErrors(errors);
+      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
+      if (!errors.dbName) {
+        validation.clearError('dbName');
+      }
+      if (!errors.token) {
+        validation.clearError('token');
+      }
+      return Object.keys(errors).length === 0;
+    });
+  }, [options.jsonData.dbName, tokenConfigured, tokenEntered, validation]);
 
   return (
     <Box width="50%">
-      <Field label="Database" required noMargin>
+      <Field label="Database" required noMargin invalid={!!fieldErrors.dbName} error={fieldErrors.dbName}>
         <Input
           id="database"
           placeholder="mydb"
@@ -27,10 +72,10 @@ export const InfluxSQLDBConnection = (props: Props) => {
         />
       </Field>
       <Space v={2} />
-      <Field label="Token" required noMargin>
+      <Field label="Token" required noMargin invalid={!!fieldErrors.token} error={fieldErrors.token}>
         <SecretInput
           id="token"
-          isConfigured={Boolean(secureJsonFields && secureJsonFields.token)}
+          isConfigured={tokenConfigured}
           onBlur={trackInfluxDBConfigV2SQLDBDetailsTokenInputField}
           onChange={onUpdateDatasourceSecureJsonDataOption(props, 'token')}
           onReset={() => updateDatasourcePluginResetOption(props, 'token')}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
@@ -25,19 +25,11 @@ export const InfluxSQLDBConnection = (props: Props) => {
       return;
     }
     if (options.jsonData.dbName) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.dbName;
-        return next;
-      });
+      setFieldErrors(({ dbName: _, ...rest }) => rest);
       validation.clearError('dbName');
     }
     if (tokenConfigured || tokenEntered) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.token;
-        return next;
-      });
+      setFieldErrors(({ token: _, ...rest }) => rest);
       validation.clearError('token');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
@@ -27,11 +27,9 @@ export const InfluxSQLDBConnection = (props: Props) => {
     }
     if (options.jsonData.dbName) {
       setFieldErrors((prev) => omit(prev, 'dbName'));
-      validation.clearError('dbName');
     }
     if (tokenConfigured || tokenEntered) {
       setFieldErrors((prev) => omit(prev, 'token'));
-      validation.clearError('token');
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
@@ -42,13 +40,6 @@ export const InfluxSQLDBConnection = (props: Props) => {
         errors.token = 'Token is required';
       }
       setFieldErrors(errors);
-      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
-      if (!errors.dbName) {
-        validation.clearError('dbName');
-      }
-      if (!errors.token) {
-        validation.clearError('token');
-      }
       return Object.keys(errors).length === 0;
     });
   }, [options.jsonData.dbName, tokenConfigured, tokenEntered, validation]);

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/InfluxSQLDBConnection.tsx
@@ -1,3 +1,4 @@
+import { omit } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import {
@@ -25,11 +26,11 @@ export const InfluxSQLDBConnection = (props: Props) => {
       return;
     }
     if (options.jsonData.dbName) {
-      setFieldErrors(({ dbName: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'dbName'));
       validation.clearError('dbName');
     }
     if (tokenConfigured || tokenEntered) {
-      setFieldErrors(({ token: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'token'));
       validation.clearError('token');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
@@ -7,7 +7,7 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => backendSrv,
 }));
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { of } from 'rxjs';
 
 import { type BackendSrv } from '@grafana/runtime';
@@ -15,7 +15,7 @@ import { type BackendSrv } from '@grafana/runtime';
 import { InfluxVersion } from '../../../types';
 
 import { UrlAndAuthenticationSection } from './UrlAndAuthenticationSection';
-import { createTestProps } from './helpers';
+import { createMockValidation, createTestProps } from './helpers';
 
 describe('UrlAndAuthenticationSection', () => {
   const onOptionsChangeMock = jest.fn();
@@ -350,6 +350,54 @@ describe('UrlAndAuthenticationSection', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('validation', () => {
+    const emptyProps = createTestProps({
+      options: {
+        url: '',
+        jsonData: { product: '', version: '' },
+        secureJsonData: {},
+        secureJsonFields: {},
+      },
+      mocks: { onOptionsChange: jest.fn() },
+    });
+
+    const filledProps = createTestProps({
+      options: {
+        url: 'http://localhost:8086',
+        jsonData: { product: 'InfluxDB OSS 2.x', version: InfluxVersion.Flux },
+        secureJsonData: {},
+        secureJsonFields: {},
+      },
+      mocks: { onOptionsChange: jest.fn() },
+    });
+
+    it('shows inline errors for url, product and version when validator is called with empty values', async () => {
+      const validation = createMockValidation();
+      render(<UrlAndAuthenticationSection {...emptyProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.getByText('URL is required')).toBeInTheDocument();
+      expect(screen.getByText('Product is required')).toBeInTheDocument();
+      expect(screen.getByText('Query language is required')).toBeInTheDocument();
+    });
+
+    it('shows no errors when all fields are filled', async () => {
+      const validation = createMockValidation();
+      render(<UrlAndAuthenticationSection {...filledProps} validation={validation} />);
+
+      await act(async () => {
+        validation.runValidator();
+      });
+
+      expect(screen.queryByText('URL is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Product is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Query language is required')).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
 import { firstValueFrom } from 'rxjs';
 
 import { onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption } from '@grafana/data';
@@ -37,8 +38,64 @@ const getQueryLanguageOptions = (productName: string): Array<{ value: string }> 
 };
 
 export const UrlAndAuthenticationSection = (props: Props) => {
-  const { options, onOptionsChange } = props;
+  const { options, onOptionsChange, validation } = props;
   const styles = useStyles2(getStyles);
+
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!validation) {
+      return;
+    }
+    if (options.url) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.url;
+        return next;
+      });
+      validation.clearError('url');
+    }
+    if (options.jsonData.product) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.product;
+        return next;
+      });
+      validation.clearError('product');
+    }
+    if (options.jsonData.version) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next.version;
+        return next;
+      });
+      validation.clearError('version');
+    }
+    return validation.registerValidation(() => {
+      const errors: Record<string, string> = {};
+      if (!options.url) {
+        errors.url = 'URL is required';
+      }
+      if (!options.jsonData.product) {
+        errors.product = 'Product is required';
+      }
+      if (!options.jsonData.version) {
+        errors.version = 'Query language is required';
+      }
+      setFieldErrors(errors);
+      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
+      if (!errors.url) {
+        validation.clearError('url');
+      }
+      if (!errors.product) {
+        validation.clearError('product');
+      }
+      if (!errors.version) {
+        validation.clearError('version');
+      }
+      return Object.keys(errors).length === 0;
+    });
+  }, [options.url, options.jsonData.product, options.jsonData.version, validation]);
 
   const isInfluxVersion = (v: string): v is InfluxVersion =>
     typeof v === 'string' && (v === InfluxVersion.Flux || v === InfluxVersion.InfluxQL || v === InfluxVersion.SQL);
@@ -178,7 +235,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
           </TextLink>
         </Text>
         <Box direction="column" marginTop={3}>
-          <Field label="URL" noMargin required>
+          <Field label="URL" noMargin required invalid={!!fieldErrors.url} error={fieldErrors.url}>
             <Input
               data-testid="influxdb-v2-config-url-input"
               placeholder="example: http://localhost:8086/"
@@ -213,6 +270,8 @@ export const UrlAndAuthenticationSection = (props: Props) => {
                     }
                     noMargin
                     required
+                    invalid={!!fieldErrors.product}
+                    error={fieldErrors.product}
                   >
                     <Combobox
                       data-testid="influxdb-v2-config-product-select"
@@ -230,6 +289,8 @@ export const UrlAndAuthenticationSection = (props: Props) => {
                     description={<div className={styles.dropdown}>The query language depends on product selection</div>}
                     noMargin
                     required
+                    invalid={!!fieldErrors.version}
+                    error={fieldErrors.version}
                   >
                     <Combobox
                       data-testid="influxdb-v2-config-query-language-select"

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -48,27 +48,15 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       return;
     }
     if (options.url) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.url;
-        return next;
-      });
+      setFieldErrors(({ url: _, ...rest }) => rest);
       validation.clearError('url');
     }
     if (options.jsonData.product) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.product;
-        return next;
-      });
+      setFieldErrors(({ product: _, ...rest }) => rest);
       validation.clearError('product');
     }
     if (options.jsonData.version) {
-      setFieldErrors((prev) => {
-        const next = { ...prev };
-        delete next.version;
-        return next;
-      });
+      setFieldErrors(({ version: _, ...rest }) => rest);
       validation.clearError('version');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -50,15 +50,12 @@ export const UrlAndAuthenticationSection = (props: Props) => {
     }
     if (options.url) {
       setFieldErrors((prev) => omit(prev, 'url'));
-      validation.clearError('url');
     }
     if (options.jsonData.product) {
       setFieldErrors((prev) => omit(prev, 'product'));
-      validation.clearError('product');
     }
     if (options.jsonData.version) {
       setFieldErrors((prev) => omit(prev, 'version'));
-      validation.clearError('version');
     }
     return validation.registerValidation(() => {
       const errors: Record<string, string> = {};
@@ -72,16 +69,6 @@ export const UrlAndAuthenticationSection = (props: Props) => {
         errors.version = 'Query language is required';
       }
       setFieldErrors(errors);
-      Object.entries(errors).forEach(([field, msg]) => validation.setError(field, msg));
-      if (!errors.url) {
-        validation.clearError('url');
-      }
-      if (!errors.product) {
-        validation.clearError('product');
-      }
-      if (!errors.version) {
-        validation.clearError('version');
-      }
       return Object.keys(errors).length === 0;
     });
   }, [options.url, options.jsonData.product, options.jsonData.version, validation]);

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { omit } from 'lodash';
 import { useEffect, useState } from 'react';
 import { firstValueFrom } from 'rxjs';
 
@@ -48,15 +49,15 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       return;
     }
     if (options.url) {
-      setFieldErrors(({ url: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'url'));
       validation.clearError('url');
     }
     if (options.jsonData.product) {
-      setFieldErrors(({ product: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'product'));
       validation.clearError('product');
     }
     if (options.jsonData.version) {
-      setFieldErrors(({ version: _, ...rest }) => rest);
+      setFieldErrors((prev) => omit(prev, 'version'));
       validation.clearError('version');
     }
     return validation.registerValidation(() => {

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/helpers.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/helpers.ts
@@ -1,3 +1,26 @@
+import { type DataSourceConfigValidationAPI } from '@grafana/data';
+
+/**
+ * Creates a mock ValidationAPI for use in tests. Captures the registered
+ * validator so tests can invoke it directly and assert on inline error display.
+ */
+export const createMockValidation = () => {
+  let registeredValidator: (() => boolean | Promise<boolean>) | null = null;
+  const api: DataSourceConfigValidationAPI & { runValidator: () => boolean | Promise<boolean> } = {
+    registerValidation: jest.fn((fn) => {
+      registeredValidator = fn;
+      return () => {};
+    }),
+    validate: jest.fn(async () => true),
+    isValid: jest.fn(() => true),
+    getErrors: jest.fn(() => ({})),
+    setError: jest.fn(),
+    clearError: jest.fn(),
+    runValidator: () => registeredValidator?.() ?? true,
+  };
+  return api;
+};
+
 /**
  * Creates a set of test props for the InfluxDB V2 config page for use in tests.
  * This function allows you to override default properties for specific test cases.


### PR DESCRIPTION
- [x] Depends on #122733 - DONE

Adds InfluxDB v2 config validation behind the `influxDBConfigValidation` feature toggle. When enabled, the following fields are validated on save and show inline errors:
   - URL, Product, Query language (`UrlAndAuthenticationSection`)
   - Organization, Default bucket, Token (`InfluxFluxDBConnection`)
   - Database, User, Password (`InfluxInfluxQLDBConnection`)
   - Database, Token (`InfluxSQLDBConnection`)

   Secret fields (token/password) are only required when not already saved (`secureJsonFields` is false and no new value is entered).

### Notes

- To test this PR the feature toggle `influxDBConfigValidation` needs to be set to true
- When `influxDBConfigValidation = false` (default), behaviour is unchanged — `validation` is `undefined`, no validators register, save proceeds as before.
- Validation only applies to the v2 config editor (`newInfluxDSConfigPageDesign = true`).


https://github.com/user-attachments/assets/8cb6b2f9-468b-4d9b-b655-cd08000eca6f
