### PR TITLE
FS: Add source label filter for settings service calls

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2749,6 +2749,15 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:         "frontendService.settingsSourceFilter",
+			Description:  "Adds a label filter for source=us when fetching settings from the settings service in the frontend service",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaFrontendPlatformSquad,
+			Expression:   "false",
+			HideFromDocs: true,
+			Generate:     Generate{Go: true},
+		},
+		{
 			Name:         "managedPluginsV2",
 			Description:  "Enables managed plugins v2 (expanded rollout, community plugin coverage)",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -320,6 +320,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-16,alertingNotificationHistoryDetail,experimental,@grafana/alerting-squad,false,false,false
 2026-02-18,react19,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-02-18,frontendServiceUseSettingsService,experimental,@grafana/grafana-frontend-platform,false,false,false
+2026-04-14,frontendService.settingsSourceFilter,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-02-25,managedPluginsV2,experimental,@grafana/plugins-platform-backend,false,false,false
 2026-02-25,rememberUserOrgForSso,GA,@grafana/identity-access-team,false,false,false
 2026-02-23,dsAbstractionApp,experimental,@grafana/grafana-datasources-core-services,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -866,6 +866,10 @@ const (
 	// Enables the frontend service to fetch tenant-specific settings overrides from the settings service
 	FlagFrontendServiceUseSettingsService = "frontendServiceUseSettingsService"
 
+	// FlagFrontendServiceSettingsSourceFilter
+	// Adds a label filter for source=us when fetching settings from the settings service in the frontend service
+	FlagFrontendServiceSettingsSourceFilter = "frontendService.settingsSourceFilter"
+
 	// FlagManagedPluginsV2
 	// Enables managed plugins v2 (expanded rollout, community plugin coverage)
 	FlagManagedPluginsV2 = "managedPluginsV2"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2398,6 +2398,20 @@
     },
     {
       "metadata": {
+        "name": "frontendService.settingsSourceFilter",
+        "resourceVersion": "1776170446239",
+        "creationTimestamp": "2026-04-14T12:40:46Z"
+      },
+      "spec": {
+        "description": "Adds a label filter for source=us when fetching settings from the settings service in the frontend service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "frontendServiceSSOAutoLogin",
         "resourceVersion": "1774373752487",
         "creationTimestamp": "2026-03-24T17:35:52Z"

--- a/pkg/services/frontend/request_config_middleware.go
+++ b/pkg/services/frontend/request_config_middleware.go
@@ -41,33 +41,46 @@ func RequestConfigMiddleware(cfg *setting.Cfg, license licensing.Licensing, sett
 			ofClient := openfeature.NewDefaultClient()
 			settingsEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceUseSettingsService, false, openfeature.TransactionContext(ctx))
 
-			if settingsEnabled {
-				if namespace, ok := request.NamespaceFrom(ctx); ok {
-					if namespace != "" && settingsService != nil {
-						// Fetch tenant overrides for relevant sections only
-						selector := metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      "section",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"security", "analytics"},
-							}, {
-								// don't return values from defaults.ini as they conflict with the services's own defaults
-								Key:      "source",
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{"defaults"},
-							}},
-						}
+			if settingsService != nil && settingsEnabled {
+				namespace, ok := request.NamespaceFrom(ctx)
 
-						settings, err := settingsService.ListAsIni(ctx, selector)
-						if err != nil {
-							settingsFetchMetric.WithLabelValues("error").Inc()
-							logger.Error("failed to fetch tenant settings", "namespace", namespace, "err", err)
-							// Fall back to base config
-						} else {
-							settingsFetchMetric.WithLabelValues("success").Inc()
-							// Merge tenant overrides with base config
-							requestConfig.ApplyOverrides(settings, logger)
+				if ok && namespace != "" {
+					// Fetch tenant overrides for relevant sections only
+					sourceFilterEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagFrontendServiceSettingsSourceFilter, false, openfeature.TransactionContext(ctx))
+
+					var sourceExpression metav1.LabelSelectorRequirement
+					if sourceFilterEnabled {
+						sourceExpression = metav1.LabelSelectorRequirement{
+							Key:      "source",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"us"},
 						}
+					} else {
+						// don't return values from defaults.ini as they conflict with the service's own defaults
+						sourceExpression = metav1.LabelSelectorRequirement{
+							Key:      "source",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"defaults"},
+						}
+					}
+
+					selector := metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "section",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"security", "analytics"},
+						}, sourceExpression},
+					}
+
+					settings, err := settingsService.ListAsIni(ctx, selector)
+					if err != nil {
+						settingsFetchMetric.WithLabelValues("error").Inc()
+						logger.Error("failed to fetch tenant settings", "namespace", namespace, "err", err)
+						// Fall back to base config
+					} else {
+						settingsFetchMetric.WithLabelValues("success").Inc()
+						// Merge tenant overrides with base config
+						requestConfig.ApplyOverrides(settings, logger)
 					}
 				}
 			}

