### PR TITLE
[release-12.3.7] [DOC] Fix broken links in the tempo data source docs

### DIFF
--- a/docs/sources/datasources/tempo/query-editor/traceql-editor.md
+++ b/docs/sources/datasources/tempo/query-editor/traceql-editor.md
@@ -38,7 +38,31 @@ refs:
 
 # Write TraceQL queries with the editor
 
+Use the **TraceQL** editor when you need structural queries across parent and child spans, aggregations, or other features that the [Search query builder](../traceql-search/) doesn't support.
+TraceQL queries follow the pattern `{ conditions } | pipeline`.
+Refer to [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/) for the full syntax.
+
+To get started, paste this query into the editor and select **Run query**:
+
+```traceql
+{ resource.service.name = "frontend" && span:status = error }
+```
+
+This returns all error spans from the `frontend` service.
+Replace `frontend` with your service name.
+For more examples, refer to [TraceQL query examples](../traceql-query-examples/).
+
+If queries return no results, check that your [Tempo data source is configured and connected](../../configure-tempo-data-source/).
+
 [//]: # 'Shared content for the TraceQL query editor'
 [//]: # 'This content is located in /docs/sources/shared/datasources/tempo-editor-traceql.md'
 
 {{< docs/shared source="grafana" lookup="datasources/tempo-editor-traceql.md" version="<GRAFANA_VERSION>" >}}
+
+## Next steps
+
+- [TraceQL query examples](../traceql-query-examples/): Copy-paste query examples for common use cases
+- [Search traces using the query builder](../traceql-search/): Build queries visually
+- [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/): Full TraceQL syntax reference
+- [Service Graph and Service Graph view](../../service-graph/): Visualize service dependencies
+- [Span filters](../../span-filters/): Refine results in the trace detail view

--- a/docs/sources/datasources/tempo/service-graph.md
+++ b/docs/sources/datasources/tempo/service-graph.md
@@ -123,3 +123,14 @@ To open a query in Prometheus with the span name of that row automatically set i
 ![Linked Prometheus data for Rate from within a service graph](/media/docs/grafana/data-sources/tempo/query-editor/tempo-ds-query-service-graph-prom.png)
 
 To open a query in Tempo with the span name of that row automatically set in the query, click a row in the **links** column.
+
+You can also use TraceQL to query the same data programmatically. Refer to [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/) to translate Service Graph observations into queries.
+
+## Troubleshoot
+
+If the Service Graph isn't displaying data, the table is empty, or you see high cardinality warnings, refer to [Service graph issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/troubleshooting/#service-graph-issues) in the troubleshooting guide.
+
+## Next steps
+
+- [Enable service graphs](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/service_graphs/enable-service-graphs/) - Set up metric generation in Tempo or Alloy.
+- [Node graph panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/node-graph/) - Navigate and customize the graph layout.

--- a/docs/sources/datasources/tempo/troubleshooting/index.md
+++ b/docs/sources/datasources/tempo/troubleshooting/index.md
@@ -44,7 +44,7 @@ For issues with Tempo itself (not the data source), refer to the Tempo product d
 
 Additional resources for Grafana Cloud:
 
-- [Troubleshoot Grafana Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshoot/), which covers quick checks, ingestion issues, TraceQL and search, service graph, exemplars, and rate limiting and retry.
+- [Troubleshoot Grafana Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshooting/), which covers quick checks, ingestion issues, TraceQL and search, service graph, exemplars, and rate limiting and retry.
 - [Investigate traces with Grafana Assistant](https://grafana.com/docs/grafana-cloud/send-data/traces/investigate-traces-with-assistant/) - Use Grafana Assistant to help troubleshoot any issues.
 - [Troubleshoot traces collection with Alloy](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/traces-with-alloy/#troubleshoot)
 - [Troubleshoot errors with metrics-generator in Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/configure/metrics-generator/#troubleshoot-errors)
@@ -174,7 +174,7 @@ These errors occur when there are issues with TraceQL queries or trace lookups.
 
    If this returns results, traces are being ingested but your specific trace ID may have been dropped by sampling or aged out. For more query examples, refer to the [TraceQL cookbook](https://grafana.com/docs/grafana-cloud/send-data/traces/traces-query-editor/traceql-cookbook/).
 
-1. For Grafana Cloud users, refer to [Troubleshoot TraceQL and search](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshoot/#traceql-and-search) for TraceQL queries that can help investigate missing traces.
+1. For Grafana Cloud users, refer to [Troubleshoot TraceQL and search](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshooting/#traceql-and-search) for TraceQL queries that can help investigate missing traces.
 
 ### TraceQL syntax errors
 
@@ -313,7 +313,7 @@ The Service Graph visualizes service dependencies and highlights request rate, e
    ```
 
 1. Check the Prometheus data source connection is working.
-1. For Grafana Cloud Traces users, refer to [Troubleshoot service graph and RED metrics](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshoot/#troubleshoot-service-graph-and-red-metrics).
+1. For Grafana Cloud Traces users, refer to [Troubleshoot service graph and RED metrics](https://grafana.com/docs/grafana-cloud/send-data/traces/troubleshooting/#troubleshoot-service-graph-and-red-metrics).
 
 ### Service Graph view table is empty
 

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -122,7 +122,7 @@ It will be removed in a future release.
 {{< /admonition >}}
 
 Using **Aggregate by**, you can calculate RED metrics (total span count, percent erroring spans, and latency information) for spans of `kind=server` that match your filter criteria, grouped by one or more attributes.
-This capability is based on the [metrics summary API](/docs/grafana-cloud/monitor-infrastructure/traces/metrics-summary-api/).
+This capability is based on the [metrics summary API](/docs/grafana-cloud/send-data/traces/metrics-summary-api/).
 Metrics summary only calculates summaries based on spans received within the last hour.
 For additional information, refer to [Traces to metrics: Ad-hoc RED metrics in Grafana Tempo with `Aggregate by`](https://grafana.com/blog/2023/12/07/traces-to-metrics-ad-hoc-red-metrics-in-grafana-tempo-with-aggregate-by/).
 


### PR DESCRIPTION
Backport 816ef4d443857f5adfc87ba50b7b8da90456772e from #122306

---

Fixes broken links in the Tempo data source docs. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
