### PR TITLE
[release-12.4.4] Chore(deps): Upgrade undici to 7.25.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -34894,9 +34894,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.12.0":
-  version: 7.18.2
-  resolution: "undici@npm:7.18.2"
-  checksum: 10/7d8b921717f5a11fe7e3631dd46ea6dbd80173bdbd454c0115d2c52595352b4a620a3e48c02c40e8f32a416b8bd0028b027cbc8ddebc2d9cdc7a283d50399e3c
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10/038d3568c72bb976e3cc389284f7f1cc64cd70d578300e4676a449fbcb624a35fe99ac127b5f3729f18b8246d6c090444ab61b1b67736bb88f52a3e913d76bf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `undici` from 7.18.2 to 7.25.0
- Fixes 7 CVEs including 3 High severity (WebSocket 64-bit frame crash, permessage-deflate crash, decompression bomb)
- Method: `yarn up -R undici`

## Test plan
- [ ] CI passes
- [ ] `yarn why undici --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)