### PR TITLE
IAM: Add read-only in-memory GlobalRole API for OSS

### DIFF
--- a/pkg/registry/apis/iam/globalrole/identity_wrapper.go
+++ b/pkg/registry/apis/iam/globalrole/identity_wrapper.go
@@ -1,0 +1,34 @@
+package globalrole
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+)
+
+// GlobalRoleIdentityWrapper wraps a grafanarest.Storage and switches the caller
+// identity to the app service identity for read operations (Get and List) only.
+// Write operations delegate to the inner storage with the original caller context.
+//
+// This is needed because regular users cannot authenticate in the "*" (cluster)
+// namespace, but GlobalRoles are cluster-scoped. Authorization for reads is
+// already enforced by GetAuthorizer() at the k8s authorization layer before
+// storage is reached.
+type GlobalRoleIdentityWrapper struct {
+	grafanarest.Storage
+}
+
+func (w *GlobalRoleIdentityWrapper) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	srvCtx, _ := identity.WithServiceIdentity(ctx, 0)
+	return w.Storage.Get(srvCtx, name, options)
+}
+
+func (w *GlobalRoleIdentityWrapper) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	srvCtx, _ := identity.WithServiceIdentity(ctx, 0)
+	return w.Storage.List(srvCtx, options)
+}

--- a/pkg/registry/apis/iam/globalrole/identity_wrapper_test.go
+++ b/pkg/registry/apis/iam/globalrole/identity_wrapper_test.go
@@ -1,0 +1,55 @@
+package globalrole
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+)
+
+// fakeStorage records what context was used for Get and List calls.
+type fakeStorage struct {
+	grafanarest.Storage
+	lastGetCtx  context.Context
+	lastListCtx context.Context
+}
+
+func (f *fakeStorage) Get(ctx context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	f.lastGetCtx = ctx
+	return &iamv0.GlobalRole{}, nil
+}
+
+func (f *fakeStorage) List(ctx context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
+	f.lastListCtx = ctx
+	return &iamv0.GlobalRoleList{}, nil
+}
+
+func TestGlobalRoleIdentityWrapperGetSwitchesIdentity(t *testing.T) {
+	inner := &fakeStorage{}
+	wrapper := &GlobalRoleIdentityWrapper{Storage: inner}
+
+	_, err := wrapper.Get(context.Background(), "test", &metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// The context should now have a service identity
+	assert.True(t, identity.IsServiceIdentity(inner.lastGetCtx))
+}
+
+func TestGlobalRoleIdentityWrapperListSwitchesIdentity(t *testing.T) {
+	inner := &fakeStorage{}
+	wrapper := &GlobalRoleIdentityWrapper{Storage: inner}
+
+	_, err := wrapper.List(context.Background(), nil)
+	require.NoError(t, err)
+
+	// The context should now have a service identity
+	assert.True(t, identity.IsServiceIdentity(inner.lastListCtx))
+}

--- a/pkg/registry/apis/iam/globalrole/inmemory/api_installer.go
+++ b/pkg/registry/apis/iam/globalrole/inmemory/api_installer.go
@@ -1,0 +1,126 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/server"
+
+	"github.com/grafana/authlib/types"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apis/iam"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/globalrole"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+var (
+	_ iam.GlobalRoleApiInstaller = (*InMemoryGlobalRoleApiInstaller)(nil)
+
+	readVerbs = map[string]bool{utils.VerbGet: true, utils.VerbList: true, utils.VerbWatch: true}
+)
+
+type InMemoryGlobalRoleApiInstaller struct {
+	accessClient types.AccessClient
+	acService    accesscontrol.Service
+	logger       log.Logger
+}
+
+func ProvideInMemoryGlobalRoleApiInstaller(
+	accessClient types.AccessClient,
+	acService accesscontrol.Service,
+) iam.GlobalRoleApiInstaller {
+	client := openfeature.NewDefaultClient()
+	ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancelFn()
+
+	if !client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzGlobalRolesApi, false, openfeature.TransactionContext(ctx)) {
+		return iam.ProvideNoopGlobalRoleApiInstaller()
+	}
+
+	return &InMemoryGlobalRoleApiInstaller{
+		accessClient: accessClient,
+		acService:    acService,
+		logger:       log.New("iam.globalrole.inmemory"),
+	}
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) GetAuthorizer() authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		authInfo, ok := types.AuthInfoFrom(ctx)
+		if !ok {
+			return authorizer.DecisionDeny, "Unauthenticated", nil
+		}
+
+		namespace := ""
+		if readVerbs[attr.GetVerb()] {
+			namespace = authInfo.GetNamespace()
+		} else {
+			return authorizer.DecisionDeny, "Write operations not supported", nil
+		}
+
+		res, err := r.accessClient.Check(ctx, authInfo, types.CheckRequest{
+			Verb:        attr.GetVerb(),
+			Group:       attr.GetAPIGroup(),
+			Resource:    attr.GetResource(),
+			Namespace:   namespace,
+			Name:        attr.GetName(),
+			Subresource: attr.GetSubresource(),
+			Path:        attr.GetPath(),
+		}, "")
+
+		if err != nil {
+			return authorizer.DecisionDeny, "Unauthorized", err
+		}
+		if !res.Allowed {
+			return authorizer.DecisionDeny, "Unauthorized", nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	})
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) RegisterStorage(
+	apiGroupInfo *server.APIGroupInfo,
+	opts *builder.APIGroupOptions,
+	storage map[string]rest.Storage,
+) error {
+	inMemoryREST := NewReadOnlyGlobalRoleREST(r.acService)
+	appIdentityWrapper := &globalrole.GlobalRoleIdentityWrapper{Storage: inMemoryREST}
+	storage[iamv0.GlobalRoleInfo.StoragePath()] = appIdentityWrapper
+	return nil
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) ValidateOnCreate(_ context.Context, _ *iamv0.GlobalRole) error {
+	return errReadOnly
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) ValidateOnUpdate(_ context.Context, _, _ *iamv0.GlobalRole) error {
+	return errReadOnly
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) ValidateOnDelete(_ context.Context, _ *iamv0.GlobalRole) error {
+	return errReadOnly
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) MutateOnCreate(_ context.Context, _ *iamv0.GlobalRole) error {
+	return nil
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) MutateOnUpdate(_ context.Context, _, _ *iamv0.GlobalRole) error {
+	return nil
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) MutateOnDelete(_ context.Context, _ *iamv0.GlobalRole) error {
+	return nil
+}
+
+func (r *InMemoryGlobalRoleApiInstaller) MutateOnConnect(_ context.Context, _ *iamv0.GlobalRole) error {
+	return nil
+}

