### PR TITLE
AccessControl: Re-land SA resource permission action set support

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -21,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -213,7 +216,7 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetUserPermission")
 	defer span.End()
 
-	actions, err := s.mapPermission(permission)
+	actions, err := s.mapPermission(ctx, permission)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +250,7 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetTeamPermission")
 	defer span.End()
 
-	actions, err := s.mapPermission(permission)
+	actions, err := s.mapPermission(ctx, permission)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +284,7 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetBuiltInRolePermission")
 	defer span.End()
 
-	actions, err := s.mapPermission(permission)
+	actions, err := s.mapPermission(ctx, permission)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +348,7 @@ func (s *Service) SetPermissions(
 			}
 		}
 
-		actions, err := s.mapPermission(cmd.Permission)
+		actions, err := s.mapPermission(ctx, cmd.Permission)
 		if err != nil {
 			return nil, err
 		}
@@ -389,7 +392,7 @@ func (s *Service) DeleteResourcePermissions(ctx context.Context, orgID int64, re
 	})
 }
 
-func (s *Service) mapPermission(permission string) ([]string, error) {
+func (s *Service) mapPermission(ctx context.Context, permission string) ([]string, error) {
 	if permission == "" {
 		return []string{}, nil
 	}
@@ -403,6 +406,17 @@ func (s *Service) mapPermission(permission string) ([]string, error) {
 		// If we only want to store action sets, return now
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if s.features.IsEnabledGlobally(featuremgmt.FlagOnlyStoreActionSets) {
+			return actions, nil
+		}
+	}
+
+	// Write action set token for service accounts. Granular actions are also written until
+	// FlagOnlyStoreServiceAccountActionSets is enabled (after the backfill migration has run).
+	if s.options.Resource == serviceaccounts.ScopeServiceAccountRoot {
+		actions = append(actions, s.options.GetActionSetName(permission))
+
+		onlyActionSets, _ := openfeature.NewDefaultClient().BooleanValue(ctx, featuremgmt.FlagOnlyStoreServiceAccountActionSets, false, openfeature.TransactionContext(ctx))
+		if onlyActionSets {
 			return actions, nil
 		}
 	}
@@ -643,7 +657,8 @@ func (a *ActionSetSvc) RegisterActionSets(ctx context.Context, pluginID string, 
 func isActionSetEnabledResource(action string) bool {
 	return strings.HasPrefix(action, dashboards.ScopeDashboardsRoot) ||
 		strings.HasPrefix(action, folder.ScopeFoldersRoot) ||
-		strings.HasPrefix(action, accesscontrol.AlertingRoutesKind)
+		strings.HasPrefix(action, accesscontrol.AlertingRoutesKind) ||
+		strings.HasPrefix(action, serviceaccounts.ScopeServiceAccountRoot)
 }
 
 // scopeResource returns the resource prefix used for Resource fields in commands/queries.

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -216,7 +216,7 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetUserPermission")
 	defer span.End()
 
-	actions, err := s.mapPermission(ctx, permission)
+	actions, err := s.mapPermission(permission)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetTeamPermission")
 	defer span.End()
 
-	actions, err := s.mapPermission(ctx, permission)
+	actions, err := s.mapPermission(permission)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 	ctx, span := tracer.Start(ctx, "accesscontrol.resourcepermissions.SetBuiltInRolePermission")
 	defer span.End()
 
-	actions, err := s.mapPermission(ctx, permission)
+	actions, err := s.mapPermission(permission)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (s *Service) SetPermissions(
 			}
 		}
 
-		actions, err := s.mapPermission(ctx, cmd.Permission)
+		actions, err := s.mapPermission(cmd.Permission)
 		if err != nil {
 			return nil, err
 		}
@@ -392,7 +392,7 @@ func (s *Service) DeleteResourcePermissions(ctx context.Context, orgID int64, re
 	})
 }
 
