### PR TITLE
Heatmap: Improve e2e coverage

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -88,7 +88,7 @@
   "dev-dashboards-output/panel-graph/graph_y_axis.v42.json": "72f51905281077a08bbf2dda4ab68c4b0bba6497c4e92050264566e583621008",
   "dev-dashboards-output/panel-heatmap/heatmap-calculate-log.v42.json": "560fd46dbf956d48aa07b0037298d0727d57c81a193b7d6eebf698cd2dc0951a",
   "dev-dashboards-output/panel-heatmap/heatmap-legacy.v42.json": "18628784ae048681f51fe7e6ff8711a0d962055420583833b3095d1da7401a08",
-  "dev-dashboards-output/panel-heatmap/heatmap-x.v42.json": "e3a9918cf0152fdc5598c225f5e3f8c3dad24b5d7c0d1cd93b74a40622288c72",
+  "dev-dashboards-output/panel-heatmap/heatmap-x.v42.json": "d1a3fb35ad06641481800eec2099c0dd157870563edb3062350b64c45d7db5f0",
   "dev-dashboards-output/panel-histogram/histogram_tests.v42.json": "b5d24c38c338f736f89c3a4e98a6605206b460133a9fdd017637f91308b4bbf0",
   "dev-dashboards-output/panel-library/panel-library.v42.json": "8915254d7cdcced110043ed807d6c5924417bd83c1a9de12d11be67045872751",
   "dev-dashboards-output/panel-logstable/logs-table.v42.json": "82b1e4b34f5cf6a3d121e4328cbc1643fbec460d7d187f37253599f09599dfd2",

