### PR TITLE
InfluxDB: Fix comment markers in Flux query editor

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
@@ -9,6 +9,7 @@ import {
   CodeEditorSuggestionItemKind,
   InlineFormLabel,
   LinkButton,
+  type Monaco,
   type MonacoEditor,
   Segment,
   type Themeable2,
@@ -17,6 +18,21 @@ import {
 
 import type InfluxDatasource from '../../../../datasource';
 import { type InfluxQuery } from '../../../../types';
+
+import { conf, language } from './language';
+
+// we must only run the setup code once
+let fluxSetupDone = false;
+const langId = 'flux';
+
+function ensureFlux(monaco: Monaco) {
+  if (!fluxSetupDone) {
+    fluxSetupDone = true;
+    monaco.languages.register({ id: langId });
+    monaco.languages.setMonarchTokensProvider(langId, language);
+    monaco.languages.setLanguageConfiguration(langId, conf);
+  }
+}
 
 interface Props extends Themeable2 {
   onChange: (query: InfluxQuery) => void;
@@ -178,13 +194,14 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
         <CodeEditor
           height={'100%'}
           containerStyles={styles.editorContainerStyles}
-          language="sql"
+          language={langId}
           value={query.query || ''}
           onBlur={this.onFluxQueryChange}
           onSave={this.onFluxQueryChange}
           showMiniMap={false}
           showLineNumbers={true}
           getSuggestions={this.getSuggestions}
+          onBeforeEditorMount={ensureFlux}
           onEditorDidMount={this.editorDidMountCallbackHack}
         />
         <div className={cx('gf-form-inline', styles.editorActions)}>

--- a/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
@@ -9,12 +9,28 @@ import {
   CodeEditorSuggestionItemKind,
   InlineFormLabel,
   LinkButton,
+  type Monaco,
   Segment,
   useStyles2,
 } from '@grafana/ui';
 
 import type InfluxDatasource from '../../../../datasource';
 import { type InfluxQuery } from '../../../../types';
+
+import { conf, language } from './language';
+
+// we must only run the setup code once
+let fluxSetupDone = false;
+const langId = 'flux';
+
+function ensureFlux(monaco: Monaco) {
+  if (!fluxSetupDone) {
+    fluxSetupDone = true;
+    monaco.languages.register({ id: langId });
+    monaco.languages.setMonarchTokensProvider(langId, language);
+    monaco.languages.setLanguageConfiguration(langId, conf);
+  }
+}
 
 interface Props {
   onChange: (query: InfluxQuery) => void;
@@ -161,13 +177,14 @@ export const FluxQueryEditor = memo(function FluxQueryEditor({ query, onChange }
       <CodeEditor
         height={'100%'}
         containerStyles={styles.editorContainerStyles}
-        language="sql"
+        language={langId}
         value={query.query || ''}
         onBlur={onFluxQueryChange}
         onSave={onFluxQueryChange}
         showMiniMap={false}
         showLineNumbers={true}
         getSuggestions={getSuggestions}
+        onBeforeEditorMount={ensureFlux}
       />
       <div className={cx('gf-form-inline', styles.editorActions)}>
         <LinkButton

--- a/public/app/plugins/datasource/influxdb/components/editor/query/flux/language.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/flux/language.ts
@@ -1,0 +1,23 @@
+import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
+
+export const language: monacoType.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenizer: {
+    root: [
+      [/"([^"\\]|\\.)*$/, 'string.invalid'],
+      [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
+      [/\/\/.*$/, 'comment'],
+    ],
+    string: [
+      [/[^\\"]+/, 'string'],
+      [/\\./, 'string.escape'],
+      [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }],
+    ],
+  },
+};
+
+export const conf: monacoType.languages.LanguageConfiguration = {
+  comments: {
+    lineComment: '//',
+  },
+};


### PR DESCRIPTION
**What is this feature?**

Registers a dedicated `flux` Monaco language for the Flux query editor. It sets `lineComment` to `//` and tokenizes `//...` as a comment. A string rule is included so `//` inside string literals is not mistakenly treated as a comment.

**Why do we need this feature?**

The Flux editor was loaded with `language="sql"`, so Monaco applied SQL's line comment. Pressing Cmd+/ inserted `--`, which is a syntax error in Flux.

**Who is this feature for?**

InfluxDB users writing Flux queries in Explore, dashboards, or variables.

**Which issue(s) does this PR fix?**:

Fixes #87021
Fixes #117963

**Special notes for your reviewer:**

Picks up from the now-closed #90160 (thanks @ArtistBanda). That PR set `lineComment` on the built-in `sql` language, which fixed the keybinding but left comments un-highlighted. @itsmylife pointed out on that PR that the comment line color should change too. Registering a separate `flux` language lets the tokenizer tag `//...` as `comment`, so Monaco themes it the right color.

I kept the language definition intentionally small. Only comments and strings are tokenized; keywords, numbers, and operators are not. Hardcoding a Flux grammar just to make this fix bigger did not seem worth it. Full syntax highlighting could be a separate change.

Verified manually in Explore with a Flux-configured InfluxDB data source: Cmd+/ toggles `//` and the comment line renders in the comment color.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
