### PR TITLE
Homepage: Support v2 dashboards if defined by a file

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -878,6 +878,8 @@ This also limits the refresh interval options in Explore.
 
 Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json".
 
+The file may contain either a classic dashboard JSON or a Kubernetes-format dashboard resource exported from the `dashboard.grafana.app` API (with top-level `apiVersion`, `kind`, `metadata` and `spec` fields). The Kubernetes-format is required for `v2` dashboard schemas.
+
 {{< admonition type="note" >}}
 On Linux, Grafana uses `/usr/share/grafana/public/dashboards/home.json` as the default home dashboard location.
 {{< /admonition >}}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -702,19 +702,67 @@ func (hs *HTTPServer) GetHomeDashboard(c *contextmodel.ReqContext) response.Resp
 		}
 	}()
 
+	doc := simplejson.New()
+	jsonParser := json.NewDecoder(file)
+	if err := jsonParser.Decode(doc); err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to load home dashboard", err)
+	}
+
+	// If the configured home dashboard file is a Kubernetes-style Grafana
+	// dashboard resource, return it to the client as that style, with the
+	// injected access shape so that frontend can use the same translator it
+	// already consumes (/dto format)
+	if isK8sDashboardResource(doc) {
+		// Getting-started panel injection still runs against the spec body so
+		// v0/v1 resources behave the same as classic home dashboards if the
+		// existing guards in addGettingStartedPanelToHomeDashboard allow it.
+		if spec, ok := doc.CheckGet("spec"); ok {
+			hs.addGettingStartedPanelToHomeDashboard(c, spec)
+		}
+		doc.Set("access", map[string]any{
+			"canSave":   false,
+			"canShare":  false,
+			"canStar":   false,
+			"canEdit":   false,
+			"canDelete": false,
+			"canAdmin":  false,
+		})
+		return response.JSON(http.StatusOK, doc)
+	}
+
 	dash := dtos.DashboardFullWithMeta{}
 	dash.Meta.CanEdit = c.HasRole(org.RoleEditor)
 	dash.Meta.FolderTitle = "General"
-	dash.Dashboard = simplejson.New()
-
-	jsonParser := json.NewDecoder(file)
-	if err := jsonParser.Decode(dash.Dashboard); err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to load home dashboard", err)
-	}
+	dash.Dashboard = doc
 
 	hs.addGettingStartedPanelToHomeDashboard(c, dash.Dashboard)
 
 	return response.JSON(http.StatusOK, &dash)
