### PR TITLE
TimeComparison: Extend buildVizPanel tests for time range fields and hoverHeader

### DIFF
--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -378,13 +378,14 @@ describe('ensureUniqueRefIds', () => {
 });
 
 describe('buildVizPanel', () => {
+  // Pass title='' to test hoverHeader behavior (no title); omit to use the defaultPanelSpec title.
   function buildPanelWithQueryOptions(queryOptions: Partial<QueryOptionsSpec>, title?: string): PanelKind {
     const base = defaultPanelSpec();
     return {
       kind: 'Panel',
       spec: {
         ...base,
-        ...(title !== undefined && { title }),
+        ...(title !== undefined ? { title } : {}),
         data: {
           kind: 'QueryGroup',
           spec: {
@@ -404,18 +405,14 @@ describe('buildVizPanel', () => {
     return viz.state.$timeRange;
   }
 
-  const singleFieldCases = [
-    { queryOptionsField: 'timeCompare', stateField: 'compareWith', value: '1d' },
-    { queryOptionsField: 'timeFrom', stateField: 'timeFrom', value: '2h' },
-    { queryOptionsField: 'timeShift', stateField: 'timeShift', value: '1h' },
-  ] as const;
+  it.each([
+    ['timeCompare', 'compareWith', '1d'],
+    ['timeFrom', 'timeFrom', '2h'],
+    ['timeShift', 'timeShift', '1h'],
+  ] as const)('maps queryOptions.%s to PanelTimeRange %s', (queryOptionsField, stateField, value) => {
+    const panelTime = getPanelTimeRange(buildPanelWithQueryOptions({ [queryOptionsField]: value }));
 
-  singleFieldCases.forEach(({ queryOptionsField, stateField, value }) => {
-    it(`maps queryOptions.${queryOptionsField} to PanelTimeRange ${stateField}`, () => {
-      const panelTime = getPanelTimeRange(buildPanelWithQueryOptions({ [queryOptionsField]: value }));
-
-      expect(panelTime.state[stateField]).toBe(value);
-    });
+    expect(panelTime.state[stateField]).toBe(value);
   });
 
   it('carries hideTimeOverride when another time field triggers PanelTimeRange creation', () => {

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -3,6 +3,7 @@ import {
   defaultPanelSpec,
   type PanelKind,
   type PanelQueryKind,
+  type QueryOptionsSpec,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
@@ -377,29 +378,121 @@ describe('ensureUniqueRefIds', () => {
 });
 
 describe('buildVizPanel', () => {
-  it('maps queryOptions.timeCompare to PanelTimeRange compareWith', () => {
+  function buildPanelWithQueryOptions(queryOptions: Partial<QueryOptionsSpec>, title?: string): PanelKind {
     const base = defaultPanelSpec();
-    const panel: PanelKind = {
+    return {
       kind: 'Panel',
       spec: {
         ...base,
+        ...(title !== undefined && { title }),
         data: {
           kind: 'QueryGroup',
           spec: {
             ...base.data.spec,
-            queryOptions: {
-              ...base.data.spec.queryOptions,
-              timeCompare: '1d',
-            },
+            queryOptions: { ...base.data.spec.queryOptions, ...queryOptions },
           },
         },
       },
     };
+  }
+
+  function getPanelTimeRange(panel: PanelKind): PanelTimeRange {
     const viz = buildVizPanel(panel);
     if (!(viz.state.$timeRange instanceof PanelTimeRange)) {
       throw new Error('$timeRange must be PanelTimeRange');
     }
-    expect(viz.state.$timeRange).toBeDefined();
-    expect(viz.state.$timeRange?.state.compareWith).toBe('1d');
+    return viz.state.$timeRange;
+  }
+
+  const singleFieldCases = [
+    { queryOptionsField: 'timeCompare', stateField: 'compareWith', value: '1d' },
+    { queryOptionsField: 'timeFrom', stateField: 'timeFrom', value: '2h' },
+    { queryOptionsField: 'timeShift', stateField: 'timeShift', value: '1h' },
+  ] as const;
+
+  singleFieldCases.forEach(({ queryOptionsField, stateField, value }) => {
+    it(`maps queryOptions.${queryOptionsField} to PanelTimeRange ${stateField}`, () => {
+      const panelTime = getPanelTimeRange(buildPanelWithQueryOptions({ [queryOptionsField]: value }));
+
+      expect(panelTime.state[stateField]).toBe(value);
+    });
+  });
+
+  it('carries hideTimeOverride when another time field triggers PanelTimeRange creation', () => {
+    const panelTime = getPanelTimeRange(buildPanelWithQueryOptions({ timeFrom: '2h', hideTimeOverride: true }));
+
+    expect(panelTime.state.hideTimeOverride).toBe(true);
+  });
+
+  it('maps all four time fields when set together', () => {
+    const panelTime = getPanelTimeRange(
+      buildPanelWithQueryOptions({
+        timeFrom: '2h',
+        timeShift: '1h',
+        hideTimeOverride: true,
+        timeCompare: '1d',
+      })
+    );
+
+    expect(panelTime.state).toMatchObject({
+      timeFrom: '2h',
+      timeShift: '1h',
+      hideTimeOverride: true,
+      compareWith: '1d',
+    });
+  });
+
+  it('does not create $timeRange when only hideTimeOverride is set', () => {
+    // hideTimeOverride alone is not one of the three trigger fields (timeFrom/timeShift/timeCompare).
+    const viz = buildVizPanel(buildPanelWithQueryOptions({ hideTimeOverride: true }));
+
+    expect(viz.state.$timeRange).toBeUndefined();
+  });
+
+  it('does not create $timeRange when no time fields are set', () => {
+    const viz = buildVizPanel(buildPanelWithQueryOptions({}));
+
+    expect(viz.state.$timeRange).toBeUndefined();
+  });
+
+  describe('hoverHeader interaction with time range', () => {
+    // hoverHeader is shown only when there's no title AND no visible time override.
+    // timeOverrideShown = (timeFrom || timeShift) && !hideTimeOverride — note timeCompare is NOT included.
+
+    it('shows hoverHeader when there is no title and no time fields', () => {
+      const viz = buildVizPanel(buildPanelWithQueryOptions({}, ''));
+
+      expect(viz.state.hoverHeader).toBe(true);
+    });
+
+    it('hides hoverHeader when timeFrom is visible (no hideTimeOverride)', () => {
+      const viz = buildVizPanel(buildPanelWithQueryOptions({ timeFrom: '2h' }, ''));
+
+      expect(viz.state.hoverHeader).toBe(false);
+    });
+
+    it('hides hoverHeader when timeShift is visible', () => {
+      const viz = buildVizPanel(buildPanelWithQueryOptions({ timeShift: '1h' }, ''));
+
+      expect(viz.state.hoverHeader).toBe(false);
+    });
+
+    it('shows hoverHeader when timeFrom is set but hideTimeOverride suppresses it', () => {
+      const viz = buildVizPanel(buildPanelWithQueryOptions({ timeFrom: '2h', hideTimeOverride: true }, ''));
+
+      expect(viz.state.hoverHeader).toBe(true);
+    });
+
+    it('shows hoverHeader when only timeCompare is set (timeCompare is not a visible time override)', () => {
+      const viz = buildVizPanel(buildPanelWithQueryOptions({ timeCompare: '1d' }, ''));
+
+      expect(viz.state.hoverHeader).toBe(true);
+    });
+
+    it('hides hoverHeader when the panel has a title, regardless of time fields', () => {
+      const viz = buildVizPanel(buildPanelWithQueryOptions({ timeFrom: '2h', hideTimeOverride: true }, 'My Panel'));
+
+      expect(viz.state.hoverHeader).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## What's added

- 12 new unit tests for V2 → Scene deserialization of time-range fields in `buildVizPanel`
- Target: `buildVizPanel` in `public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts`
- Expands the existing single-test `describe('buildVizPanel')` block; introduces a nested `describe('hoverHeader interaction with time range')`

## Coverage scope

- **All four time-range fields** round-trip correctly from `queryOptions` to `PanelTimeRange`:
  - `timeCompare` → `compareWith`
  - `timeFrom` → `timeFrom`
  - `timeShift` → `timeShift`
  - `hideTimeOverride` (carried when another trigger field is set)
- **All four set together** → full happy path
- **Guard behavior**:
  - `hideTimeOverride` alone does **not** create `$timeRange` (not a trigger field)
  - No time fields → no `$timeRange`
- **`hoverHeader` interaction** (regression protection for subtle `timeOverrideShown` rule):
  - Shown when no title + no time fields
  - Hidden when `timeFrom`/`timeShift` is visible
  - Shown when `timeFrom` + `hideTimeOverride: true` (override suppressed)
  - **Shown when only `timeCompare` is set** — timeCompare is NOT counted as a visible time override (easy to accidentally break)
  - Hidden when a title is set, regardless of time fields

## Coverage change

Measured on `layoutSerializers/utils.ts`:

| Metric     | Before  | After   | Δ         |
|------------|---------|---------|-----------|
| Statements | 69.44%  | 69.44%  | 0%        |
| Branches   | 60.00%  | 60.62%  | **+0.62%** |
| Functions  | 55%     | 55%     | 0%        |
| Lines      | 69.28%  | 69.28%  | 0%        |

Lines didn't move because the time-range assignments were already executed by the existing `timeCompare` test; the new tests exercise **different branches** of the trigger guard and cover previously-untested `hoverHeader` observable behavior.

## Context

Part of #122044 (TimeComparison: Test Coverage) — workstream 3 (V2 → Scene deserialization, complements PR #122895 which covered Scene → V2).

## Test plan

- [x] \`yarn jest --no-watch public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts\` — 35 tests pass (12 new, 23 existing)
- [x] \`yarn typecheck\` — clean across 15 projects
- [x] \`yarn eslint\` — clean
- [x] \`yarn prettier --check\` — clean