### PR TITLE
[DOC][HOLD] describe redaction modes and allowed attributes for traces LBAC

### DIFF
--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -135,14 +135,28 @@ Team B → `{ resource.service.name="frontend" }`
 
 ## How LBAC affects returned data
 
-For Trace-by-ID endpoints, unauthorized spans show only minimal intrinsic fields:
+Grafana Cloud Traces supports three redaction modes that control how unauthorized spans are handled in trace by ID search responses. The active mode is configured per tenant. To change the mode for your organization, contact Grafana Support.
+
+### Attributes mode (default)
+
+Non-matching spans are included in the response but have their attributes and intrinsics redacted. Only the following minimal fields remain visible on redacted spans:
 
 - `traceId`, `spanId`, `parentId`
 - `name`, `kind`
 - `timestamps`
 - `status`
 
-For Search, metrics, autocomplete, only spans matching LBAC rules appear.
+You can extend the set of always-visible fields by configuring `allowed_attributes` — a list of scoped attributes and intrinsics such as `span:name`, `resource.service.name`, `event:name`, or `scope.version` that are never redacted, even from non-matching spans. Contact Grafana Support to configure `allowed_attributes` for your organization.
+
+### Spans mode
+
+Non-matching spans are removed from the response entirely. This can result in broken traces where a returned span has no matching parent, creating gaps in the span tree.
+
+### Error mode
+
+If any span in a requested trace does not match the LBAC policy, the entire request returns a 404 error. This is the strictest mode and is suited for environments where partial trace visibility is not acceptable.
+
+For Search, metrics, and autocomplete endpoints, only spans matching the LBAC rules appear regardless of the configured redaction mode.
 
 ## Manage LBAC rules
 

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -135,7 +135,7 @@ Team B → `{ resource.service.name="frontend" }`
 
 ## How LBAC affects returned data
 
-Grafana Cloud Traces supports three redaction modes that control how unauthorized spans are handled in trace by ID search responses. The active mode is configured per tenant. To change the mode for your organization, contact Grafana Support.
+Cloud Traces supports three redaction modes that control how unauthorized spans are handled in trace by ID search responses. The active mode is configured per tenant. To change the mode for your organization, contact Grafana Support.
 
 ### Attributes mode (default)
 

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-tempo/index.md
@@ -146,7 +146,7 @@ Non-matching spans are included in the response but have their attributes and in
 - `timestamps`
 - `status`
 
-You can extend the set of always-visible fields by configuring `allowed_attributes` — a list of scoped attributes and intrinsics such as `span:name`, `resource.service.name`, `event:name`, or `scope.version` that are never redacted, even from non-matching spans. Contact Grafana Support to configure `allowed_attributes` for your organization.
+You can extend the set of always-visible fields by configuring `allowed_attributes`, which sets a list of scoped attributes and intrinsics that are never redacted, For example, you can set `span:name`, `resource.service.name`, `event:name`, or `scope.version` so they are never redacted, even from non-matching spans. Contact Grafana Support to configure `allowed_attributes` for your organization.
 
 ### Spans mode
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add documentation for LBAC redaction modes that will become available in Grafana Cloud Traces.

**Why do we need this feature?**

The feature is not documented.

**Who is this feature for?**

Larger organizations who use Grafana Cloud Traces and would like to adjust the redaction behavior of their LBAC data source.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
