### PR TITLE
Dashboards: Clean up server-assigned metadata from v2 exports

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -117,6 +117,7 @@ const mockV2ResourceResponse: DashboardWithAccessInfo<DashboardV2Spec> = {
     resourceVersion: '1',
     creationTimestamp: '2025-01-01T00:00:00Z',
     generation: 1,
+    ...({ uid: 'server-assigned-uuid-1234' } as Record<string, unknown>),
   },
   spec: mockV2Spec,
   access: {},
@@ -206,8 +207,31 @@ describe('ShareExportTab', () => {
       expect(result.json).not.toHaveProperty('status');
       expect(result.json).not.toHaveProperty('access');
       if ('metadata' in result.json) {
+        expect(result.json.metadata).not.toHaveProperty('uid');
+        expect(result.json.metadata).not.toHaveProperty('name');
         expect(result.json.metadata).not.toHaveProperty('resourceVersion');
         expect(result.json.metadata).not.toHaveProperty('namespace');
+        expect(result.json.metadata).not.toHaveProperty('generation');
+        expect(result.json.metadata).not.toHaveProperty('creationTimestamp');
+      }
+    });
+
+    it('should strip metadata.uid even when not sharing externally', async () => {
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource, isSharingExternally: false });
+
+      const result = await tab.getExportableDashboardJson();
+
+      expect(result.json).toMatchObject({
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'Dashboard',
+      });
+      if ('metadata' in result.json) {
+        expect(result.json.metadata).not.toHaveProperty('uid');
+        expect(result.json.metadata).toHaveProperty('name', 'test-uid-v2');
+        expect(result.json.metadata).toHaveProperty('resourceVersion');
+        expect(result.json.metadata).toHaveProperty('generation');
+        expect(result.json.metadata).toHaveProperty('creationTimestamp');
       }
     });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -277,11 +277,14 @@ function stripMetadataForExport(metadata: ObjectMeta, isSharingExternally: boole
   const result: Record<string, any> = cloneDeep(metadata);
 
   delete result['managedFields'];
+  delete result['uid'];
 
   if (isSharingExternally) {
-    delete result['uid'];
+    delete result['name'];
     delete result['resourceVersion'];
     delete result['namespace'];
+    delete result['generation'];
+    delete result['creationTimestamp'];
 
     for (const key in result['labels']) {
       if (key.startsWith('grafana.app/')) {


### PR DESCRIPTION
## What

Strips server-assigned metadata fields from v2 dashboard exports that have no import-time value and confuse users.

## Why

In the v2 resource envelope, `metadata.uid` is a server-assigned UUID (generated by unified storage), not the dashboard's URL-facing identifier - that's `metadata.name`. Users see `uid` in the exported JSON and naturally assume it's their dashboard identifier, leading to confusion during export-import workflows.

`metadata.generation` and `metadata.creationTimestamp` are also server-assigned and meaningless when importing to another instance.

**Changes:**
- `metadata.uid` is now stripped from **all** exports (was only stripped for external sharing)
- `metadata.name`, `metadata.generation`, and `metadata.creationTimestamp` are additionally stripped when sharing externally - these are instance-specific and the importing user should set their own identifier

## How to test

1. Open any v2 dashboard
2. Share > Export > toggle "Share dashboard with another instance" **off**
3. Verify `metadata.uid` is not in the JSON, but `metadata.name` is preserved
4. Toggle "Share dashboard with another instance" **on**
5. Verify `metadata.uid`, `metadata.name`, `metadata.generation`, and `metadata.creationTimestamp` are all stripped