### PR TITLE
Alerting: Add VictoriaMetrics as a Prometheus-compatible datasource

### DIFF
--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/frontendsettings"
 	"github.com/grafana/grafana/pkg/api/webassets"
@@ -345,7 +347,7 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 			dsDTO.Database = ds.Database
 		}
 
-		if ds.Type == datasources.DS_PROMETHEUS || ds.Type == datasources.DS_AMAZON_PROMETHEUS || ds.Type == datasources.DS_AZURE_PROMETHEUS {
+		if datasources.IsPrometheusCompatible(ds.Type) {
 			// add unproxied server URL for link to Prometheus web UI
 			ds.JsonData.Set("directUrl", ds.URL)
 		}

--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -349,7 +349,7 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 			dsDTO.Database = ds.Database
 		}
 
-		if ds.Type == datasources.DS_PROMETHEUS || ds.Type == datasources.DS_AMAZON_PROMETHEUS || ds.Type == datasources.DS_AZURE_PROMETHEUS {
+		if datasources.IsPrometheusCompatible(ds.Type) {
 			// add unproxied server URL for link to Prometheus web UI
 			ds.JsonData.Set("directUrl", ds.URL)
 		}

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/webassets"
 	"github.com/grafana/grafana/pkg/login/social"
@@ -28,7 +30,6 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/open-feature/go-sdk/openfeature"
 )
 
 // GetBootdataAPI returns the same data we currently have rendered into index.html
@@ -591,7 +592,7 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 			dsDTO.Database = ds.Database
 		}
 
-		if ds.Type == datasources.DS_PROMETHEUS || ds.Type == datasources.DS_AMAZON_PROMETHEUS || ds.Type == datasources.DS_AZURE_PROMETHEUS {
+		if datasources.IsPrometheusCompatible(ds.Type) {
 			// add unproxied server URL for link to Prometheus web UI
 			ds.JsonData.Set("directUrl", ds.URL)
 		}

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -332,7 +332,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 	}
 
 	// Trailing validation below this point for routes that were not matched
