### PR TITLE
Browse dashboards: show backend folder-delete error messages

### DIFF
--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, userEvent } from 'test/test-utils';
 
+import { AppEvents } from '@grafana/data';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { appEvents } from 'app/core/app_events';
 import { ManagerKind } from 'app/features/apiserver/types';
@@ -172,7 +173,7 @@ describe('browse-dashboards FolderActionsButton', () => {
 
     expect(publishSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'alert-error',
+        type: AppEvents.alertError.name,
         payload: [backendMessage],
       })
     );
@@ -195,7 +196,7 @@ describe('browse-dashboards FolderActionsButton', () => {
 
     expect(publishSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'alert-error',
+        type: AppEvents.alertError.name,
         payload: ['Error deleting folder. Please try again later.'],
       })
     );

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -6,7 +6,7 @@ import { appEvents } from 'app/core/app_events';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { ShowModalReactEvent } from 'app/types/events';
 
-import * as folderHooks from '../../../api/clients/folder/v1beta1/hooks';
+import { useDeleteFolderMutationFacade } from '../../../api/clients/folder/v1beta1/hooks';
 import { mockFolderDTO } from '../fixtures/folder.fixture';
 import * as permissions from '../permissions';
 
@@ -17,6 +17,11 @@ import { FolderActionsButton } from './FolderActionsButton';
 // Mock out the Permissions component for now
 jest.mock('app/core/components/AccessControl/Permissions', () => ({
   Permissions: () => <div>Hello!</div>,
+}));
+
+jest.mock('../../../api/clients/folder/v1beta1/hooks', () => ({
+  ...jest.requireActual('../../../api/clients/folder/v1beta1/hooks'),
+  useDeleteFolderMutationFacade: jest.fn(),
 }));
 
 const managePermissionsLabel = /Manage permissions/i;
@@ -38,6 +43,7 @@ describe('browse-dashboards FolderActionsButton', () => {
 
   beforeEach(() => {
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => mockPermissions);
+    (useDeleteFolderMutationFacade as jest.Mock).mockReturnValue(jest.fn());
   });
 
   afterEach(() => {
@@ -160,7 +166,7 @@ describe('browse-dashboards FolderActionsButton', () => {
     const mockDeleteFolder = jest.fn().mockResolvedValue({
       error: { status: 400, data: { message: backendMessage } },
     });
-    jest.spyOn(folderHooks, 'useDeleteFolderMutationFacade').mockReturnValue(mockDeleteFolder as never);
+    (useDeleteFolderMutationFacade as jest.Mock).mockReturnValue(mockDeleteFolder);
     const publishSpy = jest.spyOn(appEvents, 'publish');
 
     render(<FolderActionsButton folder={mockFolder} />);
@@ -183,7 +189,7 @@ describe('browse-dashboards FolderActionsButton', () => {
     const mockDeleteFolder = jest.fn().mockResolvedValue({
       error: { status: 500 },
     });
-    jest.spyOn(folderHooks, 'useDeleteFolderMutationFacade').mockReturnValue(mockDeleteFolder as never);
+    (useDeleteFolderMutationFacade as jest.Mock).mockReturnValue(mockDeleteFolder);
     const publishSpy = jest.spyOn(appEvents, 'publish');
 
     render(<FolderActionsButton folder={mockFolder} />);

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.test.tsx
@@ -5,6 +5,7 @@ import { appEvents } from 'app/core/app_events';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { ShowModalReactEvent } from 'app/types/events';
 
+import * as folderHooks from '../../../api/clients/folder/v1beta1/hooks';
 import { mockFolderDTO } from '../fixtures/folder.fixture';
 import * as permissions from '../permissions';
 
@@ -150,6 +151,53 @@ describe('browse-dashboards FolderActionsButton', () => {
           component: DeleteModal,
         })
       )
+    );
+  });
+
+  it('shows backend delete error message when folder deletion fails', async () => {
+    const backendMessage = 'Folder cannot be deleted: folder is not empty';
+    const mockDeleteFolder = jest.fn().mockResolvedValue({
+      error: { status: 400, data: { message: backendMessage } },
+    });
+    jest.spyOn(folderHooks, 'useDeleteFolderMutationFacade').mockReturnValue(mockDeleteFolder as never);
+    const publishSpy = jest.spyOn(appEvents, 'publish');
+
+    render(<FolderActionsButton folder={mockFolder} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: deleteMenuItemLabel }));
+
+    const showModalEvent = publishSpy.mock.calls[0][0] as ShowModalReactEvent;
+    await showModalEvent.payload.props.onConfirm();
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'alert-error',
+        payload: [backendMessage],
+      })
+    );
+  });
+
+  it('falls back to generic delete error message when backend message is missing', async () => {
+    const mockDeleteFolder = jest.fn().mockResolvedValue({
+      error: { status: 500 },
+    });
+    jest.spyOn(folderHooks, 'useDeleteFolderMutationFacade').mockReturnValue(mockDeleteFolder as never);
+    const publishSpy = jest.spyOn(appEvents, 'publish');
+
+    render(<FolderActionsButton folder={mockFolder} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Folder actions' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: deleteMenuItemLabel }));
+
+    const showModalEvent = publishSpy.mock.calls[0][0] as ShowModalReactEvent;
+    await showModalEvent.payload.props.onConfirm();
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'alert-error',
+        payload: ['Error deleting folder. Please try again later.'],
+      })
     );
   });
 

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -31,6 +31,25 @@ interface Props {
   repoType?: RepoType;
 }
 
