### PR TITLE
Dashboards: Show k8s format in provisioned save

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -28,6 +28,18 @@ jest.mock('app/features/browse-dashboards/api/browseDashboardsAPI', () => ({
   useSaveDashboardMutation: () => [saveDashboardMutationMock],
 }));
 
+jest.mock('app/features/dashboard/api/dashboard_api', () => ({
+  ...jest.requireActual('app/features/dashboard/api/dashboard_api'),
+  getDashboardAPI: jest.fn().mockResolvedValue({
+    getDashboardDTO: jest.fn().mockResolvedValue({
+      apiVersion: 'dashboard.grafana.app/v2beta1',
+      kind: 'Dashboard',
+      metadata: {},
+      spec: {},
+    }),
+  }),
+}));
+
 const ui = {
   saveDashbordText: byText('Save dashboard'),
   saveVariablesCheckbox: byTestId(selectors.pages.SaveDashboardModal.saveVariables),
@@ -245,6 +257,7 @@ describe('SaveDashboardDrawer', () => {
       dashboard.setState({ title: 'updated title' });
       openAndRender();
 
+      expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /Changes/ })).not.toBeInTheDocument();
     });
 
@@ -256,6 +269,7 @@ describe('SaveDashboardDrawer', () => {
       dashboard.setState({ title: 'updated title' });
       openAndRender();
 
+      expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /Changes/ })).not.toBeInTheDocument();
     });
 
@@ -269,6 +283,7 @@ describe('SaveDashboardDrawer', () => {
       dashboard.setState({ title: 'updated title' });
       openAndRender();
 
+      expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /Changes/ })).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -76,7 +76,7 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
       value: ExportFormat.Classic,
     },
     {
-      label: t('dashboard-scene.save-provisioned-dashboard-form.format.k8s-resource', 'K8s Resource'),
+      label: t('dashboard-scene.save-provisioned-dashboard-form.format.v2-resource', 'V2 Resource'),
       value: ExportFormat.V2Resource,
     },
   ];

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -1,10 +1,15 @@
 import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