--- a/pkg/registry/apis/iam/globalrole/inmemory/api_installer_test.go
+++ b/pkg/registry/apis/iam/globalrole/inmemory/api_installer_test.go
@@ -1,0 +1,60 @@
+package inmemory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+func newTestInstaller() *InMemoryGlobalRoleApiInstaller {
+	return &InMemoryGlobalRoleApiInstaller{
+		logger: log.New("test"),
+	}
+}
+
+func TestValidateOnCreateReturnsError(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.ValidateOnCreate(context.Background(), &iamv0.GlobalRole{})
+	require.Error(t, err)
+}
+
+func TestValidateOnUpdateReturnsError(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.ValidateOnUpdate(context.Background(), &iamv0.GlobalRole{}, &iamv0.GlobalRole{})
+	require.Error(t, err)
+}
+
+func TestValidateOnDeleteReturnsError(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.ValidateOnDelete(context.Background(), &iamv0.GlobalRole{})
+	require.Error(t, err)
+}
+
+func TestMutateOnCreateReturnsNil(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.MutateOnCreate(context.Background(), &iamv0.GlobalRole{})
+	assert.NoError(t, err)
+}
+
+func TestMutateOnUpdateReturnsNil(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.MutateOnUpdate(context.Background(), &iamv0.GlobalRole{}, &iamv0.GlobalRole{})
+	assert.NoError(t, err)
+}
+
+func TestMutateOnDeleteReturnsNil(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.MutateOnDelete(context.Background(), &iamv0.GlobalRole{})
+	assert.NoError(t, err)
+}
+
+func TestMutateOnConnectReturnsNil(t *testing.T) {
+	installer := newTestInstaller()
+	err := installer.MutateOnConnect(context.Background(), &iamv0.GlobalRole{})
+	assert.NoError(t, err)
+}

