### PR TITLE
I18n: Fix pluralization for default language by loading only plural keys

### DIFF
--- a/packages/grafana-i18n/src/i18n.test.tsx
+++ b/packages/grafana-i18n/src/i18n.test.tsx
@@ -70,18 +70,40 @@ describe('i18n', () => {
       expect(addResourceBundleSpy).toHaveBeenCalledWith('en-US', 'test', { hello: 'Hi' }, true, false);
     });
 
-    it('should not load resources for the default language', async () => {
+    it('should load only plural keys for the default language', async () => {
       const loaders: ResourceLoader[] = [
-        jest.fn(() => Promise.resolve({ hello: 'Hi' })),
-        jest.fn(() => Promise.resolve({ i18n: 'i18n' })),
+        jest.fn(() =>
+          Promise.resolve({
+            hello: 'Hi',
+            item_one: '1 item',
+            item_other: '{{count}} items',
+          })
+        ),
       ];
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
 
       await loadNamespacedResources('test', 'en-US', loaders);
 
-      expect(loaders[0]).not.toHaveBeenCalled();
-      expect(loaders[1]).not.toHaveBeenCalled();
-      expect(addResourceBundleSpy).not.toHaveBeenCalled();
+      expect(loaders[0]).toHaveBeenCalledWith('en-US');
+      expect(addResourceBundleSpy).toHaveBeenCalledTimes(1);
+      expect(addResourceBundleSpy).toHaveBeenCalledWith(
+        'en-US',
+        'test',
+        { item_one: '1 item', item_other: '{{count}} items' },
+        true,
+        false
+      );
+    });
+
+    it('should not add resource bundle if no plural keys exist for the default language', async () => {
+      const loaders: ResourceLoader[] = [jest.fn(() => Promise.resolve({ hello: 'Hi', world: 'World' }))];
+      const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
+
+      await loadNamespacedResources('test', 'en-US', loaders);
+
+      expect(loaders[0]).toHaveBeenCalledWith('en-US');
+      expect(addResourceBundleSpy).toHaveBeenCalledTimes(1);
+      expect(addResourceBundleSpy).toHaveBeenCalledWith('en-US', 'test', {}, true, false);
     });
   });
 
@@ -191,9 +213,9 @@ describe('i18n', () => {
       expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'fr-FR', 'test', { i18n: 'i18n' }, true, false);
     });
 
