### PR TITLE
fix: replace 'grafana-cli' with 'grafana cli' in custom Dockerfile

### DIFF
--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -10,7 +10,7 @@ ENV GF_PLUGIN_RENDERING_CHROME_BIN="/usr/bin/chrome"
 USER root
 
 RUN mkdir -p "$GF_PATHS_PLUGINS" && \
-    chown -R grafana:${GF_GID} "$GF_PATHS_PLUGINS" 
+    chown -R grafana:${GF_GID} "$GF_PATHS_PLUGINS"
 
 USER grafana
 
@@ -25,9 +25,9 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
         if expr match "$plugin" '.*\;.*'; then \
           pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
           pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
-          grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
+          grafana cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
         else \
-          grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
+          grafana cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
         fi \
       done \
     fi


### PR DESCRIPTION
**What is this feature?**

Just a fix. Replaces `grafana-cli` (removed) calls with `grafana cli`.

**Why do we need this feature?**

Without it [this](https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#build-a-custom-grafana-docker-image) functionality doesn't work.