--- a/pkg/services/frontend/request_config_middleware_test.go
+++ b/pkg/services/frontend/request_config_middleware_test.go
@@ -67,6 +67,36 @@ func enableSettingsOverridesToggle(t *testing.T) {
 	})
 }
 
+func enableSettingsOverridesAndSourceFilterToggle(t *testing.T) {
+	t.Helper()
+	openfeatureTestMutex.Lock()
+
+	settingsFlag := memprovider.InMemoryFlag{
+		Key:            featuremgmt.FlagFrontendServiceUseSettingsService,
+		DefaultVariant: "on",
+		Variants:       map[string]any{"on": true, "off": false},
+	}
+	sourceFilterFlag := memprovider.InMemoryFlag{
+		Key:            featuremgmt.FlagFrontendServiceSettingsSourceFilter,
+		DefaultVariant: "on",
+		Variants:       map[string]any{"on": true, "off": false},
+	}
+
+	provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagFrontendServiceUseSettingsService:   settingsFlag,
+		featuremgmt.FlagFrontendServiceSettingsSourceFilter: sourceFilterFlag,
+	})
+	require.NoError(t, err)
+
+	err = openfeature.SetProviderAndWait(provider)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		openfeatureTestMutex.Unlock()
+	})
+}
+
 func TestRequestConfigMiddleware(t *testing.T) {
 	t.Run("should store base config in request context", func(t *testing.T) {
 		license := &licensing.OSSLicensingService{}
@@ -308,17 +338,93 @@ func TestRequestConfigMiddleware(t *testing.T) {
 		assert.True(t, capturedConfig.CSPEnabled)
 		assert.Equal(t, "default-src 'self'; frame-ancestors $ALLOW_EMBEDDING_HOSTS", capturedConfig.CSPTemplate)
 	})
+
+	t.Run("should include source filter in selector when source filter toggle is enabled", func(t *testing.T) {
+		enableSettingsOverridesAndSourceFilterToggle(t)
+
+		mockSettingsService := &mockSettingsService{
+			settings: []*settingservice.Setting{},
+		}
+
+		license := &licensing.OSSLicensingService{}
+		cfg := &setting.Cfg{
+			Raw:      ini.Empty(),
+			HTTPPort: "1234",
+			AppURL:   "https://grafana.example.com",
+		}
+
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = setupTestContext(req, "stacks-123")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.True(t, mockSettingsService.called)
+
+		// Verify the selector uses source=us filter (replacing the NotIn defaults filter)
+		require.Len(t, mockSettingsService.capturedSelector.MatchExpressions, 2)
+		sourceFilter := mockSettingsService.capturedSelector.MatchExpressions[1]
+		assert.Equal(t, "source", sourceFilter.Key)
+		assert.Equal(t, metav1.LabelSelectorOpIn, sourceFilter.Operator)
+		assert.Equal(t, []string{"us"}, sourceFilter.Values)
+	})
+
+	t.Run("should not include source filter in selector when source filter toggle is disabled", func(t *testing.T) {
+		enableSettingsOverridesToggle(t)
+
+		mockSettingsService := &mockSettingsService{
+			settings: []*settingservice.Setting{},
+		}
+
+		license := &licensing.OSSLicensingService{}
+		cfg := &setting.Cfg{
+			Raw:      ini.Empty(),
+			HTTPPort: "1234",
+			AppURL:   "https://grafana.example.com",
+		}
+
+		middleware := RequestConfigMiddleware(cfg, license, mockSettingsService)
+
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := middleware(testHandler)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req = setupTestContext(req, "stacks-123")
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.True(t, mockSettingsService.called)
+
+		// Verify the selector does NOT include a source=us filter (only 2 expressions)
+		require.Len(t, mockSettingsService.capturedSelector.MatchExpressions, 2)
+	})
 }
 
 // mockSettingsService is a simple mock for testing
 type mockSettingsService struct {
-	called   bool
-	settings []*settingservice.Setting
-	err      error
+	called           bool
+	capturedSelector metav1.LabelSelector
+	settings         []*settingservice.Setting
+	err              error
 }
 
 func (m *mockSettingsService) ListAsIni(ctx context.Context, selector metav1.LabelSelector) (*ini.File, error) {
 	m.called = true
+	m.capturedSelector = selector
 	if m.err != nil {
 		return nil, m.err
 	}


### PR DESCRIPTION
**What is this feature?**

Adds a new feature flag `frontendService.settingsSourceFilter` that, when enabled, changes the settings service label selector to filter by `source=us` instead of the default `source!=defaults`.

**Why do we need this feature?**

This allows the frontend service to target a specific source when fetching settings overrides, rather than broadly excluding defaults. The two filters are mutually exclusive — the new flag replaces the existing source exclusion with a more targeted inclusion filter.

**Who is this feature for?**

Frontend platform engineers managing per-instance settings configuration.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.