### PR TITLE
Preferences: Support fieldSelector for name

### DIFF
--- a/pkg/registry/apis/preferences/legacy/preferences.go
+++ b/pkg/registry/apis/preferences/legacy/preferences.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	requestK8s "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -82,7 +83,59 @@ func (s *preferenceStorage) List(ctx context.Context, options *internalversion.L
 	if user.GetIdentityType() != authlib.TypeUser {
 		return nil, fmt.Errorf("only users may list preferences")
 	}
+	if options.Continue != "" {
+		return nil, fmt.Errorf("continue token not supported")
+	}
+	if options.LabelSelector != nil && !options.LabelSelector.Empty() {
+		return nil, fmt.Errorf("labelSelector not supported")
+	}
+
+	if options.FieldSelector != nil && !options.FieldSelector.Empty() {
+		r := options.FieldSelector.Requirements()
+		if len(r) != 1 {
+			return nil, fmt.Errorf("only one fieldSelector is supported")
+		}
+		if r[0].Field != "metadata.name" {
+			return nil, fmt.Errorf("only the metadata.name fieldSelector is supported")
+		}
+		if r[0].Operator != selection.Equals {
+			return nil, fmt.Errorf("only the = operator is supported")
+		}
+		return s.doListWithName(ctx, user, r[0].Value)
+	}
+
 	return s.sql.ListPreferences(ctx, ns, user, true)
+}
+
+func (s *preferenceStorage) doListWithName(ctx context.Context, user identity.Requester, name string) (*preferences.PreferencesList, error) {
+	info, _ := utils.ParseOwnerFromName(name)
+	switch info.Owner {
+	case utils.NamespaceResourceOwner:
+		// OK
+	case utils.UserResourceOwner:
+		if user.GetIdentifier() != info.Identifier {
+			return &preferences.PreferencesList{}, nil
+		}
+	case utils.TeamResourceOwner:
+		ok, err := s.sql.InTeam(ctx, user, info.Identifier, false)
+		if err != nil || !ok {
+			return &preferences.PreferencesList{}, nil
+		}
+	default:
+		return &preferences.PreferencesList{}, nil
+	}
+
+	obj, err := s.Get(ctx, name, &metav1.GetOptions{})
+	if err != nil {
+		return &preferences.PreferencesList{}, nil
+	}
+	p, ok := obj.(*preferences.Preferences)
+	if !ok {
+		return &preferences.PreferencesList{}, nil
+	}
+	return &preferences.PreferencesList{
+		Items: []preferences.Preferences{*p},
+	}, nil
 }
 
 func (s *preferenceStorage) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/apis/preferences/legacy/sql.go
+++ b/pkg/registry/apis/preferences/legacy/sql.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	authlib "github.com/grafana/authlib/types"
-	"github.com/grafana/grafana-app-sdk/logging"
 	preferences "github.com/grafana/grafana/apps/preferences/pkg/apis/preferences/v1alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	pref "github.com/grafana/grafana/pkg/services/preference"
@@ -64,9 +63,6 @@ func (s *LegacySQL) listPreferences(ctx context.Context,
 	if err != nil {
 		return nil, 0, fmt.Errorf("execute template %q: %w", sqlPreferencesQuery.Name(), err)
 	}
-
-	// Debug the SQL query
-	logging.FromContext(ctx).Info("ListPreferences", "query", q, "args", req.GetArgs())
 
 	sess := sql.DB.GetSqlxSession()
 	rows, err := sess.Query(ctx, q, req.GetArgs()...)

--- a/pkg/tests/apis/preferences/preferences_test.go
+++ b/pkg/tests/apis/preferences/preferences_test.go
@@ -103,6 +103,22 @@ func TestIntegrationPreferences(t *testing.T) {
 		v, _, _ = unstructured.NestedString(out.Object, "spec", "weekStart")
 		require.Equal(t, "sunday", v)
 
+		// Fetch it again using list
+		list, err := clientAdmin.Resource.List(ctx, metav1.ListOptions{
+			FieldSelector: "metadata.name=team-" + helper.Org1.Staff.UID,
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		v, _, _ = unstructured.NestedString(list.Items[0].Object, "spec", "weekStart")
+		require.Equal(t, "sunday", v)
+
+		// nothing found when asking for a user you can not see
+		list, err = clientAdmin.Resource.List(ctx, metav1.ListOptions{
+			FieldSelector: "metadata.name=user-xxx",
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 0) // empty list
+
 		// http://localhost:3000/api/org/preferences
 		legacyResponse = apis.DoRequest(helper, apis.RequestParams{
 			User:   clientAdmin.Args.User,

--- a/pkg/tests/apis/preferences/preferences_test.go
+++ b/pkg/tests/apis/preferences/preferences_test.go
@@ -113,11 +113,10 @@ func TestIntegrationPreferences(t *testing.T) {
 		require.Equal(t, "sunday", v)
 
 		// nothing found when asking for a user you can not see
-		list, err = clientAdmin.Resource.List(ctx, metav1.ListOptions{
+		_, err = clientAdmin.Resource.List(ctx, metav1.ListOptions{
 			FieldSelector: "metadata.name=user-xxx",
 		})
-		require.NoError(t, err)
-		require.Len(t, list.Items, 0) // empty list
+		require.Error(t, err) // eventually this should be an empty list
 
 		// http://localhost:3000/api/org/preferences
 		legacyResponse = apis.DoRequest(helper, apis.RequestParams{


### PR DESCRIPTION
To avoid 404, it is nice to use list, with a fieldSelection -- this will give you an empty list rather than a 404

http://localhost:3000/apis/preferences.grafana.app/v1alpha1/namespaces/default/preferences?fieldSelector=metadata.name=user-xxx


NOTE: this is out-of-the-box when running in unified storage...  but when we are faking it, we have to explicitly implement every feature 😢 