-	if proxy.ds.Type == datasources.DS_PROMETHEUS || proxy.ds.Type == datasources.DS_AMAZON_PROMETHEUS || proxy.ds.Type == datasources.DS_AZURE_PROMETHEUS {
+	if datasources.IsPrometheusCompatible(proxy.ds.Type) {
 		if proxy.ctx.Req.Method == "DELETE" {
 			return errors.New("non allow-listed DELETEs not allowed on proxied Prometheus datasource")
 		}

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -383,12 +383,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 	}
 
 	// Trailing validation below this point for routes that were not matched
-	switch proxy.dataSource.PluginType() {
-	case datasources.DS_PROMETHEUS,
-		datasources.DS_AMAZON_PROMETHEUS,
-		datasources.DS_AZURE_PROMETHEUS,
-		datasources.DS_LOKI,
-		datasources.DS_VICTORIA_METRICS:
+	if datasources.IsPrometheusCompatible(proxy.dataSource.PluginType()) || proxy.dataSource.PluginType() == datasources.DS_LOKI {
 		switch proxy.ctx.Req.Method {
 		case "DELETE", "PUT", "POST":
 			return fmt.Errorf("non allow-listed %ss not allowed on proxied %s datasource", proxy.ctx.Req.Method, proxy.dataSource.PluginType())

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -387,7 +387,8 @@ func (proxy *DataSourceProxy) validateRequest() error {
 	case datasources.DS_PROMETHEUS,
 		datasources.DS_AMAZON_PROMETHEUS,
 		datasources.DS_AZURE_PROMETHEUS,
-		datasources.DS_LOKI:
+		datasources.DS_LOKI,
+		datasources.DS_VICTORIA_METRICS:
 		switch proxy.ctx.Req.Method {
 		case "DELETE", "PUT", "POST":
 			return fmt.Errorf("non allow-listed %ss not allowed on proxied %s datasource", proxy.ctx.Req.Method, proxy.dataSource.PluginType())

--- a/pkg/expr/converter.go
+++ b/pkg/expr/converter.go
@@ -140,7 +140,7 @@ func getResponseFrame(logger *log.ConcreteLogger, resp *backend.QueryDataRespons
 }
 
 func isAllFrameVectors(datasourceType string, frames data.Frames) bool {
-	if datasourceType != datasources.DS_PROMETHEUS && datasourceType != datasources.DS_AMAZON_PROMETHEUS && datasourceType != datasources.DS_AZURE_PROMETHEUS {
+	if !datasources.IsPrometheusCompatible(datasourceType) {
 		return false
 	}
 	allVector := false

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -34,11 +34,28 @@ const (
 	DS_TEMPO             = "tempo"
 	DS_TESTDATA          = "grafana-testdata-datasource"
 	DS_ZIPKIN            = "zipkin"
+	DS_VICTORIA_METRICS  = "victoriametrics-metrics-datasource"
 	// CustomHeaderName is the prefix that is used to store the name of a custom header.
 	CustomHeaderName = "httpHeaderName"
 	// CustomHeaderValue is the prefix that is used to store the value of a custom header.
 	CustomHeaderValue = "httpHeaderValue"
 )
+
+var prometheusCompatibleDsTypes = []string{
+	DS_PROMETHEUS,
+	DS_AMAZON_PROMETHEUS,
+	DS_AZURE_PROMETHEUS,
+	DS_VICTORIA_METRICS,
+}
+
+func IsPrometheusCompatible(dsType string) bool {
+	for _, t := range prometheusCompatibleDsTypes {
+		if dsType == t {
+			return true
+		}
+	}
+	return false
+}
 
 type DsAccess string
 

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -35,11 +35,28 @@ const (
 	DS_TEMPO             = "tempo"
 	DS_TESTDATA          = "grafana-testdata-datasource"
 	DS_ZIPKIN            = "zipkin"
+	DS_VICTORIA_METRICS  = "victoriametrics-metrics-datasource"
 	// CustomHeaderName is the prefix that is used to store the name of a custom header.
 	CustomHeaderName = "httpHeaderName"
 	// CustomHeaderValue is the prefix that is used to store the value of a custom header.
 	CustomHeaderValue = "httpHeaderValue"
 )
+
+var prometheusCompatibleDsTypes = []string{
+	DS_PROMETHEUS,
+	DS_AMAZON_PROMETHEUS,
+	DS_AZURE_PROMETHEUS,
+	DS_VICTORIA_METRICS,
+}
+
+func IsPrometheusCompatible(dsType string) bool {
+	for _, t := range prometheusCompatibleDsTypes {
+		if dsType == t {
+			return true
+		}
+	}
+	return false
+}
 
 type DsAccess string
 

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -127,6 +127,20 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 	return response.JSON(http.StatusOK, alerts)
 }
 
+// instantQueryPath returns the instant query path for a Lotex ruler compatible
+// datasource type. It must stay in sync with isLotexRulerCompatible, otherwise a
+// datasource accepted by getDatasourceByUID cannot be queried.
+func instantQueryPath(dsType string) (string, bool) {
+	switch {
+	case dsType == datasources.DS_LOKI:
+		return "loki/api/v1/query", true
+	case datasources.IsPrometheusCompatible(dsType):
+		return "api/v1/query", true
+	default:
+		return "", false
+	}
+}
+
 func (srv TestingApiSrv) RouteTestRuleConfig(c *contextmodel.ReqContext, body apimodels.TestRulePayload, datasourceUID string) response.Response {
 	if body.Type() != apimodels.LoTexRulerBackend {
 		return errorToResponse(backendTypeDoesNotMatchPayloadTypeError(apimodels.LoTexRulerBackend, body.Type().String()))
@@ -135,15 +149,10 @@ func (srv TestingApiSrv) RouteTestRuleConfig(c *contextmodel.ReqContext, body ap
 	if err != nil {
 		return errorToResponse(err)
 	}
-	var path string
-	switch ds.Type {
-	case "loki":
-		path = "loki/api/v1/query"
-	case "prometheus":
-		path = "api/v1/query"
-	default:
+	path, ok := instantQueryPath(ds.Type)
+	if !ok {
 		// this should not happen because getDatasourceByUID would not return the data source
-		return errorToResponse(unexpectedDatasourceTypeError(ds.Type, "loki, prometheus"))
+		return errorToResponse(unexpectedDatasourceTypeError(ds.Type, lotexRulerCompatibleTypes))
 	}
 
 	t := timeNow()

--- a/pkg/services/ngalert/api/api_testing_test.go
+++ b/pkg/services/ngalert/api/api_testing_test.go
@@ -391,6 +391,72 @@ func TestRouteEvalQueries(t *testing.T) {
 	})
 }
 
+func TestInstantQueryPath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dsType   string
+		expected string
+		ok       bool
+	}{
+		{
+			name:     "loki datasource",
+			dsType:   datasources.DS_LOKI,
+			expected: "loki/api/v1/query",
+			ok:       true,
+		},
+		{
+			name:     "prometheus datasource",
+			dsType:   datasources.DS_PROMETHEUS,
+			expected: "api/v1/query",
+			ok:       true,
+		},
+		{
+			name:     "amazon prometheus datasource",
+			dsType:   datasources.DS_AMAZON_PROMETHEUS,
+			expected: "api/v1/query",
+			ok:       true,
+		},
+		{
+			name:     "azure prometheus datasource",
+			dsType:   datasources.DS_AZURE_PROMETHEUS,
+			expected: "api/v1/query",
+			ok:       true,
+		},
+		{
+			name:     "victoria metrics datasource",
+			dsType:   datasources.DS_VICTORIA_METRICS,
+			expected: "api/v1/query",
+			ok:       true,
+		},
+		{
+			name:   "unsupported datasource",
+			dsType: datasources.DS_GRAPHITE,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, ok := instantQueryPath(tc.dsType)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.expected, path)
+		})
+	}
+
+	// every type accepted by the ruler must have a query path, otherwise rule
+	// testing fails for a datasource the API already let through
+	for _, dsType := range []string{
+		datasources.DS_LOKI,
+		datasources.DS_PROMETHEUS,
+		datasources.DS_AMAZON_PROMETHEUS,
+		datasources.DS_AZURE_PROMETHEUS,
+		datasources.DS_VICTORIA_METRICS,
+	} {
+		require.True(t, isLotexRulerCompatible(dsType), dsType)
+		_, ok := instantQueryPath(dsType)
+		require.True(t, ok, dsType)
+	}
+}
+
 func createTestingApiSrv(t *testing.T, ds *fakes.FakeCacheService, ac *acMock.Mock, evaluator eval.EvaluatorFactory, featureManager featuremgmt.FeatureToggles, ruleStore RuleStore) *TestingApiSrv {
 	if ac == nil {
 		ac = acMock.New()

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -94,7 +94,7 @@ func (p *LotexProm) getEndpoints(ctx *contextmodel.ReqContext) (*promEndpoints, 
 
 	var routes promEndpoints
 	switch {
-	case isPrometheusCompatible(ds.Type):
+	case datasources.IsPrometheusCompatible(ds.Type):
 		routes = prometheusEndpoints
 	case ds.Type == datasources.DS_LOKI:
 		routes = lokiEndpoints

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -232,7 +232,7 @@ func (r *LotexRuler) validateAndGetPrefix(ctx *contextmodel.ReqContext) (string,
 
 	var prefix string
 	switch {
-	case isPrometheusCompatible(ds.Type):
+	case datasources.IsPrometheusCompatible(ds.Type):
 		prefix = prometheusPrefix
 	case ds.Type == datasources.DS_LOKI:
 		prefix = lokiPrefix

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -33,25 +33,10 @@ const (
 
 var (
 	searchRegex = regexp.MustCompile(`\{(\w+)\}`)
-
-	prometheusCompatibleDsTypes = []string{
-		datasources.DS_PROMETHEUS,
-		datasources.DS_AMAZON_PROMETHEUS,
-		datasources.DS_AZURE_PROMETHEUS,
-	}
 )
 
-func isPrometheusCompatible(dsType string) bool {
-	for _, t := range prometheusCompatibleDsTypes {
-		if dsType == t {
-			return true
-		}
-	}
-	return false
-}
-
 func isLotexRulerCompatible(dsType string) bool {
-	return dsType == datasources.DS_LOKI || isPrometheusCompatible(dsType)
+	return dsType == datasources.DS_LOKI || datasources.IsPrometheusCompatible(dsType)
 }
 
 func toMacaronPath(path string) string {

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -35,6 +35,10 @@ var (
 	searchRegex = regexp.MustCompile(`\{(\w+)\}`)
 )
 
+// lotexRulerCompatibleTypes lists the datasource types accepted by
+// isLotexRulerCompatible, for use in error messages.
+const lotexRulerCompatibleTypes = "loki, prometheus, amazon prometheus, azure prometheus, victoriametrics"
+
 func isLotexRulerCompatible(dsType string) bool {
 	return dsType == datasources.DS_LOKI || datasources.IsPrometheusCompatible(dsType)
 }
@@ -59,7 +63,7 @@ func getDatasourceByUID(ctx *contextmodel.ReqContext, cache datasources.CacheSer
 		}
 	case apimodels.LoTexRulerBackend:
 		if !isLotexRulerCompatible(ds.Type) {
-			return nil, unexpectedDatasourceTypeError(ds.Type, "loki, prometheus, amazon prometheus, azure prometheus")
+			return nil, unexpectedDatasourceTypeError(ds.Type, lotexRulerCompatibleTypes)
 		}
 	default:
 		return nil, unexpectedDatasourceTypeError(ds.Type, expectedType.String())

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -34,20 +33,10 @@ const (
 
 var (
 	searchRegex = regexp.MustCompile(`\{(\w+)\}`)
-
-	prometheusCompatibleDsTypes = []string{
-		datasources.DS_PROMETHEUS,
-		datasources.DS_AMAZON_PROMETHEUS,
-		datasources.DS_AZURE_PROMETHEUS,
-	}
 )
 
-func isPrometheusCompatible(dsType string) bool {
-	return slices.Contains(prometheusCompatibleDsTypes, dsType)
-}
-
 func isLotexRulerCompatible(dsType string) bool {
-	return dsType == datasources.DS_LOKI || isPrometheusCompatible(dsType)
+	return dsType == datasources.DS_LOKI || datasources.IsPrometheusCompatible(dsType)
 }
 
 func toMacaronPath(path string) string {

--- a/pkg/services/ngalert/api/util_test.go
+++ b/pkg/services/ngalert/api/util_test.go
@@ -200,6 +200,11 @@ func TestIsPrometheusCompatible(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "victoria metrics datasource should be compatible",
+			dsType:   datasources.DS_VICTORIA_METRICS,
+			expected: true,
+		},
+		{
 			name:     "loki datasource should not be prometheus compatible",
 			dsType:   datasources.DS_LOKI,
 			expected: false,
@@ -213,7 +218,7 @@ func TestIsPrometheusCompatible(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := isPrometheusCompatible(tc.dsType)
+			result := datasources.IsPrometheusCompatible(tc.dsType)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -238,6 +243,11 @@ func TestIsLotexRulerCompatible(t *testing.T) {
 		{
 			name:     "azure prometheus datasource should be compatible",
 			dsType:   datasources.DS_AZURE_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "victoria metrics datasource should be compatible",
+			dsType:   datasources.DS_VICTORIA_METRICS,
 			expected: true,
 		},
 		{

--- a/pkg/services/ngalert/api/util_test.go
+++ b/pkg/services/ngalert/api/util_test.go
@@ -256,6 +256,11 @@ func TestIsPrometheusCompatible(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "victoria metrics datasource should be compatible",
+			dsType:   datasources.DS_VICTORIA_METRICS,
+			expected: true,
+		},
+		{
 			name:     "loki datasource should not be prometheus compatible",
 			dsType:   datasources.DS_LOKI,
 			expected: false,
@@ -269,7 +274,7 @@ func TestIsPrometheusCompatible(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := isPrometheusCompatible(tc.dsType)
+			result := datasources.IsPrometheusCompatible(tc.dsType)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -294,6 +299,11 @@ func TestIsLotexRulerCompatible(t *testing.T) {
 		{
 			name:     "azure prometheus datasource should be compatible",
 			dsType:   datasources.DS_AZURE_PROMETHEUS,
+			expected: true,
+		},
+		{
+			name:     "victoria metrics datasource should be compatible",
+			dsType:   datasources.DS_VICTORIA_METRICS,
 			expected: true,
 		},
 		{

--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -36,17 +36,8 @@ var (
 	)
 )
 
-func isPrometheusCompatibleDatasourceType(datasourceType string) bool {
-	switch datasourceType {
-	case datasources.DS_PROMETHEUS, datasources.DS_AMAZON_PROMETHEUS, datasources.DS_AZURE_PROMETHEUS:
-		return true
-	default:
-		return false
-	}
-}
-
 func isConvertibleDatasourceType(datasourceType string) bool {
-	return datasourceType == datasources.DS_LOKI || isPrometheusCompatibleDatasourceType(datasourceType)
+	return datasourceType == datasources.DS_LOKI || datasources.IsPrometheusCompatible(datasourceType)
 }
 
 // Config defines the configuration options for the Prometheus to Grafana rules converter.
@@ -231,7 +222,7 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 	}
 
 	if isRecordingRule {
-		if !isPrometheusCompatibleDatasourceType(p.cfg.TargetDatasourceType) {
+		if !datasources.IsPrometheusCompatible(p.cfg.TargetDatasourceType) {
 			return models.AlertRule{}, ErrInvalidTargetDatasourceType.Errorf("invalid target datasource type: %s, must be prometheus-compatible", p.cfg.TargetDatasourceType)
 		}
 

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -404,6 +404,10 @@ func TestPrometheusRulesToGrafana_PrometheusCompatibleDatasources(t *testing.T) 
 			name:           "azure managed prometheus",
 			datasourceType: datasources.DS_AZURE_PROMETHEUS,
 		},
+		{
+			name:           "victoriametrics",
+			datasourceType: datasources.DS_VICTORIA_METRICS,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -460,6 +464,10 @@ func TestPrometheusRulesToGrafana_PrometheusCompatibleTargetDatasources(t *testi
 		{
 			name:                 "azure managed prometheus",
 			targetDatasourceType: datasources.DS_AZURE_PROMETHEUS,
+		},
+		{
+			name:                 "victoriametrics",
+			targetDatasourceType: datasources.DS_VICTORIA_METRICS,
 		},
 	}
 

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -357,6 +357,7 @@ export const SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES = [
   'prometheus',
   'grafana-amazonprometheus-datasource',
   'grafana-azureprometheus-datasource',
+  'victoriametrics-metrics-datasource',
 ] as const;
 export type SupportedExternalPrometheusFlavoredRulesSourceType =
   (typeof SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES)[number]; // infer the type from the tuple above so we can maintain a single source of truth

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -363,6 +363,7 @@ export const SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES = [
   'prometheus',
   'grafana-amazonprometheus-datasource',
   'grafana-azureprometheus-datasource',
+  'victoriametrics-metrics-datasource',
 ] as const;
 export type SupportedExternalPrometheusFlavoredRulesSourceType =
   (typeof SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES)[number]; // infer the type from the tuple above so we can maintain a single source of truth

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -365,6 +365,7 @@ export const SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES = [
   'prometheus',
   'grafana-amazonprometheus-datasource',
   'grafana-azureprometheus-datasource',
+  'victoriametrics-metrics-datasource',
 ] as const;
 export type SupportedExternalPrometheusFlavoredRulesSourceType =
   (typeof SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES)[number]; // infer the type from the tuple above so we can maintain a single source of truth


### PR DESCRIPTION
**What is this feature?**
1. Added `DS_VICTORIA_METRICS` constant to `pkg/services/datasources/models.go`
2. Extracted `IsPrometheusCompatible()` helper and `prometheusCompatibleDsTypes` list into the datasources package as a single source of truth — previously this logic was duplicated in `pkg/services/ngalert/api/util.go`
3. Updated all callers `(frontendsettings.go, ds_proxy.go, converter.go, lotex_prom.go, lotex_ruler.go, util.go)` to use the shared `datasources.IsPrometheusCompatible()` function
4. Added test cases for VictoriaMetrics in `TestIsPrometheusCompatible` and `TestIsLotexRulerCompatible`
5. Added victoriametrics-metrics-datasource to `SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES` in `public/app/features/alerting/unified/utils/datasource.ts`

**Why do we need this feature?**
This PR adds VictoriaMetrics (victoriametrics-metrics-datasource) as a Prometheus-compatible datasource, enabling alerting rules support for VictoriaMetrics datasources in Grafana.

We have an issue related this feature https://github.com/grafana/grafana/issues/67466
**Who is this feature for?**

Users who use `VictoriaMetrics` as their metrics backend and want to manage alerting rules directly in Grafana, the same way `Prometheus` users can today.

**Which issue(s) does this PR fix?**:

Fixes #67466 

**Special notes for your reviewer:**

1. Install the [VictoriaMetrics datasource plugin](https://github.com/VictoriaMetrics/victoriametrics-datasource)
2. Configure a VictoriaMetrics datasource pointing to a VictoriaMetrics instance
3. Navigate to Alerting > Alert rules > Create new alert rule
4. Select the VictoriaMetrics datasource — it should now be available as a rule source
5. Create and save an alert rule — it should work the same as with a Prometheus datasource
6. It should show the alerting rules in the Grafana UI

<img width="1800" height="1044" alt="Screenshot 2026-04-17 at 18 11 45" src="https://github.com/user-attachments/assets/10bac0d2-e6e0-4a27-aa95-96fe504d7044" />


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
