### PR TITLE
folder: remove redundant validations from Update in unified storage

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -73,6 +73,9 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return fmt.Errorf("unable to read metadata from object: %w", err)
 	}
 
+	// UID format is only validated on create. On update the Kubernetes API server enforces
+	// that the object name (which maps to the UID) is immutable, so re-validating here
+	// would be redundant.
 	if !util.IsValidShortUID(id) {
 		return dashboards.ErrDashboardInvalidUid
 	}

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -25,7 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 const folderSearchLimit = 100000
@@ -482,12 +481,6 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 
 	if cmd.SignedInUser == nil {
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
-	}
-
-	if !util.IsValidShortUID(cmd.UID) {
-		return nil, dashboards.ErrDashboardInvalidUid
-	} else if util.IsShortUIDTooLong(cmd.UID) {
-		return nil, dashboards.ErrDashboardUidTooLong
 	}
 
 	cmd.UID = strings.TrimSpace(cmd.UID)

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -483,8 +483,6 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-	cmd.UID = strings.TrimSpace(cmd.UID)
-
 	if cmd.NewTitle != nil && *cmd.NewTitle == "" {
 		return nil, dashboards.ErrDashboardTitleEmpty
 	}

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -483,7 +483,6 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-
 	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID))
 	if hasAccess, err := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator); err != nil || !hasAccess {
 		if err != nil {
@@ -492,14 +491,12 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		return nil, toFolderError(dashboards.ErrDashboardUpdateAccessDenied)
 	}
 
-	user := cmd.SignedInUser
-
 	folder, err := s.unifiedStore.Update(ctx, folder.UpdateFolderCommand{
 		UID:                  cmd.UID,
 		OrgID:                cmd.OrgID,
 		NewTitle:             cmd.NewTitle,
 		NewDescription:       cmd.NewDescription,
-		SignedInUser:         user,
+		SignedInUser:         cmd.SignedInUser,
 		Overwrite:            cmd.Overwrite,
 		Version:              cmd.Version,
 		ManagerKindClassicFP: cmd.ManagerKindClassicFP, // nolint:staticcheck

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -483,9 +483,6 @@ func (s *Service) Update(ctx context.Context, cmd *folder.UpdateFolderCommand) (
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-	if cmd.NewTitle != nil && *cmd.NewTitle == "" {
-		return nil, dashboards.ErrDashboardTitleEmpty
-	}
 
 	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID))
 	if hasAccess, err := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator); err != nil || !hasAccess {


### PR DESCRIPTION
The Kubernetes API server enforces name immutability on update and validateOnUpdate already checks title emptiness, making these checks in the service layer dead code. Removes UID format validation, a no-op TrimSpace on the UID, and the empty title guard from the Update method.

Related to https://github.com/grafana/search-and-storage-team/issues/748