+}
+
+// isK8sDashboardResource reports whether the given JSON document is a
+// Kubernetes-style Grafana dashboard resource (apiVersion in the
+// dashboard.grafana.app group, kind=Dashboard, and an object-valued spec).
+func isK8sDashboardResource(doc *simplejson.Json) bool {
+	if doc == nil {
+		return false
+	}
+
+	apiVersion, _ := doc.Get("apiVersion").String()
+	kind, _ := doc.Get("kind").String()
+	spec, hasSpec := doc.CheckGet("spec")
+	if apiVersion == "" || kind != "Dashboard" || !hasSpec {
+		return false
+	}
+	if _, err := spec.Map(); err != nil {
+		return false
+	}
+
+	group, version, ok := strings.Cut(apiVersion, "/")
+	if !ok || group != dashboardsV1.APIGroup || version == "" {
+		return false
+	}
+	return true
 }
 
 func (hs *HTTPServer) addGettingStartedPanelToHomeDashboard(c *contextmodel.ReqContext, dash *simplejson.Json) {

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -76,37 +77,178 @@ func TestGetHomeDashboard(t *testing.T) {
 		tracer:                  tracing.InitializeTracerForTest(),
 	}
 
+	// Build Kubernetes-format dashboard resources that wrap default.json as
+	// their spec, so we can verify that default_home_dashboard_path returns
+	// k8s-style dashboards verbatim to the client for both legacy (V1) and
+	// V2 schemas.
+	defaultDashJSON, err := os.ReadFile("../../public/dashboards/default.json")
+	require.NoError(t, err)
+	writeK8sDashboard := func(t *testing.T, apiVersion, name string, spec map[string]any) (string, map[string]any) {
+		t.Helper()
+		doc := map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       "Dashboard",
+			"metadata":   map[string]any{"name": name},
+			"spec":       spec,
+		}
+		b, err := json.Marshal(doc)
+		require.NoError(t, err)
+		path := filepath.Join(t.TempDir(), "k8s-home.json")
+		require.NoError(t, os.WriteFile(path, b, 0o600))
+		return path, doc
+	}
+
+	defaultDashMap := map[string]any{}
+	require.NoError(t, json.Unmarshal(defaultDashJSON, &defaultDashMap))
+
+	k8sV1Path, k8sV1Doc := writeK8sDashboard(t, "dashboard.grafana.app/v1beta1", "home-dash-v1", defaultDashMap)
+
+	// V2 spec has a fundamentally different shape (no panels/schemaVersion;
+	// uses elements/layout/variables). The resource is returned verbatim so
+	// the frontend can render it natively as v2.
+	v2Spec := map[string]any{
+		"title":    "v2 home",
+		"tags":     []string{"home", "v2"},
+		"elements": map[string]any{},
+		"layout": map[string]any{
+			"kind": "GridLayout",
+			"spec": map[string]any{"items": []any{}},
+		},
+		"variables":   []any{},
+		"annotations": []any{},
+		"cursorSync":  "Off",
+		"preload":     false,
+		"links":       []any{},
+		"timeSettings": map[string]any{
+			"from":           "now-6h",
+			"to":             "now",
+			"timezone":       "browser",
+			"autoRefresh":    "",
+			"hideTimepicker": true,
+		},
+	}
+	k8sV2Path, k8sV2Doc := writeK8sDashboard(t, "dashboard.grafana.app/v2beta1", "home-dash-v2", v2Spec)
+
+	// Unknown k8s group should be treated as a classic dashboard body and
+	// passed through inside the legacy DashboardFullWithMeta envelope.
+	unknownGroupPath := filepath.Join(t.TempDir(), "non-dashboard.json")
+	unknownDoc := map[string]any{
+		"apiVersion": "other.grafana.app/v1",
+		"kind":       "Dashboard",
+		"metadata":   map[string]any{"name": "should-not-unwrap"},
+		"spec":       map[string]any{"title": "unused"},
+	}
+	unknownBytes, err := json.Marshal(unknownDoc)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(unknownGroupPath, unknownBytes, 0o600))
+
+	readOnlyAccess := map[string]any{
+		"canSave":   false,
+		"canShare":  false,
+		"canStar":   false,
+		"canEdit":   false,
+		"canDelete": false,
+		"canAdmin":  false,
+	}
+
 	tests := []struct {
-		name                  string
-		defaultSetting        string
-		expectedDashboardPath string
+		name             string
+		defaultSetting   string
+		expectedResponse func(t *testing.T) []byte
 	}{
-		{name: "using default config", defaultSetting: "", expectedDashboardPath: "../../public/dashboards/home.json"},
-		{name: "custom path", defaultSetting: "../../public/dashboards/default.json", expectedDashboardPath: "../../public/dashboards/default.json"},
+		{
+			name:           "using default config",
+			defaultSetting: "",
+			expectedResponse: func(t *testing.T) []byte {
+				t.Helper()
+				b, err := os.ReadFile("../../public/dashboards/home.json")
+				require.NoError(t, err)
+				j, err := simplejson.NewJson(b)
+				require.NoError(t, err)
+				wrapper := dtos.DashboardFullWithMeta{}
+				wrapper.Meta.FolderTitle = "General"
+				wrapper.Dashboard = j
+				out, err := json.Marshal(wrapper)
+				require.NoError(t, err)
+				return out
+			},
+		},
+		{
+			name:           "custom path with classic dashboard",
+			defaultSetting: "../../public/dashboards/default.json",
+			expectedResponse: func(t *testing.T) []byte {
+				t.Helper()
+				b, err := os.ReadFile("../../public/dashboards/default.json")
+				require.NoError(t, err)
+				j, err := simplejson.NewJson(b)
+				require.NoError(t, err)
+				wrapper := dtos.DashboardFullWithMeta{}
+				wrapper.Meta.FolderTitle = "General"
+				wrapper.Dashboard = j
+				out, err := json.Marshal(wrapper)
+				require.NoError(t, err)
+				return out
+			},
+		},
+		{
+			name:           "custom path with v1 k8s-format dashboard is returned verbatim with access block",
+			defaultSetting: k8sV1Path,
+			expectedResponse: func(t *testing.T) []byte {
+				t.Helper()
+				// Copy so we don't mutate the shared doc.
+				resp := map[string]any{}
+				for k, v := range k8sV1Doc {
+					resp[k] = v
+				}
+				resp["access"] = readOnlyAccess
+				out, err := json.Marshal(resp)
+				require.NoError(t, err)
+				return out
+			},
+		},
+		{
+			name:           "custom path with v2 k8s-format dashboard is returned verbatim with access block",
+			defaultSetting: k8sV2Path,
+			expectedResponse: func(t *testing.T) []byte {
+				t.Helper()
+				resp := map[string]any{}
+				for k, v := range k8sV2Doc {
+					resp[k] = v
+				}
+				resp["access"] = readOnlyAccess
+				out, err := json.Marshal(resp)
+				require.NoError(t, err)
+				return out
+			},
+		},
+		{
+			name:           "unknown k8s group is wrapped in the legacy response",
+			defaultSetting: unknownGroupPath,
+			expectedResponse: func(t *testing.T) []byte {
+				t.Helper()
+				j, err := simplejson.NewJson(unknownBytes)
+				require.NoError(t, err)
+				wrapper := dtos.DashboardFullWithMeta{}
+				wrapper.Meta.FolderTitle = "General"
+				wrapper.Dashboard = j
+				out, err := json.Marshal(wrapper)
+				require.NoError(t, err)
+				return out
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dash := dtos.DashboardFullWithMeta{}
-			dash.Meta.FolderTitle = "General"
-
-			homeDashJSON, err := os.ReadFile(tc.expectedDashboardPath)
-			require.NoError(t, err, "must be able to read expected dashboard file")
 			hs.Cfg.DefaultHomeDashboardPath = tc.defaultSetting
-			bytes, err := simplejson.NewJson(homeDashJSON)
-			require.NoError(t, err, "must be able to encode file as JSON")
-
 			prefService.ExpectedPreference = &pref.Preference{}
 
-			dash.Dashboard = bytes
-
-			b, err := json.Marshal(dash)
-			require.NoError(t, err, "must be able to marshal object to JSON")
+			expectedBytes := tc.expectedResponse(t)
 
 			res := hs.GetHomeDashboard(req)
 			nr, ok := res.(*response.NormalResponse)
 			require.True(t, ok, "should return *NormalResponse")
-			require.Equal(t, b, nr.Body(), "default home dashboard should equal content on disk")
+			require.JSONEq(t, string(expectedBytes), string(nr.Body()), "home dashboard response should match expected body")
 		})
 	}
 }


### PR DESCRIPTION
This PR adds support for v2/v1 dashboards in the homepage in the backend. If the file contents is in the format of a k8s style dashboard, it just returns that format.

Frontend counterpart: https://github.com/grafana/grafana/pull/122995

V2:
<img width="1282" height="440" alt="Screenshot 2026-04-17 at 3 31 23 PM" src="https://github.com/user-attachments/assets/a5796607-8fc4-4b6d-b132-998b4ec9c800" />
<img width="472" height="499" alt="Screenshot 2026-04-17 at 3 30 52 PM" src="https://github.com/user-attachments/assets/e420d9da-d4ae-4665-9a99-ae6ed1fe7983" />


Classic style:
<img width="1243" height="300" alt="Screenshot 2026-04-17 at 3 33 34 PM" src="https://github.com/user-attachments/assets/b97406a8-8a88-4c41-a863-0e3fcce5ea27" />