### PR TITLE
Prometheus: Associate query builder param label with its input for a11y

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx
@@ -1,7 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
 import { css, cx } from '@emotion/css';
 import { Draggable } from '@hello-pangea/dnd';
-import { useEffect, useId, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as React from 'react';
 
 import { type DataSourceApi, type GrafanaTheme2, type TimeRange } from '@grafana/data';
@@ -49,7 +49,6 @@ export function OperationEditor({
   const styles = useStyles2(getStyles);
   const def = queryModeller.getOperationDef(operation.id);
   const shouldFlash = useFlash(flash);
-  const id = useId();
 
   if (!def) {
     return (
@@ -90,7 +89,7 @@ export function OperationEditor({
       <div className={styles.paramRow} key={`${paramIndex}-1`}>
         {!paramDef.hideName && (
           <div className={styles.paramName}>
-            <label htmlFor={getOperationParamId(id, paramIndex)}>{paramDef.name}</label>
+            <label htmlFor={getOperationParamId(`${operation.id}.${index}`, paramIndex)}>{paramDef.name}</label>
             {paramDef.description && (
               <Tooltip placement="top" content={paramDef.description} theme="info">
                 <Icon name="info-circle" size="sm" className={styles.infoIcon} />
@@ -104,7 +103,7 @@ export function OperationEditor({
               paramDef={paramDef}
               value={operation.params[paramIndex]}
               index={paramIndex}
-              operationId={operation.id}
+              operationId={`${operation.id}.${index}`}
               query={query}
               datasource={datasource}
               timeRange={timeRange}

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx
@@ -49,6 +49,32 @@ describe('OperationList', () => {
     });
   });
 
+  it('associates each param label with its input so screen readers announce it', () => {
+    // Regression for https://github.com/grafana/grafana/issues/66347 — the <label>
+    // used a useId-derived id while the editors used operation.id, so every param
+    // label was an orphan and Prometheus query builder fields had no accessible name.
+    setup();
+    // Rate has a Range param — the label "Range" must be linked to its combo box input.
+    expect(screen.getByLabelText('Range').tagName).toBe('INPUT');
+  });
+
+  it('gives each instance of a duplicated operation a distinct input id', () => {
+    // The id includes the operation's index so two `rate` operations don't
+    // produce duplicate `operations.rate.param.0` ids (which would confuse
+    // screen readers and collide in the DOM).
+    setup({
+      metric: 'random_metric',
+      labels: [{ label: 'instance', op: '=', value: 'localhost:9090' }],
+      operations: [
+        { id: 'rate', params: ['auto'] },
+        { id: 'rate', params: ['$__rate_interval'] },
+      ],
+    });
+    const rangeInputs = screen.getAllByLabelText('Range');
+    expect(rangeInputs).toHaveLength(2);
+    expect(rangeInputs[0].id).not.toBe(rangeInputs[1].id);
+  });
+
   it('adds an operation', async () => {
     const { onChange } = setup();
     await addOperationInQueryBuilder('Aggregations', 'Min');

--- a/packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx
@@ -150,7 +150,7 @@ function SelectInputParamEditor({
   return (
     <Stack gap={0.5} direction="row" alignItems="center">
       <Select
-        id={getOperationParamId(operationId, index)}
+        inputId={getOperationParamId(operationId, index)}
         value={valueOption}
         options={selectOptions}
         placeholder={paramDef.placeholder}


### PR DESCRIPTION
<!-- After saving this PR, drag pr66347-side-by-side.mp4 into the PR body in the browser to replace the placeholder below. -->

**What is this feature?**

An accessibility fix for the Prometheus query builder. `<label>` elements in `OperationEditor` used a `useId()`-derived id for their `htmlFor`, while the `<Select>`/`<Input>` param editors built their `id` from `operation.id`. The two strings never matched, so every param label (Range, Quantile, Seconds from now, By label, etc.) was orphan — screen readers announced only the role and the fields had no accessible name. Violates WCAG 3.3.2 (Labels or Instructions) and 4.1.2 (Name, Role, Value), `wcag-level/A`.

**Why do we need this feature?**

Fixes the `type/accessibility`, `good first issue`, `wcag/3.3.2`, `wcag/4.1.2`, `wcag-level/A` issue #66347 — "Label 'Range' is not associated with its combo box". Originally reported by an a11y audit (SEV2). The bug affects every param editor that uses the shared `OperationEditor`, not just the Range example in the issue title.

**Who is this feature for?**

Anyone using the Prometheus query builder with assistive tech. Fixing this also makes DOM-level tests (`getByLabelText`) work for these fields.

**Which issue(s) does this PR fix?**:

Fixes #66347

**Special notes for your reviewer:**

The change is small (3 files, ~30 lines) and scoped strictly to the shared `OperationEditor` pieces:

- `packages/grafana-prometheus/src/querybuilder/shared/OperationEditor.tsx` — derive the `<label htmlFor>` from `${operation.id}.${index}` so the id matches what the editors emit and duplicate operations (two `rate` ops, etc.) produce distinct ids. Drops the unused `useId` import/hook.
- `packages/grafana-prometheus/src/querybuilder/shared/OperationParamEditorRegistry.tsx` — for the Prometheus `<Select>`, use `inputId` instead of `id` so the id lands on the inner `<input>` (a labellable element) rather than the wrapper `<div>`. This is the documented accessibility contract on `@grafana/ui`'s Select.
- `packages/grafana-prometheus/src/querybuilder/shared/OperationList.test.tsx` — new regression tests: `getByLabelText('Range')` resolves to an `<INPUT>` element; duplicate `rate` operations get distinct ids.

### Verification (AXE + Playwright against a real dev build)

Recorded locally against `gdev-prometheus` in Explore → Builder mode → `+ Operations` → `Rate`. `axe-core` was run against the `label`, `aria-input-field-name`, `label-title-only`, and `form-field-multiple-labels` rules before and after the fix.

https://github.com/user-attachments/assets/916e7fd3-34b6-4a76-ac2e-85b2a0fe436d

**Left — `main`:** `<label for="operations.:r3u:.param.0">Range</label>` → `document.getElementById(for)` is `null` (orphan). axe-core flags the Range combobox (`#react-select-8-input`) under rule `label: Form elements must have labels`.

**Right — fix applied:** `<label for="operations.rate.0.param.0">Range</label>` resolves to the `<input>` inside the `<Select>`. axe-core no longer flags the Range combobox. The remaining violations on `#prometheus-dimensions-filter-item-key`, `#prometheus-dimensions-filter-item-value`, and `#react-select-4-input` (Select metric + Label filters) are pre-existing issues out of scope for this PR.

DOM-level confirmation (probe JSON saved next to the recordings):

```json
// before
{ "htmlFor": "operations.:r3u:.param.0", "pointedToExists": false, "associated": false }
// after
{ "htmlFor": "operations.rate.0.param.0", "pointedToExists": true,  "pointedToTag": "input", "associated": true }
```

### Checklist

Please check that:
- [x] It works as expected from a user's perspective — verified locally + AXE scan + new RTL regression tests.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. — N/A, bug fix to GA code.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. — N/A, no user-facing docs touched; suggest `add to changelog` label since it's a SEV2 a11y fix.
