### PR TITLE
Tempo Datasource: Fix gRPC basic auth over non-TLS connections

### DIFF
--- a/pkg/tsdb/tempo/grpc.go
+++ b/pkg/tsdb/tempo/grpc.go
@@ -177,7 +177,8 @@ func getDialOpts(ctx context.Context, settings backend.DataSourceInstanceSetting
 	if settings.BasicAuthEnabled {
 		// If basic authentication is enabled, it sets the basic authentication header for each RPC call.
 		dialOps = append(dialOps, grpc.WithPerRPCCredentials(&basicAuth{
-			Header: basicHeaderForAuth(opts.BasicAuth.User, opts.BasicAuth.Password),
+			Header:                   basicHeaderForAuth(opts.BasicAuth.User, opts.BasicAuth.Password),
+			requireTransportSecurity: secure,
 		}))
 	}
 
@@ -329,7 +330,8 @@ func MetricsStreamInterceptor() grpc.StreamClientInterceptor {
 }
 
 type basicAuth struct {
-	Header string
+	Header                   string
+	requireTransportSecurity bool
 }
 
 func (c *basicAuth) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
@@ -339,7 +341,7 @@ func (c *basicAuth) GetRequestMetadata(context.Context, ...string) (map[string]s
 }
 
 func (c *basicAuth) RequireTransportSecurity() bool {
-	return true
+	return c.requireTransportSecurity
 }
 
 func basicHeaderForAuth(username, password string) string {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes basicAuth.RequireTransportSecurity() conditional on whether the gRPC connection actually uses TLS, instead of always requiring it.

**Why do we need this feature?**

PR #111770 correctly separated basic auth from TLS handling in the Tempo datasource's gRPC client, but left RequireTransportSecurity() hardcoded to true. This causes Tempo datasources configured with basic auth over http:// to fail with: `grpc: the credentials require transport level security (use
  grpc.WithTransportCredentials() to set).`

**Who is this feature for?**

Users with Tempo datasources configured with basic auth over non-TLS connections (e.g., in-cluster communication).

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #122672

**Special notes for your reviewer:**

The secure flag is already derived from the datasource URL scheme (https → true, http → false) and was already being passed to getDialOpts. This change threads it into the basicAuth struct so gRPC doesn't reject the per-RPC credentials on insecure connections.

I tested this using the Tempo [single-binary docker-compose file](https://github.com/grafana/tempo/blob/main/example/docker-compose/single-binary/docker-compose.yaml). Before my changes, I was able to reproduce the error locally with basic-auth configured, afterwards it could connect fine.

<img width="649" height="437" alt="image" src="https://github.com/user-attachments/assets/d260965f-617a-4b38-a857-e1de9654af67" />
<img width="915" height="309" alt="image" src="https://github.com/user-attachments/assets/1e8d0607-0d40-4a80-abe2-d1ef20a665ae" />


Please check that:
- [x] It works as expected from a user's perspective.
- [x] ~If this is a pre-GA feature, it is behind a feature toggle.~ N/A
- [x] ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~ N/A