### PR TITLE
Dashboards: Mutation API — preserve panel grid positions

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addPanel.ts
@@ -10,7 +10,6 @@ import { type z } from 'zod';
 
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
-import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { buildVizPanel, getElements } from '../../serialization/layoutSerializers/utils';
 import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getVizPanelKeyForPanelId } from '../../utils/utils';
@@ -59,39 +58,37 @@ export const addPanelCommand: MutationCommand<AddPanelPayload> = {
       targetLayout.addPanel(vizPanel);
 
       const isAutoGrid = targetLayout instanceof AutoGridLayoutManager;
-      const isDefaultGrid = targetLayout instanceof DefaultGridLayoutManager;
 
       if (layoutItem) {
         if (layoutItem.kind === 'GridLayoutItem' && isAutoGrid) {
           warnings.push(
             'layoutItem adapted from GridLayoutItem to AutoGridLayoutItem: target uses AutoGridLayout which auto-arranges panels.'
           );
-        } else if (layoutItem.kind === 'AutoGridLayoutItem' && isDefaultGrid) {
-          warnings.push(
-            'layoutItem adapted from AutoGridLayoutItem to GridLayoutItem: target uses GridLayout which requires explicit positioning.'
-          );
         }
 
         const spec = layoutItem.spec;
-        if (isDefaultGrid && spec) {
-          const gridItem = vizPanel.parent;
-          if (gridItem instanceof DashboardGridItem) {
-            const updates: Record<string, number> = {};
-            if (spec.x !== undefined) {
-              updates.x = spec.x;
-            }
-            if (spec.y !== undefined) {
-              updates.y = spec.y;
-            }
-            if (spec.width !== undefined) {
-              updates.width = spec.width;
-            }
-            if (spec.height !== undefined) {
-              updates.height = spec.height;
-            }
-            if (Object.keys(updates).length > 0) {
-              gridItem.setState(updates);
-            }
+        const gridItem = vizPanel.parent;
+        if (gridItem instanceof DashboardGridItem && spec) {
+          if (layoutItem.kind === 'AutoGridLayoutItem') {
+            warnings.push(
+              'layoutItem adapted from AutoGridLayoutItem to GridLayoutItem: target uses GridLayout which requires explicit positioning.'
+            );
+          }
+          const updates: Record<string, number> = {};
+          if (spec.x !== undefined) {
+            updates.x = spec.x;
+          }
+          if (spec.y !== undefined) {
+            updates.y = spec.y;
+          }
+          if (spec.width !== undefined) {
+            updates.width = spec.width;
+          }
+          if (spec.height !== undefined) {
+            updates.height = spec.height;
+          }
+          if (Object.keys(updates).length > 0) {
+            gridItem.setState(updates);
           }
         }
       }

--- a/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/movePanel.ts
@@ -178,9 +178,14 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
       const previousLayoutItem = serializeResultLayoutItem(vizPanel);
 
       const sourceGridItem = vizPanel.parent;
-      const originalSize =
+      const originalPosition =
         sourceGridItem instanceof DashboardGridItem
-          ? { width: sourceGridItem.state.width, height: sourceGridItem.state.height }
+          ? {
+              x: sourceGridItem.state.x,
+              y: sourceGridItem.state.y,
+              width: sourceGridItem.state.width,
+              height: sourceGridItem.state.height,
+            }
           : undefined;
 
       const panelClone = vizPanel.clone();
@@ -199,8 +204,8 @@ export const movePanelCommand: MutationCommand<MovePanelPayload> = {
         } else {
           applyGridPosition(panelClone, effectivePosition);
         }
-      } else if (originalSize && !isTargetAutoGrid) {
-        applyGridPosition(panelClone, originalSize);
+      } else if (originalPosition && !isTargetAutoGrid) {
+        applyGridPosition(panelClone, originalPosition);
       }
 
       const resultLayoutItem = serializeResultLayoutItem(panelClone);


### PR DESCRIPTION
Fixes two bugs in the dashboard Mutation API where panel grid positions are lost:

**ADD_PANEL**: `layoutItem` positions were only applied when the top-level layout was a `DefaultGridLayoutManager`. Panels added inside rows or tabs (where the ancestor is `RowsLayoutManager`/`TabsLayoutManager`) had their positions silently ignored. Now checks `vizPanel.parent instanceof DashboardGridItem` instead.

**MOVE_PANEL**: When moving a panel without an explicit position, only `width`/`height` were preserved from the source — `x`/`y` were lost because `targetLayout.addPanel()` auto-positions via `findSpaceForNewPanel` (which has an 8-column minimum width). Now preserves the full original position (`x`, `y`, `width`, `height`), preventing side-by-side panel layouts from breaking when panels are moved into tabs or rows.

**Testing:** Reproduced with 4 side-by-side 6-column stat panels — the 4th panel at x=18 would wrap to the next row after being moved into a tab. With this fix, all 4 panels maintain their original positions.

Made with [Cursor](https://cursor.com)