### PR TITLE
Browse dashboards: Fix delete modal affected counts

### DIFF
--- a/packages/grafana-test-utils/src/handlers/api/folders/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/api/folders/handlers.ts
@@ -134,8 +134,11 @@ const getMockFolderCounts = (folders: number, dashboards: number, library_elemen
   };
 };
 
+export const customFolderCountsHandler = (resolver: HttpResponseResolver) =>
+  http.get('/api/folders/:uid/counts', resolver);
+
 const folderCountsHandler = () =>
-  http.get<{ uid: string }, { title: string; version: number }>('/api/folders/:uid/counts', async ({ params }) => {
+  customFolderCountsHandler(async ({ params }) => {
     const { uid } = params;
     const folder = mockTree.find((v) => v.item.uid === uid);
 

--- a/packages/grafana-test-utils/src/handlers/api/folders/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/api/folders/handlers.ts
@@ -125,12 +125,12 @@ const saveFolderHandler = () =>
     return HttpResponse.json({ ...folder.item, title: body.title });
   });
 
-const getMockFolderCounts = (folder: number, dashboard: number, librarypanel: number, alertrule: number) => {
+const getMockFolderCounts = (folders: number, dashboards: number, library_elements: number, alertrules: number) => {
   return {
-    folder,
-    dashboard,
-    librarypanel,
-    alertrule,
+    folders,
+    dashboards,
+    library_elements,
+    alertrules,
   };
 };
 

--- a/packages/grafana-test-utils/src/unstable.ts
+++ b/packages/grafana-test-utils/src/unstable.ts
@@ -13,7 +13,7 @@ export { default as allHandlers } from './handlers/all-handlers';
 export { default as scopeHandlers } from './handlers/apis/scope.grafana.app/v0alpha1/handlers';
 export { customCreateTeamHandler } from './handlers/api/teams/handlers';
 export { customSetTeamRolesHandler } from './handlers/api/access-control/handlers';
-export { customCreateFolderHandler } from './handlers/api/folders/handlers';
+export { customCreateFolderHandler, customFolderCountsHandler } from './handlers/api/folders/handlers';
 export { customCreateFolderHandler as customCreateFolderHandlerAppPlatform } from './handlers/apis/folder.grafana.app/v1beta1/handlers';
 
 export { setTestFlags, getTestFeatureFlagClient } from './utilities/featureFlags';

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -256,6 +256,27 @@ describe('browseDashboardsAPI', () => {
         alertrules: 5,
       });
     });
+
+    it('defaults missing descendant counts to zero', async () => {
+      const store = createTestStore();
+
+      server.use(customFolderCountsHandler(() => HttpResponse.json({ dashboards: 3 })));
+
+      const result = await store.dispatch(
+        browseDashboardsAPI.endpoints.getAffectedItems.initiate({
+          folderUIDs: ['folder-1'],
+          dashboardUIDs: ['dashboard-1', 'dashboard-2'],
+        })
+      );
+
+      expect(result.data).toEqual({
+        folders: 1,
+        dashboards: 5,
+        library_elements: 0,
+        alertrules: 0,
+      });
+      expect(result.data && Object.values(result.data).every(Number.isFinite)).toBe(true);
+    });
   });
 
   // RTK Query logs a console.error for void queryFn returning { data: undefined }.

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -188,6 +188,95 @@ describe('browseDashboardsAPI', () => {
     expect(deleteFolderSpy).toHaveBeenCalledTimes(1);
   });
 
