### PR TITLE
QueryEditor: Fix loss of query edits when switching queries

### DIFF
--- a/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
@@ -358,10 +358,7 @@ test.describe('Query Editor Next: Query State Preservation', { tag: ['@panels', 
   // Monaco onChange fires synchronously as the user types; if QueryEditorRenderer's handleChange
   // routes those updates by the currently selected refId instead of the originating query's
   // refId, a late onChange from the unmounting editor clobbers the newly selected query.
-  test("switching between SQL expressions preserves each expression's content", async ({
-    gotoDashboardPage,
-    page,
-  }) => {
+  test("switching between SQL expressions preserves each expression's content", async ({ gotoDashboardPage, page }) => {
     await gotoDashboardPage({ uid: DASHBOARD_UID, queryParams: editPanelUrl() });
 
     async function addSqlExpression() {

--- a/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
@@ -368,11 +368,14 @@ test.describe('Query Editor Next: Query State Preservation', { tag: ['@panels', 
       await expect(page.getByTestId('sql-expression-editor')).toBeVisible({ timeout: 15_000 });
     }
 
-    await addSqlExpression();
-    await page.locator('.monaco-editor textarea').first().fill('SELECT 1 FROM A');
+    const fillActiveSqlEditor = (text: string) =>
+      page.getByTestId('sql-expression-editor').locator('.monaco-editor textarea').fill(text);
 
     await addSqlExpression();
-    await page.locator('.monaco-editor textarea').first().fill('SELECT 2 FROM A');
+    await fillActiveSqlEditor('SELECT 1 FROM A');
+
+    await addSqlExpression();
+    await fillActiveSqlEditor('SELECT 2 FROM A');
 
     const cardB = page.locator('[data-query-sidebar-card="B"]');
     const cardC = page.locator('[data-query-sidebar-card="C"]');

--- a/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
@@ -29,6 +29,37 @@ function addTransformationButton(page: Page) {
   return page.getByLabel('Add transformation');
 }
 
+async function switchDatasource(
+  dashboardPage: DashboardPage,
+  page: Page,
+  selectors: E2ESelectorGroups,
+  datasourceName: string
+) {
+  // Datasource picker is only rendered for datasource-backed query cards (not expressions).
+  const queryACard = page.locator('[data-query-sidebar-card="A"]').first();
+  if ((await queryACard.count()) > 0) {
+    await queryACard.click();
+    await expect(queryACard).toHaveAttribute('aria-pressed', 'true');
+  }
+
+  const dataSourceInput = dashboardPage.getByGrafanaSelector(selectors.components.DataSourcePicker.inputV2);
+  await expect(dataSourceInput).toBeVisible();
+  await dataSourceInput.fill(datasourceName);
+
+  const dataSourceList = dashboardPage.getByGrafanaSelector(selectors.components.DataSourcePicker.dataSourceList);
+  await expect(dataSourceList).toBeVisible();
+  await dataSourceList.getByText(datasourceName).first().click();
+}
+
+async function ensureTestDataDatasource(dashboardPage: DashboardPage, page: Page, selectors: E2ESelectorGroups) {
+  const testDataScenarioSelect = page.getByRole('combobox', { name: 'Scenario' });
+  if ((await testDataScenarioSelect.count()) === 0) {
+    await switchDatasource(dashboardPage, page, selectors, 'gdev-testdata');
+  }
+  await expect(testDataScenarioSelect.first()).toBeVisible();
+  return testDataScenarioSelect;
+}
+
 // ---------------------------------------------------------------------------
 // Layout & Navigation
 // ---------------------------------------------------------------------------
@@ -182,37 +213,6 @@ test.describe('Query Editor Next: Sidebar Query Management', { tag: ['@panels', 
 // Datasource Switching
 // ---------------------------------------------------------------------------
 test.describe('Query Editor Next: Datasource Switching', { tag: ['@panels', '@queryEditorNext'] }, () => {
-  async function switchDatasource(
-    dashboardPage: DashboardPage,
-    page: Page,
-    selectors: E2ESelectorGroups,
-    datasourceName: string
-  ) {
-    // Datasource picker is only rendered for datasource-backed query cards (not expressions).
-    const queryACard = page.locator('[data-query-sidebar-card="A"]').first();
-    if ((await queryACard.count()) > 0) {
-      await queryACard.click();
-      await expect(queryACard).toHaveAttribute('aria-pressed', 'true');
-    }
-
-    const dataSourceInput = dashboardPage.getByGrafanaSelector(selectors.components.DataSourcePicker.inputV2);
-    await expect(dataSourceInput).toBeVisible();
-    await dataSourceInput.fill(datasourceName);
-
-    const dataSourceList = dashboardPage.getByGrafanaSelector(selectors.components.DataSourcePicker.dataSourceList);
-    await expect(dataSourceList).toBeVisible();
-    await dataSourceList.getByText(datasourceName).first().click();
-  }
-
-  async function ensureTestDataDatasource(dashboardPage: DashboardPage, page: Page, selectors: E2ESelectorGroups) {
-    const testDataScenarioSelect = page.getByRole('combobox', { name: 'Scenario' });
-    if ((await testDataScenarioSelect.count()) === 0) {
-      await switchDatasource(dashboardPage, page, selectors, 'gdev-testdata');
-    }
-    await expect(testDataScenarioSelect.first()).toBeVisible();
-    return testDataScenarioSelect;
-  }
-
   test('switching datasource updates query editor content', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID, queryParams: editPanelUrl() });
 
@@ -347,6 +347,53 @@ test.describe('Query Editor Next: Expression Flows', { tag: ['@panels', '@queryE
     await page.getByRole('button', { name: 'SQL', exact: true }).click();
 
     await expect(page.getByTestId('sql-expression-editor')).toBeVisible({ timeout: 15_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query State Preservation
+// ---------------------------------------------------------------------------
+test.describe('Query Editor Next: Query State Preservation', { tag: ['@panels', '@queryEditorNext'] }, () => {
+  // Regression cover for https://github.com/grafana/grafana/issues/122956. Prometheus' Monaco
+  // query field only commits its value via onBlur; @hello-pangea/dnd's capture-phase mousedown
+  // preventDefault suppresses the native focus transfer, so without the imperative blur in
+  // SidebarCard.handleMouseDown the editor unmounts with pending edits unflushed.
+  test('preserves pending Prometheus query edits when switching cards without blurring', async ({
+    gotoDashboardPage,
+    selectors,
+    page,
+  }) => {
+    const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID, queryParams: editPanelUrl() });
+
+    await switchDatasource(dashboardPage, page, selectors, 'gdev-prometheus');
+    await page.getByRole('radio', { name: 'Code' }).click();
+
+    const monacoTextarea = page.locator('.monaco-editor textarea').first();
+    await expect(monacoTextarea).toBeVisible({ timeout: 15_000 });
+
+    await addQueryOrExpressionButton(page).click();
+    await page.getByRole('menuitem', { name: 'Add query' }).click();
+    await expect(page.locator('[data-query-sidebar-card="B"]')).toBeVisible();
+
+    const cardA = page.locator('[data-query-sidebar-card="A"]');
+    const cardB = page.locator('[data-query-sidebar-card="B"]');
+
+    await cardA.click();
+    await expect(cardA).toHaveAttribute('aria-pressed', 'true');
+
+    const queryText = 'up{job="grafana"}';
+    await monacoTextarea.fill(queryText);
+
+    // Switch straight to B without clicking outside the editor first. The editor is still
+    // focused at this point, so this is the exact path that previously lost edits. The
+    // `delay` separates mousedown from mouseup so Monaco's `setTimeout(0)`-deferred blur
+    // can fire before React unmounts the editor — matching a real human click.
+    await cardB.click({ delay: 50 });
+    await expect(cardB).toHaveAttribute('aria-pressed', 'true');
+
+    await cardA.click();
+    await expect(cardA).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByText(queryText)).toBeVisible();
   });
 });
 

--- a/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_queryEditorNext.spec.ts
@@ -354,6 +354,44 @@ test.describe('Query Editor Next: Expression Flows', { tag: ['@panels', '@queryE
 // Query State Preservation
 // ---------------------------------------------------------------------------
 test.describe('Query Editor Next: Query State Preservation', { tag: ['@panels', '@queryEditorNext'] }, () => {
+  // Regression cover for https://github.com/grafana/grafana/pull/117785. Each SQL Expression's
+  // Monaco onChange fires synchronously as the user types; if QueryEditorRenderer's handleChange
+  // routes those updates by the currently selected refId instead of the originating query's
+  // refId, a late onChange from the unmounting editor clobbers the newly selected query.
+  test("switching between SQL expressions preserves each expression's content", async ({
+    gotoDashboardPage,
+    page,
+  }) => {
+    await gotoDashboardPage({ uid: DASHBOARD_UID, queryParams: editPanelUrl() });
+
+    async function addSqlExpression() {
+      await addQueryOrExpressionButton(page).click();
+      await page.getByRole('menuitem', { name: 'Add expression' }).click();
+      await page.getByRole('button', { name: 'SQL', exact: true }).click();
+      await expect(page.getByTestId('sql-expression-editor')).toBeVisible({ timeout: 15_000 });
+    }
+
+    await addSqlExpression();
+    await page.locator('.monaco-editor textarea').first().fill('SELECT 1 FROM A');
+
+    await addSqlExpression();
+    await page.locator('.monaco-editor textarea').first().fill('SELECT 2 FROM A');
+
+    const cardB = page.locator('[data-query-sidebar-card="B"]');
+    const cardC = page.locator('[data-query-sidebar-card="C"]');
+
+    await cardB.click();
+    await expect(cardB).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByText('SELECT 1 FROM A')).toBeVisible();
+
+    await cardC.click();
+    await expect(cardC).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByText('SELECT 2 FROM A')).toBeVisible();
+
+    await cardB.click();
+    await expect(page.getByText('SELECT 1 FROM A')).toBeVisible();
+  });
+
   // Regression cover for https://github.com/grafana/grafana/issues/122956. Prometheus' Monaco
   // query field only commits its value via onBlur; @hello-pangea/dnd's capture-phase mousedown
   // preventDefault suppresses the native focus transfer, so without the imperative blur in

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { useState } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   type DataQueryError,
@@ -149,6 +149,87 @@ describe('QueryEditorRenderer', () => {
 
     // Must show series-b, not the stale series-a value from query A's editor instance
     expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-b');
+  });
+
+  it('applies onChange called from a useEffect cleanup when switching away from a query', async () => {
+    const updateSelectedQuery = jest.fn();
+
+    // Editor that flushes a pending edit via onChange in its unmount cleanup.
+    function CleanupOnChangeEditor({ query, onChange }: { query: TestQuery; onChange: (q: DataQuery) => void }) {
+      const pendingEdit = { ...query, legendFormat: `${query.legendFormat}-edited` };
+      const pendingEditRef = useRef(pendingEdit);
+      pendingEditRef.current = pendingEdit;
+      const onChangeRef = useRef(onChange);
+      onChangeRef.current = onChange;
+
+      useEffect(() => {
+        return () => onChangeRef.current(pendingEditRef.current);
+      }, []);
+
+      return <div data-testid="cleanup-editor">{query.legendFormat}</div>;
+    }
+
+    const mockDatasourceWithCleanup: Partial<DataSourceApi<DataQuery, DataSourceJsonData>> = {
+      components: { QueryEditor: CleanupOnChangeEditor },
+    };
+
+    function buildJsx(selectedQuery: DataQuery) {
+      return (
+        <QueryEditorProvider
+          dsState={{ datasource: undefined, dsSettings: undefined, dsError: undefined }}
+          qrState={{ queries: [queryA, queryB], data: undefined, queryError: undefined }}
+          panelState={{ panel: new VizPanel({ key: 'panel-1' }), transformations: [] }}
+          alertingState={{ alertRules: [], loading: false, isDashboardSaved: true }}
+          uiState={{
+            selectedQuery,
+            selectedTransformation: null,
+            selectedAlert: null,
+            setSelectedQuery: jest.fn(),
+            setSelectedTransformation: jest.fn(),
+            setSelectedAlert: jest.fn(),
+            queryOptions: mockQueryOptionsState,
+            selectedQueryDsData: {
+              datasource: mockDatasourceWithCleanup as DataSourceApi,
+              dsSettings: ds1SettingsMock,
+            },
+            selectedQueryDsLoading: false,
+            showingDatasourceHelp: false,
+            toggleDatasourceHelp: jest.fn(),
+            transformToggles: mockTransformToggles,
+            cardType: QueryEditorType.Query,
+            pendingExpression: null,
+            setPendingExpression: jest.fn(),
+            finalizePendingExpression: jest.fn(),
+            pendingTransformation: null,
+            setPendingTransformation: jest.fn(),
+            finalizePendingTransformation: jest.fn(),
+            pendingSavedQuery: null,
+            setPendingSavedQuery: jest.fn(),
+            showVersionBanner: false,
+            selectedQueryRefIds: [],
+            selectedTransformationIds: [],
+            toggleQuerySelection: jest.fn(),
+            toggleTransformationSelection: jest.fn(),
+            clearSelection: jest.fn(),
+          }}
+          actions={{ ...mockActions, updateSelectedQuery }}
+          typeConfig={mockTypeConfig}
+        >
+          <QueryEditorRenderer />
+        </QueryEditorProvider>
+      );
+    }
+
+    const { rerender } = render(buildJsx(queryA));
+
+    await act(async () => {
+      rerender(buildJsx(queryB));
+    });
+
+    expect(updateSelectedQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ refId: 'A', legendFormat: 'series-a-edited' }),
+      'A'
+    );
   });
 
   it('shows an error when the query has an error', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { CoreApp, DataSourcePluginContextProvider } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
@@ -17,27 +17,15 @@ export function QueryEditorRenderer() {
 
   const selectedRefId = selectedQuery?.refId;
 
-  // Ref updated during render (not in an effect) so handleChange can detect
-  // and discard stale onChange calls from downstream editors on query switch.
-  const selectedRefIdRef = useRef(selectedRefId);
-  selectedRefIdRef.current = selectedRefId;
-
   // Filter panel data to only include data for this specific query
   const filteredData = useMemo(() => {
     return selectedRefId && data ? filterPanelDataToQuery(data, selectedRefId) : undefined;
   }, [data, selectedRefId]);
 
+  // Key off updatedQuery.refId so late onChange calls (e.g. editor unmount cleanup) hit the right query.
   const handleChange = useCallback(
     (updatedQuery: DataQuery) => {
-      const currentRefId = selectedRefIdRef.current;
-      if (!currentRefId) {
-        return;
-      }
-      // Discard stale onChange calls targeting a previously selected query.
-      if (updatedQuery.refId !== currentRefId) {
-        return;
-      }
-      updateSelectedQuery(updatedQuery, currentRefId);
+      updateSelectedQuery(updatedQuery, updatedQuery.refId);
     },
     [updateSelectedQuery]
   );

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.test.tsx
@@ -244,6 +244,35 @@ describe('SidebarCard', () => {
 
       expect(onSelect).toHaveBeenCalledWith({});
     });
+
+    it('fires a DOM blur on the focused editor even when mousedown preventDefault blocks focus transfer', async () => {
+      // @hello-pangea/dnd installs a capture-phase mousedown listener that preventDefaults, so the
+      // browser's native focus transfer never fires a blur on the previously focused element.
+      // Without the force-blur in handleMouseDown, Monaco-like editors never see a DOM blur and
+      // their pending value is never flushed through onChange before the editor unmounts.
+      const onSelect = jest.fn();
+      const onEditorBlur = jest.fn();
+      const user = userEvent.setup();
+      renderSidebarCard({ id: 'A', onSelect });
+
+      const suppressFocusTransfer = (e: Event) => e.preventDefault();
+      window.addEventListener('mousedown', suppressFocusTransfer, true);
+
+      const editorLike = document.createElement('input');
+      editorLike.addEventListener('blur', onEditorBlur, true);
+      document.body.appendChild(editorLike);
+      editorLike.focus();
+
+      try {
+        await user.click(screen.getByRole('button', { name: /select card A/i }));
+
+        expect(onEditorBlur).toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('mousedown', suppressFocusTransfer, true);
+        document.body.removeChild(editorLike);
+      }
+    });
   });
 
   describe('hover actions and hidden icon', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -25,6 +25,18 @@ interface SidebarCardProps {
   variant?: 'default' | 'ghost';
 }
 
+const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+  if (e.shiftKey) {
+    // Shift+Click is used for range-selection of cards, not text.
+    e.preventDefault();
+  }
+  // @hello-pangea/dnd's capture-phase mousedown listener calls preventDefault, so browser focus
+  // transfer never fires and Monaco never sees a natural blur. Force it imperatively.
+  if (document.activeElement instanceof HTMLElement && document.activeElement !== e.currentTarget) {
+    document.activeElement.blur();
+  }
+};
+
 export const SidebarCard = ({
   children,
   id,
@@ -60,6 +72,10 @@ export const SidebarCard = ({
     setHasFocusWithin(false);
   }, []);
 
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    onSelect({ multi: e.metaKey || e.ctrlKey, range: e.shiftKey });
+  };
+
   // Using a div with role="button" instead of a native button for @hello-pangea/dnd compatibility,
   // so we manually handle Enter and Space key activation.
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -93,14 +109,8 @@ export const SidebarCard = ({
     <div className={styles.wrapper}>
       <div
         className={styles.card}
-        onClick={(e) => onSelect({ multi: e.metaKey || e.ctrlKey, range: e.shiftKey })}
-        onMouseDown={(e) => {
-          // Prevent the browser's native text-selection behaviour when Shift is held
-          // (Shift+Click is used for range-selection of cards, not text).
-          if (e.shiftKey) {
-            e.preventDefault();
-          }
-        }}
+        onClick={handleClick}
+        onMouseDown={handleMouseDown}
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}
         onBlur={handleBlur}


### PR DESCRIPTION
## Motivation

This PR fixes [DPRO-25](https://linear.app/grafana/issue/DPRO-25/query-changes-are-discarded-when-switching-queries-without-blur) / fixes #122956.

In `PanelEditNext`, changes typed into a query's Monaco-backed editor (e.g. the Prometheus data source's query editor) were silently discarded when switching to another query by clicking a sidebar card, unless they first clicked outside the editor. In other words, editing query A's PromQL, then clicking card B, reverted to A's original query expression when returning to card A.

For example:

https://github.com/user-attachments/assets/7bc4b57d-9fee-4b09-9d93-bedb079758e3

## Root cause

I'm happy to describe the root cause in detail - let me know if this would be valuable. I'm leaving it out for now, for brevity's sake...there's a lot else to cover here!

## Changes

### `SidebarCard`: imperatively blur the active element on mousedown

The minimal fix for the DnD-swallowed-blur problem is to force a DOM blur ourselves before the card takes focus. I added a single branch in the existing `onMouseDown` handler:

```ts
if (document.activeElement instanceof HTMLElement && document.activeElement !== e.currentTarget) {
  document.activeElement.blur();
}
```

This runs synchronously during the click, before React schedules the state update that will unmount the editor. Monaco's internal `FocusTracker` sees the DOM blur, queues its `setTimeout(0)`, and that microtask flushes `onChange(editor.getValue())` before the unmount.

### `QueryEditorRenderer`: route `onChange` by the originating `refId`

`handleChange` previously called `updateSelectedQuery(updatedQuery, currentRefId)` using the *currently selected* refId. With `key={selectedQuery.refId}` causing editor remounts on switch, any late `onChange` from the unmounting editor (including the one our force-blur now reliably triggers) would be applied to the *new* card. The fix is a one-liner:

```ts
updateSelectedQuery(updatedQuery, updatedQuery.refId);
```

The updated query carries its own refId, and we're trusting that. This also closes the stale-closure hole from #117785 in this codepath.

### Tests

#### End-to-end

In `panelEdit_queryEditorNext.spec.ts`, we have two new Playwright tests under a `Query State Preservation` describe block:
- _Prometheus Code-mode edits survive switching without blur._ This test captures the bug. Without the `SidebarCard` and `QueryEditorRenderer` changes, this test fails.
- _SQL expressions preserve their content on switch._ Because this PR deletes code changes in `QueryEditorRenderer` that were central to fixing a bug in https://github.com/grafana/grafana/pull/117785, this test ensures that this PR doesn't undo the earlier PR's fix.

#### Unit

- **`SidebarCard.test.tsx`**: new regression test that reproduces the DnD + async-blur conditions: it installs a capture-phase `mousedown` listener that `preventDefault`s (simulating DnD), focuses an editor-like element, clicks the card, and asserts the editor-like element received a DOM blur. Verified to fail without the force-blur.
- **`QueryEditorRenderer.test.tsx`**: existing regression coverage for the stale-`onChange` routing from #117785, using the bew `updatedQuery.refId` routing.

## Risks

Low.

- The `SidebarCard` change only blurs `document.activeElement` when (a) the element is an `HTMLElement`, and (b) it isn't the card itself. The worst case on an unrelated focused element is one extra blur event on something that was about to lose focus anyway.
- The `QueryEditorRenderer` change makes `handleChange` route by the payload's `refId` rather than the ambient selected refId. This is strictly more correct (every `onChange` caller already knows its own refId) and it removes a `useRef` + a couple of guards rather than adding any.
- No API changes, no datasource-specific assumptions in the fix itself (the force-blur is datasource-agnostic.
- The fact that the new e2e tests are passing adds confidence.

## Demo

When switching away from a Monaco-based query with un-run edits, we see those edits when switching back to it. Switching away from the query doesn't run it.

https://github.com/user-attachments/assets/545eb22a-6987-4f22-b650-167c41d19020

Also, multiple SQL Expressions continue to work as expected, as they have since https://github.com/grafana/grafana/pull/117785.

https://github.com/user-attachments/assets/56357090-2836-46ea-868b-dadb803d26d7

## Testing Instructions

1. Check out `DPRO-25/fix-panel-query-save`.
2. Start the backend (`make run`) and frontend (`yarn start`) with the v2 editor toggle:
   ```ini
   [feature_toggles]
   queryEditorNext = true
   ```
3. Open any dashboard panel and enter the new query editor.
4. Ensure query A is Prometheus (e.g. `gdev-prometheus`) and Code mode.
5. Type a query (e.g. `up{job="grafana"}`). **Do not click outside the editor.**
6. Click "+ Add query" to create query B, then click card A to return.
7. **Expected:** your PromQL expression is preserved.
8. Repeat with Loki, SQL Expressions, and testdata to spot-check other datasources.

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
