### PR TITLE
Plugins: Show install button for entitled marketplace plugins

### DIFF
--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -267,4 +267,22 @@ export async function updatePluginSettings(id: string, data: Partial<PluginMeta>
   return response?.data;
 }
 
+export async function getPluginEntitlement(id: string): Promise<boolean> {
+  try {
+    await getBackendSrv().get(`${GCOM_API_ROOT}/plugins/${id}/entitlement`);
+    return true;
+  } catch (error) {
+    if (isFetchError(error)) {
+      error.isHandled = true;
+      if (error.status === 404 || error.status === 403) {
+        return false;
+      }
+      console.warn(`Failed to fetch entitlement for plugin "${id}" (status ${error.status})`);
+    } else {
+      console.warn(`Failed to fetch entitlement for plugin "${id}": unexpected error`);
+    }
+    return false;
+  }
+}
+
 export const api = { getRemotePlugins, getInstalledPlugins: getLocalPlugins, installPlugin, uninstallPlugin };

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -274,7 +274,7 @@ export async function getPluginEntitlement(id: string): Promise<boolean> {
   } catch (error) {
     if (isFetchError(error)) {
       error.isHandled = true;
-      if (error.status === 404 || error.status === 403) {
+      if (error.status === 401 || error.status === 403 || error.status === 404) {
         return false;
       }
       console.warn(`Failed to fetch entitlement for plugin "${id}" (status ${error.status})`);

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -245,12 +245,13 @@ describe('InstallControlsButton', () => {
   });
 
   describe('marketplace plugin', () => {
-    it('should render a link to grafana.com installation tab instead of install button', () => {
+    it('should render a link to grafana.com installation tab instead of install button when not entitled', () => {
       render(
         <TestProvider>
           <InstallControlsButton
             plugin={{ ...plugin, distributionType: 'marketplace' }}
             pluginStatus={PluginStatus.INSTALL}
+            entitlement={{ entitled: false, isLoading: false }}
           />
         </TestProvider>
       );
@@ -258,6 +259,39 @@ describe('InstallControlsButton', () => {
       expect(link).toHaveTextContent(/contact us/i);
       expect(link).toHaveAttribute('href', expect.stringContaining('/plugins/test-plugin?tab=installation'));
       expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('should render a disabled install button with a spinner when entitlement is loading', () => {
+      render(
+        <TestProvider>
+          <InstallControlsButton
+            plugin={{ ...plugin, distributionType: 'marketplace' }}
+            pluginStatus={PluginStatus.INSTALL}
+            entitlement={{ entitled: false, isLoading: true }}
+          />
+        </TestProvider>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent(/install/i);
+      expect(button).toBeDisabled();
+      expect(button.querySelector('svg')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should render the normal install button when the org is entitled', () => {
+      render(
+        <TestProvider>
+          <InstallControlsButton
+            plugin={{ ...plugin, distributionType: 'marketplace' }}
+            pluginStatus={PluginStatus.INSTALL}
+            entitlement={{ entitled: true, isLoading: false }}
+          />
+        </TestProvider>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent(/install/i);
+      expect(button).not.toBeDisabled();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
     });
 
     it('should not render marketplace link when distributionType is not set', () => {

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -12,6 +12,7 @@ import { isOpenSourceBuildOrUnlicenced } from 'app/features/admin/EnterpriseAuth
 import { useDispatch } from 'app/types/store';
 
 import { getExternalManageLink, isDisabledAngularPlugin, isMarketplacePlugin } from '../../helpers';
+import { type EntitlementState } from '../../hooks/usePluginEntitlement';
 import {
   useInstallStatus,
   useUninstallStatus,
@@ -31,6 +32,7 @@ type InstallControlsButtonProps = {
   latestCompatibleVersion?: Version;
   hasInstallWarning?: boolean;
   setNeedReload?: (needReload: boolean) => void;
+  entitlement?: EntitlementState;
 };
 
 export function InstallControlsButton({
@@ -39,6 +41,7 @@ export function InstallControlsButton({
   latestCompatibleVersion,
   hasInstallWarning,
   setNeedReload,
+  entitlement,
 }: InstallControlsButtonProps) {
   const dispatch = useDispatch();
   const [queryParams] = useQueryParams();
@@ -205,16 +208,26 @@ export function InstallControlsButton({
   }
 
   if (isMarketplacePlugin(plugin)) {
-    return (
-      <LinkButton
-        href={`${getExternalManageLink(plugin.id)}?tab=installation`}
-        target="_blank"
-        rel="noopener noreferrer"
-        icon="external-link-alt"
-      >
-        <Trans i18nKey="plugins.install-controls.contact-us">Contact us</Trans>
-      </LinkButton>
-    );
+    if (entitlement?.isLoading) {
+      return (
+        <Button disabled icon="spinner">
+          <Trans i18nKey="plugins.install-controls.install">Install</Trans>
+        </Button>
+      );
+    }
+
+    if (!entitlement?.entitled) {
+      return (
+        <LinkButton
+          href={`${getExternalManageLink(plugin.id)}?tab=installation`}
+          target="_blank"
+          rel="noopener noreferrer"
+          icon="external-link-alt"
+        >
+          <Trans i18nKey="plugins.install-controls.contact-us">Contact us</Trans>
+        </LinkButton>
+      );
+    }
   }
 
   const shouldDisable = isInstalling || errorInstalling || plugin.angularDetected;

--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -14,6 +14,7 @@ import {
   isInstallControlsEnabled,
   isNonAngularVersion,
 } from '../helpers';
+import { usePluginEntitlement } from '../hooks/usePluginEntitlement';
 import { useIsRemotePluginsAvailable } from '../state/hooks';
 import { type CatalogPlugin, PluginStatus, type Version } from '../types';
 
@@ -26,6 +27,7 @@ export const PluginActions = ({ plugin }: Props) => {
   const isRemotePluginsAvailable = useIsRemotePluginsAvailable();
   const latestCompatibleVersion = getLatestCompatibleVersion(plugin?.details?.versions);
   const [needReload, setNeedReload] = useState(false);
+  const entitlement = usePluginEntitlement(plugin);
 
   if (!plugin || plugin.angularDetected) {
     return null;
@@ -45,6 +47,7 @@ export const PluginActions = ({ plugin }: Props) => {
             pluginStatus={pluginStatus}
             setNeedReload={setNeedReload}
             hasInstallWarning={hasInstallWarning}
+            entitlement={entitlement}
           />
         )}
         <GetStartedWithPlugin plugin={plugin} />

--- a/public/app/features/plugins/admin/hooks/usePluginEntitlement.test.ts
+++ b/public/app/features/plugins/admin/hooks/usePluginEntitlement.test.ts
@@ -1,0 +1,161 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { PluginSignatureStatus } from '@grafana/data';
+
+import { getPluginEntitlement } from '../api';
+import { type CatalogPlugin } from '../types';
+
+import { clearEntitlementCache, usePluginEntitlement } from './usePluginEntitlement';
+
+jest.mock('../api', () => ({
+  getPluginEntitlement: jest.fn(),
+}));
+
+const mockGetPluginEntitlement = jest.mocked(getPluginEntitlement);
+
+const basePlugin: CatalogPlugin = {
+  description: 'A test plugin',
+  downloads: 0,
+  id: 'test-plugin',
+  info: {
+    logos: { small: '', large: '' },
+    keywords: [],
+  },
+  name: 'Test Plugin',
+  orgName: 'Test Org',
+  popularity: 0,
+  signature: PluginSignatureStatus.valid,
+  publishedAt: '2020-01-01',
+  updatedAt: '2021-01-01',
+  hasUpdate: false,
+  isInstalled: false,
+  isCore: false,
+  isDev: false,
+  isEnterprise: false,
+  isDisabled: false,
+  isDeprecated: false,
+  isPublished: true,
+  isPreinstalled: { found: false, withVersion: false },
+  managed: { enabled: false, strategy: undefined },
+};
+
+const marketplacePlugin: CatalogPlugin = {
+  ...basePlugin,
+  distributionType: 'marketplace',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearEntitlementCache();
+});
+
+describe('usePluginEntitlement', () => {
+  it('returns not entitled and not loading immediately for a non-marketplace plugin', () => {
+    const { result } = renderHook(() => usePluginEntitlement(basePlugin));
+    expect(result.current).toEqual({ entitled: false, isLoading: false });
+    expect(mockGetPluginEntitlement).not.toHaveBeenCalled();
+  });
+
+  it('returns not entitled and not loading for undefined plugin', () => {
+    const { result } = renderHook(() => usePluginEntitlement(undefined));
+    expect(result.current).toEqual({ entitled: false, isLoading: false });
+    expect(mockGetPluginEntitlement).not.toHaveBeenCalled();
+  });
+
+  it('returns entitled=true and isLoading=false when API indicates entitlement', async () => {
+    mockGetPluginEntitlement.mockResolvedValue(true);
+
+    const { result } = renderHook(() => usePluginEntitlement(marketplacePlugin));
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ entitled: true, isLoading: false });
+    });
+
+    expect(mockGetPluginEntitlement).toHaveBeenCalledWith('test-plugin');
+  });
+
+  it('returns entitled=false and isLoading=false when API indicates no entitlement', async () => {
+    mockGetPluginEntitlement.mockResolvedValue(false);
+
+    const { result } = renderHook(() => usePluginEntitlement(marketplacePlugin));
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ entitled: false, isLoading: false });
+    });
+
+    expect(mockGetPluginEntitlement).toHaveBeenCalledWith('test-plugin');
+  });
+
+  it('starts with isLoading=true for a marketplace plugin before the API responds', async () => {
+    let resolve: (value: boolean) => void;
+    mockGetPluginEntitlement.mockReturnValue(new Promise<boolean>((res) => (resolve = res)));
+
+    const { result } = renderHook(() => usePluginEntitlement(marketplacePlugin));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolve!(true);
+    });
+
+    expect(result.current).toEqual({ entitled: true, isLoading: false });
+  });
+
+  it('reuses cache and does not make a second API call when re-rendered with the same plugin', async () => {
+    mockGetPluginEntitlement.mockResolvedValue(true);
+
+    const { result, rerender } = renderHook(() => usePluginEntitlement(marketplacePlugin));
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ entitled: true, isLoading: false });
+    });
+
+    rerender();
+
+    expect(mockGetPluginEntitlement).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({ entitled: true, isLoading: false });
+  });
+
+  it('makes a new API call and resets state when plugin id changes', async () => {
+    const pluginA: CatalogPlugin = { ...marketplacePlugin, id: 'plugin-a' };
+    const pluginB: CatalogPlugin = { ...marketplacePlugin, id: 'plugin-b' };
+
+    mockGetPluginEntitlement.mockResolvedValue(true);
+
+    const { result, rerender } = renderHook(({ plugin }) => usePluginEntitlement(plugin), {
+      initialProps: { plugin: pluginA },
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ entitled: true, isLoading: false });
+    });
+
+    mockGetPluginEntitlement.mockResolvedValue(false);
+    rerender({ plugin: pluginB });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ entitled: false, isLoading: false });
+    });
+
+    expect(mockGetPluginEntitlement).toHaveBeenCalledTimes(2);
+    expect(mockGetPluginEntitlement).toHaveBeenCalledWith('plugin-a');
+    expect(mockGetPluginEntitlement).toHaveBeenCalledWith('plugin-b');
+  });
+
+  it('does not update state after unmount if the fetch resolves after unmount', async () => {
+    let resolve: (value: boolean) => void;
+    mockGetPluginEntitlement.mockReturnValue(new Promise<boolean>((res) => (resolve = res)));
+
+    const { unmount } = renderHook(() => usePluginEntitlement(marketplacePlugin));
+
+    unmount();
+
+    // Resolving after unmount must not throw or cause a state-update warning
+    await act(async () => {
+      resolve!(true);
+    });
+
+    // If the cancelled flag works correctly, no error is thrown and no state update occurs
+    expect(mockGetPluginEntitlement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/plugins/admin/hooks/usePluginEntitlement.ts
+++ b/public/app/features/plugins/admin/hooks/usePluginEntitlement.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+import { getPluginEntitlement } from '../api';
+import { isMarketplacePlugin } from '../helpers';
+import { type CatalogPlugin } from '../types';
+
+export type EntitlementState = {
+  entitled: boolean;
+  isLoading: boolean;
+};
+
+const entitlementCache = new Map<string, boolean>();
+
+export function clearEntitlementCache(): void {
+  entitlementCache.clear();
+}
+
+function resolveEntitlement(pluginId: string | undefined, isMarketplace: boolean): EntitlementState {
+  if (!isMarketplace || pluginId === undefined) {
+    return { entitled: false, isLoading: false };
+  }
+  const cached = entitlementCache.get(pluginId);
+  if (cached !== undefined) {
+    return { entitled: cached, isLoading: false };
+  }
+  return { entitled: false, isLoading: true };
+}
+
+export function usePluginEntitlement(plugin: CatalogPlugin | undefined): EntitlementState {
+  const isMarketplace = plugin !== undefined && isMarketplacePlugin(plugin);
+  const pluginId = plugin?.id;
+
+  const [state, setState] = useState<EntitlementState>(() => resolveEntitlement(pluginId, isMarketplace));
+
+  useEffect(() => {
+    const resolved = resolveEntitlement(pluginId, isMarketplace);
+    setState(resolved);
+
+    if (!resolved.isLoading) {
+      return;
+    }
+
+    let cancelled = false;
+    getPluginEntitlement(pluginId!)
+      .then((entitled) => {
+        if (!cancelled) {
+          entitlementCache.set(pluginId!, entitled);
+          setState({ entitled, isLoading: false });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ entitled: false, isLoading: false });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginId, isMarketplace]);
+
+  return state;
+}

--- a/public/app/features/plugins/admin/hooks/usePluginEntitlement.ts
+++ b/public/app/features/plugins/admin/hooks/usePluginEntitlement.ts
@@ -34,25 +34,21 @@ export function usePluginEntitlement(plugin: CatalogPlugin | undefined): Entitle
 
   useEffect(() => {
     const resolved = resolveEntitlement(pluginId, isMarketplace);
-    setState(resolved);
+    setState((prev) =>
+      prev.entitled === resolved.entitled && prev.isLoading === resolved.isLoading ? prev : resolved
+    );
 
     if (!resolved.isLoading) {
       return;
     }
 
     let cancelled = false;
-    getPluginEntitlement(pluginId!)
-      .then((entitled) => {
-        if (!cancelled) {
-          entitlementCache.set(pluginId!, entitled);
-          setState({ entitled, isLoading: false });
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setState({ entitled: false, isLoading: false });
-        }
-      });
+    getPluginEntitlement(pluginId!).then((entitled) => {
+      if (!cancelled) {
+        entitlementCache.set(pluginId!, entitled);
+        setState({ entitled, isLoading: false });
+      }
+    });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-catalog-team/issues/813.

### What changed?

Marketplace plugins now check org entitlement before deciding which button to show:
- **Entitled** → normal Install button
- **Not entitled / on-prem / error** → existing Contact Us button (no behavior change)

**Notes**
- The entitlement is checked via `GET /api/gnet/plugins/{slug}/entitlement`
- 401, 404 and 403 responses are treated as "not entitled" (not errors), so **on-prem** installs without a Cloud token degrade gracefully.