### PR TITLE
Homepage: Support v2 dashboards in the frontend

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -2153,9 +2153,134 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       expect(loader.state.dashboard!.serializer.initialSaveModel).toEqual(customHomeDashboardV1Spec);
     });
 
-    it('should transform v2 custom home dashboard to v1', async () => {
+    it('should render v2 custom home dashboard natively via the v2 scene builder', async () => {
+      // Backend now returns the k8s resource verbatim with an injected access
+      // block when default_home_dashboard_path points at a
+      // dashboard.grafana.app/* manifest.
       setBackendSrv({
-        get: () => Promise.resolve({ dashboard: customHomeDashboardV2Spec, meta: {} }),
+        get: () =>
+          Promise.resolve({
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'custom-home-v2',
+              creationTimestamp: '',
+              resourceVersion: '0',
+              generation: 0,
+            },
+            spec: customHomeDashboardV2Spec,
+            access: {
+              canSave: false,
+              canShare: false,
+              canStar: false,
+              canEdit: false,
+              canDelete: false,
+              canAdmin: false,
+            },
+          }),
+      } as unknown as BackendSrv);
+
+      const loader = new UnifiedDashboardScenePageStateManager({});
+      await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
+
+      expect(loader.state.dashboard).toBeDefined();
+      // When rendered natively as v2 the initial save model is the v2 spec, not
+      // a down-converted v1 payload.
+      expect(loader.state.dashboard!.serializer.initialSaveModel).toEqual(customHomeDashboardV2Spec);
+      expect(loader.state.dashboard!.state.title).toBe(customHomeDashboardV2Spec.title);
+    });
+
+    it('should render v2 custom home dashboard with non-GridLayout layouts', async () => {
+      const v2WithRowsLayout = {
+        ...customHomeDashboardV2Spec,
+        layout: {
+          kind: 'RowsLayout',
+          spec: {
+            rows: [
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'Row 1',
+                  collapse: false,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 12,
+                            height: 6,
+                            element: { kind: 'ElementReference', name: 'text_panel' },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      setBackendSrv({
+        get: () =>
+          Promise.resolve({
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'custom-home-v2-rows',
+              creationTimestamp: '',
+              resourceVersion: '0',
+              generation: 0,
+            },
+            spec: v2WithRowsLayout,
+            access: {
+              canSave: false,
+              canShare: false,
+              canStar: false,
+              canEdit: false,
+              canDelete: false,
+              canAdmin: false,
+            },
+          }),
+      } as unknown as BackendSrv);
+
+      const loader = new UnifiedDashboardScenePageStateManager({});
+      await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
+
+      // Previously this would throw "Cannot convert non-GridLayout layout to v1"
+      // because the home path force-converted v2 into v1. With native v2
+      // rendering it should succeed.
+      expect(loader.state.dashboard).toBeDefined();
+      expect(loader.state.loadError).toBeUndefined();
+    });
+
+    it('should render v1 k8s home dashboard by unwrapping spec to the classic path', async () => {
+      setBackendSrv({
+        get: () =>
+          Promise.resolve({
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: {
+              name: 'custom-home-v1',
+              creationTimestamp: '',
+              resourceVersion: '0',
+              generation: 0,
+            },
+            spec: customHomeDashboardV1Spec,
+            access: {
+              canSave: false,
+              canShare: false,
+              canStar: false,
+              canEdit: false,
+              canDelete: false,
+              canAdmin: false,
+            },
+          }),
       } as unknown as BackendSrv);
 
       const loader = new UnifiedDashboardScenePageStateManager({});

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -121,7 +121,8 @@ export type HomeDashboardDTO = DashboardDTO & {
  */
 export type HomeDashboardFetchResult =
   | HomeDashboardDTO
-  | DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>;
+  | DashboardWithAccessInfo<DashboardV2Spec>
+  | DashboardWithAccessInfo<DashboardDataDTO>;
 
 interface DashboardScenePageStateManagerLike<T> {
   fetchDashboard(options: LoadDashboardOptions): Promise<T | null>;
@@ -195,9 +196,7 @@ abstract class DashboardScenePageStateManagerBase<T>
    *      injected `access` block.
    */
   protected async fetchHomeDashboard(): Promise<HomeDashboardFetchResult | null> {
-    const rsp = await getBackendSrv().get<
-      HomeDashboardDTO | DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO> | HomeDashboardRedirectDTO
-    >('/api/dashboards/home');
+    const rsp = await getBackendSrv().get<HomeDashboardFetchResult | HomeDashboardRedirectDTO>('/api/dashboards/home');
 
     if (isRedirectResponse(rsp)) {
       const newUrl = locationUtil.processRedirectUri(rsp.redirectUri, locationService.getLocation());
@@ -211,13 +210,12 @@ abstract class DashboardScenePageStateManagerBase<T>
       return rsp;
     }
 
-    const classicRsp = rsp as HomeDashboardDTO;
-    if (classicRsp.meta) {
-      classicRsp.meta.canSave = false;
-      classicRsp.meta.canShare = false;
-      classicRsp.meta.canStar = false;
+    if (rsp.meta) {
+      rsp.meta.canSave = false;
+      rsp.meta.canShare = false;
+      rsp.meta.canStar = false;
     }
-    return classicRsp;
+    return rsp;
   }
 
   private async loadHomeDashboard(): Promise<DashboardScene | null> {
@@ -255,7 +253,7 @@ abstract class DashboardScenePageStateManagerBase<T>
     }
 
     // Neither v1 nor v2 k8s resource - must be the classic DashboardDTO shape.
-    return transformSaveModelToScene(rsp as HomeDashboardDTO, undefined, getSceneCreationOptions());
+    return transformSaveModelToScene(rsp, undefined, getSceneCreationOptions());
   }
 
   public async loadSnapshot(slug: string) {
@@ -821,7 +819,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
               },
             };
           } else {
-            rsp = homeDashboard as HomeDashboardDTO;
+            rsp = homeDashboard;
           }
           break;
         }

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -24,9 +24,15 @@ import {
   AnnoKeySourcePath,
 } from 'app/features/apiserver/types';
 import { dashboardAPIVersionResolver } from 'app/features/dashboard/api/DashboardAPIVersionResolver';
-import { ensureV2Response, transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';
+import { ensureV2Response } from 'app/features/dashboard/api/ResponseTransformers';
 import { DashboardVersionError, type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
-import { isDashboardV2Resource, isDashboardV2Spec, isV2StoredVersion } from 'app/features/dashboard/api/utils';
+import {
+  isDashboardResource,
+  isDashboardV1Resource,
+  isDashboardV2Resource,
+  isDashboardV2Spec,
+  isV2StoredVersion,
+} from 'app/features/dashboard/api/utils';
 import { initializeDashboardAnalyticsAggregator } from 'app/features/dashboard/services/DashboardAnalyticsAggregator';
 import { dashboardLoaderSrv, DashboardLoaderSrvV2 } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
@@ -107,6 +113,16 @@ export type HomeDashboardDTO = DashboardDTO & {
   dashboard: DashboardDataDTO | DashboardV2Spec;
 };
 
+/**
+ * Possible non-redirect return shapes of `/api/dashboards/home`. Either a
+ * classic `{ meta, dashboard }` envelope (legacy `home.json`) or a
+ * Kubernetes-style dashboard resource returned verbatim from the backend when
+ * `default_home_dashboard_path` points at a `dashboard.grafana.app/*` file.
+ */
+export type HomeDashboardFetchResult =
+  | HomeDashboardDTO
+  | DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>;
+
 interface DashboardScenePageStateManagerLike<T> {
   fetchDashboard(options: LoadDashboardOptions): Promise<T | null>;
   getDashboardFromCache(cacheKey: string): T | null;
@@ -168,8 +184,20 @@ abstract class DashboardScenePageStateManagerBase<T>
     return this.cache;
   }
 
-  protected async fetchHomeDashboard(): Promise<DashboardDTO | null> {
-    const rsp = await getBackendSrv().get<HomeDashboardDTO | HomeDashboardRedirectDTO>('/api/dashboards/home');
+  /**
+   * `/api/dashboards/home` can return one of three shapes:
+   *   1. A redirect to another dashboard ({@link HomeDashboardRedirectDTO}).
+   *   2. The legacy classic wrapper {@link HomeDashboardDTO} (`{ meta, dashboard }`) for
+   *      classic `home.json`-style files.
+   *   3. A Kubernetes-style dashboard resource ({@link DashboardWithAccessInfo}) when
+   *      `default_home_dashboard_path` points at a `dashboard.grafana.app/*`
+   *      manifest. In that case the backend returns the file verbatim with an
+   *      injected `access` block.
+   */
+  protected async fetchHomeDashboard(): Promise<HomeDashboardFetchResult | null> {
+    const rsp = await getBackendSrv().get<
+      HomeDashboardDTO | DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO> | HomeDashboardRedirectDTO
+    >('/api/dashboards/home');
 
     if (isRedirectResponse(rsp)) {
       const newUrl = locationUtil.processRedirectUri(rsp.redirectUri, locationService.getLocation());
@@ -177,32 +205,57 @@ abstract class DashboardScenePageStateManagerBase<T>
       return null;
     }
 
-    // If dashboard is on v2 schema convert to v1 schema, there's curently no v2 API for home dashboard
-    if (isDashboardV2Spec(rsp.dashboard)) {
-      rsp.dashboard = transformDashboardV2SpecToV1(rsp.dashboard, {
-        name: '',
-        generation: 0,
-        resourceVersion: '0',
-        creationTimestamp: '',
-      });
+    // k8s-format responses already carry an `access` block from the backend;
+    // classic responses still use the legacy `meta` flags.
+    if (isDashboardResource(rsp)) {
+      return rsp;
     }
 
-    if (rsp?.meta) {
-      rsp.meta.canSave = false;
-      rsp.meta.canShare = false;
-      rsp.meta.canStar = false;
+    const classicRsp = rsp as HomeDashboardDTO;
+    if (classicRsp.meta) {
+      classicRsp.meta.canSave = false;
+      classicRsp.meta.canShare = false;
+      classicRsp.meta.canStar = false;
     }
-
-    return rsp;
+    return classicRsp;
   }
 
   private async loadHomeDashboard(): Promise<DashboardScene | null> {
     const rsp = await this.fetchHomeDashboard();
-    if (rsp) {
-      return transformSaveModelToScene(rsp, undefined, getSceneCreationOptions());
+    if (!rsp) {
+      return null;
     }
 
-    return null;
+    // k8s-format home dashboards (dashboard.grafana.app/*) are returned
+    // verbatim by the backend. Route them through the native v1/v2 scene
+    // builders directly. In particular, v2 resources go through the v2
+    // builder which supports RowsLayout / TabsLayout / AutoGridLayout — not
+    // just GridLayout, which was the only shape the old v2->v1 downconverter
+    // could handle.
+    if (isDashboardV2Resource(rsp)) {
+      return transformSaveModelSchemaV2ToScene(rsp);
+    }
+    if (isDashboardV1Resource(rsp)) {
+      return transformSaveModelToScene(
+        {
+          dashboard: rsp.spec,
+          meta: {
+            canSave: false,
+            canShare: false,
+            canStar: false,
+            canEdit: false,
+            canDelete: false,
+            canAdmin: false,
+            k8s: rsp.metadata,
+          },
+        },
+        undefined,
+        getSceneCreationOptions()
+      );
+    }
+
+    // Neither v1 nor v2 k8s resource - must be the classic DashboardDTO shape.
+    return transformSaveModelToScene(rsp as HomeDashboardDTO, undefined, getSceneCreationOptions());
   }
 
   public async loadSnapshot(slug: string) {
@@ -735,7 +788,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
 
     try {
       switch (route) {
-        case DashboardRoutes.Home:
+        case DashboardRoutes.Home: {
           // For legacy dashboarding we keep this logic here, as dashboard can be loaded through state manager's fetchDashboard method directly
           // See DashboardPageProxy.
           const homeDashboard = await this.fetchHomeDashboard();
@@ -744,8 +797,34 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             return null;
           }
 
-          rsp = homeDashboard;
+          // A v2 k8s home resource cannot be represented as the legacy
+          // DashboardDTO shape this method returns. Signal it the same way
+          // other v2 paths in this method do so DashboardVersionError
+          // handling can switch over to the v2 state manager.
+          if (isDashboardV2Resource(homeDashboard)) {
+            throw new DashboardVersionError('v2beta1', 'Home dashboard is a v2 resource');
+          }
+
+          // For v1 k8s resources, unwrap to the classic `{ meta, dashboard }`
+          // shape the rest of this method expects.
+          if (isDashboardV1Resource(homeDashboard)) {
+            rsp = {
+              dashboard: homeDashboard.spec,
+              meta: {
+                canSave: false,
+                canShare: false,
+                canStar: false,
+                canEdit: false,
+                canDelete: false,
+                canAdmin: false,
+                k8s: homeDashboard.metadata,
+              },
+            };
+          } else {
+            rsp = homeDashboard as HomeDashboardDTO;
+          }
           break;
+        }
         case DashboardRoutes.New:
           rsp = await buildNewDashboardSaveModel(urlFolderUid);
           break;

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -160,6 +160,8 @@ export interface DashboardState {
 
 export const DASHBOARD_FROM_LS_KEY = 'DASHBOARD_FROM_LS_KEY';
 
-export function isRedirectResponse<T extends object>(dto: T | HomeDashboardRedirectDTO): dto is HomeDashboardRedirectDTO {
+export function isRedirectResponse<T extends object>(
+  dto: T | HomeDashboardRedirectDTO
+): dto is HomeDashboardRedirectDTO {
   return 'redirectUri' in dto;
 }

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -160,6 +160,6 @@ export interface DashboardState {
 
 export const DASHBOARD_FROM_LS_KEY = 'DASHBOARD_FROM_LS_KEY';
 
-export function isRedirectResponse(dto: DashboardDTO | HomeDashboardRedirectDTO): dto is HomeDashboardRedirectDTO {
+export function isRedirectResponse<T extends object>(dto: T | HomeDashboardRedirectDTO): dto is HomeDashboardRedirectDTO {
   return 'redirectUri' in dto;
 }


### PR DESCRIPTION
Frontend counterpart to https://github.com/grafana/grafana/pull/122994

Consumes k8s style home pages in the frontend