### PR TITLE
fix: add index for org_id-id columns to short_url table

### DIFF
--- a/pkg/services/sqlstore/migrations/short_url_mig.go
+++ b/pkg/services/sqlstore/migrations/short_url_mig.go
@@ -28,4 +28,6 @@ func addShortURLMigrations(mg *Migrator) {
 	mg.AddMigration("alter table short_url alter column created_by type to bigint", NewRawSQLMigration("").
 		Mysql("ALTER TABLE short_url MODIFY created_by BIGINT;").
 		Postgres("ALTER TABLE short_url ALTER COLUMN created_by TYPE BIGINT;"))
+
+	mg.AddMigration("add index short_url.org_id-id", NewAddIndexMigration(shortURLV1, &Index{Cols: []string{"org_id", "id"}}))
 }


### PR DESCRIPTION
Add index to the `short_url` table as I encountered an issue while migrate a relatively big instance using a google cloud mysql instance. Here is the encountered error: https://ops.grafana-ops.net/goto/dfjd9x9f92ygwe?orgId=stacks-27821. It states the following: `Error 1038 (HY001): Out of sort memory, consider increasing server sort buffer size`. It is basically a MySQL error stating that the `sort_buffer_size` is being exceeded. In order to make the migration list query's cost consistent across different MySQL instances. 

Ticket: https://github.com/grafana/search-and-storage-team/issues/686