### PR TITLE
Docker: Remove curl from Alpine image to fix curl CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash bubblewrap curl tzdata musl-utils && \
+RUN apk add --no-cache ca-certificates bash bubblewrap tzdata musl-utils && \
   apk info -vv | sort
 
 # glibc support for alpine x86_64 only


### PR DESCRIPTION
## Summary

- Removes `curl` from the Alpine-based Docker final image (`apk add` in the `final-alpine` stage)
- `curl` is not required for Grafana to run - it is not used in `run.sh` or the Grafana server itself
- This eliminates multiple breaching CVEs with no upstream Alpine fix currently available:
  - CVE-2025-15079 (HIGH, 8.1) - SSH known_hosts bypass
  - CVE-2025-14819 (MEDIUM, 6.8) - CA store caching issue
  - CVE-2025-13034 (MEDIUM, 6.8) - Pinned public key check skip
  - CVE-2025-14524 (MEDIUM, 6.5) - OAuth2 bearer token cross-protocol redirect
  - CVE-2025-14017 (MEDIUM, 4.8) - Multi-threaded LDAPS TLS options race
  - CVE-2025-15224 (MEDIUM, 4.7) - SSH agent used when public key auth requested

Note: The openfga CVE (CVE-2026-33729, CRITICAL) and zlib CVE (CVE-2026-22184) were already fixed by [grafana/grafana#122924](https://github.com/grafana/grafana/pull/122924) and [grafana/grafana#122930](https://github.com/grafana/grafana/pull/122930) respectively (both merged to main today), so this branch already includes those fixes.

## Test plan

- [ ] Build the Docker image and verify Grafana starts correctly without `curl`
- [ ] Verify `grafana server` starts and serves the health endpoint
- [ ] Confirm `curl` is not present in the built image (`docker run --rm grafana/grafana which curl` should fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)