### PR TITLE
Combobox: Add isOpen and onIsOpenChangeHandler

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -3,6 +3,7 @@ import { useArgs } from '@storybook/preview-api';
 import { type Meta, type StoryFn, type StoryObj } from '@storybook/react';
 import { useEffect, useState } from 'react';
 
+import { Button } from '../Button/Button';
 import { Field } from '../Forms/Field';
 
 import { Combobox, type ComboboxProps } from './Combobox';
@@ -119,6 +120,50 @@ export const CustomValue: Story = {
     createCustomValue: true,
   },
   render: BaseCombobox,
+};
+
+const onIsOpenChangeAction = action('onIsOpenChange');
+
+export const ControlledOpenState: Story = {
+  name: 'Control isOpen',
+  args: {
+    value: null,
+    placeholder: 'Choose fruit…',
+  },
+
+  render: function ControlledOpenStateStory(args: PropsAndCustomArgs) {
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const [dynamicArgs, setArgs] = useArgs();
+
+    return (
+      <>
+        <Field
+          label="Controlled dropdown open"
+          description="Button triggers combobox open via isOpen and onIsOpenChange. Close with Escape or by selecting."
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <Combobox
+              id="controlled-open-combobox"
+              {...args}
+              {...dynamicArgs}
+              isOpen={dropdownOpen}
+              onIsOpenChange={(open) => {
+                onIsOpenChangeAction(open);
+                setDropdownOpen(open);
+              }}
+              onChange={(value: ComboboxOption | null) => {
+                setArgs({ value: value?.value ?? null });
+                onChangeAction(value);
+              }}
+            />
+          </div>
+        </Field>
+        <Button variant="primary" onClick={() => setDropdownOpen(true)}>
+          Open dropdown
+        </Button>
+      </>
+    );
+  },
 };
 
 export const GroupsWithMixedLabels: Story = {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -721,6 +721,45 @@ describe('Combobox', () => {
     });
   });
 
+  describe('open state isOpen / onIsOpenChange', () => {
+    it('opens the dropdown when parent sets isOpen after interaction (controlled)', async () => {
+      const { rerender } = render(
+        <Combobox options={options} value={null} onChange={onChangeHandler} isOpen={false} onIsOpenChange={jest.fn()} />
+      );
+      expect(screen.queryByRole('option', { name: 'Option 1' })).not.toBeInTheDocument();
+
+      rerender(
+        <Combobox options={options} value={null} onChange={onChangeHandler} isOpen onIsOpenChange={jest.fn()} />
+      );
+      expect(await screen.findByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+    });
+
+    it('calls onIsOpenChange when the dropdown opens and closes', async () => {
+      const onIsOpenChange = jest.fn();
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} onIsOpenChange={onIsOpenChange} />);
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      expect(onIsOpenChange).toHaveBeenLastCalledWith(true);
+      await user.keyboard('{Escape}');
+      expect(onIsOpenChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('supports controlled isOpen with onIsOpenChange', async () => {
+      function Controlled() {
+        const [open, setOpen] = React.useState(true);
+        return (
+          <Combobox options={options} value={null} onChange={onChangeHandler} isOpen={open} onIsOpenChange={setOpen} />
+        );
+      }
+      render(<Controlled />);
+      expect(await screen.findByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Option 1' })).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('Escape key behavior in overlays', () => {
     it('should not close a Modal when pressing Escape while the menu is open', async () => {
       const onDismiss = jest.fn();

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -226,7 +226,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     (changes: { isOpen: boolean; inputValue?: string }) => {
       onIsOpenChangeProp?.(changes.isOpen);
 
-      if (changes.isOpen && changes.inputValue === '') {
+      if (changes.isOpen && (changes.inputValue ?? '') === '') {
         updateOptions('');
       }
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -75,6 +75,18 @@ interface ComboboxStaticProps<T extends string | number>
    * Message to display when there are no options found. Defaults to "No options found."
    */
   noOptionsMessage?: string;
+
+  /**
+   * When set, the dropdown open state is fully controlled by the parent. Use with {@link onIsOpenChange}
+   * (e.g. open the list after a tab click or other user action). Omit for normal uncontrolled behavior.
+   */
+  isOpen?: boolean;
+
+  /**
+   * Called whenever the menu opens or closes. Use with {@link isOpen} for controlled mode, or alone to
+   * observe open state.
+   */
+  onIsOpenChange?: (isOpen: boolean) => void;
 }
 
 interface ClearableProps<T extends string | number> {
@@ -157,6 +169,8 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     invalid,
     prefixIcon,
     noOptionsMessage,
+    isOpen: isOpenProp,
+    onIsOpenChange: onIsOpenChangeProp,
   } = props;
 
   // Value can be an actual scalar Value (string or number), or an Option (value + label), so
@@ -207,6 +221,21 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
   const labelId = `${baseId}-downshift-label`;
 
   const styles = useStyles2(getComboboxStyles);
+
+  const onIsOpenChangeHandler = useCallback(
+    (changes: { isOpen: boolean; inputValue?: string }) => {
+      onIsOpenChangeProp?.(changes.isOpen);
+
+      if (changes.isOpen && changes.inputValue === '') {
+        updateOptions('');
+      }
+
+      if (!changes.isOpen) {
+        resetSearch();
+      }
+    },
+    [onIsOpenChangeProp, updateOptions, resetSearch]
+  );
 
   // Injects the group header for the first rendered item into the range to render.
   // Accepts the range that useVirtualizer wants to render, and then returns indexes
@@ -297,15 +326,9 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
 
     scrollIntoView: () => {},
 
-    onIsOpenChange: ({ isOpen, inputValue }) => {
-      if (isOpen && inputValue === '') {
-        updateOptions(inputValue);
-      }
+    ...(isOpenProp !== undefined ? { isOpen: isOpenProp } : {}),
 
-      if (!isOpen) {
-        resetSearch();
-      }
-    },
+    onIsOpenChange: onIsOpenChangeHandler,
 
     onHighlightedIndexChange: ({ highlightedIndex, type }) => {
       if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

## Summary 📝

- Adds **controlled dropdown state** to `@grafana/ui` **Combobox**: optional `isOpen` and `onIsOpenChange`, wired through Downshift with existing open/close behavior (`updateOptions` / `resetSearch`) preserved via `onIsOpenChangeHandler`.
- Adds **unit tests** for controlled open, `onIsOpenChange` callbacks, and Escape-to-close when `isOpen` is controlled; adds a **Storybook** story (**Control isOpen**) with a `Button` + `useArgs` that shows the pattern and keeps Storybook source extractable (inline `render: function StoryName(...)`).

## Test 🧪

- [x] `yarn jest packages/grafana-ui/src/components/Combobox/Combobox.test.tsx --watchAll=false`
- [x] Storybook (`grafana-ui`): **Inputs → Combobox → Control isOpen** — “Open dropdown” opens the list; Escape or selecting an option closes; `onIsOpenChange` fires as expected
- [x] Smoke: uncontrolled Combobox stories still open/close and search/reset as before (no `isOpen` prop)

<img width="1690" height="928" alt="Screenshot 2026-04-17 at 12 57 06 PM" src="https://github.com/user-attachments/assets/f283587e-44fe-4891-9b18-5245cc061720" />


**Why do we need this feature?**
- Allows users to control the combobox dropdown opening and closing

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #
- https://github.com/grafana/logs-drilldown/issues/1855

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