--- a/pkg/registry/apis/iam/globalrole/inmemory/models.go
+++ b/pkg/registry/apis/iam/globalrole/inmemory/models.go
@@ -1,0 +1,60 @@
+package inmemory
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	gapiutils "github.com/grafana/grafana/pkg/services/apiserver/utils"
+)
+
+func roleDTOToV0GlobalRole(dto *accesscontrol.RoleDTO, startTime time.Time) *iamv0.GlobalRole {
+	r := &iamv0.GlobalRole{
+		TypeMeta: iamv0.GlobalRoleInfo.TypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              dto.UID,
+			ResourceVersion:   fmt.Sprintf("%d", dto.Version),
+			CreationTimestamp: metav1.NewTime(startTime),
+			Annotations: map[string]string{
+				accesscontrol.RoleNameAnnotation: dto.Name,
+			},
+		},
+		Spec: iamv0.GlobalRoleSpec{
+			Title:       dto.DisplayName,
+			Description: dto.Description,
+			Group:       dto.Group,
+			Permissions: toV0Permissions(dto.Permissions),
+		},
+	}
+
+	if dto.Hidden {
+		r.Annotations[accesscontrol.RoleHiddenAnnotation] = strconv.FormatBool(dto.Hidden)
+	}
+
+	r.SetUpdateTimestamp(startTime)
+	r.Annotations[utils.AnnoKeyUpdatedTimestamp] = startTime.Format(time.RFC3339)
+	r.SetGeneration(dto.Version)
+	r.UID = gapiutils.CalculateClusterWideUID(r)
+
+	// All basic roles are managed by grafana
+	r.Annotations[utils.AnnoKeyManagerKind] = string(utils.ManagerKindGrafana)
+	r.Annotations[utils.AnnoKeyManagerIdentity] = "grafana"
+
+	return r
+}
+
+func toV0Permissions(perms []accesscontrol.Permission) []iamv0.GlobalRolespecPermission {
+	result := make([]iamv0.GlobalRolespecPermission, 0, len(perms))
+	for _, p := range perms {
+		result = append(result, iamv0.GlobalRolespecPermission{
+			Action: p.Action,
+			Scope:  p.Scope,
+		})
+	}
+	return result
+}

