### PR TITLE
Alerting: Add field selector support to `AlertRule` and `RecordingRule` resources

### DIFF
--- a/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
@@ -73,13 +75,59 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid label selector for %s: %s", model.FolderLabelKey, err))
 	}
 
+	var (
+		titleFilter     provisioning.ListRuleStringFilter
+		pausedFilter    provisioning.ListRuleBoolFilter
+		dashboardFilter provisioning.ListRuleStringFilter
+		panelIDFilter   provisioning.ListRuleStringFilter
+	)
+	if opts.FieldSelector != nil && !opts.FieldSelector.Empty() {
+		for _, r := range opts.FieldSelector.Requirements() {
+			isEq := r.Operator == selection.Equals || r.Operator == selection.DoubleEquals
+			switch r.Field {
+			case "spec.title":
+				if !isEq {
+					return nil, k8serrors.NewBadRequest("unsupported operator for spec.title (only = supported)")
+				}
+				titleFilter.Include = []string{r.Value}
+			case "spec.paused":
+				if !isEq {
+					return nil, k8serrors.NewBadRequest("unsupported operator for spec.paused (only = supported)")
+				}
+				v, err := strconv.ParseBool(r.Value)
+				if err != nil {
+					return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid value for spec.paused: %s", r.Value))
+				}
+				pausedFilter.Value = &v
+			case "spec.panelRef.dashboardUID":
+				if !isEq {
+					return nil, k8serrors.NewBadRequest("unsupported operator for spec.panelRef.dashboardUID (only = supported)")
+				}
+				dashboardFilter.Include = []string{r.Value}
+			case "spec.panelRef.panelID":
+				if !isEq {
+					return nil, k8serrors.NewBadRequest("unsupported operator for spec.panelRef.panelID (only = supported)")
+				}
+				if _, err := strconv.ParseInt(r.Value, 10, 64); err != nil {
+					return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid value for spec.panelRef.panelID: %s", r.Value))
+				}
+				panelIDFilter.Include = []string{r.Value}
+			default:
+				return nil, k8serrors.NewBadRequest(fmt.Sprintf("unknown field selector: %s", r.Field))
+			}
+		}
+	}
+
 	rules, provenanceMap, continueToken, err := s.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
-		RuleType:      ngmodels.RuleTypeFilterAlerting,
-		Limit:         opts.Limit,
-		ContinueToken: opts.Continue,
-		GroupFilter:   groupFilter,
-		FolderFilter:  folderFilter,
-		// TODO: add field selectors for filtering
+		RuleType:        ngmodels.RuleTypeFilterAlerting,
+		Limit:           opts.Limit,
+		ContinueToken:   opts.Continue,
+		GroupFilter:     groupFilter,
+		FolderFilter:    folderFilter,
+		TitleFilter:     titleFilter,
+		PausedFilter:    pausedFilter,
+		DashboardFilter: dashboardFilter,
+		PanelIDFilter:   panelIDFilter,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
@@ -19,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -74,13 +76,42 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid label selector for %s: %s", model.FolderLabelKey, err))
 	}
 
+	var (
+		titleFilter  provisioning.ListRuleStringFilter
+		pausedFilter provisioning.ListRuleBoolFilter
+	)
+	if opts.FieldSelector != nil && !opts.FieldSelector.Empty() {
+		for _, r := range opts.FieldSelector.Requirements() {
+			isEq := r.Operator == selection.Equals || r.Operator == selection.DoubleEquals
+			switch r.Field {
+			case "spec.title":
+				if !isEq {
+					return nil, k8serrors.NewBadRequest("unsupported operator for spec.title (only = supported)")
+				}
+				titleFilter.Include = []string{r.Value}
+			case "spec.paused":
+				if !isEq {
+					return nil, k8serrors.NewBadRequest("unsupported operator for spec.paused (only = supported)")
+				}
+				v, err := strconv.ParseBool(r.Value)
+				if err != nil {
+					return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid value for spec.paused: %s", r.Value))
+				}
+				pausedFilter.Value = &v
+			default:
+				return nil, k8serrors.NewBadRequest(fmt.Sprintf("unknown field selector: %s", r.Field))
+			}
+		}
+	}
+
 	rules, provenanceMap, continueToken, err := s.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
 		RuleType:      ngmodels.RuleTypeFilterRecording,
 		Limit:         opts.Limit,
 		ContinueToken: opts.Continue,
 		GroupFilter:   groupFilter,
 		FolderFilter:  folderFilter,
