### PR TITLE
Select: Fix filterOption type to match react-select wrapped shape

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -159,7 +159,7 @@ const isInternal = (timeZone: TimeZone): boolean => {
 };
 
 const useFilterBySearchIndex = () => {
-  return useCallback((option: SelectableValue, searchQuery: string) => {
+  return useCallback((option: { data: SelectableValue }, searchQuery: string) => {
     if (!searchQuery || !option.data || !option.data.searchIndex) {
       return true;
     }

--- a/packages/grafana-ui/src/components/Select/SelectBase.test.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.test.tsx
@@ -10,10 +10,24 @@ import { Drawer } from '../Drawer/Drawer';
 import { Modal } from '../Modal/Modal';
 
 import { SelectBase } from './SelectBase';
+import { type SelectCommonProps } from './types';
 
 // Used to select an option or options from a Select in unit tests
 const selectOptionInTest = async (input: HTMLElement, optionOrOptions: string | RegExp | Array<string | RegExp>) =>
   await waitFor(() => select(input, optionOrOptions, { container: document.body }));
+
+// Compile-time regression guard for issue #121194. Never runs — it exists so
+// tsc fails if filterOption's declared shape drifts back to a bare
+// SelectableValue<T>, which does not match the wrapped shape react-select
+// actually passes at runtime. Under the wrapped shape, SelectableValue fields
+// like `description` live on `option.data`, not at the top level, so the line
+// below is a type error and @ts-expect-error swallows it. If the type reverts,
+// `option.description` becomes valid again and the directive fails tsc.
+const _filterOptionShapeGuard: NonNullable<SelectCommonProps<number>['filterOption']> = (option) => {
+  // @ts-expect-error - description must be read via option.data.description
+  return option.description === 'sentinel';
+};
+void _filterOptionShapeGuard;
 
 describe('SelectBase', () => {
   const onChangeHandler = jest.fn();
@@ -225,6 +239,40 @@ describe('SelectBase', () => {
       await userEvent.click(screen.getByText(/option 2/i));
       const menuOptions = screen.getAllByTestId(selectors.components.Select.option);
       expect(menuOptions).toHaveLength(2);
+    });
+
+    it('filterOption callback receives label, value, and full option data', async () => {
+      const filterSpy = jest.fn().mockReturnValue(true);
+      const describedOptions: Array<SelectableValue<number>> = [
+        { label: 'Alpha', value: 1, description: 'first letter' },
+        { label: 'Beta', value: 2, description: 'second letter' },
+      ];
+
+      render(
+        <SelectBase
+          onChange={onChangeHandler}
+          options={describedOptions}
+          aria-label="Filter target"
+          filterOption={filterSpy}
+        />
+      );
+
+      const selectEl = screen.getByLabelText('Filter target');
+      await userEvent.click(selectEl);
+      await userEvent.type(selectEl, 'a');
+
+      // react-select hands the callback the wrapped shape, not a bare SelectableValue.
+      // `data` holds the full original option so callers can read any field on it,
+      // while `label` and `value` are the resolved getOptionLabel / getOptionValue results.
+      expect(filterSpy).toHaveBeenCalled();
+      expect(filterSpy.mock.calls[0][1]).toBe('a');
+      expect(filterSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          label: 'Alpha',
+          value: 1,
+          data: expect.objectContaining({ label: 'Alpha', value: 1, description: 'first letter' }),
+        })
+      );
     });
   });
 

--- a/packages/grafana-ui/src/components/Select/SelectPerf.story.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectPerf.story.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
 export default meta;
 
 const _customFilter = createFilter({ ignoreAccents: false });
-function customFilter(opt: SelectableValue, searchQuery: string) {
+function customFilter(opt: { label?: string; value?: string; data: SelectableValue }, searchQuery: string) {
   return _customFilter(
     {
       label: opt.label ?? '',

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -41,7 +41,14 @@ export interface SelectCommonProps<T> {
   createOptionPosition?: 'first' | 'last';
   defaultValue?: any;
   disabled?: boolean;
-  filterOption?: (option: SelectableValue<T>, searchQuery: string) => boolean;
+  /**
+   * Custom filter function for options shown in the menu. The callback
+   * receives react-select's wrapped option shape: `data` holds the full
+   * `SelectableValue<T>`, while `label` and `value` are the resolved
+   * `getOptionLabel` / `getOptionValue` results — the same shape that
+   * react-select's own `createFilter` expects.
+   */
+  filterOption?: (option: { label?: string; value?: T; data: SelectableValue<T> }, searchQuery: string) => boolean;
   formatOptionLabel?: (item: SelectableValue<T>, formatOptionMeta: FormatOptionLabelMeta<T>) => React.ReactNode;
   /** Function for formatting the text that is displayed when creating a new value*/
   formatCreateLabel?: (input: string) => React.ReactNode;

--- a/public/app/core/components/TagFilter/TagFilter.tsx
+++ b/public/app/core/components/TagFilter/TagFilter.tsx
@@ -29,7 +29,10 @@ export interface Props {
   disabled?: boolean;
 }
 
-const filterOption = (option: SelectableValue<string>, searchQuery: string) => {
+const filterOption = (
+  option: { label?: string; value?: string; data: SelectableValue<string> },
+  searchQuery: string
+) => {
   const regex = RegExp(escapeStringForRegex(searchQuery), 'i');
   return Boolean(option.value && regex.test(option.value));
 };

--- a/public/app/plugins/datasource/opentsdb/components/FilterSection.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/FilterSection.tsx
@@ -109,12 +109,15 @@ export function FilterSection({
 
   // We are matching words split with space
   const splitSeparator = ' ';
-  const customFilterOption = useCallback((option: SelectableValue<string>, searchQuery: string) => {
-    const label = option.value ?? '';
+  const customFilterOption = useCallback(
+    (option: { label?: string; value?: string; data: SelectableValue<string> }, searchQuery: string) => {
+      const label = option.value ?? '';
 
-    const searchWords = searchQuery.split(splitSeparator);
-    return searchWords.reduce((acc, cur) => acc && label.toLowerCase().includes(cur.toLowerCase()), true);
-  }, []);
+      const searchWords = searchQuery.split(splitSeparator);
+      return searchWords.reduce((acc, cur) => acc && label.toLowerCase().includes(cur.toLowerCase()), true);
+    },
+    []
+  );
 
   const tagValueSearch = debounce((query: string) => suggestTagValues(query), 350);
 


### PR DESCRIPTION
## What is this feature?

Fixes the declared type of the `filterOption` prop on `Select` / `MultiSelect` / `AsyncSelect` in `@grafana/ui` so it matches the wrapped option shape that react-select actually passes to the callback at runtime: `{ label, value, data: SelectableValue<T> }`.

Before this change, the prop was typed as `(option: SelectableValue<T>, searchQuery: string) => boolean`, which said consumers could read `option.description`, `option.icon`, etc. at the top level. At runtime they'd get `undefined` for those — the real fields live on `option.data`.

## Why do we need this feature?

Issue #121194 flagged this contract drift. Plugin authors writing `filterOption` callbacks end up in one of two bad states:

1. Trust the declared `SelectableValue<T>` type and hit silent runtime failures (e.g. `option.description` returns `undefined`).
2. Defensively read `option.data.description` and hit type errors, or lean on `SelectableValue<any>`'s stealth index signature to paper over the mismatch.

`TimeZonePicker.useFilterBySearchIndex` already relies on the wrapped shape at runtime (`option.data.searchIndex`) — it only compiles today because `SelectableValue<T>` defaults `T = any`, and its `[key: string]: any` index signature makes `.data` a stealth `any`.

## Who is this feature for?

Plugin and app authors using `@grafana/ui` `Select` / `MultiSelect` / `AsyncSelect` who need a custom filter. The fix aligns the declared type with react-select's actual `FilterOptionOption` shape so `filterOption` callbacks can be written against an honest contract.

## Which issue(s) does this PR fix?

Fixes #121194

## Verification

**react-select runtime behavior confirmed from source** — see `node_modules/react-select/dist/Select-1b9abbe3.cjs.dev.js` around `_filterOption`: react-select builds `{ label, value, data }` via `toCategorizedOption` and passes that to the user's callback. The declared type should reflect this.

**Local build** — ran in a fresh worktree off `upstream/main`:

- `yarn typecheck` — clean across all 15 nx projects
- `yarn lint` — clean
- `yarn prettier:check` — clean
- `yarn jest packages/grafana-ui/src/components/Select/SelectBase.test.tsx` — 25 passed, including the new runtime test

**Compile-time regression guard verified** — I stashed `types.ts` to simulate the type reverting, re-ran `tsc` on `@grafana/ui`, and confirmed the `@ts-expect-error` guard at `SelectBase.test.tsx:27` fires `TS2578 Unused '@ts-expect-error' directive.`. Restoring the fix makes it compile cleanly again.

**Downstream tests** — ran all tests under `DateTimePickers/TimeZonePicker`, `core/components/TagFilter`, and `datasource/opentsdb` to catch any behavior change from the callsite annotation updates. 42/42 green.

## What changed

- `packages/grafana-ui/src/components/Select/types.ts` — `filterOption` type now declares the wrapped shape. JSDoc explains why.
- `packages/grafana-ui/src/components/Select/SelectBase.test.tsx`:
  - New runtime test mounts `<SelectBase>` with a filter spy, types into the input, and asserts the spy was called with `{ label, value, data }`.
  - Module-level `_filterOptionShapeGuard` const uses `@ts-expect-error` on `option.description` so tsc fails if the declared shape drifts back to bare `SelectableValue<T>`.
- `packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx` — `useFilterBySearchIndex` callback annotation updated to `{ data: SelectableValue }`. Body unchanged.
- `packages/grafana-ui/src/components/Select/SelectPerf.story.tsx` — `customFilter` annotation updated. Body unchanged.
- `public/app/core/components/TagFilter/TagFilter.tsx` — standalone `filterOption` annotation updated. Body unchanged.
- `public/app/plugins/datasource/opentsdb/components/FilterSection.tsx` — `customFilterOption` annotation updated inside `useCallback`. Body unchanged.

No runtime behavior changes — this is a types-only fix with one new regression test.

## Scope notes

I deliberately kept this to the minimum required to change the declared type and keep the tree compiling. Plugin authors with custom `filterOption` callbacks that explicitly annotate the argument may need to update their annotations; callsites that pass a callback without an annotation (like `OrgPicker.tsx` in this repo) continue to work because the inferred type naturally follows the prop.

I also considered the other two resolutions the issue suggests (wrap at the Grafana level so the runtime matches `SelectableValue<T>`, or support both shapes). Those would change behavior for `TimeZonePicker` and anyone else already reading `option.data.*`, so I went with the "update the types to reflect reality" path the reporter explicitly welcomed.

## Special notes for your reviewer

- [x] Works as expected from user's perspective (runtime is unchanged; this is a type fix only)
- [x] Pre-GA features behind a feature toggle — N/A
- [x] Docs updated; notable improvements added to What's New — N/A (internal type fix)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
