### PR TITLE
[release-12.1.11] Chore(deps): Upgrade protobufjs to >= 7.5.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27155,8 +27155,8 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0":
-  version: 7.3.2
-  resolution: "protobufjs@npm:7.3.2"
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -27170,7 +27170,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/816604aa0649a93fd5d3ef2858ef038f482d18eebcfb4201fe85c0d3bcccc12410f9e3e73262f1219e6b5bed4f27b28c3bf7c931c409dfb1fd563a304d541d89
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Semver-compatible upgrade of `protobufjs` to fix a known CVE
- Fixed version: >= 7.5.5
- Method: `yarn up -R protobufjs`

## Test plan
- [ ] CI passes
- [ ] `yarn why protobufjs --recursive` shows no vulnerable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)