-		// TODO: add field selectors for filtering
+		TitleFilter:   titleFilter,
+		PausedFilter:  pausedFilter,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -1060,6 +1060,13 @@ type ListAlertRulesQuery struct {
 	DashboardUID string
 	PanelID      int64
 
+	// IsPaused filters rules by their paused state.
+	// nil means no filter; true means only paused rules; false means only non-paused rules.
+	IsPaused *bool
+	// TitleExact filters rules to those with an exact title match (case-sensitive).
+	// Empty string means no filter.
+	TitleExact string
+
 	ReceiverName     string
 	TimeIntervalName string
 

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
@@ -93,22 +94,34 @@ type ListRuleBoolFilter struct {
 }
 
 type ListAlertRulesOptions struct {
-	RuleType      models.RuleTypeFilter
-	Limit         int64
-	ContinueToken string
-	GroupFilter   ListRuleStringFilter
-	FolderFilter  ListRuleStringFilter
+	RuleType        models.RuleTypeFilter
+	Limit           int64
+	ContinueToken   string
+	GroupFilter     ListRuleStringFilter
+	FolderFilter    ListRuleStringFilter
+	TitleFilter     ListRuleStringFilter
+	PausedFilter    ListRuleBoolFilter
+	DashboardFilter ListRuleStringFilter
+	PanelIDFilter   ListRuleStringFilter
 	// TODO: add the following filters
-	// title filter - string
-	// paused filter - bool
-	// dashboard filter - string
-	// panel filter - string
 	// receiver filter - string
 	// metric filter - string
 	// targetDatasourceUID filter - string
 }
 
 func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identity.Requester, opts ListAlertRulesOptions) (rules []*models.AlertRule, provenances map[string]models.Provenance, nextToken string, err error) {
+	titleExact := ""
+	if len(opts.TitleFilter.Include) > 0 {
+		titleExact = opts.TitleFilter.Include[0]
+	}
+	dashboardUID := ""
+	if len(opts.DashboardFilter.Include) > 0 {
+		dashboardUID = opts.DashboardFilter.Include[0]
+	}
+	panelID := int64(0)
+	if len(opts.PanelIDFilter.Include) > 0 {
+		panelID, _ = strconv.ParseInt(opts.PanelIDFilter.Include[0], 10, 64)
+	}
 	q := models.ListAlertRulesExtendedQuery{
 		ListAlertRulesQuery: models.ListAlertRulesQuery{
 			OrgID:                user.GetOrgID(),
@@ -116,6 +129,10 @@ func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identi
 			ExcludeRuleGroups:    opts.GroupFilter.Exclude,
 			RuleGroupExists:      opts.GroupFilter.Exists,
 			ExcludeNamespaceUIDs: opts.FolderFilter.Exclude,
+			TitleExact:           titleExact,
+			IsPaused:             opts.PausedFilter.Value,
+			DashboardUID:         dashboardUID,
+			PanelID:              panelID,
 		},
 		RuleType:      opts.RuleType,
 		Limit:         opts.Limit,

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -2085,6 +2085,135 @@ func TestListAlertRules(t *testing.T) {
 			require.ElementsMatch(t, expected, got)
 		})
 	})
