### PR TITLE
Search: disable unnecessary DocValues to reduce index size

### DIFF
--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -15,6 +15,7 @@ import (
 
 func GetBleveMappings(fields resource.SearchableDocumentFields, selectableFields []string) (mapping.IndexMapping, error) {
 	mapper := bleve.NewIndexMapping()
+	mapper.DocValuesDynamic = false // only folder and title_phrase need DocValues
 	mapper.ScoringModel = index.BM25Scoring
 
 	err := RegisterCustomAnalyzers(mapper)
@@ -45,6 +46,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	titleNgramMapping := bleve.NewTextFieldMapping()
 	titleNgramMapping.Analyzer = TITLE_ANALYZER
 	titleNgramMapping.Store = false // already stored in title
+	titleNgramMapping.DocValues = false
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_NGRAM, titleNgramMapping)
 
 	// for searching by title - uses ngram token filter
@@ -52,13 +54,21 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	titleSearchMapping := bleve.NewTextFieldMapping()
 	titleSearchMapping.Analyzer = TITLE_ANALYZER
 	titleSearchMapping.Store = false // already stored in title
+	titleSearchMapping.DocValues = false
 
 	// mapping for title to search on words/tokens larger than the ngram size
 	titleWordMapping := bleve.NewTextFieldMapping()
 	titleWordMapping.Analyzer = standard.Name
 	titleWordMapping.Store = true
+	titleWordMapping.DocValues = false
+
+	// separate keyword mapping for title (no DocValues — only the standalone title_phrase needs them)
+	titleKeywordMapping := bleve.NewKeywordFieldMapping()
+	titleKeywordMapping.Store = false
+	titleKeywordMapping.DocValues = false
+
 	// NOTE: this causes 3 title fields in the response
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleWordMapping, titleSearchMapping, titlePhraseMapping)
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleWordMapping, titleSearchMapping, titleKeywordMapping)
 
 	descriptionMapping := &mapping.FieldMapping{
 		Name:               resource.SEARCH_FIELD_DESCRIPTION,
@@ -156,7 +166,9 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 		IncludeTermVectors: false,
 		IncludeInAll:       true,
 	})
-	source.AddFieldMappingsAt("timestampMillis", mapping.NewNumericFieldMapping())
+	timestampMillisMapping := mapping.NewNumericFieldMapping()
+	timestampMillisMapping.DocValues = false
+	source.AddFieldMappingsAt("timestampMillis", timestampMillisMapping)
 
 	mapper.AddSubDocumentMapping("source", source)
 	mapper.AddSubDocumentMapping("manager", manager)
@@ -186,6 +198,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 			if def.Properties != nil && def.Properties.Filterable && def.Type == resourcepb.ResourceTableColumnDefinition_STRING {
 				keywordMapping := bleve.NewKeywordFieldMapping()
 				keywordMapping.Store = true
+				keywordMapping.DocValues = false
 
 				fieldMapper.AddFieldMappingsAt(def.Name, keywordMapping)
 			}

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/blevesearch/bleve/v2/document"
+	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -51,4 +53,52 @@ func TestDocumentMapping(t *testing.T) {
 	fmt.Printf("DOC: fields %d\n", len(doc.Fields))
 	fmt.Printf("DOC: size %d\n", doc.Size())
 	require.Equal(t, 21, len(doc.Fields))
+}
+
+func TestDocValuesConfiguration(t *testing.T) {
+	t.Run("DocValuesDynamic is disabled", func(t *testing.T) {
+		mappings, err := search.GetBleveMappings(nil, nil)
+		require.NoError(t, err)
+
+		impl, ok := mappings.(*mapping.IndexMappingImpl)
+		require.True(t, ok)
+		assert.False(t, impl.DocValuesDynamic, "DocValuesDynamic should be false to prevent dynamic fields from getting DocValues")
+	})
+
+	t.Run("only folder and title_phrase have DocValues", func(t *testing.T) {
+		mappings, err := search.GetBleveMappings(nil, nil)
+		require.NoError(t, err)
+
+		data := resource.IndexableDocument{
+			Title:       "title",
+			Description: "descr",
+			Tags:        []string{"a", "b"},
+			Created:     12345,
+			Folder:      "xyz",
+			CreatedBy:   "user:ryan",
+			Labels:      map[string]string{"a": "b"},
+			RV:          1234,
+			Manager:     &utils.ManagerProperties{Kind: utils.ManagerKindRepo, Identity: "rrr"},
+			Source:      &utils.SourceProperties{Path: "ppp", Checksum: "ooo", TimestampMillis: 1234},
+		}
+		data.UpdateCopyFields()
+
+		doc := document.NewDocument("id")
+		err = mappings.MapDocument(doc, data)
+		require.NoError(t, err)
+
+		fieldsWithDocValues := map[string]bool{
+			resource.SEARCH_FIELD_FOLDER:       true,
+			resource.SEARCH_FIELD_TITLE_PHRASE: true,
+		}
+
+		for _, f := range doc.Fields {
+			hasDocValues := f.Options().IncludeDocValues()
+			if fieldsWithDocValues[f.Name()] {
+				assert.True(t, hasDocValues, "field %q should have DocValues enabled", f.Name())
+			} else {
+				assert.False(t, hasDocValues, "field %q should not have DocValues enabled", f.Name())
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Disable bleve DocValues on all fields except `folder` (authz DocValueReader) and `title_phrase` (default sort)
- Set `DocValuesDynamic=false` to prevent dynamic fields (`labels.*`, `reference.*`, `fields.*`) from getting DocValues
- Stop sharing `titlePhraseMapping` between `title_phrase` and `title` fields so only `title_phrase` retains DocValues

Ref: grafana/search-and-storage-team#744
Parent: grafana/search-and-storage-team#737

## Details

DocValues are columnar per-document stored values that enable sorting and faceting. In a 10K-document index, DocValues account for ~3.3 MB (11.6% of the zap file). Analysis confirmed only two fields actually need them:

- **`folder`** — read by the authz `DocValueReader` (`bleve.go:1984`)
- **`title_phrase`** — used for default sort (`bleve.go:1406`)

All other fields either use factory functions that default to `DocValues: true` (`NewTextFieldMapping`, `NewKeywordFieldMapping`, `NewNumericFieldMapping`) or inherit `DocValuesDynamic=true` for dynamic fields.

### Trade-off: enterprise sort fields

Clients can sort by arbitrary fields via `req.SortBy`. The UI exposes 4 enterprise-only sort options that map to dynamic `fields.*` and are affected by this change:

- `views_total` → `fields.views_total`
- `views_last_30_days` → `fields.views_last_30_days`
- `errors_total` → `fields.errors_total`
- `errors_last_30_days` → `fields.errors_last_30_days`

Without DocValues, bleve falls back to building a term cache from the inverted index (dictionary + postings scan per segment, in `snapshot_index.go:documentVisitFieldTermsOnSegment`). Sorting still works correctly but is slower than the columnar DocValues path for large result sets.

The default alphabetical sort (`title_phrase`) is **not affected**.

### Savings

~2.98 MB per 10K-document segment, realized through natural index rebuilds on upgrade (no forced rebuild).

## Test plan

- [x] `go test ./pkg/storage/unified/search/...` — existing tests pass
- [x] New `TestDocValuesConfiguration` verifies `DocValuesDynamic=false` and that only `folder`/`title_phrase` fields have DocValues after `MapDocument()`
- [x] Existing integration tests exercise sorting by `title_phrase` and authz DocValue reading for `folder`