### PR TITLE
[release-11.6.15] Chore(deps): Upgrade undici to 6.25.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31837,9 +31837,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.19.5":
-  version: 6.21.1
-  resolution: "undici@npm:6.21.1"
-  checksum: 10/eeccc07e9073ae8e755fdc0dc8cdfaa426c01ec6f815425c3ecedba2e5394cea4993962c040dd168951714a82f0d001a13018c3ae3ad4534f0fa97afe425c08d
+  version: 6.25.0
+  resolution: "undici@npm:6.25.0"
+  checksum: 10/a475e45da3e1d1073283bb70531666f09a432eabff2b857bd7063d469a1ee1486192ff61dc0dadbb526673ce1120fee14d66a59b6b17d1e0bd3a4d5f0a52d0a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `undici` from 6.21.1 to 6.25.0
- Fixes 6 CVEs including WebSocket crash, HTTP smuggling, CRLF injection, and decompression bomb
- Method: `yarn up -R undici`

## Test plan
- [ ] CI passes
- [ ] `yarn why undici --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)