### PR TITLE
unified-storage: remove search dual reader feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1261,11 +1261,6 @@ export interface FeatureToggles {
   */
   alertingNotificationHistory?: boolean;
   /**
-  * Enable dual reader for unified storage search
-  * @default false
-  */
-  unifiedStorageSearchDualReaderEnabled?: boolean;
-  /**
   * Supports __from and __to macros that always use the dashboard level time range
   * @default false
   */

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -158,7 +158,7 @@ func RegisterAPIService(
 		dual:                              dual,
 		unified:                           unified,
 		userSearchClient: resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0.UserResourceInfo.GroupResource(),
-			unified, user.NewUserLegacySearchClient(orgService, tracing, cfg), features),
+			unified, user.NewUserLegacySearchClient(orgService, tracing, cfg)),
 		teamSearch:                       NewTeamSearchHandler(tracing, dual, team.NewLegacyTeamSearchClient(legacyTeamSearchService(teamService), tracing), unified, features, accessClient),
 		resourcePermissionsSearchHandler: newResourcePermissionsSearchHandler(resourcePermsSearchBackend, resourcePermsSearchAuthorizer),
 		tracing:                          tracing,
@@ -478,7 +478,6 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamsAPIGroup(opts builder.AP
 			iamv0.TeamBindingResourceInfo.GroupResource(),
 			b.unified,
 			legacyTeamBindingSearchClient,
-			b.features,
 		)
 
 		storage[teamResource.StoragePath("members")] = team.NewTeamMembersREST(teamBindingSearchClient, b.tracing, b.features)
@@ -577,7 +576,6 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateUsersAPIGroup(opts builder.AP
 			iamv0.TeamBindingResourceInfo.GroupResource(),
 			b.unified,
 			legacyTeamBindingSearchClient,
-			b.features,
 		)
 
 		statusStore := grafanaregistry.NewRegistryStatusStore(opts.Scheme, userUniStore)

--- a/pkg/registry/apis/iam/team_search.go
+++ b/pkg/registry/apis/iam/team_search.go
@@ -69,7 +69,7 @@ type TeamSearchHandler struct {
 }
 
 func NewTeamSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyTeamSearcher resourcepb.ResourceIndexClient, resourceClient resource.ResourceClient, features featuremgmt.FeatureToggles, accessClient authlib.AccessClient) *TeamSearchHandler {
-	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0alpha1.TeamResourceInfo.GroupResource(), resourceClient, legacyTeamSearcher, features)
+	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0alpha1.TeamResourceInfo.GroupResource(), resourceClient, legacyTeamSearcher)
 
 	return &TeamSearchHandler{
 		client:       searchClient,

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -50,7 +50,7 @@ func TestSearchFallback(t *testing.T) {
 			}
 			dual := dualwrite.ProvideServiceForTests(cfg)
 
-			searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0.UserResourceInfo.GroupResource(), mockClient, mockLegacyClient, featuremgmt.WithFeatures())
+			searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), iamv0.UserResourceInfo.GroupResource(), mockClient, mockLegacyClient)
 			searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), searchClient, featuremgmt.WithFeatures(), cfg, nil)
 
 			rr := httptest.NewRecorder()

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2160,15 +2160,6 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:         "unifiedStorageSearchDualReaderEnabled",
-			Description:  "Enable dual reader for unified storage search",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaSearchAndStorageSquad,
-			HideFromDocs: true,
-			Expression:   "false",
-			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "dashboardLevelTimeMacros",
 			Description: "Supports __from and __to macros that always use the dashboard level time range",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -251,7 +251,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-07-03,foldersAppPlatformAPI,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2025-07-16,otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true
 2025-07-17,alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
