### PR TITLE
Alerting: Use correct AlertManagerImplementation fallback in card

### DIFF
--- a/public/app/features/alerting/unified/components/settings/ExternalAlertmanagers.tsx
+++ b/public/app/features/alerting/unified/components/settings/ExternalAlertmanagers.tsx
@@ -1,6 +1,6 @@
 import { Stack } from '@grafana/ui';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
-import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+import { AlertManagerImplementation, AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
 
 import { type ExternalAlertmanagerDataSourceWithStatus } from '../../hooks/useExternalAmSelector';
 import {
@@ -67,7 +67,7 @@ export const ExternalAlertmanagers = ({ onEditConfiguration }: Props) => {
             provisioned={isProvisioned}
             readOnly={isReadOnly}
             showStatus={!forwardingDisabled}
-            implementation={jsonData.implementation ?? 'Prometheus'}
+            implementation={jsonData.implementation ?? AlertManagerImplementation.mimir}
             receiving={isReceiving}
             status={status}
             onEditConfiguration={handleEditConfiguration}


### PR DESCRIPTION
**What is this feature?**

Replaces the hardcoded string `'Prometheus'` fallback with the typed enum value `AlertManagerImplementation.mimir` when setting the default `implementation` prop on external Alertmanager cards.

**Why do we need this feature?**

Using a raw string `'Prometheus'` is brittle and inconsistent with the rest of the codebase which uses the `AlertManagerImplementation` enum. This change improves type safety and maintainability.

**Who is this feature for?**

Developers and maintainers of the Grafana alerting codebase.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.