-import { useCallback, useMemo } from 'react';
+import { omit } from 'lodash';
+import { useCallback, useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { Trans } from '@grafana/i18n';
-import { Button, ClipboardButton, Stack, CodeEditor, Box, TextLink } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { Button, ClipboardButton, Stack, CodeEditor, Box, Label, RadioButtonGroup, Spinner, TextLink } from '@grafana/ui';
+import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
+import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
+import { ExportFormat } from 'app/features/dashboard/api/types';
 
 import { type DashboardScene } from '../scene/DashboardScene';
 
@@ -19,14 +24,51 @@ export interface Props {
 }
 
 export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: Props) {
-  const dashboardJSON = useMemo(() => JSON.stringify(changeInfo.changedSaveModel, null, 2), [changeInfo]);
+  const hasK8sMeta = Boolean(dashboard.state.meta.k8s);
+  const [exportFormat, setExportFormat] = useState<ExportFormat>(
+    hasK8sMeta ? ExportFormat.V2Resource : ExportFormat.Classic
+  );
+  const uid = dashboard.state.uid;
+
+  const classicJson = useMemo(() => JSON.stringify(changeInfo.changedSaveModel, null, 2), [changeInfo]);
+
+  const k8sResource = useAsync(async () => {
+    if (exportFormat !== ExportFormat.V2Resource || !uid) {
+      return null;
+    }
+    const api = await getDashboardAPI('v2');
+    const resource = await api.getDashboardDTO(uid);
+    return JSON.stringify(
+      {
+        apiVersion: resource.apiVersion,
+        kind: 'Dashboard',
+        metadata: omit(resource.metadata, 'managedFields'),
+        spec: resource.spec,
+      },
+      null,
+      2
+    );
+  }, [exportFormat, uid]);
+
+  const isK8sMode = exportFormat === ExportFormat.V2Resource && hasK8sMeta;
+  const displayJson = isK8sMode ? (k8sResource.value ?? '') : classicJson;
 
   const saveToFile = useCallback(() => {
-    const blob = new Blob([dashboardJSON], {
+    const blob = new Blob([displayJson], {
       type: 'application/json;charset=utf-8',
     });
     saveAs(blob, changeInfo.changedSaveModel.title + '-' + new Date().getTime() + '.json');
-  }, [changeInfo.changedSaveModel, dashboardJSON]);
+  }, [changeInfo.changedSaveModel.title, displayJson]);
+
+  const formatOptions = [
+    { label: t('dashboard-scene.save-provisioned-dashboard-form.format.classic', 'Classic'), value: ExportFormat.Classic },
+    {
+      label: t('dashboard-scene.save-provisioned-dashboard-form.format.k8s-resource', 'K8s Resource'),
+      value: ExportFormat.V2Resource,
+    },
+  ];
+
+  const modelLabel = t('dashboard-scene.save-provisioned-dashboard-form.format.model-label', 'Model');
 
   return (
     <div className={styles.container}>
@@ -55,34 +97,59 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
           </Trans>
         </div>
 
+        {hasK8sMeta && (
+          <QueryOperationRow
+            id="provisioned-dashboard-advanced-options"
+            index={0}
+            title={t('dashboard-scene.save-provisioned-dashboard-form.advanced-options', 'Advanced options')}
+            isOpen={false}
+          >
+            <Box marginTop={2}>
+              <Stack gap={1} alignItems="center">
+                <Label>{modelLabel}</Label>
+                <RadioButtonGroup
+                  options={formatOptions}
+                  value={exportFormat}
+                  onChange={setExportFormat}
+                  aria-label={modelLabel}
+                />
+              </Stack>
+            </Box>
+          </QueryOperationRow>
+        )}
+
         <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />
 
         <div className={styles.json}>
-          <AutoSizer disableWidth>
-            {({ height }) => (
-              <CodeEditor
-                width="100%"
-                height={height}
-                language="json"
-                showLineNumbers={true}
-                showMiniMap={dashboardJSON.length > 100}
-                value={dashboardJSON}
-                readOnly={true}
-              />
-            )}
-          </AutoSizer>
+          {isK8sMode && k8sResource.loading ? (
+            <Spinner />
+          ) : (
+            <AutoSizer disableWidth>
+              {({ height }) => (
+                <CodeEditor
+                  width="100%"
+                  height={height}
+                  language="json"
+                  showLineNumbers={true}
+                  showMiniMap={displayJson.length > 100}
+                  value={displayJson}
+                  readOnly={true}
+                />
+              )}
+            </AutoSizer>
+          )}
         </div>
         <Box paddingTop={2}>
           <Stack gap={2}>
             <Button variant="secondary" onClick={drawer.onClose} fill="outline">
               <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.cancel">Cancel</Trans>
             </Button>
-            <ClipboardButton icon="copy" getText={() => dashboardJSON}>
+            <ClipboardButton icon="copy" getText={() => displayJson} disabled={isK8sMode && k8sResource.loading}>
               <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.copy-json-to-clipboard">
                 Copy JSON to clipboard
               </Trans>
             </ClipboardButton>
-            <Button type="submit" onClick={saveToFile}>
+            <Button type="submit" onClick={saveToFile} disabled={isK8sMode && k8sResource.loading}>
               <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.save-json-to-file">
                 Save JSON to file
               </Trans>

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -6,7 +6,17 @@ import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { Trans, t } from '@grafana/i18n';
-import { Button, ClipboardButton, Stack, CodeEditor, Box, Label, RadioButtonGroup, Spinner, TextLink } from '@grafana/ui';
+import {
+  Button,
+  ClipboardButton,
+  Stack,
+  CodeEditor,
+  Box,
+  Label,
+  RadioButtonGroup,
+  Spinner,
+  TextLink,
+} from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
@@ -61,7 +71,10 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
   }, [changeInfo.changedSaveModel.title, displayJson]);
 
   const formatOptions = [
-    { label: t('dashboard-scene.save-provisioned-dashboard-form.format.classic', 'Classic'), value: ExportFormat.Classic },
+    {
+      label: t('dashboard-scene.save-provisioned-dashboard-form.format.classic', 'Classic'),
+      value: ExportFormat.Classic,
+    },
     {
       label: t('dashboard-scene.save-provisioned-dashboard-form.format.k8s-resource', 'K8s Resource'),
       value: ExportFormat.V2Resource,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7532,8 +7532,8 @@
       "form-loading-error-unknown": "An unexpected error occurred while loading the form.",
       "format": {
         "classic": "Classic",
-        "k8s-resource": "K8s Resource",
-        "model-label": "Model"
+        "model-label": "Model",
+        "v2-resource": "V2 Resource"
       },
       "label-description": "Description",
       "label-target-folder": "Target folder",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7522,6 +7522,7 @@
       "update-all": "Update all"
     },
     "save-provisioned-dashboard-form": {
+      "advanced-options": "Advanced options",
       "cancel": "Cancel",
       "cannot-be-saved": "This dashboard cannot be saved from the Grafana UI because it has been provisioned from another source. Copy the JSON or save it to a file below, then you can update your dashboard in the provisioning source.",
       "copy-json-to-clipboard": "Copy JSON to clipboard",
@@ -7529,6 +7530,11 @@
       "file-path": "<strong>File path:</strong> {{filePath}}",
       "form-loading-error": "Error loading form",
       "form-loading-error-unknown": "An unexpected error occurred while loading the form.",
+      "format": {
+        "classic": "Classic",
+        "k8s-resource": "K8s Resource",
+        "model-label": "Model"
+      },
       "label-description": "Description",
       "label-target-folder": "Target folder",
       "label-title": "Title",


### PR DESCRIPTION
This PR changes the save display for provisioned dashboards to show k8s format by default (and allow json in the advanced options), following what is done in the export view (See for why here: https://github.com/grafana/grafana/issues/122663#issuecomment-4272706225)

<img width="568" height="631" alt="Screenshot 2026-04-20 at 11 47 18 AM" src="https://github.com/user-attachments/assets/fe2664d3-26aa-42ad-8bc3-ef1753f766c3" />

<img width="548" height="387" alt="Screenshot 2026-04-20 at 12 06 19 PM" src="https://github.com/user-attachments/assets/1d1d69cc-4c94-4205-9207-7c7acf5ddccd" />