--- a/pkg/registry/apis/iam/globalrole/inmemory/models_test.go
+++ b/pkg/registry/apis/iam/globalrole/inmemory/models_test.go
@@ -1,0 +1,207 @@
+package inmemory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+func TestRoleDTOToV0GlobalRole(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		dto             *accesscontrol.RoleDTO
+		expectedName    string
+		expectedTitle   string
+		expectedDesc    string
+		expectedGroup   string
+		expectedVersion string
+		expectedHidden  bool
+	}{
+		{
+			name: "basic admin role",
+			dto: &accesscontrol.RoleDTO{
+				UID:         "basic_admin",
+				Name:        "basic:admin",
+				DisplayName: "Admin",
+				Description: "Admin role",
+				Group:       "basic",
+				Version:     1,
+				Hidden:      false,
+				Permissions: []accesscontrol.Permission{
+					{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+				},
+			},
+			expectedName:    "basic_admin",
+			expectedTitle:   "Admin",
+			expectedDesc:    "Admin role",
+			expectedGroup:   "basic",
+			expectedVersion: "1",
+			expectedHidden:  false,
+		},
+		{
+			name: "basic editor role",
+			dto: &accesscontrol.RoleDTO{
+				UID:         "basic_editor",
+				Name:        "basic:editor",
+				DisplayName: "Editor",
+				Description: "Editor role",
+				Group:       "basic",
+				Version:     2,
+				Hidden:      false,
+			},
+			expectedName:    "basic_editor",
+			expectedTitle:   "Editor",
+			expectedDesc:    "Editor role",
+			expectedGroup:   "basic",
+			expectedVersion: "2",
+			expectedHidden:  false,
+		},
+		{
+			name: "basic viewer role",
+			dto: &accesscontrol.RoleDTO{
+				UID:         "basic_viewer",
+				Name:        "basic:viewer",
+				DisplayName: "Viewer",
+				Description: "Viewer role",
+				Group:       "basic",
+				Version:     1,
+				Hidden:      false,
+			},
+			expectedName:    "basic_viewer",
+			expectedTitle:   "Viewer",
+			expectedDesc:    "Viewer role",
+			expectedGroup:   "basic",
+			expectedVersion: "1",
+			expectedHidden:  false,
+		},
+		{
+			name: "basic grafana admin role",
+			dto: &accesscontrol.RoleDTO{
+				UID:         "basic_grafana_admin",
+				Name:        "basic:grafana_admin",
+				DisplayName: "Grafana Admin",
+				Description: "Grafana Admin role",
+				Group:       "basic",
+				Version:     3,
+				Hidden:      false,
+			},
+			expectedName:    "basic_grafana_admin",
+			expectedTitle:   "Grafana Admin",
+			expectedDesc:    "Grafana Admin role",
+			expectedGroup:   "basic",
+			expectedVersion: "3",
+			expectedHidden:  false,
+		},
+		{
+			name: "hidden basic none role",
+			dto: &accesscontrol.RoleDTO{
+				UID:         "basic_none",
+				Name:        "basic:none",
+				DisplayName: "No basic role",
+				Description: "No basic role",
+				Group:       "basic",
+				Version:     1,
+				Hidden:      true,
+			},
+			expectedName:    "basic_none",
+			expectedTitle:   "No basic role",
+			expectedDesc:    "No basic role",
+			expectedGroup:   "basic",
+			expectedVersion: "1",
+			expectedHidden:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := roleDTOToV0GlobalRole(tc.dto, startTime)
+
+			// ObjectMeta.Name == UID
+			assert.Equal(t, tc.expectedName, result.Name)
+			assert.Equal(t, tc.expectedVersion, result.ResourceVersion)
+			assert.Equal(t, startTime, result.CreationTimestamp.Time)
+
+			// Annotations
+			assert.Equal(t, tc.dto.Name, result.Annotations[accesscontrol.RoleNameAnnotation])
+			if tc.expectedHidden {
+				assert.Equal(t, "true", result.Annotations[accesscontrol.RoleHiddenAnnotation])
+			} else {
+				_, exists := result.Annotations[accesscontrol.RoleHiddenAnnotation]
+				assert.False(t, exists)
+			}
+
+			// Spec fields
+			assert.Equal(t, tc.expectedTitle, result.Spec.Title)
+			assert.Equal(t, tc.expectedDesc, result.Spec.Description)
+			assert.Equal(t, tc.expectedGroup, result.Spec.Group)
+
+			// Manager annotations
+			assert.Equal(t, string(utils.ManagerKindGrafana), result.Annotations[utils.AnnoKeyManagerKind])
+			assert.Equal(t, "grafana", result.Annotations[utils.AnnoKeyManagerIdentity])
+
+			// UID should be non-empty (CalculateClusterWideUID)
+			assert.NotEmpty(t, result.UID)
+
+			// Generation should match version
+			assert.Equal(t, tc.dto.Version, result.Generation)
+
+			// Updated timestamp annotation
+			assert.Equal(t, startTime.Format(time.RFC3339), result.Annotations[utils.AnnoKeyUpdatedTimestamp])
+		})
+	}
+}
+
+func TestToV0Permissions(t *testing.T) {
+	perms := []accesscontrol.Permission{
+		{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+		{Action: "folders:read", Scope: "folders:uid:abc"},
+		{Action: "users:read", Scope: ""},
+	}
+
+	result := toV0Permissions(perms)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "dashboards:read", result[0].Action)
+	assert.Equal(t, "dashboards:uid:*", result[0].Scope)
+	assert.Equal(t, "folders:read", result[1].Action)
+	assert.Equal(t, "folders:uid:abc", result[1].Scope)
+	assert.Equal(t, "users:read", result[2].Action)
+	assert.Equal(t, "", result[2].Scope)
+}
+
+func TestToV0PermissionsEmpty(t *testing.T) {
+	result := toV0Permissions(nil)
+	require.NotNil(t, result)
+	require.Len(t, result, 0)
+}
+
+func TestRoleDTOToV0GlobalRolePermissionsPopulated(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	dto := &accesscontrol.RoleDTO{
+		UID:         "basic_admin",
+		Name:        "basic:admin",
+		DisplayName: "Admin",
+		Description: "Admin role",
+		Group:       "basic",
+		Version:     1,
+		Permissions: []accesscontrol.Permission{
+			{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+			{Action: "dashboards:write", Scope: "dashboards:uid:*"},
+			{Action: "folders:read", Scope: ""},
+		},
+	}
+
+	result := roleDTOToV0GlobalRole(dto, startTime)
+	require.Len(t, result.Spec.Permissions, 3)
+	assert.Equal(t, "dashboards:read", result.Spec.Permissions[0].Action)
+	assert.Equal(t, "dashboards:uid:*", result.Spec.Permissions[0].Scope)
+	assert.Equal(t, "dashboards:write", result.Spec.Permissions[1].Action)
+	assert.Equal(t, "folders:read", result.Spec.Permissions[2].Action)
+}

--- a/pkg/registry/apis/iam/globalrole/inmemory/rest.go
+++ b/pkg/registry/apis/iam/globalrole/inmemory/rest.go
@@ -1,0 +1,92 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+var _ grafanarest.Storage = (*ReadOnlyGlobalRoleREST)(nil)
+
+var errReadOnly = apierrors.NewMethodNotSupported(
+	iamv0.GlobalRoleInfo.GroupResource(), "write operations",
+)
+
+// ReadOnlyGlobalRoleREST serves basic roles from memory via the accesscontrol.Service.
+type ReadOnlyGlobalRoleREST struct {
+	acService accesscontrol.Service
+	startTime time.Time
+}
+
+func NewReadOnlyGlobalRoleREST(acService accesscontrol.Service) *ReadOnlyGlobalRoleREST {
+	return &ReadOnlyGlobalRoleREST{
+		acService: acService,
+		startTime: time.Now(),
+	}
+}
+
+func (r *ReadOnlyGlobalRoleREST) New() runtime.Object {
+	return iamv0.GlobalRoleInfo.NewFunc()
+}
+
+func (r *ReadOnlyGlobalRoleREST) NewList() runtime.Object {
+	return iamv0.GlobalRoleInfo.NewListFunc()
+}
+
+func (r *ReadOnlyGlobalRoleREST) NamespaceScoped() bool {
+	return false
+}
+
+func (r *ReadOnlyGlobalRoleREST) GetSingularName() string {
+	return iamv0.GlobalRoleInfo.GetSingularName()
+}
+
+func (r *ReadOnlyGlobalRoleREST) Destroy() {}
+
+func (r *ReadOnlyGlobalRoleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	roles := r.acService.GetStaticRoles(ctx)
+	for _, dto := range roles {
+		if dto.UID == name {
+			return roleDTOToV0GlobalRole(dto, r.startTime), nil
+		}
+	}
+	return nil, apierrors.NewNotFound(iamv0.GlobalRoleInfo.GroupResource(), name)
+}
+
+func (r *ReadOnlyGlobalRoleREST) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	roles := r.acService.GetStaticRoles(ctx)
+	items := make([]iamv0.GlobalRole, 0, len(roles))
+	for _, dto := range roles {
+		items = append(items, *roleDTOToV0GlobalRole(dto, r.startTime))
+	}
+	return &iamv0.GlobalRoleList{Items: items}, nil
+}
+
+func (r *ReadOnlyGlobalRoleREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return iamv0.GlobalRoleInfo.TableConverter().ConvertToTable(ctx, object, tableOptions)
+}
+
+func (r *ReadOnlyGlobalRoleREST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	return nil, errReadOnly
+}
+
+func (r *ReadOnlyGlobalRoleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, errReadOnly
+}
+
+func (r *ReadOnlyGlobalRoleREST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	return nil, false, errReadOnly
+}
+
+func (r *ReadOnlyGlobalRoleREST) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *internalversion.ListOptions) (runtime.Object, error) {
+	return nil, errReadOnly
+}