+
+	t.Run("TitleFilter", func(t *testing.T) {
+		matchTitle := "exact-match-title"
+		matchRules := gen.With(gen.WithGroupKey(groupKey1), gen.WithUniqueGroupIndex(), gen.WithTitle(matchTitle)).GenerateManyRef(2)
+		otherRules := gen.With(gen.WithGroupKey(groupKey2), gen.WithUniqueGroupIndex()).GenerateManyRef(3)
+
+		initWithTitleData := func(t *testing.T) (*AlertRuleService, *fakeRuleAccessControlService) {
+			service, ruleStore, _, ac := initService(t)
+			service.folderService = fs
+			ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+			return service, ac
+		}
+
+		t.Run("Include should return only rules with the exact title", func(t *testing.T) {
+			service, _ := initWithTitleData(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				TitleFilter: ListRuleStringFilter{Include: []string{matchTitle}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.Equal(t, matchTitle, r.Title)
+			}
+		})
+	})
+
+	t.Run("PausedFilter", func(t *testing.T) {
+		pausedRules := gen.With(gen.WithGroupKey(groupKey1), gen.WithUniqueGroupIndex(), gen.WithIsPaused(true)).GenerateManyRef(2)
+		activeRules := gen.With(gen.WithGroupKey(groupKey2), gen.WithUniqueGroupIndex(), gen.WithIsPaused(false)).GenerateManyRef(3)
+
+		initWithPausedData := func(t *testing.T) (*AlertRuleService, *fakeRuleAccessControlService) {
+			service, ruleStore, _, ac := initService(t)
+			service.folderService = fs
+			ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(pausedRules, activeRules...)}
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+			return service, ac
+		}
+
+		t.Run("true should return only paused rules", func(t *testing.T) {
+			service, _ := initWithPausedData(t)
+			trueVal := true
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				PausedFilter: ListRuleBoolFilter{Value: &trueVal},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.True(t, r.IsPaused)
+			}
+		})
+
+		t.Run("false should return only non-paused rules", func(t *testing.T) {
+			service, _ := initWithPausedData(t)
+			falseVal := false
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				PausedFilter: ListRuleBoolFilter{Value: &falseVal},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.False(t, r.IsPaused)
+			}
+		})
+	})
+
+	t.Run("DashboardFilter", func(t *testing.T) {
+		dashUID := "dash-abc"
+		otherDashUID := "dash-xyz"
+		dashRules := gen.With(gen.WithGroupKey(groupKey1), gen.WithUniqueGroupIndex(), gen.WithDashboardAndPanel(&dashUID, nil)).GenerateManyRef(2)
+		otherRules := gen.With(gen.WithGroupKey(groupKey2), gen.WithUniqueGroupIndex(), gen.WithDashboardAndPanel(&otherDashUID, nil)).GenerateManyRef(3)
+
+		initWithDashData := func(t *testing.T) (*AlertRuleService, *fakeRuleAccessControlService) {
+			service, ruleStore, _, ac := initService(t)
+			service.folderService = fs
+			ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(dashRules, otherRules...)}
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+			return service, ac
+		}
+
+		t.Run("Include should return only rules with the exact dashboardUID", func(t *testing.T) {
+			service, _ := initWithDashData(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				DashboardFilter: ListRuleStringFilter{Include: []string{dashUID}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.Equal(t, dashUID, r.GetDashboardUID())
+			}
+		})
+	})
+
+	t.Run("PanelIDFilter", func(t *testing.T) {
+		panelID := int64(42)
+		panelIDStr := "42"
+		dashUID := "dash-for-panel"
+		panelRules := gen.With(gen.WithGroupKey(groupKey1), gen.WithUniqueGroupIndex(), gen.WithDashboardAndPanel(&dashUID, &panelID)).GenerateManyRef(2)
+		otherPanelID := int64(99)
+		otherRules := gen.With(gen.WithGroupKey(groupKey2), gen.WithUniqueGroupIndex(), gen.WithDashboardAndPanel(&dashUID, &otherPanelID)).GenerateManyRef(3)
+
+		initWithPanelData := func(t *testing.T) (*AlertRuleService, *fakeRuleAccessControlService) {
+			service, ruleStore, _, ac := initService(t)
+			service.folderService = fs
+			ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(panelRules, otherRules...)}
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+			return service, ac
+		}
+
+		t.Run("Include should return only rules with the exact panelID", func(t *testing.T) {
+			service, _ := initWithPanelData(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				PanelIDFilter: ListRuleStringFilter{Include: []string{panelIDStr}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.Equal(t, panelID, r.GetPanelID())
+			}
+		})
+	})
 }
 
 func TestGetAlertRules(t *testing.T) {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -1097,9 +1097,15 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 
 	if query.DashboardUID != "" {
 		q = q.Where("dashboard_uid = ?", query.DashboardUID)
-		if query.PanelID != 0 {
-			q = q.Where("panel_id = ?", query.PanelID)
-		}
+	}
+	if query.PanelID != 0 {
+		q = q.Where("panel_id = ?", query.PanelID)
+	}
+	if query.IsPaused != nil {
+		q = q.Where("is_paused = ?", *query.IsPaused)
+	}
+	if query.TitleExact != "" {
+		q = q.Where("title = ?", query.TitleExact)
 	}
 
 	if len(query.NamespaceUIDs) > 0 {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -3257,6 +3257,159 @@ func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
 		require.Len(t, result, 1)
 		require.Equal(t, noGroupRule.UID, result[0].UID)
 	})
