### PR TITLE
Secrets: Add context to DEK method signatures

### DIFF
--- a/pkg/registry/apis/secret/encryption/manager/manager.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager.go
@@ -196,7 +196,7 @@ func (s *EncryptionManager) currentDataKey(ctx context.Context, namespace xkube.
 func (s *EncryptionManager) dataKeyByLabel(ctx context.Context, namespace, label string, skipCache bool) (string, []byte, error) {
 	// 0. Get data key from in-memory cache (stored encrypted).
 	if !skipCache {
-		if entry, exists := s.dataKeyCache.GetByLabel(namespace, label); exists && entry.Active {
+		if entry, exists := s.dataKeyCache.GetByLabel(ctx, namespace, label); exists && entry.Active {
 			// Decrypt the cached data key before returning.
 			decrypted, err := s.decryptCachedDataKey(ctx, entry.EncryptedDataKey)
 			if err != nil {
@@ -350,7 +350,7 @@ func (s *EncryptionManager) dataKeyById(ctx context.Context, namespace, id strin
 
 	// 0. Get data key from in-memory cache (stored encrypted).
 	if !skipCache {
-		if entry, exists := s.dataKeyCache.GetById(namespace, id); exists && entry.Active {
+		if entry, exists := s.dataKeyCache.GetById(ctx, namespace, id); exists && entry.Active {
 			// Decrypt the cached data key before returning.
 			decrypted, err := s.decryptCachedDataKey(ctx, entry.EncryptedDataKey)
 			if err != nil {
@@ -441,7 +441,7 @@ func (s *EncryptionManager) ConsolidateNamespace(ctx context.Context, namespace 
 		results[i] = &contracts.EncryptedPayload{DataKeyID: newKeyID, EncryptedData: encrypted}
 	}
 
-	s.dataKeyCache.Flush(namespace.String())
+	s.dataKeyCache.Flush(ctx, namespace.String())
 	// TODO: Decide later if the cache should be primed with the new DEK here
 
 	return results, nil
@@ -454,7 +454,7 @@ func (s *EncryptionManager) Run(ctx context.Context) error {
 		select {
 		case <-gc.C:
 			s.log.Debug("Removing expired data keys from cache...")
-			s.dataKeyCache.RemoveExpired()
+			s.dataKeyCache.RemoveExpired(ctx)
 			s.log.Debug("Removing expired data keys from cache finished successfully")
 		case <-ctx.Done():
 			s.log.Debug("Grafana is shutting down; stopping...")
@@ -483,7 +483,7 @@ func (s *EncryptionManager) cacheDataKey(ctx context.Context, namespace string, 
 		EncryptedDataKey: encryptedForCache,
 		Active:           dataKey.Active,
 	}
-	s.dataKeyCache.Set(namespace, entry)
+	s.dataKeyCache.Set(ctx, namespace, entry)
 }
 
 // decryptCachedDataKey decrypts a data key retrieved from the cache.

--- a/pkg/registry/apis/secret/encryption/manager/manager_test.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager_test.go
@@ -613,7 +613,7 @@ func TestIntegration_SecretsService(t *testing.T) {
 			// (created within a rolled-back transaction) is no longer in memory.
 			// Without flushing, the test would pass trivially because the phantom key
 			// would still be in the cache.
-			svc.(*EncryptionManager).dataKeyCache.Flush(namespace.String())
+			svc.(*EncryptionManager).dataKeyCache.Flush(ctx, namespace.String())
 
 			// Therefore, the data encrypted after this point, become unrecoverable after a restart.
 			// So, the different test cases here are there to prevent that from happening again
@@ -669,21 +669,21 @@ type stubCache struct {
 	setCalled        bool
 }
 
-func (c *stubCache) GetByLabel(namespace, label string) (encryption.DataKeyCacheEntry, bool) {
+func (c *stubCache) GetByLabel(_ context.Context, namespace, label string) (encryption.DataKeyCacheEntry, bool) {
 	c.getByLabelCalled = true
 	return encryption.DataKeyCacheEntry{}, false
 }
 
-func (c *stubCache) GetById(namespace, id string) (encryption.DataKeyCacheEntry, bool) {
+func (c *stubCache) GetById(_ context.Context, namespace, id string) (encryption.DataKeyCacheEntry, bool) {
 	c.getByIdCalled = true
 	return encryption.DataKeyCacheEntry{}, false
 }
 
-func (c *stubCache) Set(namespace string, entry encryption.DataKeyCacheEntry) {
+func (c *stubCache) Set(_ context.Context, namespace string, entry encryption.DataKeyCacheEntry) {
 	c.setCalled = true
 }
-func (c *stubCache) Flush(namespace string) {}
-func (c *stubCache) RemoveExpired()         {}
+func (c *stubCache) Flush(_ context.Context, namespace string) {}
+func (c *stubCache) RemoveExpired(_ context.Context)           {}
 
 func TestEncryptionService_WithSkipCache(t *testing.T) {
 	ctx := context.Background()
@@ -825,20 +825,20 @@ func TestEncryptionService_FlushCache(t *testing.T) {
 
 	// Verify the key is in the cache by checking both by ID and by label
 	label := encryption.KeyLabel(svc.providerConfig.CurrentProvider)
-	_, existsById := dekCache.GetById(namespace.String(), dataKeyID)
+	_, existsById := dekCache.GetById(ctx, namespace.String(), dataKeyID)
 	assert.True(t, existsById, "DEK should be cached by ID before flush")
 
-	_, existsByLabel := dekCache.GetByLabel(namespace.String(), label)
+	_, existsByLabel := dekCache.GetByLabel(ctx, namespace.String(), label)
 	assert.True(t, existsByLabel, "DEK should be cached by label before flush")
 
 	// Flush the cache for this namespace
-	svc.dataKeyCache.Flush(namespace.String())
+	svc.dataKeyCache.Flush(ctx, namespace.String())
 
 	// Verify the cache is empty for this namespace
-	_, existsById = dekCache.GetById(namespace.String(), dataKeyID)
+	_, existsById = dekCache.GetById(ctx, namespace.String(), dataKeyID)
 	assert.False(t, existsById, "DEK should not be in cache by ID after flush")
 
-	_, existsByLabel = dekCache.GetByLabel(namespace.String(), label)
+	_, existsByLabel = dekCache.GetByLabel(ctx, namespace.String(), label)
 	assert.False(t, existsByLabel, "DEK should not be in cache by label after flush")
 
 	// Verify we can still decrypt - this should fetch from DB and re-cache
@@ -847,6 +847,6 @@ func TestEncryptionService_FlushCache(t *testing.T) {
 	assert.Equal(t, plaintext, decrypted)
 
 	// Verify the key is back in the cache after the decrypt operation
-	_, existsById = dekCache.GetById(namespace.String(), dataKeyID)
+	_, existsById = dekCache.GetById(ctx, namespace.String(), dataKeyID)
 	assert.True(t, existsById, "DEK should be re-cached by ID after decrypt")
 }

--- a/pkg/registry/apis/secret/encryption/manager/oss_dek_cache.go
+++ b/pkg/registry/apis/secret/encryption/manager/oss_dek_cache.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"strconv"
 	"sync"
 	"time"
@@ -34,7 +35,7 @@ func ProvideOSSDataKeyCache(cfg *setting.Cfg) encryption.DataKeyCache {
 	}
 }
 
-func (c *ossDataKeyCache) GetById(namespace, id string) (_ encryption.DataKeyCacheEntry, exists bool) {
+func (c *ossDataKeyCache) GetById(_ context.Context, namespace, id string) (_ encryption.DataKeyCacheEntry, exists bool) {
 	defer func() {
 		cacheReadsCounter.With(prometheus.Labels{
 			"hit":    strconv.FormatBool(exists),
@@ -62,7 +63,7 @@ func (c *ossDataKeyCache) GetById(namespace, id string) (_ encryption.DataKeyCac
 	return entry, true
 }
 
-func (c *ossDataKeyCache) GetByLabel(namespace, label string) (_ encryption.DataKeyCacheEntry, exists bool) {
+func (c *ossDataKeyCache) GetByLabel(_ context.Context, namespace, label string) (_ encryption.DataKeyCacheEntry, exists bool) {
 	defer func() {
 		cacheReadsCounter.With(prometheus.Labels{
 			"hit":    strconv.FormatBool(exists),
@@ -89,7 +90,7 @@ func (c *ossDataKeyCache) GetByLabel(namespace, label string) (_ encryption.Data
 	return entry, true
 }
 
-func (c *ossDataKeyCache) Set(namespace string, entry encryption.DataKeyCacheEntry) {
+func (c *ossDataKeyCache) Set(_ context.Context, namespace string, entry encryption.DataKeyCacheEntry) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
@@ -100,7 +101,7 @@ func (c *ossDataKeyCache) Set(namespace string, entry encryption.DataKeyCacheEnt
 	c.byLabel[namespacedKey{namespace, entry.Label}] = entry
 }
 
-func (c *ossDataKeyCache) RemoveExpired() {
+func (c *ossDataKeyCache) RemoveExpired(_ context.Context) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
@@ -117,7 +118,7 @@ func (c *ossDataKeyCache) RemoveExpired() {
 	}
 }
 
-func (c *ossDataKeyCache) Flush(namespace string) {
+func (c *ossDataKeyCache) Flush(_ context.Context, namespace string) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 

--- a/pkg/registry/apis/secret/encryption/manager/oss_dek_cache_test.go
+++ b/pkg/registry/apis/secret/encryption/manager/oss_dek_cache_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 
 func TestOSSDataKeyCache(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	settings := setting.NewCfg()
 	settings.SecretsManagement = setting.SecretsManagerSettings{
@@ -28,9 +30,9 @@ func TestOSSDataKeyCache(t *testing.T) {
 	}
 
 	t.Run("Set and GetById and GetByLabel", func(t *testing.T) {
-		cache.Set(namespace, entry)
+		cache.Set(ctx, namespace, entry)
 
-		retrieved, exists := cache.GetById(namespace, entry.Id)
+		retrieved, exists := cache.GetById(ctx, namespace, entry.Id)
 		require.True(t, exists, "entry should exist after adding")
 		assert.Equal(t, entry.Id, retrieved.Id)
 		assert.Equal(t, entry.Label, retrieved.Label)
@@ -39,7 +41,7 @@ func TestOSSDataKeyCache(t *testing.T) {
 		assert.Equal(t, namespace, retrieved.Namespace)
 		assert.True(t, retrieved.Expiration.After(time.Now()), "expiration should be in the future")
 
-		retrieved, exists = cache.GetByLabel(namespace, entry.Label)
+		retrieved, exists = cache.GetByLabel(ctx, namespace, entry.Label)
 		require.True(t, exists, "entry should exist after adding")
 		assert.Equal(t, entry.Id, retrieved.Id)
 		assert.Equal(t, entry.Label, retrieved.Label)
@@ -52,6 +54,7 @@ func TestOSSDataKeyCache(t *testing.T) {
 
 func TestOSSDataKeyCache_FalseConditions(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	settings := setting.NewCfg()
 	settings.SecretsManagement = setting.SecretsManagerSettings{
@@ -68,20 +71,20 @@ func TestOSSDataKeyCache_FalseConditions(t *testing.T) {
 	}
 
 	t.Run("GetById and GetByLabel return false for non-existent namespace", func(t *testing.T) {
-		_, exists := cache.GetById("non-existent-namespace", "any-id")
+		_, exists := cache.GetById(ctx, "non-existent-namespace", "any-id")
 		assert.False(t, exists)
 
-		_, exists = cache.GetByLabel("non-existent-namespace", "any-label")
+		_, exists = cache.GetByLabel(ctx, "non-existent-namespace", "any-label")
 		assert.False(t, exists)
 	})
 
 	t.Run("GetById and GetByLabel return false for non-existent id/label", func(t *testing.T) {
-		cache.Set(namespace, entry)
+		cache.Set(ctx, namespace, entry)
 
-		_, exists := cache.GetById(namespace, "non-existent-id")
+		_, exists := cache.GetById(ctx, namespace, "non-existent-id")
 		assert.False(t, exists)
 
-		_, exists = cache.GetByLabel(namespace, "non-existent-label")
+		_, exists = cache.GetByLabel(ctx, namespace, "non-existent-label")
 		assert.False(t, exists)
 	})
 
@@ -98,14 +101,14 @@ func TestOSSDataKeyCache_FalseConditions(t *testing.T) {
 			Label:            "expired-label",
 			EncryptedDataKey: []byte("expired-data"),
 		}
-		shortCache.Set(namespace, expiredEntry)
+		shortCache.Set(ctx, namespace, expiredEntry)
 
 		time.Sleep(10 * time.Millisecond)
 
-		_, exists := shortCache.GetById(namespace, expiredEntry.Id)
+		_, exists := shortCache.GetById(ctx, namespace, expiredEntry.Id)
 		assert.False(t, exists, "should return false for expired entry")
 
-		_, exists = shortCache.GetByLabel(namespace, expiredEntry.Label)
+		_, exists = shortCache.GetByLabel(ctx, namespace, expiredEntry.Label)
 		assert.False(t, exists, "should return false for expired entry")
 	})
 
@@ -128,10 +131,10 @@ func TestOSSDataKeyCache_FalseConditions(t *testing.T) {
 		testCache.byLabel[namespacedKey{namespace: "correct-namespace", value: mismatchedEntry.Label}] = mismatchedEntry
 		testCache.mtx.Unlock()
 
-		_, exists := testCache.GetById("correct-namespace", mismatchedEntry.Id)
+		_, exists := testCache.GetById(ctx, "correct-namespace", mismatchedEntry.Id)
 		assert.False(t, exists, "should return false when entry namespace doesn't match lookup namespace")
 
-		_, exists = testCache.GetByLabel("correct-namespace", mismatchedEntry.Label)
+		_, exists = testCache.GetByLabel(ctx, "correct-namespace", mismatchedEntry.Label)
 		assert.False(t, exists, "should return false when entry namespace doesn't match lookup namespace")
 	})
 }
@@ -139,6 +142,7 @@ func TestOSSDataKeyCache_FalseConditions(t *testing.T) {
 // Test namespace isolation
 func TestOSSDataKeyCache_NamespaceIsolation(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	settings := setting.NewCfg()
 	settings.SecretsManagement = setting.SecretsManagerSettings{
@@ -164,28 +168,28 @@ func TestOSSDataKeyCache_NamespaceIsolation(t *testing.T) {
 	}
 
 	t.Run("entries with same ID and label in different namespaces are isolated", func(t *testing.T) {
-		cache.Set(namespace1, entry1)
-		cache.Set(namespace2, entry2)
+		cache.Set(ctx, namespace1, entry1)
+		cache.Set(ctx, namespace2, entry2)
 
-		retrieved1, exists := cache.GetById(namespace1, entry1.Id)
+		retrieved1, exists := cache.GetById(ctx, namespace1, entry1.Id)
 		require.True(t, exists)
 		assert.Equal(t, entry1.EncryptedDataKey, retrieved1.EncryptedDataKey)
 		assert.Equal(t, namespace1, retrieved1.Namespace)
 		assert.True(t, retrieved1.Active)
 
-		retrieved2, exists := cache.GetById(namespace2, entry2.Id)
+		retrieved2, exists := cache.GetById(ctx, namespace2, entry2.Id)
 		require.True(t, exists)
 		assert.Equal(t, entry2.EncryptedDataKey, retrieved2.EncryptedDataKey)
 		assert.Equal(t, namespace2, retrieved2.Namespace)
 		assert.False(t, retrieved2.Active)
 
-		retrieved1, exists = cache.GetByLabel(namespace1, entry1.Label)
+		retrieved1, exists = cache.GetByLabel(ctx, namespace1, entry1.Label)
 		require.True(t, exists)
 		assert.Equal(t, entry1.EncryptedDataKey, retrieved1.EncryptedDataKey)
 		assert.Equal(t, namespace1, retrieved1.Namespace)
 		assert.True(t, retrieved1.Active)
 
-		retrieved2, exists = cache.GetByLabel(namespace2, entry2.Label)
+		retrieved2, exists = cache.GetByLabel(ctx, namespace2, entry2.Label)
 		require.True(t, exists)
 		assert.Equal(t, entry2.EncryptedDataKey, retrieved2.EncryptedDataKey)
 		assert.Equal(t, namespace2, retrieved2.Namespace)
@@ -194,21 +198,22 @@ func TestOSSDataKeyCache_NamespaceIsolation(t *testing.T) {
 
 	t.Run("cannot retrieve entry from wrong namespace", func(t *testing.T) {
 		// flush both namespaces since the cache is full of stuff now
-		cache.Flush(namespace1)
-		cache.Flush(namespace2)
+		cache.Flush(ctx, namespace1)
+		cache.Flush(ctx, namespace2)
 
-		cache.Set(namespace1, entry1)
+		cache.Set(ctx, namespace1, entry1)
 
-		_, exists := cache.GetById(namespace2, entry1.Id)
+		_, exists := cache.GetById(ctx, namespace2, entry1.Id)
 		assert.False(t, exists, "should not find entry from different namespace")
 
-		_, exists = cache.GetByLabel(namespace2, entry1.Label)
+		_, exists = cache.GetByLabel(ctx, namespace2, entry1.Label)
 		assert.False(t, exists, "should not find entry from different namespace")
 	})
 }
 
 func TestOSSDataKeyCache_Expiration(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	t.Run("entries expire after TTL", func(t *testing.T) {
 		settings := setting.NewCfg()
 		settings.SecretsManagement = setting.SecretsManagerSettings{
@@ -223,23 +228,23 @@ func TestOSSDataKeyCache_Expiration(t *testing.T) {
 			EncryptedDataKey: []byte("expiring-data"),
 		}
 
-		cache.Set(namespace, entry)
+		cache.Set(ctx, namespace, entry)
 
 		// Should exist immediately
-		_, exists := cache.GetById(namespace, entry.Id)
+		_, exists := cache.GetById(ctx, namespace, entry.Id)
 		assert.True(t, exists, "entry should exist immediately after adding")
 
-		_, exists = cache.GetByLabel(namespace, entry.Label)
+		_, exists = cache.GetByLabel(ctx, namespace, entry.Label)
 		assert.True(t, exists, "entry should exist immediately after adding")
 
 		// Wait for expiration
 		time.Sleep(100 * time.Millisecond)
 
 		// Should not exist after expiration
-		_, exists = cache.GetById(namespace, entry.Id)
+		_, exists = cache.GetById(ctx, namespace, entry.Id)
 		assert.False(t, exists, "entry should not exist after TTL expires")
 
-		_, exists = cache.GetByLabel(namespace, entry.Label)
+		_, exists = cache.GetByLabel(ctx, namespace, entry.Label)
 		assert.False(t, exists, "entry should not exist after TTL expires")
 	})
 
@@ -259,7 +264,7 @@ func TestOSSDataKeyCache_Expiration(t *testing.T) {
 			EncryptedDataKey: []byte("expired-data-1"),
 		}
 
-		cache.Set(namespace, expiredEntry)
+		cache.Set(ctx, namespace, expiredEntry)
 
 		// Wait for expiration
 		time.Sleep(100 * time.Millisecond)
@@ -271,19 +276,19 @@ func TestOSSDataKeyCache_Expiration(t *testing.T) {
 			EncryptedDataKey: []byte("fresh-data-1"),
 		}
 
-		cache.Set(namespace, freshEntry)
+		cache.Set(ctx, namespace, freshEntry)
 
 		// Before RemoveExpired, expired entries still exist in the map
 		// but GetById/GetByLabel return false due to IsExpired() check
 
 		// Call RemoveExpired
-		cache.RemoveExpired()
+		cache.RemoveExpired(ctx)
 
 		// Fresh entry should still exist
-		_, exists := cache.GetById(namespace, freshEntry.Id)
+		_, exists := cache.GetById(ctx, namespace, freshEntry.Id)
 		assert.True(t, exists, "fresh entry should still exist after RemoveExpired")
 
-		_, exists = cache.GetByLabel(namespace, freshEntry.Label)
+		_, exists = cache.GetByLabel(ctx, namespace, freshEntry.Label)
 		assert.True(t, exists, "fresh entry should still exist after RemoveExpired")
 
 		// Expired entry should not exist
@@ -316,8 +321,8 @@ func TestOSSDataKeyCache_Expiration(t *testing.T) {
 			EncryptedDataKey: []byte("expired-data"),
 		}
 
-		cache.Set(ns1, ns1ExpiredEntry)
-		cache.Set(ns2, ns2ExpiredEntry)
+		cache.Set(ctx, ns1, ns1ExpiredEntry)
+		cache.Set(ctx, ns2, ns2ExpiredEntry)
 
 		time.Sleep(100 * time.Millisecond)
 
@@ -332,22 +337,22 @@ func TestOSSDataKeyCache_Expiration(t *testing.T) {
 			EncryptedDataKey: []byte("fresh-data-ns2"),
 		}
 
-		cache.Set(ns1, ns1FreshEntry)
-		cache.Set(ns2, ns2FreshEntry)
+		cache.Set(ctx, ns1, ns1FreshEntry)
+		cache.Set(ctx, ns2, ns2FreshEntry)
 
-		cache.RemoveExpired()
+		cache.RemoveExpired(ctx)
 
 		// Fresh entries in both namespaces should exist
-		_, exists := cache.GetById(ns1, ns1FreshEntry.Id)
+		_, exists := cache.GetById(ctx, ns1, ns1FreshEntry.Id)
 		assert.True(t, exists)
 
-		_, exists = cache.GetByLabel(ns1, ns1FreshEntry.Label)
+		_, exists = cache.GetByLabel(ctx, ns1, ns1FreshEntry.Label)
 		assert.True(t, exists)
 
-		_, exists = cache.GetById(ns2, ns2FreshEntry.Id)
+		_, exists = cache.GetById(ctx, ns2, ns2FreshEntry.Id)
 		assert.True(t, exists)
 
-		_, exists = cache.GetByLabel(ns2, ns2FreshEntry.Label)
+		_, exists = cache.GetByLabel(ctx, ns2, ns2FreshEntry.Label)
 		assert.True(t, exists)
 
 		// Expired entries in both namespaces should not exist
@@ -369,6 +374,7 @@ func TestOSSDataKeyCache_Expiration(t *testing.T) {
 // Test Flush()
 func TestOSSDataKeyCache_Flush(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	settings := setting.NewCfg()
 	settings.SecretsManagement = setting.SecretsManagerSettings{
@@ -392,57 +398,57 @@ func TestOSSDataKeyCache_Flush(t *testing.T) {
 	}
 
 	t.Run("Flush removes all entries from specified namespace", func(t *testing.T) {
-		cache.Set(namespace1, entry1)
+		cache.Set(ctx, namespace1, entry1)
 
 		// Verify entries exist
-		_, exists := cache.GetById(namespace1, entry1.Id)
+		_, exists := cache.GetById(ctx, namespace1, entry1.Id)
 		require.True(t, exists)
 
-		_, exists = cache.GetByLabel(namespace1, entry1.Label)
+		_, exists = cache.GetByLabel(ctx, namespace1, entry1.Label)
 		require.True(t, exists)
 
 		// Flush namespace1
-		cache.Flush(namespace1)
+		cache.Flush(ctx, namespace1)
 
 		// Entries should no longer exist
-		_, exists = cache.GetById(namespace1, entry1.Id)
+		_, exists = cache.GetById(ctx, namespace1, entry1.Id)
 		assert.False(t, exists, "entry should not exist after flush")
 
-		_, exists = cache.GetByLabel(namespace1, entry1.Label)
+		_, exists = cache.GetByLabel(ctx, namespace1, entry1.Label)
 		assert.False(t, exists, "entry should not exist after flush")
 	})
 
 	t.Run("Flush only affects specified namespace", func(t *testing.T) {
-		cache.Set(namespace1, entry1)
-		cache.Set(namespace2, entry2)
+		cache.Set(ctx, namespace1, entry1)
+		cache.Set(ctx, namespace2, entry2)
 
 		// Flush only namespace1
-		cache.Flush(namespace1)
+		cache.Flush(ctx, namespace1)
 
 		// namespace1 entries should not exist
-		_, exists := cache.GetById(namespace1, entry1.Id)
+		_, exists := cache.GetById(ctx, namespace1, entry1.Id)
 		assert.False(t, exists)
 
-		_, exists = cache.GetByLabel(namespace1, entry1.Label)
+		_, exists = cache.GetByLabel(ctx, namespace1, entry1.Label)
 		assert.False(t, exists)
 
 		// namespace2 entries should still exist
-		_, exists = cache.GetById(namespace2, entry2.Id)
+		_, exists = cache.GetById(ctx, namespace2, entry2.Id)
 		assert.True(t, exists, "entries in other namespace should not be affected")
 
-		_, exists = cache.GetByLabel(namespace2, entry2.Label)
+		_, exists = cache.GetByLabel(ctx, namespace2, entry2.Label)
 		assert.True(t, exists, "entries in other namespace should not be affected")
 	})
 
 	t.Run("Flush on non-existent namespace does not panic", func(t *testing.T) {
 		assert.NotPanics(t, func() {
-			cache.Flush("non-existent-namespace")
+			cache.Flush(ctx, "non-existent-namespace")
 		})
 	})
 
 	t.Run("can add entries after flush", func(t *testing.T) {
-		cache.Set(namespace1, entry1)
-		cache.Flush(namespace1)
+		cache.Set(ctx, namespace1, entry1)
+		cache.Flush(ctx, namespace1)
 
 		// Add new entry after flush
 		newEntry := encryption.DataKeyCacheEntry{
@@ -450,13 +456,13 @@ func TestOSSDataKeyCache_Flush(t *testing.T) {
 			Label:            "new-label",
 			EncryptedDataKey: []byte("new-data"),
 		}
-		cache.Set(namespace1, newEntry)
+		cache.Set(ctx, namespace1, newEntry)
 
 		// New entry should exist
-		_, exists := cache.GetById(namespace1, "new-key")
+		_, exists := cache.GetById(ctx, namespace1, "new-key")
 		assert.True(t, exists, "should be able to add entries after flush")
 
-		_, exists = cache.GetByLabel(namespace1, "new-label")
+		_, exists = cache.GetByLabel(ctx, namespace1, "new-label")
 		assert.True(t, exists, "should be able to add entries after flush")
 	})
 }

--- a/pkg/registry/apis/secret/encryption/manager/test_helpers.go
+++ b/pkg/registry/apis/secret/encryption/manager/test_helpers.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,18 +60,18 @@ func setupTestService(tb testing.TB) *EncryptionManager {
 type NoopDataKeyCache struct {
 }
 
-func (c *NoopDataKeyCache) GetById(namespace, id string) (encryption.DataKeyCacheEntry, bool) {
+func (c *NoopDataKeyCache) GetById(_ context.Context, namespace, id string) (encryption.DataKeyCacheEntry, bool) {
 	return encryption.DataKeyCacheEntry{}, false
 }
 
-func (c *NoopDataKeyCache) GetByLabel(namespace, label string) (encryption.DataKeyCacheEntry, bool) {
+func (c *NoopDataKeyCache) GetByLabel(_ context.Context, namespace, label string) (encryption.DataKeyCacheEntry, bool) {
 	return encryption.DataKeyCacheEntry{}, false
 }
 
-func (c *NoopDataKeyCache) Set(namespace string, entry encryption.DataKeyCacheEntry) {
+func (c *NoopDataKeyCache) Set(_ context.Context, namespace string, entry encryption.DataKeyCacheEntry) {
 }
 
-func (c *NoopDataKeyCache) RemoveExpired() {
+func (c *NoopDataKeyCache) RemoveExpired(_ context.Context) {
 }
 
-func (c *NoopDataKeyCache) Flush(namespace string) {}
+func (c *NoopDataKeyCache) Flush(_ context.Context, namespace string) {}

--- a/pkg/registry/apis/secret/encryption/secrets.go
+++ b/pkg/registry/apis/secret/encryption/secrets.go
@@ -45,13 +45,13 @@ func KeyLabel(providerID ProviderID) string {
 // Per AppSec, data keys in this cache must be encrypted at-rest.
 type DataKeyCache interface {
 	// The implementation of Set must ensure the key is retrievable by both key and label
-	Set(namespace string, entry DataKeyCacheEntry)
+	Set(ctx context.Context, namespace string, entry DataKeyCacheEntry)
 
-	GetById(namespace, id string) (DataKeyCacheEntry, bool)
-	GetByLabel(namespace, label string) (DataKeyCacheEntry, bool)
+	GetById(ctx context.Context, namespace, id string) (DataKeyCacheEntry, bool)
+	GetByLabel(ctx context.Context, namespace, label string) (DataKeyCacheEntry, bool)
 
-	RemoveExpired()
-	Flush(namespace string)
+	RemoveExpired(ctx context.Context)
+	Flush(ctx context.Context, namespace string)
 }
 
 type DataKeyCacheEntry struct {


### PR DESCRIPTION
Prerequisite for the Enterprise Redis cache implementation, which makes network calls and thus should take a context.

Enterprise https://github.com/grafana/grafana-enterprise/pull/11704