-2025-07-18,unifiedStorageSearchDualReaderEnabled,experimental,@grafana/search-and-storage,false,false,false
 2025-07-31,dashboardLevelTimeMacros,experimental,@grafana/dashboards-squad,false,false,true
 2025-07-25,alertmanagerRemoteSecondaryWithRemoteState,experimental,@grafana/alerting-squad,false,false,false
 2025-07-31,restrictedPluginApis,GA,@grafana/plugins-platform-backend,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -702,10 +702,6 @@ const (
 	// Enables the notification history feature
 	FlagAlertingNotificationHistory = "alertingNotificationHistory"
 
-	// FlagUnifiedStorageSearchDualReaderEnabled
-	// Enable dual reader for unified storage search
-	FlagUnifiedStorageSearchDualReaderEnabled = "unifiedStorageSearchDualReaderEnabled"
-
 	// FlagAlertmanagerRemoteSecondaryWithRemoteState
 	// Starts Grafana in remote secondary mode pulling the latest state from the remote Alertmanager to avoid duplicate notifications.
 	FlagAlertmanagerRemoteSecondaryWithRemoteState = "alertmanagerRemoteSecondaryWithRemoteState"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5541,7 +5541,8 @@
       "metadata": {
         "name": "unifiedStorageSearchDualReaderEnabled",
         "resourceVersion": "1771434338561",
-        "creationTimestamp": "2025-07-18T12:43:56Z"
+        "creationTimestamp": "2025-07-18T12:43:56Z",
+        "deletionTimestamp": "2026-04-16T15:44:59Z"
       },
       "spec": {
         "description": "Enable dual reader for unified storage search",

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -42,13 +41,12 @@ type DualWriter interface {
 }
 
 func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient resourcepb.ResourceIndexClient,
-	legacyClient resourcepb.ResourceIndexClient, features featuremgmt.FeatureToggles) resourcepb.ResourceIndexClient {
+	legacyClient resourcepb.ResourceIndexClient) resourcepb.ResourceIndexClient {
 	return &searchWrapper{
 		dual:          dual,
 		groupResource: gr,
 		unifiedClient: unifiedClient,
 		legacyClient:  legacyClient,
-		features:      features,
 		logger:        log.New("unified-storage.search-client"),
 	}
 }
@@ -59,7 +57,6 @@ type searchWrapper struct {
 
 	unifiedClient resourcepb.ResourceIndexClient
 	legacyClient  resourcepb.ResourceIndexClient
-	features      featuremgmt.FeatureToggles
 	logger        log.Logger
 }
 
@@ -100,10 +97,9 @@ func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]struct{}) float
 	return float64(matches) / float64(len(legacyUIDs)) * 100.0
 }
 
-// If dual reader feature flag is enabled, and legacy is the main storage,
-// and we are writing to unified (which means we are effectively dual writing),
-// then make a background call to unified
-func shouldMakeBackgroundCall(ctx context.Context, features featuremgmt.FeatureToggles, dual DualWriter, gr schema.GroupResource) (bool, error) {
+// If legacy is the main storage and we are writing to unified (dual writing),
+// make a background call to unified to compare results.
+func shouldMakeBackgroundCall(ctx context.Context, dual DualWriter, gr schema.GroupResource) (bool, error) {
 	unifiedIsMainStorage, err := dual.ReadFromUnified(ctx, gr)
 	if err != nil {
 		return false, err
@@ -114,13 +110,7 @@ func shouldMakeBackgroundCall(ctx context.Context, features featuremgmt.FeatureT
 		return false, err
 	}
 
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	res := features != nil &&
-		features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) &&
-		!unifiedIsMainStorage &&
-		status.WriteUnified
-
-	return res, nil
+	return !unifiedIsMainStorage && status.WriteUnified, nil
 }
 
 func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest,
@@ -134,7 +124,7 @@ func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceSta
 		client = s.unifiedClient
 	}
 
-	makeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
+	makeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.dual, s.groupResource)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +160,7 @@ func (s *searchWrapper) Search(ctx context.Context, in *resourcepb.ResourceSearc
 		client = s.unifiedClient
 	}
 
-	makeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
+	makeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.dual, s.groupResource)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/resource/search_client_test.go
+++ b/pkg/storage/unified/resource/search_client_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -97,34 +96,32 @@ func (f *fakeResourceIndexClient) RebuildIndexes(ctx context.Context, in *resour
 	return f.rebuildResponse, f.rebuildErr
 }
 