-func (s *Service) mapPermission(ctx context.Context, permission string) ([]string, error) {
+func (s *Service) mapPermission(permission string) ([]string, error) {
 	if permission == "" {
 		return []string{}, nil
 	}
@@ -415,7 +415,7 @@ func (s *Service) mapPermission(ctx context.Context, permission string) ([]strin
 	if s.options.Resource == serviceaccounts.ScopeServiceAccountRoot {
 		actions = append(actions, s.options.GetActionSetName(permission))
 
-		onlyActionSets, _ := openfeature.NewDefaultClient().BooleanValue(ctx, featuremgmt.FlagOnlyStoreServiceAccountActionSets, false, openfeature.TransactionContext(ctx))
+		onlyActionSets, _ := openfeature.NewDefaultClient().BooleanValue(context.Background(), featuremgmt.FlagOnlyStoreServiceAccountActionSets, false, openfeature.EvaluationContext{})
 		if onlyActionSets {
 			return actions, nil
 		}

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -664,7 +664,7 @@ func TestMapPermission_ServiceAccount(t *testing.T) {
 
 	t.Run("flag off: emits action set token AND granular actions", func(t *testing.T) {
 		svc := &Service{options: saOpts}
-		actions, err := svc.mapPermission(context.Background(), "Edit")
+		actions, err := svc.mapPermission("Edit")
 		require.NoError(t, err)
 		assert.Contains(t, actions, saOpts.GetActionSetName("Edit"), "should include action set token")
 		assert.Contains(t, actions, serviceaccounts.ActionRead, "should include granular read action")
@@ -685,7 +685,7 @@ func TestMapPermission_ServiceAccount(t *testing.T) {
 		require.NoError(t, openfeature.SetProviderAndWait(provider))
 
 		svc := &Service{options: saOpts}
-		actions, err := svc.mapPermission(context.Background(), "Edit")
+		actions, err := svc.mapPermission("Edit")
 		require.NoError(t, err)
 		require.Len(t, actions, 1)
 		assert.Equal(t, saOpts.GetActionSetName("Edit"), actions[0])

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -2,8 +2,11 @@ package resourcepermissions
 
 import (
 	"context"
+	"sync"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/team/teamimpl"
@@ -26,6 +30,8 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
+
+var openfeatureTestMutex sync.Mutex
 
 type setUserPermissionTest struct {
 	desc     string
@@ -645,6 +651,52 @@ func TestGetActionSetName(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestMapPermission_ServiceAccount(t *testing.T) {
+	saOpts := Options{
+		Resource: serviceaccounts.ScopeServiceAccountRoot,
+		PermissionsToActions: map[string][]string{
+			"Edit":  {serviceaccounts.ActionRead, serviceaccounts.ActionWrite},
+			"Admin": {serviceaccounts.ActionRead, serviceaccounts.ActionWrite, serviceaccounts.ActionDelete},
+		},
+	}
+
+	t.Run("flag off: emits action set token AND granular actions", func(t *testing.T) {
+		svc := &Service{options: saOpts}
+		actions, err := svc.mapPermission(context.Background(), "Edit")
+		require.NoError(t, err)
+		assert.Contains(t, actions, saOpts.GetActionSetName("Edit"), "should include action set token")
+		assert.Contains(t, actions, serviceaccounts.ActionRead, "should include granular read action")
+		assert.Contains(t, actions, serviceaccounts.ActionWrite, "should include granular write action")
+	})
+
+	t.Run("flag on: emits only action set token", func(t *testing.T) {
+		openfeatureTestMutex.Lock()
+		defer func() {
+			_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+			openfeatureTestMutex.Unlock()
+		}()
+
+		provider, err := featuremgmt.CreateStaticProviderWithStandardFlags(map[string]memprovider.InMemoryFlag{
+			featuremgmt.FlagOnlyStoreServiceAccountActionSets: setting.NewInMemoryFlag(featuremgmt.FlagOnlyStoreServiceAccountActionSets, true),
+		})
+		require.NoError(t, err)
+		require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+		svc := &Service{options: saOpts}
+		actions, err := svc.mapPermission(context.Background(), "Edit")
+		require.NoError(t, err)
+		require.Len(t, actions, 1)
+		assert.Equal(t, saOpts.GetActionSetName("Edit"), actions[0])
+	})
+}
+
+func TestIsActionSetEnabledResource_ServiceAccount(t *testing.T) {
+	t.Run("serviceaccounts actions are enabled", func(t *testing.T) {
+		assert.True(t, isActionSetEnabledResource(serviceaccounts.ScopeServiceAccountRoot+":edit"))
+		assert.True(t, isActionSetEnabledResource(serviceaccounts.ScopeServiceAccountRoot+":admin"))
+	})
 }
 
 func setupTestEnvironment(t *testing.T, ops Options) (*Service, user.Service, team.Service) {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2390,6 +2390,15 @@ var (
 			Expression:   "true",
 		},
 		{
+			Name:         "onlyStoreServiceAccountActionSets",
+			Description:  "When storing service account resource permissions, only store action sets and not the full list of underlying permissions",
+			Stage:        FeatureStageExperimental,
+			Generate:     Generate{LegacyGo: true},
+			HideFromDocs: true,
+			Owner:        identityAccessTeam,
+			Expression:   "false",
+		},
+		{
 			Name:         "excludeRedundantManagedPermissions",
 			Description:  "Exclude redundant individual dashboard/folder permissions from managed roles at query time",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -279,6 +279,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-10-17,pluginStoreServiceLoading,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-11-12,newPanelPadding,preview,@grafana/dashboards-squad,false,false,true
 2025-10-20,onlyStoreActionSets,GA,@grafana/identity-access-team,false,false,false
+2026-04-15,onlyStoreServiceAccountActionSets,experimental,@grafana/identity-access-team,false,false,false
 2026-02-18,excludeRedundantManagedPermissions,experimental,@grafana/identity-access-team,false,false,false
 2025-12-16,pluginInsights,experimental,@grafana/plugins-platform-backend,false,false,true
 2025-10-29,panelTimeSettings,preview,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -750,6 +750,10 @@ const (
 	// When storing dashboard and folder resource permissions, only store action sets and not the full list of underlying permission
 	FlagOnlyStoreActionSets = "onlyStoreActionSets"
 
+	// FlagOnlyStoreServiceAccountActionSets
+	// When storing service account resource permissions, only store action sets and not the full list of underlying permissions
+	FlagOnlyStoreServiceAccountActionSets = "onlyStoreServiceAccountActionSets"
+
 	// FlagExcludeRedundantManagedPermissions
 	// Exclude redundant individual dashboard/folder permissions from managed roles at query time
 	FlagExcludeRedundantManagedPermissions = "excludeRedundantManagedPermissions"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4054,6 +4054,20 @@
     },
     {
       "metadata": {
+        "name": "onlyStoreServiceAccountActionSets",
+        "resourceVersion": "1776254687768",
+        "creationTimestamp": "2026-04-15T12:04:47Z"
+      },
+      "spec": {
+        "description": "When storing service account resource permissions, only store action sets and not the full list of underlying permissions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "opentsdbBackendMigration",
         "resourceVersion": "1775137669107",
         "creationTimestamp": "2025-12-04T08:11:33Z",

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 )
 
+const ScopeServiceAccountRoot = "serviceaccounts"
+
 var (
 	ScopeAll = "serviceaccounts:*"
 	ScopeID  = accesscontrol.Scope("serviceaccounts", "id", accesscontrol.Parameter(":serviceAccountId"))


### PR DESCRIPTION
## Why
Re-lands #122698, which was reverted by #122865. The original change was correct; the revert was unrelated to this code.

## What
- `mapPermission` now accepts `ctx` and writes an action set token when the resource is a service account
- Granular actions continue to be written (dual-write) until `FlagOnlyStoreServiceAccountActionSets` is enabled — this flag should only be flipped after the backfill migration from #122718 has run
- `isActionSetEnabledResource` updated to include `serviceaccounts`
- `ScopeServiceAccountRoot` const added to `pkg/services/serviceaccounts/models.go`
- `onlyStoreServiceAccountActionSets` feature flag added (Experimental, default off)

## How to test
```
go test ./pkg/services/accesscontrol/resourcepermissions/ ./pkg/services/serviceaccounts/ ./pkg/services/featuremgmt/
```
All pass. New tests: `TestMapPermission_ServiceAccount`, `TestIsActionSetEnabledResource_ServiceAccount`.

## Notes
- Depends on migration from #122940 (re-land of #122718) already on main
- Mapper changes from #122933 (re-land of #122684) already on main