-    it('should not load resources when language is the default language', async () => {
+    it('should load only plural keys when language is the default language', async () => {
       const loaders: ResourceLoader[] = [
-        jest.fn(() => Promise.resolve({ hello: 'Hi' })),
+        jest.fn(() => Promise.resolve({ hello: 'Hi', item_one: '1 item', item_other: '{{count}} items' })),
         jest.fn(() => Promise.resolve({ i18n: 'i18n' })),
       ];
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
@@ -203,9 +225,18 @@ describe('i18n', () => {
       const { language } = await initPluginTranslations('test', loaders);
 
       expect(language).toBe('en-US');
-      expect(loaders[0]).not.toHaveBeenCalled();
-      expect(loaders[1]).not.toHaveBeenCalled();
-      expect(addResourceBundleSpy).not.toHaveBeenCalled();
+      expect(loaders[0]).toHaveBeenCalledWith('en-US');
+      expect(loaders[1]).toHaveBeenCalledWith('en-US');
+      expect(addResourceBundleSpy).toHaveBeenCalledTimes(2);
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(
+        1,
+        'en-US',
+        'test',
+        { item_one: '1 item', item_other: '{{count}} items' },
+        true,
+        false
+      );
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'en-US', 'test', {}, true, false);
     });
   });
 });

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -47,7 +47,11 @@ export async function loadNamespacedResources(namespace: string, language: strin
     loaders.map(async (loader) => {
       try {
         const resources = await loader(resolvedLanguage);
-        addResourceBundle(resolvedLanguage, namespace, shouldFilterPluralKeys ? filterPluralKeys(resources) : resources);
+        addResourceBundle(
+          resolvedLanguage,
+          namespace,
+          shouldFilterPluralKeys ? filterPluralKeys(resources) : resources
+        );
       } catch (error) {
         console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
       }

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -7,6 +7,7 @@ import { initReactI18next, setDefaults, setI18n, Trans as I18NextTrans, getI18n 
 import { DEFAULT_LANGUAGE, PSEUDO_LOCALE } from './constants';
 import { initRegionalFormat } from './dates';
 import { LANGUAGES } from './languages';
+import { filterPluralKeys } from './plurals';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
 
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
@@ -38,17 +39,15 @@ export async function loadNamespacedResources(namespace: string, language: strin
 
   const resolvedLanguage = language === PSEUDO_LOCALE ? DEFAULT_LANGUAGE : language;
 
-  // Don't load resources for the default language as they are already embedded in the source code.
-  // Pseudo-locale still needs the default-language resources loaded for post-processing.
-  if (language === DEFAULT_LANGUAGE) {
-    return;
-  }
+  // For the default language, only load plural keys since singular forms are already embedded in source code.
+  // Pseudo-locale still needs all default-language resources loaded for post-processing.
+  const shouldFilterPluralKeys = language === DEFAULT_LANGUAGE;
 
   return Promise.all(
     loaders.map(async (loader) => {
       try {
         const resources = await loader(resolvedLanguage);
-        addResourceBundle(resolvedLanguage, namespace, resources);
+        addResourceBundle(resolvedLanguage, namespace, shouldFilterPluralKeys ? filterPluralKeys(resources) : resources);
       } catch (error) {
         console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
       }

--- a/packages/grafana-i18n/src/internal/index.ts
+++ b/packages/grafana-i18n/src/internal/index.ts
@@ -19,3 +19,5 @@ export {
   initializeI18n,
   loadNamespacedResources,
 } from '../i18n';
+
+export { filterPluralKeys } from '../plurals';

--- a/packages/grafana-i18n/src/plurals.test.ts
+++ b/packages/grafana-i18n/src/plurals.test.ts
@@ -1,0 +1,126 @@
+import { filterPluralKeys } from './plurals';
+
+describe('filterPluralKeys', () => {
+  it('should keep only plural-suffixed keys from a flat object', () => {
+    const input = {
+      hello: 'Hi',
+      item_one: '1 item',
+      item_other: '{{count}} items',
+    };
+
+    expect(filterPluralKeys(input)).toEqual({
+      item_one: '1 item',
+      item_other: '{{count}} items',
+    });
+  });
+
+  it('should keep plural keys in nested objects and prune non-plural branches', () => {
+    const input = {
+      'browse-dashboards': {
+        counts: {
+          folder_one: '{{count}} folder',
+          folder_other: '{{count}} folders',
+          title: 'Browse',
+        },
+        header: {
+          title: 'Dashboards',
+          subtitle: 'Manage your dashboards',
+        },
+      },
+    };
+
+    expect(filterPluralKeys(input)).toEqual({
+      'browse-dashboards': {
+        counts: {
+          folder_one: '{{count}} folder',
+          folder_other: '{{count}} folders',
+        },
+      },
+    });
+  });
+
+  it('should prune empty branches entirely', () => {
+    const input = {
+      section: {
+        title: 'Hello',
+        subtitle: 'World',
+      },
+    };
+
+    expect(filterPluralKeys(input)).toEqual({});
+  });
+
+  it('should handle all i18next plural suffixes', () => {
+    const input = {
+      key_zero: 'zero',
+      key_one: 'one',
+      key_two: 'two',
+      key_few: 'few',
+      key_many: 'many',
+      key_other: 'other',
+      key_invalid: 'not a plural',
+    };
+
+    expect(filterPluralKeys(input)).toEqual({
+      key_zero: 'zero',
+      key_one: 'one',
+      key_two: 'two',
+      key_few: 'few',
+      key_many: 'many',
+      key_other: 'other',
+    });
+  });
+
+  it('should not match keys where suffix is part of a word (e.g. "everyone")', () => {
+    const input = {
+      everyone: 'Everyone',
+      someone: 'Someone',
+      leftover_none: 'None left',
+    };
+
+    expect(filterPluralKeys(input)).toEqual({});
+  });
+
+  it('should return an empty object for empty input', () => {
+    expect(filterPluralKeys({})).toEqual({});
+  });
+
+  it('should not mutate the input object', () => {
+    const input = {
+      section: {
+        item_one: '1 item',
+        item_other: '{{count}} items',
+        title: 'Section',
+      },
+    };
+    const inputCopy = JSON.parse(JSON.stringify(input));
+
+    filterPluralKeys(input);
+
+    expect(input).toEqual(inputCopy);
+  });
+
+  it('should handle deeply nested plural keys', () => {
+    const input = {
+      level1: {
+        level2: {
+          level3: {
+            count_one: '{{count}} thing',
+            count_other: '{{count}} things',
+          },
+        },
+      },
+    };
+
+    expect(filterPluralKeys(input)).toEqual({
+      level1: {
+        level2: {
+          level3: {
+            count_one: '{{count}} thing',
+            count_other: '{{count}} things',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/grafana-i18n/src/plurals.ts
+++ b/packages/grafana-i18n/src/plurals.ts
@@ -1,0 +1,28 @@
+import { type Resources } from './types';
+
+const PLURAL_SUFFIXES = ['_zero', '_one', '_two', '_few', '_many', '_other'] as const;
+
+function isPluralKey(key: string): boolean {
+  return PLURAL_SUFFIXES.some((suffix) => key.endsWith(suffix));
+}
+
+function isResources(value: unknown): value is Resources {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function filterPluralKeys(resources: Resources): Resources {
+  const result: Resources = {};
+
+  for (const [key, value] of Object.entries(resources)) {
+    if (isResources(value)) {
+      const filtered = filterPluralKeys(value);
+      if (Object.keys(filtered).length > 0) {
+        result[key] = filtered;
+      }
+    } else if (isPluralKey(key)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}

--- a/public/app/core/internationalization/loadTranslations.ts
+++ b/public/app/core/internationalization/loadTranslations.ts
@@ -1,6 +1,7 @@
 import { type BackendModule } from 'i18next';
 
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
+import { filterPluralKeys } from '@grafana/i18n/internal';
 
 import { LANGUAGES } from './constants';
 
@@ -19,9 +20,14 @@ export const loadTranslations: BackendModule = {
       return callback(new Error(`No message loader available for ${language}`), null);
     }
 
-    // don't load messages for DEFAULT_LANGUAGE as they are already embedded in the source code
+    // For the default language, only load plural keys since singular forms are already embedded in source code.
     if (localeDef.code === DEFAULT_LANGUAGE) {
-      return callback(null, {});
+      const namespaceLoader = localeDef.loader[namespace];
+      if (!namespaceLoader) {
+        return callback(null, {});
+      }
+      const messages = await namespaceLoader();
+      return callback(null, filterPluralKeys(messages));
     }
 
     const namespaceLoader = localeDef.loader[namespace];

--- a/public/app/core/internationalization/loadTranslations.ts
+++ b/public/app/core/internationalization/loadTranslations.ts
@@ -27,6 +27,9 @@ export const loadTranslations: BackendModule = {
         return callback(null, {});
       }
       const messages = await namespaceLoader();
+      if (typeof messages === 'string') {
+        return callback(null, messages);
+      }
       return callback(null, filterPluralKeys(messages));
     }
 

--- a/public/app/features/plugins/importer/addTranslationsToI18n.test.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.test.ts
@@ -40,7 +40,7 @@ describe('addTranslationsToI18n', () => {
     server.close();
   });
 
-  it('should not load translations when resolved language matches fallback language', async () => {
+  it('should load only plural keys when resolved language is en-US with no plural keys', async () => {
     await addTranslationsToI18n({
       resolvedLanguage: 'en-US',
       fallbackLanguage: 'en-US',
@@ -50,7 +50,25 @@ describe('addTranslationsToI18n', () => {
       },
     });
 
-    expect(addResourceBundleSpy).not.toHaveBeenCalled();
+    expect(addResourceBundleSpy).toHaveBeenCalledTimes(1);
+    expect(addResourceBundleSpy).toHaveBeenCalledWith('en-US', 'test-panel', {});
+  });
+
+  it('should load only plural keys when resolved language is en-US with plural keys', async () => {
+    await addTranslationsToI18n({
+      resolvedLanguage: 'en-US',
+      fallbackLanguage: 'en-US',
+      pluginId: 'test-panel',
+      translations: {
+        'en-US': '/public/plugins/test-panel/locales/en-US/test-panel-plurals.json',
+      },
+    });
+
+    expect(addResourceBundleSpy).toHaveBeenCalledTimes(1);
+    expect(addResourceBundleSpy).toHaveBeenCalledWith('en-US', 'test-panel', {
+      item_one: '1 item',
+      item_other: '{{count}} items',
+    });
   });
 
   it('should add translations that match the resolved language first', async () => {

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
-import { addResourceBundle } from '@grafana/i18n/internal';
+import { addResourceBundle, filterPluralKeys } from '@grafana/i18n/internal';
 
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';
@@ -17,38 +17,42 @@ export async function addTranslationsToI18n({
   pluginId,
   translations,
 }: AddTranslationsToI18nOptions): Promise<void> {
-  if (resolvedLanguage === DEFAULT_LANGUAGE) {
-    return;
-  }
-
   const resolvedPath = translations[resolvedLanguage];
   const fallbackPath = translations[fallbackLanguage];
   const path = resolvedPath ?? fallbackPath;
 
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    if (resolvedLanguage !== DEFAULT_LANGUAGE) {
+      console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    }
     return;
   }
 
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
-        resolvedLanguage,
-        fallbackLanguage,
-        path,
-      });
+      if (resolvedLanguage !== DEFAULT_LANGUAGE) {
+        console.warn(`Could not find default export for plugin ${pluginId}`, {
+          resolvedLanguage,
+          fallbackLanguage,
+          path,
+        });
+      }
       return;
     }
 
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
-    addResourceBundle(language, pluginId, module.default);
+    // For the default language, only load plural keys since singular forms are already embedded in source code.
+    const resources = resolvedLanguage === DEFAULT_LANGUAGE ? filterPluralKeys(module.default) : module.default;
+    addResourceBundle(language, pluginId, resources);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
-      resolvedLanguage,
-      fallbackLanguage,
-      error,
-      path,
-    });
+    if (resolvedLanguage !== DEFAULT_LANGUAGE) {
+      console.warn(`Could not load translation for plugin ${pluginId}`, {
+        resolvedLanguage,
+        fallbackLanguage,
+        error,
+        path,
+      });
+    }
   }
 }

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -25,6 +25,8 @@ export const mockAmdModule = `define([], function() {
 const mockTranslation = (value: string) =>
   `System.register([],function(e){return{execute:function(){e("default",{"testKey":"${value}"})}}})`;
 
+const mockTranslationWithPlurals = `System.register([],function(e){return{execute:function(){e("default",{"title":"Test","item_one":"1 item","item_other":"{{count}} items"})}}})`;
+
 const mockTranslationWithNoDefaultExport = `System.register([],function(e){return{execute:function(){e({"testKey":"unknown"})}}})`;
 
 const server = setupServer(
@@ -86,6 +88,15 @@ const server = setupServer(
     '/public/plugins/test-panel/locales/pt-BR/no-default-export.json',
     () =>
       new HttpResponse(mockTranslationWithNoDefaultExport, {
+        headers: {
+          'Content-Type': 'text/javascript',
+        },
+      })
+  ),
+  http.get(
+    '/public/plugins/test-panel/locales/en-US/test-panel-plurals.json',
+    () =>
+      new HttpResponse(mockTranslationWithPlurals, {
         headers: {
           'Content-Type': 'text/javascript',
         },


### PR DESCRIPTION
## Summary
- Fixes i18n pluralization that broke after skipping en-US locale loading (#122188, #120923)
- Instead of skipping en-US entirely, loads locale files but filters to only plural-suffixed keys (`_one`, `_other`, `_zero`, `_few`, `_many`, `_two`)
- Preserves ~98% of the memory optimization (only 176 of 10,216 keys loaded) while restoring correct pluralization

Fixes #122481

## Details

The optimization to skip loading en-US translations assumed all English strings are embedded in source code via `t()` calls. However, `t()` only takes a single `defaultMessage` (the singular form), while i18next needs `_one`/`_other` suffixed keys in the resource bundle for plural resolution. Without those keys, calls like `t('key', '{{count}} folder', { count: 5 })` always returned the singular form.

A new `filterPluralKeys` utility recursively walks translation objects and retains only keys ending with i18next plural suffixes. This is applied in all three locations that previously skipped en-US loading:
- `loadTranslations.ts` (core Grafana backend module)
- `loadNamespacedResources` in `i18n.tsx` (plugin/scenes translations)
- `addTranslationsToI18n.ts` (legacy plugin translations)

## Test plan
- [x] `filterPluralKeys` utility: 8 unit tests covering flat/nested objects, all suffixes, edge cases, empty input, no mutation
- [x] `i18n.test.tsx`: Updated tests verify loaders are called for en-US and only plural keys are added
- [x] `addTranslationsToI18n.test.ts`: Updated + new test with plural mock data
- [x] All 228 browse-dashboards tests pass (the area where the bug was reported)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Manual: navigate to Dashboards, select multiple items, click Delete — verify "12 items" not "12 item"