### PR TITLE
IAM: Skip hidden users filtering for service identities

### DIFF
--- a/pkg/registry/apis/iam/user/store_wrapper.go
+++ b/pkg/registry/apis/iam/user/store_wrapper.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
@@ -76,7 +77,12 @@ func (f *StoreWrapper) getHiddenUsers(ctx context.Context) (map[string]struct{},
 
 // AfterGet returns NotFound if the user's login is in the hidden users list
 // and the requester is not the user themselves.
+// Service identities (e.g. Zanzana) bypass hidden user filtering entirely.
 func (f *StoreWrapper) AfterGet(ctx context.Context, obj runtime.Object) error {
+	if identity.IsServiceIdentity(ctx) {
+		return nil
+	}
+
 	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
@@ -104,7 +110,12 @@ func (f *StoreWrapper) AfterGet(ctx context.Context, obj runtime.Object) error {
 }
 
 // FilterList removes hidden users from the list, except for the requester themselves.
+// Service identities (e.g. Zanzana) bypass hidden user filtering entirely.
 func (f *StoreWrapper) FilterList(ctx context.Context, list runtime.Object) (runtime.Object, error) {
+	if identity.IsServiceIdentity(ctx) {
+		return list, nil
+	}
+
 	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return nil, err
@@ -135,7 +146,12 @@ func (f *StoreWrapper) FilterList(ctx context.Context, list runtime.Object) (run
 }
 
 // BeforeCreate returns Forbidden if the new user's login is in the hidden users list.
+// Service identities bypass hidden user restrictions.
 func (f *StoreWrapper) BeforeCreate(ctx context.Context, obj runtime.Object) error {
+	if identity.IsServiceIdentity(ctx) {
+		return nil
+	}
+
 	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
@@ -158,7 +174,12 @@ func (f *StoreWrapper) BeforeCreate(ctx context.Context, obj runtime.Object) err
 }
 
 // BeforeUpdate returns Forbidden if the target user (old object) or the new login is in the hidden users list.
+// Service identities bypass hidden user restrictions.
 func (f *StoreWrapper) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Object) error {
+	if identity.IsServiceIdentity(ctx) {
+		return nil
+	}
+
 	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err
@@ -192,7 +213,12 @@ func (f *StoreWrapper) BeforeUpdate(ctx context.Context, oldObj, obj runtime.Obj
 }
 
 // BeforeDelete returns Forbidden if the target user is in the hidden users list.
+// Service identities bypass hidden user restrictions.
 func (f *StoreWrapper) BeforeDelete(ctx context.Context, obj runtime.Object) error {
+	if identity.IsServiceIdentity(ctx) {
+		return nil
+	}
+
 	hiddenUsers, err := f.getHiddenUsers(ctx)
 	if err != nil {
 		return err

--- a/pkg/registry/apis/iam/user/store_wrapper_test.go
+++ b/pkg/registry/apis/iam/user/store_wrapper_test.go
@@ -284,6 +284,50 @@ func TestStoreWrapper_SettingService_Error(t *testing.T) {
 	})
 }
 
+func TestStoreWrapper_ServiceIdentityBypass(t *testing.T) {
+	sw := NewStoreWrapper(nil, &fakeSettingService{
+		settings: []*settingsvc.Setting{
+			{Section: "users", Key: "hidden_users", Value: "admin"},
+		},
+	})
+
+	// Create a service identity context — should bypass all hidden user filtering.
+	svcCtx, _ := identity.WithServiceIdentity(context.Background(), 1)
+	hiddenUser := &iamv0.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin"},
+		Spec:       iamv0.UserSpec{Login: "admin"},
+	}
+
+	t.Run("AfterGet allows hidden user", func(t *testing.T) {
+		require.NoError(t, sw.AfterGet(svcCtx, hiddenUser))
+	})
+
+	t.Run("FilterList returns all users", func(t *testing.T) {
+		list := &iamv0.UserList{
+			Items: []iamv0.User{
+				{Spec: iamv0.UserSpec{Login: "visible"}},
+				{Spec: iamv0.UserSpec{Login: "admin"}},
+			},
+		}
+		result, err := sw.FilterList(svcCtx, list)
+		require.NoError(t, err)
+		assert.Len(t, result.(*iamv0.UserList).Items, 2)
+	})
+
+	t.Run("BeforeCreate allows hidden login", func(t *testing.T) {
+		require.NoError(t, sw.BeforeCreate(svcCtx, hiddenUser))
+	})
+
+	t.Run("BeforeUpdate allows hidden user", func(t *testing.T) {
+		newObj := &iamv0.User{ObjectMeta: metav1.ObjectMeta{Name: "admin"}, Spec: iamv0.UserSpec{Login: "newlogin"}}
+		require.NoError(t, sw.BeforeUpdate(svcCtx, hiddenUser, newObj))
+	})
+
+	t.Run("BeforeDelete allows hidden user", func(t *testing.T) {
+		require.NoError(t, sw.BeforeDelete(svcCtx, hiddenUser))
+	})
+}
+
 // withAuthInfo adds a StaticRequester to the context so claims.AuthInfoFrom succeeds.
 func withAuthInfo(ctx context.Context, login string) context.Context {
 	return claims.WithAuthInfo(ctx, &identity.StaticRequester{


### PR DESCRIPTION
## Summary
- Service identities (e.g. Zanzana) now bypass hidden user filtering in the user `StoreWrapper`
- Adds an `identity.IsServiceIdentity(ctx)` early return in all five store wrapper methods: `AfterGet`, `FilterList`, `BeforeCreate`, `BeforeUpdate`, `BeforeDelete`
- This is consistent with the IAM authorizer which already grants service identities full access (`authorizer.go:50`)

## Test plan
- [x] Added `TestStoreWrapper_ServiceIdentityBypass` covering all five methods with a service identity context and hidden users configured
- [x] Existing store wrapper tests continue to pass (hidden user filtering still works for regular users)