### PR TITLE
TTRD: Remove noisy tracking events

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -4,7 +4,7 @@ import Skeleton from 'react-loading-skeleton';
 import { type GrafanaTheme2, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import {
   type SceneObjectState,
   SceneObjectBase,
@@ -116,19 +116,10 @@ export class DashboardControls extends SceneObjectBase<DashboardControlsState> {
         refreshPickerDeactivation = this.state.refreshPicker.activate();
       }
 
-      // Subscribe to time range changes to track interactions
-      const timeRange = sceneGraph.getTimeRange(this);
-      const timeRangeSubscription = timeRange.subscribeToState((newState, prevState) => {
-        if (newState.value !== prevState.value) {
-          reportInteraction('grafana_dashboards_time_picker_changed');
-        }
-      });
-
       return () => {
         if (refreshPickerDeactivation) {
           refreshPickerDeactivation();
         }
-        timeRangeSubscription.unsubscribe();
       };
     });
   }

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -1,9 +1,9 @@
 import { css, cx } from '@emotion/css';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { type GrafanaTheme2, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import {
   ControlsLabel,
   type ControlsLayout,
@@ -13,7 +13,6 @@ import {
   type SceneVariables,
   SceneVariableSet,
   type SceneVariableState,
-  SceneVariableValueChangedEvent,
   useSceneObjectState,
 } from '@grafana/scenes';
 import { useElementSelection, useStyles2 } from '@grafana/ui';
@@ -30,17 +29,6 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
   const { variables } = sceneGraph.getVariables(dashboard)!.useState();
   const { isEditing } = dashboard.useState();
   const isEditingNewLayouts = isEditing && config.featureToggles.dashboardNewLayouts;
-
-  // Subscribe to variable value changes to track interactions
-  useEffect(() => {
-    const subscription = dashboard.subscribeToEvent(SceneVariableValueChangedEvent, () => {
-      reportInteraction('grafana_dashboards_variable_changed');
-    });
-
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [dashboard]);
 
   const visibleVariables = variables.filter(
     (v: SceneVariable) =>

--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -2,7 +2,7 @@ import { useEffect, useReducer } from 'react';
 
 import { dateMath, type TimeRange, type TimeZone } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction, TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { defaultIntervals, isWeekStart, RefreshPicker } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { TimePickerWithHistory } from 'app/core/components/TimePicker/TimePickerWithHistory';
@@ -66,7 +66,6 @@ export function DashNavTimeControls({
     };
 
     getTimeSrv().setTime(nextRange);
-    reportInteraction('grafana_dashboards_time_picker_changed');
   };
 
   const handleChangeTimeZone = (timeZone: TimeZone) => {

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -20,7 +20,7 @@ import {
   VariableRefresh,
   type VariableWithOptions,
 } from '@grafana/data';
-import { config, locationService, logWarning, reportInteraction } from '@grafana/runtime';
+import { config, locationService, logWarning } from '@grafana/runtime';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -614,7 +614,6 @@ export const variableUpdated = (
 
     return Promise.all(promises).then(() => {
       if (emitChangeEvents) {
-        reportInteraction('grafana_dashboards_variable_changed');
         events.publish(new VariablesChanged(event));
         locationService.partial(getQueryWithVariables(rootStateKey, getState));
       }


### PR DESCRIPTION
**What is this ?**
Removes two high-volume tracking events: `grafana_dashboards_time_picker_changed` and `grafana_dashboards_variable_changed`. Both were fired on every time range or variable change in dashboards (scenes and non-scenes paths).
[Documentation](https://docs.google.com/document/d/1dyUi-S_a2PGVz-tPYx_HHEPzmpvSaDubQlFBlrvBftI/edit?tab=t.0) got updated too.

Events got introduced by [this PR](https://github.com/grafana/grafana/pull/119138).

**Why do we need this ?**
These events are too noisy and generate excessive telemetry volume. I got approached by the analytics team as they had to disable these two events.

**Special notes for your reviewer:**

The removals cover all four call sites:
- `DashboardControls.tsx` (scenes: time range subscription)
- `VariableControls.tsx` (scenes: variable value changed event)
- `DashNavTimeControls.tsx` (non-scenes: time picker handler)
- `variables/state/actions.ts` (non-scenes: variable updated action)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.