### PR TITLE
[release-12.4.4] [DOC] Fix broken links in the tempo data source docs

### DIFF
--- a/docs/sources/datasources/tempo/query-editor/traceql-editor.md
+++ b/docs/sources/datasources/tempo/query-editor/traceql-editor.md
@@ -17,7 +17,31 @@ weight: 400
 
 # Write TraceQL queries with the editor
 
+Use the **TraceQL** editor when you need structural queries across parent and child spans, aggregations, or other features that the [Search query builder](../traceql-search/) doesn't support.
+TraceQL queries follow the pattern `{ conditions } | pipeline`.
+Refer to [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/) for the full syntax.
+
+To get started, paste this query into the editor and select **Run query**:
+
+```traceql
+{ resource.service.name = "frontend" && span:status = error }
+```
+
+This returns all error spans from the `frontend` service.
+Replace `frontend` with your service name.
+For more examples, refer to [TraceQL query examples](../traceql-query-examples/).
+
+If queries return no results, check that your [Tempo data source is configured and connected](../../configure-tempo-data-source/).
+
 [//]: # 'Shared content for the TraceQL query editor'
 [//]: # 'This content is located in /docs/sources/shared/datasources/tempo-editor-traceql.md'
 
 {{< docs/shared source="grafana" lookup="datasources/tempo-editor-traceql.md" version="<GRAFANA_VERSION>" >}}
+
+## Next steps
+
+- [TraceQL query examples](../traceql-query-examples/): Copy-paste query examples for common use cases
+- [Search traces using the query builder](../traceql-search/): Build queries visually
+- [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/): Full TraceQL syntax reference
+- [Service Graph and Service Graph view](../../service-graph/): Visualize service dependencies
+- [Span filters](../../span-filters/): Refine results in the trace detail view

--- a/docs/sources/datasources/tempo/service-graph.md
+++ b/docs/sources/datasources/tempo/service-graph.md
@@ -77,3 +77,14 @@ To open a query in Prometheus with the span name of that row automatically set i
 ![Linked Prometheus data for Rate from within a service graph](/media/docs/grafana/data-sources/tempo/query-editor/tempo-ds-query-service-graph-prom.png)
 
 To open a query in Tempo with the span name of that row automatically set in the query, click a row in the **links** column.
+
+You can also use TraceQL to query the same data programmatically. Refer to [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/) to translate Service Graph observations into queries.
+
+## Troubleshoot
+
+If the Service Graph isn't displaying data, the table is empty, or you see high cardinality warnings, refer to [Service graph issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/troubleshooting/#service-graph-issues) in the troubleshooting guide.
+
+## Next steps
+
+- [Enable service graphs](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/service_graphs/enable-service-graphs/) - Set up metric generation in Tempo or Alloy.
+- [Node graph panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/node-graph/) - Navigate and customize the graph layout.

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -122,7 +122,7 @@ It will be removed in a future release.
 {{< /admonition >}}
 
 Using **Aggregate by**, you can calculate RED metrics (total span count, percent erroring spans, and latency information) for spans of `kind=server` that match your filter criteria, grouped by one or more attributes.
-This capability is based on the [metrics summary API](/docs/grafana-cloud/monitor-infrastructure/traces/metrics-summary-api/).
+This capability is based on the [metrics summary API](/docs/grafana-cloud/send-data/traces/metrics-summary-api/).
 Metrics summary only calculates summaries based on spans received within the last hour.
 For additional information, refer to [Traces to metrics: Ad-hoc RED metrics in Grafana Tempo with `Aggregate by`](https://grafana.com/blog/2023/12/07/traces-to-metrics-ad-hoc-red-metrics-in-grafana-tempo-with-aggregate-by/).
 


### PR DESCRIPTION
Backport 816ef4d443857f5adfc87ba50b7b8da90456772e from #122306

---

Fixes broken links in the Tempo data source docs. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
