### PR TITLE
Docs: API Migration clarification note

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances.md
@@ -44,10 +44,10 @@ This is different from the [**No Data** state](ref:no-data-state), which occurs 
 
 A stale alert instance transitions to the **Normal (MissingSeries)** state as **Resolved**, and is then evicted:
 
-| Eval. Interval   | 1   | 2               | 3                                       | 4   |
-| :--------------- | :-- | :-------------- | :-------------------------------------- | :-- |
-| Alert instance A | ✔   | ✔               | ✔                                       | ✔   |
-| Alert instance B | ✔   | `MissingSeries` | ️`Normal(MissingSeries)` 📩<sup>\*</sup> |     |
+| Eval. Interval   | 1   | 2               | 3                                        | 4   |
+| :--------------- | :-- | :-------------- | :--------------------------------------- | :-- |
+| Alert instance A | ✔  | ✔              | ✔                                       | ✔  |
+| Alert instance B | ✔  | `MissingSeries` | ️`Normal(MissingSeries)` 📩<sup>\*</sup> |     |
 
 {{< admonition type="note" >}}
 

--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/stale-alert-instances.md
@@ -44,10 +44,10 @@ This is different from the [**No Data** state](ref:no-data-state), which occurs 
 
 A stale alert instance transitions to the **Normal (MissingSeries)** state as **Resolved**, and is then evicted:
 
-| Eval. Interval   | 1   | 2               | 3                                        | 4   |
-| :--------------- | :-- | :-------------- | :--------------------------------------- | :-- |
-| Alert instance A | ✔  | ✔              | ✔                                       | ✔  |
-| Alert instance B | ✔  | `MissingSeries` | ️`Normal(MissingSeries)` 📩<sup>\*</sup> |     |
+| Eval. Interval   | 1   | 2               | 3                                       | 4   |
+| :--------------- | :-- | :-------------- | :-------------------------------------- | :-- |
+| Alert instance A | ✔   | ✔               | ✔                                       | ✔   |
+| Alert instance B | ✔   | `MissingSeries` | ️`Normal(MissingSeries)` 📩<sup>\*</sup> |     |
 
 {{< admonition type="note" >}}
 

--- a/docs/sources/alerting/guides/missing-data.md
+++ b/docs/sources/alerting/guides/missing-data.md
@@ -172,13 +172,13 @@ Grafana marks missing series as [**stale**](ref:stale-alert-instances) after two
 
 If an alert instance becomes stale, you’ll find it in the [alert history](ref:alert-history) as `Normal (Missing Series)` before it disappears. This table shows the eviction process from the previous example:
 
-| Time  | region1               | region2                               | Alert triggered                                                          |
-| :---- | :-------------------- | :------------------------------------ | :----------------------------------------------------------------------- |
-| 00:00 | 1.5s 🟢               | 1s 🟢                                 | 🟢🟢 No Alerts                                                           |
-| 01:00 | 3s 🔴 <br> `Alerting` | 3s 🔴 <br> `Alerting`                 | 🔴🔴 Alert instances triggered for both regions                          |
+| Time  | region1               | region2                              | Alert triggered                                                          |
+| :---- | :-------------------- | :----------------------------------- | :----------------------------------------------------------------------- |
+| 00:00 | 1.5s 🟢               | 1s 🟢                                | 🟢🟢 No Alerts                                                           |
+| 01:00 | 3s 🔴 <br> `Alerting` | 3s 🔴 <br> `Alerting`                | 🔴🔴 Alert instances triggered for both regions                          |
 | 02:00 | 1.6s 🟢               | `(MissingSeries)`⚠️ <br> `Alerting` ️ | 🟢🔴 Region2 missing, state maintained.                                  |
-| 03:00 | 1.4s 🟢               | `(MissingSeries)` <br> `Normal`       | 🟢🟢 `region2` was resolved, 📩 notification sent, and instance evicted. |
-| 04:00 | 1.4s 🟢               | —                                     | 🟢 No Alerts. `region2` was evicted.                                     |
+| 03:00 | 1.4s 🟢               | `(MissingSeries)` <br> `Normal`      | 🟢🟢 `region2` was resolved, 📩 notification sent, and instance evicted. |
+| 04:00 | 1.4s 🟢               | —                                    | 🟢 No Alerts. `region2` was evicted.                                     |
 
 ### Why doesn’t MissingSeries match No Data behavior?
 