+
+	t.Run("TitleExact", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		matchTitle := "exact-title-match"
+		matchGen := ruleGen.With(ruleGen.WithTitle(matchTitle))
+		otherGen := ruleGen.With(ruleGen.WithUniqueTitle())
+
+		match1 := createRule(t, store, matchGen)
+		match2 := createRule(t, store, matchGen)
+		createRule(t, store, otherGen)
+		createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:      orgID,
+				TitleExact: matchTitle,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{match1.UID, match2.UID}, gotUIDs)
+	})
+
+	t.Run("IsPaused=true", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		pausedGen := ruleGen.With(ruleGen.WithIsPaused(true))
+		activeGen := ruleGen.With(ruleGen.WithIsPaused(false))
+
+		paused1 := createRule(t, store, pausedGen)
+		paused2 := createRule(t, store, pausedGen)
+		createRule(t, store, activeGen)
+		createRule(t, store, activeGen)
+
+		trueVal := true
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:    orgID,
+				IsPaused: &trueVal,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{paused1.UID, paused2.UID}, gotUIDs)
+	})
+
+	t.Run("IsPaused=false", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		pausedGen := ruleGen.With(ruleGen.WithIsPaused(true))
+		activeGen := ruleGen.With(ruleGen.WithIsPaused(false))
+
+		createRule(t, store, pausedGen)
+		createRule(t, store, pausedGen)
+		active1 := createRule(t, store, activeGen)
+		active2 := createRule(t, store, activeGen)
+
+		falseVal := false
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:    orgID,
+				IsPaused: &falseVal,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{active1.UID, active2.UID}, gotUIDs)
+	})
+
+	t.Run("DashboardUID", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		dashUID := "my-dashboard"
+		otherDashUID := "other-dashboard"
+		dashGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&dashUID, nil))
+		otherGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&otherDashUID, nil))
+
+		dash1 := createRule(t, store, dashGen)
+		dash2 := createRule(t, store, dashGen)
+		createRule(t, store, otherGen)
+		createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:        orgID,
+				DashboardUID: dashUID,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{dash1.UID, dash2.UID}, gotUIDs)
+	})
+
+	t.Run("PanelID independent of DashboardUID", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		dashUID := "dash-for-panel"
+		panelID := int64(42)
+		otherPanelID := int64(99)
+		panelGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&dashUID, &panelID))
+		otherGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&dashUID, &otherPanelID))
+
+		panel1 := createRule(t, store, panelGen)
+		panel2 := createRule(t, store, panelGen)
+		createRule(t, store, otherGen)
+		createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:   orgID,
+				PanelID: panelID,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{panel1.UID, panel2.UID}, gotUIDs)
+	})
 }
 
 func TestIntegration_ListDeletedRules(t *testing.T) {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -326,24 +326,24 @@ func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQu
 	return f.listAlertRules(q)
 }
 
