### PR TITLE
Remove log line

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -138,7 +138,6 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 			"rule_uid", httpreq.Header.Get("X-Rule-Uid"),
 			"caller", getCaller(ctx),
 		)
-		connectLogger.Debug("received query-service request")
 		responderOnObjectFn := func(statusCode *int, obj runtime.Object) {
 			if *statusCode/100 == 4 {
 				span.SetStatus(codes.Error, strconv.Itoa(*statusCode))


### PR DESCRIPTION
Now that the mt-querier has more traffic, sometimes the logs are a bit too much to query through. I'm trying to find little logs we can remove to reduce noise. 