### PR TITLE
[release-12.3.7] Chore(deps): Upgrade undici to 7.25.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -33199,9 +33199,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.12.0":
-  version: 7.13.0
-  resolution: "undici@npm:7.13.0"
-  checksum: 10/a51ba5c95046159e7def34d67a48605ff913e357e2aab6d51f2201f8ed09f9237f90d5bbe1beb6b3cc890940b500dc0c208527cf597de27d4a964a8c5f721f65
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10/038d3568c72bb976e3cc389284f7f1cc64cd70d578300e4676a449fbcb624a35fe99ac127b5f3729f18b8246d6c090444ab61b1b67736bb88f52a3e913d76bf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `undici` from 7.13.0 to 7.25.0
- Fixes 7 CVEs including 3 High severity (WebSocket 64-bit frame crash, permessage-deflate crash, decompression bomb)
- Method: `yarn up -R undici`

## Test plan
- [ ] CI passes
- [ ] `yarn why undici --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)