### PR TITLE
AccessControl: backfill SA action set tokens to managed roles

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/service_account_action_set_migration.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/service_account_action_set_migration.go
@@ -41,7 +41,7 @@ func (m *saActionSetMigrator) addSAActionSetActions() error {
 	sql := `
 	SELECT permission.role_id, permission.action, permission.scope FROM permission
 		LEFT JOIN role ON permission.role_id = role.id
-		WHERE permission.action IN ('serviceaccounts:read', 'serviceaccounts:write', 'serviceaccounts:delete', 'serviceaccounts:edit', 'serviceaccounts:admin')
+		WHERE permission.action IN ('serviceaccounts:write', 'serviceaccounts:delete', 'serviceaccounts:edit', 'serviceaccounts:admin')
 		AND permission.scope LIKE 'serviceaccounts:id:%'
 		AND role.name LIKE 'managed:%'
 `
@@ -85,7 +85,6 @@ func (m *saActionSetMigrator) addSAActionSetActions() error {
 				groupedPermissions[result.RoleID][result.Scope] = "edit"
 			}
 		}
-		// serviceaccounts:read alone does not map to any action set level (no "view" for SAs).
 	}
 
 	toAdd := make([]accesscontrol.Permission, 0, len(groupedPermissions))
@@ -93,11 +92,6 @@ func (m *saActionSetMigrator) addSAActionSetActions() error {
 
 	for roleID, permissions := range groupedPermissions {
 		for scope, level := range permissions {
-			if level == "" {
-				// Only serviceaccounts:read was present — no action set token exists for this level.
-				continue
-			}
-
 			kind, attr, identifier := accesscontrol.SplitScope(scope)
 			toAdd = append(toAdd, accesscontrol.Permission{
 				RoleID:     roleID,

--- a/pkg/services/sqlstore/migrations/accesscontrol/service_account_action_set_migration.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/service_account_action_set_migration.go
@@ -1,0 +1,134 @@
+package accesscontrol
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+const AddSAActionSetMigrationID = "adding service account action set permissions"
+
+func AddSAActionSetPermissionsMigrator(mg *migrator.Migrator) {
+	mg.AddMigration(AddSAActionSetMigrationID, &saActionSetMigrator{})
+}
+
+type saActionSetMigrator struct {
+	sess     *xorm.Session
+	migrator *migrator.Migrator
+	migrator.MigrationBase
+}
+
+var _ migrator.CodeMigration = new(saActionSetMigrator)
+
+func (m *saActionSetMigrator) SQL(migrator.Dialect) string {
+	return "code migration"
+}
+
+func (m *saActionSetMigrator) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	m.sess = sess
+	m.migrator = mg
+	return m.addSAActionSetActions()
+}
+
+func (m *saActionSetMigrator) addSAActionSetActions() error {
+	var results []accesscontrol.Permission
+
+	// Fetch SA granular actions and any existing action set tokens for managed roles.
+	// serviceaccounts:delete is the key differentiator: its presence signals Admin level.
+	sql := `
+	SELECT permission.role_id, permission.action, permission.scope FROM permission
+		LEFT JOIN role ON permission.role_id = role.id
+		WHERE permission.action IN ('serviceaccounts:read', 'serviceaccounts:write', 'serviceaccounts:delete', 'serviceaccounts:edit', 'serviceaccounts:admin')
+		AND permission.scope LIKE 'serviceaccounts:id:%'
+		AND role.name LIKE 'managed:%'
+`
+	if err := m.sess.SQL(sql).Find(&results); err != nil {
+		return fmt.Errorf("failed to query service account permissions: %w", err)
+	}
+
+	// groupedPermissions tracks the highest action set level per (roleID, scope).
+	// hasActionSet tracks pairs that already have a token, so we skip them.
+	groupedPermissions := make(map[int64]map[string]string) // map[roleID][scope] = "edit"|"admin"
+	hasActionSet := make(map[int64]map[string]bool)         // map[roleID][scope] = true
+
+	for _, result := range results {
+		if isSAActionSetToken(result.Action) {
+			if _, ok := hasActionSet[result.RoleID]; !ok {
+				hasActionSet[result.RoleID] = make(map[string]bool)
+			}
+			hasActionSet[result.RoleID][result.Scope] = true
+			// Remove from groupedPermissions if we already queued it — no need to insert.
+			delete(groupedPermissions[result.RoleID], result.Scope)
+			continue
+		}
+
+		// Skip if we already know this pair has a token.
+		if hasActionSet[result.RoleID][result.Scope] {
+			continue
+		}
+
+		if _, ok := groupedPermissions[result.RoleID]; !ok {
+			groupedPermissions[result.RoleID] = make(map[string]string)
+		}
+
+		// Promote to the highest level seen for this (roleID, scope).
+		// Admin is signalled by serviceaccounts:delete; edit by serviceaccounts:write.
+		current := groupedPermissions[result.RoleID][result.Scope]
+		switch result.Action {
+		case "serviceaccounts:delete":
+			groupedPermissions[result.RoleID][result.Scope] = "admin"
+		case "serviceaccounts:write":
+			if current != "admin" {
+				groupedPermissions[result.RoleID][result.Scope] = "edit"
+			}
+		}
+		// serviceaccounts:read alone does not map to any action set level (no "view" for SAs).
+	}
+
+	toAdd := make([]accesscontrol.Permission, 0, len(groupedPermissions))
+	now := time.Now()
+
+	for roleID, permissions := range groupedPermissions {
+		for scope, level := range permissions {
+			if level == "" {
+				// Only serviceaccounts:read was present — no action set token exists for this level.
+				continue
+			}
+
+			kind, attr, identifier := accesscontrol.SplitScope(scope)
+			toAdd = append(toAdd, accesscontrol.Permission{
+				RoleID:     roleID,
+				Scope:      scope,
+				Action:     "serviceaccounts:" + level,
+				Kind:       kind,
+				Attribute:  attr,
+				Identifier: identifier,
+				Created:    now,
+				Updated:    now,
+			})
+		}
+	}
+
+	if len(toAdd) > 0 {
+		err := batch(len(toAdd), batchSize, func(start, end int) error {
+			m.migrator.Logger.Debug(fmt.Sprintf("inserting service account action set permissions %v", toAdd[start:end]))
+			if _, err := m.sess.InsertMulti(toAdd[start:end]); err != nil {
+				return fmt.Errorf("failed to insert service account action set permissions: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		m.migrator.Logger.Debug("updated managed roles with service account action set permissions")
+	}
+
+	return nil
+}
+
+func isSAActionSetToken(action string) bool {
+	return action == "serviceaccounts:edit" || action == "serviceaccounts:admin"
+}

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/service_account_action_set_migration_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/service_account_action_set_migration_test.go
@@ -1,0 +1,165 @@
+package test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestSAActionSetMigration(t *testing.T) {
+	x := setupTestDB(t)
+
+	type migrationTestCase struct {
+		desc               string
+		existingRolePerms  map[string]map[string][]string // roleName -> scope -> actions
+		expectedActionSets map[string]map[string]string   // roleName -> scope -> expected action set token
+	}
+
+	testCases := []migrationTestCase{
+		{
+			desc:              "empty perms — nothing to do",
+			existingRolePerms: map[string]map[string][]string{},
+		},
+		{
+			desc: "non-managed role is skipped",
+			existingRolePerms: map[string]map[string][]string{
+				"my_custom_role": {
+					"serviceaccounts:id:1": {"serviceaccounts:read", "serviceaccounts:write"},
+				},
+			},
+		},
+		{
+			desc: "managed role with only serviceaccounts:read gets no action set (no view level for SAs)",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": {"serviceaccounts:read"},
+				},
+			},
+		},
+		{
+			desc: "managed edit grant gets serviceaccounts:edit token",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": {"serviceaccounts:read", "serviceaccounts:write"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": "serviceaccounts:edit",
+				},
+			},
+		},
+		{
+			desc: "managed admin grant gets serviceaccounts:admin token",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": {"serviceaccounts:read", "serviceaccounts:write", "serviceaccounts:delete"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": "serviceaccounts:admin",
+				},
+			},
+		},
+		{
+			desc: "existing action set token is not duplicated",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": {"serviceaccounts:read", "serviceaccounts:write", "serviceaccounts:edit"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": "serviceaccounts:edit",
+				},
+			},
+		},
+		{
+			desc: "multiple roles and SA IDs are handled independently",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": {"serviceaccounts:read", "serviceaccounts:write"},
+					"serviceaccounts:id:2": {"serviceaccounts:read", "serviceaccounts:write", "serviceaccounts:delete"},
+				},
+				"managed:teams:1:permissions": {
+					"serviceaccounts:id:1": {"serviceaccounts:read", "serviceaccounts:write", "serviceaccounts:delete"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"serviceaccounts:id:1": "serviceaccounts:edit",
+					"serviceaccounts:id:2": "serviceaccounts:admin",
+				},
+				"managed:teams:1:permissions": {
+					"serviceaccounts:id:1": "serviceaccounts:admin",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?`, acmig.AddSAActionSetMigrationID)
+			require.NoError(t, errDeleteMig)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
+			_, errDeletePerms := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerms)
+
+			orgID := 1
+			rolePerms := map[string][]rawPermission{}
+			for roleName, permissions := range tc.existingRolePerms {
+				rawPerms := []rawPermission{}
+				for scope, actions := range permissions {
+					for _, action := range actions {
+						rawPerms = append(rawPerms, rawPermission{Scope: scope, Action: action})
+					}
+				}
+				rolePerms[roleName] = rawPerms
+			}
+			putTestPermissions(t, x, map[int64]map[string][]rawPermission{int64(orgID): rolePerms})
+
+			acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+			acmig.AddSAActionSetPermissionsMigrator(acmigrator)
+
+			require.NoError(t, acmigrator.Start(false, 0))
+
+			for roleName, existingPerms := range tc.existingRolePerms {
+				role := accesscontrol.Role{}
+				hasRole, err := x.Table("role").Where("org_id = ? AND name = ?", orgID, roleName).Get(&role)
+				require.NoError(t, err)
+				require.True(t, hasRole, "expected role to exist: %s", roleName)
+
+				perms := []accesscontrol.Permission{}
+				_, err = x.Table("permission").Where("role_id = ?", role.ID).FindAndCount(&perms)
+				require.NoError(t, err)
+
+				gotByScopeAction := map[string][]string{}
+				for _, p := range perms {
+					gotByScopeAction[p.Scope] = append(gotByScopeAction[p.Scope], p.Action)
+				}
+
+				for scope, originalActions := range existingPerms {
+					got := gotByScopeAction[scope]
+					// All original actions must still be present.
+					for _, a := range originalActions {
+						require.Contains(t, got, a, "original action missing after migration: role=%s scope=%s action=%s", roleName, scope, a)
+					}
+					// Check the expected action set token was added (or was already present).
+					if expectedToken, ok := tc.expectedActionSets[roleName][scope]; ok {
+						require.True(t, slices.Contains(got, expectedToken),
+							"expected action set token %q for role=%s scope=%s; got %v", expectedToken, roleName, scope, got)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -128,6 +128,8 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 
 	accesscontrol.AddActionSetPermissionsMigrator(mg)
 
+	accesscontrol.AddSAActionSetPermissionsMigrator(mg)
+
 	externalsession.AddMigration(mg)
 
 	accesscontrol.AddReceiverCreateScopeMigration(mg)


### PR DESCRIPTION
**What is this feature?**

SQL migration that backfills action set tokens for service accounts into existing managed roles.

**Why do we need this feature?**

Managed roles created before action set support contain only granular SA actions (e.g. `serviceaccounts:read`, `serviceaccounts:write`). This migration ensures those roles also carry the equivalent action set token (`serviceaccounts:edit` / `serviceaccounts:admin`), so the K8s ResourcePermission API can read them correctly.

**Who is this feature for?**

Internal — part of the SA ResourcePermission K8s API epic (identity-access-team#1996).

**Which issue(s) does this PR fix?**

Part of identity-access-team#1999

**Special notes for your reviewer:**

- Re-land of #122718, caught in the mass revert of SA changes (#122865). Migration logic unchanged.
- Purely additive — no deletes or updates to existing rows. Safe to roll back; no automatic down migration.
- Runs unconditionally on first restart after deploy (no flag, no manual step).
- Logic: scans managed roles with SA granular actions on `serviceaccounts:id:%` scopes; inserts `serviceaccounts:edit` (has `:write`) or `serviceaccounts:admin` (has `:delete`); skips read-only and already-tokenised pairs.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.