### PR TITLE
QueryEditor: Fix misleading query UI from stale target datasource references

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -114,7 +114,9 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   getInterpolatedDataSourceUID(): string | undefined {
     if (this.props.query.datasource) {
       const instanceSettings = this.dataSourceSrv.getInstanceSettings(this.props.query.datasource);
-      return instanceSettings?.rawRef?.uid ?? instanceSettings?.uid;
+      if (instanceSettings) {
+        return instanceSettings.rawRef?.uid ?? instanceSettings.uid;
+      }
     }
 
     return this.props.dataSource.rawRef?.uid ?? this.props.dataSource.uid;


### PR DESCRIPTION


<!--
**What this PR does / why we need it**:
-->
Fixes an issue #122934   where importing dashboards across different Grafana instances (e.g., from Test to Prod) causes the query editor to break and display the `-- Grafana --` internal datasource ("Query type: Random Walk") instead of the correct Query Editor UI.

**What happened:**
When a panel uses a data source variable (like `${PROM_ENV}`), the underlying `targets` JSON can sometimes still retain explicit, hardcoded `uid` strings from the *original* Grafana instance. When this dashboard is imported to a new instance, that hardcoded `uid` no longer exists. 

Previously, `QueryEditorRow` attempted to resolve this stale `uid`, received `undefined`, and immediately returned `undefined`. This forced the UI into a broken state, even though the query itself still executed successfully using the panel-level variable.

**The Fix:**
Updated `getInterpolatedDataSourceUID` to verify that `instanceSettings` is successfully retrieved. If it is `undefined` (because the target UID is stale/invalid), it now correctly skips to the final `return` statement, falling back to `this.props.dataSource` (the panel-level data source, which contains the correct variable reference).

<!--
**Which issue(s) this PR fixes**:
-->
Fixes #122934

<!--
**Special notes for your reviewer**:
-->
This is purely a UI presentation fix. The actual query execution was already correctly prioritizing the variable, which is why the data populated successfully despite the UI showing a "Random Walk" editor. 

<!--
**How to test this PR**:
-->
**Testing UI fallback via JSON Model:**
1. Create a **Data source variable** (e.g., `${PROM_ENV}`) pulling from an existing data source (like Prometheus).
2. Create a new dashboard panel. Set its Data source dropdown to your `${PROM_ENV}` variable. 
3. Verify the Prometheus query editor appears normally.
4. Click the panel **Settings (gear icon) -> JSON Model**.
5. Find the `"targets"` array and manually corrupt the target's data source UID to simulate a stale imported ID:
   ```json
   "targets": [
     {
       "datasource": {
         "type": "prometheus",
         "uid": "stale-id-from-another-instance"
       }
     }
   ]

6. Save the JSON changes and return to the panel edit view.
7. Before this PR: The query editor UI breaks and shows the  ` -- Grafana --`  internal datasource ("Query type: Random Walk").
8. After this PR: The UI gracefully ignores stale-id-from-another-instance, falls back to ${PROM_ENV}, and continues to render the correct Prometheus query editor without issue.

Please check that:
- [x] It works as expected from a user's perspective.