+  describe('getAffectedItems', () => {
+    it('aggregates plural descendant count keys', async () => {
+      const store = createTestStore();
+
+      server.use(
+        http.get('/api/folders/folder-1/counts', () =>
+          HttpResponse.json({
+            folders: 2,
+            dashboards: 3,
+            library_elements: 4,
+            alertrules: 5,
+          })
+        ),
+        http.get('/api/folders/folder-2/counts', () =>
+          HttpResponse.json({
+            folders: 1,
+            dashboards: 2,
+            library_elements: 3,
+            alertrules: 4,
+          })
+        )
+      );
+
+      const result = await store.dispatch(
+        browseDashboardsAPI.endpoints.getAffectedItems.initiate({
+          folderUIDs: ['folder-1', 'folder-2'],
+          dashboardUIDs: ['dashboard-1'],
+        })
+      );
+
+      expect(result.data).toEqual({
+        folders: 5,
+        dashboards: 6,
+        library_elements: 7,
+        alertrules: 9,
+      });
+    });
+
+    it('falls back to legacy descendant count keys', async () => {
+      const store = createTestStore();
+
+      server.use(
+        http.get('/api/folders/folder-1/counts', () =>
+          HttpResponse.json({
+            folder: 2,
+            dashboard: 3,
+            librarypanel: 4,
+            alertrule: 5,
+          })
+        )
+      );
+
+      const result = await store.dispatch(
+        browseDashboardsAPI.endpoints.getAffectedItems.initiate({
+          folderUIDs: ['folder-1'],
+          dashboardUIDs: [],
+        })
+      );
+
+      expect(result.data).toEqual({
+        folders: 3,
+        dashboards: 3,
+        library_elements: 4,
+        alertrules: 5,
+      });
+    });
+
+    it('defaults missing descendant counts to zero', async () => {
+      const store = createTestStore();
+
+      server.use(http.get('/api/folders/folder-1/counts', () => HttpResponse.json({ dashboards: 3 })));
+
+      const result = await store.dispatch(
+        browseDashboardsAPI.endpoints.getAffectedItems.initiate({
+          folderUIDs: ['folder-1'],
+          dashboardUIDs: ['dashboard-1', 'dashboard-2'],
+        })
+      );
+
+      expect(result.data).toEqual({
+        folders: 1,
+        dashboards: 5,
+        library_elements: 0,
+        alertrules: 0,
+      });
+      expect(result.data && Object.values(result.data).every(Number.isFinite)).toBe(true);
+    });
+  });
+
   // RTK Query logs a console.error for void queryFn returning { data: undefined }.
   describe('deleteFolders', () => {
     let consoleErrorSpy: jest.SpyInstance;

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -256,27 +256,6 @@ describe('browseDashboardsAPI', () => {
         alertrules: 5,
       });
     });
