### PR TITLE
Forms: Remove gf-form from ButtonRow.tsx

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2114,11 +2114,6 @@
       "count": 2
     }
   },
-  "public/app/features/datasources/components/ButtonRow.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 1
-    }
-  },
   "public/app/features/datasources/components/DataSourcePluginState.tsx": {
     "@grafana/no-gf-form": {
       "count": 3

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1975,11 +1975,6 @@
       "count": 2
     }
   },
-  "public/app/features/datasources/components/ButtonRow.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 1
-    }
-  },
   "public/app/features/datasources/components/DataSourcePluginState.tsx": {
     "@grafana/no-gf-form": {
       "count": 3

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
-import { Button } from '@grafana/ui';
+import { Button, Stack } from '@grafana/ui';
 
 export interface Props {
   canSave: boolean;
@@ -14,7 +14,7 @@ export interface Props {
 
 export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Props) {
   return (
-    <div className="gf-form-button-row">
+    <Stack direction="row" gap={2}>
       <Button
         type="button"
         variant="destructive"
@@ -41,6 +41,6 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Pr
           <Trans i18nKey="datasources.button-row.test">Test</Trans>
         </Button>
       )}
-    </div>
+    </Stack>
   );
 }

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
-import { Button } from '@grafana/ui';
+import { Button, Stack } from '@grafana/ui';
 
 export interface Props {
   canSave: boolean;
@@ -14,7 +14,7 @@ export interface Props {
 
 export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Props) {
   return (
-    <div className="gf-form-button-row">
+    <Stack direction="row" gap={2} wrap="wrap">
       <Button
         type="button"
         variant="destructive"
@@ -41,6 +41,6 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Pr
           <Trans i18nKey="datasources.button-row.test">Test</Trans>
         </Button>
       )}
-    </div>
+    </Stack>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Part of #65513. Replaces the `gf-form-button-row` SASS class in `public/app/features/datasources/components/ButtonRow.tsx` with a `Stack` layout component from `@grafana/ui`, and drops the now-stale entry in `eslint-suppressions.json`.

**Why do we need this feature?**

The `gf-form-*` SASS classes are being removed in favor of Emotion-based layout primitives (see umbrella issue #65513). Scoped to one file per PR, as suggested by @tskarhed in the umbrella thread.

**Who is this feature for?**

Grafana maintainers — reduces SASS surface area. No user-facing behavior change.

**Which issue(s) does this PR fix?**:

Part of #65513

**Special notes for your reviewer**:

Mirrors the pattern established in #113021 (`DataSourceLoadError.tsx`).

The old global SASS rule `.gf-form-button-row` (still defined at `packages/grafana-ui/src/themes/GlobalStyles/forms.ts:190-195` and still needed by `UserLdapSyncInfo.tsx`) provides `paddingTop: theme.spacing(3)` + child `marginRight: theme.spacing(2)`. The replacement `<Stack direction="row" gap={2}>` preserves the inter-button spacing (16px) but does not preserve the 24px top padding — same trade-off accepted in #113021.

DOM measurements from a local dev build at the data source edit page (`/connections/datasources/edit/<uid>`, Delete/Test branch):

| | Before | After |
|---|---|---|
| Wrapper | `<div class="gf-form-button-row">` (global SASS) | `<Stack>` (Emotion, `css-cq4ugg`) |
| `display` | `block` | `flex` (`flex-direction: row`) |
| `padding-top` | `24px` | `0px` |
| inter-button spacing | child `margin-right: 16px` | `gap: 16px` |

Unit tests (`ButtonRow.test.tsx`) are unchanged and still pass — they assert on `data-testid` / text content, which is wrapper-agnostic.

- [x] Works as expected from user's perspective (verified against local dev server)
- [ ] Pre-GA features behind a feature toggle — N/A
- [ ] Docs updated — N/A (no user-facing change)
