### PR TITLE
fix: dynamic datasource type handling during migration

### DIFF
--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -16,17 +16,17 @@ import (
 	secret "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/storage/unified/migrations"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // DataSourceMigrator handles migrating datasources from legacy SQL storage.
 type DataSourceMigrator interface {
 	MigrateDataSources(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
-	// PluginGroups returns the distinct per-plugin GroupResources present in the
-	// given namespace. Called before opening the bulk stream so every group that
-	// MigrateDataSources will write to is pre-authorized — including cloud-only
-	// plugin types that are not known at compile time.
-	PluginGroups(ctx context.Context, namespace string) ([]schema.GroupResource, error)
+	// PluginGroups resolves the distinct per-plugin GroupResources for the given
+	// namespace, including stale groups from unified storage, for bulk stream
+	// pre-authorization.
+	PluginGroups(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error)
 }
 
 type dataSourceMigrator struct {
@@ -192,20 +192,46 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	return nil
 }
 
-func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string) ([]schema.GroupResource, error) {
+func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error) {
 	dsList, err := m.getter(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
 	seen := make(map[string]bool, len(dsList))
-	result := make([]schema.GroupResource, 0, len(dsList))
+	legacy := make([]schema.GroupResource, 0, len(dsList))
 	for _, ds := range dsList {
 		group := ds.GroupVersionKind().Group
 		if group == "" || seen[group] {
 			continue
 		}
 		seen[group] = true
-		result = append(result, schema.GroupResource{Group: group, Resource: "datasources"})
+		legacy = append(legacy, schema.GroupResource{Group: group, Resource: "datasources"})
+	}
+
+	existing, err := storageGroupsForDatasources(ctx, namespace, client)
+	if err != nil {
+		return nil, err
+	}
+	return migrations.MergeGroupResources(legacy, existing), nil
+}
+
+// storageGroupsForDatasources queries unified storage for distinct API groups
+// that currently hold datasource data in the given namespace. This ensures
+// stale groups (migrated previously but since deleted from legacy) are included
+// in the bulk collection so their data is cleaned up on re-migration.
+func storageGroupsForDatasources(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error) {
+	resp, err := client.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: namespace})
+	if err != nil {
+		return nil, fmt.Errorf("getting storage stats: %w", err)
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("getting storage stats: %s", resp.Error.Message)
+	}
+	var result []schema.GroupResource
+	for _, s := range resp.Stats {
+		if s.Resource == "datasources" {
+			result = append(result, schema.GroupResource{Group: s.Group, Resource: s.Resource})
+		}
 	}
 	return result, nil
 }

--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
@@ -21,6 +22,11 @@ import (
 // DataSourceMigrator handles migrating datasources from legacy SQL storage.
 type DataSourceMigrator interface {
 	MigrateDataSources(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
+	// PluginGroups returns the distinct per-plugin GroupResources present in the
+	// given namespace. Called before opening the bulk stream so every group that
+	// MigrateDataSources will write to is pre-authorized — including cloud-only
+	// plugin types that are not known at compile time.
+	PluginGroups(ctx context.Context, namespace string) ([]schema.GroupResource, error)
 }
 
 type dataSourceMigrator struct {
@@ -184,6 +190,24 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 
 	opts.Progress(-2, fmt.Sprintf("finished datasources... (%d)", len(dsList)))
 	return nil
+}
+
+func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string) ([]schema.GroupResource, error) {
+	dsList, err := m.getter(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(dsList))
+	result := make([]schema.GroupResource, 0, len(dsList))
+	for _, ds := range dsList {
+		group := ds.GroupVersionKind().Group
+		if group == "" || seen[group] {
+			continue
+		}
+		seen[group] = true
+		result = append(result, schema.GroupResource{Group: group, Resource: "datasources"})
+	}
+	return result, nil
 }
 
 func (m *dataSourceMigrator) createSecrets(ctx context.Context, dsSecrets common.InlineSecureValues, objRef common.ObjectReference) (common.InlineSecureValues, error) {

--- a/pkg/registry/apis/datasource/migrator/registrar.go
+++ b/pkg/registry/apis/datasource/migrator/registrar.go
@@ -25,6 +25,7 @@ func DataSourceMigration(dsMigrator DataSourceMigrator) migrations.MigrationDefi
 			DataSourceCountValidation(),
 		},
 		// data_source table is still used by other code paths
-		RenameTables: []string{},
+		RenameTables:       []string{},
+		ResourceGroupsFunc: dsMigrator.PluginGroups,
 	}
 }

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -111,22 +111,24 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 
 	origResources := opts.Resources
 
