### PR TITLE
Prefs: Fix patch preferences for teams not working

### DIFF
--- a/pkg/registry/apis/preferences/legacy/preferences.go
+++ b/pkg/registry/apis/preferences/legacy/preferences.go
@@ -158,6 +158,7 @@ func (s *preferenceStorage) Get(ctx context.Context, name string, options *metav
 			req.TeamUID = owner.Identifier
 			return false, nil
 		case utils.NamespaceResourceOwner:
+			req.Namespace = true
 			return false, nil
 		default:
 			return false, fmt.Errorf("unsupported name")

--- a/pkg/registry/apis/preferences/legacy/queries.go
+++ b/pkg/registry/apis/preferences/legacy/queries.go
@@ -39,6 +39,7 @@ type preferencesQuery struct {
 	UserTeams []string // also requires user UID
 	TeamUID   string
 	All       bool // explicitly request all preferences
+	Namespace bool // get the org preferences
 
 	UserTable        string
 	TeamTable        string
@@ -61,7 +62,7 @@ func (r preferencesQuery) Validate() error {
 		return fmt.Errorf("user required when filtering by a set of teams")
 	}
 	if r.UserUID == "" && r.TeamUID == "" {
-		if r.All {
+		if r.All || r.Namespace {
 			return nil // OK
 		}
 		return fmt.Errorf("to list all preferences, explicitly set the .All flag")

--- a/pkg/registry/apis/preferences/legacy/queries_test.go
+++ b/pkg/registry/apis/preferences/legacy/queries_test.go
@@ -84,6 +84,12 @@ func TestPreferencesQueries(t *testing.T) {
 						q.TeamUID = "ttt"
 					}),
 				},
+				{
+					Name: "namespace",
+					Data: getPreferencesQuery(1, func(q *preferencesQuery) {
+						q.Namespace = true
+					}),
+				},
 			},
 			sqlPreferencesRV: {
 				{

--- a/pkg/registry/apis/preferences/legacy/sql.go
+++ b/pkg/registry/apis/preferences/legacy/sql.go
@@ -206,6 +206,6 @@ func (s *LegacySQL) getLegacyTeamID(ctx context.Context, orgId int64, team strin
 
 	var id int64
 	sess := sql.DB.GetSqlxSession()
-	err = sess.Select(ctx, &id, "SELECT id FROM team WHERE org_id=? AND uid=?", orgId, team)
+	err = sess.Get(ctx, &id, "SELECT id FROM team WHERE org_id=? AND uid=?", orgId, team)
 	return id, err
 }

--- a/pkg/registry/apis/preferences/legacy/sql_preferences_query.sql
+++ b/pkg/registry/apis/preferences/legacy/sql_preferences_query.sql
@@ -22,6 +22,8 @@ WHERE p.org_id = {{ .Arg .OrgID }}
    OR (p.user_id = 0 AND p.team_id = 0)
   {{ end }}
   )
+{{ else if .Namespace }} 
+  AND p.user_id = 0 AND p.team_id = 0
 {{ else if not .All }}
   invalid query -- specify All to list all permissions in query
 {{ end }}

--- a/pkg/registry/apis/preferences/legacy/sql_test.go
+++ b/pkg/registry/apis/preferences/legacy/sql_test.go
@@ -1,0 +1,59 @@
+package legacy
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+
+	infradb "github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/services/sqlstore/session"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+)
+
+// testDB wraps FakeDB but returns a real SessionDB backed by sqlmock.
+type testDB struct {
+	dbtest.FakeDB
+	sess *session.SessionDB
+}
+
+func (t *testDB) GetSqlxSession() *session.SessionDB {
+	return t.sess
+}
+
+var _ infradb.DB = (*testDB)(nil)
+
+func newTestLegacySQL(t *testing.T) (*LegacySQL, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	sess := session.GetSession(sqlxDB)
+	helper := &legacysql.LegacyDatabaseHelper{
+		DB:    &testDB{sess: sess},
+		Table: func(n string) string { return n },
+	}
+
+	store := &LegacySQL{db: func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return helper, nil
+	}}
+	return store, mock
+}
+
+func TestGetLegacyTeamID(t *testing.T) {
+	store, mock := newTestLegacySQL(t)
+
+	mock.ExpectQuery("SELECT id FROM team").
+		WithArgs(int64(1), "ffj1xdbwxf6kga").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+
+	id, err := store.getLegacyTeamID(context.Background(), 1, "ffj1xdbwxf6kga")
+	require.NoError(t, err)
+	require.Equal(t, int64(42), id)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/registry/apis/preferences/legacy/testdata/mysql--sql_preferences_query-namespace.sql
+++ b/pkg/registry/apis/preferences/legacy/testdata/mysql--sql_preferences_query-namespace.sql
@@ -1,0 +1,15 @@
+SELECT p.id, p.org_id,
+  p.json_data,
+  p.timezone,
+  p.theme,
+  p.week_start,
+  p.home_dashboard_uid,
+  u.uid as user_uid,
+  t.uid as team_uid,
+  p.created, p.updated
+ FROM `grafana`.`preferences` as p 
+ LEFT JOIN `grafana`.`user` as u ON p.user_id = u.id
+ LEFT JOIN `grafana`.`team` as t ON p.team_id = t.id
+WHERE p.org_id = 1 
+  AND p.user_id = 0 AND p.team_id = 0
+ORDER BY p.user_id asc, p.team_id asc, p.org_id asc

--- a/pkg/registry/apis/preferences/legacy/testdata/postgres--sql_preferences_query-namespace.sql
+++ b/pkg/registry/apis/preferences/legacy/testdata/postgres--sql_preferences_query-namespace.sql
@@ -1,0 +1,15 @@
+SELECT p.id, p.org_id,
+  p.json_data,
+  p.timezone,
+  p.theme,
+  p.week_start,
+  p.home_dashboard_uid,
+  u.uid as user_uid,
+  t.uid as team_uid,
+  p.created, p.updated
+ FROM "grafana"."preferences" as p 
+ LEFT JOIN "grafana"."user" as u ON p.user_id = u.id
+ LEFT JOIN "grafana"."team" as t ON p.team_id = t.id
+WHERE p.org_id = 1 
+  AND p.user_id = 0 AND p.team_id = 0
+ORDER BY p.user_id asc, p.team_id asc, p.org_id asc

--- a/pkg/registry/apis/preferences/legacy/testdata/sqlite--sql_preferences_query-namespace.sql
+++ b/pkg/registry/apis/preferences/legacy/testdata/sqlite--sql_preferences_query-namespace.sql
@@ -1,0 +1,15 @@
+SELECT p.id, p.org_id,
+  p.json_data,
+  p.timezone,
+  p.theme,
+  p.week_start,
+  p.home_dashboard_uid,
+  u.uid as user_uid,
+  t.uid as team_uid,
+  p.created, p.updated
+ FROM "grafana"."preferences" as p 
+ LEFT JOIN "grafana"."user" as u ON p.user_id = u.id
+ LEFT JOIN "grafana"."team" as t ON p.team_id = t.id
+WHERE p.org_id = 1 
+  AND p.user_id = 0 AND p.team_id = 0
+ORDER BY p.user_id asc, p.team_id asc, p.org_id asc


### PR DESCRIPTION
Fixes an issue where when trying to save team preferences, it fails with `expected slice but got int64`.

Claude says this is because `sess.Select` returns multiple values and expects the output type to be a slice, but we're just selecting a single int value.

Also added a test for this, checked it failed on the old implementation. Test inspired by iam/legacy tests