--- a/docs/sources/alerting/guides/missing-data.md
+++ b/docs/sources/alerting/guides/missing-data.md
@@ -172,13 +172,13 @@ Grafana marks missing series as [**stale**](ref:stale-alert-instances) after two
 
 If an alert instance becomes stale, you’ll find it in the [alert history](ref:alert-history) as `Normal (Missing Series)` before it disappears. This table shows the eviction process from the previous example:
 
-| Time  | region1               | region2                              | Alert triggered                                                          |
-| :---- | :-------------------- | :----------------------------------- | :----------------------------------------------------------------------- |
-| 00:00 | 1.5s 🟢               | 1s 🟢                                | 🟢🟢 No Alerts                                                           |
-| 01:00 | 3s 🔴 <br> `Alerting` | 3s 🔴 <br> `Alerting`                | 🔴🔴 Alert instances triggered for both regions                          |
+| Time  | region1               | region2                               | Alert triggered                                                          |
+| :---- | :-------------------- | :------------------------------------ | :----------------------------------------------------------------------- |
+| 00:00 | 1.5s 🟢               | 1s 🟢                                 | 🟢🟢 No Alerts                                                           |
+| 01:00 | 3s 🔴 <br> `Alerting` | 3s 🔴 <br> `Alerting`                 | 🔴🔴 Alert instances triggered for both regions                          |
 | 02:00 | 1.6s 🟢               | `(MissingSeries)`⚠️ <br> `Alerting` ️ | 🟢🔴 Region2 missing, state maintained.                                  |
-| 03:00 | 1.4s 🟢               | `(MissingSeries)` <br> `Normal`      | 🟢🟢 `region2` was resolved, 📩 notification sent, and instance evicted. |
-| 04:00 | 1.4s 🟢               | —                                    | 🟢 No Alerts. `region2` was evicted.                                     |
+| 03:00 | 1.4s 🟢               | `(MissingSeries)` <br> `Normal`       | 🟢🟢 `region2` was resolved, 📩 notification sent, and instance evicted. |
+| 04:00 | 1.4s 🟢               | —                                     | 🟢 No Alerts. `region2` was evicted.                                     |
 
 ### Why doesn’t MissingSeries match No Data behavior?
 

