### PR TITLE
Docs: PDC and Alerting update

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules.md
+++ b/docs/sources/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules.md
@@ -49,6 +49,8 @@ Grafana does not contain an embedded time-series database to store recording rul
 
 Grafana-managed recording rules offer the same Prometheus-like semantics but allow you to query [data sources supported by alerting](ref:alerting-data-sources). Additionally, you can use recording rules to import and map data from other data sources into Prometheus.
 
+In Grafana Cloud, recording rules support writing to Prometheus-compatible data sources configured with [Private Data Source Connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) (PDC). This allows you to write recording rule results to a Prometheus or Mimir instance in a private network without opening that network to inbound traffic from Grafana Cloud.
+
 {{< admonition type="note" >}}
 
 Grafana-managed recording rules are enabled by default in Grafana Cloud.

--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -159,6 +159,8 @@ You can add multiple exemplars.
 
 - **Private data source connect** - _Only for Grafana Cloud users._ Private data source connect, or PDC, allows you to establish a private, secured connection between a Grafana Cloud instance, or stack, and data sources secured within a private network. Click the drop-down to locate the URL for PDC. For more information regarding Grafana PDC refer to [Private data source connect (PDC)](/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure Grafana private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc) for steps on setting up a PDC connection.
 
+  PDC supports both querying and writing to Prometheus-compatible data sources. This means [Grafana-managed recording rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules/) can write their results to a Prometheus or Mimir instance behind a PDC connection.
+
   If you use PDC with SIGv4 (AWS Signature Version 4 Authentication), the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
 
   Click **Manage private data source connect** to open your PDC connection page and view your configuration details.


### PR DESCRIPTION
This PR adds a paragraph in both the Alerting GMA docs and the PDC docs to clarify PDC supports both querying and writing to Prometheus-compatible data sources and that Grafana Cloud can write results to Prom/Mimir instances behind a PDC connection.
