### PR TITLE
AppInstaller: Skip dual writer for resources without legacy storage

### DIFF
--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -59,16 +59,21 @@ func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupI
 			if dualWriteSupported {
 				if unifiedStorage, ok := storage.(grafanarest.Storage); ok {
 					log.Debug("Configuring dual writer for storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
-					storage, err = NewDualWriter(
-						gr,
-						s.storageOpts,
-						legacyProvider.GetLegacyStorage(gr.WithVersion(v)),
-						unifiedStorage,
-						s.dualWriteService,
-						s.builderMetrics,
-					)
-					if err != nil {
-						return err
+					legacyStorage := legacyProvider.GetLegacyStorage(gr.WithVersion(v))
+					if legacyStorage == nil {
+						log.Debug("Skipping dual writer; no legacy storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
+					} else {
+						storage, err = NewDualWriter(
+							gr,
+							s.storageOpts,
+							legacyStorage,
+							unifiedStorage,
+							s.dualWriteService,
+							s.builderMetrics,
+						)
+						if err != nil {
+							return err
+						}
 					}
 				} else if statusRest, ok := storage.(*appsdkapiserver.StatusREST); ok {
 					parentPath := strings.TrimSuffix(storagePath, "/status")


### PR DESCRIPTION
**What is this feature?**

When a multi-resource app implements `LegacyStorageProvider`, the app installer now skips dual writer setup for resources whose `GetLegacyStorage` returns nil, instead of passing nil into `NewDualWriter` (which would panic if the storage mode isn't `StorageModeUnified`).

**Why do we need this feature?**

Apps that register multiple resources may have a mix of legacy-backed and unified-only resources. Currently, `GetLegacyStorage` is called for every registered resource, and the result is passed directly to `NewDualWriter` with no nil check. If a resource has no legacy storage (e.g. a new resource type that only uses unified storage), this causes a nil pointer dereference when dual-write mode is active.

**Who is this feature for?**

App developers adding new unified-only resources to existing apps that already implement `LegacyStorageProvider` for other resources.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.