-	// TODO... the migrator must be able to dynamically define the groups
-	// The bulk processor will clean up any resources in these groups, and
-	// initialize authorization scoped to this set of resources
-	if len(opts.Resources) == 1 && opts.Resources[0].Group == "datasource.grafana.app" {
-		// This should be loaded from the DB, or the plugin scanning
-		plugins := []string{
-			"alertmanager", "azuremonitor", "cloud-monitoring", "cloudwatch", "dashboard", "elasticsearch",
-			"grafana-postgresql-datasource", "grafana-pyroscope-datasource", "grafana-testdata-datasource",
-			"graphite", "influxdb", "jaeger", "loki", "mixed", "mssql", "mysql", "opentsdb", "parca", "prometheus",
-			"tempo", "zipkin",
+	// If a definition provides a dynamic group resolver, call it to discover
+	// which plugin-specific groups actually exist in this namespace. This
+	// replaces the static resource list for bulk stream pre-authorization so
+	// that every group the migrator will write — including cloud-only plugin
+	// types not known at compile time — is properly registered.
+	// If the resolver returns empty (namespace has no data), keep opts.Resources
+	// unchanged so the stream can still be opened and closed cleanly.
+	for _, res := range origResources {
+		resolveFn := m.registry.GetResourceGroupsFunc(res)
+		if resolveFn == nil {
+			continue
 		}
-		opts.Resources = make([]schema.GroupResource, 0, len(plugins))
-		for _, p := range plugins {
-			opts.Resources = append(opts.Resources, schema.GroupResource{
-				Group: p + ".datasource.grafana.app", Resource: "datasources",
-			})
+		resolved, err := resolveFn(ctx, opts.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("resolving resource groups for %s/%s: %w", res.Group, res.Resource, err)
+		}
+		if len(resolved) > 0 {
+			opts.Resources = resolved
 		}
 	}
 

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -116,8 +116,14 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 	// replaces the static resource list for bulk stream pre-authorization so
 	// that every group the migrator will write — including cloud-only plugin
 	// types not known at compile time — is properly registered.
-	// If the resolver returns empty (namespace has no data), keep opts.Resources
-	// unchanged so the stream can still be opened and closed cleanly.
+	//
+	// We also union in any groups already stored in unified storage for the
+	// same resource. This ensures stale groups (e.g. a datasource plugin that
+	// was previously migrated but has since been deleted from legacy) are
+	// included in the collection so their data is cleaned up on re-migration.
+	//
+	// If the merged result is empty (namespace has no data at all), keep
+	// opts.Resources unchanged so the stream can still open and close cleanly.
 	for _, res := range origResources {
 		resolveFn := m.registry.GetResourceGroupsFunc(res)
 		if resolveFn == nil {
@@ -127,8 +133,13 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 		if err != nil {
 			return nil, fmt.Errorf("resolving resource groups for %s/%s: %w", res.Group, res.Resource, err)
 		}
-		if len(resolved) > 0 {
-			opts.Resources = resolved
+		existing, err := m.existingStorageGroups(ctx, opts.Namespace, res.Resource)
+		if err != nil {
+			return nil, fmt.Errorf("querying existing storage groups for %s/%s: %w", res.Group, res.Resource, err)
+		}
+		merged := mergeGroupResources(resolved, existing)
+		if len(merged) > 0 {
+			opts.Resources = merged
 		}
 	}
 
@@ -157,6 +168,40 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 	}
 	m.log.Info("finished migrating legacy resources", "namespace", opts.Namespace, "orgId", info.OrgID, "stackId", info.StackID)
 	return stream.CloseAndRecv()
+}
+
+// existingStorageGroups queries unified storage for distinct API groups that
+// currently hold data for the given resource name in namespace. Used to ensure
+// stale plugin groups (migrated in a previous run but since deleted from legacy)
+// are included in the bulk collection so their data is cleaned up on re-migration.
+func (m *unifiedMigration) existingStorageGroups(ctx context.Context, namespace, resource string) ([]schema.GroupResource, error) {
+	resp, err := m.client.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: namespace})
+	if err != nil {
+		return nil, fmt.Errorf("getting storage stats: %w", err)
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("getting storage stats: %s", resp.Error.Message)
+	}
+	var result []schema.GroupResource
+	for _, s := range resp.Stats {
+		if s.Resource == resource {
+			result = append(result, schema.GroupResource{Group: s.Group, Resource: s.Resource})
+		}
+	}
+	return result, nil
+}
+
+// mergeGroupResources returns the union of a and b, deduplicated by Group.
+func mergeGroupResources(a, b []schema.GroupResource) []schema.GroupResource {
+	seen := make(map[string]bool, len(a)+len(b))
+	result := make([]schema.GroupResource, 0, len(a)+len(b))
+	for _, gr := range append(a, b...) {
+		if !seen[gr.Group] {
+			seen[gr.Group] = true
+			result = append(result, gr)
+		}
+	}
+	return result
 }
 
 type RebuildIndexOptions struct {

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -112,34 +112,23 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 	origResources := opts.Resources
 
 	// If a definition provides a dynamic group resolver, call it to discover
-	// which plugin-specific groups actually exist in this namespace. This
-	// replaces the static resource list for bulk stream pre-authorization so
-	// that every group the migrator will write — including cloud-only plugin
-	// types not known at compile time — is properly registered.
+	// which groups actually exist in this namespace. The resolver receives the
+	// SearchClient so it can also query unified storage for stale groups and
+	// merge them in — keeping all resource-specific logic in the resolver.
 	//
-	// We also union in any groups already stored in unified storage for the
-	// same resource. This ensures stale groups (e.g. a datasource plugin that
-	// was previously migrated but has since been deleted from legacy) are
-	// included in the collection so their data is cleaned up on re-migration.
-	//
-	// If the merged result is empty (namespace has no data at all), keep
+	// If the result is empty (namespace has no data at all), keep
 	// opts.Resources unchanged so the stream can still open and close cleanly.
 	for _, res := range origResources {
 		resolveFn := m.registry.GetResourceGroupsFunc(res)
 		if resolveFn == nil {
 			continue
 		}
-		resolved, err := resolveFn(ctx, opts.Namespace)
+		resolved, err := resolveFn(ctx, opts.Namespace, m.client)
 		if err != nil {
 			return nil, fmt.Errorf("resolving resource groups for %s/%s: %w", res.Group, res.Resource, err)
 		}
-		existing, err := m.existingStorageGroups(ctx, opts.Namespace, res.Resource)
-		if err != nil {
-			return nil, fmt.Errorf("querying existing storage groups for %s/%s: %w", res.Group, res.Resource, err)
-		}
-		merged := mergeGroupResources(resolved, existing)
-		if len(merged) > 0 {
-			opts.Resources = merged
+		if len(resolved) > 0 {
+			opts.Resources = resolved
 		}
 	}
 
@@ -170,29 +159,8 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 	return stream.CloseAndRecv()
 }
 
-// existingStorageGroups queries unified storage for distinct API groups that
-// currently hold data for the given resource name in namespace. Used to ensure
-// stale plugin groups (migrated in a previous run but since deleted from legacy)
-// are included in the bulk collection so their data is cleaned up on re-migration.
-func (m *unifiedMigration) existingStorageGroups(ctx context.Context, namespace, resource string) ([]schema.GroupResource, error) {
-	resp, err := m.client.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: namespace})
-	if err != nil {
-		return nil, fmt.Errorf("getting storage stats: %w", err)
-	}
-	if resp.Error != nil {
-		return nil, fmt.Errorf("getting storage stats: %s", resp.Error.Message)
-	}
-	var result []schema.GroupResource
-	for _, s := range resp.Stats {
-		if s.Resource == resource {
-			result = append(result, schema.GroupResource{Group: s.Group, Resource: s.Resource})
-		}
-	}
-	return result, nil
-}
-
-// mergeGroupResources returns the union of a and b, deduplicated by Group.
-func mergeGroupResources(a, b []schema.GroupResource) []schema.GroupResource {
+// MergeGroupResources returns the union of a and b, deduplicated by Group.
+func MergeGroupResources(a, b []schema.GroupResource) []schema.GroupResource {
 	seen := make(map[string]bool, len(a)+len(b))
 	result := make([]schema.GroupResource, 0, len(a)+len(b))
 	for _, gr := range append(a, b...) {

--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util/xorm"
 )
@@ -44,13 +45,10 @@ type MigrationDefinition struct {
 	RenameTables    []string                              // Legacy tables to rename with _legacy suffix after successful migration
 	SkipWhenMissing bool                                  // For fully migrated resources, the table may not exist at all
 	// ResourceGroupsFunc, when set, is called before opening the bulk stream to
-	// discover the actual resource groups present in the namespace. The returned
-	// groups replace Resources for stream pre-authorization, allowing migrations
-	// (e.g. datasources) whose groups are determined by runtime data — such as
-	// plugin type — rather than a fixed registry list. Cloud-only plugin types
-	// are handled automatically: the func queries real data, so it returns only
-	// the groups that actually exist in that instance.
-	ResourceGroupsFunc func(ctx context.Context, namespace string) ([]schema.GroupResource, error)
+	// resolve the actual groups present in the namespace, replacing the static
+	// Resources list for stream pre-authorization. The SearchClient is provided
+	// so implementations can also account for stale groups in unified storage.
+	ResourceGroupsFunc func(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error)
 }
 
 // CreateValidators creates validators from the stored factory functions.
@@ -177,7 +175,7 @@ func (r *MigrationRegistry) HasResource(gr schema.GroupResource) bool {
 // GetResourceGroupsFunc returns the ResourceGroupsFunc for the definition that
 // covers the given resource, or nil if none is registered or the definition has
 // no dynamic resolver.
-func (r *MigrationRegistry) GetResourceGroupsFunc(gr schema.GroupResource) func(ctx context.Context, namespace string) ([]schema.GroupResource, error) {
+func (r *MigrationRegistry) GetResourceGroupsFunc(gr schema.GroupResource) func(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	for _, def := range r.definitions {

--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -43,6 +43,14 @@ type MigrationDefinition struct {
 	Validators      []ValidatorFactory                    // Validator factories (validators created lazily)
 	RenameTables    []string                              // Legacy tables to rename with _legacy suffix after successful migration
 	SkipWhenMissing bool                                  // For fully migrated resources, the table may not exist at all
+	// ResourceGroupsFunc, when set, is called before opening the bulk stream to
+	// discover the actual resource groups present in the namespace. The returned
+	// groups replace Resources for stream pre-authorization, allowing migrations
+	// (e.g. datasources) whose groups are determined by runtime data — such as
+	// plugin type — rather than a fixed registry list. Cloud-only plugin types
+	// are handled automatically: the func queries real data, so it returns only
+	// the groups that actually exist in that instance.
+	ResourceGroupsFunc func(ctx context.Context, namespace string) ([]schema.GroupResource, error)
 }
 
 // CreateValidators creates validators from the stored factory functions.
@@ -164,4 +172,18 @@ func (r *MigrationRegistry) HasResource(gr schema.GroupResource) bool {
 		}
 	}
 	return false
+}
+
+// GetResourceGroupsFunc returns the ResourceGroupsFunc for the definition that
+// covers the given resource, or nil if none is registered or the definition has
+// no dynamic resolver.
+func (r *MigrationRegistry) GetResourceGroupsFunc(gr schema.GroupResource) func(ctx context.Context, namespace string) ([]schema.GroupResource, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, def := range r.definitions {
+		if _, ok := def.Migrators[gr]; ok {
+			return def.ResourceGroupsFunc
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Removes the hard-coded handling of the datasource types. We need this change in order to handle cloud only datasources properly. This new dynamic approach would handle both oss and cloud cases. There is a catch to take into account when reviewing; we will need to make 2 db calls in OSS migrations and 2 http calls when migrating in cloud.

Ticket: https://github.com/grafana/search-and-storage-team/issues/732