### PR TITLE
fix: validate full notification settings object for alert rules

### DIFF
--- a/pkg/registry/apps/alerting/rules/alertrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat.go
@@ -318,7 +318,7 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.AlertRule) (*ngmodels.
 
 	sourceSettings := k8sRule.Spec.NotificationSettings
 	if sourceSettings != nil {
-		settings, err := convertNotificationSettings(sourceSettings)
+		settings, err := ConvertNotificationSettings(sourceSettings)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +328,7 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.AlertRule) (*ngmodels.
 	return domainRule, nil
 }
 
-func convertNotificationSettings(sourceSettings *model.AlertRuleNotificationSettings) (ngmodels.NotificationSettings, error) {
+func ConvertNotificationSettings(sourceSettings *model.AlertRuleNotificationSettings) (ngmodels.NotificationSettings, error) {
 	res := ngmodels.NotificationSettings{}
 
 	if sourceSettings.SimplifiedRouting != nil {

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -116,17 +116,15 @@ func RegisterAppInstaller(
 				return nil
 			}
 
-			if notificationSettings.NamedRoutingTree != nil {
-				if err := vd.Validate(ngmodels.NotificationSettingsFromPolicy(notificationSettings.NamedRoutingTree.RoutingTree)); err != nil {
-					return err
-				}
-				return nil
-			}
-
-			// Only validate receiver presence; construct minimal settings
-			if err := vd.Validate(ngmodels.NotificationSettingsFromContact(ngmodels.ContactPointRouting{Receiver: notificationSettings.SimplifiedRouting.Receiver})); err != nil {
+			settingsModel, err := alertrule.ConvertNotificationSettings(&notificationSettings)
+			if err != nil {
 				return err
 			}
+
+			if err := vd.Validate(settingsModel); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
This changes the alert rule notification settings validation for the app platform API to validate the entire notification settings object instead of just the receiver. The API facing impact of this is that validation errors for the optional fields are now correctly thrown with a 400 status code instead of 500.

## Testing
- I called the API locally using a bad value for groupInterval and verified that the error is coming from the validation layer rather than the domain layer now