### PR TITLE
Unified storage: Skip migrations if dualwrite state shows they were already migrated

### DIFF
--- a/pkg/registry/apis/dashboard/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/migration_registrar.go
@@ -14,7 +14,7 @@ func FoldersDashboardsMigration(migrator migrator.FoldersDashboardsMigrator) mig
 	dashboardGR := schema.GroupResource{Group: v1.GROUP, Resource: v1.DASHBOARD_RESOURCE}
 
 	return migrations.MigrationDefinition{
-		ID:          "folders-dashboards",
+		ID:          migrations.FoldersDashboardsMigrationID,
 		MigrationID: "folders and dashboards migration",
 		Resources: []migrations.ResourceInfo{
 			{GroupResource: folderGR, LockTables: []string{"dashboard", "dashboard_version", "dashboard_provisioning"}},

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
@@ -70,6 +72,21 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, mg *migra
 	}
 
 	r.log.Info("Starting migration for all organizations", "org_count", len(orgs), "resources", r.resources)
+
+	// Skip migration if all resources are already on unified storage
+	// this handles earlier instances that were writing directly to unistore and never
+	// migrated through the legacy path. without this check, the migration would wip
+	// unistore and repopulate from sql, resulting in data loss
+	alreadyMigrated, err := r.isAlreadyOnUnifiedStorage(sess)
+	if err != nil {
+		r.log.Error("failed to check dualwrite state, aborting migration", "error", err)
+		return fmt.Errorf("failed to check dualwrite state: %w", err)
+	}
+	if alreadyMigrated {
+		r.log.Debug("skipping migration: resources already on unified storage per dualwrite state",
+			"resources", r.definition.ConfigResources())
+		return nil
+	}
 
 	if opts.DriverName == migrator.SQLite {
 		// reuse transaction in SQLite to avoid "database is locked" errors
@@ -321,4 +338,57 @@ func ParseOrgIDFromNamespace(namespace string) (int64, error) {
 type orgInfo struct {
 	ID   int64  `xorm:"id"`
 	Name string `xorm:"name"`
+}
+
+// dualwriteKVNamespace was used in older verisons of grafana to keep track of dual writer state.
+// it is no longer used, other than for backwards compatibility
+const dualwriteKVNamespace = "unified.dualwrite"
+
+// dualwriteStorageStatus holds info to determine whether a resource was already migrated to unified storage
+type dualwriteStorageStatus struct {
+	ReadUnified  bool  `json:"read_unified"`
+	WriteUnified bool  `json:"write_unified"`
+	WriteLegacy  bool  `json:"write_legacy"`
+	Migrated     int64 `json:"migrated"`
+}
+
+// isAlreadyOnUnifiedStorage checks the kv_store for dualwrite state used by G12.
+// Returns true when all resources in the definition were already migrated to unified storage
+// (read_unified=true, write_unified=true, write_legacy=false, and migrated>0)
+// This is to prevent data loss, as otherwise it will be wiped and repopulated from sql,
+// destroying resources that only exist in unified storage.
+func (r *MigrationRunner) isAlreadyOnUnifiedStorage(sess *xorm.Session) (bool, error) {
+	configResources := r.definition.ConfigResources()
+	if len(configResources) == 0 {
+		return false, nil
+	}
+
+	for _, key := range configResources {
+		orgID := int64(0)
+		ns := dualwriteKVNamespace
+		k := key
+		item := kvstore.Item{
+			OrgId:     &orgID,
+			Namespace: &ns,
+			Key:       &k,
+		}
+		found, err := sess.Get(&item)
+		if err != nil {
+			return false, fmt.Errorf("failed to query dualwrite state for %s: %w", key, err)
+		}
+		if !found {
+			return false, nil
+		}
+
+		var status dualwriteStorageStatus
+		if err := json.Unmarshal([]byte(item.Value), &status); err != nil {
+			return false, fmt.Errorf("failed to parse dualwrite state for %s: %w", key, err)
+		}
+
+		if !status.ReadUnified || !status.WriteUnified || status.WriteLegacy || status.Migrated == 0 {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -3,7 +3,10 @@ package migrations
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -75,7 +78,7 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, mg *migra
 
 	// Skip migration if all resources are already on unified storage
 	// this handles earlier instances that were writing directly to unistore and never
-	// migrated through the legacy path. without this check, the migration would wip
+	// migrated through the legacy path. without this check, the migration would wipe
 	// unistore and repopulate from sql, resulting in data loss
 	alreadyMigrated, err := r.isAlreadyOnUnifiedStorage(sess)
 	if err != nil {
@@ -344,6 +347,11 @@ type orgInfo struct {
 // it is no longer used, other than for backwards compatibility
 const dualwriteKVNamespace = "unified.dualwrite"
 
+// dualwriteFileName is the name of the file used by G12.0.0 to persist dualwrite state
+// in the data directory. It contains a JSON-encoded map of resource keys
+// (e.g. "dashboards.dashboard.grafana.app") to dualwriteStorageStatus.
+const dualwriteFileName = "dualwrite.json"
+
 // dualwriteStorageStatus holds info to determine whether a resource was already migrated to unified storage
 type dualwriteStorageStatus struct {
 	ReadUnified  bool  `json:"read_unified"`
@@ -352,43 +360,95 @@ type dualwriteStorageStatus struct {
 	Migrated     int64 `json:"migrated"`
 }
 
-// isAlreadyOnUnifiedStorage checks the kv_store for dualwrite state used by G12.
+// migratedToUnified reports whether the status indicates a completed migration to unified storage.
+func (s dualwriteStorageStatus) migratedToUnified() bool {
+	return s.ReadUnified && s.WriteUnified && !s.WriteLegacy && s.Migrated > 0
+}
+
+// isAlreadyOnUnifiedStorage checks persisted dualwrite state used by prior versions of Grafana.
 // Returns true when all resources in the definition were already migrated to unified storage
-// (read_unified=true, write_unified=true, write_legacy=false, and migrated>0)
-// This is to prevent data loss, as otherwise it will be wiped and repopulated from sql,
-// destroying resources that only exist in unified storage.
+// (read_unified=true, write_unified=true, write_legacy=false, and migrated>0).
+// This is to prevent data loss, as otherwise unified storage will be wiped and repopulated
+// from sql, destroying resources that only exist in unified storage.
+//
+// Two historical locations are checked:
+//   - kv_store table with namespace "unified.dualwrite" (12.1.0+)
+//   - <data_path>/dualwrite.json file containing a map[string]StorageStatus (12.0.0)
 func (r *MigrationRunner) isAlreadyOnUnifiedStorage(sess *xorm.Session) (bool, error) {
 	configResources := r.definition.ConfigResources()
 	if len(configResources) == 0 {
 		return false, nil
 	}
 
+	fileStatuses, err := r.readDualwriteFile()
+	if err != nil {
+		return false, fmt.Errorf("failed to read dualwrite state file: %w", err)
+	}
+
 	for _, key := range configResources {
-		orgID := int64(0)
-		ns := dualwriteKVNamespace
-		k := key
-		item := kvstore.Item{
-			OrgId:     &orgID,
-			Namespace: &ns,
-			Key:       &k,
+		if status, ok := fileStatuses[key]; ok {
+			if !status.migratedToUnified() {
+				return false, nil
+			}
+			continue
 		}
-		found, err := sess.Get(&item)
+
+		status, found, err := r.readDualwriteKVState(sess, key)
 		if err != nil {
-			return false, fmt.Errorf("failed to query dualwrite state for %s: %w", key, err)
+			return false, err
 		}
-		if !found {
-			return false, nil
-		}
-
-		var status dualwriteStorageStatus
-		if err := json.Unmarshal([]byte(item.Value), &status); err != nil {
-			return false, fmt.Errorf("failed to parse dualwrite state for %s: %w", key, err)
-		}
-
-		if !status.ReadUnified || !status.WriteUnified || status.WriteLegacy || status.Migrated == 0 {
+		if !found || !status.migratedToUnified() {
 			return false, nil
 		}
 	}
 
 	return true, nil
+}
+
+// readDualwriteKVState loads dualwrite state for the given resource key from kv_store.
+func (r *MigrationRunner) readDualwriteKVState(sess *xorm.Session, key string) (dualwriteStorageStatus, bool, error) {
+	orgID := int64(0)
+	ns := dualwriteKVNamespace
+	k := key
+	item := kvstore.Item{
+		OrgId:     &orgID,
+		Namespace: &ns,
+		Key:       &k,
+	}
+	found, err := sess.Get(&item)
+	if err != nil {
+		return dualwriteStorageStatus{}, false, fmt.Errorf("failed to query dualwrite state for %s: %w", key, err)
+	}
+	if !found {
+		return dualwriteStorageStatus{}, false, nil
+	}
+
+	var status dualwriteStorageStatus
+	if err := json.Unmarshal([]byte(item.Value), &status); err != nil {
+		return dualwriteStorageStatus{}, false, fmt.Errorf("failed to parse dualwrite state for %s: %w", key, err)
+	}
+	return status, true, nil
+}
+
+// readDualwriteFile loads dualwrite state written by G12.0.0 from <data_path>/dualwrite.json.
+// Returns an empty map (not an error) when the file or data path is not present.
+func (r *MigrationRunner) readDualwriteFile() (map[string]dualwriteStorageStatus, error) {
+	if r.cfg == nil || r.cfg.DataPath == "" {
+		return nil, nil
+	}
+
+	path := filepath.Join(r.cfg.DataPath, dualwriteFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var statuses map[string]dualwriteStorageStatus
+	if err := json.Unmarshal(data, &statuses); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	return statuses, nil
 }

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -343,7 +343,7 @@ type orgInfo struct {
 	Name string `xorm:"name"`
 }
 
-// dualwriteKVNamespace was used in older verisons of grafana to keep track of dual writer state.
+// dualwriteKVNamespace was used in older versions of grafana to keep track of dual writer state.
 // it is no longer used, other than for backwards compatibility
 const dualwriteKVNamespace = "unified.dualwrite"
 
@@ -437,8 +437,8 @@ func (r *MigrationRunner) readDualwriteFile() (map[string]dualwriteStorageStatus
 		return nil, nil
 	}
 
-	path := filepath.Join(r.cfg.DataPath, dualwriteFileName)
-	data, err := os.ReadFile(path)
+	path := filepath.Clean(filepath.Join(r.cfg.DataPath, dualwriteFileName))
+	data, err := os.ReadFile(path) // #nosec G304 -- path is derived from trusted config
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -347,6 +347,10 @@ type orgInfo struct {
 // it is no longer used, other than for backwards compatibility
 const dualwriteKVNamespace = "unified.dualwrite"
 
+// FoldersDashboardsMigrationID is the definition ID of the folders/dashboards migration.
+// It is the only migration whose legacy dualwrite state we need to verify.
+const FoldersDashboardsMigrationID = "folders-dashboards"
+
 // dualwriteFileName is the name of the file used by G12.0.0 to persist dualwrite state
 // in the data directory. It contains a JSON-encoded map of resource keys
 // (e.g. "dashboards.dashboard.grafana.app") to dualwriteStorageStatus.
@@ -374,7 +378,14 @@ func (s dualwriteStorageStatus) migratedToUnified() bool {
 // Two historical locations are checked:
 //   - kv_store table with namespace "unified.dualwrite" (12.1.0+)
 //   - <data_path>/dualwrite.json file containing a map[string]StorageStatus (12.0.0)
+//
+// This legacy path was only ever exposed for folders/dashboards, so this check is skipped
+// for every other migration definition.
 func (r *MigrationRunner) isAlreadyOnUnifiedStorage(sess *xorm.Session) (bool, error) {
+	if r.definition.ID != FoldersDashboardsMigrationID {
+		return false, nil
+	}
+
 	configResources := r.definition.ConfigResources()
 	if len(configResources) == 0 {
 		return false, nil

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -2,7 +2,10 @@ package migrations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -700,11 +703,12 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 		},
 	}
 
-	insertKVState := func(t *testing.T, key string, readUnified bool, migrated int64) {
+	insertKVState := func(t *testing.T, key string, status dualwriteStorageStatus) {
 		t.Helper()
 		orgID := int64(0)
 		ns := dualwriteKVNamespace
-		value := fmt.Sprintf(`{"read_unified":%v,"migrated":%d}`, readUnified, migrated)
+		value, err := json.Marshal(status)
+		require.NoError(t, err)
 		item := kvstore.Item{
 			OrgId:     &orgID,
 			Namespace: &ns,
@@ -715,21 +719,59 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 		// delete any existing entry first
 		_, _ = sess.Delete(&item)
 		now := time.Now()
-		item.Value = value
+		item.Value = string(value)
 		item.Created = now
 		item.Updated = now
-		_, err := sess.Insert(&item)
+		_, err = sess.Insert(&item)
 		require.NoError(t, err)
+	}
+
+	deleteKVState := func(t *testing.T, key string) {
+		t.Helper()
+		orgID := int64(0)
+		ns := dualwriteKVNamespace
+		item := kvstore.Item{
+			OrgId:     &orgID,
+			Namespace: &ns,
+			Key:       &key,
+		}
+		sess := env.engine.NewSession()
+		defer sess.Close()
+		_, _ = sess.Delete(&item)
+	}
+
+	writeDualwriteFile := func(t *testing.T, dataPath string, statuses map[string]dualwriteStorageStatus) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(dataPath, 0755))
+		data, err := json.Marshal(statuses)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dataPath, dualwriteFileName), data, 0644))
 	}
 
 	newSession := func() *xorm.Session {
 		return env.engine.NewSession()
 	}
 
+	newRunnerWithDataPath := func(t *testing.T, dataPath string) *MigrationRunner {
+		t.Helper()
+		cfg := setting.NewCfg()
+		cfg.DataPath = dataPath
+		fake := &fakeUnifiedMigrator{migrateResponse: &resourcepb.BulkResponse{}}
+		return NewMigrationRunner(fake, noopLocker(), &transactionalTableRenamer{log: logger}, cfg, def, nil)
+	}
+
 	runner, _ := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
 	configKey := def.ConfigResources()[0] // "dashboards.dashboard.grafana.app"
 
+	migratedStatus := dualwriteStorageStatus{
+		ReadUnified:  true,
+		WriteUnified: true,
+		WriteLegacy:  false,
+		Migrated:     1776363974703,
+	}
+
 	t.Run("returns false when no kv_store entry exists", func(t *testing.T) {
+		deleteKVState(t, configKey)
 		sess := newSession()
 		defer sess.Close()
 		got, err := runner.isAlreadyOnUnifiedStorage(sess)
@@ -738,7 +780,7 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 	})
 
 	t.Run("returns false when read_unified is false", func(t *testing.T) {
-		insertKVState(t, configKey, false, 1234)
+		insertKVState(t, configKey, dualwriteStorageStatus{ReadUnified: false, WriteUnified: true, Migrated: 1234})
 		sess := newSession()
 		defer sess.Close()
 		got, err := runner.isAlreadyOnUnifiedStorage(sess)
@@ -747,7 +789,7 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 	})
 
 	t.Run("returns false when migrated is zero", func(t *testing.T) {
-		insertKVState(t, configKey, true, 0)
+		insertKVState(t, configKey, dualwriteStorageStatus{ReadUnified: true, WriteUnified: true, Migrated: 0})
 		sess := newSession()
 		defer sess.Close()
 		got, err := runner.isAlreadyOnUnifiedStorage(sess)
@@ -755,8 +797,17 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 		require.False(t, got)
 	})
 
-	t.Run("returns true when read_unified and migrated are set", func(t *testing.T) {
-		insertKVState(t, configKey, true, 1776363974703)
+	t.Run("returns false when write_legacy is true", func(t *testing.T) {
+		insertKVState(t, configKey, dualwriteStorageStatus{ReadUnified: true, WriteUnified: true, WriteLegacy: true, Migrated: 1234})
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("returns true when kv_store status shows migration complete", func(t *testing.T) {
+		insertKVState(t, configKey, migratedStatus)
 		sess := newSession()
 		defer sess.Close()
 		got, err := runner.isAlreadyOnUnifiedStorage(sess)
@@ -764,15 +815,80 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 		require.True(t, got)
 	})
 
+	t.Run("returns true when dualwrite.json file shows migration complete", func(t *testing.T) {
+		deleteKVState(t, configKey)
+		dataPath := t.TempDir()
+		writeDualwriteFile(t, dataPath, map[string]dualwriteStorageStatus{configKey: migratedStatus})
+		r := newRunnerWithDataPath(t, dataPath)
+		sess := newSession()
+		defer sess.Close()
+		got, err := r.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	t.Run("returns false when dualwrite.json shows migration not complete", func(t *testing.T) {
+		deleteKVState(t, configKey)
+		dataPath := t.TempDir()
+		writeDualwriteFile(t, dataPath, map[string]dualwriteStorageStatus{
+			configKey: {ReadUnified: false, WriteUnified: true, WriteLegacy: true, Migrated: 0},
+		})
+		r := newRunnerWithDataPath(t, dataPath)
+		sess := newSession()
+		defer sess.Close()
+		got, err := r.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("dualwrite.json takes precedence over kv_store for the same key", func(t *testing.T) {
+		insertKVState(t, configKey, migratedStatus)
+		dataPath := t.TempDir()
+		writeDualwriteFile(t, dataPath, map[string]dualwriteStorageStatus{
+			configKey: {ReadUnified: false, WriteUnified: true, WriteLegacy: true, Migrated: 0},
+		})
+		r := newRunnerWithDataPath(t, dataPath)
+		sess := newSession()
+		defer sess.Close()
+		got, err := r.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("falls back to kv_store when key is missing from dualwrite.json", func(t *testing.T) {
+		insertKVState(t, configKey, migratedStatus)
+		dataPath := t.TempDir()
+		writeDualwriteFile(t, dataPath, map[string]dualwriteStorageStatus{
+			"something.else": {ReadUnified: true, WriteUnified: true, Migrated: 1},
+		})
+		r := newRunnerWithDataPath(t, dataPath)
+		sess := newSession()
+		defer sess.Close()
+		got, err := r.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	t.Run("returns false when dualwrite.json does not exist and no kv_store entry", func(t *testing.T) {
+		deleteKVState(t, configKey)
+		dataPath := t.TempDir() // directory exists but no dualwrite.json in it
+		r := newRunnerWithDataPath(t, dataPath)
+		sess := newSession()
+		defer sess.Close()
+		got, err := r.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
 	t.Run("Run skips migration when already on unified storage", func(t *testing.T) {
-		insertKVState(t, configKey, true, 1776363974703)
+		insertKVState(t, configKey, migratedStatus)
 		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
 		runMigration(t, env.engine, runner2, migrator.SQLite)
 		require.Equal(t, 0, fake.migrateCalled, "Migrate should not be called when already on unified storage")
 	})
 
 	t.Run("Run proceeds with migration when not on unified storage", func(t *testing.T) {
-		insertKVState(t, configKey, false, 0)
+		insertKVState(t, configKey, dualwriteStorageStatus{ReadUnified: false, WriteUnified: false, Migrated: 0})
 		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
 		runMigration(t, env.engine, runner2, migrator.SQLite)
 		require.Equal(t, 1, fake.migrateCalled, "Migrate should be called when not on unified storage")

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
@@ -684,5 +685,96 @@ func TestIntegrationBuildRenamePairs(t *testing.T) {
 		_, err := buildRenamePairs(logger, mg, []string{table})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unexpected state")
+	})
+}
+
+func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
+	env := newTestEnv(t)
+
+	gr := schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}
+	def := MigrationDefinition{
+		ID: "test-unified-check", MigrationID: "test-unified-check-migration",
+		Resources: []ResourceInfo{{GroupResource: gr}},
+		Migrators: map[schema.GroupResource]MigratorFunc{
+			gr: func(context.Context, int64, MigrateOptions, resourcepb.BulkStore_BulkProcessClient) error { return nil },
+		},
+	}
+
+	insertKVState := func(t *testing.T, key string, readUnified bool, migrated int64) {
+		t.Helper()
+		orgID := int64(0)
+		ns := dualwriteKVNamespace
+		value := fmt.Sprintf(`{"read_unified":%v,"migrated":%d}`, readUnified, migrated)
+		item := kvstore.Item{
+			OrgId:     &orgID,
+			Namespace: &ns,
+			Key:       &key,
+		}
+		sess := env.engine.NewSession()
+		defer sess.Close()
+		// delete any existing entry first
+		_, _ = sess.Delete(&item)
+		now := time.Now()
+		item.Value = value
+		item.Created = now
+		item.Updated = now
+		_, err := sess.Insert(&item)
+		require.NoError(t, err)
+	}
+
+	newSession := func() *xorm.Session {
+		return env.engine.NewSession()
+	}
+
+	runner, _ := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
+	configKey := def.ConfigResources()[0] // "dashboards.dashboard.grafana.app"
+
+	t.Run("returns false when no kv_store entry exists", func(t *testing.T) {
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("returns false when read_unified is false", func(t *testing.T) {
+		insertKVState(t, configKey, false, 1234)
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("returns false when migrated is zero", func(t *testing.T) {
+		insertKVState(t, configKey, true, 0)
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("returns true when read_unified and migrated are set", func(t *testing.T) {
+		insertKVState(t, configKey, true, 1776363974703)
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	t.Run("Run skips migration when already on unified storage", func(t *testing.T) {
+		insertKVState(t, configKey, true, 1776363974703)
+		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
+		runMigration(t, env.engine, runner2, migrator.SQLite)
+		require.Equal(t, 0, fake.migrateCalled, "Migrate should not be called when already on unified storage")
+	})
+
+	t.Run("Run proceeds with migration when not on unified storage", func(t *testing.T) {
+		insertKVState(t, configKey, false, 0)
+		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
+		runMigration(t, env.engine, runner2, migrator.SQLite)
+		require.Equal(t, 1, fake.migrateCalled, "Migrate should be called when not on unified storage")
 	})
 }

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -742,10 +742,10 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 
 	writeDualwriteFile := func(t *testing.T, dataPath string, statuses map[string]dualwriteStorageStatus) {
 		t.Helper()
-		require.NoError(t, os.MkdirAll(dataPath, 0755))
+		require.NoError(t, os.MkdirAll(dataPath, 0750))
 		data, err := json.Marshal(statuses)
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filepath.Join(dataPath, dualwriteFileName), data, 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dataPath, dualwriteFileName), data, 0600))
 	}
 
 	newSession := func() *xorm.Session {

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -696,7 +696,7 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 
 	gr := schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}
 	def := MigrationDefinition{
-		ID: "test-unified-check", MigrationID: "test-unified-check-migration",
+		ID: FoldersDashboardsMigrationID, MigrationID: "folders and dashboards migration",
 		Resources: []ResourceInfo{{GroupResource: gr}},
 		Migrators: map[schema.GroupResource]MigratorFunc{
 			gr: func(context.Context, int64, MigrateOptions, resourcepb.BulkStore_BulkProcessClient) error { return nil },
@@ -775,6 +775,23 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 		sess := newSession()
 		defer sess.Close()
 		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("returns false for non-folders-dashboards definitions even when kv_store shows migrated", func(t *testing.T) {
+		insertKVState(t, configKey, migratedStatus)
+		otherDef := MigrationDefinition{
+			ID: "shorturls", MigrationID: "shorturls migration",
+			Resources: []ResourceInfo{{GroupResource: gr}},
+			Migrators: map[schema.GroupResource]MigratorFunc{
+				gr: func(context.Context, int64, MigrateOptions, resourcepb.BulkStore_BulkProcessClient) error { return nil },
+			},
+		}
+		otherRunner, _ := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, otherDef)
+		sess := newSession()
+		defer sess.Close()
+		got, err := otherRunner.isAlreadyOnUnifiedStorage(sess)
 		require.NoError(t, err)
 		require.False(t, got)
 	})

--- a/pkg/storage/unified/migrations/testcases/folders_dashboards.go
+++ b/pkg/storage/unified/migrations/testcases/folders_dashboards.go
@@ -20,11 +20,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/storage/unified/migrations"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// foldersAndDashboardsTestCase tests the "folders-dashboards" ResourceMigration
+// foldersAndDashboardsTestCase tests the folders-dashboards ResourceMigration.
 type foldersAndDashboardsTestCase struct {
 	parentFolderUID   string
 	childFolderUID    string
@@ -44,7 +45,7 @@ func NewFoldersAndDashboardsTestCase() ResourceMigratorTestCase {
 }
 
 func (tc *foldersAndDashboardsTestCase) Name() string {
-	return "folders-dashboards"
+	return migrations.FoldersDashboardsMigrationID
 }
 
 func (tc *foldersAndDashboardsTestCase) FeatureToggles() []string {


### PR DESCRIPTION
**What is this feature?**

This PR skips unified storage migrations if the kv_store table OR the dualwrite.json file in the datapath already shows that the instance was migrated (via git sync) for folders & dashboards

**Why do we need this feature?**

We were re-running migrations after an instance was already migrated to unistore via git sync. This results in either data loss of dashboards not in git sync or a borked instance where old versions of dashboards are migrated and git sync cannot reclaim it.

Scenario 1 (data loss): Fresh instance in G12
1. Start Grafana with the git sync feature toggles enabled (provisioning, kubernetesClientDashboardsFolders, kubernetesDashboards, and grafanaAPIServerEnsureKubectlAccess)
2. Create a repo, and save it to a folder (do not do full instance sync)
3. Create dashboards and folders outside of that folder, these will be stored in unified storage.
4. Upgrade to G13, this will run the unified storage migration, which as a first step removes all dashboards & folders in unified storage.
5. The dashboards & folders created outside of git sync will be gone.

Scenario 2 (old dashboard versions, borked repo): Scenario 2: Older instance
1. Start Grafana 11 (or 12 without the git sync feature toggles enabled)
2. Create some dashboards and folders
3. Enable the git sync feature toggles
4. Create a repo. This will force a full instance sync rather than just a folder
5. Make some changes to the dashboards or folders.
6. Upgrade to G13
7. The migration will run again, which wipes everything in unistore, this will revert those dashboards to the older version (will not reflect the changes in step 5)
8. The changes will be still available in git, but git sync will not sync / update them to the newest version, because the manager annotations will not exist, so git sync will say that there is a uid that already exists for that dashboard


Fixes https://github.com/grafana/grafana/issues/122804

**Testing**
1. Run grafana 12:
 docker run --rm -p 3000:3000  -e GF_DATABASE_TYPE=mysql -e GF_DATABASE_HOST=host.docker.internal:13306 -e GF_DATABASE_USER=<>  -e GF_DATABASE_PASSWORD=<>  -e GF_DATABASE_NAME=<> -v /tmp/grafana-custom.ini:/etc/grafana/grafana.ini -v /tmp/grafana-data:/var/lib/grafana grafana/grafana:12.0.0
with custom.ini of:
```
  [feature_toggles]                                                                                                                          
  provisioning = true                                                                                                                        
  kubernetesClientDashboardsFolders = true                                                                                                   
  kubernetesDashboards = true                                                                                                                
  grafanaAPIServerEnsureKubectlAccess = true
```
2. Create a dashboard
3. Stop the docker grafana
4. Locally on this branch, add to the customl.ini:
```
[paths]                                                                                                                                                                                           
data = /tmp/grafana-data  

[database]
type = mysql
user = <>
password = <>
host = localhost
port = 13306
name = <>
```
6. Then run make run. 

Then also try but starting with 12.2
 