### PR TITLE
Provisioning: api version integration test improvement

### DIFF
--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -72,8 +72,6 @@ func connectionBody(name, apiVersion string) map[string]interface{} {
 // of which version was used for creation. Covers GET, LIST, CREATE, UPDATE, and
 // DELETE across both Repository and Connection resources.
 func TestIntegrationVersionConsistency(t *testing.T) {
-	t.Skip("skip flaky test")
-
 	helper := sharedHelper(t)
 
 	type resourceDef struct {

--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -113,9 +113,11 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 					t.Run(tc.name, func(t *testing.T) {
 						name := fmt.Sprintf("ver-get-%s-%d", res.resource[:4], i)
 						body := res.body(name, "provisioning.grafana.app/"+tc.createVersion)
-						helper.RESTDo(t, "POST", tc.createVersion, res.resource, body)
+						_, err := helper.RESTDo("POST", tc.createVersion, res.resource, body)
+						require.NoError(t, err)
 
-						obj := helper.RESTDo(t, "GET", tc.queryVersion, res.resource+"/"+name)
+						obj, err := helper.RESTDo("GET", tc.queryVersion, res.resource+"/"+name)
+						require.NoError(t, err)
 						assert.Equal(t, tc.expectedVersion, obj["apiVersion"])
 					})
 				}
@@ -129,7 +131,8 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 				for _, version := range []string{"v0alpha1", "v1beta1"} {
 					t.Run(version, func(t *testing.T) {
 						expected := "provisioning.grafana.app/" + version
-						obj := helper.RESTDo(t, "GET", version, res.resource)
+						obj, err := helper.RESTDo("GET", version, res.resource)
+						require.NoError(t, err)
 						assert.Equal(t, expected, obj["apiVersion"])
 
 						items, _ := obj["items"].([]interface{})
@@ -151,7 +154,8 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 				expected := "provisioning.grafana.app/" + version
 				name := "ver-create-" + version
 				body := repositoryBody(name, expected, helper.ProvisioningPath)
-				obj := helper.RESTDo(t, "POST", version, "repositories", body)
+				obj, err := helper.RESTDo("POST", version, "repositories", body)
+				require.NoError(t, err)
 				assert.Equal(t, expected, obj["apiVersion"])
 			})
 		}
@@ -163,12 +167,22 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 				expected := "provisioning.grafana.app/" + version
 				name := "ver-update-" + version
 				body := repositoryBody(name, expected, helper.ProvisioningPath)
-				helper.RESTDo(t, "POST", version, "repositories", body)
+				_, err := helper.RESTDo("POST", version, "repositories", body)
+				require.NoError(t, err)
 
-				current := helper.RESTDo(t, "GET", version, "repositories/"+name)
-				require.NoError(t, unstructured.SetNestedField(current, "Updated Title", "spec", "title"))
-
-				obj := helper.RESTDo(t, "PUT", version, "repositories/"+name, current)
+				var obj map[string]interface{}
+				err = common.RetryOnConflict(t, func() error {
+					current, err := helper.RESTDo("GET", version, "repositories/"+name)
+					if err != nil {
+						return err
+					}
+					if err := unstructured.SetNestedField(current, "Updated Title", "spec", "title"); err != nil {
+						return err
+					}
+					obj, err = helper.RESTDo("PUT", version, "repositories/"+name, current)
+					return err
+				})
+				require.NoError(t, err)
 				assert.Equal(t, expected, obj["apiVersion"])
 			})
 		}
@@ -180,9 +194,11 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 				expected := "provisioning.grafana.app/" + version
 				name := "ver-delete-" + version
 				body := repositoryBody(name, expected, helper.ProvisioningPath)
-				helper.RESTDo(t, "POST", version, "repositories", body)
+				_, err := helper.RESTDo("POST", version, "repositories", body)
+				require.NoError(t, err)
 
