### PR TITLE
TimeComparison: Add tests for Scene to V2 time range serialization

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -1578,7 +1578,7 @@ describe('vizPanelToSchemaV2 time range fields', () => {
 
   function getQueryOptions(timeRange?: SceneTimeRange | PanelTimeRange) {
     const result = vizPanelToSchemaV2(buildPanel(timeRange), undefined, false);
-    expect(result.kind).toEqual('Panel')
+    expect(result.kind).toEqual('Panel');
     return (result.spec as PanelSpec).data.spec.queryOptions;
   }
 
@@ -1615,19 +1615,15 @@ describe('vizPanelToSchemaV2 time range fields', () => {
     });
   });
 
-  const isolationCases = [
-    { name: 'timeFrom only', state: { timeFrom: '2h' }, field: 'timeFrom', value: '2h' },
-    { name: 'timeShift only', state: { timeShift: '1h' }, field: 'timeShift', value: '1h' },
-    { name: 'hideTimeOverride only', state: { hideTimeOverride: true }, field: 'hideTimeOverride', value: true },
-    { name: 'compareWith only maps to timeCompare', state: { compareWith: '1d' }, field: 'timeCompare', value: '1d' },
-  ] as const;
+  it.each([
+    ['timeFrom only', { timeFrom: '2h' }, 'timeFrom', '2h'],
+    ['timeShift only', { timeShift: '1h' }, 'timeShift', '1h'],
+    ['hideTimeOverride only', { hideTimeOverride: true }, 'hideTimeOverride', true],
+    ['compareWith only maps to timeCompare', { compareWith: '1d' }, 'timeCompare', '1d'],
+  ] as const)('should serialize %s', (_, state, field, value) => {
+    const queryOptions = getQueryOptions(new PanelTimeRange(state));
 
-  isolationCases.forEach(({ name, state, field, value }) => {
-    it(`should serialize ${name}`, () => {
-      const queryOptions = getQueryOptions(new PanelTimeRange(state));
-
-      expect(queryOptions[field]).toBe(value);
-    });
+    expect(queryOptions[field]).toBe(value);
   });
 });
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -1583,11 +1583,13 @@ describe('vizPanelToSchemaV2 time range fields', () => {
     return (result.spec as PanelSpec).data.spec.queryOptions;
   }
 
-  function expectNoTimeRangeFields(queryOptions: ReturnType<typeof getQueryOptions>) {
-    expect(queryOptions.timeFrom).toBeUndefined();
-    expect(queryOptions.timeShift).toBeUndefined();
-    expect(queryOptions.hideTimeOverride).toBeUndefined();
-    expect(queryOptions.timeCompare).toBeUndefined();
+  function expectNoTimeRangeFields(queryOptions: ReturnType<typeof getQueryOptions>, except?: string) {
+    const fields = ['timeFrom', 'timeShift', 'hideTimeOverride', 'timeCompare'] as const;
+    for (const f of fields) {
+      if (f !== except) {
+        expect(queryOptions[f]).toBeUndefined();
+      }
+    }
   }
 
   it('should omit time range fields when the panel has no $timeRange', () => {
@@ -1625,6 +1627,7 @@ describe('vizPanelToSchemaV2 time range fields', () => {
     const queryOptions = getQueryOptions(new PanelTimeRange(state));
 
     expect(queryOptions[field]).toBe(value);
+    expectNoTimeRangeFields(queryOptions, field);
   });
 });
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -1578,10 +1578,8 @@ describe('vizPanelToSchemaV2 time range fields', () => {
 
   function getQueryOptions(timeRange?: SceneTimeRange | PanelTimeRange) {
     const result = vizPanelToSchemaV2(buildPanel(timeRange), undefined, false);
-    if (result.kind !== 'Panel') {
-      throw new Error(`Expected PanelKind, got ${result.kind}`);
-    }
-    return result.spec.data.spec.queryOptions;
+    expect(result.kind).toEqual('Panel')
+    return (result.spec as PanelSpec).data.spec.queryOptions;
   }
 
   function expectNoTimeRangeFields(queryOptions: ReturnType<typeof getQueryOptions>) {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -42,6 +42,7 @@ import {
   type RowsLayoutSpec,
   type TabsLayoutSpec,
   defaultDataQueryKind,
+  type PanelSpec,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -61,6 +61,7 @@ import { RowItem } from '../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { TabItem } from '../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../scene/layout-tabs/TabsLayoutManager';
+import { PanelTimeRange } from '../scene/panel-timerange/PanelTimeRange';
 import { type DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { djb2Hash } from '../utils/djb2Hash';
 
@@ -1562,6 +1563,73 @@ describe('vizPanelToSchemaV2 snapshot repeat clones', () => {
     expect(snapshotElement.kind).toBe('Panel');
     expect(snapshotElement.spec.id).toBe(djb2Hash(cloneKey));
     expect(snapshotElement.spec.id).not.toBe(normalElement.spec.id);
+  });
+});
+
+describe('vizPanelToSchemaV2 time range fields', () => {
+  function buildPanel(timeRange?: SceneTimeRange | PanelTimeRange) {
+    return new VizPanel({
+      key: 'panel-1',
+      pluginId: 'timeseries',
+      title: 'Test',
+      ...(timeRange && { $timeRange: timeRange }),
+    });
+  }
+
+  function getQueryOptions(timeRange?: SceneTimeRange | PanelTimeRange) {
+    const result = vizPanelToSchemaV2(buildPanel(timeRange), undefined, false);
+    if (result.kind !== 'Panel') {
+      throw new Error(`Expected PanelKind, got ${result.kind}`);
+    }
+    return result.spec.data.spec.queryOptions;
+  }
+
+  function expectNoTimeRangeFields(queryOptions: ReturnType<typeof getQueryOptions>) {
+    expect(queryOptions.timeFrom).toBeUndefined();
+    expect(queryOptions.timeShift).toBeUndefined();
+    expect(queryOptions.hideTimeOverride).toBeUndefined();
+    expect(queryOptions.timeCompare).toBeUndefined();
+  }
+
+  it('should omit time range fields when the panel has no $timeRange', () => {
+    expectNoTimeRangeFields(getQueryOptions());
+  });
+
+  it('should omit time range fields when $timeRange is a SceneTimeRange (not PanelTimeRange)', () => {
+    expectNoTimeRangeFields(getQueryOptions(new SceneTimeRange({})));
+  });
+
+  it('should serialize all four time range fields when set on PanelTimeRange', () => {
+    const queryOptions = getQueryOptions(
+      new PanelTimeRange({
+        timeFrom: '2h',
+        timeShift: '1h',
+        hideTimeOverride: true,
+        compareWith: '1d',
+      })
+    );
+
+    expect(queryOptions).toMatchObject({
+      timeFrom: '2h',
+      timeShift: '1h',
+      hideTimeOverride: true,
+      timeCompare: '1d',
+    });
+  });
+
+  const isolationCases = [
+    { name: 'timeFrom only', state: { timeFrom: '2h' }, field: 'timeFrom', value: '2h' },
+    { name: 'timeShift only', state: { timeShift: '1h' }, field: 'timeShift', value: '1h' },
+    { name: 'hideTimeOverride only', state: { hideTimeOverride: true }, field: 'hideTimeOverride', value: true },
+    { name: 'compareWith only maps to timeCompare', state: { compareWith: '1d' }, field: 'timeCompare', value: '1d' },
+  ] as const;
+
+  isolationCases.forEach(({ name, state, field, value }) => {
+    it(`should serialize ${name}`, () => {
+      const queryOptions = getQueryOptions(new PanelTimeRange(state));
+
+      expect(queryOptions[field]).toBe(value);
+    });
   });
 });
 


### PR DESCRIPTION
## What's added

- 7 new unit tests for time-range serialization in the Scene → V2 transformer
- Target: `getVizPanelQueryOptions` in `public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts` (tested via the exported `vizPanelToSchemaV2`)
- Added to the existing test file under a new `describe('vizPanelToSchemaV2 time range fields')` block

## Coverage scope

- **All four `PanelTimeRange` fields** serialized correctly:
  - `timeFrom`
  - `timeShift`
  - `hideTimeOverride`
  - `compareWith` → `timeCompare` (name remap)
- **No `$timeRange`** on the panel → fields are omitted from `queryOptions`
- **`$timeRange` is a `SceneTimeRange` (not a `PanelTimeRange`)** → the `instanceof PanelTimeRange` guard correctly skips serialization
- **Each field in isolation** (parameterized testCases) — ensures one field set doesn't interfere with others

## Coverage change

Measured on `transformSceneToSaveModelSchemaV2.ts`:

| Metric     | Before  | After   | Δ         |
|------------|---------|---------|-----------|
| Statements | 76.27%  | 77.29%  | **+1.02%** |
| Branches   | 77.91%  | 78.09%  | +0.18%    |
| Functions  | 80%     | 80%     | 0%        |
| Lines      | 76.34%  | 77.37%  | **+1.03%** |

Adds coverage for the four `PanelTimeRange` field assignments in `getVizPanelQueryOptions` (lines 555–558) that had no prior tests. Function count is unchanged because `getVizPanelQueryOptions` was already reached indirectly by other tests — this PR covers the body, not the call-path.

## Context

Part of #122044 (TimeComparison: Test Coverage) — workstream 2 (verify unit-test coverage).

## Test plan

- [x] \`yarn jest --no-watch public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts\` — 49 tests pass (7 new, 42 existing)
- [x] \`yarn typecheck\` — clean across 15 projects
- [x] \`yarn eslint\` — clean
- [x] \`yarn prettier --check\` — clean