### PR TITLE
Prometheus: Use @grafana/prometheus v13.1.2

### DIFF
--- a/.github/workflows/externalized-datasources-reminder.yml
+++ b/.github/workflows/externalized-datasources-reminder.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened]
     paths:
+      - "packages/grafana-prometheus/**"
       - "public/app/plugins/datasource/cloudwatch/**"
       - "public/app/plugins/datasource/cloud-monitoring/**"
       - "public/app/plugins/datasource/graphite/**"

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "@grafana/monaco-logql": "^0.0.8",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/plugin-ui": "^0.13.1",
-    "@grafana/prometheus": "workspace:*",
+    "@grafana/prometheus": "13.1.2",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "7.3.11",
     "@grafana/scenes-react": "7.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,7 +3733,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/prometheus@workspace:*, @grafana/prometheus@workspace:packages/grafana-prometheus":
+"@grafana/prometheus@npm:13.1.2":
+  version: 13.1.2
+  resolution: "@grafana/prometheus@npm:13.1.2"
+  dependencies:
+    "@emotion/css": "npm:11.13.5"
+    "@floating-ui/react": "npm:0.27.19"
+    "@grafana/plugin-ui": "npm:^0.13.1"
+    "@hello-pangea/dnd": "npm:18.0.1"
+    "@leeoniya/ufuzzy": "npm:1.0.19"
+    "@lezer/common": "npm:1.5.2"
+    "@lezer/highlight": "npm:1.2.3"
+    "@lezer/lr": "npm:1.4.8"
+    "@prometheus-io/lezer-promql": "npm:0.307.3"
+    "@types/debounce-promise": "npm:3.1.9"
+    "@types/lodash": "npm:4.17.20"
+    "@types/react": "npm:18.3.18"
+    "@types/react-dom": "npm:18.3.5"
+    "@types/react-highlight-words": "npm:0.20.0"
+    "@types/semver": "npm:7.7.1"
+    "@types/uuid": "npm:10.0.0"
+    debounce-promise: "npm:3.1.2"
+    lodash: "npm:^4.17.23"
+    moment: "npm:2.30.1"
+    moment-timezone: "npm:0.5.47"
+    monaco-editor: "npm:0.34.1"
+    monaco-promql: "npm:1.8.0"
+    pluralize: "npm:8.0.0"
+    prismjs: "npm:1.30.0"
+    react-highlight-words: "npm:0.21.0"
+    react-use: "npm:17.6.0"
+    react-window: "npm:1.8.11"
+    rxjs: "npm:7.8.2"
+    semver: "npm:7.7.3"
+    uuid: "npm:11.1.0"
+  peerDependencies:
+    "@grafana/assistant": ">=0.1.0"
+    "@grafana/data": ">=11.5.0"
+    "@grafana/e2e-selectors": ">=11.5.0"
+    "@grafana/i18n": ">=12.3.0"
+    "@grafana/runtime": ">=11.5.0"
+    "@grafana/schema": ">=11.5.0"
+    "@grafana/ui": ">=11.5.0"
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  peerDependenciesMeta:
+    "@grafana/assistant":
+      optional: true
+  checksum: 10/d96748add1b29ed9251dbf0f7d65ece846c3ce29760a6f74e21f8f4c7614a15ec79f657c8764d4a1fa117cb45ea531ab91d8bc99495919e78bcc6ae8ce82d7d2
+  languageName: node
+  linkType: hard
+
+"@grafana/prometheus@workspace:packages/grafana-prometheus":
   version: 0.0.0-use.local
   resolution: "@grafana/prometheus@workspace:packages/grafana-prometheus"
   dependencies:
@@ -20194,7 +20245,7 @@ __metadata:
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:^3.4.12"
     "@grafana/plugin-ui": "npm:^0.13.1"
-    "@grafana/prometheus": "workspace:*"
+    "@grafana/prometheus": "npm:13.1.2"
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": "npm:7.3.11"
     "@grafana/scenes-react": "npm:7.3.11"


### PR DESCRIPTION
**What is this feature?**

We moved grafana-prometheus package to `grafana/grafana-prometheus-datasource` repository. We'll keep developing it in this new repository so we don't need `grafana-prometheus` package to be in `grafana/grafana` repo. So this PR:

- makes sure grafana will continue to work with `@grafana/prometheus` package instead of using it in workspace

Next step would be removing grafana-prometheus package from repo completely. This will be done in a separate PR.