### PR TITLE
Community notifications: onboard dashboards squad

### DIFF
--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -15,6 +15,21 @@
         "fr_notify": true,
         "fr_weekly": true
       }
+    },
+    {
+      "name": "dashboards",
+      "kickoff_date": "2026-04-16",
+      "adoption_date": "2025-04-16",
+      "codeowners_teams": [
+        "@grafana/dashboards-squad"
+      ],
+      "area_labels": ["area/dashboard"],
+      "enabled": {
+        "pr_notify": false,
+        "pr_weekly": true,
+        "fr_notify": false,
+        "fr_weekly": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the dashboards squad to the team notifications config.

**Config:**
- Team: `dashboards`
- Codeowners: `@grafana/dashboards-squad`
- Area label: `area/dashboard`
- Enabled: PR weekly digest + FR weekly digest

cc @Antonio-Calero-Grafana for review and vault setup.