### PR TITLE
Dashboards: Separate adhoc filters from variables in section-level edit pane

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
@@ -243,6 +243,5 @@ Panels in the grouping resolve grouping-level variables first, then fall back to
 The panel query editor is context-aware, so the autocomplete only shows the variables available to the panel you're editing.
 Also, grouping-level variables carry over when you convert between rows and tabs, change layouts, and work with repeating rows and tabs.
 
-Grouping-level variables are supported for all variable types.
-However, they aren't supported for the public preview **Filter and group by** feature, which replaces the **Filters** variable when the `dashboardUnifiedDrilldownControls` feature toggle is enabled.
+Grouping-level variables are supported for all variable types, including the public preview **Filter and group by** feature when the `dashboardUnifiedDrilldownControls` feature toggle is enabled.
 For more information on **Filter and group by**, refer to the [Dashboard controls documentation](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-controls/#filter-and-group-by).

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -748,9 +748,6 @@ export const versionedComponents = {
       addLinkButton: {
         '12.6.0': 'data-testid add link button',
       },
-      addFilterButton: {
-        '13.0.0': 'data-testid add filter button',
-      },
       variableNameInput: {
         '12.0.0': 'data-testid variable name input',
       },

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -748,6 +748,9 @@ export const versionedComponents = {
       addLinkButton: {
         '12.6.0': 'data-testid add link button',
       },
+      addFilterButton: {
+        '13.0.0': 'data-testid add filter button',
+      },
       variableNameInput: {
         '12.0.0': 'data-testid variable name input',
       },

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -9,6 +9,7 @@ import { Box, Icon, ScrollContainer, Sidebar, Text, useElementSelection, useStyl
 
 import { DashboardLinksSet } from '../settings/links/DashboardLinksSet';
 import { LinkEdit } from '../settings/links/LinkAddEditableElement';
+import { DashboardFiltersSet } from '../settings/variables/DashboardFiltersSet';
 import { isRepeatCloneOrChildOf } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor } from '../utils/utils';
@@ -72,8 +73,12 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
     e.stopPropagation();
 
     if (!isSelected) {
-      if (sceneObject instanceof LinkEdit || sceneObject instanceof DashboardLinksSet) {
-        // Select directly via editPane.selectObject because link objects are not
+      if (
+        sceneObject instanceof LinkEdit ||
+        sceneObject instanceof DashboardLinksSet ||
+        sceneObject instanceof DashboardFiltersSet
+      ) {
+        // Select directly via editPane.selectObject because these objects are not
         // in the scene graph, so sceneGraph.findByKey (used by onSelect) can't find them.
         editPane.selectObject(sceneObject);
       } else {

--- a/public/app/features/dashboard-scene/edit-pane/SectionFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/SectionFiltersList.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+
+import { AdHocFiltersVariable, CustomVariable, SceneVariableSet } from '@grafana/scenes';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
+import { RowItem } from '../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
+
+import { SectionFiltersCategoryTitle, SectionFiltersList } from './SectionFiltersList';
+
+jest.mock('./add-new/AddFilters', () => ({
+  openAddFilterForm: jest.fn(),
+}));
+
+jest.mock('../utils/interactions', () => ({
+  DashboardInteractions: {
+    addFilterButtonClicked: jest.fn(),
+  },
+}));
+
+describe('SectionFiltersList', () => {
+  it('renders only adhoc filter variables', () => {
+    const row = buildRow({ includeFilter: true, includeCustom: true });
+
+    render(<SectionFiltersList sectionOwner={row} />);
+
+    expect(screen.getByText('filter0')).toBeInTheDocument();
+    expect(screen.queryByText('custom0')).not.toBeInTheDocument();
+  });
+
+  it('shows add filter button when no filters exist', () => {
+    const row = buildRow({ includeCustom: true });
+
+    render(<SectionFiltersList sectionOwner={row} />);
+
+    expect(screen.getByText('Add filter')).toBeInTheDocument();
+  });
+
+  it('counts only adhoc filter variables when collapsed', () => {
+    const row = buildRow({ includeFilter: true, includeCustom: true });
+
+    render(<SectionFiltersCategoryTitle sectionOwner={row} isExpanded={false} />);
+
+    expect(screen.getByText('Filters (1)')).toBeInTheDocument();
+  });
+});
+
+function buildRow({
+  includeFilter = false,
+  includeCustom = false,
+}: { includeFilter?: boolean; includeCustom?: boolean } = {}) {
+  const variables = [
+    ...(includeFilter ? [new AdHocFiltersVariable({ name: 'filter0', type: 'adhoc' })] : []),
+    ...(includeCustom ? [new CustomVariable({ name: 'custom0', query: 'a,b', value: ['a'], text: ['a'] })] : []),
+  ];
+
+  const row = new RowItem({
+    $variables: new SceneVariableSet({ variables }),
+    layout: AutoGridLayoutManager.createEmpty(),
+  });
+
+  new DashboardScene({
+    body: new RowsLayoutManager({
+      rows: [row],
+    }),
+  });
+
+  return row;
+}

--- a/public/app/features/dashboard-scene/edit-pane/SectionFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/SectionFiltersList.tsx
@@ -1,0 +1,77 @@
+import { Trans, t } from '@grafana/i18n';
+import { type SceneObject, SceneVariableSet } from '@grafana/scenes';
+import { Box, Button, Stack } from '@grafana/ui';
+
+import { isAdHocVariable } from '../settings/variables/utils';
+import { DashboardInteractions } from '../utils/interactions';
+import { getDashboardSceneFor } from '../utils/utils';
+import { filterSectionRepeatLocalVariables } from '../variables/utils';
+
+import { openAddFilterForm } from './add-new/AddFilters';
+
+export interface SectionFiltersCategoryTitleProps {
+  sectionOwner: SceneObject;
+  isExpanded: boolean;
+}
+
+export function SectionFiltersCategoryTitle({ sectionOwner, isExpanded }: SectionFiltersCategoryTitleProps) {
+  const variableSet = sectionOwner.state.$variables;
+  const filterCount =
+    variableSet instanceof SceneVariableSet
+      ? filterSectionRepeatLocalVariables(variableSet.state.variables, variableSet).filter(isAdHocVariable).length
+      : 0;
+
+  return (
+    <Stack direction="row" alignItems="center" gap={1} flex={1}>
+      <span style={{ flexGrow: 1 }}>
+        {isExpanded || filterCount === 0
+          ? t('dashboard.edit-pane.section-filters.title', 'Filters')
+          : `${t('dashboard.edit-pane.section-filters.title', 'Filters')} (${filterCount})`}
+      </span>
+    </Stack>
+  );
+}
+
+export interface SectionFiltersListProps {
+  sectionOwner: SceneObject;
+}
+
+export function SectionFiltersList({ sectionOwner }: SectionFiltersListProps) {
+  const variableSet = sectionOwner.state.$variables;
+  const filters =
+    variableSet instanceof SceneVariableSet
+      ? filterSectionRepeatLocalVariables(variableSet.useState().variables, variableSet).filter(isAdHocVariable)
+      : [];
+  const dashboard = getDashboardSceneFor(sectionOwner);
+
+  return (
+    <Stack direction="column" gap={0}>
+      {filters.map((variable) => (
+        <Button
+          key={variable.state.key!}
+          variant="secondary"
+          size="sm"
+          fill="text"
+          onClick={() => dashboard.state.editPane.selectObject(variable, { force: true })}
+        >
+          {variable.state.name}
+        </Button>
+      ))}
+
+      <Box display="flex" paddingTop={filters.length > 0 ? 1 : 0} paddingBottom={2}>
+        <Button
+          fullWidth
+          icon="plus"
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            openAddFilterForm(dashboard, sectionOwner);
+            DashboardInteractions.addSectionFilterButtonClicked({ source: 'edit_pane' });
+          }}
+        >
+          <Trans i18nKey="dashboard-scene.section-filters-list.add-filter">Add filter</Trans>
+        </Button>
+      </Box>
+    </Stack>
+  );
+}

--- a/public/app/features/dashboard-scene/edit-pane/SectionVariablesList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/SectionVariablesList.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
-import { CustomVariable, LocalValueVariable, SceneVariableSet } from '@grafana/scenes';
+import { config } from '@grafana/runtime';
+import { AdHocFiltersVariable, CustomVariable, LocalValueVariable, SceneVariableSet } from '@grafana/scenes';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
@@ -11,7 +12,7 @@ import { SectionVariablesCategoryTitle, SectionVariablesList } from './SectionVa
 
 describe('SectionVariablesList', () => {
   it('does not render local repeat variables in section variables list', () => {
-    const row = buildRowWithVariables();
+    const row = buildRow();
 
     render(<SectionVariablesList sectionOwner={row} />);
 
@@ -20,19 +21,39 @@ describe('SectionVariablesList', () => {
   });
 
   it('counts only non-local variables in title', () => {
-    const row = buildRowWithVariables();
+    const row = buildRow();
 
     render(<SectionVariablesCategoryTitle sectionOwner={row} isExpanded={false} />);
 
-    expect(screen.getByText('Variables (1)')).toBeInTheDocument();
+    expect(screen.getByText('Variables (2)')).toBeInTheDocument();
+  });
+
+  describe('when dashboardUnifiedDrilldownControls is enabled', () => {
+    beforeEach(() => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
+    });
+
+    afterEach(() => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
+    });
+
+    it('excludes adhoc variables from the list', () => {
+      const row = buildRow();
+
+      render(<SectionVariablesList sectionOwner={row} />);
+
+      expect(screen.getByText('custom0')).toBeInTheDocument();
+      expect(screen.queryByText('filter0')).not.toBeInTheDocument();
+    });
   });
 });
 
-function buildRowWithVariables() {
+function buildRow() {
   const variableSet = new SceneVariableSet({
     variables: [
       new LocalValueVariable({ name: 'custom0', value: 'glo3', text: 'glo3' }),
       new CustomVariable({ name: 'custom0', query: 'sec1,sec2', value: ['sec1'], text: ['sec1'] }),
+      new AdHocFiltersVariable({ name: 'filter0', type: 'adhoc' }),
     ],
   });
 

--- a/public/app/features/dashboard-scene/edit-pane/SectionVariablesList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/SectionVariablesList.tsx
@@ -1,9 +1,11 @@
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { type SceneObject, SceneVariableSet } from '@grafana/scenes';
 import { Box, Button, Stack } from '@grafana/ui';
 
 import { openAddSectionVariablePane } from '../settings/variables/VariableTypeSelectionPane';
+import { isAdHocVariable } from '../settings/variables/utils';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor } from '../utils/utils';
 import { filterSectionRepeatLocalVariables } from '../variables/utils';
@@ -16,11 +18,13 @@ export interface SectionVariablesCategoryTitleProps {
 
 export function SectionVariablesCategoryTitle({ sectionOwner, isExpanded }: SectionVariablesCategoryTitleProps) {
   const variableSet = sectionOwner.state.$variables;
-  const variableCount =
+  const allVariables =
     variableSet instanceof SceneVariableSet
-      ? filterSectionRepeatLocalVariables(variableSet.state.variables, variableSet).length
-      : 0;
-  const dashboard = getDashboardSceneFor(sectionOwner);
+      ? filterSectionRepeatLocalVariables(variableSet.state.variables, variableSet)
+      : [];
+  const variableCount = config.featureToggles.dashboardUnifiedDrilldownControls
+    ? allVariables.filter((v) => !isAdHocVariable(v)).length
+    : allVariables.length;
 
   return (
     <Stack direction="row" alignItems="center" gap={1} flex={1}>
@@ -29,17 +33,6 @@ export function SectionVariablesCategoryTitle({ sectionOwner, isExpanded }: Sect
           ? t('dashboard.edit-pane.section-variables.title', 'Variables')
           : `${t('dashboard.edit-pane.section-variables.title', 'Variables')} (${variableCount})`}
       </span>
-      <Button
-        icon="plus"
-        variant="secondary"
-        size="sm"
-        fill="text"
-        onClick={(e) => {
-          e.stopPropagation();
-          openAddSectionVariablePane(dashboard, sectionOwner);
-        }}
-        tooltip={t('dashboard.edit-pane.section-variables.add-tooltip', 'Add variable')}
-      />
     </Stack>
   );
 }
@@ -51,31 +44,14 @@ export interface SectionVariablesListProps {
 
 export function SectionVariablesList({ sectionOwner }: SectionVariablesListProps) {
   const variableSet = sectionOwner.state.$variables;
-  const variables =
+  const allVariables =
     variableSet instanceof SceneVariableSet
       ? filterSectionRepeatLocalVariables(variableSet.useState().variables, variableSet)
       : [];
+  const variables = config.featureToggles.dashboardUnifiedDrilldownControls
+    ? allVariables.filter((v) => !isAdHocVariable(v))
+    : allVariables;
   const dashboard = getDashboardSceneFor(sectionOwner);
-
-  if (variables.length === 0) {
-    return (
-      <Box display="flex" paddingTop={0} paddingBottom={2}>
-        <Button
-          fullWidth
-          icon="plus"
-          size="sm"
-          variant="secondary"
-          onClick={() => {
-            openAddSectionVariablePane(dashboard, sectionOwner);
-            DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
-          }}
-          data-testid={selectors.components.PanelEditor.ElementEditPane.addVariableButton}
-        >
-          <Trans i18nKey="dashboard-scene.variables-list.add-variable">Add variable</Trans>
-        </Button>
-      </Box>
-    );
-  }
 
   return (
     <Stack direction="column" gap={0}>
@@ -90,6 +66,22 @@ export function SectionVariablesList({ sectionOwner }: SectionVariablesListProps
           {variable.state.name}
         </Button>
       ))}
+
+      <Box display="flex" paddingTop={variables.length > 0 ? 1 : 0} paddingBottom={2}>
+        <Button
+          fullWidth
+          icon="plus"
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            openAddSectionVariablePane(dashboard, sectionOwner);
+            DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
+          }}
+          data-testid={selectors.components.PanelEditor.ElementEditPane.addVariableButton}
+        >
+          <Trans i18nKey="dashboard-scene.variables-list.add-variable">Add variable</Trans>
+        </Button>
+      </Box>
     </Stack>
   );
 }

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.test.tsx
@@ -1,0 +1,96 @@
+import { AdHocFiltersVariable, SceneVariableSet } from '@grafana/scenes';
+
+import { DashboardScene } from '../../scene/DashboardScene';
+import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
+import { RowItem } from '../../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
+import { dashboardEditActions } from '../shared';
+
+import { openAddFilterForm } from './AddFilters';
+
+jest.mock('../shared', () => ({
+  dashboardEditActions: {
+    addVariable: jest.fn(),
+  },
+}));
+
+const addVariableMock = jest.mocked(dashboardEditActions.addVariable);
+
+describe('openAddFilterForm', () => {
+  beforeEach(() => {
+    addVariableMock.mockClear();
+  });
+
+  it('adds an adhoc filter to the dashboard variable set', () => {
+    const variableSet = new SceneVariableSet({ variables: [] });
+    const dashboard = new DashboardScene({ $variables: variableSet, isEditing: true });
+    jest.spyOn(dashboard.state.editPane, 'selectObject');
+
+    openAddFilterForm(dashboard, dashboard);
+
+    expect(addVariableMock).toHaveBeenCalledTimes(1);
+    const { source, addedObject } = addVariableMock.mock.calls[0][0];
+    expect(source).toBe(variableSet);
+    expect(addedObject).toBeInstanceOf(AdHocFiltersVariable);
+    expect(dashboard.state.editPane.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
+  });
+
+  it('adds an adhoc filter to a section variable set', () => {
+    const sectionVarSet = new SceneVariableSet({ variables: [] });
+    const row = new RowItem({
+      $variables: sectionVarSet,
+      layout: AutoGridLayoutManager.createEmpty(),
+    });
+    const dashboard = new DashboardScene({
+      body: new RowsLayoutManager({ rows: [row] }),
+      isEditing: true,
+    });
+    jest.spyOn(dashboard.state.editPane, 'selectObject');
+
+    openAddFilterForm(dashboard, row);
+
+    expect(addVariableMock).toHaveBeenCalledTimes(1);
+    const { source, addedObject } = addVariableMock.mock.calls[0][0];
+    expect(source).toBe(sectionVarSet);
+    expect(addedObject).toBeInstanceOf(AdHocFiltersVariable);
+    expect(dashboard.state.editPane.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
+  });
+
+  it('creates a variable set on the section if none exists', () => {
+    const row = new RowItem({ layout: AutoGridLayoutManager.createEmpty() });
+    const dashboard = new DashboardScene({
+      body: new RowsLayoutManager({ rows: [row] }),
+      isEditing: true,
+    });
+    jest.spyOn(dashboard.state.editPane, 'selectObject');
+
+    expect(row.state.$variables).toBeUndefined();
+
+    openAddFilterForm(dashboard, row);
+
+    expect(row.state.$variables).toBeInstanceOf(SceneVariableSet);
+    expect(addVariableMock).toHaveBeenCalledTimes(1);
+    const { source, addedObject } = addVariableMock.mock.calls[0][0];
+    expect(source).toBe(row.state.$variables);
+    expect(addedObject).toBeInstanceOf(AdHocFiltersVariable);
+  });
+
+  it('generates a unique name when filters already exist', () => {
+    const existingFilter = new AdHocFiltersVariable({ name: 'filter0', type: 'adhoc' });
+    const sectionVarSet = new SceneVariableSet({ variables: [existingFilter] });
+    const row = new RowItem({
+      $variables: sectionVarSet,
+      layout: AutoGridLayoutManager.createEmpty(),
+    });
+    const dashboard = new DashboardScene({
+      body: new RowsLayoutManager({ rows: [row] }),
+      isEditing: true,
+    });
+    jest.spyOn(dashboard.state.editPane, 'selectObject');
+
+    openAddFilterForm(dashboard, row);
+
+    const { addedObject } = addVariableMock.mock.calls[0][0];
+    expect(addedObject.state.name).not.toBe('filter0');
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { t } from '@grafana/i18n';
-import { sceneGraph, SceneVariableSet } from '@grafana/scenes';
+import { type SceneObject, SceneVariableSet } from '@grafana/scenes';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
 import {
@@ -15,25 +15,26 @@ import { dashboardEditActions } from '../shared';
 
 import { AddButton } from './AddButton';
 
-export function openAddFilterPane(dashboard: DashboardScene) {
-  const variablesSet = sceneGraph.getVariables(dashboard);
+export function openAddFilterForm(dashboard: DashboardScene, sectionOwner: SceneObject) {
+  const existing = sectionOwner.state.$variables;
+  const variablesSet = existing instanceof SceneVariableSet ? existing : new SceneVariableSet({ variables: [] });
 
-  if (!(variablesSet instanceof SceneVariableSet)) {
-    return;
+  if (!existing) {
+    sectionOwner.setState({ $variables: variablesSet });
   }
 
   const name = getVariableNamePrefix(ADHOC_VARIABLE_TYPE);
   const newVar = getVariableScene(ADHOC_VARIABLE_TYPE, {
     name: getNextAvailableId(name, variablesSet.state.variables ?? []),
   });
+
   dashboardEditActions.addVariable({ source: variablesSet, addedObject: newVar });
   dashboard.state.editPane.selectObject(newVar, { force: true, multi: false });
-  DashboardInteractions.variableTypeSelected({ type: ADHOC_VARIABLE_TYPE });
 }
 
 export function AddFilters({ dashboardScene }: { dashboardScene: DashboardScene }) {
   const onAddFiltersClick = useCallback(() => {
-    openAddFilterPane(dashboardScene);
+    openAddFilterForm(dashboardScene, dashboardScene);
     DashboardInteractions.addFilterButtonClicked({ source: 'edit_pane' });
   }, [dashboardScene]);
 

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
@@ -34,7 +34,7 @@ export function openAddFilterPane(dashboard: DashboardScene) {
 export function AddFilters({ dashboardScene }: { dashboardScene: DashboardScene }) {
   const onAddFiltersClick = useCallback(() => {
     openAddFilterPane(dashboardScene);
-    DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
+    DashboardInteractions.addFilterButtonClicked({ source: 'edit_pane' });
   }, [dashboardScene]);
 
   return (

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
@@ -15,7 +15,7 @@ import { dashboardEditActions } from '../shared';
 
 import { AddButton } from './AddButton';
 
-function openAddFilterPane(dashboard: DashboardScene) {
+export function openAddFilterPane(dashboard: DashboardScene) {
   const variablesSet = sceneGraph.getVariables(dashboard);
 
   if (!(variablesSet instanceof SceneVariableSet)) {

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardEditableElement.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useId, useMemo } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { type SceneObject, SceneVariableSet } from '@grafana/scenes';
 import { Button } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
@@ -14,10 +15,12 @@ import {
   type EditableDashboardElementInfo,
 } from '../../scene/types/EditableDashboardElement';
 import { DashboardLinksSet } from '../../settings/links/DashboardLinksSet';
+import { DashboardFiltersSet } from '../../settings/variables/DashboardFiltersSet';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 
 import { DashboardAnnotationsList } from './DashboardAnnotationsList';
 import { DashboardDescriptionInput, DashboardTitleInput } from './DashboardBasicOptions';
+import { AddFilterButton, DashboardFiltersList } from './DashboardFiltersList';
 import { AddLinkButton, DashboardLinksList } from './DashboardLinksList';
 import { AddVariableButton, DashboardVariablesList } from './DashboardVariablesList';
 
@@ -50,16 +53,25 @@ function useEditPaneOptions(
   }, [dashboard, dashboardDescriptionInputId, dashboardTitleInputId]);
 
   const layoutCategory = useLayoutCategory(body);
+  const filtersCategory = useFiltersCategory(dashboard);
   const variablesCategory = useVariablesCategory(dashboard);
   const annotationsCategory = useAnnotationsCategory(dashboardSceneGraph.getDataLayers(dashboard));
   const linksCategory = useLinksCategory(dashboard);
 
-  return [dashboardOptions, ...layoutCategory, ...variablesCategory, ...annotationsCategory, ...linksCategory];
+  return [
+    dashboardOptions,
+    ...layoutCategory,
+    ...filtersCategory,
+    ...variablesCategory,
+    ...annotationsCategory,
+    ...linksCategory,
+  ];
 }
 
 export class DashboardEditableElement implements EditableDashboardElement {
   public readonly isEditableDashboardElement = true;
   private _linksSet?: DashboardLinksSet;
+  private _filtersSet?: DashboardFiltersSet;
 
   public constructor(private dashboard: DashboardScene) {}
 
@@ -78,12 +90,20 @@ export class DashboardEditableElement implements EditableDashboardElement {
     return this._linksSet;
   }
 
+  private getFiltersSet(): DashboardFiltersSet {
+    if (!this._filtersSet) {
+      this._filtersSet = new DashboardFiltersSet({ dashboardRef: this.dashboard.getRef() });
+    }
+    return this._filtersSet;
+  }
+
   public getOutlineChildren(isEditing: boolean): SceneObject[] {
     const { $variables, body } = this.dashboard.state;
     if (!isEditing || !$variables) {
       return body.getOutlineChildren();
     }
     return [
+      ...(config.featureToggles.dashboardUnifiedDrilldownControls ? [this.getFiltersSet()] : []),
       $variables,
       dashboardSceneGraph.getDataLayers(this.dashboard),
       this.getLinksSet(),
@@ -109,6 +129,48 @@ export class DashboardEditableElement implements EditableDashboardElement {
   }
 }
 
+function useFiltersCategory(dashboard: DashboardScene): OptionsPaneCategoryDescriptor[] {
+  const { $variables } = dashboard.useState();
+  const filterListId = useId();
+  const addFilterButtonId = useId();
+
+  return useMemo(() => {
+    if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
+      return [];
+    }
+
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard-scene.use-filters-category.category.title.filters', 'Filters'),
+      id: 'dashboard-filters',
+    });
+
+    const hasFilters =
+      $variables instanceof SceneVariableSet && $variables.state.variables.some((v) => v.state.type === 'adhoc');
+
+    if (hasFilters) {
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: '',
+          id: filterListId,
+          skipField: true,
+          render: () => <DashboardFiltersList variableSet={$variables} />,
+        })
+      );
+    }
+
+    category.addItem(
+      new OptionsPaneItemDescriptor({
+        title: '',
+        id: addFilterButtonId,
+        skipField: true,
+        render: () => <AddFilterButton dashboard={dashboard} />,
+      })
+    );
+
+    return [category];
+  }, [$variables, addFilterButtonId, filterListId, dashboard]);
+}
+
 function useVariablesCategory(dashboard: DashboardScene): OptionsPaneCategoryDescriptor[] {
   const { $variables } = dashboard.useState();
   const variableListId = useId();
@@ -121,14 +183,20 @@ function useVariablesCategory(dashboard: DashboardScene): OptionsPaneCategoryDes
     });
 
     if ($variables instanceof SceneVariableSet && $variables.state.variables.length) {
-      category.addItem(
-        new OptionsPaneItemDescriptor({
-          title: '',
-          id: variableListId,
-          skipField: true,
-          render: () => <DashboardVariablesList variableSet={$variables} />,
-        })
-      );
+      const hasVariables = config.featureToggles.dashboardUnifiedDrilldownControls
+        ? $variables.state.variables.some((v) => v.state.type !== 'adhoc')
+        : true;
+
+      if (hasVariables) {
+        category.addItem(
+          new OptionsPaneItemDescriptor({
+            title: '',
+            id: variableListId,
+            skipField: true,
+            render: () => <DashboardVariablesList variableSet={$variables} />,
+          })
+        );
+      }
     }
 
     category.addItem(

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardEditableElement.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../scene/types/EditableDashboardElement';
 import { DashboardLinksSet } from '../../settings/links/DashboardLinksSet';
 import { DashboardFiltersSet } from '../../settings/variables/DashboardFiltersSet';
+import { isAdHocVariable } from '../../settings/variables/utils';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 
 import { DashboardAnnotationsList } from './DashboardAnnotationsList';
@@ -144,8 +145,7 @@ function useFiltersCategory(dashboard: DashboardScene): OptionsPaneCategoryDescr
       id: 'dashboard-filters',
     });
 
-    const hasFilters =
-      $variables instanceof SceneVariableSet && $variables.state.variables.some((v) => v.state.type === 'adhoc');
+    const hasFilters = $variables instanceof SceneVariableSet && $variables.state.variables.some(isAdHocVariable);
 
     if (hasFilters) {
       category.addItem(
@@ -184,7 +184,7 @@ function useVariablesCategory(dashboard: DashboardScene): OptionsPaneCategoryDes
 
     if ($variables instanceof SceneVariableSet && $variables.state.variables.length) {
       const hasVariables = config.featureToggles.dashboardUnifiedDrilldownControls
-        ? $variables.state.variables.some((v) => v.state.type !== 'adhoc')
+        ? $variables.state.variables.some((v) => !isAdHocVariable(v))
         : true;
 
       if (hasVariables) {

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { VariableHide } from '@grafana/data';
-import { AdHocFiltersVariable, SceneVariableSet, type SceneVariable } from '@grafana/scenes';
+import { AdHocFiltersVariable, ConstantVariable, SceneVariableSet, type SceneVariable } from '@grafana/scenes';
 
 import { DashboardScene } from '../../scene/DashboardScene';
 import { activateFullSceneTree } from '../../utils/test-utils';
@@ -143,6 +143,31 @@ describe('<DashboardFiltersList />', () => {
 
         const aboveNames = Array.from(elements.aboveListItems()).map((item) => item.textContent);
         expect(aboveNames).toEqual(['visibleFilter2', 'visibleFilter1']);
+      });
+
+      test('drag-reorder does not move non-filter variables from their original positions', async () => {
+        const { visibleFilter1, visibleFilter2 } = buildTestFilters();
+        const nonFilterVar = new ConstantVariable({ name: 'queryVar', hide: VariableHide.dontHide });
+        const variableSet = new SceneVariableSet({
+          variables: [visibleFilter1, nonFilterVar, visibleFilter2],
+        });
+        const dashboardScene = new DashboardScene({ $variables: variableSet, isEditing: true });
+        activateFullSceneTree(dashboardScene);
+
+        const { container, findByText } = render(<DashboardFiltersList variableSet={variableSet} />);
+
+        const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
+        const handle = dragHandles[0] as HTMLElement;
+        handle.focus();
+        fireEvent.keyDown(handle, { keyCode: 32 });
+        await findByText(/you have lifted an item/i);
+        fireEvent.keyDown(handle, { keyCode: 40 });
+        await findByText(/you have moved the item/i);
+        fireEvent.keyDown(handle, { keyCode: 32 });
+        await findByText(/you have dropped the item/i);
+
+        const names = variableSet.state.variables.map((v) => v.state.name);
+        expect(names).toEqual(['visibleFilter2', 'queryVar', 'visibleFilter1']);
       });
     });
   });

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
@@ -10,7 +10,7 @@ import { activateFullSceneTree } from '../../utils/test-utils';
 import { DashboardFiltersList } from './DashboardFiltersList';
 
 jest.mock('../add-new/AddFilters', () => ({
-  openAddFilterPane: jest.fn(),
+  openAddFilterForm: jest.fn(),
 }));
 
 jest.mock('../../utils/interactions', () => ({

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { VariableHide } from '@grafana/data';
+import { AdHocFiltersVariable, SceneVariableSet, type SceneVariable } from '@grafana/scenes';
+
+import { DashboardScene } from '../../scene/DashboardScene';
+import { activateFullSceneTree } from '../../utils/test-utils';
+
+import { DashboardFiltersList } from './DashboardFiltersList';
+
+jest.mock('../add-new/AddFilters', () => ({
+  openAddFilterPane: jest.fn(),
+}));
+
+jest.mock('../../utils/interactions', () => ({
+  DashboardInteractions: {
+    addFilterButtonClicked: jest.fn(),
+  },
+}));
+
+jest.mock('app/core/hooks/useQueryParams', () => ({
+  useQueryParams: () => [{}, () => {}],
+}));
+jest.mock('react-use', () => ({
+  useLocalStorage: () => [{}, () => {}],
+}));
+
+function renderFiltersList(variables: SceneVariable[] = []) {
+  const user = userEvent.setup();
+
+  const variableSet = new SceneVariableSet({ variables });
+  const dashboardScene = new DashboardScene({
+    $variables: variableSet,
+    isEditing: true,
+  });
+  activateFullSceneTree(dashboardScene);
+  jest.spyOn(dashboardScene.state.editPane, 'selectObject');
+
+  const renderResult = render(<DashboardFiltersList variableSet={variableSet} />);
+
+  return {
+    ...renderResult,
+    user,
+    elements: {
+      dashboardScene,
+      aboveListItems: () => within(renderResult.getByTestId('filters-list-visible')).getAllByTestId('filter-name'),
+      controlsMenuListItems: () =>
+        within(renderResult.getByTestId('filters-list-controls-menu')).getAllByTestId('filter-name'),
+      hiddenListItems: () => within(renderResult.getByTestId('filters-list-hidden')).getAllByTestId('filter-name'),
+    },
+  };
+}
+
+function buildTestFilters() {
+  return {
+    visibleFilter1: new AdHocFiltersVariable({ name: 'visibleFilter1', type: 'adhoc', hide: VariableHide.dontHide }),
+    visibleFilter2: new AdHocFiltersVariable({ name: 'visibleFilter2', type: 'adhoc', hide: VariableHide.hideLabel }),
+    controlsMenuFilter1: new AdHocFiltersVariable({
+      name: 'controlsMenuFilter1',
+      type: 'adhoc',
+      hide: VariableHide.inControlsMenu,
+    }),
+    hiddenFilter1: new AdHocFiltersVariable({
+      name: 'hiddenFilter1',
+      type: 'adhoc',
+      hide: VariableHide.hideVariable,
+    }),
+  };
+}
+
+describe('<DashboardFiltersList />', () => {
+  test('renders 3 sections (one per filter display type)', () => {
+    const { visibleFilter1, visibleFilter2, controlsMenuFilter1, hiddenFilter1 } = buildTestFilters();
+    const { getByRole, elements } = renderFiltersList([
+      hiddenFilter1,
+      controlsMenuFilter1,
+      visibleFilter2,
+      visibleFilter1,
+    ]);
+
+    [/above dashboard/i, /controls menu/i, /hidden/i].forEach((name) => {
+      expect(getByRole('heading', { name })).toBeInTheDocument();
+    });
+
+    const aboveNames = Array.from(elements.aboveListItems()).map((item) => item.textContent);
+    expect(aboveNames).toEqual(['visibleFilter2', 'visibleFilter1']);
+
+    const controlsMenuNames = Array.from(elements.controlsMenuListItems()).map((item) => item.textContent);
+    expect(controlsMenuNames).toEqual(['controlsMenuFilter1']);
+
+    const hiddenNames = Array.from(elements.hiddenListItems()).map((item) => item.textContent);
+    expect(hiddenNames).toEqual(['hiddenFilter1']);
+  });
+
+  describe('User interactions', () => {
+    describe('when a filter name is clicked', () => {
+      test('selects the filter in the pane', async () => {
+        const { visibleFilter1 } = buildTestFilters();
+        const { user, getByText, elements } = renderFiltersList([visibleFilter1]);
+
+        await user.click(getByText(visibleFilter1.state.name));
+
+        expect(elements.dashboardScene.state.editPane.selectObject).toHaveBeenCalledWith(visibleFilter1);
+      });
+    });
+
+    describe('drag and drop', () => {
+      async function dragItem(
+        container: HTMLElement,
+        findByText: (text: RegExp) => Promise<HTMLElement>,
+        itemIndex: number,
+        direction: 'up' | 'down',
+        positions = 1
+      ) {
+        const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
+        const handle = dragHandles[itemIndex] as HTMLElement;
+        handle.focus();
+        expect(handle).toHaveFocus();
+
+        fireEvent.keyDown(handle, { keyCode: 32 });
+        await findByText(/you have lifted an item/i);
+
+        const arrowKey = direction === 'down' ? 40 : 38;
+        for (let i = 0; i < positions; i++) {
+          fireEvent.keyDown(handle, { keyCode: arrowKey });
+          await findByText(/you have moved the item/i);
+        }
+
+        fireEvent.keyDown(handle, { keyCode: 32 });
+        await findByText(/you have dropped the item/i);
+      }
+
+      test('reorders visible filters when dragged down by one position', async () => {
+        const { visibleFilter1, visibleFilter2, controlsMenuFilter1 } = buildTestFilters();
+        const { container, findByText, elements } = renderFiltersList([
+          visibleFilter1,
+          visibleFilter2,
+          controlsMenuFilter1,
+        ]);
+
+        await dragItem(container, findByText, 0, 'down');
+
+        const aboveNames = Array.from(elements.aboveListItems()).map((item) => item.textContent);
+        expect(aboveNames).toEqual(['visibleFilter2', 'visibleFilter1']);
+      });
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -95,14 +95,7 @@ export function AddFilterButton({ dashboard }: { dashboard: DashboardScene }) {
 
   return (
     <Box display="flex" paddingTop={1} paddingBottom={1}>
-      <Button
-        fullWidth
-        icon="plus"
-        size="sm"
-        variant="secondary"
-        onClick={onAddFilter}
-        data-testid={selectors.components.PanelEditor.ElementEditPane.addFilterButton}
-      >
+      <Button fullWidth icon="plus" size="sm" variant="secondary" onClick={onAddFilter}>
         <Trans i18nKey="dashboard-scene.filters-list.add-filter">Add filter</Trans>
       </Button>
     </Box>

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -2,12 +2,12 @@ import { DragDropContext } from '@hello-pangea/dnd';
 import { useCallback, useMemo } from 'react';
 
 import { VariableHide } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { type SceneVariableSet, type SceneVariable } from '@grafana/scenes';
 import { Box, Button } from '@grafana/ui';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
+import { isAdHocVariable } from '../../settings/variables/utils';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getDashboardSceneFor } from '../../utils/utils';
 import { openAddFilterPane } from '../add-new/AddFilters';
@@ -28,7 +28,7 @@ const DROPPABLE_TO_HIDE: Record<string, VariableHide> = {
 
 export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariableSet }) {
   const { variables } = variableSet.useState();
-  const filters = useMemo(() => variables.filter((v) => v.state.type === 'adhoc'), [variables]);
+  const filters = useMemo(() => variables.filter(isAdHocVariable), [variables]);
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(filters), [filters]);
 
   const onClickFilter = useCallback((variable: SceneVariable) => {

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -1,0 +1,122 @@
+import { DragDropContext } from '@hello-pangea/dnd';
+import { useCallback, useMemo } from 'react';
+
+import { VariableHide } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { t, Trans } from '@grafana/i18n';
+import { type SceneVariableSet, type SceneVariable } from '@grafana/scenes';
+import { Box, Button } from '@grafana/ui';
+
+import { type DashboardScene } from '../../scene/DashboardScene';
+import { DashboardInteractions } from '../../utils/interactions';
+import { getDashboardSceneFor } from '../../utils/utils';
+import { openAddFilterPane } from '../add-new/AddFilters';
+
+import { partitionVariablesByDisplay } from './DashboardVariablesList';
+import { DraggableList } from './DraggableList';
+import { createDragEndHandler } from './variablesDragEndHandler';
+
+const ID_FILTERS_VISIBLE_LIST = 'filters-list-visible';
+const ID_FILTERS_CONTROLS_MENU_LIST = 'filters-list-controls-menu';
+const ID_FILTERS_HIDDEN_LIST = 'filters-list-hidden';
+
+const DROPPABLE_TO_HIDE: Record<string, VariableHide> = {
+  [ID_FILTERS_VISIBLE_LIST]: VariableHide.dontHide,
+  [ID_FILTERS_CONTROLS_MENU_LIST]: VariableHide.inControlsMenu,
+  [ID_FILTERS_HIDDEN_LIST]: VariableHide.hideVariable,
+};
+
+export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariableSet }) {
+  const { variables } = variableSet.useState();
+  const { filters, nonFilters } = useMemo(() => {
+    const filters: SceneVariable[] = [];
+    const nonFilters: SceneVariable[] = [];
+    for (const v of variables) {
+      if (v.state.type === 'adhoc') {
+        filters.push(v);
+      } else {
+        nonFilters.push(v);
+      }
+    }
+    return { filters, nonFilters };
+  }, [variables]);
+  const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(filters), [filters]);
+
+  const onClickFilter = useCallback((variable: SceneVariable) => {
+    const { editPane } = getDashboardSceneFor(variable).state;
+    editPane.selectObject(variable);
+  }, []);
+
+  const onDragEnd = useMemo(
+    () =>
+      createDragEndHandler(
+        variableSet,
+        {
+          visible: ID_FILTERS_VISIBLE_LIST,
+          controlsMenu: ID_FILTERS_CONTROLS_MENU_LIST,
+          hidden: ID_FILTERS_HIDDEN_LIST,
+        },
+        visible,
+        controlsMenu,
+        hidden,
+        nonFilters,
+        t('dashboard-scene.filters-list.reorder-description', 'Reorder filters list'),
+        DROPPABLE_TO_HIDE
+      ),
+    [variableSet, nonFilters, visible, controlsMenu, hidden]
+  );
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <DraggableList
+        items={visible}
+        droppableId={ID_FILTERS_VISIBLE_LIST}
+        title={t('dashboard-scene.filters-list.title-above-dashboard', 'Above dashboard ({{count}})', {
+          count: visible.length,
+        })}
+        onClickItem={onClickFilter}
+        renderItemLabel={renderItemLabel}
+      />
+      <DraggableList
+        items={controlsMenu}
+        droppableId={ID_FILTERS_CONTROLS_MENU_LIST}
+        title={t('dashboard-scene.filters-list.title-controls-menu', 'Controls menu ({{count}})', {
+          count: controlsMenu.length,
+        })}
+        onClickItem={onClickFilter}
+        renderItemLabel={renderItemLabel}
+      />
+      <DraggableList
+        items={hidden}
+        droppableId={ID_FILTERS_HIDDEN_LIST}
+        title={t('dashboard-scene.filters-list.title-hidden', 'Hidden ({{count}})', { count: hidden.length })}
+        onClickItem={onClickFilter}
+        renderItemLabel={renderItemLabel}
+      />
+    </DragDropContext>
+  );
+}
+
+const renderItemLabel = (v: SceneVariable) => <span data-testid="filter-name">{v.state.name}</span>;
+
+export function AddFilterButton({ dashboard }: { dashboard: DashboardScene }) {
+  const onAddFilter = useCallback(() => {
+    openAddFilterPane(dashboard);
+    DashboardInteractions.addFilterButtonClicked({ source: 'edit_pane' });
+  }, [dashboard]);
+
+  return (
+    <Box display="flex" paddingTop={1} paddingBottom={1}>
+      <Button
+        fullWidth
+        icon="plus"
+        size="sm"
+        variant="secondary"
+        onClick={onAddFilter}
+        data-testid={selectors.components.PanelEditor.ElementEditPane.addFilterButton}
+      >
+        <Trans i18nKey="dashboard-scene.filters-list.add-filter">Add filter</Trans>
+      </Button>
+    </Box>
+  );
+}

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -10,7 +10,7 @@ import { type DashboardScene } from '../../scene/DashboardScene';
 import { isAdHocVariable } from '../../settings/variables/utils';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getDashboardSceneFor } from '../../utils/utils';
-import { openAddFilterPane } from '../add-new/AddFilters';
+import { openAddFilterForm } from '../add-new/AddFilters';
 
 import { partitionVariablesByDisplay } from './DashboardVariablesList';
 import { DraggableList } from './DraggableList';
@@ -89,7 +89,7 @@ const renderItemLabel = (v: SceneVariable) => <span data-testid="filter-name">{v
 
 export function AddFilterButton({ dashboard }: { dashboard: DashboardScene }) {
   const onAddFilter = useCallback(() => {
-    openAddFilterPane(dashboard);
+    openAddFilterForm(dashboard, dashboard);
     DashboardInteractions.addFilterButtonClicked({ source: 'edit_pane' });
   }, [dashboard]);
 

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -28,18 +28,7 @@ const DROPPABLE_TO_HIDE: Record<string, VariableHide> = {
 
 export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariableSet }) {
   const { variables } = variableSet.useState();
-  const { filters, nonFilters } = useMemo(() => {
-    const filters: SceneVariable[] = [];
-    const nonFilters: SceneVariable[] = [];
-    for (const v of variables) {
-      if (v.state.type === 'adhoc') {
-        filters.push(v);
-      } else {
-        nonFilters.push(v);
-      }
-    }
-    return { filters, nonFilters };
-  }, [variables]);
+  const filters = useMemo(() => variables.filter((v) => v.state.type === 'adhoc'), [variables]);
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(filters), [filters]);
 
   const onClickFilter = useCallback((variable: SceneVariable) => {
@@ -59,11 +48,10 @@ export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariab
         visible,
         controlsMenu,
         hidden,
-        nonFilters,
         t('dashboard-scene.filters-list.reorder-description', 'Reorder filters list'),
         DROPPABLE_TO_HIDE
       ),
-    [variableSet, nonFilters, visible, controlsMenu, hidden]
+    [variableSet, visible, controlsMenu, hidden]
   );
 
   return (

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.test.tsx
@@ -2,7 +2,8 @@ import { fireEvent, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { VariableHide } from '@grafana/data';
-import { ConstantVariable, SceneVariableSet, type SceneVariable } from '@grafana/scenes';
+import { config } from '@grafana/runtime';
+import { AdHocFiltersVariable, ConstantVariable, SceneVariableSet, type SceneVariable } from '@grafana/scenes';
 
 import { DashboardScene } from '../../scene/DashboardScene';
 import { SnapshotVariable } from '../../serialization/custom-variables/SnapshotVariable';
@@ -145,6 +146,26 @@ describe('<DashboardVariablesList />', () => {
         const aboveNames = Array.from(elements.aboveListItems()).map((item) => item.textContent);
         expect(aboveNames).toEqual(['visibleVar2', 'visibleVar1']);
       });
+    });
+  });
+
+  describe('when dashboardUnifiedDrilldownControls is enabled', () => {
+    beforeEach(() => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = true;
+    });
+
+    afterEach(() => {
+      config.featureToggles.dashboardUnifiedDrilldownControls = false;
+    });
+
+    test('excludes adhoc variables from the rendered list', () => {
+      const { visibleVar1 } = buildTestVariables();
+      const adhocFilter = new AdHocFiltersVariable({ name: 'adhocFilter', type: 'adhoc', hide: VariableHide.dontHide });
+      const { queryByText, elements } = renderVariablesList([visibleVar1, adhocFilter]);
+
+      const aboveNames = Array.from(elements.aboveListItems()).map((item) => item.textContent);
+      expect(aboveNames).toEqual(['visibleVar1']);
+      expect(queryByText('adhocFilter')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
@@ -10,7 +10,7 @@ import { Box, Button } from '@grafana/ui';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { openAddVariablePane } from '../../settings/variables/VariableTypeSelectionPane';
-import { isEditableVariableType } from '../../settings/variables/utils';
+import { isAdHocVariable, isEditableVariableType } from '../../settings/variables/utils';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getDashboardSceneFor } from '../../utils/utils';
 
@@ -35,7 +35,7 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
     if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
       return editable;
     }
-    return editable.filter((v) => v.state.type !== 'adhoc');
+    return editable.filter((v) => !isAdHocVariable(v));
   }, [variables]);
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(editable), [editable]);
 

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
@@ -30,21 +30,12 @@ const DROPPABLE_TO_HIDE: Record<string, VariableHide> = {
 
 export function DashboardVariablesList({ variableSet }: { variableSet: SceneVariableSet }) {
   const { variables } = variableSet.useState();
-  const { editable, nonEditable } = useMemo(() => {
-    const result = partitionVariablesByEditability(variables);
+  const editable = useMemo(() => {
+    const { editable } = partitionVariablesByEditability(variables);
     if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
-      return result;
+      return editable;
     }
-    const filteredEditable: SceneVariable[] = [];
-    const filteredNonEditable = [...result.nonEditable];
-    for (const v of result.editable) {
-      if (v.state.type === 'adhoc') {
-        filteredNonEditable.push(v);
-      } else {
-        filteredEditable.push(v);
-      }
-    }
-    return { editable: filteredEditable, nonEditable: filteredNonEditable };
+    return editable.filter((v) => v.state.type !== 'adhoc');
   }, [variables]);
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(editable), [editable]);
 
@@ -61,14 +52,13 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
         visible,
         controlsMenu,
         hidden,
-        nonEditable,
         t(
           'dashboard-scene.variables-list.create-drag-end-handler.description.reorder-variables-list',
           'Reorder variables list'
         ),
         DROPPABLE_TO_HIDE
       ),
-    [variableSet, nonEditable, visible, controlsMenu, hidden]
+    [variableSet, visible, controlsMenu, hidden]
   );
 
   return (

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
@@ -1,9 +1,10 @@
-import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
+import { DragDropContext } from '@hello-pangea/dnd';
 import { useCallback, useMemo } from 'react';
 
 import { VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { type SceneVariableSet, type SceneVariable } from '@grafana/scenes';
 import { Box, Button } from '@grafana/ui';
 
@@ -12,10 +13,10 @@ import { openAddVariablePane } from '../../settings/variables/VariableTypeSelect
 import { isEditableVariableType } from '../../settings/variables/utils';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getDashboardSceneFor } from '../../utils/utils';
-import { dashboardEditActions } from '../shared';
 
 import { DraggableList } from './DraggableList';
 import { partitionSceneObjects } from './helpers';
+import { createDragEndHandler } from './variablesDragEndHandler';
 
 const ID_VISIBLE_LIST = 'variables-list-visible';
 const ID_CONTROLS_MENU_LIST = 'variables-list-controls-menu';
@@ -29,7 +30,22 @@ const DROPPABLE_TO_HIDE: Record<string, VariableHide> = {
 
 export function DashboardVariablesList({ variableSet }: { variableSet: SceneVariableSet }) {
   const { variables } = variableSet.useState();
-  const { editable, nonEditable } = useMemo(() => partitionVariablesByEditability(variables), [variables]);
+  const { editable, nonEditable } = useMemo(() => {
+    const result = partitionVariablesByEditability(variables);
+    if (!config.featureToggles.dashboardUnifiedDrilldownControls) {
+      return result;
+    }
+    const filteredEditable: SceneVariable[] = [];
+    const filteredNonEditable = [...result.nonEditable];
+    for (const v of result.editable) {
+      if (v.state.type === 'adhoc') {
+        filteredNonEditable.push(v);
+      } else {
+        filteredEditable.push(v);
+      }
+    }
+    return { editable: filteredEditable, nonEditable: filteredNonEditable };
+  }, [variables]);
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(editable), [editable]);
 
   const onClickVariable = useCallback((variable: SceneVariable) => {
@@ -37,61 +53,21 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
     editPane.selectObject(variable);
   }, []);
 
-  const onDragEnd = useCallback(
-    (result: DropResult) => {
-      const { source, destination } = result;
-      if (!destination) {
-        return;
-      }
-
-      const isSameList = source.droppableId === destination.droppableId;
-      if (isSameList && source.index === destination.index) {
-        return;
-      }
-
-      const currentVariables = variableSet.state.variables;
-      const lists: Record<string, SceneVariable[]> = {
-        [ID_VISIBLE_LIST]: [...visible],
-        [ID_CONTROLS_MENU_LIST]: [...controlsMenu],
-        [ID_HIDDEN_LIST]: [...hidden],
-      };
-
-      const sourceList = lists[source.droppableId];
-      const destList = isSameList ? sourceList : lists[destination.droppableId];
-
-      const [moved] = sourceList.splice(source.index, 1);
-      destList.splice(destination.index, 0, moved);
-
-      const oldHide = moved.state.hide ?? VariableHide.dontHide;
-      const newHide = getTargetHide(destination.droppableId, oldHide);
-
-      dashboardEditActions.edit({
-        source: variableSet,
-        description: t(
+  const onDragEnd = useMemo(
+    () =>
+      createDragEndHandler(
+        variableSet,
+        { visible: ID_VISIBLE_LIST, controlsMenu: ID_CONTROLS_MENU_LIST, hidden: ID_HIDDEN_LIST },
+        visible,
+        controlsMenu,
+        hidden,
+        nonEditable,
+        t(
           'dashboard-scene.variables-list.create-drag-end-handler.description.reorder-variables-list',
           'Reorder variables list'
         ),
-        perform: () => {
-          if (newHide !== oldHide) {
-            moved.setState({ hide: newHide });
-          }
-          variableSet.setState({
-            variables: [
-              ...nonEditable,
-              ...lists[ID_VISIBLE_LIST],
-              ...lists[ID_CONTROLS_MENU_LIST],
-              ...lists[ID_HIDDEN_LIST],
-            ],
-          });
-        },
-        undo: () => {
-          if (newHide !== oldHide) {
-            moved.setState({ hide: oldHide });
-          }
-          variableSet.setState({ variables: currentVariables });
-        },
-      });
-    },
+        DROPPABLE_TO_HIDE
+      ),
     [variableSet, nonEditable, visible, controlsMenu, hidden]
   );
 
@@ -127,15 +103,6 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
 }
 
 const renderItemLabel = (v: SceneVariable) => <span data-testid="variable-name">{v.state.name}</span>;
-
-function getTargetHide(droppableId: string, currentHide: VariableHide): VariableHide {
-  if (droppableId === ID_VISIBLE_LIST) {
-    return currentHide === VariableHide.dontHide || currentHide === VariableHide.hideLabel
-      ? currentHide
-      : VariableHide.dontHide;
-  }
-  return DROPPABLE_TO_HIDE[droppableId];
-}
 
 export function AddVariableButton({ dashboard }: { dashboard: DashboardScene }) {
   const onAddVariable = useCallback(() => {

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/variablesDragEndHandler.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/variablesDragEndHandler.ts
@@ -31,7 +31,6 @@ export function createDragEndHandler(
   visible: SceneVariable[],
   controlsMenu: SceneVariable[],
   hidden: SceneVariable[],
-  preserved: SceneVariable[],
   description: string,
   droppableToHide: Record<string, VariableHide>
 ) {
@@ -63,7 +62,7 @@ export function createDragEndHandler(
     const newHide = getTargetHide(destination.droppableId, oldHide, listIds.visible, droppableToHide);
 
     const reordered = [...lists[listIds.visible], ...lists[listIds.controlsMenu], ...lists[listIds.hidden]];
-    const preservedSet = new Set(preserved);
+    const draggableSet = new Set(reordered);
 
     dashboardEditActions.edit({
       source: variableSet,
@@ -74,7 +73,7 @@ export function createDragEndHandler(
         }
 
         let reorderedIdx = 0;
-        const merged = currentVariables.map((v) => (preservedSet.has(v) ? v : reordered[reorderedIdx++]));
+        const merged = currentVariables.map((v) => (draggableSet.has(v) ? reordered[reorderedIdx++] : v));
 
         variableSet.setState({ variables: merged });
       },

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/variablesDragEndHandler.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/variablesDragEndHandler.ts
@@ -62,6 +62,9 @@ export function createDragEndHandler(
     const oldHide = moved.state.hide ?? VariableHide.dontHide;
     const newHide = getTargetHide(destination.droppableId, oldHide, listIds.visible, droppableToHide);
 
+    const reordered = [...lists[listIds.visible], ...lists[listIds.controlsMenu], ...lists[listIds.hidden]];
+    const preservedSet = new Set(preserved);
+
     dashboardEditActions.edit({
       source: variableSet,
       description,
@@ -69,14 +72,11 @@ export function createDragEndHandler(
         if (newHide !== oldHide) {
           moved.setState({ hide: newHide });
         }
-        variableSet.setState({
-          variables: [
-            ...preserved,
-            ...lists[listIds.visible],
-            ...lists[listIds.controlsMenu],
-            ...lists[listIds.hidden],
-          ],
-        });
+
+        let reorderedIdx = 0;
+        const merged = currentVariables.map((v) => (preservedSet.has(v) ? v : reordered[reorderedIdx++]));
+
+        variableSet.setState({ variables: merged });
       },
       undo: () => {
         if (newHide !== oldHide) {

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/variablesDragEndHandler.ts
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/variablesDragEndHandler.ts
@@ -1,0 +1,89 @@
+import { type DropResult } from '@hello-pangea/dnd';
+
+import { VariableHide } from '@grafana/data';
+import { type SceneVariable, type SceneVariableSet } from '@grafana/scenes';
+
+import { dashboardEditActions } from '../shared';
+
+export interface ListIds {
+  visible: string;
+  controlsMenu: string;
+  hidden: string;
+}
+
+export function getTargetHide(
+  droppableId: string,
+  currentHide: VariableHide,
+  visibleListId: string,
+  droppableToHide: Record<string, VariableHide>
+): VariableHide {
+  if (droppableId === visibleListId) {
+    return currentHide === VariableHide.dontHide || currentHide === VariableHide.hideLabel
+      ? currentHide
+      : VariableHide.dontHide;
+  }
+  return droppableToHide[droppableId];
+}
+
+export function createDragEndHandler(
+  variableSet: SceneVariableSet,
+  listIds: ListIds,
+  visible: SceneVariable[],
+  controlsMenu: SceneVariable[],
+  hidden: SceneVariable[],
+  preserved: SceneVariable[],
+  description: string,
+  droppableToHide: Record<string, VariableHide>
+) {
+  return (result: DropResult) => {
+    const { source, destination } = result;
+    if (!destination) {
+      return;
+    }
+
+    const isSameList = source.droppableId === destination.droppableId;
+    if (isSameList && source.index === destination.index) {
+      return;
+    }
+
+    const currentVariables = variableSet.state.variables;
+    const lists: Record<string, SceneVariable[]> = {
+      [listIds.visible]: [...visible],
+      [listIds.controlsMenu]: [...controlsMenu],
+      [listIds.hidden]: [...hidden],
+    };
+
+    const sourceList = lists[source.droppableId];
+    const destList = isSameList ? sourceList : lists[destination.droppableId];
+
+    const [moved] = sourceList.splice(source.index, 1);
+    destList.splice(destination.index, 0, moved);
+
+    const oldHide = moved.state.hide ?? VariableHide.dontHide;
+    const newHide = getTargetHide(destination.droppableId, oldHide, listIds.visible, droppableToHide);
+
+    dashboardEditActions.edit({
+      source: variableSet,
+      description,
+      perform: () => {
+        if (newHide !== oldHide) {
+          moved.setState({ hide: newHide });
+        }
+        variableSet.setState({
+          variables: [
+            ...preserved,
+            ...lists[listIds.visible],
+            ...lists[listIds.controlsMenu],
+            ...lists[listIds.hidden],
+          ],
+        });
+      },
+      undo: () => {
+        if (newHide !== oldHide) {
+          moved.setState({ hide: oldHide });
+        }
+        variableSet.setState({ variables: currentVariables });
+      },
+    });
+  };
+}

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
@@ -3,6 +3,7 @@ import { useId, useMemo, useRef } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Alert, Field, Input, Switch, TextLink } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -11,6 +12,7 @@ import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constan
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { useConditionalRenderingEditor } from '../../conditional-rendering/hooks/useConditionalRenderingEditor';
+import { SectionFiltersCategoryTitle, SectionFiltersList } from '../../edit-pane/SectionFiltersList';
 import { SectionVariablesCategoryTitle, SectionVariablesList } from '../../edit-pane/SectionVariablesList';
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { getQueryRunnerFor } from '../../utils/utils';
@@ -96,8 +98,36 @@ export function useEditOptions(this: RowItem, isNewElement: boolean): OptionsPan
     return category;
   }, [model]);
 
+  const sectionFiltersCategory = useMemo(() => {
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard.rows-layout.row-options.section-filters.title', 'Filters'),
+      id: 'dash-row-section-filters',
+      isOpenDefault: true,
+      renderTitle: (isExpanded: boolean) => (
+        <SectionFiltersCategoryTitle sectionOwner={model} isExpanded={isExpanded} />
+      ),
+    });
+
+    category.addItem(
+      new OptionsPaneItemDescriptor({
+        title: '',
+        id: 'dash-row-section-filters-list',
+        skipField: true,
+        render: () => <SectionFiltersList sectionOwner={model} />,
+      })
+    );
+
+    return category;
+  }, [model]);
+
   const editOptions = sectionVariablesEnabled
-    ? [rowCategory, sectionVariablesCategory, ...layoutCategory, repeatCategory]
+    ? [
+        rowCategory,
+        ...(config.featureToggles.dashboardUnifiedDrilldownControls ? [sectionFiltersCategory] : []),
+        sectionVariablesCategory,
+        ...layoutCategory,
+        repeatCategory,
+      ]
     : [rowCategory, ...layoutCategory, repeatCategory];
 
   const conditionalRenderingCategory = useMemo(

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Alert, Field, Input, TextLink } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -11,6 +12,7 @@ import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constan
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { useConditionalRenderingEditor } from '../../conditional-rendering/hooks/useConditionalRenderingEditor';
+import { SectionFiltersCategoryTitle, SectionFiltersList } from '../../edit-pane/SectionFiltersList';
 import { SectionVariablesCategoryTitle, SectionVariablesList } from '../../edit-pane/SectionVariablesList';
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { getQueryRunnerFor } from '../../utils/utils';
@@ -80,8 +82,36 @@ export function useEditOptions(this: TabItem, isNewElement: boolean): OptionsPan
     return category;
   }, [model]);
 
+  const sectionFiltersCategory = useMemo(() => {
+    const category = new OptionsPaneCategoryDescriptor({
+      title: t('dashboard.tabs-layout.tab-options.section-filters.title', 'Filters'),
+      id: 'tab-section-filters',
+      isOpenDefault: true,
+      renderTitle: (isExpanded: boolean) => (
+        <SectionFiltersCategoryTitle sectionOwner={model} isExpanded={isExpanded} />
+      ),
+    });
+
+    category.addItem(
+      new OptionsPaneItemDescriptor({
+        title: '',
+        id: 'tab-section-filters-list',
+        skipField: true,
+        render: () => <SectionFiltersList sectionOwner={model} />,
+      })
+    );
+
+    return category;
+  }, [model]);
+
   const editOptions = sectionVariablesEnabled
-    ? [tabCategory, sectionVariablesCategory, ...layoutCategory, repeatCategory]
+    ? [
+        tabCategory,
+        ...(config.featureToggles.dashboardUnifiedDrilldownControls ? [sectionFiltersCategory] : []),
+        sectionVariablesCategory,
+        ...layoutCategory,
+        repeatCategory,
+      ]
     : [tabCategory, ...layoutCategory, repeatCategory];
 
   const conditionalRenderingCategory = useMemo(

--- a/public/app/features/dashboard-scene/settings/variables/DashboardFiltersSet.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/DashboardFiltersSet.tsx
@@ -21,6 +21,8 @@ import {
   type EditableDashboardElementInfo,
 } from '../../scene/types/EditableDashboardElement';
 
+import { isAdHocVariable } from './utils';
+
 export interface DashboardFiltersSetState extends SceneObjectState {
   dashboardRef: SceneObjectRef<DashboardScene>;
 }
@@ -91,7 +93,7 @@ export class DashboardFiltersSet extends SceneObjectBase<DashboardFiltersSetStat
     if (!(variableSet instanceof SceneVariableSet)) {
       return [];
     }
-    return variableSet.state.variables.filter((v) => v.state.type === 'adhoc');
+    return variableSet.state.variables.filter(isAdHocVariable);
   }
 
   public useEditPaneOptions = useEditPaneOptions.bind(this, this.state.dashboardRef);

--- a/public/app/features/dashboard-scene/settings/variables/DashboardFiltersSet.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/DashboardFiltersSet.tsx
@@ -1,0 +1,98 @@
+import { useId, useMemo } from 'react';
+
+import { t } from '@grafana/i18n';
+import {
+  type SceneObject,
+  SceneObjectBase,
+  type SceneObjectRef,
+  type SceneObjectState,
+  type SceneVariable,
+  SceneVariableSet,
+  sceneGraph,
+} from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+
+import { AddFilterButton, DashboardFiltersList } from '../../edit-pane/dashboard/DashboardFiltersList';
+import { partitionVariablesByDisplay } from '../../edit-pane/dashboard/DashboardVariablesList';
+import { type DashboardScene } from '../../scene/DashboardScene';
+import {
+  type EditableDashboardElement,
+  type EditableDashboardElementInfo,
+} from '../../scene/types/EditableDashboardElement';
+
+export interface DashboardFiltersSetState extends SceneObjectState {
+  dashboardRef: SceneObjectRef<DashboardScene>;
+}
+
+function useEditPaneOptions(
+  this: DashboardFiltersSet,
+  dashboardRef: SceneObjectRef<DashboardScene>
+): OptionsPaneCategoryDescriptor[] {
+  const filterListId = useId();
+  const addFilterButtonId = useId();
+  const dashboard = dashboardRef.resolve();
+  const variableSet = sceneGraph.getVariables(dashboard);
+
+  const options = useMemo(() => {
+    const category = new OptionsPaneCategoryDescriptor({ title: '', id: 'filters' });
+
+    if (variableSet instanceof SceneVariableSet) {
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          title: '',
+          id: filterListId,
+          skipField: true,
+          render: () => <DashboardFiltersList variableSet={variableSet} />,
+        })
+      );
+    }
+
+    category.addItem(
+      new OptionsPaneItemDescriptor({
+        title: '',
+        id: addFilterButtonId,
+        skipField: true,
+        render: () => <AddFilterButton dashboard={dashboard} />,
+      })
+    );
+
+    return category;
+  }, [filterListId, addFilterButtonId, dashboard, variableSet]);
+
+  return [options];
+}
+
+export class DashboardFiltersSet extends SceneObjectBase<DashboardFiltersSetState> implements EditableDashboardElement {
+  public readonly isEditableDashboardElement = true;
+
+  public constructor(state: DashboardFiltersSetState) {
+    super({ ...state, key: 'dashboard-filters-set' });
+  }
+
+  public getEditableElementInfo(): EditableDashboardElementInfo {
+    const filters = this.getAdhocVariables();
+    return {
+      typeName: t('dashboard.edit-pane.elements.filters-set', 'Filters'),
+      icon: 'filter',
+      instanceName: t('dashboard.edit-pane.elements.filters-set', 'Filters'),
+      isHidden: filters.length === 0,
+    };
+  }
+
+  public getOutlineChildren(): SceneObject[] {
+    const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(this.getAdhocVariables());
+    return [...visible, ...controlsMenu, ...hidden];
+  }
+
+  private getAdhocVariables(): SceneVariable[] {
+    const dashboard = this.state.dashboardRef.resolve();
+    const variableSet = sceneGraph.getVariables(dashboard);
+    if (!(variableSet instanceof SceneVariableSet)) {
+      return [];
+    }
+    return variableSet.state.variables.filter((v) => v.state.type === 'adhoc');
+  }
+
+  public useEditPaneOptions = useEditPaneOptions.bind(this, this.state.dashboardRef);
+}

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -5,6 +5,7 @@ import { useCallback, useId, useMemo } from 'react';
 import { type GrafanaTheme2, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { type SceneObject, type SceneVariable, type SceneVariableSet } from '@grafana/scenes';
 import { Box, Button, Icon, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
@@ -56,11 +57,15 @@ export class VariableSetEditableElement implements EditableDashboardElement {
   }
 
   public getOutlineChildren() {
-    const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(
-      filterSectionRepeatLocalVariables(this.set.state.variables, this.set)
-        // filter out system and snapshot variables
-        .filter((variable) => isEditableVariableType(variable.state.type))
+    let variables = filterSectionRepeatLocalVariables(this.set.state.variables, this.set).filter((variable) =>
+      isEditableVariableType(variable.state.type)
     );
+
+    if (config.featureToggles.dashboardUnifiedDrilldownControls) {
+      variables = variables.filter((variable) => variable.state.type !== 'adhoc');
+    }
+
+    const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(variables);
     return [...visible, ...controlsMenu, ...hidden];
   }
 
@@ -100,10 +105,12 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
     const editableVariables: SceneVariable[] = [];
     const nonEditableVariables: SceneVariable[] = [];
     filterSectionRepeatLocalVariables(variables, set).forEach((variable) => {
-      if (isEditableVariableType(variable.state.type)) {
-        editableVariables.push(variable);
-      } else {
+      if (!isEditableVariableType(variable.state.type)) {
         nonEditableVariables.push(variable);
+      } else if (config.featureToggles.dashboardUnifiedDrilldownControls && variable.state.type === 'adhoc') {
+        nonEditableVariables.push(variable);
+      } else {
+        editableVariables.push(variable);
       }
     });
     return {

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -101,27 +101,21 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
     [set]
   );
 
-  const { editableVariables, nonEditableVariables } = useMemo(() => {
-    const editableVariables: SceneVariable[] = [];
-    const nonEditableVariables: SceneVariable[] = [];
-    filterSectionRepeatLocalVariables(variables, set).forEach((variable) => {
+  const editableVariables = useMemo(() => {
+    return filterSectionRepeatLocalVariables(variables, set).filter((variable) => {
       if (!isEditableVariableType(variable.state.type)) {
-        nonEditableVariables.push(variable);
-      } else if (config.featureToggles.dashboardUnifiedDrilldownControls && variable.state.type === 'adhoc') {
-        nonEditableVariables.push(variable);
-      } else {
-        editableVariables.push(variable);
+        return false;
       }
+      if (config.featureToggles.dashboardUnifiedDrilldownControls && variable.state.type === 'adhoc') {
+        return false;
+      }
+      return true;
     });
-    return {
-      editableVariables,
-      nonEditableVariables,
-    };
   }, [variables, set]);
 
   const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(editableVariables);
 
-  const nonEditableSet = useMemo(() => new Set(nonEditableVariables), [nonEditableVariables]);
+  const editableSet = useMemo(() => new Set(editableVariables), [editableVariables]);
 
   const createDragEndHandler = useCallback(
     (sourceList: SceneVariable[], mergeLists: (updatedList: SceneVariable[]) => SceneVariable[]) => {
@@ -147,7 +141,7 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
 
             const reordered = mergeLists(updatedList);
             let reorderedIdx = 0;
-            const merged = currentList.map((v) => (nonEditableSet.has(v) ? v : reordered[reorderedIdx++]));
+            const merged = currentList.map((v) => (editableSet.has(v) ? reordered[reorderedIdx++] : v));
 
             set.setState({ variables: merged });
           },
@@ -157,7 +151,7 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
         });
       };
     },
-    [nonEditableSet, set]
+    [editableSet, set]
   );
 
   const onVisibleDragEnd = useMemo(

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -24,7 +24,7 @@ import { getDashboardSceneFor } from '../../utils/utils';
 import { filterSectionRepeatLocalVariables } from '../../variables/utils';
 
 import { openAddVariablePane } from './VariableTypeSelectionPane';
-import { isEditableVariableType } from './utils';
+import { isAdHocVariable, isEditableVariableType } from './utils';
 
 function useEditPaneOptions(this: VariableSetEditableElement, set: SceneVariableSet): OptionsPaneCategoryDescriptor[] {
   const variableListId = useId();
@@ -62,7 +62,7 @@ export class VariableSetEditableElement implements EditableDashboardElement {
     );
 
     if (config.featureToggles.dashboardUnifiedDrilldownControls) {
-      variables = variables.filter((variable) => variable.state.type !== 'adhoc');
+      variables = variables.filter((variable) => !isAdHocVariable(variable));
     }
 
     const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(variables);
@@ -106,7 +106,7 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
       if (!isEditableVariableType(variable.state.type)) {
         return false;
       }
-      if (config.featureToggles.dashboardUnifiedDrilldownControls && variable.state.type === 'adhoc') {
+      if (config.featureToggles.dashboardUnifiedDrilldownControls && isAdHocVariable(variable)) {
         return false;
       }
       return true;

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -121,6 +121,8 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
 
   const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(editableVariables);
 
+  const nonEditableSet = useMemo(() => new Set(nonEditableVariables), [nonEditableVariables]);
+
   const createDragEndHandler = useCallback(
     (sourceList: SceneVariable[], mergeLists: (updatedList: SceneVariable[]) => SceneVariable[]) => {
       return (result: DropResult) => {
@@ -143,9 +145,11 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
             const [movedVariable] = updatedList.splice(result.source.index, 1);
             updatedList.splice(result.destination.index, 0, movedVariable);
 
-            set.setState({
-              variables: [...nonEditableVariables, ...mergeLists(updatedList)],
-            });
+            const reordered = mergeLists(updatedList);
+            let reorderedIdx = 0;
+            const merged = currentList.map((v) => (nonEditableSet.has(v) ? v : reordered[reorderedIdx++]));
+
+            set.setState({ variables: merged });
           },
           undo: () => {
             set.setState({ variables: currentList });
@@ -153,7 +157,7 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
         });
       };
     },
-    [nonEditableVariables, set]
+    [nonEditableSet, set]
   );
 
   const onVisibleDragEnd = useMemo(

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -131,8 +131,6 @@ export const getEditableVariables: () => Record<EditableVariableType, EditableVa
   },
 });
 
-export const ADHOC_VARIABLE_TYPE = 'adhoc';
-
 export function getEditableVariableDefinition(type: string): EditableVariableConfig {
   const editableVariables = getEditableVariables();
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -144,6 +144,12 @@ export function getEditableVariableDefinition(type: string): EditableVariableCon
   return editableVariable;
 }
 
+export const ADHOC_VARIABLE_TYPE = 'adhoc';
+
+export function isAdHocVariable(variable: SceneVariable): boolean {
+  return variable.state.type === ADHOC_VARIABLE_TYPE;
+}
+
 export const EDITABLE_VARIABLES_SELECT_ORDER: EditableVariableType[] = [
   'query',
   'custom',

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -104,6 +104,10 @@ export const DashboardInteractions = {
     reportDashboardInteraction('add_filter_button_clicked', properties);
   },
 
+  addSectionFilterButtonClicked: (properties: { source: 'edit_pane' }) => {
+    reportDashboardInteraction('add_section_filter_button_clicked', properties);
+  },
+
   // dashboards_new_variable_type_selected
   // when a user selects a variable type when creating a new variable
   variableTypeSelected: (properties: { type: string }) => {

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -100,6 +100,10 @@ export const DashboardInteractions = {
     reportDashboardInteraction('add_link_button_clicked', properties);
   },
 
+  addFilterButtonClicked: (properties: { source: 'edit_pane' }) => {
+    reportDashboardInteraction('add_filter_button_clicked', properties);
+  },
+
   // dashboards_new_variable_type_selected
   // when a user selects a variable type when creating a new variable
   variableTypeSelected: (properties: { type: string }) => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5639,11 +5639,6 @@
         "variable": "{{type}} variable",
         "variable-set": "Variables"
       },
-      "filters": {
-        "add-filter": "Add filter",
-        "reorder": "Drag to reorder",
-        "select-filter": "Select"
-      },
       "links": {
         "add-link": "Add link",
         "reorder": "Drag to reorder",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5651,8 +5651,10 @@
           "title": "Row header"
         }
       },
+      "section-filters": {
+        "title": "Filters"
+      },
       "section-variables": {
-        "add-tooltip": "Add variable",
         "title": "Variables"
       },
       "variable": {
@@ -6204,6 +6206,9 @@
           "hide-header": "Hide row header",
           "title": "Title"
         },
+        "section-filters": {
+          "title": "Filters"
+        },
         "section-variables": {
           "title": "Variables"
         },
@@ -6362,6 +6367,9 @@
             "description": "Repeat this tab for each value in the selected variable.",
             "title": "Repeat by variable"
           }
+        },
+        "section-filters": {
+          "title": "Filters"
         },
         "section-variables": {
           "title": "Variables"
@@ -7557,6 +7565,9 @@
       "disabled-tooltip": "Save the dashboard before creating alert rules",
       "new-alert-rule": "New alert rule",
       "title-no-alerting-capable-query-found": "No alerting capable query found"
+    },
+    "section-filters-list": {
+      "add-filter": "Add filter"
     },
     "selection-options-form": {
       "description-enables-multiple-values-selected": "Enables multiple values to be selected at the same time",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5622,6 +5622,7 @@
         "annotation-set": "Annotations & Alerts",
         "dashboard": "Dashboard",
         "element": "Element",
+        "filters-set": "Filters",
         "link-set": "Links",
         "local-variable": "Local variable",
         "multiple-elements": "Multiple elements",
@@ -5637,6 +5638,11 @@
         "tabs": "Tabs",
         "variable": "{{type}} variable",
         "variable-set": "Variables"
+      },
+      "filters": {
+        "add-filter": "Add filter",
+        "reorder": "Drag to reorder",
+        "select-filter": "Select"
       },
       "links": {
         "add-link": "Add link",
@@ -7074,6 +7080,16 @@
       "sql-name": "Transform with SQL",
       "sql-transformation-description": "Manipulate your data using MySQL-like syntax"
     },
+    "filters-list": {
+      "add-filter": "Add filter",
+      "reorder-description": "Reorder filters list",
+      "title-above-dashboard_one": "Above dashboard ({{count}})",
+      "title-above-dashboard_other": "Above dashboard ({{count}})",
+      "title-controls-menu_one": "Controls menu ({{count}})",
+      "title-controls-menu_other": "Controls menu ({{count}})",
+      "title-hidden_one": "Hidden ({{count}})",
+      "title-hidden_other": "Hidden ({{count}})"
+    },
     "general-settings-edit-view": {
       "default_grid_options": {
         "label": {
@@ -7642,6 +7658,13 @@
       "page-nav": {
         "text": {
           "settings": "Settings"
+        }
+      }
+    },
+    "use-filters-category": {
+      "category": {
+        "title": {
+          "filters": "Filters"
         }
       }
     },


### PR DESCRIPTION
**What is this feature?**

When `dashboardUnifiedDrilldownControls` is enabled, adhoc filter variables are shown in a dedicated "Filters" category in the row/tab edit pane, separate from regular variables.

<img width="386" height="568" alt="Screenshot 2026-04-16 at 1 25 03 PM" src="https://github.com/user-attachments/assets/750a2156-3214-4bdb-8f9b-1cb1788fcff5" />

