### PR TITLE
Docs: Add G13 tldr to what's new

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v13-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v13-0.md
@@ -51,6 +51,7 @@ posts:
       - whats-new/2026-04-07-alerting-provenance-permissions-now-enforced-on-kubernetes-style-notification-apis.md
   - title: Other
     items:
+      - whats-new/2026-04-15-deprecation-of-api-path.md
       - whats-new/2026-03-30-pre-scenes-architecture-feature-toggle-removal.md
       - whats-new/2026-03-04-grafana-database-metrics-deprecation.md
   - title: Breaking changes

--- a/docs/sources/whatsnew/whats-new-in-v13-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v13-0.md
@@ -78,7 +78,9 @@ Welcome to Grafana 13.0! In this Grafana release we help solve the blinking curs
 
 Dynamic dashboards, our next generation of dashboarding, reaches general availability. The increased flexibility and adaptability makes building dashboards delightful, and helps teams consolidate and share a single source of truth. Additionally reaching general availability, Git Sync allows powerful bidirectional GitOps-helping you to manage your Grafana resources reliably at scale.
 
-And that’s not all. There is a lot more to discover in Grafana 13, from the new Gauge visualization, new data sources, improved annotations, the list goes on. Read on to find out more and try for yourself.
+And that’s not all. There is a lot more to discover in Grafana 13, from the new Gauge visualization, new data sources, improved annotations, the list goes on. Read on to find out more and try for yourself!
+
+{{< youtube id=OYd0ahylGGI >}}
 
 For even more detail about all the changes in this release, refer to the [changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md). For the specific steps we recommend when you upgrade to v13.0, check out our [Upgrade Guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/upgrade-guide/upgrade-v13.0/).
 

--- a/docs/sources/whatsnew/whats-new-in-v13-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v13-0.md
@@ -38,6 +38,7 @@ posts:
       - whats-new/2026-04-01-query-experience-next.md
   - title: AI
     items:
+      - whats-new/2026-04-20-grafana-assistant-becomes-available-on-prem.md
       - whats-new/2026-04-03-sql-expressions-support-in-grafana-assistant.md
   - title: Data sources
     items:


### PR DESCRIPTION
This PR adds the Grafana 13 tl;dr video to the What's New in Grafana 13 doc