+//nolint:gocyclo // this function is intentionally not split to keep the logic in one place, making it easier to maintain the filtering logic in tests
 func (f *RuleStore) listAlertRules(q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
-	hasDashboard := func(r *models.AlertRule, dashboardUID string, panelID int64) bool {
-		if dashboardUID != "" {
-			if r.DashboardUID == nil || *r.DashboardUID != dashboardUID {
-				return false
-			}
-			if panelID > 0 {
-				if r.PanelID == nil || *r.PanelID != panelID {
-					return false
-				}
-			}
-		}
-		return true
-	}
-
 	ruleList := models.RulesGroup{}
 	for _, r := range f.Rules[q.OrgID] {
-		if !hasDashboard(r, q.DashboardUID, q.PanelID) {
+		if q.DashboardUID != "" {
+			if r.DashboardUID == nil || *r.DashboardUID != q.DashboardUID {
+				continue
+			}
+		}
+		if q.PanelID != 0 {
+			if r.PanelID == nil || *r.PanelID != q.PanelID {
+				continue
+			}
+		}
+		if q.IsPaused != nil && r.IsPaused != *q.IsPaused {
+			continue
+		}
+		if q.TitleExact != "" && r.Title != q.TitleExact {
 			continue
 		}
 		if len(q.NamespaceUIDs) > 0 && !slices.Contains(q.NamespaceUIDs, r.NamespaceUID) {

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -1022,3 +1022,179 @@ func TestIntegrationListWithLabelSelectors(t *testing.T) {
 		}
 	})
 }
+
+func TestIntegrationListWithFieldSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	client := common.NewAlertRuleClient(t, helper.Org1.Admin)
+
+	common.CreateTestFolder(t, helper, "fs-folder")
+
+	baseRule := func(folder string) *v0alpha1.AlertRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUniqueUID(),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return &v0alpha1.AlertRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Annotations: map[string]string{
+					"grafana.app/folder": folder,
+				},
+			},
+			Spec: v0alpha1.AlertRuleSpec{
+				Title: rule.Title,
+				Expressions: v0alpha1.AlertRuleExpressionMap{
+					"A": {
+						QueryType:     util.Pointer("query"),
+						DatasourceUID: util.Pointer(v0alpha1.AlertRuleDatasourceUID(rule.Data[0].DatasourceUID)),
+						Model:         rule.Data[0].Model,
+						Source:        util.Pointer(true),
+						RelativeTimeRange: &v0alpha1.AlertRuleRelativeTimeRange{
+							From: v0alpha1.AlertRulePromDurationWMillis("5m"),
+							To:   v0alpha1.AlertRulePromDurationWMillis("0s"),
+						},
+					},
+				},
+				Trigger: v0alpha1.AlertRuleIntervalTrigger{
+					Interval: v0alpha1.AlertRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
+				},
+				NoDataState:  v0alpha1.AlertRuleNoDataState(rule.NoDataState),
+				ExecErrState: v0alpha1.AlertRuleExecErrState(rule.ExecErrState),
+			},
+		}
+	}
+
+	t.Run("filter by spec.title", func(t *testing.T) {
+		r1 := baseRule("fs-folder")
+		r1.Spec.Title = "field-sel-title-unique-abc"
+		r2 := baseRule("fs-folder")
+
+		created1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		created2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, created1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, created2.Name, v1.DeleteOptions{})
+		})
+
+		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.title=field-sel-title-unique-abc"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		require.Equal(t, "field-sel-title-unique-abc", list.Items[0].Spec.Title)
+	})
+
+	t.Run("filter by spec.paused", func(t *testing.T) {
+		paused1 := baseRule("fs-folder")
+		paused1.Spec.Paused = util.Pointer(true)
+		paused2 := baseRule("fs-folder")
+		paused2.Spec.Paused = util.Pointer(true)
+		active1 := baseRule("fs-folder")
+		active2 := baseRule("fs-folder")
+
+		cp1, err := client.Create(ctx, paused1, v1.CreateOptions{})
+		require.NoError(t, err)
+		cp2, err := client.Create(ctx, paused2, v1.CreateOptions{})
+		require.NoError(t, err)
+		ca1, err := client.Create(ctx, active1, v1.CreateOptions{})
+		require.NoError(t, err)
+		ca2, err := client.Create(ctx, active2, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, cp1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, cp2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, ca1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, ca2.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("true returns only paused rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.paused=true",
+			})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.Paused)
+				require.True(t, *item.Spec.Paused)
+			}
+		})
+
+		t.Run("false returns only non-paused rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.paused=false",
+			})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.True(t, item.Spec.Paused == nil || !*item.Spec.Paused)
+			}
+		})
+	})
+
+	t.Run("filter by spec.panelRef.dashboardUID", func(t *testing.T) {
+		dashUID := "fs-dash-abc"
+		r1 := baseRule("fs-folder")
+		r1.Spec.PanelRef = &v0alpha1.AlertRulePanelRef{DashboardUID: dashUID, PanelID: 1}
+		r2 := baseRule("fs-folder")
+		r2.Spec.PanelRef = &v0alpha1.AlertRulePanelRef{DashboardUID: dashUID, PanelID: 2}
+		r3 := baseRule("fs-folder")
+		r3.Spec.PanelRef = &v0alpha1.AlertRulePanelRef{DashboardUID: "other-dash", PanelID: 1}
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.panelRef.dashboardUID=" + dashUID})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 2)
+		for _, item := range list.Items {
+			require.NotNil(t, item.Spec.PanelRef)
+			require.Equal(t, dashUID, item.Spec.PanelRef.DashboardUID)
+		}
+	})
+
+	t.Run("filter by spec.panelRef.panelID", func(t *testing.T) {
+		dashUID := "fs-dash-panel"
+		r1 := baseRule("fs-folder")
+		r1.Spec.PanelRef = &v0alpha1.AlertRulePanelRef{DashboardUID: dashUID, PanelID: 7}
+		r2 := baseRule("fs-folder")
+		r2.Spec.PanelRef = &v0alpha1.AlertRulePanelRef{DashboardUID: dashUID, PanelID: 7}
+		r3 := baseRule("fs-folder")
+		r3.Spec.PanelRef = &v0alpha1.AlertRulePanelRef{DashboardUID: dashUID, PanelID: 99}
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.panelRef.panelID=7"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 2)
+		for _, item := range list.Items {
+			require.NotNil(t, item.Spec.PanelRef)
+			require.Equal(t, int64(7), item.Spec.PanelRef.PanelID)
+		}
+	})
+}

