### PR TITLE
unified-storage: return 400 on ReadResource when RV is too large

### DIFF
--- a/pkg/apiserver/storage/testing/store_tests.go
+++ b/pkg/apiserver/storage/testing/store_tests.go
@@ -208,7 +208,9 @@ func RunTestGet(ctx context.Context, t *testing.T, store storage.Interface) {
 				return
 			}
 			if tt.expectRVTooLarge {
-				if err == nil || !storage.IsTooLargeResourceVersion(err) {
+				// Our implementation differs from etcd by returning 400 (bad request) instead of 504 with
+				// a retry duration.
+				if err == nil || !apierrors.IsBadRequest(err) || !strings.Contains(err.Error(), "too large resource version") {
 					t.Errorf("expecting resource version too high error, but get: %v", err)
 				}
 				return

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -817,9 +817,9 @@ func (s *Storage) validateMinimumResourceVersion(minimumResourceVersion string, 
 	// "will be at least 'resourceVersion'".
 	if rvMin > rvActual {
 		// NOTE, the etcd3 flavor throws a 504 using storage.NewTooLargeResourceVersionError
-		// We are throwing a 401 because this is a client error rather than a server error
-		return apierrors.NewResourceExpired(
-			fmt.Sprintf("too large resource version: %d (current %d)", rvMin, rvActual),
+		// We are throwing a 400 because this is a client error rather than a server error in our case.
+		return apierrors.NewBadRequest(
+			fmt.Sprintf("resource version too large: %d (current %d)", rvMin, rvActual),
 		)
 	}
 	return nil

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -819,7 +819,7 @@ func (s *Storage) validateMinimumResourceVersion(minimumResourceVersion string, 
 		// NOTE, the etcd3 flavor throws a 504 using storage.NewTooLargeResourceVersionError
 		// We are throwing a 400 because this is a client error rather than a server error in our case.
 		return apierrors.NewBadRequest(
-			fmt.Sprintf("resource version too large: %d (current %d)", rvMin, rvActual),
+			fmt.Sprintf("too large resource version: %d (current %d)", rvMin, rvActual),
 		)
 	}
 	return nil

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -981,19 +981,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 		// Check if the requested RV is higher than the latest available RV
 		if req.ResourceVersion > latestRV {
 			return &BackendReadResponse{
-				Error: &resourcepb.ErrorResult{
-					Code:    http.StatusGatewayTimeout,
-					Reason:  string(metav1.StatusReasonTimeout), // match etcd behavior
-					Message: "ResourceVersion is larger than max",
-					Details: &resourcepb.ErrorDetails{
-						Causes: []*resourcepb.ErrorCause{
-							{
-								Reason:  string(metav1.CauseTypeResourceVersionTooLarge),
-								Message: fmt.Sprintf("requested: %d, current %d", req.ResourceVersion, latestRV),
-							},
-						},
-					},
-				},
+				Error: NewBadRequestError(fmt.Sprintf("resource version too large: %d (current %d)", req.ResourceVersion, latestRV)),
 			}
 		}
 	}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -981,7 +981,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 		// Check if the requested RV is higher than the latest available RV
 		if req.ResourceVersion > latestRV {
 			return &BackendReadResponse{
-				Error: NewBadRequestError(fmt.Sprintf("resource version too large: %d (current %d)", req.ResourceVersion, latestRV)),
+				Error: NewBadRequestError(fmt.Sprintf("too large resource version: %d (current %d)", req.ResourceVersion, latestRV)),
 			}
 		}
 	}

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -683,14 +683,9 @@ func TestKvStorageBackend_ReadResource_TooHighResourceVersion(t *testing.T) {
 
 	response := backend.ReadResource(ctx, readReq)
 	require.NotNil(t, response.Error, "ReadResource should return error for too high resource version")
-	require.Equal(t, int32(504), response.Error.Code) // http.StatusGatewayTimeout
-	require.Equal(t, "Timeout", response.Error.Reason)
-	require.Equal(t, "ResourceVersion is larger than max", response.Error.Message)
-	require.NotNil(t, response.Error.Details)
-	require.Len(t, response.Error.Details.Causes, 1)
-	require.Equal(t, "ResourceVersionTooLarge", response.Error.Details.Causes[0].Reason)
-	require.Contains(t, response.Error.Details.Causes[0].Message, "requested:")
-	require.Contains(t, response.Error.Details.Causes[0].Message, "current")
+	require.Equal(t, int32(400), response.Error.Code)
+	require.Equal(t, "BadRequest", response.Error.Reason)
+	require.Contains(t, response.Error.Message, "resource version too large")
 }
 
 func TestKvStorageBackend_ListIterator_Success(t *testing.T) {

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -685,7 +685,7 @@ func TestKvStorageBackend_ReadResource_TooHighResourceVersion(t *testing.T) {
 	require.NotNil(t, response.Error, "ReadResource should return error for too high resource version")
 	require.Equal(t, int32(400), response.Error.Code)
 	require.Equal(t, "BadRequest", response.Error.Reason)
-	require.Contains(t, response.Error.Message, "resource version too large")
+	require.Contains(t, response.Error.Message, "too large resource version")
 }
 
 func TestKvStorageBackend_ListIterator_Success(t *testing.T) {


### PR DESCRIPTION
Small follow up to #122367: returns 400 (bad request, client error) on `ReadResource`, staying consistent with `List` when RV is larger than the latest RV.