-func setupTestSearchClient(t *testing.T) (schema.GroupResource, *fakeResourceIndexClient, *fakeResourceIndexClient, featuremgmt.FeatureToggles) {
+func setupTestSearchClient(t *testing.T) (schema.GroupResource, *fakeResourceIndexClient, *fakeResourceIndexClient) {
 	t.Helper()
 	gr := schema.GroupResource{Group: "test", Resource: "items"}
 	unifiedClient := newFakeResourceIndexClient()
 	legacyClient := newFakeResourceIndexClient()
-	features := featuremgmt.WithFeatures()
-	return gr, unifiedClient, legacyClient, features
+	return gr, unifiedClient, legacyClient
 }
 
-func setupTestSearchWrapper(t *testing.T, dual *fakeDualWriter, unifiedClient, legacyClient *fakeResourceIndexClient, features featuremgmt.FeatureToggles, gr schema.GroupResource) *searchWrapper {
+func setupTestSearchWrapper(t *testing.T, dual *fakeDualWriter, unifiedClient, legacyClient *fakeResourceIndexClient, gr schema.GroupResource) *searchWrapper {
 	t.Helper()
 	return &searchWrapper{
 		dual:          dual,
 		groupResource: gr,
 		unifiedClient: unifiedClient,
 		legacyClient:  legacyClient,
-		features:      features,
 		logger:        log.NewNopLogger(),
 	}
 }
 
 func TestSearchClient_NewSearchClient(t *testing.T) {
-	gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+	gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 	t.Run("always returns wrapper", func(t *testing.T) {
 		dual := &fakeDualWriter{}
 
-		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
+		client := NewSearchClient(dual, gr, unifiedClient, legacyClient)
 
 		wrapper, ok := client.(*searchWrapper)
 		require.True(t, ok)
@@ -136,19 +133,18 @@ func TestSearchClient_NewSearchClient(t *testing.T) {
 }
 
 func TestSearchWrapper_Search(t *testing.T) {
-	// gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
 	req := &resourcepb.ResourceSearchRequest{Query: "test"}
 	expectedResponse := &resourcepb.ResourceSearchResponse{TotalHits: 0}
 
 	t.Run("uses unified client when reading from unified", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: true, status: dualwrite.StorageStatus{ReadUnified: true, WriteUnified: true}}
 
 		unifiedClient.searchResponse = expectedResponse
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, features, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.Search(ctx, req)
 
@@ -159,33 +155,30 @@ func TestSearchWrapper_Search(t *testing.T) {
 	})
 
 	t.Run("uses legacy client when not reading from unified", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
 
 		legacyClient.searchResponse = expectedResponse
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, features, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.Search(ctx, req)
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedResponse, resp)
-
-		assert.Empty(t, unifiedClient.searchCalled, "unified Search should not have been called")
 	})
 
-	t.Run("do not make a background call to unified when feature flag enabled and using legacy with mode 0", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+	t.Run("does not make background call when not dual writing", func(t *testing.T) {
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: false}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.searchResponse = expectedResponse
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.Search(ctx, req)
 
@@ -199,19 +192,18 @@ func TestSearchWrapper_Search(t *testing.T) {
 		assert.Empty(t, unifiedClient.searchCalled, "unified Search should not have been called")
 	})
 
-	t.Run("makes background call to unified when feature flag enabled and using legacy", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+	t.Run("makes background call to unified when dual writing with legacy primary", func(t *testing.T) {
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.searchResponse = expectedResponse
 
 		// Configure background call to unified client
 		unifiedClient.searchResponse = &resourcepb.ResourceSearchResponse{TotalHits: 0}
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.Search(ctx, req)
 
@@ -228,18 +220,17 @@ func TestSearchWrapper_Search(t *testing.T) {
 	})
 
 	t.Run("handles background call error gracefully", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.searchResponse = expectedResponse
 
 		// Background call returns error - should be handled gracefully
 		unifiedClient.searchErr = assert.AnError
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.Search(ctx, req)
 
@@ -257,18 +248,17 @@ func TestSearchWrapper_Search(t *testing.T) {
 	})
 
 	t.Run("background request times out after 500ms", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.searchResponse = expectedResponse
 
 		// Configure unified client to take longer than the 500ms timeout
 		unifiedClient.searchDelay = 600 * time.Millisecond // Longer than 500ms timeout
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		start := time.Now()
 		resp, err := wrapper.Search(ctx, req)
@@ -290,11 +280,10 @@ func TestSearchWrapper_Search(t *testing.T) {
 	})
 
 	t.Run("background request completes successfully when within timeout", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.searchResponse = expectedResponse
 
@@ -302,7 +291,7 @@ func TestSearchWrapper_Search(t *testing.T) {
 		unifiedClient.searchDelay = 100 * time.Millisecond // Well within 500ms timeout
 		unifiedClient.searchResponse = &resourcepb.ResourceSearchResponse{TotalHits: 0}
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		start := time.Now()
 		resp, err := wrapper.Search(ctx, req)
@@ -324,19 +313,18 @@ func TestSearchWrapper_Search(t *testing.T) {
 }
 
 func TestSearchWrapper_GetStats(t *testing.T) {
-	// gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
 	req := &resourcepb.ResourceStatsRequest{Namespace: "test"}
 	expectedResponse := &resourcepb.ResourceStatsResponse{Stats: []*resourcepb.ResourceStatsResponse_Stats{{Count: 100}}}
 
 	t.Run("uses unified client when reading from unified", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: true, status: dualwrite.StorageStatus{ReadUnified: true, WriteUnified: true}}
 
 		unifiedClient.statsResponse = expectedResponse
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, features, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.GetStats(ctx, req)
 
@@ -346,16 +334,15 @@ func TestSearchWrapper_GetStats(t *testing.T) {
 		assert.Empty(t, legacyClient.statsCalled, "legacy GetStats should not have been called")
 	})
 
-	t.Run("Do not make background call to unified when feature flag enabled and using legacy with mode 0", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+	t.Run("does not make background call when not dual writing", func(t *testing.T) {
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: false}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.statsResponse = expectedResponse
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.GetStats(ctx, req)
 
@@ -369,19 +356,18 @@ func TestSearchWrapper_GetStats(t *testing.T) {
 		assert.Empty(t, unifiedClient.statsCalled, "unified GetStats should not have been called")
 	})
 
-	t.Run("makes background call to unified when feature flag enabled and using legacy", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+	t.Run("makes background call to unified when dual writing with legacy primary", func(t *testing.T) {
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.statsResponse = expectedResponse
 
 		// Configure background call to unified client
 		unifiedClient.statsResponse = &resourcepb.ResourceStatsResponse{Stats: []*resourcepb.ResourceStatsResponse_Stats{{Count: 50}}}
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		resp, err := wrapper.GetStats(ctx, req)
 
@@ -398,18 +384,17 @@ func TestSearchWrapper_GetStats(t *testing.T) {
 	})
 
 	t.Run("background GetStats request times out after 500ms", func(t *testing.T) {
-		gr, unifiedClient, legacyClient, _ := setupTestSearchClient(t)
+		gr, unifiedClient, legacyClient := setupTestSearchClient(t)
 
 		ctx := testutil.NewDefaultTestContext(t)
 		dual := &fakeDualWriter{readFromUnified: false, status: dualwrite.StorageStatus{ReadUnified: false, WriteUnified: true}}
-		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
 
 		legacyClient.statsResponse = expectedResponse
 
 		// Configure unified client to take longer than the 500ms timeout
 		unifiedClient.statsDelay = 600 * time.Millisecond // Longer than 500ms timeout
 
-		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, gr)
 
 		start := time.Now()
 		resp, err := wrapper.GetStats(ctx, req)


### PR DESCRIPTION
We introduced this feature back in July as we were rolling out search for the first time. This PR removes the feature toggle and enables this for good, so we continue to match the dual writer behavior without needing the flag (which is currently enabled everywhere already)