### PR TITLE
Dynamic dashboards: Fix tooltip position when selecting layout

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -110,6 +110,7 @@ const NewLayoutEmpty = ({ dashboard, styles }: NewLayoutEmptyProps) => {
                 <Trans i18nKey="dashboard.empty.select-layout-header">Select layout</Trans>
               </Text>
               <Tooltip
+                placement="top"
                 content={
                   <Trans i18nKey="dashboard.empty.layout-default-hint">
                     The selected layout will also be used as the default for all new tabs and rows. You can change this


### PR DESCRIPTION
Before:
<img width="1040" height="322" alt="image" src="https://github.com/user-attachments/assets/7498c892-319c-47c8-9c7a-248ff3d3dbc4" />

After:
<img width="756" height="439" alt="Screenshot 2026-04-16 at 12 45 09" src="https://github.com/user-attachments/assets/c3e94181-0e0b-4400-8397-8d7a52bb5af6" />
