### PR TITLE
[release-11.6.15] Docker: Bump Alpine-based images to 3.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG JS_SRC=js-builder
 
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
-FROM alpine:3.23.3 AS alpine-base
+FROM alpine:3.23.4 AS alpine-base
 FROM ubuntu:22.04 AS ubuntu-base
 FROM golang:1.25.9-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:22-alpine AS js-builder-base

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,7 +59,7 @@ docker_build () {
   esac
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
-    base_image="${base_arch}alpine:3.23.3"
+    base_image="${base_arch}alpine:3.23.4"
   else
     libc=""
     base_image="${base_arch}ubuntu:22.04"

--- a/pkg/build/daggerbuild/artifacts/package_targz.go
+++ b/pkg/build/daggerbuild/artifacts/package_targz.go
@@ -219,7 +219,7 @@ func (t *Tarball) Builder(ctx context.Context, opts *pipeline.ArtifactContainerO
 	version := t.Version
 
 	container := opts.Client.Container().
-		From("alpine:3.23.3").
+		From("alpine:3.23.4").
 		WithExec([]string{"apk", "add", "--update", "tar"}).
 		WithExec([]string{"/bin/sh", "-c", fmt.Sprintf("echo %s > VERSION", version)})
 

--- a/pkg/build/daggerbuild/frontend/node.go
+++ b/pkg/build/daggerbuild/frontend/node.go
@@ -9,7 +9,7 @@ import (
 
 // NodeVersionContainer returns a container whose `stdout` will return the node version from the '.nvmrc' file in the directory 'src'.
 func NodeVersion(d *dagger.Client, src *dagger.Directory) *dagger.Container {
-	return d.Container().From("alpine:3.23.3").
+	return d.Container().From("alpine:3.23.4").
 		WithMountedDirectory("/src", src).
 		WithWorkdir("/src").
 		WithExec([]string{"cat", ".nvmrc"})

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -102,14 +102,15 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		uid, err := s.store.CreateSnapshot(ctx, cloudmigration.CloudMigrationSnapshot{
-			UID:            "test uid",
+		uid := "test uid"
+
+		_, err = s.store.CreateSnapshot(ctx, cloudmigration.CloudMigrationSnapshot{
+			UID:            uid,
 			SessionUID:     sess.UID,
 			Status:         cloudmigration.SnapshotStatusCreating,
 			GMSSnapshotUID: "gms uid",
 		})
 		require.NoError(t, err)
-		assert.Equal(t, "test uid", uid)
 
 		// Make sure status is coming from the db only
 		snapshot, err := s.GetSnapshot(ctx, cloudmigration.GetSnapshotsQuery{
@@ -174,7 +175,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusPendingProcessing), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		require.Eventually(t, gmsClientFake.ValidateSnapshotStatusCallCount, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("test case: gms snapshot processing", func(t *testing.T) {
@@ -198,7 +199,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		require.Eventually(t, gmsClientFake.ValidateSnapshotStatusCallCount, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("test case: gms snapshot finished", func(t *testing.T) {
@@ -222,7 +223,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		require.Eventually(t, gmsClientFake.ValidateSnapshotStatusCallCount, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("test case: gms snapshot canceled", func(t *testing.T) {
@@ -246,7 +247,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusCanceled), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		require.Eventually(t, gmsClientFake.ValidateSnapshotStatusCallCount, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("test case: gms snapshot error", func(t *testing.T) {
@@ -270,7 +271,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		require.Eventually(t, gmsClientFake.ValidateSnapshotStatusCallCount, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("test case: gms snapshot unknown", func(t *testing.T) {
@@ -340,15 +341,17 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		require.NotNil(t, snapshot)
 		require.Eventually(t, func() bool { return gmsClientFake.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 
-		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
-			SnapshotUID: snapshotUID,
-			SessionUID:  sessionUID,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, snapshot)
-		require.Len(t, snapshot.Resources, 1)
-		require.Equal(t, "A", snapshot.Resources[0].RefID)
-		require.Equal(t, "fake", snapshot.Resources[0].Error)
+		require.EventuallyWithTf(t, func(t *assert.CollectT) {
+			snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+				SnapshotUID: snapshotUID,
+				SessionUID:  sessionUID,
+			})
+			assert.NoError(t, err)
+			assert.NotNil(t, snapshot)
+			assert.Len(t, snapshot.Resources, 1)
+			assert.Equal(t, "A", snapshot.Resources[0].RefID)
+			assert.Equal(t, "fake", snapshot.Resources[0].Error)
+		}, 5*time.Second, 100*time.Millisecond, "DB wasn't applied to local snapshot in time")
 	})
 }
 
@@ -374,8 +377,9 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	uid, err := s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
-		UID:            uuid.NewString(),
+	uid := uuid.NewString()
+	_, err = s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
+		UID:            uid,
 		SessionUID:     sess.UID,
 		Status:         cloudmigration.SnapshotStatusCreating,
 		GMSSnapshotUID: "gms uid",
@@ -406,50 +410,47 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 	}
 
 	// make sure GMS is called when snapshot is pending processing or processing
-	for i, status := range []cloudmigration.SnapshotStatus{
+	for _, status := range []cloudmigration.SnapshotStatus{
 		cloudmigration.SnapshotStatusPendingProcessing,
 		cloudmigration.SnapshotStatusProcessing,
 	} {
-		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
-			UID:       uid,
-			SessionID: sess.UID,
-			Status:    status,
+		// in this case since the background sync will run, we can create a brand new snapshot to avoid race problems.
+		snapshotUID := uuid.NewString()
+		_, err := s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
+			UID:            snapshotUID,
+			SessionUID:     sess.UID,
+			Status:         status,
+			GMSSnapshotUID: "gms uid 2",
 		})
-		assert.NoError(t, err)
-		_, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
-			SnapshotUID: uid,
+		require.NoError(t, err)
+
+		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+			SnapshotUID: snapshotUID,
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 }, time.Second, 10*time.Millisecond)
+		assert.Equal(t, status, snapshot.Status)
+
+		// then we wait for the sync to complete before the next status.
+		require.Eventually(
+			t,
+			func() bool {
+				cms, _ := s.store.GetSnapshotByUID(context.Background(), sess.OrgID, sess.UID, snapshotUID, 0, 0)
+				return cms.Status == cloudmigration.SnapshotStatusFinished
+			},
+			5*time.Second,
+			100*time.Millisecond,
+			"Snapshot status should be updated to Finished after sync completes",
+		)
 	}
-	assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 2 }, time.Second, 10*time.Millisecond)
-}
 
-func Test_DeletedDashboardsNotMigrated(t *testing.T) {
-	t.Parallel()
-
-	s := setUpServiceTest(t, false).(*Service)
-
-	// modify what the mock returns for just this test case
-	dashMock := s.dashboardService.(*dashboards.FakeDashboardService)
-	dashMock.On("GetAllDashboardsByOrgId", mock.Anything, int64(1)).Return(
-		[]*dashboards.Dashboard{
-			{UID: "1", OrgID: 1, Data: simplejson.New()},
-			{UID: "2", OrgID: 1, Data: simplejson.New(), Deleted: time.Now()},
-		},
-		nil,
+	assert.Never(
+		t,
+		func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 2 },
+		5*time.Second,
+		100*time.Millisecond,
+		"GMS client mock GetSnapshotStatus called more than expected: %d times", gmsClientMock.GetSnapshotStatusCallCount(),
 	)
-
-	data, err := s.getMigrationDataJSON(context.TODO(), &user.SignedInUser{OrgID: 1})
-	assert.NoError(t, err)
-	dashCount := 0
-	for _, it := range data.Items {
-		if it.Type == cloudmigration.DashboardDataType {
-			dashCount++
-		}
-	}
-	assert.Equal(t, 1, dashCount)
 }
 
 // Implementation inspired by ChatGPT, OpenAI's language model.
@@ -1048,4 +1049,8 @@ func (m *gmsClientMock) GetSnapshotStatusCallCount() int {
 	defer m.mu.RUnlock()
 
 	return m.getStatusCalled
+}
+
+func (m *gmsClientMock) ValidateSnapshotStatusCallCount() bool {
+	return m.GetSnapshotStatusCallCount() >= 1
 }

--- a/pkg/util/ticker/ticker_test.go
+++ b/pkg/util/ticker/ticker_test.go
@@ -28,8 +28,6 @@ func TestTicker(t *testing.T) {
 			return tick
 		case <-ctx.Done():
 			require.Failf(t, fmt.Sprintf("%v", ctx.Err()), "timeout reading the channel")
-		default:
-			require.Failf(t, "channel is empty but it should have a tick", "")
 		}
 		return time.Time{}
 	}


### PR DESCRIPTION
Backport 278da5e95a41b8c58c3f704e083ba22233e312b8 from #122930

---

Bumps Alpine to solve CVEs in the underlying image.
