### PR TITLE
IAM: Validate team and user existence on TeamBinding create

### DIFF
--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -3,6 +3,7 @@ package iam
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/authlib/types"
 
@@ -105,6 +106,10 @@ type IdentityAccessManagementAPIBuilder struct {
 	features featuremgmt.FeatureToggles
 
 	tracing tracing.Tracer
+
+	// Getters for existence validation during TeamBinding create
+	teamGetter rest.Getter
+	userGetter rest.Getter
 
 	cfgProvider    configprovider.ConfigProvider
 	settingService settingsvc.Service

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -460,6 +460,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamsAPIGroup(opts builder.AP
 		return err
 	}
 	storage[teamResource.StoragePath()] = teamUniStore
+	b.teamGetter = teamUniStore
 
 	if b.legacyTeamStore != nil {
 		dw, err := opts.DualWriteBuilder(teamResource.GroupResource(), b.legacyTeamStore, teamUniStore)
@@ -468,6 +469,9 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamsAPIGroup(opts builder.AP
 		}
 
 		storage[teamResource.StoragePath()] = dw
+		if getter, ok := dw.(rest.Getter); ok {
+			b.teamGetter = getter
+		}
 	}
 
 	if b.dual != nil && b.unified != nil {
@@ -567,6 +571,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateUsersAPIGroup(opts builder.AP
 		}
 	}
 
+	b.userGetter = userStore
 	storage[userResource.StoragePath()] = storewrapper.New(userStore, user.NewStoreWrapper(b.cfgProvider, b.settingService), storewrapper.WithPreserveIdentity())
 
 	if b.dual != nil && b.unified != nil {
@@ -870,7 +875,7 @@ func (b *IdentityAccessManagementAPIBuilder) validateCreate(ctx context.Context,
 	case *iamv0.Team:
 		return team.ValidateOnCreate(ctx, typedObj)
 	case *iamv0.TeamBinding:
-		return teambinding.ValidateOnCreate(ctx, typedObj)
+		return teambinding.ValidateOnCreate(ctx, typedObj, b.teamGetter, b.userGetter)
 	case *iamv0.ResourcePermission:
 		return resourcepermission.ValidateCreateAndUpdateInput(ctx, typedObj, b.mappers)
 	case *iamv0.ExternalGroupMapping:

--- a/pkg/registry/apis/iam/teambinding/validate.go
+++ b/pkg/registry/apis/iam/teambinding/validate.go
@@ -4,12 +4,14 @@ import (
 	"context"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
-func ValidateOnCreate(ctx context.Context, obj *iamv0alpha1.TeamBinding) error {
+func ValidateOnCreate(ctx context.Context, obj *iamv0alpha1.TeamBinding, teamGetter, userGetter rest.Getter) error {
 	_, err := identity.GetRequester(ctx)
 	if err != nil {
 		return apierrors.NewUnauthorized("no identity found")
@@ -29,6 +31,29 @@ func ValidateOnCreate(ctx context.Context, obj *iamv0alpha1.TeamBinding) error {
 
 	if obj.Spec.TeamRef.Name == "" {
 		return apierrors.NewBadRequest("teamRef is required")
+	}
+
+	// Skip existence validation for service identities (e.g. TeamSync) to avoid
+	// performance overhead — those callers are expected to reference valid teams and users.
+	// Only validate existence for requests made through the API with a normal identity.
+	if !identity.IsServiceIdentity(ctx) {
+		if teamGetter != nil {
+			if _, err := teamGetter.Get(ctx, obj.Spec.TeamRef.Name, &metav1.GetOptions{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return apierrors.NewBadRequest("team does not exist")
+				}
+				return err
+			}
+		}
+
+		if userGetter != nil {
+			if _, err := userGetter.Get(ctx, obj.Spec.Subject.Name, &metav1.GetOptions{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return apierrors.NewBadRequest("user does not exist")
+				}
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/teambinding/validate_test.go
+++ b/pkg/registry/apis/iam/teambinding/validate_test.go
@@ -2,10 +2,15 @@ package teambinding
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/authlib/types"
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
@@ -14,10 +19,13 @@ import (
 
 func TestValidateOnCreate(t *testing.T) {
 	tests := []struct {
-		name      string
-		requester *identity.StaticRequester
-		obj       *iamv0alpha1.TeamBinding
-		want      error
+		name        string
+		requester   *identity.StaticRequester
+		obj         *iamv0alpha1.TeamBinding
+		teamGetter  rest.Getter
+		userGetter  rest.Getter
+		want        error
+		errContains string
 	}{
 		{
 			name: "valid team binding create",
@@ -37,7 +45,9 @@ func TestValidateOnCreate(t *testing.T) {
 					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
 				},
 			},
-			want: nil,
+			teamGetter: foundGetter(),
+			userGetter: foundGetter(),
+			want:       nil,
 		},
 		{
 			name: "invalid team binding - invalid subject kind",
@@ -156,13 +166,110 @@ func TestValidateOnCreate(t *testing.T) {
 			},
 			want: apierrors.NewUnauthorized("no identity found"),
 		},
+		{
+			name: "invalid team binding - team does not exist",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeUser,
+				OrgRole: identity.RoleAdmin,
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
+						Name: "test-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "nonexistent-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+				},
+			},
+			teamGetter: notFoundGetter("teams"),
+			userGetter: foundGetter(),
+			want:       apierrors.NewBadRequest("team does not exist"),
+		},
+		{
+			name: "invalid team binding - user does not exist",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeUser,
+				OrgRole: identity.RoleAdmin,
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
+						Name: "nonexistent-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "test-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionMember,
+				},
+			},
+			teamGetter: foundGetter(),
+			userGetter: notFoundGetter("users"),
+			want:       apierrors.NewBadRequest("user does not exist"),
+		},
+		{
+			name: "team getter returns unexpected error",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeUser,
+				OrgRole: identity.RoleAdmin,
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
+						Name: "test-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "test-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+				},
+			},
+			teamGetter:  errorGetter(),
+			userGetter:  foundGetter(),
+			errContains: "internal error",
+		},
+		{
+			name: "service identity skips existence validation",
+			requester: &identity.StaticRequester{
+				Type:    types.TypeServiceAccount,
+				OrgRole: identity.RoleAdmin,
+			},
+			obj: &iamv0alpha1.TeamBinding{
+				Spec: iamv0alpha1.TeamBindingSpec{
+					Subject: iamv0alpha1.TeamBindingspecSubject{
+						Kind: "User",
+						Name: "nonexistent-user",
+					},
+					TeamRef: iamv0alpha1.TeamBindingTeamRef{
+						Name: "nonexistent-team",
+					},
+					Permission: iamv0alpha1.TeamBindingTeamPermissionAdmin,
+				},
+			},
+			teamGetter: notFoundGetter("teams"),
+			userGetter: notFoundGetter("users"),
+			want:       nil,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := identity.WithRequester(context.Background(), test.requester)
-			err := ValidateOnCreate(ctx, test.obj)
-			assert.Equal(t, test.want, err)
+			var ctx context.Context
+			if test.requester != nil && test.requester.Type == types.TypeServiceAccount {
+				ctx = identity.WithServiceIdentityContext(context.Background(), 1)
+			} else {
+				ctx = identity.WithRequester(context.Background(), test.requester)
+			}
+			err := ValidateOnCreate(ctx, test.obj, test.teamGetter, test.userGetter)
+			if test.errContains != "" {
+				assert.ErrorContains(t, err, test.errContains)
+			} else {
+				assert.Equal(t, test.want, err)
+			}
 		})
 	}
 }
@@ -452,4 +559,27 @@ func TestValidateOnUpdate(t *testing.T) {
 			assert.Equal(t, test.want, err)
 		})
 	}
+}
+
+type fakeGetter struct {
+	obj runtime.Object
+	err error
+}
+
+func (f *fakeGetter) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	return f.obj, f.err
+}
+
+var _ rest.Getter = (*fakeGetter)(nil)
+
+func foundGetter() rest.Getter {
+	return &fakeGetter{obj: &metav1.PartialObjectMetadata{}}
+}
+
+func notFoundGetter(resource string) rest.Getter {
+	return &fakeGetter{err: apierrors.NewNotFound(schema.GroupResource{Resource: resource}, "not-found")}
+}
+
+func errorGetter() rest.Getter {
+	return &fakeGetter{err: fmt.Errorf("internal error")}
 }

