### PR TITLE
Folders: Remove redundant permissions check on Folder Service Create method

### DIFF
--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -454,30 +454,6 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-	if cmd.ParentUID != "" {
-		// Check that the user is allowed to create a subfolder in this folder
-		parentUIDScope := folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.ParentUID)
-		legacyEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, parentUIDScope)
-		newEvaluator := accesscontrol.EvalPermission(folder.ActionFoldersCreate, parentUIDScope)
-		evaluator := accesscontrol.EvalAny(legacyEvaluator, newEvaluator)
-		hasAccess, evalErr := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator)
-		if evalErr != nil {
-			return nil, evalErr
-		}
-		if !hasAccess {
-			return nil, folder.ErrCreationAccessDenied.Errorf("user is missing the permission with action either folders:create or folders:write and scope %s or any of the parent folder scopes", parentUIDScope)
-		}
-	} else {
-		evaluator := accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
-		hasAccess, evalErr := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator)
-		if evalErr != nil {
-			return nil, evalErr
-		}
-		if !hasAccess {
-			return nil, folder.ErrCreationAccessDenied.Errorf("user is missing the permission with action folders:create and scope folders:uid:general, which is required to create a folder under the root level")
-		}
-	}
-
 	cmd = &folder.CreateFolderCommand{
 		// TODO: Today, if a UID isn't specified, the dashboard store
 		// generates a new UID. The new folder store will need to do this as

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -320,16 +320,6 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				require.Equal(t, folder.ErrAccessDenied, err)
 			})
 
