### PR TITLE
[release-12.4.4] Unified storage: Skip migrations if dualwrite state shows they were already migrated

### DIFF
--- a/pkg/registry/apis/dashboard/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/migration_registrar.go
@@ -13,7 +13,7 @@ func FoldersDashboardsMigration(migrator migrator.FoldersDashboardsMigrator) mig
 	dashboardGR := schema.GroupResource{Group: v1beta1.GROUP, Resource: v1beta1.DASHBOARD_RESOURCE}
 
 	return migrations.MigrationDefinition{
-		ID:          "folders-dashboards",
+		ID:          migrations.FoldersDashboardsMigrationID,
 		MigrationID: "folders and dashboards migration",
 		Resources: []migrations.ResourceInfo{
 			{GroupResource: folderGR, LockTable: "folder"},

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -2,11 +2,16 @@ package migrations
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
@@ -33,6 +38,7 @@ type MigrationRunner struct {
 	cfg             *setting.Cfg
 	autoEnableMode5 bool
 	log             log.Logger
+	migrationID     string
 	resources       []schema.GroupResource
 	validators      []Validator
 }
@@ -42,6 +48,7 @@ func NewMigrationRunner(unifiedMigrator UnifiedMigrator, migrationID string, res
 	r := &MigrationRunner{
 		unifiedMigrator: unifiedMigrator,
 		log:             log.New("storage.unified.migration_runner." + migrationID),
+		migrationID:     migrationID,
 		resources:       resources,
 		validators:      validators,
 	}
@@ -49,6 +56,16 @@ func NewMigrationRunner(unifiedMigrator UnifiedMigrator, migrationID string, res
 		opt(r)
 	}
 	return r
+}
+
+// ConfigResources returns the resource identifiers in the format used by setting.UnifiedStorage config.
+// The format is "resource.group" (e.g., "dashboards.dashboard.grafana.app").
+func (r *MigrationRunner) configResources() []string {
+	result := make([]string, len(r.resources))
+	for i, ri := range r.resources {
+		result[i] = ri.Resource + "." + ri.Group
+	}
+	return result
 }
 
 // RunOptions configures a migration run.
@@ -71,6 +88,21 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, opts RunO
 	}
 
 	r.log.Info("Starting migration for all organizations", "org_count", len(orgs), "resources", r.resources)
+
+	// Skip migration if all resources are already on unified storage
+	// this handles earlier instances that were writing directly to unistore and never
+	// migrated through the legacy path. without this check, the migration would wipe
+	// unistore and repopulate from sql, resulting in data loss
+	alreadyMigrated, err := r.isAlreadyOnUnifiedStorage(sess)
+	if err != nil {
+		r.log.Error("failed to check dualwrite state, aborting migration", "error", err)
+		return fmt.Errorf("failed to check dualwrite state: %w", err)
+	}
+	if alreadyMigrated {
+		r.log.Debug("skipping migration: resources already on unified storage per dualwrite state",
+			"resources", r.configResources())
+		return nil
+	}
 
 	if opts.DriverName == migrator.SQLite {
 		// reuse transaction in SQLite to avoid "database is locked" errors
@@ -313,4 +345,125 @@ func ParseOrgIDFromNamespace(namespace string) (int64, error) {
 type orgInfo struct {
 	ID   int64  `xorm:"id"`
 	Name string `xorm:"name"`
+}
+
+// dualwriteKVNamespace was used in older versions of grafana to keep track of dual writer state.
+// it is no longer used, other than for backwards compatibility
+const dualwriteKVNamespace = "unified.dualwrite"
+
+// FoldersDashboardsMigrationID is the definition ID of the folders/dashboards migration.
+// It is the only migration whose legacy dualwrite state we need to verify.
+const FoldersDashboardsMigrationID = "folders-dashboards"
+
+// dualwriteFileName is the name of the file used by G12.0.0 to persist dualwrite state
+// in the data directory. It contains a JSON-encoded map of resource keys
+// (e.g. "dashboards.dashboard.grafana.app") to dualwriteStorageStatus.
+const dualwriteFileName = "dualwrite.json"
+
+// dualwriteStorageStatus holds info to determine whether a resource was already migrated to unified storage
+type dualwriteStorageStatus struct {
+	ReadUnified  bool  `json:"read_unified"`
+	WriteUnified bool  `json:"write_unified"`
+	WriteLegacy  bool  `json:"write_legacy"`
+	Migrated     int64 `json:"migrated"`
+}
+
+// migratedToUnified reports whether the status indicates a completed migration to unified storage.
+func (s dualwriteStorageStatus) migratedToUnified() bool {
+	return s.ReadUnified && s.WriteUnified && !s.WriteLegacy && s.Migrated > 0
+}
+
+// isAlreadyOnUnifiedStorage checks persisted dualwrite state used by prior versions of Grafana.
+// Returns true when all resources in the definition were already migrated to unified storage
+// (read_unified=true, write_unified=true, write_legacy=false, and migrated>0).
+// This is to prevent data loss, as otherwise unified storage will be wiped and repopulated
+// from sql, destroying resources that only exist in unified storage.
+//
+// Two historical locations are checked:
+//   - kv_store table with namespace "unified.dualwrite" (12.1.0+)
+//   - <data_path>/dualwrite.json file containing a map[string]StorageStatus (12.0.0)
+//
+// This legacy path was only ever exposed for folders/dashboards, so this check is skipped
+// for every other migration definition.
+func (r *MigrationRunner) isAlreadyOnUnifiedStorage(sess *xorm.Session) (bool, error) {
+	if r.migrationID != FoldersDashboardsMigrationID {
+		return false, nil
+	}
+
+	configResources := r.configResources()
+	if len(configResources) == 0 {
+		return false, nil
+	}
+
+	fileStatuses, err := r.readDualwriteFile()
+	if err != nil {
+		return false, fmt.Errorf("failed to read dualwrite state file: %w", err)
+	}
+
+	for _, key := range configResources {
+		if status, ok := fileStatuses[key]; ok {
+			if !status.migratedToUnified() {
+				return false, nil
+			}
+			continue
+		}
+
+		status, found, err := r.readDualwriteKVState(sess, key)
+		if err != nil {
+			return false, err
+		}
+		if !found || !status.migratedToUnified() {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// readDualwriteKVState loads dualwrite state for the given resource key from kv_store.
+func (r *MigrationRunner) readDualwriteKVState(sess *xorm.Session, key string) (dualwriteStorageStatus, bool, error) {
+	orgID := int64(0)
+	ns := dualwriteKVNamespace
+	k := key
+	item := kvstore.Item{
+		OrgId:     &orgID,
+		Namespace: &ns,
+		Key:       &k,
+	}
+	found, err := sess.Get(&item)
+	if err != nil {
+		return dualwriteStorageStatus{}, false, fmt.Errorf("failed to query dualwrite state for %s: %w", key, err)
+	}
+	if !found {
+		return dualwriteStorageStatus{}, false, nil
+	}
+
+	var status dualwriteStorageStatus
+	if err := json.Unmarshal([]byte(item.Value), &status); err != nil {
+		return dualwriteStorageStatus{}, false, fmt.Errorf("failed to parse dualwrite state for %s: %w", key, err)
+	}
+	return status, true, nil
+}
+
+// readDualwriteFile loads dualwrite state written by G12.0.0 from <data_path>/dualwrite.json.
+// Returns an empty map (not an error) when the file or data path is not present.
+func (r *MigrationRunner) readDualwriteFile() (map[string]dualwriteStorageStatus, error) {
+	if r.cfg == nil || r.cfg.DataPath == "" {
+		return nil, nil
+	}
+
+	path := filepath.Clean(filepath.Join(r.cfg.DataPath, dualwriteFileName))
+	data, err := os.ReadFile(path) // #nosec G304 -- path is derived from trusted config
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var statuses map[string]dualwriteStorageStatus
+	if err := json.Unmarshal(data, &statuses); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	return statuses, nil
 }

--- a/pkg/storage/unified/migrations/testcases/folders_dashboards.go
+++ b/pkg/storage/unified/migrations/testcases/folders_dashboards.go
@@ -8,12 +8,13 @@ import (
 
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/storage/unified/migrations"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// foldersAndDashboardsTestCase tests the "folders-dashboards" ResourceMigration
+// foldersAndDashboardsTestCase tests the folders-dashboards ResourceMigration.
 type foldersAndDashboardsTestCase struct {
 	parentFolderUID   string
 	childFolderUID    string
@@ -33,7 +34,7 @@ func NewFoldersAndDashboardsTestCase() ResourceMigratorTestCase {
 }
 
 func (tc *foldersAndDashboardsTestCase) Name() string {
-	return "folders-dashboards"
+	return migrations.FoldersDashboardsMigrationID
 }
 
 func (tc *foldersAndDashboardsTestCase) Resources() []schema.GroupVersionResource {


### PR DESCRIPTION
Backport 87c749179511bbb810516bb01b501f5d0f38747a from #122866

---

**What is this feature?**

This PR skips unified storage migrations if the kv_store table OR the dualwrite.json file in the datapath already shows that the instance was migrated (via git sync) for folders & dashboards

**Why do we need this feature?**

We were re-running migrations after an instance was already migrated to unistore via git sync. This results in either data loss of dashboards not in git sync or a borked instance where old versions of dashboards are migrated and git sync cannot reclaim it.

Scenario 1 (data loss): Fresh instance in G12
1. Start Grafana with the git sync feature toggles enabled (provisioning, kubernetesClientDashboardsFolders, kubernetesDashboards, and grafanaAPIServerEnsureKubectlAccess)
2. Create a repo, and save it to a folder (do not do full instance sync)
3. Create dashboards and folders outside of that folder, these will be stored in unified storage.
4. Upgrade to G13, this will run the unified storage migration, which as a first step removes all dashboards & folders in unified storage.
5. The dashboards & folders created outside of git sync will be gone.

Scenario 2 (old dashboard versions, borked repo): Scenario 2: Older instance
1. Start Grafana 11 (or 12 without the git sync feature toggles enabled)
2. Create some dashboards and folders
3. Enable the git sync feature toggles
4. Create a repo. This will force a full instance sync rather than just a folder
5. Make some changes to the dashboards or folders.
6. Upgrade to G13
7. The migration will run again, which wipes everything in unistore, this will revert those dashboards to the older version (will not reflect the changes in step 5)
8. The changes will be still available in git, but git sync will not sync / update them to the newest version, because the manager annotations will not exist, so git sync will say that there is a uid that already exists for that dashboard


Fixes https://github.com/grafana/grafana/issues/122804

**Testing**
1. Run grafana 12:
 docker run --rm -p 3000:3000  -e GF_DATABASE_TYPE=mysql -e GF_DATABASE_HOST=host.docker.internal:13306 -e GF_DATABASE_USER=<>  -e GF_DATABASE_PASSWORD=<>  -e GF_DATABASE_NAME=<> -v /tmp/grafana-custom.ini:/etc/grafana/grafana.ini -v /tmp/grafana-data:/var/lib/grafana grafana/grafana:12.0.0
with custom.ini of:
```
  [feature_toggles]                                                                                                                          
  provisioning = true                                                                                                                        
  kubernetesClientDashboardsFolders = true                                                                                                   
  kubernetesDashboards = true                                                                                                                
  grafanaAPIServerEnsureKubectlAccess = true
```
2. Create a dashboard
3. Stop the docker grafana
4. Locally on this branch, add to the customl.ini:
```
[paths]                                                                                                                                                                                           
data = /tmp/grafana-data  

[database]
type = mysql
user = <>
password = <>
host = localhost
port = 13306
name = <>
```
6. Then run make run. 

Then also try but starting with 12.2
 