--- a/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
+++ b/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
@@ -779,3 +779,119 @@ func TestIntegrationListWithLabelSelectors(t *testing.T) {
 		}
 	})
 }
+
+func TestIntegrationListWithFieldSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := common.GetTestHelper(t)
+	client := common.NewRecordingRuleClient(t, helper.Org1.Admin)
+
+	common.CreateTestFolder(t, helper, "rr-fs-folder")
+
+	baseRule := func(folder string) *v0alpha1.RecordingRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUniqueUID(),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithAllRecordingRules(),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return &v0alpha1.RecordingRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Annotations: map[string]string{
+					"grafana.app/folder": folder,
+				},
+			},
+			Spec: v0alpha1.RecordingRuleSpec{
+				Title:  rule.Title,
+				Metric: v0alpha1.RecordingRuleMetricName(rule.Record.Metric),
+				Expressions: v0alpha1.RecordingRuleExpressionMap{
+					"A": {
+						QueryType:     util.Pointer(rule.Data[0].QueryType),
+						DatasourceUID: util.Pointer(v0alpha1.RecordingRuleDatasourceUID(rule.Data[0].DatasourceUID)),
+						Model:         rule.Data[0].Model,
+						Source:        util.Pointer(true),
+						RelativeTimeRange: &v0alpha1.RecordingRuleRelativeTimeRange{
+							From: v0alpha1.RecordingRulePromDurationWMillis("5m"),
+							To:   v0alpha1.RecordingRulePromDurationWMillis("0s"),
+						},
+					},
+				},
+				Trigger: v0alpha1.RecordingRuleIntervalTrigger{
+					Interval: v0alpha1.RecordingRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
+				},
+			},
+		}
+	}
+
+	t.Run("filter by spec.title", func(t *testing.T) {
+		r1 := baseRule("rr-fs-folder")
+		r1.Spec.Title = "rr-field-sel-title-unique-xyz"
+		r2 := baseRule("rr-fs-folder")
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+		})
+
+		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.title=rr-field-sel-title-unique-xyz"})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		require.Equal(t, "rr-field-sel-title-unique-xyz", list.Items[0].Spec.Title)
+	})
+
+	t.Run("filter by spec.paused", func(t *testing.T) {
+		paused1 := baseRule("rr-fs-folder")
+		paused1.Spec.Paused = util.Pointer(true)
+		paused2 := baseRule("rr-fs-folder")
+		paused2.Spec.Paused = util.Pointer(true)
+		active1 := baseRule("rr-fs-folder")
+		active2 := baseRule("rr-fs-folder")
+
+		cp1, err := client.Create(ctx, paused1, v1.CreateOptions{})
+		require.NoError(t, err)
+		cp2, err := client.Create(ctx, paused2, v1.CreateOptions{})
+		require.NoError(t, err)
+		ca1, err := client.Create(ctx, active1, v1.CreateOptions{})
+		require.NoError(t, err)
+		ca2, err := client.Create(ctx, active2, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, cp1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, cp2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, ca1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, ca2.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("true returns only paused rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=rr-fs-folder",
+				FieldSelector: "spec.paused=true",
+			})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.Paused)
+				require.True(t, *item.Spec.Paused)
+			}
+		})
+
+		t.Run("false returns only non-paused rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=rr-fs-folder",
+				FieldSelector: "spec.paused=false",
+			})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.True(t, item.Spec.Paused == nil || !*item.Spec.Paused)
+			}
+		})
+	})
+}


### PR DESCRIPTION
**What is this feature?**

This PR adds field selector support to `AlertRule` and `RecordingRule` list operations backed by legacy storage.

Supported selectors in this change:
- `spec.title`
- `spec.paused`
- `spec.panelRef.dashboardUID` for `AlertRule`
- `spec.panelRef.panelID` for `AlertRule`

The implementation parses supported field selectors in the API storage layer, maps them into provisioning service filters, applies them in the rule store query path, and adds unit and integration coverage for the new filtering behavior.

**Why do we need this feature?**

Without server-side field selectors, clients listing alerting resources through the Kubernetes-style API cannot efficiently narrow results to rules that match common fields like title, paused state, dashboard UID, or panel ID. This makes automation and targeted lookups more expensive and less consistent.

**Who is this feature for?**

This is mainly for engineers, operators, and integrations that manage `AlertRule` and `RecordingRule` resources through the API and need server-side filtering when listing rules.

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

This change also adds validation for unsupported field selectors, unsupported operators, and invalid values for boolean and panel ID filters.

Tests were added for:
- provisioning service filtering
- rule store filtering
- integration coverage for listing `AlertRule` resources with field selectors
- integration coverage for listing `RecordingRule` resources with field selectors

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.