+const getDeleteFolderErrorMessage = (error: unknown) => {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  if ('data' in error && error.data && typeof error.data === 'object' && 'message' in error.data) {
+    const { message } = error.data as { message?: unknown };
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  if ('message' in error && typeof error.message === 'string' && error.message.length > 0) {
+    return error.message;
+  }
+
+  return undefined;
+};
+
 export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [showPermissionsDrawer, setShowPermissionsDrawer] = useState(false);
@@ -73,14 +92,14 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
     const result = await deleteFolder(folder);
 
     if (result.error) {
+      const fallbackMessage = t(
+        'browse-dashboards.folder-actions-button.delete-folder-error',
+        'Error deleting folder. Please try again later.'
+      );
+
       appEvents.publish({
         type: AppEvents.alertError.name,
-        payload: [
-          t(
-            'browse-dashboards.folder-actions-button.delete-folder-error',
-            'Error deleting folder. Please try again later.'
-          ),
-        ],
+        payload: [getDeleteFolderErrorMessage(result.error) ?? fallbackMessage],
       });
       return;
     }

--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -18,6 +18,7 @@ import { ShowModalReactEvent } from 'app/types/events';
 import { type FolderDTO } from 'app/types/folders';
 
 import { useDeleteFolderMutationFacade, useMoveFolderMutationFacade } from '../../../api/clients/folder/v1beta1/hooks';
+import { extractErrorMessage } from '../../../api/utils';
 import { ManagerKind } from '../../apiserver/types';
 import { getFolderPermissions } from '../permissions';
 
@@ -30,25 +31,6 @@ interface Props {
   isReadOnlyRepo?: boolean;
   repoType?: RepoType;
 }
-
-const getDeleteFolderErrorMessage = (error: unknown) => {
-  if (!error || typeof error !== 'object') {
-    return undefined;
-  }
-
-  if ('data' in error && error.data && typeof error.data === 'object' && 'message' in error.data) {
-    const { message } = error.data as { message?: unknown };
-    if (typeof message === 'string' && message.length > 0) {
-      return message;
-    }
-  }
-
-  if ('message' in error && typeof error.message === 'string' && error.message.length > 0) {
-    return error.message;
-  }
-
-  return undefined;
-};
 
 export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props) {
   const [isOpen, setIsOpen] = useState(false);
@@ -99,7 +81,7 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
 
       appEvents.publish({
         type: AppEvents.alertError.name,
-        payload: [getDeleteFolderErrorMessage(result.error) ?? fallbackMessage],
+        payload: [extractErrorMessage(result.error, fallbackMessage)],
       });
       return;
     }


### PR DESCRIPTION
Solves https://github.com/grafana/grafana/issues/122290



## Summary
Improve folder deletion error feedback in Browse Dashboards folder actions by showing the backend-provided message instead of always showing a generic error.

## Problem
When deleting a non-empty folder (common in Cloud), the UI displayed a generic failure message, which hid the actual reason from users.

## Root Cause
The folder actions delete flow ignored `result.error` details and always emitted a static alert message.

## Changes
- Updated folder actions delete handling to extract and show backend error text when available (`error.data.message`).
- Kept existing generic fallback message when no backend message exists.
- Added tests for both paths:
  - uses backend message for non-empty-folder errors
  - falls back to generic message when backend message is missing

## Verification
- Ran targeted tests in `public/app/features/browse-dashboards` using local ts-jest globals override for this environment.
- Confirmed passing for the modified folder actions tests and related browse-dashboards tests.