### PR TITLE
fix(plugins): skip core plugins during preinstall instead of fatal exit

### DIFF
--- a/pkg/services/pluginsintegration/plugininstaller/service.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service.go
@@ -125,6 +125,10 @@ func (s *Service) installPlugins(ctx context.Context, pluginsToInstall []setting
 		compatOpts := plugins.NewAddOpts(s.cfg.BuildVersion, runtime.GOOS, runtime.GOARCH, installPlugin.URL)
 		err := s.pluginInstaller.Add(ctx, installPlugin.ID, installPlugin.Version, compatOpts)
 		if err != nil {
+			if errors.Is(err, plugins.ErrInstallCorePlugin) {
+				s.log.Warn("Skipping core plugin from install list", "pluginId", installPlugin.ID)
+				continue
+			}
 			var dupeErr plugins.DuplicateError
 			if errors.As(err, &dupeErr) {
 				s.log.Debug("Plugin already installed", "pluginId", installPlugin.ID, "version", installPlugin.Version)

--- a/pkg/services/pluginsintegration/plugininstaller/service_test.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service_test.go
@@ -70,6 +70,7 @@ func TestService_Run(t *testing.T) {
 		pluginsToInstallSync []setting.InstallPlugin
 		existingPlugins      []*plugins.Plugin
 		pluginsToFail        []string
+		pluginsCoreErr       []string
 		latestPlugin         *repo.PluginArchiveInfo
 	}{
 		{
@@ -117,6 +118,20 @@ func TestService_Run(t *testing.T) {
 			shouldThrowError:     true,
 			pluginsToInstallSync: []setting.InstallPlugin{{ID: "myplugin"}},
 			pluginsToFail:        []string{"myplugin"},
+		},
+		{
+			name:                 "when a core plugin is in sync install list, it should skip and not fail",
+			shouldInstall:        false,
+			shouldThrowError:     false,
+			pluginsToInstallSync: []setting.InstallPlugin{{ID: "coreplugin"}},
+			pluginsCoreErr:       []string{"coreplugin"},
+		},
+		{
+			name:             "when a core plugin is in async install list, it should skip and not fail",
+			shouldInstall:    false,
+			shouldThrowError: false,
+			pluginsToInstall: []setting.InstallPlugin{{ID: "coreplugin"}},
+			pluginsCoreErr:   []string{"coreplugin"},
 		},
 		{
 			name:             "Updates a plugin",
@@ -191,6 +206,11 @@ func TestService_Run(t *testing.T) {
 				store,
 				&pluginfakes.FakePluginInstaller{
 					AddFunc: func(ctx context.Context, pluginID string, version string, opts plugins.AddOpts) error {
+						for _, plugin := range tt.pluginsCoreErr {
+							if plugin == pluginID {
+								return plugins.ErrInstallCorePlugin
+							}
+						}
 						for _, plugin := range tt.pluginsToFail {
 							if plugin == pluginID {
 								return errors.New("Failed to install plugin")


### PR DESCRIPTION
## Summary

- When a core plugin (e.g. `stackdriver`) is in the `GF_INSTALL_PLUGINS` list or `preinstall_sync` config, the `backgroundinstaller` now logs a warning and skips it instead of fatally exiting with code 1
- This prevents permanent CrashLoopBackOff on Kubernetes when users have core plugins in their install list — a regression between 11.x and 12.x caused by the move from `docker/run.sh` to the Go-based preinstall path (#105145)

## Context

Customer escalation: https://github.com/grafana/support-escalations/issues/21767

In 11.x, `docker/run.sh` handled `GF_INSTALL_PLUGINS` and tolerated core plugins in the list. In 12.x, `GF_INSTALL_PLUGINS` is mapped to `preinstall_sync` (#105292, #105145), which uses the `backgroundinstaller` with `failOnErr=true`. When the installer encounters a core plugin, it gets `ErrInstallCorePlugin` and fatally exits — crashing the pod on every restart.

The fix adds an `ErrInstallCorePlugin` check in `installPlugins()` before the `failOnErr` gate, so core plugins are skipped with a warning in both sync and async paths.

## Test plan

- [x] New test: sync install with core plugin skips and does not fail
- [x] New test: async install with core plugin skips and does not fail
- [x] All existing `plugininstaller` tests pass
- [ ] Manual: deploy `grafana-enterprise:12.3.x` with `stackdriver` in `GF_INSTALL_PLUGINS`, verify pod starts without CrashLoopBackOff