### PR TITLE
Docs: Migration guide for APIs

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
@@ -21,7 +21,7 @@ title: 'Query History HTTP API '
 
 # Query history API
 
-{{< docs/shared lookup="developers/deprecated-apis.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+{{< docs/shared lookup="developers/deprecated-apis-nonmigrated.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 This API can be used to add queries to Query history. It requires that the user is logged in and that Query history feature is enabled in config file.
 

--- a/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
@@ -38,8 +38,8 @@ Currently the following replacements apply:
 
 | **Feature** | **Legacy API**      | **New API**                                                                                                                               |
 | ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Dashboards  | `/api/dashboards/*` | `[apis/dashboard.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard)` |
-| Folders     | `/api/folders/*`    | `[apis/folder.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/folder)`       |
+| Dashboards  | `/api/dashboards/*` | [`apis/dashboard.grafana.app/*`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard) |
+| Folders     | `/api/folders/*`    | [`apis/folder.grafana.app/*`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/folder)       |
 
 ## Deprecation notes
 

--- a/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
@@ -36,9 +36,10 @@ The API migration process is underway and there may not be an exact `/apis` matc
 
 Currently the following replacements apply:
 
-|**Feature**|**Legacy API**|**New API**|
-|Dashboards|`/api/dashboards/*`|`[apis/dashboard.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard)`|
-|Folders|`/api/folders/*`|`[apis/folder.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/folder)`|
+| **Feature** | **Legacy API**      | **New API**                                                                                                                               |
+| ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Dashboards  | `/api/dashboards/*` | `[apis/dashboard.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard)` |
+| Folders     | `/api/folders/*`    | `[apis/folder.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/folder)`       |
 
 ## Deprecation notes
 

--- a/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
@@ -45,6 +45,8 @@ Currently the following replacements apply:
 
 ### Query history API
 
-The Query History APIs will not be migrated to the new Grafana App Platform. Instead, the Grafana product will revert to using local on-device storage for this functionality. This approach reduces the amount of traffic to the backend with minimal change in functionality.
+The [Query History API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/api-legacy/query_history) will not be migrated.
 
-If you're using this API, Grafana will provide a sample implementation for adoption.
+Grafana will revert to using local on-device storage for this functionality, since this approach reduces the amount of traffic to the backend with minimal change in functionality.
+
+If you're using this API, TBC

--- a/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
@@ -1,0 +1,49 @@
+---
+aliases:
+  - ../../../http_api/new_api_structure/ # /docs/grafana/next/http_api/new_api_structure/
+  - ../../../developers/http_api/apis/ # /docs/grafana/next/developers/http_api/apis/
+canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/apis/
+description: ''
+keywords:
+  - grafana
+  - http
+  - documentation
+  - api
+labels:
+  products:
+    - enterprise
+    - oss
+    - cloud
+title: Migrate to the new APIs
+menuTitle: Migrate to new APIs
+weight: 01
+---
+
+# Migrate to the new APIs
+
+{{< admonition type="note" >}}
+New APIs available in Grafana 12 and later.
+Legacy APIs deprecated in Grafana 13.
+{{< /admonition >}}
+
+Grafana is migrating existing APIs to the new `/apis` model, a Kubernetes-style API layer which follows a standardized API structure alongside consistent API versioning. Refer to the [New API structure in Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis) documentation for more details.
+
+**Legacy APIs are not being disabled for the moment**. Removal of legacy APIs is planned for a future major release, and any breaking changes will be announced well in advance to avoid disruptions.
+
+## Migration overview
+
+The API migration process is underway and there may not be an exact `/apis` match to the legacy API you're using. Some legacy APIs may not be migrated at all.
+
+Currently the following replacements apply:
+
+|**Feature**|**Legacy API**|**New API**|
+|Dashboards|`/api/dashboards/*`|`[apis/dashboard.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard)`|
+|Folders|`/api/folders/*`|`[apis/folder.grafana.app/*](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/folder)`|
+
+## Deprecation notes
+
+### Query history API
+
+The Query History APIs will not be migrated to the new Grafana App Platform. Instead, the Grafana product will revert to using local on-device storage for this functionality. This approach reduces the amount of traffic to the backend with minimal change in functionality.
+
+If you're using this API, Grafana will provide a sample implementation for adoption.

--- a/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis-migration.md
@@ -47,6 +47,4 @@ Currently the following replacements apply:
 
 The [Query History API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/api-legacy/query_history) will not be migrated.
 
-Grafana will revert to using local on-device storage for this functionality, since this approach reduces the amount of traffic to the backend with minimal change in functionality.
-
-If you're using this API, TBC
+This functionality is being deprecated. Grafana will revert to using local on-device storage for this functionality, since this approach reduces the amount of traffic to the backend with minimal change in functionality. If you're using this API, consider using a similar approach.

--- a/docs/sources/developer-resources/api-reference/http-api/apis.md
+++ b/docs/sources/developer-resources/api-reference/http-api/apis.md
@@ -33,6 +33,8 @@ Grafana 13 marks the deprecation of legacy API endpoints (`/api`) in favor of a 
 
 Note that while Grafana is working on migrating existing APIs to the new `/apis` model, currently there may not be an exact match to the legacy API you're using.
 
+For more information refer to [Migrate to the new APIs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis-migration) documentation.
+
 ## API structure
 
 ### API path

--- a/docs/sources/shared/developers/deprecated-apis-nonmigrated.md
+++ b/docs/sources/shared/developers/deprecated-apis-nonmigrated.md
@@ -1,0 +1,13 @@
+---
+headless: true
+comments: |
+  This file is used in legacy APIs.
+---
+
+{{< admonition type="note" >}}
+
+Starting in Grafana 13, `/api` endpoints are being deprecated in favor of the `/apis` route. **This change doesn't disrupt or break your current setup**. Legacy APIs are not being disabled and remain fully accessible and operative, but `/api` routes will no longer be updated.
+
+**This API will not be migrated**. Refer to [API deprecation notes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/apis-migration#deprecation-notes) for more details and alternatives.
+
+{{< /admonition >}}


### PR DESCRIPTION
Covers https://github.com/grafana/grafana/issues/122812.

Previews:

- https://deploy-preview-grafana-122949-zb444pucvq-vp.a.run.app/docs/grafana/latest/developer-resources/api-reference/http-api/apis-migration/
- https://deploy-preview-grafana-122949-zb444pucvq-vp.a.run.app/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/query_history/