### PR TITLE
unified-storage: send periodic bookmarks in resource server Watch

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -416,7 +416,7 @@ func (s *Storage) Watch(ctx context.Context, key string, opts storage.ListOption
 	}
 
 	reporter := apierrors.NewClientErrorReporter(500, "WATCH", "")
-	decoder := newStreamDecoder(client, s.newFunc, predicate, s.codec, cancelWatch)
+	decoder := newStreamDecoder(client, s.newFunc, predicate, s.codec, cancelWatch, cmd.SendInitialEvents)
 
 	return watch.NewStreamWatcher(decoder, reporter), nil
 }

--- a/pkg/storage/unified/apistore/stream.go
+++ b/pkg/storage/unified/apistore/stream.go
@@ -25,15 +25,19 @@ type streamDecoder struct {
 	codec       runtime.Codec
 	cancelWatch context.CancelFunc
 	done        sync.WaitGroup
+
+	sendInitialEvents   bool
+	initialBookmarkSent bool
 }
 
-func newStreamDecoder(client resourcepb.ResourceStore_WatchClient, newFunc func() runtime.Object, predicate storage.SelectionPredicate, codec runtime.Codec, cancelWatch context.CancelFunc) *streamDecoder {
+func newStreamDecoder(client resourcepb.ResourceStore_WatchClient, newFunc func() runtime.Object, predicate storage.SelectionPredicate, codec runtime.Codec, cancelWatch context.CancelFunc, sendInitialEvents bool) *streamDecoder {
 	return &streamDecoder{
-		client:      client,
-		newFunc:     newFunc,
-		predicate:   predicate,
-		codec:       codec,
-		cancelWatch: cancelWatch,
+		client:            client,
+		newFunc:           newFunc,
+		predicate:         predicate,
+		codec:             codec,
+		cancelWatch:       cancelWatch,
+		sendInitialEvents: sendInitialEvents,
 	}
 }
 func (d *streamDecoder) toObject(w *resourcepb.WatchEvent_Resource) (runtime.Object, error) {
@@ -93,7 +97,6 @@ decode:
 		if evt.Type == resourcepb.WatchEvent_BOOKMARK {
 			obj := d.newFunc()
 
-			// here k8s expects an empty object with just resource version and k8s.io/initial-events-end annotation
 			accessor, err := utils.MetaAccessor(obj)
 			if err != nil {
 				klog.Errorf("error getting object accessor: %s", err)
@@ -101,7 +104,10 @@ decode:
 			}
 
 			accessor.SetResourceVersionInt64(evt.Resource.Version)
-			accessor.SetAnnotations(map[string]string{"k8s.io/initial-events-end": "true"})
+			if d.sendInitialEvents && !d.initialBookmarkSent {
+				accessor.SetAnnotations(map[string]string{"k8s.io/initial-events-end": "true"})
+				d.initialBookmarkSent = true
+			}
 			return watch.Bookmark, obj, nil
 		}
 

--- a/pkg/storage/unified/apistore/stream_test.go
+++ b/pkg/storage/unified/apistore/stream_test.go
@@ -1,0 +1,124 @@
+package apistore
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// mockWatchClient implements resourcepb.ResourceStore_WatchClient for testing.
+type mockWatchClient struct {
+	grpc.ClientStream
+	ctx    context.Context
+	events []*resourcepb.WatchEvent
+	idx    int
+}
+
+func (m *mockWatchClient) Recv() (*resourcepb.WatchEvent, error) {
+	if m.idx >= len(m.events) {
+		return nil, io.EOF
+	}
+	evt := m.events[m.idx]
+	m.idx++
+	return evt, nil
+}
+
+func (m *mockWatchClient) Context() context.Context     { return m.ctx }
+func (m *mockWatchClient) Header() (metadata.MD, error) { return nil, nil }
+func (m *mockWatchClient) Trailer() metadata.MD         { return nil }
+func (m *mockWatchClient) CloseSend() error             { return nil }
+func (m *mockWatchClient) SendMsg(any) error            { return nil }
+func (m *mockWatchClient) RecvMsg(any) error            { return nil }
+
+func unstructuredCodec() runtime.Codec {
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+	return codecs.LegacyCodec()
+}
+
+func TestStreamDecoderBookmarkAnnotation(t *testing.T) {
+	newFunc := func() runtime.Object { return &unstructured.Unstructured{} }
+	predicate := storage.Everything
+
+	t.Run("initial-events-end annotation only on first bookmark when sendInitialEvents is true", func(t *testing.T) {
+		client := &mockWatchClient{
+			ctx: t.Context(),
+			events: []*resourcepb.WatchEvent{
+				{
+					Type:     resourcepb.WatchEvent_BOOKMARK,
+					Resource: &resourcepb.WatchEvent_Resource{Version: 10},
+				},
+				{
+					Type:     resourcepb.WatchEvent_BOOKMARK,
+					Resource: &resourcepb.WatchEvent_Resource{Version: 20},
+				},
+				{
+					Type:     resourcepb.WatchEvent_BOOKMARK,
+					Resource: &resourcepb.WatchEvent_Resource{Version: 30},
+				},
+			},
+		}
+
+		decoder := newStreamDecoder(client, newFunc, predicate, unstructuredCodec(), func() {}, true)
+
+		// First bookmark should have the initial-events-end annotation.
+		action, obj, err := decoder.Decode()
+		require.NoError(t, err)
+		require.Equal(t, watch.Bookmark, action)
+		accessor, err := utils.MetaAccessor(obj)
+		require.NoError(t, err)
+		annotations := accessor.GetAnnotations()
+		require.Equal(t, "true", annotations["k8s.io/initial-events-end"])
+
+		// Subsequent bookmarks should *not* have the annotation.
+		for range 2 {
+			action, obj, err = decoder.Decode()
+			require.NoError(t, err)
+			require.Equal(t, watch.Bookmark, action)
+			accessor, err = utils.MetaAccessor(obj)
+			require.NoError(t, err)
+			annotations = accessor.GetAnnotations()
+			require.Empty(t, annotations["k8s.io/initial-events-end"])
+		}
+	})
+
+	t.Run("no initial-events-end annotation when sendInitialEvents is false", func(t *testing.T) {
+		client := &mockWatchClient{
+			ctx: t.Context(),
+			events: []*resourcepb.WatchEvent{
+				{
+					Type:     resourcepb.WatchEvent_BOOKMARK,
+					Resource: &resourcepb.WatchEvent_Resource{Version: 10},
+				},
+				{
+					Type:     resourcepb.WatchEvent_BOOKMARK,
+					Resource: &resourcepb.WatchEvent_Resource{Version: 20},
+				},
+			},
+		}
+
+		decoder := newStreamDecoder(client, newFunc, predicate, unstructuredCodec(), func() {}, false)
+
+		for range 2 {
+			action, obj, err := decoder.Decode()
+			require.NoError(t, err)
+			require.Equal(t, watch.Bookmark, action)
+			accessor, err := utils.MetaAccessor(obj)
+			require.NoError(t, err)
+			annotations := accessor.GetAnnotations()
+			require.Empty(t, annotations["k8s.io/initial-events-end"])
+		}
+	})
+}

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -163,15 +163,16 @@ func newClient(opts options.StorageOptions,
 		}
 
 		serverOptions := sql.ServerOptions{
-			Backend:       backend,
-			Cfg:           cfg,
-			Tracer:        tracer,
-			Reg:           reg,
-			AccessClient:  authzc,
-			SearchOptions: searchOptions,
-			IndexMetrics:  indexMetrics,
-			Features:      features,
-			SecureValues:  secure,
+			Backend:        backend,
+			Cfg:            cfg,
+			Tracer:         tracer,
+			Reg:            reg,
+			AccessClient:   authzc,
+			SearchOptions:  searchOptions,
+			StorageMetrics: storageMetrics,
+			IndexMetrics:   indexMetrics,
+			Features:       features,
+			SecureValues:   secure,
 		}
 
 		if cfg.QOSEnabled {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -42,6 +42,10 @@ var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/resourc
 // Uses gRPC Unavailable so clients with retry interceptors will retry on another backend.
 var errStopping = status.Error(codes.Unavailable, "server is stopping")
 
+// defaultBookmarkFrequency is how often periodic bookmark events are sent
+// to Watch clients that have AllowWatchBookmarks enabled.
+const defaultBookmarkFrequency = 10 * time.Second
+
 // ResourceServer implements all gRPC services
 type ResourceServer interface {
 	SearchServer
@@ -326,6 +330,10 @@ type ResourceServerOptions struct {
 	OwnsIndexFn func(key NamespacedResource) (bool, error)
 
 	QuotasConfig QuotasConfig
+
+	// BookmarkFrequency controls how often periodic bookmark events are sent to
+	// Watch clients that set AllowWatchBookmarks. Zero defaults to defaultBookmarkFrequency.
+	BookmarkFrequency time.Duration
 }
 
 func (opts ResourceServerOptions) bulkBatchOptions() BulkBatchOptions {
@@ -421,6 +429,10 @@ func NewUninitializedResourceServer(opts ResourceServerOptions) (*server, error)
 		opts.QOSConfig.MaxRetries = 3
 	}
 
+	if opts.BookmarkFrequency == 0 {
+		opts.BookmarkFrequency = defaultBookmarkFrequency
+	}
+
 	// Initialize the blob storage
 	blobstore, err := initializeBlobStorage(opts)
 	if err != nil {
@@ -453,6 +465,7 @@ func NewUninitializedResourceServer(opts ResourceServerOptions) (*server, error)
 		searchClient:                   opts.SearchClient,
 		quotasConfig:                   opts.QuotasConfig,
 		artificialSuccessfulWriteDelay: opts.Search.IndexMinUpdateInterval,
+		bookmarkFrequency:              opts.BookmarkFrequency,
 	}
 
 	if opts.Search.Resources != nil {
@@ -549,6 +562,8 @@ type server struct {
 	// Set from SearchOptions.IndexMinUpdateInterval.
 	artificialSuccessfulWriteDelay time.Duration
 	storageEnabled                 bool
+
+	bookmarkFrequency time.Duration
 }
 
 // Init implements ResourceServer.
@@ -1566,19 +1581,38 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 		mostRecentRV = s.mostRecentRV.Load()
 	}
 
-	var initialEventsRV int64 // resource version coming from the initial events
+	lastBookmarkRV := int64(-1)
+	sendBookmark := func(rv int64) error {
+		// Don't send repeated bookmarks if no new events were received.
+		if rv <= 0 || rv == lastBookmarkRV {
+			return nil
+		}
+
+		if err := srv.Send(&resourcepb.WatchEvent{
+			Type:     resourcepb.WatchEvent_BOOKMARK,
+			Resource: &resourcepb.WatchEvent_Resource{Version: rv},
+		}); err != nil {
+			return fmt.Errorf("sending bookmark: %w", err)
+		}
+
+		lastBookmarkRV = rv
+		return nil
+	}
+
+	var lastEmittedRV int64 // tracks the most recent RV sent to the client
 	if req.SendInitialEvents {
 		// Backfill the stream by adding every existing entities.
-		initialEventsRV, err = s.backend.ListIterator(ctx, &resourcepb.ListRequest{Options: req.Options}, func(iter ListIterator) error {
+		initialEventsRV, err := s.backend.ListIterator(ctx, &resourcepb.ListRequest{Options: req.Options}, func(iter ListIterator) error {
 			for iter.Next() {
 				if err := iter.Error(); err != nil {
 					return err
 				}
+				rv := iter.ResourceVersion()
 				if err := srv.Send(&resourcepb.WatchEvent{
 					Type: resourcepb.WatchEvent_ADDED,
 					Resource: &resourcepb.WatchEvent_Resource{
 						Value:   iter.Value(),
-						Version: iter.ResourceVersion(),
+						Version: rv,
 					},
 				}); err != nil {
 					return err
@@ -1589,31 +1623,42 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 		if err != nil {
 			return err
 		}
-	}
-	if req.SendInitialEvents && req.AllowWatchBookmarks {
-		if err := srv.Send(&resourcepb.WatchEvent{
-			Type: resourcepb.WatchEvent_BOOKMARK,
-			Resource: &resourcepb.WatchEvent_Resource{
-				Version: initialEventsRV,
-			},
-		}); err != nil {
-			return err
+
+		lastEmittedRV = initialEventsRV
+		if req.AllowWatchBookmarks {
+			if err := sendBookmark(lastEmittedRV); err != nil {
+				return err
+			}
 		}
 	}
 
 	var since int64 // resource version to start watching from
 	switch {
 	case req.SendInitialEvents:
-		since = initialEventsRV
+		since = lastEmittedRV
 	case req.Since == 0:
 		since = mostRecentRV
 	default:
 		since = req.Since
 	}
+
+	// Set up periodic bookmark ticker when the client opted in.
+	var bookmarkC <-chan time.Time
+	if req.AllowWatchBookmarks && s.bookmarkFrequency > 0 {
+		ticker := time.NewTicker(s.bookmarkFrequency)
+		defer ticker.Stop()
+		bookmarkC = ticker.C
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+
+		case <-bookmarkC:
+			if err := sendBookmark(lastEmittedRV); err != nil {
+				return err
+			}
 
 		case event, ok := <-stream:
 			if !ok {
@@ -1659,6 +1704,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				if err := srv.Send(resp); err != nil {
 					return err
 				}
+				lastEmittedRV = event.ResourceVersion
 
 				if s.storageMetrics != nil {
 					// record latency - resource version can be either a unix microsecond timestamp (SQL backend)

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1607,12 +1607,11 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				if err := iter.Error(); err != nil {
 					return err
 				}
-				rv := iter.ResourceVersion()
 				if err := srv.Send(&resourcepb.WatchEvent{
 					Type: resourcepb.WatchEvent_ADDED,
 					Resource: &resourcepb.WatchEvent_Resource{
 						Value:   iter.Value(),
-						Version: rv,
+						Version: iter.ResourceVersion(),
 					},
 				}); err != nil {
 					return err

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	authlib "github.com/grafana/authlib/types"
@@ -1047,5 +1050,264 @@ func TestGracefulShutdown(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("Stop did not respect context deadline")
 		}
+	})
+}
+
+// mockWatchServer implements resourcepb.ResourceStore_WatchServer for testing.
+type mockWatchServer struct {
+	grpc.ServerStream
+	ctx    context.Context
+	events chan *resourcepb.WatchEvent
+}
+
+func newMockWatchServer(ctx context.Context) *mockWatchServer {
+	return &mockWatchServer{
+		ctx:    ctx,
+		events: make(chan *resourcepb.WatchEvent, 100),
+	}
+}
+
+func (m *mockWatchServer) Send(evt *resourcepb.WatchEvent) error {
+	select {
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	case m.events <- evt:
+		return nil
+	}
+}
+
+func (m *mockWatchServer) Context() context.Context     { return m.ctx }
+func (m *mockWatchServer) SetHeader(metadata.MD) error  { return nil }
+func (m *mockWatchServer) SendHeader(metadata.MD) error { return nil }
+func (m *mockWatchServer) SetTrailer(metadata.MD)       {}
+func (m *mockWatchServer) SendMsg(any) error            { return nil }
+func (m *mockWatchServer) RecvMsg(any) error            { return nil }
+
+func TestPeriodicBookmarks(t *testing.T) {
+	testUser := &identity.StaticRequester{
+		Type:           authlib.TypeUser,
+		Login:          "testuser",
+		UserID:         123,
+		UserUID:        "u123",
+		OrgRole:        identity.RoleAdmin,
+		IsGrafanaAdmin: true,
+	}
+
+	group := "playlist.grafana.app"
+	resource := "playlists"
+	namespace := "default"
+
+	var counter int
+	createPlaylist := func(srv *server) error {
+		counter += 1
+		name := fmt.Sprintf("bookmark-test-%d", counter)
+
+		value := []byte(`{
+		"apiVersion": "playlist.grafana.app/v0alpha1",
+		"kind": "Playlist",
+		"metadata": {
+			"name": "` + name + `",
+			"namespace": "` + namespace + `",
+			"uid": "` + fmt.Sprintf("bm-test-uid-%d", counter) + `",
+			"annotations": {
+				"grafana.app/repoName": "test",
+				"grafana.app/repoPath": "path/to/item",
+				"grafana.app/repoTimestamp": "2024-02-02T00:00:00Z"
+			}
+		},
+		"spec": {
+			"title": "` + fmt.Sprintf("playlist %d", counter) + `",
+			"interval": "5m",
+			"items": [{"type": "dashboard_by_uid", "value": "abc"}]
+		}
+	}`)
+
+		key := &resourcepb.ResourceKey{
+			Group:     group,
+			Resource:  resource,
+			Namespace: namespace,
+			Name:      name,
+		}
+
+		ctx := authlib.WithAuthInfo(t.Context(), testUser)
+		created, err := srv.Create(ctx, &resourcepb.CreateRequest{Key: key, Value: value})
+		if err != nil {
+			return err
+		}
+		if created.Error != nil {
+			return fmt.Errorf("creating playlist: %v", created.Error)
+		}
+
+		return nil
+	}
+
+	setup := func(t *testing.T) *server {
+		t.Helper()
+		db, err := badger.Open(badger.DefaultOptions("").
+			WithInMemory(true).
+			WithLogger(nil))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+		kv := NewBadgerKV(db)
+		store, err := NewKVStorageBackend(KVBackendOptions{
+			KvStore:      kv,
+			WatchOptions: WatchOptions{SettleDelay: 1 * time.Millisecond},
+		})
+		require.NoError(t, err)
+
+		srv, err := NewResourceServer(ResourceServerOptions{
+			Backend:           store,
+			BookmarkFrequency: 50 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Stop(stopCtx)
+		})
+
+		// Create a resource so initial events backfill produces a non-zero RV.
+		require.NoError(t, createPlaylist(srv))
+		return srv
+	}
+
+	waitForBookmarks := func(t *testing.T, mock *mockWatchServer, expected int) (bool, []*resourcepb.WatchEvent) {
+		var bookmarks []*resourcepb.WatchEvent
+		for {
+			select {
+			case evt := <-mock.events:
+				if evt.Type == resourcepb.WatchEvent_BOOKMARK {
+					bookmarks = append(bookmarks, evt)
+					if expected > 0 && len(bookmarks) >= expected {
+						return false, bookmarks
+					}
+				}
+			case <-time.After(time.Second):
+				return true, bookmarks
+			}
+		}
+	}
+
+	t.Run("bookmarks sent periodically when AllowWatchBookmarks is true and there are new RVs to report", func(t *testing.T) {
+		srv := setup(t)
+		ctx, cancel := context.WithCancel(authlib.WithAuthInfo(t.Context(), testUser))
+		defer cancel()
+
+		mock := newMockWatchServer(ctx)
+
+		var eg errgroup.Group
+		eg.Go(func() error {
+			return srv.Watch(&resourcepb.WatchRequest{
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:    group,
+						Resource: resource,
+					},
+				},
+				SendInitialEvents:   true,
+				AllowWatchBookmarks: true,
+			}, mock)
+		})
+
+		// keep creating resources, so that new bookmarks are sent
+		eg.Go(func() error {
+			ticker := time.NewTicker(20 * time.Millisecond)
+			for {
+				select {
+				case <-ticker.C:
+					if err := createPlaylist(srv); err != nil {
+						return err
+					}
+
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		})
+
+		// Collect events until we see at least 2 bookmarks (initial + periodic) or timeout.
+		timedOut, bookmarks := waitForBookmarks(t, mock, 2)
+		require.False(t, timedOut, "timed out waiting for bookmarks", "expected: 2, got: %d", len(bookmarks))
+
+		cancel() // stop the watch
+		require.NoError(t, eg.Wait())
+
+		// Bookmarks should have increasing RVs.
+		require.Greater(t, bookmarks[0].Resource.Version, int64(0))
+		require.Greater(t, bookmarks[1].Resource.Version, bookmarks[0].Resource.Version)
+	})
+
+	t.Run("bookmarks are not repeated when AllowWatchBookmarks is true and no resources were created", func(t *testing.T) {
+		srv := setup(t)
+		ctx, cancel := context.WithCancel(authlib.WithAuthInfo(t.Context(), testUser))
+		defer cancel()
+
+		mock := newMockWatchServer(ctx)
+
+		var eg errgroup.Group
+		eg.Go(func() error {
+			return srv.Watch(&resourcepb.WatchRequest{
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:    group,
+						Resource: resource,
+					},
+				},
+				SendInitialEvents:   true,
+				AllowWatchBookmarks: true,
+			}, mock)
+		})
+
+		// Collect all bookmarks for the next 1s.
+		_, bookmarks := waitForBookmarks(t, mock, 0)
+		cancel() // stop the watch
+		require.NoError(t, eg.Wait())
+
+		// Bookmarks should have increasing RVs.
+		require.Len(t, bookmarks, 1)
+		require.Greater(t, bookmarks[0].Resource.Version, int64(0))
+	})
+
+	t.Run("no bookmarks when AllowWatchBookmarks is false", func(t *testing.T) {
+		srv := setup(t)
+		ctx, cancel := context.WithCancel(authlib.WithAuthInfo(t.Context(), testUser))
+		defer cancel()
+
+		mock := newMockWatchServer(ctx)
+		watchDone := make(chan error, 1)
+		go func() {
+			watchDone <- srv.Watch(&resourcepb.WatchRequest{
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:    group,
+						Resource: resource,
+					},
+				},
+				SendInitialEvents:   true,
+				AllowWatchBookmarks: false,
+			}, mock)
+		}()
+
+		// Wait longer than the bookmark frequency — we should see zero bookmarks.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+		<-watchDone
+
+		// Drain events and check for bookmarks.
+		var bookmarkCount int
+	drain:
+		for {
+			select {
+			case evt := <-mock.events:
+				if evt.Type == resourcepb.WatchEvent_BOOKMARK {
+					bookmarkCount++
+				}
+			default:
+				break drain
+			}
+		}
+
+		require.Equal(t, 0, bookmarkCount, "expected no bookmarks when AllowWatchBookmarks is false")
 	})
 }

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1098,7 +1098,7 @@ func TestPeriodicBookmarks(t *testing.T) {
 	namespace := "default"
 
 	var counter int
-	createPlaylist := func(srv *server) error {
+	createPlaylist := func(testCtx context.Context, srv *server) error {
 		counter += 1
 		name := fmt.Sprintf("bookmark-test-%d", counter)
 
@@ -1129,7 +1129,7 @@ func TestPeriodicBookmarks(t *testing.T) {
 			Name:      name,
 		}
 
-		ctx := authlib.WithAuthInfo(t.Context(), testUser)
+		ctx := authlib.WithAuthInfo(testCtx, testUser)
 		created, err := srv.Create(ctx, &resourcepb.CreateRequest{Key: key, Value: value})
 		if err != nil {
 			return err
@@ -1168,7 +1168,7 @@ func TestPeriodicBookmarks(t *testing.T) {
 		})
 
 		// Create a resource so initial events backfill produces a non-zero RV.
-		require.NoError(t, createPlaylist(srv))
+		require.NoError(t, createPlaylist(t.Context(), srv))
 		return srv
 	}
 
@@ -1216,7 +1216,7 @@ func TestPeriodicBookmarks(t *testing.T) {
 			for {
 				select {
 				case <-ticker.C:
-					if err := createPlaylist(srv); err != nil {
+					if err := createPlaylist(t.Context(), srv); err != nil {
 						return err
 					}
 

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1275,9 +1275,9 @@ func TestPeriodicBookmarks(t *testing.T) {
 		defer cancel()
 
 		mock := newMockWatchServer(ctx)
-		watchDone := make(chan error, 1)
-		go func() {
-			watchDone <- srv.Watch(&resourcepb.WatchRequest{
+		var eg errgroup.Group
+		eg.Go(func() error {
+			return srv.Watch(&resourcepb.WatchRequest{
 				Options: &resourcepb.ListOptions{
 					Key: &resourcepb.ResourceKey{
 						Group:    group,
@@ -1287,27 +1287,13 @@ func TestPeriodicBookmarks(t *testing.T) {
 				SendInitialEvents:   true,
 				AllowWatchBookmarks: false,
 			}, mock)
-		}()
+		})
 
-		// Wait longer than the bookmark frequency — we should see zero bookmarks.
-		time.Sleep(200 * time.Millisecond)
+		// Collect all bookmarks for the next 1s.
+		_, bookmarks := waitForBookmarks(t, mock, 0)
 		cancel()
-		<-watchDone
+		require.NoError(t, eg.Wait())
 
-		// Drain events and check for bookmarks.
-		var bookmarkCount int
-	drain:
-		for {
-			select {
-			case evt := <-mock.events:
-				if evt.Type == resourcepb.WatchEvent_BOOKMARK {
-					bookmarkCount++
-				}
-			default:
-				break drain
-			}
-		}
-
-		require.Equal(t, 0, bookmarkCount, "expected no bookmarks when AllowWatchBookmarks is false")
+		require.Empty(t, bookmarks)
 	})
 }


### PR DESCRIPTION
This PR changes the resource server implementation of `Watch` so that it sends periodic (default 10s) "bookmarks" when the client allows it. These bookmarks serve the purpose of indicating to the client that no new events are expected _after_ the RV included in the bookmark. This allows reconnecting clients to use that RV instead of starting from scratch or requesting to `SendInitialEvents`, or sending unnecessarily outdated RVs.

In particular, if the client is using an informer (which automatically reconnects after ~5-10mins), the bookmark allows the server to help the client update its "last known" RV even if no events reach the caller. This is particularly useful for cases where the caller is watching for resources based on some predicate (such as a label filter, for example), as that filtering currently happens on the client.

Without this change the `watch_latency_seconds` metric we collect can look like we're sending events with huge delays, when in reality we are just sending repeated events due to outdated RVs.

Ticket: https://github.com/grafana/search-and-storage-team/issues/749