### PR TITLE
Perf: use date-fns deep imports instead of barrel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,5 @@ devenv/docker/blocks/auth/signer/keys/ec_private_key.pem
 .specs
 .playwright-mcp/
 overrides.yaml
+
+.profiles

--- a/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
@@ -1,4 +1,6 @@
-import { differenceInMinutes, parseISO, toDate } from 'date-fns';
+import { differenceInMinutes } from 'date-fns/differenceInMinutes';
+import { parseISO } from 'date-fns/parseISO';
+import { toDate } from 'date-fns/toDate';
 import { type Page } from 'playwright-core';
 
 import { test, expect, type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -171,6 +171,7 @@ module.exports = [
       '@grafana/no-border-radius-literal': 'error',
       '@grafana/no-unreduced-motion': 'error',
       '@grafana/no-restricted-img-srcs': 'error',
+      '@grafana/no-direct-date-fns': 'error',
       'react-prefer-function-component/react-prefer-function-component': ['error', { allowJsxUtilityClass: true }],
       'react/prop-types': 'off',
       // need to ignore emotion's `css` prop, see https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md#rule-options

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:coverage:changes": "jest --coverage --changedSince=origin/main",
     "test:storybook": "yarn workspace @grafana/ui storybook:test",
     "test:accessibility-report": "./scripts/generate-a11y-report.sh",
+    "test:profile": "node --cpu-prof --cpu-prof-dir=.profiles --cpu-prof-name=grafana-jest-$(date -u +\"%Y-%m-%dT%H:%M:%S\").cpuprofile node_modules/.bin/jest --runInBand --no-coverage --no-cache",
     "test:ci": "mkdir -p reports/junit && JEST_JUNIT_OUTPUT_DIR=reports/junit jest --ci --reporters=default --reporters=jest-junit -w ${TEST_MAX_WORKERS:-100%} --shard=${TEST_SHARD:-1}/${TEST_SHARD_TOTAL:-1}",
     "lint": "yarn run lint:ts && yarn run lint:sass",
     "lint:ts": "eslint ./ ./public/app/extensions/ --cache --no-error-on-unmatched-pattern",

--- a/packages/grafana-data/src/datetime/durationutil.ts
+++ b/packages/grafana-data/src/datetime/durationutil.ts
@@ -1,4 +1,7 @@
-import { add, type Duration, intervalToDuration, type Interval, isAfter } from 'date-fns';
+import type { Duration, Interval } from 'date-fns';
+import { add } from 'date-fns/add';
+import { intervalToDuration } from 'date-fns/intervalToDuration';
+import { isAfter } from 'date-fns/isAfter';
 
 const durationMap: Record<string, string[]> = {
   years: ['y', 'Y', 'years'],

--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.test.ts
@@ -1,4 +1,5 @@
-import { getPanelPlugin, mockStandardFieldConfigOptions } from '../../test';
+import { mockStandardFieldConfigOptions } from '../../test/helpers/fieldConfig';
+import { getPanelPlugin } from '../../test/helpers/pluginMocks';
 import { standardEditorsRegistry, standardFieldConfigEditorRegistry } from '../field/standardFieldConfigEditorRegistry';
 import { type FieldConfig } from '../types/dataFrame';
 import { FieldColorModeId } from '../types/fieldColor';

--- a/packages/grafana-data/src/transformations/transformers/convertFrameType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFrameType.test.ts
@@ -1,8 +1,8 @@
 import { type DataTransformerConfig } from '@grafana/schema';
 
 import { toDataFrame } from '../../dataframe/processDataFrame';
-import { mockTransformationsRegistry } from '../../internal';
 import { FieldType } from '../../types/dataFrame';
+import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
 import { transformDataFrame } from '../transformDataFrame';
 
 import { convertFrameTypeTransformer, type ConvertFrameTypeTransformerOptions, FrameType } from './convertFrameType';

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -52,7 +52,6 @@ module.exports = createNoRestrictedSyntax(
   {
     name: 'no-direct-date-fns',
     selector: 'ImportDeclaration[source.value="date-fns"][importKind!="type"]',
-    message:
-      'Use deep imports instead (e.g. date-fns/format) to avoid pulling in the entire library.',
+    message: 'Use deep imports instead (e.g. date-fns/format) to avoid pulling in the entire library.',
   }
 );

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -48,5 +48,11 @@ module.exports = createNoRestrictedSyntax(
     selector: 'MemberExpression[object.name="config"][property.name="panels"]',
     message:
       'Usage of config.panels is not allowed. Use the function getPanelPluginMetas or usePanelPluginMetas from @grafana/runtime/internal instead',
+  },
+  {
+    name: 'no-direct-date-fns',
+    selector: 'ImportDeclaration[source.value="date-fns"][importKind!="type"]',
+    message:
+      'Use deep imports instead (e.g. date-fns/format) to avoid pulling in the entire library.',
   }
 );

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { formatDuration } from 'date-fns';
+import { formatDuration } from 'date-fns/formatDuration';
 import { memo } from 'react';
 
 import { type SelectableValue, parseDuration } from '@grafana/data';

--- a/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import { type ReactNode } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/core/utils/timeRegions.test.ts
+++ b/public/app/core/utils/timeRegions.test.ts
@@ -1,4 +1,4 @@
-import { type Duration } from 'date-fns';
+import type { Duration } from 'date-fns';
 
 import { type AbsoluteTimeRange, dateTimeForTimeZone, reverseParseDuration, type TimeRange } from '@grafana/data';
 import { convertToCron, type TimeRegionConfig } from 'app/core/utils/timeRegions';

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -1,5 +1,7 @@
 import { css, cx } from '@emotion/css';
-import { addMinutes, subDays, subHours } from 'date-fns';
+import { addMinutes } from 'date-fns/addMinutes';
+import { subDays } from 'date-fns/subDays';
+import { subHours } from 'date-fns/subHours';
 import { type Location } from 'history';
 import { useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import { addDays, subDays } from 'date-fns';
+import { addDays } from 'date-fns/addDays';
+import { subDays } from 'date-fns/subDays';
 import { uniqueId } from 'lodash';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';

--- a/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { formatDistanceToNowStrict } from 'date-fns';
+import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
 import { isEmpty, isUndefined } from 'lodash';
 import { Fragment } from 'react/jsx-runtime';
 

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { formatDistanceToNowStrict } from 'date-fns';
+import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
 import { groupBy, uniqueId } from 'lodash';
 import { Fragment, memo, useEffect, useRef } from 'react';
 

--- a/public/app/features/alerting/unified/rule-list/components/util.ts
+++ b/public/app/features/alerting/unified/rule-list/components/util.ts
@@ -1,4 +1,6 @@
-import { addMilliseconds, formatDistanceToNowStrict, isBefore } from 'date-fns';
+import { addMilliseconds } from 'date-fns/addMilliseconds';
+import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
+import { isBefore } from 'date-fns/isBefore';
 import { type ComponentProps } from 'react';
 
 import { type StateIcon } from '@grafana/alerting/unstable';

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { intervalToDuration } from 'date-fns';
+import { intervalToDuration } from 'date-fns/intervalToDuration';
 import Skeleton from 'react-loading-skeleton';
 
 import {


### PR DESCRIPTION
**What is this feature?**

Replaces `date-fns` barrel imports (e.g. `import { add, isAfter } from 'date-fns'`) with deep imports (e.g. `import { add } from 'date-fns/add'`) across the codebase.

Also adds a `test:profile` script to `package.json` for CPU-profiling Jest runs and updates `.gitignore` to exclude profile output.

**Why do we need this feature?**

Barrel imports from `date-fns` pull in the entire module graph even when only a few functions are used. This adds unnecessary parse/compile overhead during development, test runs, and builds. Deep imports allow bundlers and test runners to load only the specific modules needed, improving startup time and reducing memory usage.