### PR TITLE
Search: Fix data race in TestConcurrentIndexUpdateSearchAndRebuild

### DIFF
--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1442,7 +1442,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 				}
 
 				idx := be.GetIndex(ns)
-				_, err = idx.UpdateIndex(ctx)
+				_, err := idx.UpdateIndex(ctx)
 				if err != nil {
 					if errors.Is(err, bleve.ErrorIndexClosed) || errors.Is(err, context.Canceled) {
 						continue


### PR DESCRIPTION
## Summary

- Fix a data race in `TestConcurrentIndexUpdateSearchAndRebuild` where all 25 goroutines shared the outer-scope `err` variable via `_, err =` instead of declaring a local one with `_, err :=`
- The shared variable caused one goroutine to overwrite `err` between another goroutine's `UpdateIndex` return and its `errors.Is` check, bypassing the `ErrorIndexClosed` guard and failing at `require.NoError`
- One-character fix: `=` → `:=` on line 1445

## Test plan

- [x] `go test -race -run TestConcurrentIndexUpdateSearchAndRebuild -count=3` passes clean (previously detected 3 distinct data races)
- CI failure reference: https://github.com/grafana/grafana/actions/runs/24460629915/job/71473591139