### PR TITLE
Field Selector: fix conditional output in react components

### DIFF
--- a/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
@@ -81,7 +81,7 @@ export const ActiveFields = ({
           <LogLevelField active={Boolean(logLevelActive)} toggle={toggleLevel} />
         </div>
       )}
-      {(active.length || suggested.length) && (
+      {(active.length > 0 || suggested.length > 0) && (
         <>
           <div className={styles.columnHeader}>
             <Trans i18nKey="explore.logs-table-multi-select.selected-fields">Selected fields</Trans>


### PR DESCRIPTION
This PR removes unwanted output (0) from a React conditional.

Before:

<img width="231" height="217" alt="Before" src="https://github.com/user-attachments/assets/34d0cc5c-746b-40b7-92df-62f588a8a5f7" />


After:

<img width="227" height="290" alt="After" src="https://github.com/user-attachments/assets/d91d0612-9d50-41df-943e-e467e4cc8546" />