--- a/pkg/registry/apis/iam/globalrole/inmemory/rest_test.go
+++ b/pkg/registry/apis/iam/globalrole/inmemory/rest_test.go
@@ -1,0 +1,181 @@
+package inmemory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+func newTestStaticRoles() map[string]*accesscontrol.RoleDTO {
+	return map[string]*accesscontrol.RoleDTO{
+		"basic:admin": {
+			UID:         "basic_admin",
+			Name:        "basic:admin",
+			DisplayName: "Admin",
+			Description: "Admin role",
+			Group:       "basic",
+			Version:     1,
+			Permissions: []accesscontrol.Permission{
+				{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+				{Action: "dashboards:write", Scope: "dashboards:uid:*"},
+			},
+		},
+		"basic:editor": {
+			UID:         "basic_editor",
+			Name:        "basic:editor",
+			DisplayName: "Editor",
+			Description: "Editor role",
+			Group:       "basic",
+			Version:     1,
+			Permissions: []accesscontrol.Permission{
+				{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+			},
+		},
+		"basic:viewer": {
+			UID:         "basic_viewer",
+			Name:        "basic:viewer",
+			DisplayName: "Viewer",
+			Description: "Viewer role",
+			Group:       "basic",
+			Version:     1,
+			Permissions: []accesscontrol.Permission{
+				{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+			},
+		},
+		"basic:grafana_admin": {
+			UID:         "basic_grafana_admin",
+			Name:        "basic:grafana_admin",
+			DisplayName: "Grafana Admin",
+			Description: "Grafana Admin role",
+			Group:       "basic",
+			Version:     1,
+			Permissions: []accesscontrol.Permission{
+				{Action: "users:read", Scope: ""},
+			},
+		},
+		"basic:none": {
+			UID:         "basic_none",
+			Name:        "basic:none",
+			DisplayName: "No basic role",
+			Description: "No basic role",
+			Group:       "basic",
+			Version:     1,
+			Hidden:      true,
+		},
+	}
+}
+
+type mockACService struct {
+	accesscontrol.Service
+	roles map[string]*accesscontrol.RoleDTO
+}
+
+func (m *mockACService) GetStaticRoles(_ context.Context) map[string]*accesscontrol.RoleDTO {
+	return m.roles
+}
+
+func newTestREST() *ReadOnlyGlobalRoleREST {
+	svc := &mockACService{roles: newTestStaticRoles()}
+	return NewReadOnlyGlobalRoleREST(svc)
+}
+
+func TestGetReturnsCorrectRole(t *testing.T) {
+	r := newTestREST()
+	obj, err := r.Get(context.Background(), "basic_admin", &metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	role, ok := obj.(*iamv0.GlobalRole)
+	require.True(t, ok)
+	assert.Equal(t, "basic_admin", role.Name)
+	assert.Equal(t, "Admin", role.Spec.Title)
+	assert.Equal(t, "Admin role", role.Spec.Description)
+	assert.Equal(t, "basic", role.Spec.Group)
+	require.Len(t, role.Spec.Permissions, 2)
+}
+
+func TestGetReturnsNotFound(t *testing.T) {
+	r := newTestREST()
+	_, err := r.Get(context.Background(), "nonexistent", &metav1.GetOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestListReturnsAllRolesWithPermissions(t *testing.T) {
+	r := newTestREST()
+	obj, err := r.List(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	list, ok := obj.(*iamv0.GlobalRoleList)
+	require.True(t, ok)
+	require.Len(t, list.Items, 5)
+
+	// Build a name->role map for stable assertions
+	roleMap := make(map[string]iamv0.GlobalRole, len(list.Items))
+	for _, item := range list.Items {
+		roleMap[item.Name] = item
+	}
+
+	// Verify admin role has permissions
+	admin, ok := roleMap["basic_admin"]
+	require.True(t, ok)
+	require.Len(t, admin.Spec.Permissions, 2)
+	assert.Equal(t, "dashboards:read", admin.Spec.Permissions[0].Action)
+
+	// Verify the none role has hidden annotation
+	none, ok := roleMap["basic_none"]
+	require.True(t, ok)
+	assert.Equal(t, "true", none.Annotations[accesscontrol.RoleHiddenAnnotation])
+}
+
+func TestCreateReturnsMethodNotSupported(t *testing.T) {
+	r := newTestREST()
+	_, err := r.Create(context.Background(), nil, nil, &metav1.CreateOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsMethodNotSupported(err))
+}
+
+func TestUpdateReturnsMethodNotSupported(t *testing.T) {
+	r := newTestREST()
+	_, _, err := r.Update(context.Background(), "test", nil, nil, nil, false, &metav1.UpdateOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsMethodNotSupported(err))
+}
+
+func TestDeleteReturnsMethodNotSupported(t *testing.T) {
+	r := newTestREST()
+	_, _, err := r.Delete(context.Background(), "test", nil, &metav1.DeleteOptions{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsMethodNotSupported(err))
+}
+
+func TestDeleteCollectionReturnsMethodNotSupported(t *testing.T) {
+	r := newTestREST()
+	_, err := r.DeleteCollection(context.Background(), nil, &metav1.DeleteOptions{}, nil)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsMethodNotSupported(err))
+}
+
+func TestNamespaceScoped(t *testing.T) {
+	r := newTestREST()
+	assert.False(t, r.NamespaceScoped())
+}
+
+func TestConvertToTable(t *testing.T) {
+	r := newTestREST()
+	obj, err := r.Get(context.Background(), "basic_admin", &metav1.GetOptions{})
+	require.NoError(t, err)
+
+	table, err := r.ConvertToTable(context.Background(), obj, nil)
+	require.NoError(t, err)
+	require.NotNil(t, table)
+	require.Len(t, table.Rows, 1)
+}

--- a/pkg/registry/apis/wireset.go
+++ b/pkg/registry/apis/wireset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/registry/apis/iam"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/externalgroupmapping"
+	inmemory "github.com/grafana/grafana/pkg/registry/apis/iam/globalrole/inmemory"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/noopstorage"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
 	"github.com/grafana/grafana/pkg/registry/apis/ofrep"
@@ -30,7 +31,7 @@ import (
 var WireSetExts = wire.NewSet(
 	noopstorage.ProvideStorageBackend,
 	iam.ProvideNoopRoleApiInstaller,
-	iam.ProvideNoopGlobalRoleApiInstaller,
+	inmemory.ProvideInMemoryGlobalRoleApiInstaller,
 	iam.ProvideNoopTeamLBACApiInstaller,
 	iam.ProvideNoopExternalGroupMappingApiInstaller,
 	wire.Bind(new(iam.RoleBindingStorageBackend), new(*noopstorage.StorageBackendImpl)),

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -59,6 +59,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/registry/apis/iam"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/externalgroupmapping"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/globalrole/inmemory"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/noopstorage"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
 	"github.com/grafana/grafana/pkg/registry/apis/ofrep"
@@ -912,7 +913,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
-	globalRoleApiInstaller := iam.ProvideNoopGlobalRoleApiInstaller()
+	globalRoleApiInstaller := inmemory.ProvideInMemoryGlobalRoleApiInstaller(accessClient, acimplService)
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()
 	externalGroupMappingApiInstaller := iam.ProvideNoopExternalGroupMappingApiInstaller()
 	storageBackendImpl := noopstorage.ProvideStorageBackend()
@@ -1612,7 +1613,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessControl, acimplService, accessClient, registerer, resourceClient, zanzanaClient)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
-	globalRoleApiInstaller := iam.ProvideNoopGlobalRoleApiInstaller()
+	globalRoleApiInstaller := inmemory.ProvideInMemoryGlobalRoleApiInstaller(accessClient, acimplService)
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()
 	externalGroupMappingApiInstaller := iam.ProvideNoopExternalGroupMappingApiInstaller()
 	storageBackendImpl := noopstorage.ProvideStorageBackend()

--- a/pkg/services/accesscontrol/annotations.go
+++ b/pkg/services/accesscontrol/annotations.go
@@ -1,0 +1,8 @@
+package accesscontrol
+
+const (
+	// RoleNameAnnotation is the annotation key for the legacy role name on a GlobalRole.
+	RoleNameAnnotation = "iam.grafana.app/role-name"
+	// RoleHiddenAnnotation is the annotation key indicating a hidden role.
+	RoleHiddenAnnotation = "iam.grafana.app/hidden"
+)


### PR DESCRIPTION
## Summary
- Implements `InMemoryGlobalRoleApiInstaller` that serves basic roles (Admin, Editor, Viewer, None, Grafana Admin) from `accesscontrol.Service` as `v0alpha1.GlobalRole` objects through the k8s apiserver storage interface
- Enables the reconciler to read basic role permissions into Zanzana without requiring a database backend
- Moves `GlobalRoleIdentityWrapper` and annotation constants (`RoleNameAnnotation`, `RoleHiddenAnnotation`) from enterprise to OSS for shared use

## Changes
- **`pkg/services/accesscontrol/annotations.go`** — New constants for role annotations (previously enterprise-only)
- **`pkg/registry/apis/iam/globalrole/inmemory/models.go`** — Model translation from `RoleDTO` to `v0alpha1.GlobalRole`
- **`pkg/registry/apis/iam/globalrole/inmemory/rest.go`** — Read-only REST storage implementing `grafanarest.Storage`
- **`pkg/registry/apis/iam/globalrole/identity_wrapper.go`** — Identity wrapper (ported from enterprise) for cluster-scoped reads
- **`pkg/registry/apis/iam/globalrole/inmemory/api_installer.go`** — `InMemoryGlobalRoleApiInstaller` implementing `GlobalRoleApiInstaller`
- **`pkg/registry/apis/wireset.go`** — Replaced `ProvideNoopGlobalRoleApiInstaller` with new provider
- **`pkg/server/wire_gen.go`** — Regenerated Wire code

## Test plan
- [x] Unit tests for model translation (all 5 roles, permissions, annotations, manager annotations)
- [x] Unit tests for REST storage (Get, List, write rejection, ConvertToTable, NamespaceScoped)
- [x] Unit tests for API installer (validation hooks reject writes, mutation hooks return nil)
- [x] Unit tests for identity wrapper (Get/List switch to service identity)
- [x] `go build -tags oss ./pkg/server/...` compiles successfully
- [ ] Manual verification with `kubernetesAuthzGlobalRolesApi` + `zanzana` feature flags enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)