### PR TITLE
fix(prometheus): fetch new labels on blur instead of change for series limit input

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricSelector.tsx
@@ -14,6 +14,7 @@ export function MetricSelector() {
   const styles = useStyles2(getStylesMetricSelector);
   const [metricSearchTerm, setMetricSearchTerm] = useState('');
   const { metrics, selectedMetric, seriesLimit, setSeriesLimit, onMetricClick } = useMetricsBrowser();
+  const [seriesLimitInput, setSeriesLimitInput] = useState<string>(String(seriesLimit));
 
   const filteredMetrics = useMemo(() => {
     return metrics.filter((m) => m.name === selectedMetric || m.name.includes(metricSearchTerm));
@@ -51,12 +52,18 @@ export function MetricSelector() {
         </Label>
         <div>
           <Input
-            onChange={(e) => setSeriesLimit(parseInt(e.currentTarget.value.trim(), 10))}
+            onChange={(e) => setSeriesLimitInput(e.currentTarget.value)}
+            onBlur={() => {
+              const parsed = parseInt(seriesLimitInput.trim(), 10);
+              if (!isNaN(parsed)) {
+                setSeriesLimit(parsed);
+              }
+            }}
             aria-label={t(
               'grafana-prometheus.components.metric-selector.aria-label-limit-results-from-series-endpoint',
               'Limit results from series endpoint'
             )}
-            value={seriesLimit}
+            value={seriesLimitInput}
             data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.seriesLimit}
           />
         </div>


### PR DESCRIPTION
## Summary

Changes the series limit input in the Prometheus Metrics Browser to only trigger a backend fetch on `onBlur` instead of on every `onChange` keystroke.

## Problem

Currently, when changing the series limit value in the Prometheus metrics browser, every keystroke triggers a new fetch request to the backend (debounced at 300ms). This is wasteful and causes unnecessary API calls while the user is still typing.

## Changes

- Added local state (`seriesLimitInput`) to track the input value during editing
- Changed the Input's `onChange` to update only local state (so the user sees what they type)
- Added `onBlur` handler that parses the value and calls `setSeriesLimit` only when the user leaves the field
- The actual fetch is only triggered once the user finishes editing and moves focus away

## Testing

- Type a series limit value: the input should update visually on each keystroke
- Move focus away (Tab, click elsewhere): the fetch should trigger with the new value
- Invalid/non-numeric values are ignored (no fetch triggered)

Closes #120727