--- a/docs/sources/developer-resources/api-reference/http-api/_index.md
+++ b/docs/sources/developer-resources/api-reference/http-api/_index.md
@@ -31,8 +31,6 @@ If you need to manage or access other resources from your [Grafana Cloud Stack](
 
 Grafana is deprecating legacy APIs (`/api`) in favor of a new generation of improved APIs (`/apis`) which follow a standardized API structure alongside consistent API versioning. To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
 
-Note that legacy `/api` endpoints are not being disabled or removed, they remain fully accessible and will continue to work. However, `/api` routes will no longer be updated and **will be removed in a future major release.** For a list of the legacy APIs refer to [Legacy Grafana HTTP API ](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/api-legacy/).
-
 These are the available new generation APIs:
 
 - [Dashboards API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard/)

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/_index.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/_index.md
@@ -23,9 +23,7 @@ weight: 1000
 
 # Legacy Grafana HTTP API
 
-Grafana 13 marks the deprecation of legacy API endpoints in favor of a new generation of improved APIs (`/apis`), a Kubernetes-style API layer which follows a standardized API structure alongside consistent API versioning. To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-This change doesn't disrupt or break your current setup. Legacy `/api` endpoints are not being disabled or removed, they remain fully accessible and will continue to work. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 The following legacy APIs are available:
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/access_control.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/access_control.md
@@ -24,19 +24,15 @@ title: RBAC HTTP API
 
 # RBAC API
 
-{{< admonition type="caution" >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
-
-> Role-based access control API is only available in Grafana Cloud or Grafana Enterprise. Read more about [Grafana Enterprise](/docs/grafana/latest/introduction/grafana-enterprise/).
-
-The API can be used to create, update, delete, get, and list roles.
+Use this API to create, update, delete, get, and list roles.
 
 To check which basic or fixed roles have the required permissions, refer to [RBAC role definitions](/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions).
+
+## Requirements
+
+Role-based access control API is only available in Grafana Cloud or Grafana Enterprise. Read more about [Grafana Enterprise](/docs/grafana/latest/introduction/grafana-enterprise/).
 
 ## Get status
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/admin.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/admin.md
@@ -20,13 +20,7 @@ title: 'Admin HTTP API '
 
 # Admin API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Requirements
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning.md
@@ -22,12 +22,6 @@ title: 'Alerting Provisioning HTTP API '
 
 # Alerting provisioning HTTP API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 {{< docs/shared lookup="alerts/alerting_provisioning.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md
@@ -23,17 +23,13 @@ title: Annotations HTTP API
 
 # Annotations API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 Annotations are saved in the Grafana database (sqlite, mysql or postgres). Annotations can be organization annotations that can be shown on any dashboard by configuring an annotation data source - they are filtered by tags. Or they can be tied to a panel on a dashboard and are then only shown on that panel.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
+## Requirements
+
+If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 
 ## Find Annotations
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/authentication.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/authentication.md
@@ -21,19 +21,9 @@ aliases:
   - ../../../../developer-resources/api-reference/http-api/api-legacy/authentication/ #legacy folder
 ---
 
-{{< admonition type="caution" >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
-
-{{< admonition type="note" >}}
-
-To learn about authentication for Grafana APIs refer to [Authenticate HTTP API requests](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/#authenticate-http-api-requests).
-
-{{< /admonition >}}
+**To learn about authentication for Grafana APIs refer to [Authenticate HTTP API requests](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/#authenticate-http-api-requests).**
 
 # Authentication (deprecated)
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/correlations.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/correlations.md
@@ -22,13 +22,7 @@ title: 'Correlations HTTP API '
 
 # Correlations API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API can be used to define correlations between data sources.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions.md
@@ -25,13 +25,7 @@ title: Dashboard Permissions HTTP API
 
 # Dashboard Permissions API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API can be used to update/get the permissions for a dashboard.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_public.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_public.md
@@ -27,19 +27,11 @@ refs:
 
 # Shared Dashboards API
 
-{{< admonition type="caution" >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
-
-{{< admonition type="note" >}}
+## Requirements
 
 If you're running Grafana Enterprise, you'll need to have specific permissions for some endpoints. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
-
-{{< /admonition >}}
 
 ## Create a shared dashboard
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_versions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_versions.md
@@ -23,13 +23,7 @@ title: 'Dashboard Versions HTTP API '
 
 # Dashboard Versions
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Get all dashboard versions by dashboard UID
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/data_source.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/data_source.md
@@ -22,15 +22,11 @@ title: Data source HTTP API
 
 # Data source API
 
-{{< admonition type="caution" >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
+## Requirements
 
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
-
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
+If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 
 ## Get all data sources
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules.md
@@ -23,13 +23,7 @@ menuTitle: Data source LBAC rules HTTP API
 
 # Data source LBAC rules API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 LBAC (Label-Based Access Control) rules can be set for teams.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
@@ -27,13 +27,7 @@ menuTitle: Data source permissions HTTP API
 
 # Data source Permissions API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 > The Data Source Permissions is only available in Grafana Enterprise. Read more about [Grafana Enterprise](/docs/grafana/latest/introduction/grafana-enterprise/).
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search.md
@@ -24,13 +24,7 @@ title: Folder/Dashboard Search HTTP API
 
 # Folder/Dashboard Search API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Search folders and dashboards
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_permissions.md
@@ -25,13 +25,7 @@ title: Folder Permissions HTTP API
 
 # Folder Permissions API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API can be used to update/get the permissions for a folder.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/library_element.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/library_element.md
@@ -21,13 +21,7 @@ title: 'Library Element HTTP API '
 
 # Library Element API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Identifier (id) vs unique identifier (uid)
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/licensing.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/licensing.md
@@ -21,13 +21,7 @@ title: Licensing HTTP API
 
 # Enterprise License API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise](/docs/grafana/latest/introduction/grafana-enterprise/).
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/org.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/org.md
@@ -21,13 +21,7 @@ title: Organization HTTP API
 
 # Organization API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 The Organization HTTP API is divided in two resources, `/api/org` (current organization)
 and `/api/orgs` (admin organizations). One big difference between these are that

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/other.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/other.md
@@ -20,13 +20,7 @@ title: 'Other HTTP API '
 
 # Frontend Settings API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Get Settings
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/preferences.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/preferences.md
@@ -21,13 +21,7 @@ title: 'Preferences API'
 
 # User and Org Preferences API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 Keys:
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching.md
@@ -26,17 +26,11 @@ title: Query and Resource Caching HTTP API
 
 # Query and resource caching API
 
-{{< admonition type="caution" >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
+## Requirements
 
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
-
-{{< admonition type="note" >}}
-If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
-{{< /admonition >}}
+If you're running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 
 ## Enable caching for a data source
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
@@ -21,13 +21,7 @@ title: 'Query History HTTP API '
 
 # Query history API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API can be used to add queries to Query history. It requires that the user is logged in and that Query history feature is enabled in config file.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/reporting.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/reporting.md
@@ -20,13 +20,7 @@ title: Reporting API
 
 # Reporting API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API allows you to interact programmatically with the [Reporting](/docs/grafana/latest/dashboards/create-reports/) feature.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/serviceaccount.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/serviceaccount.md
@@ -21,13 +21,7 @@ title: Service account HTTP API
 
 # Service account API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 > For Grafana Cloud instances, please use a Bearer token to authenticate. The examples within this section reference Basic authentication which is for On-Prem Grafana instances.

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/short_url.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/short_url.md
@@ -21,13 +21,7 @@ title: 'Short URL HTTP API '
 
 # Short URL API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 Use this API to create shortened URLs. A short URL represents a longer URL containing complex query parameters in a smaller and simpler format.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/snapshot.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/snapshot.md
@@ -21,13 +21,7 @@ title: 'Snapshot API'
 
 # Snapshot API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Create new snapshot
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/sso-settings.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/sso-settings.md
@@ -23,13 +23,7 @@ title: SSO Settings API
 
 # SSO Settings API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/team.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/team.md
@@ -23,13 +23,7 @@ title: Team HTTP API
 
 # Team API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API can be used to manage Teams and Team Memberships.
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/team_sync.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/team_sync.md
@@ -26,13 +26,7 @@ title: Team Sync HTTP API
 
 # Team Sync API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 > Team Sync is only available in Grafana Enterprise. Read more about [Grafana Enterprise](/docs/grafana/latest/introduction/grafana-enterprise/).
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/user.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/user.md
@@ -27,13 +27,7 @@ refs:
 
 # User API
 
-{{< admonition type="caution" >}}
-
-Starting in Grafana 13, `/api` endpoints are being deprecated. This change doesn't disrupt or break your current setup: legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and **will be removed in a future major release.**
-
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
-
-{{< /admonition >}}
+{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 {{< admonition type="caution" >}}
 You can't authenticate to the User HTTP API with service account tokens.

--- a/docs/sources/developer-resources/api-reference/http-api/apis.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis.md
@@ -27,11 +27,11 @@ Available in Grafana 12 and later.
 
 Grafana 13 marks the deprecation of legacy API endpoints (`/api`) in favor of a new generation of improved APIs (`/apis`), a Kubernetes-style API layer which follows a standardized API structure alongside consistent API versioning.
 
-## Migrate from `api` endpoints
+## Migrate from legacy `api` endpoints
+
+**Legacy APIs are not being disabled for the moment**. Removal of legacy APIs is planned for a future major release, and any breaking changes will be announced well in advance to avoid disruptions.
 
 Note that while Grafana is working on migrating existing APIs to the new `/apis` model, currently there may not be an exact match to the legacy API you're using.
-
-**Legacy APIs are not being disabled or removed for the moment**, and any breaking changes will be announced well in advance to avoid disruptions. However, legacy `/api` routes will no longer be updated.
 
 ## API structure
 

--- a/docs/sources/developer-resources/api-reference/http-api/apis.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis.md
@@ -27,6 +27,10 @@ Available in Grafana 12 and later.
 
 Grafana 13 marks the deprecation of legacy API endpoints (`/api`) in favor of a new generation of improved APIs (`/apis`), a Kubernetes-style API layer which follows a standardized API structure alongside consistent API versioning.
 
+## Migrate from `api` endpoints
+
+Note that while Grafana is working on migrating existing APIs to the new `/apis` model, currently there may not be an exact match to the legacy API you're using.
+
 **Legacy APIs are not being disabled or removed for the moment**, and any breaking changes will be announced well in advance to avoid disruptions. However, legacy `/api` routes will no longer be updated.
 
 ## API structure

--- a/docs/sources/shared/developers/deprecated-apis.md
+++ b/docs/sources/shared/developers/deprecated-apis.md
@@ -6,10 +6,10 @@ comments: |
 
 {{< admonition type="note" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `apis` route. To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
+Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `/apis` route. Note that while Grafana is working on migrating existing APIs, currently there may not be an exact match to the legacy API you're using. 
 
-**This change doesn't disrupt or break your current setup**. Legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and will be removed in a future major release.
+**This change doesn't disrupt or break your current setup**. Legacy APIs are not being disabled and remain fully accessible and operative, but `/api` routes will no longer be updated. 
 
-Note that while Grafana is working on migrating existing APIs, currently there may not be an exact match to the legacy API you're using.  
+To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis). 
 
 {{< /admonition >}}

--- a/docs/sources/shared/developers/deprecated-apis.md
+++ b/docs/sources/shared/developers/deprecated-apis.md
@@ -4,7 +4,7 @@ comments: |
   This file is used in legacy APIs.
 ---
 
-{{< admonition type="caution" >}}
+{{< admonition type="note" >}}
 
 Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `apis` route. To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
 

--- a/docs/sources/shared/developers/deprecated-apis.md
+++ b/docs/sources/shared/developers/deprecated-apis.md
@@ -6,10 +6,10 @@ comments: |
 
 {{< admonition type="note" >}}
 
-Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `/apis` route. Note that while Grafana is working on migrating existing APIs, currently there may not be an exact match to the legacy API you're using. 
+Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `/apis` route. Note that while Grafana is working on migrating existing APIs, currently there may not be an exact match to the legacy API you're using.
 
-**This change doesn't disrupt or break your current setup**. Legacy APIs are not being disabled and remain fully accessible and operative, but `/api` routes will no longer be updated. 
+**This change doesn't disrupt or break your current setup**. Legacy APIs are not being disabled and remain fully accessible and operative, but `/api` routes will no longer be updated.
 
-To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis). 
+To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
 
 {{< /admonition >}}

--- a/docs/sources/shared/developers/deprecated-apis.md
+++ b/docs/sources/shared/developers/deprecated-apis.md
@@ -1,0 +1,15 @@
+---
+headless: true
+comments: |
+  This file is used in legacy APIs.
+---
+
+{{< admonition type="caution" >}}
+
+Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `apis` route. To learn more refer to the [new API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis).
+
+**This change doesn't disrupt or break your current setup**. Legacy APIs are not being disabled and remain fully accessible and operative. However, `/api` routes will no longer be updated and will be removed in a future major release.
+
+Note that while Grafana is working on migrating existing APIs, currently there may not be an exact match to the legacy API you're using.  
+
+{{< /admonition >}}


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/122809.

Previews: 

- https://deploy-preview-grafana-122811-zb444pucvq-vp.a.run.app/docs/grafana/latest/developer-resources/api-reference/http-api/apis/ 
- https://deploy-preview-grafana-122811-zb444pucvq-vp.a.run.app/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/