### PR TITLE
Folders: move title validation to folder API server

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -80,8 +81,14 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return dashboards.ErrDashboardUidTooLong
 	}
 
+	f.Spec.Title = strings.TrimSpace(f.Spec.Title)
+
 	if f.Spec.Title == "" {
 		return folder.ErrTitleEmpty
+	}
+
+	if strings.EqualFold(f.Spec.Title, dashboards.RootFolderName) {
+		return folder.ErrNameExists
 	}
 
 	parentName := meta.GetFolder()
@@ -125,8 +132,14 @@ func validateOnUpdate(ctx context.Context,
 		return err
 	}
 
+	obj.Spec.Title = strings.TrimSpace(obj.Spec.Title)
+
 	if obj.Spec.Title == "" {
 		return folder.ErrTitleEmpty
+	}
+
+	if strings.EqualFold(obj.Spec.Title, dashboards.RootFolderName) {
+		return folder.ErrNameExists
 	}
 
 	if folderObj.GetFolder() == oldFolder.GetFolder() {

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -207,6 +207,42 @@ func TestValidateCreate(t *testing.T) {
 			maxDepth: setting.NewCfg().MaxNestedFolderDepth,
 		},
 		{
+			name: "title is reserved name General",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc123",
+				},
+				Spec: folders.FolderSpec{
+					Title: "General",
+				},
+			},
+			expectedErr: "folder.name-exists",
+		},
+		{
+			name: "title is reserved name General case insensitive",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc123",
+				},
+				Spec: folders.FolderSpec{
+					Title: "GENERAL",
+				},
+			},
+			expectedErr: "folder.name-exists",
+		},
+		{
+			name: "title is reserved name General with surrounding whitespace",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc123",
+				},
+				Spec: folders.FolderSpec{
+					Title: "  General  ",
+				},
+			},
+			expectedErr: "folder.name-exists",
+		},
+		{
 			name: "cannot create a circular reference",
 			folder: &folders.Folder{
 				ObjectMeta: metav1.ObjectMeta{
@@ -314,6 +350,66 @@ func TestValidateUpdate(t *testing.T) {
 					Title: "old title",
 				},
 			},
+		},
+		{
+			name: "title is reserved name General",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "General",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "old title",
+				},
+			},
+			expectedErr: "folder.name-exists",
+		},
+		{
+			name: "title is reserved name General case insensitive",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "GENERAL",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "old title",
+				},
+			},
+			expectedErr: "folder.name-exists",
+		},
+		{
+			name: "title is reserved name General with surrounding whitespace",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "  General  ",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nnn",
+				},
+				Spec: folders.FolderSpec{
+					Title: "old title",
+				},
+			},
+			expectedErr: "folder.name-exists",
 		},
 		{
 			name: "error to move into k6 folder",

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -484,15 +484,6 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-	if cmd.NewTitle != nil && *cmd.NewTitle != "" {
-		title := strings.TrimSpace(*cmd.NewTitle)
-		cmd.NewTitle = &title
-
-		if strings.EqualFold(*cmd.NewTitle, dashboards.RootFolderName) {
-			return nil, folder.ErrNameExists
-		}
-	}
-
 	if !util.IsValidShortUID(cmd.UID) {
 		return nil, dashboards.ErrDashboardInvalidUid
 	} else if util.IsShortUIDTooLong(cmd.UID) {


### PR DESCRIPTION
Moves title whitespace trimming and rejection of the reserved name "General" from the legacy service layer into validateOnCreate and validateOnUpdate in the folder API server, so the validation is enforced consistently at the API boundary for both create and update operations.

This title validation got introduced originally [here](https://github.com/grafana/grafana/pull/10809/changes#diff-988b297be8cec3b21776f684e379c839f1c72beeb8be922d3b0b95c8bb5a1b48R221)

Part of https://github.com/grafana/search-and-storage-team/issues/748