### PR TITLE
Secrets: Fix data race in consolidation stats

### DIFF
--- a/pkg/registry/apis/secret/service/consolidation.go
+++ b/pkg/registry/apis/secret/service/consolidation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -51,9 +52,12 @@ func (s *ConsolidationService) Consolidate(ctx context.Context, opts *contracts.
 
 	// Some debug statistics for local testing
 	consolidateStart := time.Now()
-	totalComputeTime := int64(0)
-	numberOfBatches := 0
-	numberOfValues := 0
+
+	var (
+		totalComputeTime atomic.Int64
+		numberOfBatches  atomic.Int64
+		numberOfValues   atomic.Int64
+	)
 
 	chunkSize := 100
 	if opts != nil && opts.ChunkSize > 0 {
@@ -85,13 +89,15 @@ func (s *ConsolidationService) Consolidate(ctx context.Context, opts *contracts.
 
 	// Finalize a single namespace by re-encrypting all values with a new data key
 	finalizeNamespace := func(ns string, values []*contracts.EncryptedValue) error {
-		numberOfBatches++
-		numberOfValues += len(values)
+		numberOfBatches.Add(1)
+		numberOfValues.Add(int64(len(values)))
+
 		start := time.Now()
+
 		log.Debug("ConsolidationService.Consolidate: finalizing namespace", "namespace", ns, "values", len(values))
 		defer func() {
 			log.Debug("ConsolidationService.Consolidate: finalized namespace", "namespace", ns, "values", len(values), "time", time.Since(start))
-			totalComputeTime += time.Since(start).Milliseconds()
+			totalComputeTime.Add(time.Since(start).Milliseconds())
 		}()
 
 		if len(values) == 0 {
@@ -175,6 +181,6 @@ func (s *ConsolidationService) Consolidate(ctx context.Context, opts *contracts.
 
 	// TODO: After all values are re-encrypted, we can safely remove the old data keys.
 
-	log.Info("ConsolidationService.Consolidate: finished", "duration", time.Since(consolidateStart), "totalComputeTime", totalComputeTime, "numberOfNamespaces", numberOfBatches, "numberOfValues", numberOfValues)
+	log.Info("ConsolidationService.Consolidate: finished", "duration", time.Since(consolidateStart), "totalComputeTime", totalComputeTime.Load(), "numberOfNamespaces", numberOfBatches.Load(), "numberOfValues", numberOfValues.Load())
 	return nil
 }


### PR DESCRIPTION
When running all Secrets tests with `-race`, found this race condition:
```
~/Projects/grafana (main ✗) go test -race -run 'TestConsolidation/consolidation_with_multiple_workers' -count=5 ./pkg/registry/apis/secret/service/
==================
WARNING: DATA RACE
Read at 0x00c0020ce268 by goroutine 239:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:88 +0x7c
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:147 +0x184
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.gowrap1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:154 +0x6c

Previous write at 0x00c0020ce268 by goroutine 240:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:88 +0x8c
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:147 +0x184
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.gowrap1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:154 +0x6c

Goroutine 239 (running) created at:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:136 +0x30c
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:163 +0x7f0
  github.com/grafana/grafana/pkg/registry/apis/secret/service_test.TestConsolidation.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation_test.go:137 +0x2f8
  testing.tRunner()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1997 +0x3c

Goroutine 240 (running) created at:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:136 +0x30c
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:169 +0x8c4
  github.com/grafana/grafana/pkg/registry/apis/secret/service_test.TestConsolidation.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation_test.go:137 +0x2f8
  testing.tRunner()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1997 +0x3c
==================
==================
WARNING: DATA RACE
Read at 0x00c0020ce278 by goroutine 239:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:89 +0xa4
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:147 +0x184
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.gowrap1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:154 +0x6c

Previous write at 0x00c0020ce278 by goroutine 240:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:89 +0xb4
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:147 +0x184
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3.gowrap1()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:154 +0x6c

Goroutine 239 (running) created at:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:136 +0x30c
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:163 +0x7f0
  github.com/grafana/grafana/pkg/registry/apis/secret/service_test.TestConsolidation.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation_test.go:137 +0x2f8
  testing.tRunner()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1997 +0x3c

Goroutine 240 (running) created at:
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate.func3()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:136 +0x30c
  github.com/grafana/grafana/pkg/registry/apis/secret/service.(*ConsolidationService).Consolidate()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation.go:169 +0x8c4
  github.com/grafana/grafana/pkg/registry/apis/secret/service_test.TestConsolidation.func2()
      /Users/user/Projects/grafana/pkg/registry/apis/secret/service/consolidation_test.go:137 +0x2f8
  testing.tRunner()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/testing/testing.go:1997 +0x3c
==================
--- FAIL: TestConsolidation (0.00s)
    --- FAIL: TestConsolidation/consolidation_with_multiple_workers_preserves_decrypted_content (0.70s)
        testing.go:1617: race detected during execution of test
FAIL
FAIL    github.com/grafana/grafana/pkg/registry/apis/secret/service     5.449s
FAIL
```