### PR TITLE
TimeRangePicker: Fix calendar reverting when clicking a date range

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -333,6 +333,27 @@ describe('TimeRangeForm', () => {
     expect(to).toHaveClass('react-calendar__tile--rangeEnd');
   });
 
+  it('should update the selected range when clicking the same date twice in the calendar', async () => {
+    const { getAllByRole, getCalendarDayByLabelText, findByLabelText } = setup();
+    const openCalendarButton = getAllByRole('button', { name: 'Open calendar' });
+
+    await user.click(openCalendarButton[0]);
+
+    const targetDay = getCalendarDayByLabelText('June 15, 2021');
+    await user.click(targetDay);
+    await user.click(targetDay);
+
+    const updatedTarget = getCalendarDayByLabelText('June 15, 2021');
+    expect(updatedTarget).toHaveClass('react-calendar__tile--rangeStart');
+    expect(updatedTarget).toHaveClass('react-calendar__tile--rangeEnd');
+
+    const previousRangeStart = getCalendarDayByLabelText('June 17, 2021');
+    expect(previousRangeStart).not.toHaveClass('react-calendar__tile--rangeStart');
+
+    expect(await findByLabelText('From')).toHaveValue('2021-06-15 00:00:00');
+    expect(await findByLabelText('To')).toHaveValue('2021-06-15 23:59:59');
+  });
+
   it('should copy time range to clipboard', async () => {
     setup();
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -79,7 +79,7 @@ export const TimeRangeContent = (props: Props) => {
     register,
     formState: { errors },
     setValue,
-    getValues,
+    watch,
   } = useForm<FormState>({
     defaultValues: {
       from: valueAsString(value.raw.from, timeZone),
@@ -259,8 +259,8 @@ export const TimeRangeContent = (props: Props) => {
       <TimePickerCalendar
         isFullscreen={isFullscreen}
         isOpen={isOpen}
-        from={dateTimeParse(getValues('from'), { timeZone })}
-        to={dateTimeParse(getValues('to'), { timeZone })}
+        from={dateTimeParse(watch('from'), { timeZone })}
+        to={dateTimeParse(watch('to'), { timeZone })}
         onApply={onApply}
         onClose={() => setOpen(false)}
         onChange={onChange}


### PR DESCRIPTION
**What is this feature?**

Fixes a regression in `TimeRangePicker` where selecting a date range in the calendar (including clicking the same date twice) caused the calendar to revert to the previously selected range. Uses `react-hook-form`'s `watch` in place of `getValues` so `<TimePickerCalendar>` re-renders when form values change, and adds a regression test covering the "click same date twice" case.

**Why do we need this feature?**

#122259 migrated `TimeRangeContent` to `react-hook-form` and switched from `useState` to `getValues('from')` / `getValues('to')` when passing props to `<TimePickerCalendar>`. `getValues` is not reactive — `setValue` from the calendar's `onChange` updated the form state but did not trigger a re-render, so the `value` prop passed to `react-calendar` stayed stale and the calendar displayed the old range instead of the user's new selection.

## Test plan
- [ ] Open any dashboard, open the `TimeRangePicker` calendar
- [ ] Click the same date twice — the calendar should select that single date (not revert to the previous range)
- [ ] Click date A then date B — the new range A–B should remain selected (not revert to the previous range)
- [ ] `yarn jest packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)