### PR TITLE
APIServer: Lowercase manifest plural in registerStorageOptions

### DIFF
--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -270,7 +271,7 @@ func registerStorageOptions(
 			}
 			gr := schema.GroupResource{
 				Group:    md.Group,
-				Resource: k.Plural,
+				Resource: strings.ToLower(k.Plural),
 			}
 			if _, done := registered[gr.String()]; done {
 				continue


### PR DESCRIPTION
**What is this feature?**

Fixes `registerStorageOptions` to lowercase the manifest's `Plural` field before constructing the `GroupResource` used to call `GetStorageOptions`.

**Why do we need this feature?**

App manifests define plural names in PascalCase (e.g. `RuleChains`, `AlertRules`), but k8s resources and the schema codegen use lowercase (`rulechains`, `alertrules`). `registerStorageOptions` passes the manifest's casing verbatim into the `GroupResource`, so when a `StorageOptionsProvider` compares against the lowercase `GroupResource` from the schema, it never matches. This silently prevents storage options (like folder support) from being applied.

**Who is this feature for?**

App developers implementing `StorageOptionsProvider` for unified-storage-only resources.

**Which issue(s) does this PR fix?**:

N/A (found while implementing `StorageOptionsProvider` for the alerting RuleChain resource)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.