### PR TITLE
Azure Monitor: "Can not support requested time grain" bug

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.test.ts
@@ -254,6 +254,46 @@ describe('AzureMonitor: metrics dataHooks', () => {
         });
       });
     });
+
+    it('updates allowedTimeGrainsMs when metric changes but aggregation and timeGrain remain the same', async () => {
+      // Simulate switching to a metric (e.g. AKS Cluster Health) that only supports a limited set of time grains.
+      // The query already has aggregation and timeGrain set, so only allowedTimeGrainsMs differs.
+      datasource.azureMonitorDatasource.getMetricMetadata = jest.fn().mockResolvedValue({
+        primaryAggType: 'Average',
+        supportedAggTypes: ['Average'],
+        supportedTimeGrains: [
+          { label: 'Auto', value: 'auto' },
+          { label: '5 minutes', value: 'PT5M' },
+          { label: '1 hour', value: 'PT1H' },
+          { label: '1 day', value: 'P1D' },
+        ],
+        dimensions: [],
+      });
+
+      const query = {
+        ...bareQuery,
+        azureMonitor: {
+          ...metricsMetadataConfig.emptyQueryPartial,
+          aggregation: 'Average',
+          timeGrain: 'auto',
+          // Stale allowedTimeGrainsMs from the previous metric (includes PT1M which the new metric doesn't support)
+          allowedTimeGrainsMs: [60_000, 300_000, 900_000, 1_800_000, 3_600_000, 21_600_000, 43_200_000, 86_400_000],
+        },
+      };
+      renderHook(() => metricsMetadataConfig.hook(query, datasource, onChange));
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith({
+          ...query,
+          azureMonitor: {
+            ...query.azureMonitor,
+            aggregation: 'Average',
+            timeGrain: 'auto',
+            allowedTimeGrainsMs: [300_000, 3_600_000, 86_400_000],
+          },
+        });
+      });
+    });
   });
 
   describe('useMetricNamespaces', () => {

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.ts
@@ -186,9 +186,13 @@ export const useMetricMetadata = (query: AzureMonitorQuery, datasource: Datasour
       );
 
     const currentAllowedTimeGrainsMs = query.azureMonitor?.allowedTimeGrainsMs ?? [];
+    // Only consider the time grains changed when we have actual metadata with non-empty time grains.
+    // An empty list means either metadata hasn't loaded yet or the metric has no grains reported —
+    // in either case we should not overwrite existing allowedTimeGrainsMs.
     const allowedTimeGrainsChanged =
-      newAllowedTimeGrainsMs.length !== currentAllowedTimeGrainsMs.length ||
-      newAllowedTimeGrainsMs.some((v, i) => v !== currentAllowedTimeGrainsMs[i]);
+      newAllowedTimeGrainsMs.length > 0 &&
+      (newAllowedTimeGrainsMs.length !== currentAllowedTimeGrainsMs.length ||
+        newAllowedTimeGrainsMs.some((v, i) => v !== currentAllowedTimeGrainsMs[i]));
 
     if (newAggregation !== aggregation || newTimeGrain !== timeGrain || allowedTimeGrainsChanged) {
       onChange({

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.ts
@@ -179,19 +179,25 @@ export const useMetricMetadata = (query: AzureMonitorQuery, datasource: Datasour
   useEffect(() => {
     const newAggregation = aggregation || metricMetadata.primaryAggType;
     const newTimeGrain = timeGrain || 'auto';
+    const newAllowedTimeGrainsMs = metricMetadata.timeGrains
+      .filter((timeGrain) => timeGrain.value !== 'auto')
+      .map((timeGrain) =>
+        rangeUtil.intervalToMs(TimegrainConverter.createKbnUnitFromISO8601Duration(timeGrain.value))
+      );
 
-    if (newAggregation !== aggregation || newTimeGrain !== timeGrain) {
+    const currentAllowedTimeGrainsMs = query.azureMonitor?.allowedTimeGrainsMs ?? [];
+    const allowedTimeGrainsChanged =
+      newAllowedTimeGrainsMs.length !== currentAllowedTimeGrainsMs.length ||
+      newAllowedTimeGrainsMs.some((v, i) => v !== currentAllowedTimeGrainsMs[i]);
+
+    if (newAggregation !== aggregation || newTimeGrain !== timeGrain || allowedTimeGrainsChanged) {
       onChange({
         ...query,
         azureMonitor: {
           ...query.azureMonitor,
           aggregation: newAggregation,
           timeGrain: newTimeGrain,
-          allowedTimeGrainsMs: metricMetadata.timeGrains
-            .filter((timeGrain) => timeGrain.value !== 'auto')
-            .map((timeGrain) =>
-              rangeUtil.intervalToMs(TimegrainConverter.createKbnUnitFromISO8601Duration(timeGrain.value))
-            ),
+          allowedTimeGrainsMs: newAllowedTimeGrainsMs,
         },
       });
     }

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/dataHooks.ts
@@ -181,9 +181,7 @@ export const useMetricMetadata = (query: AzureMonitorQuery, datasource: Datasour
     const newTimeGrain = timeGrain || 'auto';
     const newAllowedTimeGrainsMs = metricMetadata.timeGrains
       .filter((timeGrain) => timeGrain.value !== 'auto')
-      .map((timeGrain) =>
-        rangeUtil.intervalToMs(TimegrainConverter.createKbnUnitFromISO8601Duration(timeGrain.value))
-      );
+      .map((timeGrain) => rangeUtil.intervalToMs(TimegrainConverter.createKbnUnitFromISO8601Duration(timeGrain.value)));
 
     const currentAllowedTimeGrainsMs = query.azureMonitor?.allowedTimeGrainsMs ?? [];
     // Only consider the time grains changed when we have actual metadata with non-empty time grains.


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/120482

Updates allowedTimeGrainsMs when metric changes, but aggregation and timeGrain remain the same.