--- a/pkg/tests/apis/iam/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/team_binding_integration_test.go
@@ -232,6 +232,42 @@ func doTeamBindingCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHel
 		require.Contains(t, statusErr.ErrStatus.Message, "teamRef is required")
 	})
 
+	t.Run("should not be able to create team binding with non-existent team", func(t *testing.T) {
+		ctx := context.Background()
+		teamBindingClient := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Admin,
+			Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+			GVR:       gvrTeamBindings,
+		})
+
+		toCreate := createTeamBindingObject(helper, user.GetName(), "non-existent-team")
+
+		_, err := teamBindingClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code)
+		require.Contains(t, statusErr.ErrStatus.Message, "team does not exist")
+	})
+
+	t.Run("should not be able to create team binding with non-existent user", func(t *testing.T) {
+		ctx := context.Background()
+		teamBindingClient := helper.GetResourceClient(apis.ResourceClientArgs{
+			User:      helper.Org1.Admin,
+			Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+			GVR:       gvrTeamBindings,
+		})
+
+		toCreate := createTeamBindingObject(helper, "non-existent-user", team.GetName())
+
+		_, err := teamBindingClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code)
+		require.Contains(t, statusErr.ErrStatus.Message, "user does not exist")
+	})
+
 	t.Run("should not be able to create team binding with invalid permission", func(t *testing.T) {
 		ctx := context.Background()
 		teamBindingClient := helper.GetResourceClient(apis.ResourceClientArgs{


### PR DESCRIPTION
## Summary
- Adds existence validation for `teamRef.name` (team) and `subject.name` (user) during TeamBinding creation using `rest.Getter` lookups by `metadata.name`
- Skips validation for service identities (e.g. TeamSync) to avoid performance overhead
- Wires team and user getters from the storage layer into the validation function

Closes https://github.com/grafana/identity-access-team/issues/1984

## Test plan
- [x] Unit tests for team not found, user not found, getter error propagation, and service identity skip
- [x] Integration tests for non-existent team and non-existent user on TeamBinding create