-			t.Run("When creating folder should return access denied error", func(t *testing.T) {
-				_, err := folderService.Create(ctx, &folder.CreateFolderCommand{
-					OrgID:        orgID,
-					Title:        f.Title,
-					UID:          f.UID,
-					SignedInUser: noPermUsr,
-				})
-				require.Error(t, err)
-			})
-
 			title := "Folder-TEST"
 			t.Run("When updating folder should return access denied error", func(t *testing.T) {
 				_, err := folderService.Update(ctx, &folder.UpdateFolderCommand{

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -818,9 +818,13 @@ func TestIntegrationFolderCreatePermissionsK8S(t *testing.T) {
 			},
 		},
 		{
-			description:  "subfolder creation succeeds with folders:write scoped to the parent (legacy permission)",
+			// folders:write alone no longer grants create access via the k8s API.
+			// The legacy EvalAny(folders:write, folders:create) fallback lived in the
+			// Folder Service Create method and has been removed; the unified storage
+			// server only checks the "create" verb (folders:create).
+			description:  "subfolder creation fails with only folders:write scoped to the parent",
 			parentUID:    "parent",
-			expectedCode: http.StatusCreated,
+			expectedCode: http.StatusForbidden,
 			permissions: []resourcepermissions.SetResourcePermissionCommand{
 				{
 					Actions:           []string{"folders:write"},

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -756,6 +756,170 @@ func TestIntegrationFolderCreatePermissions(t *testing.T) {
 	}
 }
 
+// TestIntegrationFolderCreatePermissionsK8S verifies that create-permission enforcement holds
+// when folders are created directly through the k8s API (folder.grafana.app/v1).
+// These cases were previously guarded by two explicit RBAC checks in the Folder Service
+// Create method and are now enforced inside the unified storage server (server.newEvent).
+func TestIntegrationFolderCreatePermissionsK8S(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	if !db.IsTestDbSQLite() {
+		t.Skip("test only on sqlite for now")
+	}
+
+	type testCase struct {
+		description  string
+		parentUID    string // empty → root-level folder
+		permissions  []resourcepermissions.SetResourcePermissionCommand
+		expectedCode int
+	}
+
+	tcs := []testCase{
+		{
+			description:  "root folder creation succeeds with folders:create on wildcard scope",
+			expectedCode: http.StatusCreated,
+			permissions: []resourcepermissions.SetResourcePermissionCommand{
+				{
+					Actions:           []string{"folders:create"},
+					Resource:          "folders",
+					ResourceAttribute: "uid",
+					ResourceID:        "*",
+				},
+			},
+		},
+		{
+			description:  "root folder creation fails with no permissions",
+			expectedCode: http.StatusForbidden,
+			permissions:  []resourcepermissions.SetResourcePermissionCommand{},
+		},
+		{
+			description:  "root folder creation fails when folders:create is scoped only to a specific subfolder",
+			expectedCode: http.StatusForbidden,
+			permissions: []resourcepermissions.SetResourcePermissionCommand{
+				{
+					Actions:           []string{"folders:create"},
+					Resource:          "folders",
+					ResourceAttribute: "uid",
+					ResourceID:        "some-other-folder",
+				},
+			},
+		},
+		{
+			description:  "subfolder creation succeeds with folders:create scoped to the parent",
+			parentUID:    "parent",
+			expectedCode: http.StatusCreated,
+			permissions: []resourcepermissions.SetResourcePermissionCommand{
+				{
+					Actions:           []string{"folders:create"},
+					Resource:          "folders",
+					ResourceAttribute: "uid",
+					ResourceID:        "parent",
+				},
+			},
+		},
+		{
+			description:  "subfolder creation succeeds with folders:write scoped to the parent (legacy permission)",
+			parentUID:    "parent",
+			expectedCode: http.StatusCreated,
+			permissions: []resourcepermissions.SetResourcePermissionCommand{
+				{
+					Actions:           []string{"folders:write"},
+					Resource:          "folders",
+					ResourceAttribute: "uid",
+					ResourceID:        "parent",
+				},
+			},
+		},
+		{
+			description:  "subfolder creation fails with no permissions on the parent",
+			parentUID:    "parent",
+			expectedCode: http.StatusForbidden,
+			permissions:  []resourcepermissions.SetResourcePermissionCommand{},
+		},
+		{
+			description:  "subfolder creation fails when permission is scoped to a different folder",
+			parentUID:    "parent",
+			expectedCode: http.StatusForbidden,
+			permissions: []resourcepermissions.SetResourcePermissionCommand{
+				{
+					Actions:           []string{"folders:create"},
+					Resource:          "folders",
+					ResourceAttribute: "uid",
+					ResourceID:        "wrong-folder",
+				},
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		t.Run(fmt.Sprintf("Mode_%d", mode), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				AppModeProduction:    true,
+				DisableAnonymous:     true,
+				APIServerStorageType: "unified",
+			})
+
+			for i, tc := range tcs {
+				t.Run(tc.description, func(t *testing.T) {
+					username := fmt.Sprintf("k8s-perm-user-%d", i)
+					folderUID := fmt.Sprintf("k8s-perm-folder-%d", i)
+					parentUID := fmt.Sprintf("k8s-perm-parent-%d", i)
+
+					// Remap the "parent" sentinel to a unique UID for this test case.
+					permissions := make([]resourcepermissions.SetResourcePermissionCommand, len(tc.permissions))
+					for j, p := range tc.permissions {
+						permissions[j] = p
+						if p.ResourceID == "parent" {
+							permissions[j].ResourceID = parentUID
+						}
+					}
+
+					// Create the parent folder as admin when the test case needs one.
+					if tc.parentUID != "" {
+						parentCreate := apis.DoRequest(helper, apis.RequestParams{
+							User:   helper.Org1.Admin,
+							Method: http.MethodPost,
+							Path:   "/api/folders",
+							Body:   []byte(fmt.Sprintf(`{"uid":%q,"title":"Parent folder %d"}`, parentUID, i)),
+						}, &folder.Folder{})
+						require.Equal(t, http.StatusOK, parentCreate.Response.StatusCode)
+					}
+
+					user := helper.CreateUser(username, apis.Org1, org.RoleViewer, permissions)
+					userID, _ := user.Identity.GetInternalID()
+					t.Cleanup(helper.CleanupTestResources([]string{folderUID, parentUID}, []int64{userID}))
+
+					client := helper.GetResourceClient(apis.ResourceClientArgs{
+						User: user,
+						GVR:  gvr,
+					})
+
+					obj := &unstructured.Unstructured{
+						Object: map[string]any{
+							"spec": map[string]any{
+								"title": "Test folder",
+							},
+						},
+					}
+					obj.SetName(folderUID)
+					if tc.parentUID != "" {
+						obj.SetAnnotations(map[string]string{
+							utils.AnnoKeyFolder: parentUID,
+						})
+					}
+
+					_, err := client.Resource.Create(context.Background(), obj, metav1.CreateOptions{})
+					if tc.expectedCode == http.StatusCreated {
+						require.NoError(t, err)
+					} else {
+						helper.EnsureStatusError(err, tc.expectedCode, "Access denied")
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestIntegrationFolderGetPermissions(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -818,10 +818,10 @@ func TestIntegrationFolderCreatePermissionsK8S(t *testing.T) {
 			},
 		},
 		{
-			// folders:write alone no longer grants create access via the k8s API.
-			// The legacy EvalAny(folders:write, folders:create) fallback lived in the
-			// Folder Service Create method and has been removed; the unified storage
-			// server only checks the "create" verb (folders:create).
+			// folders:write has never been sufficient to create a folder via the k8s API.
+			// The authz/rbac service maps VerbCreate → folders:create (with action sets
+			// folders:edit and folders:admin). folders:write is a separate granular action
+			// that is not in any of those sets, so it does not grant create access.
 			description:  "subfolder creation fails with only folders:write scoped to the parent",
 			parentUID:    "parent",
 			expectedCode: http.StatusForbidden,


### PR DESCRIPTION
Permissions are now handled by the folder api server. The folder service should not be evaluating permissions.

Part of https://github.com/grafana/search-and-storage-team/issues/748