--- a/devenv/dev-dashboards/panel-heatmap/heatmap-x.json
+++ b/devenv/dev-dashboards/panel-heatmap/heatmap-x.json
@@ -95,6 +95,25 @@
       },
       "fieldConfig": {
         "defaults": {
+          "links": [
+            {
+              "title": "Heatmap docs data link",
+              "url": "https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/visualizations/heatmap/"
+            }
+          ],
+          "actions": [
+            {
+              "fetch": {
+                "body": "{}",
+                "headers": [["Content-Type", "application/json"]],
+                "method": "GET",
+                "queryParams": [],
+                "url": "https://grafana.com"
+              },
+              "title": "Heatmap unsupported action",
+              "type": "fetch"
+            }
+          ],
           "custom": {
             "hideFrom": {
               "legend": false,
@@ -159,7 +178,7 @@
           "refId": "A"
         }
       ],
-      "title": "Row heatmap",
+      "title": "Row heatmap (data links)",
       "type": "heatmap"
     },
     {
@@ -375,6 +394,6 @@
   "timezone": "",
   "title": "Heatmap X axis",
   "uid": "5Y0jv6pVz",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/e2e-playwright/panels-suite/heatmap.spec.ts
+++ b/e2e-playwright/panels-suite/heatmap.spec.ts
@@ -4,18 +4,26 @@ const DASHBOARD_UID = '5Y0jv6pVz';
 const TIME_RANGE_PAN_DASHBOARD_UID = 'YoacZIq7z';
 
 test.describe('Panels test: Heatmap', { tag: ['@panels', '@heatmap'] }, () => {
-  test('renders successfully', async ({ gotoDashboardPage, selectors, page }) => {
+  test.use({
+    viewport: { width: 1280, height: 2200 },
+  });
+
+  test('renders dashboard with row and cells heatmaps', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
     });
 
-    // check that gauges are rendered
-    const uplot = page.locator('.uplot');
-    await expect(uplot, 'panels are rendered').toHaveCount(2);
+    await test.step('Row layout and cells heatmap panels are present', async () => {
+      await expect(page.getByText('Row heatmap (data links)')).toBeVisible();
+      await expect(page.getByText('Cells heatmap')).toBeVisible();
+    });
 
-    // check that no panel errors exist
-    const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));
-    await expect(errorInfo, 'no errors in the panels').toBeHidden();
+    await test.step('Two uPlot heatmaps render without panel errors', async () => {
+      const uplot = page.locator('.uplot');
+      await expect(uplot, 'row + cells heatmaps').toHaveCount(2);
+      const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));
+      await expect(errorInfo, 'no errors in the panels').toBeHidden();
+    });
   });
 
   test('"no data"', async ({ gotoDashboardPage, selectors, page }) => {
@@ -31,7 +39,145 @@ test.describe('Panels test: Heatmap', { tag: ['@panels', '@heatmap'] }, () => {
     await expect(emptyMessage, 'that the empty text appears').toHaveText('No data');
   });
 
-  // TODO tooltips, legends, and panel editing
+  test('tooltip: hover, pin, dismiss with Escape; Hidden mode hides tooltip', async ({
+    gotoDashboardPage,
+    selectors,
+    page,
+  }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '4' }),
+    });
+
+    const heatmapUplot = page.locator('.uplot').first();
+    await expect(heatmapUplot, 'uplot is rendered').toBeVisible();
+
+    const uOver = heatmapUplot.locator('.u-over');
+    const box = await uOver.boundingBox();
+    if (!box) {
+      throw new Error('u-over bounding box not found');
+    }
+    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+    const alt = { x: Math.round(box.width / 4), y: center.y };
+
+    const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+
+    await test.step('Hover shows tooltip', async () => {
+      await heatmapUplot.hover({ position: center, force: true });
+      await expect(tooltip, 'tooltip appears on hover').toBeVisible();
+    });
+
+    await test.step('Click pins tooltip; hover elsewhere keeps it pinned', async () => {
+      await heatmapUplot.click({ position: center, force: true });
+      await heatmapUplot.hover({ position: alt, force: true });
+      await expect(tooltip, 'tooltip pinned on click').toBeVisible();
+    });
+
+    await test.step('Escape dismisses pinned tooltip', async () => {
+      await page.keyboard.press('Escape');
+      await expect(tooltip, 'tooltip closed on Escape').toBeHidden();
+    });
+
+    await test.step('Tooltip mode Hidden suppresses tooltip on hover', async () => {
+      const tooltipModeOption = page.getByTestId('data-testid Tooltip Tooltip mode field property editor');
+      await tooltipModeOption.scrollIntoViewIfNeeded();
+      await tooltipModeOption.getByRole('radio', { name: /hidden/i }).click();
+      await heatmapUplot.hover({ position: center, force: true });
+      await expect(tooltip, 'tooltip not shown when disabled').toBeHidden();
+    });
+  });
+
+  test('data links in pinned tooltip; field actions are not offered (heatmap)', async ({
+    gotoDashboardPage,
+    selectors,
+    page,
+  }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '4' }),
+    });
+
+    const heatmapUplot = page.locator('.uplot').first();
+    await expect(heatmapUplot, 'uplot is rendered').toBeVisible();
+
+    const uOver = heatmapUplot.locator('.u-over');
+    const box = await uOver.boundingBox();
+    if (!box) {
+      throw new Error('u-over bounding box not found');
+    }
+    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+
+    const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+
+    await heatmapUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip shown on hover').toBeVisible();
+    await heatmapUplot.click({ position: center, force: true });
+    await expect(
+      page.getByTestId(selectors.components.Portal.container).getByRole('button', { name: 'Close' }),
+      'tooltip pinned on click'
+    ).toBeVisible();
+
+    await expect(tooltip.getByText('Heatmap docs data link'), 'data link visible in tooltip').toBeVisible();
+
+    await expect(
+      tooltip.getByRole('button', { name: 'Heatmap unsupported action' }),
+      'field actions are not supported for heatmap (see docs)'
+    ).toHaveCount(0);
+  });
+
+  test('legend: toggling Show legend hides and shows color scale', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '4' }),
+    });
+
+    const legend = page.getByTestId('data-testid viz-layout-legend');
+    await expect(legend, 'legend is rendered').toBeVisible();
+
+    const panelOptionsLegendGroup = page.getByTestId('data-testid Options group Legend');
+    await panelOptionsLegendGroup.scrollIntoViewIfNeeded();
+    const legendSwitch = panelOptionsLegendGroup.getByLabel('Show legend');
+    const legendLabel = panelOptionsLegendGroup.getByText('Show legend', { exact: true });
+
+    await test.step('Turn legend off', async () => {
+      await expect(legendSwitch, 'legend is enabled by default').toBeChecked();
+      await legendLabel.click();
+      await expect(legendSwitch).not.toBeChecked({ timeout: 400 });
+      await expect(legend, 'legend is no longer visible').not.toBeVisible();
+    });
+
+    await test.step('Turn legend back on', async () => {
+      await legendLabel.click();
+      await expect(legendSwitch).toBeChecked({ timeout: 400 });
+      await expect(legend, 'legend visible again').toBeVisible();
+    });
+  });
+
+  test('panel options: Y axis reverse and tooltip histogram toggle', async ({ gotoDashboardPage, page }) => {
+    test.slow();
+    await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '4' }),
+    });
+
+    // Histogram first: toggling Y reverse re-renders the chart and can destabilize the options pane
+    // while the next control is still settling (30s timeout + closed page flake).
+    const histogramField = page.getByTestId('data-testid Tooltip Show histogram (Y axis) field property editor');
+    await histogramField.scrollIntoViewIfNeeded();
+    const histogramInput = histogramField.locator('input[type="checkbox"]');
+    const histogramLabel = histogramField.getByText('Show histogram (Y axis)', { exact: true });
+    await expect(histogramInput, 'histogram starts off').not.toBeChecked();
+    await histogramLabel.click();
+    await expect(histogramInput, 'histogram toggled on').toBeChecked();
+
+    const reverseField = page.getByTestId('data-testid Y Axis Reverse field property editor');
+    await reverseField.scrollIntoViewIfNeeded();
+    const reverseInput = reverseField.locator('input[type="checkbox"]');
+    const reverseLabel = reverseField.getByText('Reverse', { exact: true });
+    await expect(reverseInput, 'reverse starts off').not.toBeChecked();
+    await reverseLabel.click();
+    await expect(reverseInput, 'reverse toggled on').toBeChecked();
+  });
 });
 
 test.use({


### PR DESCRIPTION
1. Smoke: dashboard loads row + cells heatmaps, without errors.
2. No-data panel shows No data.
3. Tooltips: hover, pin, Escape to dismiss. Tooltip mode Hidden suppresses hover tooltips.
5. Data links appear in a pinned tooltip on the row heatmap.
6. Legend: Show legend toggles color scale visibility.
7. Options: Show histogram (Y axis) and Y axis reverse toggles in the panel editor.
8. Existing x-axis time-range pan test unchanged.

Closes https://github.com/grafana/grafana/issues/112993