### PR TITLE
[release-12.4.4] [DOC] Clarify trace ID cardinality guidance in trace correlations

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -134,6 +134,12 @@ You can configure a custom query where you can use a [template language](https:/
 1. Switch on **Use custom query**.
 1. Specify a custom query to be used to query the logs. You can use various variables to make that query relevant for current span. The link will only be shown only if all the variables are interpolated with non-empty values to prevent creating an invalid query.
 
+   If a tag like `pod` is stored as Loki [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) instead of an indexed label, it can't appear in the stream selector `{}`. Move it to a pipeline filter instead:
+
+   ```logql
+   {${__tags}} | pod=`${__span.tags["k8s.pod.name"]}` |= `${__trace.traceId}`
+   ```
+
 ### Configure trace to logs
 
 The following table describes the ways in which you can configure your trace to logs settings:

--- a/docs/sources/datasources/tempo/traces-in-grafana/trace-correlations.md
+++ b/docs/sources/datasources/tempo/traces-in-grafana/trace-correlations.md
@@ -110,6 +110,11 @@ In this example, you configure trace to logs by service name and a trace identif
      {service_name="$serviceName"} | trace_id=`$traceID` |= ``
      ```
 
+     In this query, `service_name` is the only [stream label](https://grafana.com/docs/loki/latest/get-started/labels/) used inside `{}`. Stream labels should be low-cardinality values that describe the source of your logs.
+     The `trace_id` field appears after the `|` pipe as a [pipeline filter](https://grafana.com/docs/loki/latest/query/log_queries/#line-filter-expression), which searches log content or [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) without creating additional streams.
+     Don't use trace IDs or other high-cardinality values as stream labels because each unique value creates a separate stream, which degrades Loki performance.
+     For more information, refer to [Label best practices](https://grafana.com/docs/loki/latest/get-started/labels/bp-labels/) and [Cardinality](https://grafana.com/docs/loki/latest/get-started/labels/cardinality/).
+
      {{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-correlations-example-1-step-2.png" max-width="900px" class="docs-image--no-shadow" alt="Using correlations for a trace" >}}
 
 1. On step 3, configure the correlation source:
@@ -159,6 +164,13 @@ In this example, you configure trace corrections with a custom URL.
 
 - **Name clearly:** Use descriptive names indicating source and target. For example: **Trace to errors in logs**.
 
-- **Limit scope**: For high-cardinality fields (like `traceID`), ensure your target system can handle frequent queries.
+- **Use low-cardinality stream labels:** When targeting Loki, use only low-cardinality values like `service_name`, `namespace`, or `cluster` inside the stream selector `{}`. Place high-cardinality values like trace IDs in [pipeline filters](https://grafana.com/docs/loki/latest/query/log_queries/#line-filter-expression) (after `|`) or store them as [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/). Using trace IDs as stream labels creates excessive streams and degrades Loki performance. For more information, refer to [Cardinality](https://grafana.com/docs/loki/latest/get-started/labels/cardinality/) and [Label best practices](https://grafana.com/docs/loki/latest/get-started/labels/bp-labels/). For detailed guidance on mapping span attributes to Loki labels, refer to [Trace to logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#trace-to-logs).
 
 - **Template wisely:** Use multiple `$variable` tokens if you need to inject more than one field.
+
+## Next steps
+
+- [Trace to logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#trace-to-logs): Link spans to log queries in Loki with tag mapping and cardinality guidance.
+- [Trace to metrics](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#trace-to-metrics): Link spans to metrics queries in Prometheus.
+- [Trace to profiles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#trace-to-profiles): Link spans to profiling data in Grafana Pyroscope.
+- [Configure the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/): Return to connection, authentication, and streaming settings.


### PR DESCRIPTION
Backport b8535a3aa06d50d290d8c2f26e6567a4b0bc8f9b from #122342

---


Addresses [grafana/loki#18373](https://github.com/grafana/loki/issues/18373) by clarifying that trace_id in the Loki query example is a pipeline filter, not a stream label, and doesn't cause high-cardinality issues
Replaces the vague "Limit scope" best practice with actionable cardinality guidance and links to Loki's label, cardinality, and structured metadata docs
Adds a Next steps section linking to related correlation pages

Fixes https://github.com/grafana/loki/issues/18373
Fixes https://github.com/grafana/support-escalations/issues/18558

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