-
-    it('defaults missing descendant counts to zero', async () => {
-      const store = createTestStore();
-
-      server.use(customFolderCountsHandler(() => HttpResponse.json({ dashboards: 3 })));
-
-      const result = await store.dispatch(
-        browseDashboardsAPI.endpoints.getAffectedItems.initiate({
-          folderUIDs: ['folder-1'],
-          dashboardUIDs: ['dashboard-1', 'dashboard-2'],
-        })
-      );
-
-      expect(result.data).toEqual({
-        folders: 1,
-        dashboards: 5,
-        library_elements: 0,
-        alertrules: 0,
-      });
-      expect(result.data && Object.values(result.data).every(Number.isFinite)).toBe(true);
-    });
   });
 
   // RTK Query logs a console.error for void queryFn returning { data: undefined }.

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -9,6 +9,7 @@ import { config, setBackendSrv } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import server, { setupMockServer } from '@grafana/test-utils/server';
+import { customFolderCountsHandler } from '@grafana/test-utils/unstable';
 import { folderAPIv1beta1 } from 'app/api/clients/folder/v1beta1';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -193,21 +194,22 @@ describe('browseDashboardsAPI', () => {
       const store = createTestStore();
 
       server.use(
-        http.get('/api/folders/folder-1/counts', () =>
-          HttpResponse.json({
-            folders: 2,
-            dashboards: 3,
-            library_elements: 4,
-            alertrules: 5,
-          })
-        ),
-        http.get('/api/folders/folder-2/counts', () =>
-          HttpResponse.json({
-            folders: 1,
-            dashboards: 2,
-            library_elements: 3,
-            alertrules: 4,
-          })
+        customFolderCountsHandler(({ params }) =>
+          HttpResponse.json(
+            params.uid === 'folder-1'
+              ? {
+                  folders: 2,
+                  dashboards: 3,
+                  library_elements: 4,
+                  alertrules: 5,
+                }
+              : {
+                  folders: 1,
+                  dashboards: 2,
+                  library_elements: 3,
+                  alertrules: 4,
+                }
+          )
         )
       );
 
@@ -230,7 +232,7 @@ describe('browseDashboardsAPI', () => {
       const store = createTestStore();
 
       server.use(
-        http.get('/api/folders/folder-1/counts', () =>
+        customFolderCountsHandler(() =>
           HttpResponse.json({
             folder: 2,
             dashboard: 3,
@@ -258,7 +260,7 @@ describe('browseDashboardsAPI', () => {
     it('defaults missing descendant counts to zero', async () => {
       const store = createTestStore();
 
-      server.use(http.get('/api/folders/folder-1/counts', () => HttpResponse.json({ dashboards: 3 })));
+      server.use(customFolderCountsHandler(() => HttpResponse.json({ dashboards: 3 })));
 
       const result = await store.dispatch(
         browseDashboardsAPI.endpoints.getAffectedItems.initiate({

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -79,6 +79,15 @@ interface RestoreDashboardArgs {
   dashboard: Resource<Dashboard | DashboardV2Spec>;
 }
 
+// We need to do this as the API will return different responses depending on the type of storage used, even though we
+// are using the old api/ endpoint.
+const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => ({
+  folders: folderCounts.folders ?? folderCounts.folder ?? 0,
+  dashboards: folderCounts.dashboards ?? folderCounts.dashboard ?? 0,
+  library_elements: folderCounts.library_elements ?? folderCounts.librarypanel ?? 0,
+  alertrules: folderCounts.alertrules ?? folderCounts.alertrule ?? 0,
+});
+
 export interface ListFolderQueryArgs {
   page: number;
   parentUid: string | undefined;
@@ -238,10 +247,11 @@ export const browseDashboardsAPI = createApi({
           };
 
           for (const folderCounts of results) {
-            totalCounts.folders += folderCounts.folder;
-            totalCounts.dashboards += folderCounts.dashboard;
-            totalCounts.alertrules += folderCounts.alertrule;
-            totalCounts.library_elements += folderCounts.librarypanel;
+            const normalizedCounts = normalizeDescendantCounts(folderCounts);
+            totalCounts.folders += normalizedCounts.folders;
+            totalCounts.dashboards += normalizedCounts.dashboards;
+            totalCounts.alertrules += normalizedCounts.alertrules;
+            totalCounts.library_elements += normalizedCounts.library_elements;
           }
 
           return { data: totalCounts };

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -79,25 +79,14 @@ interface RestoreDashboardArgs {
   dashboard: Resource<Dashboard | DashboardV2Spec>;
 }
 
-// We need to do this as the API will return different responses depending on the type of storage used, even though we
-// are using the old api/ endpoint.
-const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => {
-  if ('folders' in folderCounts) {
-    return {
-      folders: folderCounts.folders ?? 0,
-      dashboards: folderCounts.dashboards ?? 0,
-      library_elements: folderCounts.library_elements ?? 0,
-      alertrules: folderCounts.alertrules ?? 0,
-    };
-  } else {
-    return {
-      folders: folderCounts.folder ?? 0,
-      dashboards: folderCounts.dashboard ?? 0,
-      library_elements: folderCounts.librarypanel ?? 0,
-      alertrules: folderCounts.alertrule ?? 0,
-    };
-  }
-};
+// We need to do this as the API will return different responses depending on the type of storage used and existing
+// resource types, even when we are using the old api/ endpoint.
+const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => ({
+  folders: folderCounts.folders ?? folderCounts.folder ?? 0,
+  dashboards: folderCounts.dashboards ?? folderCounts.dashboard ?? 0,
+  library_elements: folderCounts.library_elements ?? folderCounts.librarypanel ?? 0,
+  alertrules: folderCounts.alertrules ?? folderCounts.alertrule ?? 0,
+});
 
 export interface ListFolderQueryArgs {
   page: number;

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -81,12 +81,23 @@ interface RestoreDashboardArgs {
 
 // We need to do this as the API will return different responses depending on the type of storage used, even though we
 // are using the old api/ endpoint.
-const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => ({
-  folders: folderCounts.folders ?? folderCounts.folder ?? 0,
-  dashboards: folderCounts.dashboards ?? folderCounts.dashboard ?? 0,
-  library_elements: folderCounts.library_elements ?? folderCounts.librarypanel ?? 0,
-  alertrules: folderCounts.alertrules ?? folderCounts.alertrule ?? 0,
-});
+const normalizeDescendantCounts = (folderCounts: DescendantCountDTO): DescendantCount => {
+  if ('folders' in folderCounts) {
+    return {
+      folders: folderCounts.folders ?? 0,
+      dashboards: folderCounts.dashboards ?? 0,
+      library_elements: folderCounts.library_elements ?? 0,
+      alertrules: folderCounts.alertrules ?? 0,
+    };
+  } else {
+    return {
+      folders: folderCounts.folder ?? 0,
+      dashboards: folderCounts.dashboard ?? 0,
+      library_elements: folderCounts.librarypanel ?? 0,
+      alertrules: folderCounts.alertrule ?? 0,
+    };
+  }
+};
 
 export interface ListFolderQueryArgs {
   page: number;

--- a/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.test.tsx
@@ -2,11 +2,21 @@ import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TestProvider } from 'test/helpers/TestProvider';
 
+import { setBackendSrv } from '@grafana/runtime';
+import { setupMockServer } from '@grafana/test-utils/server';
+import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { backendSrv } from 'app/core/services/backend_srv';
+
 import { DeleteModal, type Props } from './DeleteModal';
 
 function render(...[ui, options]: Parameters<typeof rtlRender>) {
   rtlRender(<TestProvider>{ui}</TestProvider>, options);
 }
+
+const [_, { folderA }] = getFolderFixtures();
+
+setBackendSrv(backendSrv);
+setupMockServer();
 
 describe('browse-dashboards DeleteModal', () => {
   const mockOnDismiss = jest.fn();
@@ -73,5 +83,25 @@ describe('browse-dashboards DeleteModal', () => {
 
     await userEvent.click(await screen.findByRole('button', { name: 'Close' }));
     expect(mockOnDismiss).toHaveBeenCalled();
+  });
+
+  it('shows a numeric affected item count for a single folder selection', async () => {
+    render(
+      <DeleteModal
+        {...defaultProps}
+        selectedItems={{
+          $all: false,
+          folder: {
+            [folderA.item.uid]: true,
+          },
+          dashboard: {},
+          panel: {},
+        }}
+      />
+    );
+
+    expect(await screen.findByText(/This action will delete the folder/i)).toBeInTheDocument();
+    expect(await screen.findByText(/5 item/)).toBeInTheDocument();
+    expect(screen.queryByText(/NaN item/)).not.toBeInTheDocument();
   });
 });

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -49,22 +49,20 @@ export interface FolderState {
 
 /**
  * API response from `/api/folders/${folderUID}/counts`
- * Supports both the current resource-style keys and older legacy aliases which depends on whether the unified storage
- * is used or not.
+ * Supports both the current resource-style keys and older legacy aliases, which depends on whether the unified storage
+ * is used or not. Also, the API does not exactly guarantee the shape or keys as it does it dynamically based on
+ * existing resource types.
  */
-export type DescendantCountDTO =
-  | {
-      folders: number;
-      dashboards: number;
-      library_elements: number;
-      alertrules: number;
-    }
-  | {
-      folder: number;
-      dashboard: number;
-      librarypanel: number;
-      alertrule: number;
-    };
+export interface DescendantCountDTO {
+  folders?: number;
+  dashboards?: number;
+  library_elements?: number;
+  alertrules?: number;
+  folder?: number;
+  dashboard?: number;
+  librarypanel?: number;
+  alertrule?: number;
+}
 
 type DescendantResource = 'folders' | 'dashboards' | 'library_elements' | 'alertrules';
 /** Summary of descendant counts by resource type, with keys matching the App Platform API response */

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -49,15 +49,22 @@ export interface FolderState {
 
 /**
  * API response from `/api/folders/${folderUID}/counts`
- * @deprecated The properties here are inconsistently named with App Platform API responses.
- * Avoid using this type as it will be removed after app platform folder migration is complete
+ * Supports both the current resource-style keys and older legacy aliases which depends on whether the unified storage
+ * is used or not.
  */
-export interface DescendantCountDTO {
-  folder: number;
-  dashboard: number;
-  librarypanel: number;
-  alertrule: number;
-}
+export type DescendantCountDTO =
+  | {
+      folders: number;
+      dashboards: number;
+      library_elements: number;
+      alertrules: number;
+    }
+  | {
+      folder: number;
+      dashboard: number;
+      librarypanel: number;
+      alertrule: number;
+    };
 
 type DescendantResource = 'folders' | 'dashboards' | 'library_elements' | 'alertrules';
 /** Summary of descendant counts by resource type, with keys matching the App Platform API response */

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4323,15 +4323,15 @@
     },
     "counts": {
       "alertRule_one": "{{count}} alert rule",
-      "alertRule_other": "{{count}} alert rule",
+      "alertRule_other": "{{count}} alert rules",
       "dashboard_one": "{{count}} dashboard",
-      "dashboard_other": "{{count}} dashboard",
+      "dashboard_other": "{{count}} dashboards",
       "folder_one": "{{count}} folder",
-      "folder_other": "{{count}} folder",
+      "folder_other": "{{count}} folders",
       "libraryPanel_one": "{{count}} library panel",
-      "libraryPanel_other": "{{count}} library panel",
+      "libraryPanel_other": "{{count}} library panels",
       "total_one": "{{count}} item",
-      "total_other": "{{count}} item"
+      "total_other": "{{count}} items"
     },
     "create-new": {
       "dashboard-group": "Dashboard"


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/122499
Will fix https://github.com/grafana/grafana/issues/122481 (with the caveat that there is separate issue with pluralization as a whole see https://raintank-corp.slack.com/archives/C025WTVRBSN/p1776318484686039?thread_ts=1776279599.434699&cid=C025WTVRBSN)

Seems like the `/api/folders/${folderUID}/counts` endpoint returns different shape depending on whether unified storage is used or not.