### PR TITLE
query: map timeout/cancel errors to explicit status codes

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -178,9 +178,15 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 
 			statusCode := 0
 			var k8sErr *errorsK8s.StatusError
-			if errors.As(err, &k8sErr) {
+			switch {
+			case errors.As(err, &k8sErr):
 				statusCode = int(k8sErr.Status().Code)
-			} else {
+			case errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+				statusCode = http.StatusGatewayTimeout
+			case errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled):
+				// 499 follows the widely used "client closed request" convention.
+				statusCode = 499
+			default:
 				// we do not know what kind of error it is,
 				// we do not know what status code will get assigned to it,
 				// so we use the zero to indicate the unknown.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

These errors currently get recorded as `statusCode=0` in the metric. In an audit, I found that 504s are missing for all our API servers for the K8s metric `..._request_total` (based on an investigation post-timeout and timeout related semantics often cause this gap).

Luckily, for query service, we already do have a custom metric. Equally true is that we see high `..._request_terminations_total`{code="504"}` for query service. It would be useful from an o11y perspective to track these errors in a metric that we can use numerator over denominator analysis.

See how `statusCode=0` is currently a perfect match for the curve against `..._request_terminations_total`{code="504"}`:

https://ops.grafana-ops.net/goto/bfj79mxh22fb4f?orgId=stacks-27821

**Why do we need this feature?**

Core Services O11y

**Who is this feature for?**

Core Services

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