-				obj := helper.RESTDo(t, "DELETE", version, "repositories/"+name)
+				obj, err := helper.RESTDo("DELETE", version, "repositories/"+name)
+				require.NoError(t, err)
 				if kind, _ := obj["kind"].(string); kind == "Repository" {
 					assert.Equal(t, expected, obj["apiVersion"])
 				}

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -2918,8 +2918,7 @@ func SharedHelper(t *testing.T, env *SharedEnv) *ProvisioningTestHelper {
 // RESTDo performs a REST request against the provisioning API and returns the
 // response as an unstructured map. The subpath is appended to
 // /apis/provisioning.grafana.app/<version>/namespaces/<namespace>/.
-func (h *ProvisioningTestHelper) RESTDo(t *testing.T, method, version, subpath string, body ...map[string]interface{}) map[string]interface{} {
-	t.Helper()
+func (h *ProvisioningTestHelper) RESTDo(method, version, subpath string, body ...map[string]interface{}) (map[string]interface{}, error) {
 	ns := h.Namespace
 	if ns == "" {
 		ns = "default"
@@ -2929,19 +2928,27 @@ func (h *ProvisioningTestHelper) RESTDo(t *testing.T, method, version, subpath s
 	req := h.AdminREST.Verb(method).AbsPath(absPath)
 	if len(body) > 0 && body[0] != nil {
 		bodyBytes, err := json.Marshal(body[0])
-		require.NoError(t, err)
+		if err != nil {
+			return nil, err
+		}
 		req = req.Body(bodyBytes).SetHeader("Content-Type", "application/json")
 	}
 
 	result := req.Do(context.Background())
-	require.NoError(t, result.Error())
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
 
 	raw, err := result.Raw()
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	var obj map[string]interface{}
-	require.NoError(t, json.Unmarshal(raw, &obj))
-	return obj
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
 }
 
 // LabelPendingDelete is the label key written by the tenant watcher to mark
@@ -2952,7 +2959,7 @@ const LabelPendingDelete = "cloud.grafana.com/pending-delete"
 // It retries on 409 Conflict to handle concurrent status updates from the controller.
 func SetPendingDeleteLabel(t *testing.T, resource dynamic.ResourceInterface, name string) {
 	t.Helper()
-	err := RetryOnConflict(func() error {
+	err := RetryOnConflict(t, func() error {
 		obj, err := resource.Get(t.Context(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -2969,15 +2976,16 @@ func SetPendingDeleteLabel(t *testing.T, resource dynamic.ResourceInterface, nam
 	require.NoError(t, err, "setting the pending-delete label on %q should be allowed", name)
 }
 
-// RetryOnConflict retries fn on 409 Conflict up to 5 times, returning the last
-// error (or nil on success).
-func RetryOnConflict(fn func() error) error {
-	var err error
-	for range 10 {
-		err = fn()
-		if !apierrors.IsConflict(err) {
-			return err
+// RetryOnConflict retries fn while it returns a 409 Conflict, using
+// EventuallyWithT so the retry window is time-bounded.
+func RetryOnConflict(t *testing.T, fn func() error) error {
+	t.Helper()
+	var lastErr error
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		lastErr = fn()
+		if apierrors.IsConflict(lastErr) {
+			c.Errorf("conflict error, retrying: %v", lastErr)
 		}
-	}
-	return err
+	}, WaitTimeoutDefault, 200*time.Millisecond, "operation failed with persistent 409 Conflict")
+	return lastErr
 }

--- a/pkg/tests/apis/provisioning/connection/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/connection/pending_delete_test.go
@@ -187,7 +187,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteAdmission(t *testing.T) 
 		common.SetPendingDeleteLabel(t, helper.Connections.Resource, connName)
 
 		// Always re-Get to avoid stale resourceVersion conflicts from concurrent status updates.
-		err := common.RetryOnConflict(func() error {
+		err := common.RetryOnConflict(t, func() error {
 			obj, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -209,7 +209,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteAdmission(t *testing.T) 
 		// Echo back the current object via UpdateStatus. The admission webhook must
 		// pass status-subresource requests through without a Forbidden rejection,
 		// regardless of whether the pending-delete label is set.
-		err := common.RetryOnConflict(func() error {
+		err := common.RetryOnConflict(t, func() error {
 			obj, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -226,7 +226,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteAdmission(t *testing.T) 
 		common.SetPendingDeleteLabel(t, helper.Connections.Resource, connName)
 
 		// Always re-Get to avoid stale resourceVersion conflicts from concurrent status updates.
-		err := common.RetryOnConflict(func() error {
+		err := common.RetryOnConflict(t, func() error {
 			obj, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return err

--- a/pkg/tests/apis/provisioning/repository/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/repository/pending_delete_test.go
@@ -167,7 +167,7 @@ func TestIntegrationProvisioning_RepositoryPendingDeleteAdmission(t *testing.T) 
 		common.SetPendingDeleteLabel(t, helper.Repositories.Resource, repoName)
 
 		// Always re-Get to avoid stale resourceVersion conflicts from concurrent status updates.
-		err := common.RetryOnConflict(func() error {
+		err := common.RetryOnConflict(t, func() error {
 			obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -189,7 +189,7 @@ func TestIntegrationProvisioning_RepositoryPendingDeleteAdmission(t *testing.T) 
 		// Echo back the current object via UpdateStatus. The admission webhook must
 		// pass status-subresource requests through without a Forbidden rejection,
 		// regardless of whether the pending-delete label is set.
-		err := common.RetryOnConflict(func() error {
+		err := common.RetryOnConflict(t, func() error {
 			obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -206,7 +206,7 @@ func TestIntegrationProvisioning_RepositoryPendingDeleteAdmission(t *testing.T) 
 		common.SetPendingDeleteLabel(t, helper.Repositories.Resource, repoName)
 
 		// Always re-Get to avoid stale resourceVersion conflicts from concurrent status updates.
-		err := common.RetryOnConflict(func() error {
+		err := common.RetryOnConflict(t, func() error {
 			obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Improve flaky test due to optimistic locking failures. This PR have been tested by running the test 20 times in a row succesfully.

**Why do we need this feature?**

API version tests may fail if a reconciler change the resource version before a read-write cycle completes. The test should be resilient to it.

**Who is this feature for?**

Grafana devs sanity.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [x ] It works as expected from a user's perspective.
- [ x] If this is a pre-GA feature, it is behind a feature toggle.
- [ x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
