### PR TITLE
Prometheus: Prevent prometheus package to be released automatically

### DIFF
--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -2,6 +2,7 @@
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "name": "@grafana/prometheus",
+  "private": true,
   "version": "13.1.0-pre",
   "description": "Grafana Prometheus Library",
   "keywords": [


### PR DESCRIPTION
**What is this feature?**

For our externalization efforts we'll stop releasing prometheus package from this repo. 


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
