### PR TITLE
Datasources: Add default button to datasource header

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -284,6 +284,8 @@ export const getButtonStyles = (props: StyleProps) => {
     }),
     disabled: css(disabledStyles, {
       '&:hover': css(disabledStyles),
+      '&:focus': css(disabledStyles),
+      '&:focus-visible': css(disabledStyles),
     }),
     img: css({
       width: '16px',

--- a/public/app/features/datasources/components/EditDataSourceActions.test.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.test.tsx
@@ -537,40 +537,31 @@ describe('EditDataSourceActions', () => {
   });
 
   describe('Default Actions', () => {
-    it('should render make default button when data source is not default', () => {
+    it('should render make default button when data source is not default and editable', () => {
       mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
 
       render(<EditDataSourceActions uid="test-uid" />);
 
       expect(screen.getByText('Make default')).toBeInTheDocument();
-      expect(screen.queryByText('Default')).not.toBeInTheDocument();
+      expect(screen.queryByText('Remove default')).not.toBeInTheDocument();
     });
 
-    it('should render default badge when data source is default', () => {
+    it('should render remove default button when data source is default and editable', () => {
       mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
 
       render(<EditDataSourceActions uid="test-uid" />);
 
-      expect(screen.getByText('Default')).toBeInTheDocument();
+      expect(screen.getByText('Remove default')).toBeInTheDocument();
       expect(screen.queryByText('Make default')).not.toBeInTheDocument();
     });
 
-    it('should disable make default button for read-only users', () => {
+    it('should not render make default button when data source is not default but not editable', () => {
       mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
       mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
 
       render(<EditDataSourceActions uid="test-uid" />);
 
-      expect(screen.getByText('Make default').closest('button')).toHaveAttribute('aria-disabled', 'true');
-    });
-
-    it('should render remove default button when data source is default and editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: false });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByLabelText('Remove default')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
     });
 
     it('should not render remove default button when data source is default but not editable', () => {
@@ -580,6 +571,15 @@ describe('EditDataSourceActions', () => {
       render(<EditDataSourceActions uid="test-uid" />);
 
       expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
+    });
+
+    it('should render default badge when data source is default but not editable', () => {
+      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
+
+      render(<EditDataSourceActions uid="test-uid" />);
+
+      expect(screen.getByText('Default')).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/datasources/components/EditDataSourceActions.test.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { PluginExtensionTypes, type IconName } from '@grafana/data';
 import { setPluginLinksHook, config, getDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
+import { useDispatch } from 'app/types/store';
 
 import { getMockDataSource } from '../mocks/dataSourcesMocks';
 
@@ -10,6 +11,10 @@ import { EditDataSourceActions } from './EditDataSourceActions';
 
 // Mock dependencies
 jest.mock('app/core/services/context_srv');
+jest.mock('app/types/store', () => ({
+  ...jest.requireActual('app/types/store'),
+  useDispatch: jest.fn(),
+}));
 jest.mock('../utils', () => ({
   constructDataSourceExploreUrl: jest.fn(
     () => '/explore?left=%7B%22datasource%22:%22Test%20Prometheus%22,%22context%22:%22explore%22%7D'
@@ -52,6 +57,7 @@ const mockContextSrv = jest.mocked(contextSrv);
 // Mock getDataSourceSrv and favorite hooks
 const mockGetDataSourceSrv = jest.mocked(getDataSourceSrv);
 const mockUseFavoriteDatasources = jest.mocked(require('@grafana/runtime').useFavoriteDatasources);
+const mockUseDispatch = jest.mocked(useDispatch);
 
 // Create mock datasource instance
 const mockDataSourceInstance = {
@@ -103,10 +109,19 @@ const mockDataSource = getMockDataSource({
   typeName: 'Prometheus',
 });
 
+const mockDataSourceRights = {
+  hasWriteRights: true,
+  readOnly: false,
+};
+
 // Mock useDataSource hook
 jest.mock('../state/hooks', () => ({
-  useDataSource: (uid: string) => (uid === 'not-found' ? {} : mockDataSource),
+  useDataSource: jest.fn((uid: string) => (uid === 'not-found' ? {} : mockDataSource)),
+  useDataSourceRights: jest.fn((uid: string) => (uid === 'not-found' ? {} : mockDataSourceRights)),
 }));
+
+const mockUseDataSource = jest.mocked(require('../state/hooks').useDataSource);
+const mockUseDataSourceRights = jest.mocked(require('../state/hooks').useDataSourceRights);
 
 describe('EditDataSourceActions', () => {
   beforeEach(() => {
@@ -133,6 +148,11 @@ describe('EditDataSourceActions', () => {
     // Default: feature toggle disabled, so no favorite hook
     mockUseFavoriteDatasources.mockReturnValue({ ...mockFavoriteHook, enabled: false });
     config.featureToggles.favoriteDatasources = false;
+
+    // Reset default hook mocks
+    mockUseDispatch.mockReturnValue(jest.fn());
+    mockUseDataSource.mockImplementation((uid: string) => (uid === 'not-found' ? {} : mockDataSource));
+    mockUseDataSourceRights.mockImplementation((uid: string) => (uid === 'not-found' ? {} : mockDataSourceRights));
   });
 
   describe('Core Actions', () => {
@@ -513,6 +533,53 @@ describe('EditDataSourceActions', () => {
 
       const favoriteButton = screen.getByTestId('favorite-button');
       expect(favoriteButton).toBeDisabled();
+    });
+  });
+
+  describe('Default Actions', () => {
+    it('should render make default button when data source is not default', () => {
+      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+
+      render(<EditDataSourceActions uid="test-uid" />);
+
+      expect(screen.getByText('Make default')).toBeInTheDocument();
+      expect(screen.queryByText('Default')).not.toBeInTheDocument();
+    });
+
+    it('should render default badge when data source is default', () => {
+      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+
+      render(<EditDataSourceActions uid="test-uid" />);
+
+      expect(screen.getByText('Default')).toBeInTheDocument();
+      expect(screen.queryByText('Make default')).not.toBeInTheDocument();
+    });
+
+    it('should disable make default button for read-only users', () => {
+      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+
+      render(<EditDataSourceActions uid="test-uid" />);
+
+      expect(screen.getByText('Make default').closest('button')).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should render remove default button when data source is default and editable', () => {
+      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: false });
+
+      render(<EditDataSourceActions uid="test-uid" />);
+
+      expect(screen.getByLabelText('Remove default')).toBeInTheDocument();
+    });
+
+    it('should not render remove default button when data source is default but not editable', () => {
+      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+
+      render(<EditDataSourceActions uid="test-uid" />);
+
+      expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -10,7 +10,7 @@ import {
   reportInteraction,
   isFetchError,
 } from '@grafana/runtime';
-import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Badge, Stack, Tooltip } from '@grafana/ui';
+import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Badge, Tooltip } from '@grafana/ui';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -99,48 +99,56 @@ const DefaultButton = ({ uid }: { uid: string }) => {
     setLoading(false);
   };
 
-  return dataSource.isDefault ? (
-    <Badge
-      text={
-        <Stack direction="row" alignItems="center" gap={1}>
+  if (!editable) {
+    return dataSource.isDefault ? (
+      <Badge
+        text={
           <Tooltip
-            content={t(
-              'datasources.edit-data-source-actions.default-tooltip',
-              'The default data source is preselected in new panels.'
-            )}
+            content={[
+              t(
+                'datasources.edit-data-source-actions.default-active',
+                'This data source is currently set as the default.'
+              ),
+              t(
+                'datasources.edit-data-source-actions.default-tooltip',
+                'The default data source is preselected in new panels.'
+              ),
+            ].join(' ')}
           >
             <span>
               <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
             </span>
           </Tooltip>
-          {editable && (
-            <IconButton
-              name={loading ? 'spinner' : 'times'}
-              size="xs"
-              variant="secondary"
-              onClick={() => onChangeDefault(false)}
-              disabled={loading}
-              tooltip={t('datasources.edit-data-source-actions.default-remove', 'Remove default')}
-            />
-          )}
-        </Stack>
-      }
-      color="blue"
-    />
-  ) : (
+        }
+        color="blue"
+      />
+    ) : null;
+  }
+
+  return (
     <Button
       variant="secondary"
       size="sm"
-      tooltip={t(
-        'datasources.edit-data-source-actions.default-tooltip',
-        'The default data source is preselected in new panels.'
-      )}
-      onClick={editable ? () => onChangeDefault(true) : undefined}
+      tooltip={[
+        dataSource.isDefault &&
+          t('datasources.edit-data-source-actions.default-active', 'This data source is currently set as the default.'),
+        t(
+          'datasources.edit-data-source-actions.default-tooltip',
+          'The default data source is preselected in new panels.'
+        ),
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={() => onChangeDefault(!dataSource.isDefault)}
       icon={loading ? 'spinner' : undefined}
       iconPlacement="right"
-      disabled={!editable || loading}
+      disabled={loading}
     >
-      <Trans i18nKey="datasources.edit-data-source-actions.default-button">Make default</Trans>
+      {dataSource.isDefault ? (
+        <Trans i18nKey="datasources.edit-data-source-actions.default-remove-button">Remove default</Trans>
+      ) : (
+        <Trans i18nKey="datasources.edit-data-source-actions.default-make-button">Make default</Trans>
+      )}
     </Button>
   );
 };

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -10,7 +10,9 @@ import {
   reportInteraction,
   isFetchError,
 } from '@grafana/runtime';
-import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Field, Badge, Stack, Tooltip } from '@grafana/ui';
+import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Badge, Stack, Tooltip } from '@grafana/ui';
+import { createErrorNotification } from 'app/core/copy/appNotification';
+import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useDispatch } from 'app/types/store';
 
@@ -65,7 +67,6 @@ const FavoriteButton = ({ uid }: { uid: string }) => {
 
 const DefaultButton = ({ uid }: { uid: string }) => {
   const [loading, setLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string>();
 
   const dataSource = useDataSource(uid);
   const rights = useDataSourceRights(uid);
@@ -78,7 +79,6 @@ const DefaultButton = ({ uid }: { uid: string }) => {
       return;
     }
     setLoading(true);
-    setErrorMessage(undefined);
 
     try {
       // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
@@ -86,67 +86,62 @@ const DefaultButton = ({ uid }: { uid: string }) => {
       await api.updateDataSource({ ...ds, isDefault: value });
       dispatch(setIsDefault(value));
     } catch (error) {
-      if (isFetchError(error)) {
-        setErrorMessage(error.data.message);
-      } else if (error instanceof Error) {
-        setErrorMessage(error.message);
-      } else {
-        setErrorMessage(t('datasources.edit-data-source-actions.default-error', 'An unknown error occurred'));
-      }
+      dispatch(
+        notifyApp(
+          createErrorNotification(
+            t('datasources.edit-data-source-actions.default-error', 'Failed to update default data source'),
+            isFetchError(error) ? error.data.message : error instanceof Error ? error.message : undefined
+          )
+        )
+      );
     }
 
     setLoading(false);
   };
 
-  return (
-    <Field invalid={!!errorMessage} error={errorMessage} validationMessageHorizontalOverflow noMargin>
-      <>
-        {dataSource.isDefault ? (
-          <Badge
-            text={
-              <Stack direction="row" alignItems="center" gap={1}>
-                <Tooltip
-                  content={t(
-                    'datasources.edit-data-source-actions.default-tooltip',
-                    'The default data source is preselected in new panels.'
-                  )}
-                >
-                  <span>
-                    <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
-                  </span>
-                </Tooltip>
-                {editable && (
-                  <IconButton
-                    name={loading ? 'spinner' : 'times'}
-                    size="xs"
-                    variant="secondary"
-                    onClick={() => onChangeDefault(false)}
-                    disabled={loading}
-                    tooltip={t('datasources.edit-data-source-actions.default-remove', 'Remove default')}
-                  />
-                )}
-              </Stack>
-            }
-            color="blue"
-          />
-        ) : (
-          <Button
-            variant="secondary"
-            size="sm"
-            tooltip={t(
+  return dataSource.isDefault ? (
+    <Badge
+      text={
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Tooltip
+            content={t(
               'datasources.edit-data-source-actions.default-tooltip',
               'The default data source is preselected in new panels.'
             )}
-            onClick={editable ? () => onChangeDefault(true) : undefined}
-            icon={loading ? 'spinner' : undefined}
-            iconPlacement="right"
-            disabled={!editable || loading}
           >
-            <Trans i18nKey="datasources.edit-data-source-actions.default-button">Make default</Trans>
-          </Button>
-        )}
-      </>
-    </Field>
+            <span>
+              <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
+            </span>
+          </Tooltip>
+          {editable && (
+            <IconButton
+              name={loading ? 'spinner' : 'times'}
+              size="xs"
+              variant="secondary"
+              onClick={() => onChangeDefault(false)}
+              disabled={loading}
+              tooltip={t('datasources.edit-data-source-actions.default-remove', 'Remove default')}
+            />
+          )}
+        </Stack>
+      }
+      color="blue"
+    />
+  ) : (
+    <Button
+      variant="secondary"
+      size="sm"
+      tooltip={t(
+        'datasources.edit-data-source-actions.default-tooltip',
+        'The default data source is preselected in new panels.'
+      )}
+      onClick={editable ? () => onChangeDefault(true) : undefined}
+      icon={loading ? 'spinner' : undefined}
+      iconPlacement="right"
+      disabled={!editable || loading}
+    >
+      <Trans i18nKey="datasources.edit-data-source-actions.default-button">Make default</Trans>
+    </Button>
   );
 };
 

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -100,50 +100,52 @@ const DefaultButton = ({ uid }: { uid: string }) => {
 
   return (
     <Field invalid={!!errorMessage} error={errorMessage} validationMessageHorizontalOverflow noMargin>
-      {dataSource.isDefault ? (
-        <Badge
-          text={
-            <Stack direction="row" alignItems="center" gap={1}>
-              <Tooltip
-                content={t(
-                  'datasources.edit-data-source-actions.default-tooltip',
-                  'The default data source is preselected in new panels.'
+      <>
+        {dataSource.isDefault ? (
+          <Badge
+            text={
+              <Stack direction="row" alignItems="center" gap={1}>
+                <Tooltip
+                  content={t(
+                    'datasources.edit-data-source-actions.default-tooltip',
+                    'The default data source is preselected in new panels.'
+                  )}
+                >
+                  <span>
+                    <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
+                  </span>
+                </Tooltip>
+                {editable && (
+                  <IconButton
+                    name={loading ? 'spinner' : 'times'}
+                    size="xs"
+                    variant="secondary"
+                    onClick={() => onChangeDefault(false)}
+                    disabled={loading}
+                    tooltip={t('datasources.edit-data-source-actions.default-remove', 'Remove default')}
+                  />
                 )}
-              >
-                <span>
-                  <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
-                </span>
-              </Tooltip>
-              {editable && (
-                <IconButton
-                  name={loading ? 'spinner' : 'times'}
-                  size="xs"
-                  variant="secondary"
-                  onClick={() => onChangeDefault(false)}
-                  disabled={loading}
-                  tooltip={t('datasources.edit-data-source-actions.default-remove', 'Remove default')}
-                />
-              )}
-            </Stack>
-          }
-          color="blue"
-        />
-      ) : (
-        <Button
-          variant="secondary"
-          size="sm"
-          tooltip={t(
-            'datasources.edit-data-source-actions.default-tooltip',
-            'The default data source is preselected in new panels.'
-          )}
-          onClick={editable ? () => onChangeDefault(true) : undefined}
-          icon={loading ? 'spinner' : undefined}
-          iconPlacement="right"
-          disabled={!editable || loading}
-        >
-          <Trans i18nKey="datasources.edit-data-source-actions.default-button">Make default</Trans>
-        </Button>
-      )}
+              </Stack>
+            }
+            color="blue"
+          />
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            tooltip={t(
+              'datasources.edit-data-source-actions.default-tooltip',
+              'The default data source is preselected in new panels.'
+            )}
+            onClick={editable ? () => onChangeDefault(true) : undefined}
+            icon={loading ? 'spinner' : undefined}
+            iconPlacement="right"
+            disabled={!editable || loading}
+          >
+            <Trans i18nKey="datasources.edit-data-source-actions.default-button">Make default</Trans>
+          </Button>
+        )}
+      </>
     </Field>
   );
 };

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -1,11 +1,23 @@
+import { useState } from 'react';
+
 import { PluginExtensionPoints } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, usePluginLinks, useFavoriteDatasources, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
-import { Button, Dropdown, LinkButton, Menu, Icon, IconButton } from '@grafana/ui';
+import {
+  config,
+  usePluginLinks,
+  useFavoriteDatasources,
+  getDataSourceSrv,
+  reportInteraction,
+  isFetchError,
+} from '@grafana/runtime';
+import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Field, Badge, Stack, Tooltip } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
+import { useDispatch } from 'app/types/store';
 
+import * as api from '../api';
 import { ALLOWED_DATASOURCE_EXTENSION_PLUGINS } from '../constants';
-import { useDataSource } from '../state/hooks';
+import { useDataSource, useDataSourceRights } from '../state/hooks';
+import { setIsDefault } from '../state/reducers';
 import { trackDsConfigClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
@@ -48,6 +60,91 @@ const FavoriteButton = ({ uid }: { uid: string }) => {
         data-testid="favorite-button"
       />
     )
+  );
+};
+
+const DefaultButton = ({ uid }: { uid: string }) => {
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  const dataSource = useDataSource(uid);
+  const rights = useDataSourceRights(uid);
+  const editable = rights.hasWriteRights && !rights.readOnly;
+
+  const dispatch = useDispatch();
+
+  const onChangeDefault = async (value: boolean) => {
+    if (loading) {
+      return;
+    }
+    setLoading(true);
+    setErrorMessage(undefined);
+
+    try {
+      // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
+      const ds = await api.getDataSourceByUid(uid);
+      await api.updateDataSource({ ...ds, isDefault: value });
+      dispatch(setIsDefault(value));
+    } catch (error) {
+      if (isFetchError(error)) {
+        setErrorMessage(error.data.message);
+      } else if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage(t('datasources.edit-data-source-actions.default-error', 'An unknown error occurred'));
+      }
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <Field invalid={!!errorMessage} error={errorMessage} validationMessageHorizontalOverflow noMargin>
+      {dataSource.isDefault ? (
+        <Badge
+          text={
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Tooltip
+                content={t(
+                  'datasources.edit-data-source-actions.default-tooltip',
+                  'The default data source is preselected in new panels.'
+                )}
+              >
+                <span>
+                  <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
+                </span>
+              </Tooltip>
+              {editable && (
+                <IconButton
+                  name={loading ? 'spinner' : 'times'}
+                  size="xs"
+                  variant="secondary"
+                  onClick={() => onChangeDefault(false)}
+                  disabled={loading}
+                  tooltip={t('datasources.edit-data-source-actions.default-remove', 'Remove default')}
+                />
+              )}
+            </Stack>
+          }
+          color="blue"
+        />
+      ) : (
+        <Button
+          variant="secondary"
+          size="sm"
+          tooltip={t(
+            'datasources.edit-data-source-actions.default-tooltip',
+            'The default data source is preselected in new panels.'
+          )}
+          onClick={editable ? () => onChangeDefault(true) : undefined}
+          icon={loading ? 'spinner' : undefined}
+          iconPlacement="right"
+          disabled={!editable || loading}
+        >
+          <Trans i18nKey="datasources.edit-data-source-actions.default-button">Make default</Trans>
+        </Button>
+      )}
+    </Field>
   );
 };
 
@@ -105,6 +202,7 @@ export function EditDataSourceActions({ uid }: Props) {
   return (
     <>
       <FavoriteButton uid={uid} />
+      <DefaultButton uid={uid} />
       {hasExploreRights && (
         <>
           {!hasActions ? (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8144,10 +8144,11 @@
     },
     "edit-data-source-actions": {
       "add-favorite": "Add to favorites",
-      "default-button": "Make default",
+      "default-active": "This data source is currently set as the default.",
       "default-error": "Failed to update default data source",
       "default-label": "Default",
-      "default-remove": "Remove default",
+      "default-make-button": "Make default",
+      "default-remove-button": "Remove default",
       "default-tooltip": "The default data source is preselected in new panels.",
       "explore-data": "Explore data",
       "open-in-explore": "Open in Explore View",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8145,7 +8145,7 @@
     "edit-data-source-actions": {
       "add-favorite": "Add to favorites",
       "default-button": "Make default",
-      "default-error": "An unknown error occurred",
+      "default-error": "Failed to update default data source",
       "default-label": "Default",
       "default-remove": "Remove default",
       "default-tooltip": "The default data source is preselected in new panels.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8144,6 +8144,11 @@
     },
     "edit-data-source-actions": {
       "add-favorite": "Add to favorites",
+      "default-button": "Make default",
+      "default-error": "An unknown error occurred",
+      "default-label": "Default",
+      "default-remove": "Remove default",
+      "default-tooltip": "The default data source is preselected in new panels.",
       "explore-data": "Explore data",
       "open-in-explore": "Open in Explore View",
       "remove-favorite": "Remove from favorites"


### PR DESCRIPTION
**What is this feature?**

Following on from #122053, this adds the `isDefault` setting as a button to the data source actions in the header. Instead of a toggle, this opts for a button if the data source is not currently default, and a badge w/ an icon button is the data source is currently the default.

**Why do we need this feature?**

Building off the work in #122053, the desire is to remove the basic settings from the form for name + default, and instead rely on these new settings in the header.

**Who is this feature for?**

All administrators.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
