### PR TITLE
Fix: Allow wildcard namespace in ofrep call validation

### DIFF
--- a/pkg/registry/apis/ofrep/http_routes.go
+++ b/pkg/registry/apis/ofrep/http_routes.go
@@ -189,7 +189,8 @@ func (b *APIBuilder) validateNamespaceIfPresent(r *http.Request, evalCtx evalCon
 		attribute.String("eval_ctx_namespace", evalCtx.namespace),
 	)
 
-	valid := evalCtx.namespace == authNamespace
+	// Wildcard auth namespace grants cluster-wide access — valid for any specific namespace.
+	valid := evalCtx.namespace == authNamespace || authNamespace == "*"
 	span.SetAttributes(attribute.Bool("validation.success", valid))
 	return authNamespace, valid
 }

--- a/pkg/registry/apis/ofrep/http_routes_test.go
+++ b/pkg/registry/apis/ofrep/http_routes_test.go
@@ -75,6 +75,12 @@ func TestAPIBuilder_ValidateNamespaceIfPresent(t *testing.T) {
 			expectedValid: true,
 		},
 		{
+			name:          "wildcard auth namespace - valid for any specific namespace",
+			authNamespace: "*",
+			requestBody:   `{"context":{"namespace":"stacks-1"}}`,
+			expectedValid: true,
+		},
+		{
 			name:          "empty body - always valid",
 			authNamespace: "stacks-1",
 			requestBody:   ``,


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/118624 and https://github.com/grafana/grafana/pull/120977
