### PR TITLE
Feature Toggles: Add anyPageReporting feature flag

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -33,6 +33,8 @@ export const FlagKeys = {
   QueryEditorNext: "queryEditorNext",
   /** Enables recently viewed dashboards section in the browsing dashboard page */
   RecentlyViewedDashboards: "recentlyViewedDashboards",
+  /** Enables reporting for any page in Grafana */
+  ReportingAnyPageReporting: "reporting.anyPageReporting",
   /** Enables the splash screen modal for introducing new Grafana features on first session */
   SplashScreen: "splashScreen",
   /** Enables the 'Customize with Assistant' button on suggested dashboard cards */
@@ -205,6 +207,18 @@ export const useFlagQueryEditorNext = (options?: ReactFlagEvaluationOptions): bo
 */
 export const useFlagRecentlyViewedDashboards = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("recentlyViewedDashboards", false, options).value;
+};
+
+
+/**
+* Enables reporting for any page in Grafana
+*
+* **Details:**
+* - flag key: `reporting.anyPageReporting`
+* - default value: `false`
+*/
+export const useFlagReportingAnyPageReporting = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("reporting.anyPageReporting", false, options).value;
 };
 
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3029,6 +3029,14 @@ var (
 			Owner:       grafanaDatasourcesCoreServicesSquad,
 			Expression:  "false",
 		},
+		{
+			Name:        "reporting.anyPageReporting",
+			Description: "Enables reporting for any page in Grafana",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSharingSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true, React: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -353,3 +353,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-09,clickHouseConfigValidation,experimental,@grafana/data-sources-plugins,false,false,false
 2026-04-04,grafana.newPreferencesPage,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-04-14,datasource.useNewCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
+2026-04-17,reporting.anyPageReporting,experimental,@grafana/sharing-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -949,4 +949,8 @@ const (
 	// FlagDatasourceUseNewCRUDAPIs
 	// Use the new datasource API groups for datasource CRUD requests, backend flag
 	FlagDatasourceUseNewCRUDAPIs = "datasource.useNewCRUDAPIs"
+
+	// FlagReportingAnyPageReporting
+	// Enables reporting for any page in Grafana
+	FlagReportingAnyPageReporting = "reporting.anyPageReporting"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -972,6 +972,24 @@
     },
     {
       "metadata": {
+        "name": "anyPageReporting",
+        "resourceVersion": "1776396837578",
+        "creationTimestamp": "2026-04-17T01:00:25Z",
+        "deletionTimestamp": "2026-04-17T03:36:57Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-04-17 03:33:57.578996 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables reporting for any page in Grafana",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "appPlatformGrpcClientAuth",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2024-10-14T10:47:18Z"
@@ -4914,6 +4932,19 @@
         "description": "Enables render binding support for report rendering",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "reporting.anyPageReporting",
+        "resourceVersion": "1776397017304",
+        "creationTimestamp": "2026-04-17T03:36:57Z"
+      },
+      "spec": {
+        "description": "Enables reporting for any page in Grafana",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
         "expression": "false"
       }
     },


### PR DESCRIPTION
**What is this feature?**

Adds a new `anyPageReporting` feature flag that enables reporting for any page in Grafana. The flag is registered as experimental and disabled by default.

**Why do we need this feature?**

To gate the rollout of any-page reporting capabilities behind a feature toggle, allowing incremental testing and controlled enablement.

**Who is this feature for?**

Grafana operators and users who want to generate reports from any page, not just dashboards.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

- The flag is `FeatureStageExperimental` with a TODO comment asking whether it can be promoted to `PublicPreview` or `GeneralAvailability`.
- It is disabled by default (`Expression: "false"`) since experimental flags cannot be enabled by default per registry constraints.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.