### PR TITLE
Makefile: Ensure cue can run when `$GOBIN` is not the same path as `$GOPATH/bin`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 GIT_BASE = remotes/origin/main
 
 CUE_VERSION = v0.16.0
-CUE = $(shell go env GOPATH)/bin/cue
+CUE = cue
 
 # GNU xargs has flag -r, and BSD xargs (e.g. MacOS) has that behaviour by default
 XARGSR = $(shell xargs --version 2>&1 | grep -q GNU && echo xargs -r || echo xargs)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ endif
 GIT_BASE = remotes/origin/main
 
 CUE_VERSION = v0.16.0
-CUE = cue
+CUE_DIR     = $(shell go env GOPATH)/bin/cue-$(CUE_VERSION)
+CUE         = $(CUE_DIR)/cue
 
 # GNU xargs has flag -r, and BSD xargs (e.g. MacOS) has that behaviour by default
 XARGSR = $(shell xargs --version 2>&1 | grep -q GNU && echo xargs -r || echo xargs)
@@ -291,8 +292,14 @@ gen-app-manifests-unistore: ## Generate unified storage app manifests list
 	fi
 
 .PHONY: install-cue
-install-cue:
-	go install cuelang.org/go/cmd/cue@$(CUE_VERSION)
+install-cue: $(CUE)
+
+$(CUE):
+	@echo "Installing CUE version $(CUE_VERSION)"
+	@rm -rf $(dir $(CUE_DIR))cue-v*/
+	@mkdir -p $(CUE_DIR)
+	GOBIN=$(CUE_DIR) go install cuelang.org/go/cmd/cue@$(CUE_VERSION)
+	@touch $@
 
 .PHONY: fix-cue
 fix-cue: install-cue ## Format and fix CUE files. Use app=<name> to fix a specific app.


### PR DESCRIPTION
**What is this feature?**

Follow the app-sdk pattern of setting the `GOBIN` environment variable when installing cue to ensure it's accessible from the path we expect it to be installed at.

**Why do we need this feature?**

`go install` places binaries in `GOBIN` when set, not necessarily in `GOPATH/bin`. The hardcoded path causes `make gen-apps` (and any target using `fix-cue`) to fail with "No such file or directory" when `GOBIN` differs from `GOPATH/bin`.

**Who is this feature for?**

Anyone running `make gen-apps` or `make fix-cue` locally with a non-default `GOBIN`.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.