### PR TITLE
Logs Table: Add Log Details Support

### DIFF
--- a/e2e-playwright/panels-suite/logstable.spec.ts
+++ b/e2e-playwright/panels-suite/logstable.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@grafana/plugin-e2e';
 const DASHBOARD_UID = 'adhjhtt';
 
 test.use({ viewport: { width: 2000, height: 1080 } });
-test.describe.only('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () => {
+test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () => {
   test.describe('Defaults', () => {
     test('Should render logs table panel', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({

--- a/e2e-playwright/panels-suite/logstable.spec.ts
+++ b/e2e-playwright/panels-suite/logstable.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@grafana/plugin-e2e';
 const DASHBOARD_UID = 'adhjhtt';
 
 test.use({ viewport: { width: 2000, height: 1080 } });
-test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () => {
+test.describe.only('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () => {
   test.describe('Defaults', () => {
     test('Should render logs table panel', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({
@@ -112,7 +112,7 @@ test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () =
       await page.getByRole('button', { name: 'Collapse sidebar' }).click();
       await expect(page.getByText('Selected fields'), 'Field selector title is no longer visible').not.toBeVisible();
     });
-    test('Show inspect button', async ({ page, gotoDashboardPage, selectors }) => {
+    test('Show details button', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({
         uid: DASHBOARD_UID,
         queryParams: new URLSearchParams({ editPanel: '2' }),
@@ -141,26 +141,15 @@ test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () =
         )
         .toEqual(false);
 
-      // Click inspect on 9th row
+      // Click details on 9th row
       await page.getByRole('gridcell').getByLabel('Show details').nth(9).click();
 
-      // Assert drawer header is visible
-      await expect(
-        page.getByRole('heading', { name: 'Inspect value' }),
-        'Inspect drawer title is visible'
-      ).toBeVisible();
-
-      // Assert the inspect drawer shows the correct log line body
-      await expect(
-        page.getByRole('dialog', { name: 'Inspect value' }).locator('.view-lines'),
-        'Drawer contains correct log line'
-      ).toContainText(
-        `level=info ts=2026-02-06T18:42:46.211051027Z caller=poller.go:133 msg="blocklist poll complete" seconds=526`
-      );
+      // Assert header is visible
+      await expect(page.getByPlaceholder('Search field names and values'), 'Log details is visible').toBeVisible();
     });
   });
   test.describe('Options', () => {
-    test('Inspect button', async ({ page, gotoDashboardPage, selectors }) => {
+    test('Log details', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({
         uid: DASHBOARD_UID,
         queryParams: new URLSearchParams({ editPanel: '2' }),
@@ -170,15 +159,12 @@ test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () =
         dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Default Logs Table Panel'))
       ).toBeVisible();
 
-      const optionWrapper = page.getByTestId('data-testid Logs Table Show inspect button field property editor');
-      const option = optionWrapper.getByLabel(/Show inspect button/);
-      const inspectLogLineButton = page.getByLabel('Show details');
-      await expect(option, 'Inspect button panel option is in the document').toHaveCount(1);
-      await expect(option, 'Inspect button panel option is initially checked').toBeChecked();
-      await expect(inspectLogLineButton.nth(0), 'Inspect button is visible in the logs table viz').toBeVisible();
+      const optionWrapper = page.getByTestId('data-testid Logs Table Enable log details field property editor');
+      const option = optionWrapper.getByLabel(/Enable log details/);
+      await expect(option, 'Enable log details is in the document').toHaveCount(1);
+      await expect(option, 'Enable log details panel option is initially checked').toBeChecked();
       await optionWrapper.click();
-      await expect(option, 'Inspect button panel option is no longer checked').not.toBeChecked({ timeout: 400 });
-      await expect(inspectLogLineButton, 'Inspect button is no longer in the logs table viz').toHaveCount(0);
+      await expect(option, 'Enable log details panel option is no longer checked').not.toBeChecked({ timeout: 400 });
     });
     test('Copy log line button', async ({ page, gotoDashboardPage, selectors, context }) => {
       const dashboardPage = await gotoDashboardPage({

--- a/e2e-playwright/panels-suite/logstable.spec.ts
+++ b/e2e-playwright/panels-suite/logstable.spec.ts
@@ -15,8 +15,8 @@ test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () =
         dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Default Logs Table Panel'))
       ).toBeVisible();
 
-      // View log line button should be defined by default
-      await expect(page.getByLabel('View log line').first(), 'View log line button defined by default').toBeVisible();
+      // Show details button should be defined by default
+      await expect(page.getByLabel('Show details').first(), 'Show details button defined by default').toBeVisible();
 
       // timestamp and log body headers should be visible
       await expect(
@@ -142,7 +142,7 @@ test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () =
         .toEqual(false);
 
       // Click inspect on 9th row
-      await page.getByRole('gridcell').getByLabel('View log line').nth(9).click();
+      await page.getByRole('gridcell').getByLabel('Show details').nth(9).click();
 
       // Assert drawer header is visible
       await expect(
@@ -172,7 +172,7 @@ test.describe('Panels test: LogsTable', { tag: ['@panels', '@logstable'] }, () =
 
       const optionWrapper = page.getByTestId('data-testid Logs Table Show inspect button field property editor');
       const option = optionWrapper.getByLabel(/Show inspect button/);
-      const inspectLogLineButton = page.getByLabel('View log line');
+      const inspectLogLineButton = page.getByLabel('Show details');
       await expect(option, 'Inspect button panel option is in the document').toHaveCount(1);
       await expect(option, 'Inspect button panel option is initially checked').toBeChecked();
       await expect(inspectLogLineButton.nth(0), 'Inspect button is visible in the logs table viz').toBeVisible();

--- a/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
@@ -17,23 +17,23 @@ export const pluginVersion = "13.1.0-pre";
 export interface Options {
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
+  enableLogDetails?: boolean;
   fieldSelectorWidth?: number;
   isLabelFilterActive?: unknown;
   logDetailsWidth?: number;
   permalinkedLogId?: string;
   showControls?: boolean;
   showCopyLogLink?: boolean;
-  showInspectLogLine?: boolean;
   sortOrder?: common.LogsSortOrder;
   wrapText?: boolean;
 }
 
 export const defaultOptions: Partial<Options> = {
   displayedFields: [],
+  enableLogDetails: true,
   fieldSelectorWidth: 220,
   logDetailsWidth: 400,
   showControls: true,
   showCopyLogLink: false,
-  showInspectLogLine: true,
   sortOrder: common.LogsSortOrder.Descending,
 };

--- a/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
@@ -18,6 +18,7 @@ export interface Options {
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
   fieldSelectorWidth?: number;
+  logDetailsWidth?: number;
   permalinkedLogId?: string;
   showControls?: boolean;
   showCopyLogLink?: boolean;
@@ -29,6 +30,7 @@ export interface Options {
 export const defaultOptions: Partial<Options> = {
   displayedFields: [],
   fieldSelectorWidth: 220,
+  logDetailsWidth: 400,
   showControls: true,
   showCopyLogLink: false,
   showInspectLogLine: true,

--- a/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
@@ -18,6 +18,7 @@ export interface Options {
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
   fieldSelectorWidth?: number;
+  isLabelFilterActive?: unknown;
   logDetailsWidth?: number;
   permalinkedLogId?: string;
   showControls?: boolean;

--- a/public/app/features/explore/Logs/ExploreLogsTable.test.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import {
   type AbsoluteTimeRange,
@@ -36,6 +37,10 @@ jest.mock('@grafana/runtime', () => ({
   getAppEvents: jest.fn(() => ({
     publish: publishMockFn,
   })),
+  usePluginLinks: jest.fn(() => ({ isLoading: false, links: [] })),
+  getDataSourceSrv: jest.fn(() => ({
+    get: jest.fn().mockResolvedValue(null),
+  })),
 }));
 
 const mockGetUrlSearchParams = jest.fn(() => {
@@ -46,6 +51,13 @@ jest.mock('@grafana/data', () => ({
   urlUtil: {
     getUrlSearchParams: () => mockGetUrlSearchParams(),
   },
+}));
+
+const useBooleanFlagValueMock = jest.fn((_: string, defaultValue: boolean) => defaultValue);
+
+jest.mock('@openfeature/react-sdk', () => ({
+  ...jest.requireActual('@openfeature/react-sdk'),
+  useBooleanFlagValue: (flag: string, defaultValue: boolean) => useBooleanFlagValueMock(flag, defaultValue),
 }));
 
 describe('ExploreLogsTable', () => {
@@ -128,6 +140,16 @@ describe('ExploreLogsTable', () => {
     expect(headers[0].textContent).toBe('Time');
     expect(headers[1].textContent).toBe('detected_level');
     expect(headers[2].textContent).toBe('Line');
+  });
+
+  it('opens log details when Show details is clicked', async () => {
+    const user = userEvent.setup();
+    render(setUp());
+    await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
+
+    await user.click(screen.getAllByLabelText('Show details')[0]);
+
+    expect(screen.getByLabelText('Close log details sidebar')).toBeVisible();
   });
 
   describe('options', () => {

--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -14,6 +14,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { type AdHocFilterItem, PanelContextProvider } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
 import { LogsTable } from 'app/plugins/panel/logstable/LogsTable';
+import { getLogDetailsWidth } from 'app/plugins/panel/logstable/LogsTableDetails';
 import { type Options } from 'app/plugins/panel/logstable/options/types';
 import { defaultOptions as logsTablePanelDefaultOptions } from 'app/plugins/panel/logstable/panelcfg.gen';
 import { type BuildLinkToLogLine } from 'app/plugins/panel/logstable/types';
@@ -86,6 +87,8 @@ export function ExploreLogsTable(props: {
       if (options.wrapText !== undefined && options.wrapText !== wrapText) {
         setWrapText(options.wrapText);
         store.set(`${SETTING_KEY_ROOT}.wrapText`, options.wrapText);
+      } else if (options.logDetailsWidth !== undefined && options.logDetailsWidth > 0) {
+        store.set(`${SETTING_KEY_ROOT}.logDetailsWidth`, options.logDetailsWidth);
       }
       props.onOptionsChange(options);
     },
@@ -101,6 +104,7 @@ export function ExploreLogsTable(props: {
       showCopyLogLink: true,
       ...props.externalOptions,
       permalinkedLogId: props.externalOptions.permalinkedLogId ?? selectedLogInfo?.id,
+      logDetailsWidth: parseInt(store.get(`${SETTING_KEY_ROOT}.logDetailsWidth`) ?? getLogDetailsWidth(), 10),
       wrapText,
     }),
     [props.buildLinkToLogLine, props.externalOptions, selectedLogInfo?.id, wrapText]

--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -21,14 +21,10 @@ import { type BuildLinkToLogLine } from 'app/plugins/panel/logstable/types';
 
 import { SETTING_KEY_ROOT } from './utils/logs';
 
-/**
- * New Logs Table panel
- * @param props
- * @constructor
- */
-export function ExploreLogsTable(props: {
+interface Props {
   eventBus: EventBus;
   data: PanelData;
+  isLabelFilterActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   timeZone: 'utc' | 'browser' | string;
   buildLinkToLogLine: BuildLinkToLogLine;
   width: number;
@@ -42,14 +38,19 @@ export function ExploreLogsTable(props: {
     Options,
     'sortBy' | 'sortOrder' | 'displayedFields' | 'permalinkedLogId' | 'frameIndex' | 'fieldSelectorWidth'
   >;
-}) {
+}
+
+/**
+ * New Logs Table panel
+ */
+export function ExploreLogsTable(props: Props) {
   const { onClickFilterLabel, onClickFilterOutLabel } = props;
   const frames = useMemo(() => props?.data.series ?? [], [props.data.series]);
   const frame = useMemo(() => frames[props.externalOptions.frameIndex], [frames, props.externalOptions.frameIndex]);
   const [wrapText, setWrapText] = useState(store.getBool(`${SETTING_KEY_ROOT}.wrapText`, false));
   const [columnWidths, setColumnWidths] = useState<ColumnWidth[]>(getColumnWidthsFromStorage());
 
-  const onCellFilterAdded = useCallback(
+  const handleAdHocFilter = useCallback(
     (filter: AdHocFilterItem) => {
       const { value, key, operator } = filter;
       if (!onClickFilterLabel || !onClickFilterOutLabel) {
@@ -103,11 +104,12 @@ export function ExploreLogsTable(props: {
       showControls: true,
       showCopyLogLink: true,
       ...props.externalOptions,
+      isLabelFilterActive: props.isLabelFilterActive,
       permalinkedLogId: props.externalOptions.permalinkedLogId ?? selectedLogInfo?.id,
       logDetailsWidth: parseInt(store.get(`${SETTING_KEY_ROOT}.logDetailsWidth`) ?? getLogDetailsWidth(), 10),
       wrapText,
     }),
-    [props.buildLinkToLogLine, props.externalOptions, selectedLogInfo?.id, wrapText]
+    [props.buildLinkToLogLine, props.externalOptions, props.isLabelFilterActive, selectedLogInfo?.id, wrapText]
   );
 
   const handleFieldConfigChange = useCallback((config: FieldConfigSource) => {
@@ -158,7 +160,7 @@ export function ExploreLogsTable(props: {
       value={{
         eventsScope: 'explore',
         eventBus: props.eventBus,
-        onAddAdHocFilter: onCellFilterAdded,
+        onAddAdHocFilter: handleAdHocFilter,
         app: CoreApp.Explore,
       }}
     >

--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -14,7 +14,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { type AdHocFilterItem, PanelContextProvider } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
 import { LogsTable } from 'app/plugins/panel/logstable/LogsTable';
-import { getLogDetailsWidth } from 'app/plugins/panel/logstable/LogsTableDetails';
+import { getDefaultLogDetailsWidth } from 'app/plugins/panel/logstable/LogsTableDetails';
 import { type Options } from 'app/plugins/panel/logstable/options/types';
 import { defaultOptions as logsTablePanelDefaultOptions } from 'app/plugins/panel/logstable/panelcfg.gen';
 import { type BuildLinkToLogLine } from 'app/plugins/panel/logstable/types';
@@ -106,7 +106,7 @@ export function ExploreLogsTable(props: Props) {
       ...props.externalOptions,
       isLabelFilterActive: props.isLabelFilterActive,
       permalinkedLogId: props.externalOptions.permalinkedLogId ?? selectedLogInfo?.id,
-      logDetailsWidth: parseInt(store.get(`${SETTING_KEY_ROOT}.logDetailsWidth`) ?? getLogDetailsWidth(), 10),
+      logDetailsWidth: parseInt(store.get(`${SETTING_KEY_ROOT}.logDetailsWidth`) ?? getDefaultLogDetailsWidth(), 10),
       wrapText,
     }),
     [props.buildLinkToLogLine, props.externalOptions, props.isLabelFilterActive, selectedLogInfo?.id, wrapText]

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -913,6 +913,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             <ExploreLogsTable
               eventBus={eventBus}
               data={panelData}
+              isLabelFilterActive={props.isFilterLabelActive}
               timeZone={timeZone}
               buildLinkToLogLine={onTablePermalinkClick}
               externalOptions={tableOptions}

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -80,7 +80,8 @@ LogLineDetails.displayName = 'LogLineDetails';
 const LogLineDetailsTabs = memo(
   ({ focusLogLine, logs, timeRange, timeZone }: Pick<Props, 'focusLogLine' | 'logs' | 'timeRange' | 'timeZone'>) => {
     const { app, fontSize, noInteractions, wrapLogMessage } = useLogListContext();
-    const { currentLog, setCurrentLog, showDetails, toggleDetails } = useLogDetailsContext();
+    const { currentLog, closeDetails, detailsMode, setCurrentLog, showDetails, setDetailsMode, toggleDetails } =
+      useLogDetailsContext();
     const [search, setSearch] = useState('');
     const inputRef = useRef('');
 
@@ -142,7 +143,15 @@ const LogLineDetailsTabs = memo(
             })}
           </TabsBar>
         )}
-        <LogLineDetailsHeader focusLogLine={focusLogLine} log={currentLog} search={search} onSearch={handleSearch} />
+        <LogLineDetailsHeader
+          closeDetails={closeDetails}
+          detailsMode={detailsMode}
+          focusLogLine={focusLogLine}
+          log={currentLog}
+          search={search}
+          setDetailsMode={setDetailsMode}
+          onSearch={handleSearch}
+        />
         <ScrollContainer>
           <LogLineDetailsComponent
             log={currentLog}
@@ -168,7 +177,7 @@ export interface InlineLogLineDetailsProps {
 
 export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, timeZone }: InlineLogLineDetailsProps) => {
   const { app, fontSize, logOptionsStorageKey, noInteractions } = useLogListContext();
-  const { detailsWidth } = useLogDetailsContext();
+  const { closeDetails, detailsMode, detailsWidth, setDetailsMode } = useLogDetailsContext();
   const styles = useStyles2(getStyles, 'inline', undefined, fontSize);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [search, setSearch] = useState('');
@@ -222,9 +231,12 @@ export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, time
     <div className={`${styles.inlineWrapper} log-line-inline-details`} style={{ maxWidth: detailsWidth }}>
       <div className={styles.inlineContainer}>
         <LogLineDetailsHeader
+          closeDetails={closeDetails}
+          detailsMode={detailsMode}
+          inlineNoScroll={inlineNoScroll}
           log={log}
           search={search}
-          inlineNoScroll={inlineNoScroll}
+          setDetailsMode={setDetailsMode}
           setInlineNoScroll={setInlineNoScroll}
           onSearch={handleSearch}
         />

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -36,8 +36,8 @@ interface LogLineDetailsFieldsProps {
 }
 
 export const LogLineDetailsFields = memo(({ disableActions, fields, log, logs, search }: LogLineDetailsFieldsProps) => {
-  const { fontSize } = useLogListContext();
-  const styles = useStyles2(getFieldsStyles, fontSize);
+  const { onClickShowField, fontSize } = useLogListContext();
+  const styles = useStyles2(getFieldsStyles, fontSize, onClickShowField);
   const getLogs = useCallback(() => logs, [logs]);
   const filteredFields = useMemo(() => (search ? filterFields(fields, search) : fields), [fields, search]);
 
@@ -112,11 +112,15 @@ export const LogLineDetailsLabelFields = ({ fields, log, logs, search }: LogLine
   );
 };
 
-const getFieldsStyles = (theme: GrafanaTheme2, fontSize: LogListFontSize) => ({
+const getFieldsStyles = (
+  theme: GrafanaTheme2,
+  fontSize: LogListFontSize,
+  onClickShowField?: (key: string) => void
+) => ({
   fieldsTable: css({
     display: 'grid',
     gap: fontSize === 'small' ? theme.spacing(0.25, 0.5) : theme.spacing(0.5, 1),
-    gridTemplateColumns: `${fontSize === 'small' ? theme.spacing(10) : theme.spacing(11.5)} fit-content(30%) 1fr`,
+    gridTemplateColumns: `${fontSize === 'small' ? (onClickShowField ? theme.spacing(10) : theme.spacing(7)) : onClickShowField ? theme.spacing(11.5) : theme.spacing(7.5)} fit-content(30%) 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',
@@ -304,7 +308,7 @@ export const LogLineDetailsField = ({
                   onClick={filterOutLabel}
                 />
               )}
-              {singleKey && displayedFields.includes(keys[0]) && (
+              {onClickHideField && singleKey && displayedFields.includes(keys[0]) && (
                 <IconButton
                   variant="primary"
                   size={fontSize === 'small' ? 'sm' : undefined}
@@ -313,7 +317,7 @@ export const LogLineDetailsField = ({
                   onClick={hideField}
                 />
               )}
-              {singleKey && !displayedFields.includes(keys[0]) && (
+              {onClickShowField && singleKey && !displayedFields.includes(keys[0]) && (
                 <IconButton
                   tooltip={t(
                     'logs.log-line-details.fields.toggle-field-button.field-instead-message',

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -84,8 +84,8 @@ interface LogLineDetailsLabelFieldsProps {
 }
 
 export const LogLineDetailsLabelFields = ({ fields, log, logs, search }: LogLineDetailsLabelFieldsProps) => {
-  const { fontSize } = useLogListContext();
-  const styles = useStyles2(getFieldsStyles, fontSize);
+  const { fontSize, onClickShowField } = useLogListContext();
+  const styles = useStyles2(getFieldsStyles, fontSize, onClickShowField);
   const getLogs = useCallback(() => logs, [logs]);
   const filteredFields = useMemo(() => (search ? filterLabels(fields, search) : fields), [fields, search]);
 

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -15,19 +15,25 @@ import { useLogIsPinned, useLogListContext } from './LogListContext';
 import { type LogListModel } from './processing';
 
 interface Props {
+  closeDetails: () => void;
+  detailsMode: LogLineDetailsMode;
   focusLogLine?: (log: LogListModel) => void;
   inlineNoScroll?: boolean;
   log: LogListModel;
   search: string;
   setInlineNoScroll?(inlineNoScroll: boolean): void;
+  setDetailsMode?(mode: LogLineDetailsMode): void;
   onSearch(newSearch: string): void;
 }
 
 export const LogLineDetailsHeader = ({
+  closeDetails,
+  detailsMode,
   focusLogLine,
   inlineNoScroll,
   log,
   search,
+  setDetailsMode,
   setInlineNoScroll,
   onSearch,
 }: Props) => {
@@ -47,7 +53,7 @@ export const LogLineDetailsHeader = ({
     isAssistantAvailable,
     openAssistantByLog,
   } = useLogListContext();
-  const { closeDetails, detailsMode, setDetailsMode, toggleDetails } = useLogDetailsContext();
+  const { toggleDetails } = useLogDetailsContext();
   const pinned = useLogIsPinned(log);
   const styles = useStyles2(getStyles, detailsMode, wrapLogMessage);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -110,7 +116,7 @@ export const LogLineDetailsHeader = ({
       store.set(`${logOptionsStorageKey}.detailsMode`, newMode);
     }
 
-    setDetailsMode(newMode);
+    setDetailsMode?.(newMode);
 
     reportInteractionWrapper('logs_log_line_details_header_toggle_details_mode', {
       newMode,
@@ -277,15 +283,17 @@ export const LogLineDetailsHeader = ({
             onClick={toggleDetailsScroll}
           />
         )}
-        <IconButton
-          name={detailsMode === 'inline' ? 'web-section' : 'gf-layout-simple'}
-          tooltip={
-            detailsMode === 'inline'
-              ? t('logs.log-line-details.sidebar-mode', 'Anchor to the right')
-              : t('logs.log-line-details.inline-mode', 'Display inline')
-          }
-          onClick={toggleDetailsMode}
-        />
+        {setDetailsMode && (
+          <IconButton
+            name={detailsMode === 'inline' ? 'web-section' : 'gf-layout-simple'}
+            tooltip={
+              detailsMode === 'inline'
+                ? t('logs.log-line-details.sidebar-mode', 'Anchor to the right')
+                : t('logs.log-line-details.inline-mode', 'Display inline')
+            }
+            onClick={toggleDetailsMode}
+          />
+        )}
         <div className={styles.divider} />
         {detailsMode === 'sidebar' ? (
           <IconButton

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -271,28 +271,30 @@ export const LogLineDetailsHeader = ({
             tabIndex={0}
           />
         )}
-        <div className={`${styles.divider} ${styles.dividerMargin}`} />
-        {detailsMode === 'inline' && inlineNoScroll !== undefined && (
-          <IconButton
-            name={inlineNoScroll === true ? 'compress-arrows' : 'expand-arrows'}
-            tooltip={
-              inlineNoScroll === true
-                ? t('logs.log-line-details.inline-with-scrolls', 'Switch to condensed view')
-                : t('logs.log-line-details.inline-no-scrolls', 'Switch to expanded view')
-            }
-            onClick={toggleDetailsScroll}
-          />
-        )}
         {setDetailsMode && (
-          <IconButton
-            name={detailsMode === 'inline' ? 'web-section' : 'gf-layout-simple'}
-            tooltip={
-              detailsMode === 'inline'
-                ? t('logs.log-line-details.sidebar-mode', 'Anchor to the right')
-                : t('logs.log-line-details.inline-mode', 'Display inline')
-            }
-            onClick={toggleDetailsMode}
-          />
+          <>
+            <div className={`${styles.divider} ${styles.dividerMargin}`} />
+            {detailsMode === 'inline' && inlineNoScroll !== undefined && (
+              <IconButton
+                name={inlineNoScroll === true ? 'compress-arrows' : 'expand-arrows'}
+                tooltip={
+                  inlineNoScroll === true
+                    ? t('logs.log-line-details.inline-with-scrolls', 'Switch to condensed view')
+                    : t('logs.log-line-details.inline-no-scrolls', 'Switch to expanded view')
+                }
+                onClick={toggleDetailsScroll}
+              />
+            )}
+            <IconButton
+              name={detailsMode === 'inline' ? 'web-section' : 'gf-layout-simple'}
+              tooltip={
+                detailsMode === 'inline'
+                  ? t('logs.log-line-details.sidebar-mode', 'Anchor to the right')
+                  : t('logs.log-line-details.inline-mode', 'Display inline')
+              }
+              onClick={toggleDetailsMode}
+            />
+          </>
         )}
         <div className={styles.divider} />
         {detailsMode === 'sidebar' ? (

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -326,8 +326,8 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, wrapLogMessag
   }),
   header: css({
     alignItems: 'center',
-    borderTopLeftRadius: theme.shape.radius.default,
-    borderTopRightRadius: theme.shape.radius.default,
+    borderTopLeftRadius: mode === 'inline' ? theme.shape.radius.default : undefined,
+    borderTopRightRadius: mode === 'inline' ? theme.shape.radius.default : undefined,
     background: theme.colors.background.canvas,
     display: 'flex',
     flexDirection: !wrapLogMessage && mode === 'inline' ? 'row-reverse' : 'row',

--- a/public/app/plugins/panel/logstable/LogDetailsContext.test.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.test.tsx
@@ -1,0 +1,158 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { createLogLine } from 'app/features/logs/components/mocks/logRow';
+import { type LogListModel } from 'app/features/logs/components/panel/processing';
+
+import {
+  emptyContextData,
+  LogDetailsContext,
+  LogDetailsContextProvider,
+  type LogDetailsContextData,
+  useLogDetailsContext,
+  useLogDetailsContextData,
+} from './LogDetailsContext';
+
+const log1 = createLogLine({ uid: 'uid-1', rowId: 'row-1' });
+const log2 = createLogLine({ uid: 'uid-2', rowId: 'row-2' });
+
+const contextValue: LogDetailsContextData = {
+  ...emptyContextData,
+  currentLog: log1,
+  closeDetails: () => {},
+  detailsDisplayed: () => false,
+  enableLogDetails: true,
+  logs: [log1, log2],
+  setCurrentLog: () => {},
+  showDetails: [log1],
+  toggleDetails: () => {},
+};
+
+const staticWrapper = ({ children }: { children: ReactNode }) => (
+  <LogDetailsContext.Provider value={contextValue}>{children}</LogDetailsContext.Provider>
+);
+
+test('Provides the Log Details Context data', () => {
+  const { result } = renderHook(() => useLogDetailsContext(), { wrapper: staticWrapper });
+
+  expect(result.current).toEqual(contextValue);
+});
+
+test('Allows to access context attributes', () => {
+  const { result } = renderHook(() => useLogDetailsContextData('enableLogDetails'), { wrapper: staticWrapper });
+
+  expect(result.current).toEqual(contextValue.enableLogDetails);
+});
+
+function renderLogDetailsProviderHook(logs: LogListModel[], enableLogDetails = true) {
+  const props = { logs, enableLogDetails };
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <LogDetailsContextProvider enableLogDetails={props.enableLogDetails} logs={props.logs}>
+      {children}
+    </LogDetailsContextProvider>
+  );
+  const hook = renderHook(() => useLogDetailsContext(), { wrapper: Wrapper });
+  return {
+    ...hook,
+    setProviderProps(next: Partial<{ logs: LogListModel[]; enableLogDetails: boolean }>) {
+      Object.assign(props, next);
+      hook.rerender();
+    },
+  };
+}
+
+describe('LogDetailsContextProvider', () => {
+  test('starts with no details', () => {
+    const { result } = renderLogDetailsProviderHook([log1, log2]);
+
+    expect(result.current.showDetails).toEqual([]);
+    expect(result.current.currentLog).toBeUndefined();
+    expect(result.current.detailsDisplayed(0)).toBe(false);
+  });
+
+  test('does not expand when log details are disabled', () => {
+    const { result } = renderLogDetailsProviderHook([log1, log2], false);
+
+    act(() => {
+      result.current.toggleDetails(0);
+    });
+
+    expect(result.current.showDetails).toEqual([]);
+    expect(result.current.currentLog).toBeUndefined();
+  });
+
+  test('toggleDetails expands by row index and collapses on second toggle', () => {
+    const { result } = renderLogDetailsProviderHook([log1, log2]);
+
+    act(() => {
+      result.current.toggleDetails(0);
+    });
+    expect(result.current.showDetails.map((l) => l.uid)).toEqual([log1.uid]);
+    expect(result.current.currentLog?.uid).toBe(log1.uid);
+    expect(result.current.detailsDisplayed(0)).toBe(true);
+
+    act(() => {
+      result.current.toggleDetails(0);
+    });
+    expect(result.current.showDetails).toEqual([]);
+    expect(result.current.currentLog).toBeUndefined();
+    expect(result.current.detailsDisplayed(0)).toBe(false);
+  });
+
+  test('toggleDetails accepts a log model reference', () => {
+    const { result } = renderLogDetailsProviderHook([log1, log2]);
+
+    act(() => {
+      result.current.toggleDetails(log2);
+    });
+    expect(result.current.showDetails.map((l) => l.uid)).toEqual([log2.uid]);
+    expect(result.current.currentLog?.uid).toBe(log2.uid);
+  });
+
+  test('when collapsing the active log with other rows expanded, currentLog moves to the last expanded row', () => {
+    const { result } = renderLogDetailsProviderHook([log1, log2]);
+
+    act(() => {
+      result.current.toggleDetails(0);
+    });
+    act(() => {
+      result.current.toggleDetails(1);
+    });
+    expect(result.current.currentLog?.uid).toBe(log2.uid);
+
+    act(() => {
+      result.current.toggleDetails(1);
+    });
+    expect(result.current.currentLog?.uid).toBe(log1.uid);
+    expect(result.current.showDetails.map((l) => l.uid)).toEqual([log1.uid]);
+  });
+
+  test('closeDetails clears expanded state', () => {
+    const { result } = renderLogDetailsProviderHook([log1, log2]);
+
+    act(() => {
+      result.current.toggleDetails(0);
+    });
+    act(() => {
+      result.current.closeDetails();
+    });
+
+    expect(result.current.showDetails).toEqual([]);
+    expect(result.current.currentLog).toBeUndefined();
+  });
+
+  test('removes expanded rows that disappear from the logs prop', async () => {
+    const { result, setProviderProps } = renderLogDetailsProviderHook([log1, log2]);
+
+    act(() => {
+      result.current.toggleDetails(0);
+    });
+    expect(result.current.showDetails).toHaveLength(1);
+
+    setProviderProps({ logs: [log2] });
+
+    await waitFor(() => {
+      expect(result.current.showDetails).toEqual([]);
+    });
+  });
+});

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -91,7 +91,6 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
           setCurrentLog(newShowDetails[newShowDetails.length - 1]);
         }
       } else {
-        // Supporting one displayed details for now
         setShowDetails([...showDetails, log]);
         setCurrentLog(log);
       }

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -8,8 +8,9 @@ export interface LogDetailsContextData {
   detailsDisplayed: (rowIndex: number) => boolean;
   enableLogDetails: boolean;
   logs: LogListModel[];
+  setCurrentLog(log: LogListModel): void;
   showDetails: LogListModel[];
-  toggleDetails: (rowIndex: number) => void;
+  toggleDetails: (log: number | LogListModel) => void;
 }
 
 export const emptyContextData: LogDetailsContextData = {
@@ -18,6 +19,7 @@ export const emptyContextData: LogDetailsContextData = {
   detailsDisplayed: () => false,
   enableLogDetails: false,
   logs: [],
+  setCurrentLog: () => {},
   showDetails: [],
   toggleDetails: () => {},
 };
@@ -72,13 +74,13 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
   );
 
   const toggleDetails = useCallback(
-    (rowIndex: number) => {
+    (logRef: number | LogListModel) => {
       if (!enableLogDetails) {
         return;
       }
-      const log = logs.at(rowIndex);
+      const log = typeof logRef === 'number' ? logs.at(logRef) : logRef;
       if (!log) {
-        console.error(`LogDetailsContext: undefined log at rowIndex ${rowIndex}`);
+        console.error(`LogDetailsContext: undefined log with reference ${logRef}`);
         return;
       }
       const found = showDetails.find((stateLog) => stateLog.uid === log.uid);
@@ -105,6 +107,7 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
         detailsDisplayed,
         enableLogDetails,
         logs,
+        setCurrentLog,
         showDetails,
         toggleDetails,
       }}

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -5,10 +5,10 @@ import { type LogRowModel } from '@grafana/data';
 export interface LogDetailsContextData {
   currentLog: LogRowModel | undefined;
   closeDetails: () => void;
-  detailsDisplayed: (log: LogRowModel) => boolean;
+  detailsDisplayed: (rowIndex: number) => boolean;
   enableLogDetails: boolean;
   showDetails: LogRowModel[];
-  toggleDetails: (log: LogRowModel) => void;
+  toggleDetails: (rowIndex: number) => void;
 }
 
 export const emptyContextData: LogDetailsContextData = {
@@ -36,11 +36,7 @@ export interface Props {
   logs: LogRowModel[];
 }
 
-export const LogDetailsContextProvider = ({
-  children,
-  enableLogDetails,
-  logs,
-}: Props) => {
+export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: Props) => {
   const [showDetails, setShowDetails] = useState<LogRowModel[]>([]);
   const [currentLog, setCurrentLog] = useState<LogRowModel | undefined>(undefined);
 
@@ -63,13 +59,24 @@ export const LogDetailsContextProvider = ({
   }, []);
 
   const detailsDisplayed = useCallback(
-    (log: LogRowModel) => !!showDetails.find((shownLog) => shownLog.uid === log.uid),
-    [showDetails]
+    (rowIndex: number) => {
+      const log = logs.at(rowIndex);
+      if (!log) {
+        return false;
+      }
+      return !!showDetails.find((shownLog) => shownLog.uid === log.uid);
+    },
+    [logs, showDetails]
   );
 
   const toggleDetails = useCallback(
-    (log: LogRowModel) => {
+    (rowIndex: number) => {
       if (!enableLogDetails) {
+        return;
+      }
+      const log = logs.at(rowIndex);
+      if (!log) {
+        console.error(`LogDetailsContext: undefined log at rowIndex ${rowIndex}`);
         return;
       }
       const found = showDetails.find((stateLog) => stateLog.uid === log.uid);
@@ -85,7 +92,7 @@ export const LogDetailsContextProvider = ({
         setCurrentLog(log);
       }
     },
-    [currentLog, enableLogDetails, showDetails]
+    [currentLog, enableLogDetails, logs, showDetails]
   );
 
   return (

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,0 +1,105 @@
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+
+import { type LogRowModel } from '@grafana/data';
+
+export interface LogDetailsContextData {
+  currentLog: LogRowModel | undefined;
+  closeDetails: () => void;
+  detailsDisplayed: (log: LogRowModel) => boolean;
+  enableLogDetails: boolean;
+  showDetails: LogRowModel[];
+  toggleDetails: (log: LogRowModel) => void;
+}
+
+export const emptyContextData: LogDetailsContextData = {
+  currentLog: undefined,
+  closeDetails: () => {},
+  detailsDisplayed: () => false,
+  enableLogDetails: false,
+  showDetails: [],
+  toggleDetails: () => {},
+};
+export const LogDetailsContext = createContext<LogDetailsContextData>(emptyContextData);
+
+export const useLogDetailsContextData = (key: keyof LogDetailsContextData) => {
+  const data: LogDetailsContextData = useContext(LogDetailsContext);
+  return data[key];
+};
+
+export const useLogDetailsContext = (): LogDetailsContextData => {
+  return useContext(LogDetailsContext);
+};
+
+export interface Props {
+  children?: ReactNode;
+  enableLogDetails: boolean;
+  logs: LogRowModel[];
+}
+
+export const LogDetailsContextProvider = ({
+  children,
+  enableLogDetails,
+  logs,
+}: Props) => {
+  const [showDetails, setShowDetails] = useState<LogRowModel[]>([]);
+  const [currentLog, setCurrentLog] = useState<LogRowModel | undefined>(undefined);
+
+  // Sync show details
+  useEffect(() => {
+    if (!showDetails.length) {
+      return;
+    }
+    const newShowDetails = showDetails.filter(
+      (expandedLog) => logs.findIndex((log) => log.uid === expandedLog.uid) >= 0
+    );
+    if (newShowDetails.length !== showDetails.length) {
+      setShowDetails(newShowDetails);
+    }
+  }, [logs, showDetails]);
+
+  const closeDetails = useCallback(() => {
+    setShowDetails([]);
+    setCurrentLog(undefined);
+  }, []);
+
+  const detailsDisplayed = useCallback(
+    (log: LogRowModel) => !!showDetails.find((shownLog) => shownLog.uid === log.uid),
+    [showDetails]
+  );
+
+  const toggleDetails = useCallback(
+    (log: LogRowModel) => {
+      if (!enableLogDetails) {
+        return;
+      }
+      const found = showDetails.find((stateLog) => stateLog.uid === log.uid);
+      if (found) {
+        const newShowDetails = showDetails.filter((stateLog) => stateLog.uid !== log.uid);
+        setShowDetails(newShowDetails);
+        if (currentLog && currentLog.uid === log.uid) {
+          setCurrentLog(newShowDetails[newShowDetails.length - 1]);
+        }
+      } else {
+        // Supporting one displayed details for now
+        setShowDetails([...showDetails, log]);
+        setCurrentLog(log);
+      }
+    },
+    [currentLog, enableLogDetails, showDetails]
+  );
+
+  return (
+    <LogDetailsContext.Provider
+      value={{
+        closeDetails,
+        currentLog,
+        detailsDisplayed,
+        enableLogDetails,
+        showDetails,
+        toggleDetails,
+      }}
+    >
+      {children}
+    </LogDetailsContext.Provider>
+  );
+};

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,13 +1,14 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
-import { type LogRowModel } from '@grafana/data';
+import { type LogListModel } from 'app/features/logs/components/panel/processing';
 
 export interface LogDetailsContextData {
-  currentLog: LogRowModel | undefined;
+  currentLog: LogListModel | undefined;
   closeDetails: () => void;
   detailsDisplayed: (rowIndex: number) => boolean;
   enableLogDetails: boolean;
-  showDetails: LogRowModel[];
+  logs: LogListModel[];
+  showDetails: LogListModel[];
   toggleDetails: (rowIndex: number) => void;
 }
 
@@ -16,6 +17,7 @@ export const emptyContextData: LogDetailsContextData = {
   closeDetails: () => {},
   detailsDisplayed: () => false,
   enableLogDetails: false,
+  logs: [],
   showDetails: [],
   toggleDetails: () => {},
 };
@@ -33,12 +35,12 @@ export const useLogDetailsContext = (): LogDetailsContextData => {
 export interface Props {
   children?: ReactNode;
   enableLogDetails: boolean;
-  logs: LogRowModel[];
+  logs: LogListModel[];
 }
 
 export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: Props) => {
-  const [showDetails, setShowDetails] = useState<LogRowModel[]>([]);
-  const [currentLog, setCurrentLog] = useState<LogRowModel | undefined>(undefined);
+  const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
+  const [currentLog, setCurrentLog] = useState<LogListModel | undefined>(undefined);
 
   // Sync show details
   useEffect(() => {
@@ -102,6 +104,7 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
         currentLog,
         detailsDisplayed,
         enableLogDetails,
+        logs,
         showDetails,
         toggleDetails,
       }}

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '@grafana/data';
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { defaultTableOptions } from '@grafana/schema';
-import { PanelContextProvider } from '@grafana/ui';
+import { PanelContextProvider, type PanelContext } from '@grafana/ui';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 
@@ -24,6 +24,10 @@ import { LogsTable } from './LogsTable';
 import { type Options } from './options/types';
 import { defaultOptions } from './panelcfg.gen';
 import { getPanelData } from './testsUtils';
+
+jest.mock('@openfeature/react-sdk', () => ({
+  useBooleanFlagValue: jest.fn().mockReturnValue(false),
+}));
 
 const fieldConfig: FieldConfigSource = {
   defaults: {},
@@ -56,12 +60,20 @@ jest.mock('@grafana/runtime', () => ({
   getAppEvents: jest.fn(() => ({
     publish: publishMockFn,
   })),
+  getDataSourceSrv: jest.fn(() => ({
+    get: () => Promise.resolve(null),
+  })),
+  usePluginLinks: jest.fn().mockReturnValue({
+    links: [],
+    isLoading: false,
+  }),
 }));
 
 const setUp = (
   props?: Partial<React.ComponentProps<typeof LogsTable>>,
   options?: Partial<Options>,
-  app = CoreApp.Dashboard
+  app = CoreApp.Dashboard,
+  panelContext?: Partial<PanelContext>
 ) => {
   return render(
     <PanelContextProvider
@@ -69,6 +81,7 @@ const setUp = (
         app,
         eventsScope: 'test',
         eventBus: new EventBusSrv(),
+        ...panelContext,
       }}
     >
       <LogsTable
@@ -293,7 +306,7 @@ describe('LogsTable', () => {
       expect(headers[0].textContent).toEqual('timestamp');
       expect(headers[1].textContent).toEqual('level');
 
-      // Two log rows; inspect control exists only in the custom timestamp column (one per row).
+      // Two log rows; show details exists only in the custom timestamp column (one per row).
       expect(screen.getAllByLabelText('Show details')).toHaveLength(2);
     });
 
@@ -314,6 +327,47 @@ describe('LogsTable', () => {
       expect(headers[1].textContent).toEqual('timestamp');
 
       expect(screen.getAllByLabelText('Show details')).toHaveLength(2);
+    });
+  });
+
+  describe('Log details', () => {
+    it('opens the log details view when "Show details" is clicked', async () => {
+      setUp(undefined, { showInspectLogLine: true });
+      await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
+
+      expect(screen.queryByLabelText('Close log details sidebar')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getAllByLabelText('Show details')[0]);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Close log details sidebar')).toBeInTheDocument();
+      });
+    });
+
+    it('calls onAddAdHocFilter when using filter-for from log details', async () => {
+      const onAddAdHocFilter = jest.fn();
+      setUp(undefined, { showInspectLogLine: true }, CoreApp.Dashboard, { onAddAdHocFilter });
+      await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
+
+      await userEvent.click(screen.getAllByLabelText('Show details')[0]);
+
+      await userEvent.click(screen.getAllByLabelText('Filter for value')[0]);
+
+      expect(onAddAdHocFilter).toHaveBeenCalledTimes(1);
+      expect(onAddAdHocFilter).toHaveBeenCalledWith({
+        key: 'level',
+        value: 'info',
+        operator: '=',
+      });
+
+      await userEvent.click(screen.getAllByLabelText('Filter out value')[0]);
+
+      expect(onAddAdHocFilter).toHaveBeenCalledTimes(2);
+      expect(onAddAdHocFilter).toHaveBeenCalledWith({
+        key: 'level',
+        value: 'info',
+        operator: '!=',
+      });
     });
   });
 });

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -296,7 +296,7 @@ describe('LogsTable', () => {
       const { container } = setUp(
         { onOptionsChange },
         {
-          showInspectLogLine: true,
+          enableLogDetails: true,
         }
       );
       await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
@@ -315,7 +315,7 @@ describe('LogsTable', () => {
       const { container } = setUp(
         { onOptionsChange },
         {
-          showInspectLogLine: true,
+          enableLogDetails: true,
           displayedFields: ['level', LOGS_DATAPLANE_TIMESTAMP_NAME, LOGS_DATAPLANE_BODY_NAME],
         }
       );
@@ -332,7 +332,7 @@ describe('LogsTable', () => {
 
   describe('Log details', () => {
     it('opens the log details view when "Show details" is clicked', async () => {
-      setUp(undefined, { showInspectLogLine: true });
+      setUp(undefined, { enableLogDetails: true });
       await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
 
       expect(screen.queryByLabelText('Close log details sidebar')).not.toBeInTheDocument();
@@ -346,7 +346,7 @@ describe('LogsTable', () => {
 
     it('calls onAddAdHocFilter when using filter-for from log details', async () => {
       const onAddAdHocFilter = jest.fn();
-      setUp(undefined, { showInspectLogLine: true }, CoreApp.Dashboard, { onAddAdHocFilter });
+      setUp(undefined, { enableLogDetails: true }, CoreApp.Dashboard, { onAddAdHocFilter });
       await waitFor(() => expect(screen.queryByText('Selected fields')).toBeInTheDocument());
 
       await userEvent.click(screen.getAllByLabelText('Show details')[0]);

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -294,7 +294,7 @@ describe('LogsTable', () => {
       expect(headers[1].textContent).toEqual('level');
 
       // Two log rows; inspect control exists only in the custom timestamp column (one per row).
-      expect(screen.getAllByLabelText('View log line')).toHaveLength(2);
+      expect(screen.getAllByLabelText('Show details')).toHaveLength(2);
     });
 
     it('when level is the first column, renders exactly one custom cell per data row', async () => {
@@ -313,7 +313,7 @@ describe('LogsTable', () => {
       expect(headers[0].textContent).toEqual('level');
       expect(headers[1].textContent).toEqual('timestamp');
 
-      expect(screen.getAllByLabelText('View log line')).toHaveLength(2);
+      expect(screen.getAllByLabelText('Show details')).toHaveLength(2);
     });
   });
 });

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -243,15 +243,17 @@ export const LogsTable = ({
   );
 
   const logRows = useMemo(() => {
-    const logs = dataFrameToLogsModel(
-      panelData.series,
-      panelData.request?.intervalMs,
-      undefined,
-      panelData.request?.targets,
-      false
-    );
+    const logs = rawTableFrame
+      ? dataFrameToLogsModel(
+          [rawTableFrame],
+          panelData.request?.intervalMs,
+          undefined,
+          panelData.request?.targets,
+          false
+        )
+      : null;
     return logs?.rows || [];
-  }, [panelData.request?.intervalMs, panelData.request?.targets, panelData.series]);
+  }, [panelData.request?.intervalMs, panelData.request?.targets, rawTableFrame]);
 
   const noSeries = data.series.length === 0;
   const noValues = data.series[frameIndex]?.fields?.[0]?.values?.length === 0;

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -28,7 +28,7 @@ import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 
 import { LogDetailsContextProvider } from './LogDetailsContext';
-import { LogsTableDetails } from './LogsTableDetails';
+import { getLogDetailsWidth, LogsTableDetails } from './LogsTableDetails';
 import { TableNGWrap } from './TableNGWrap';
 import { LogsTableFields } from './fieldSelector/LogsTableFields';
 import { detectLevelField } from './fields/logs';
@@ -238,6 +238,7 @@ export const LogsTable = ({
       sortOrder: LogsSortOrder.Descending,
       sortBy: [{ displayName: timeFieldName, desc: true }],
       fieldSelectorWidth: options.fieldSelectorWidth ?? getDefaultFieldSelectorWidth(),
+      logDetailsWidth: options.logDetailsWidth ? options.logDetailsWidth : getLogDetailsWidth(),
       ...options,
       wrapText,
     }),
@@ -320,7 +321,7 @@ export const LogsTable = ({
             logOptionsStorageKey={SETTING_KEY_ROOT}
           />
 
-          <LogsTableDetails timeRange={data.timeRange} timeZone={timeZone} />
+          <LogsTableDetails onOptionsChange={handleTableOptionsChange} timeRange={data.timeRange} timeZone={timeZone} />
         </LogDetailsContextProvider>
       )}
     </div>

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -28,7 +28,7 @@ import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 
 import { LogDetailsContextProvider } from './LogDetailsContext';
-import { getLogDetailsWidth, LogsTableDetails } from './LogsTableDetails';
+import { getDefaultLogDetailsWidth, LogsTableDetails } from './LogsTableDetails';
 import { TableNGWrap } from './TableNGWrap';
 import { LogsTableFields } from './fieldSelector/LogsTableFields';
 import { detectLevelField } from './fields/logs';
@@ -243,7 +243,7 @@ export const LogsTable = ({
       sortOrder: LogsSortOrder.Descending,
       sortBy: [{ displayName: timeFieldName, desc: true }],
       fieldSelectorWidth: options.fieldSelectorWidth ?? getDefaultFieldSelectorWidth(),
-      logDetailsWidth: options.logDetailsWidth ? options.logDetailsWidth : getLogDetailsWidth(),
+      logDetailsWidth: options.logDetailsWidth ? options.logDetailsWidth : getDefaultLogDetailsWidth(),
       ...options,
       wrapText,
     }),

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -16,6 +16,7 @@ import { SETTING_KEY_ROOT } from 'app/features/explore/Logs/utils/logs';
 import { getDefaultFieldSelectorWidth } from 'app/features/logs/components/fieldSelector/FieldSelector';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 import { getLogsPanelState } from 'app/features/logs/components/panel/panelState/getLogsPanelState';
+import { LogListModel } from 'app/features/logs/components/panel/processing';
 import {
   DATAPLANE_SEVERITY_NAME,
   LOGS_DATAPLANE_BODY_NAME,
@@ -27,6 +28,7 @@ import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 
 import { LogDetailsContextProvider } from './LogDetailsContext';
+import { LogsTableDetails } from './LogsTableDetails';
 import { TableNGWrap } from './TableNGWrap';
 import { LogsTableFields } from './fieldSelector/LogsTableFields';
 import { detectLevelField } from './fields/logs';
@@ -250,10 +252,17 @@ export const LogsTable = ({
           undefined,
           panelData.request?.targets,
           false
+        ).rows.map(
+          (logRow) =>
+            new LogListModel(logRow, {
+              escape: false,
+              timeZone,
+              wrapLogMessage: true,
+            })
         )
       : null;
-    return logs?.rows || [];
-  }, [panelData.request?.intervalMs, panelData.request?.targets, rawTableFrame]);
+    return logs ?? [];
+  }, [panelData.request?.intervalMs, panelData.request?.targets, rawTableFrame, timeZone]);
 
   const noSeries = data.series.length === 0;
   const noValues = data.series[frameIndex]?.fields?.[0]?.values?.length === 0;
@@ -310,6 +319,8 @@ export const LogsTable = ({
             onWrapTextClick={handleWrapTextClick}
             logOptionsStorageKey={SETTING_KEY_ROOT}
           />
+
+          <LogsTableDetails timeRange={data.timeRange} timeZone={timeZone} />
         </LogDetailsContextProvider>
       )}
     </div>

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -23,8 +23,10 @@ import {
   type LogsFrame,
   parseLogsFrame,
 } from 'app/features/logs/logsFrame';
+import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 
+import { LogDetailsContextProvider } from './LogDetailsContext';
 import { TableNGWrap } from './TableNGWrap';
 import { LogsTableFields } from './fieldSelector/LogsTableFields';
 import { detectLevelField } from './fields/logs';
@@ -240,6 +242,17 @@ export const LogsTable = ({
     [options, timeFieldName, wrapText]
   );
 
+  const logRows = useMemo(() => {
+    const logs = dataFrameToLogsModel(
+      panelData.series,
+      panelData.request?.intervalMs,
+      undefined,
+      panelData.request?.targets,
+      false
+    );
+    return logs?.rows || [];
+  }, [panelData.request?.intervalMs, panelData.request?.targets, panelData.series]);
+
   const noSeries = data.series.length === 0;
   const noValues = data.series[frameIndex]?.fields?.[0]?.values?.length === 0;
 
@@ -257,7 +270,7 @@ export const LogsTable = ({
   return (
     <div className={styles.wrapper} ref={containerRef}>
       {renderTable && containerElement && (
-        <>
+        <LogDetailsContextProvider enableLogDetails logs={logRows}>
           <LogsTableFields
             tableWidth={width}
             fieldSelectorWidth={options.fieldSelectorWidth}
@@ -295,7 +308,7 @@ export const LogsTable = ({
             onWrapTextClick={handleWrapTextClick}
             logOptionsStorageKey={SETTING_KEY_ROOT}
           />
-        </>
+        </LogDetailsContextProvider>
       )}
     </div>
   );

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -49,6 +49,11 @@ import {
 
 interface LogsTablePanelProps extends Omit<PanelProps<Options>, 'timeRange'> {}
 
+/**
+ * Props:
+ * Determines if a given key => value filter is active in a given query. Used by Log details.
+ * isLabelFilterActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
+ */
 export const LogsTable = ({
   data,
   width,

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -287,7 +287,7 @@ export const LogsTable = ({
   return (
     <div className={styles.wrapper} ref={containerRef}>
       {renderTable && containerElement && (
-        <LogDetailsContextProvider enableLogDetails logs={logRows}>
+        <LogDetailsContextProvider enableLogDetails={options.enableLogDetails ?? true} logs={logRows}>
           <LogsTableFields
             tableWidth={width}
             fieldSelectorWidth={options.fieldSelectorWidth}

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -321,7 +321,12 @@ export const LogsTable = ({
             logOptionsStorageKey={SETTING_KEY_ROOT}
           />
 
-          <LogsTableDetails onOptionsChange={handleTableOptionsChange} timeRange={data.timeRange} timeZone={timeZone} />
+          <LogsTableDetails
+            options={tableOptions}
+            onOptionsChange={handleTableOptionsChange}
+            timeRange={data.timeRange}
+            timeZone={timeZone}
+          />
         </LogDetailsContextProvider>
       )}
     </div>

--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { CoreApp, dateTime, EventBusSrv, LogLevel } from '@grafana/data';
 import { type DataSourceSrv, getDataSourceSrv, usePluginLinks } from '@grafana/runtime';
 import { defaultTableOptions } from '@grafana/schema';
-import { PanelContext, PanelContextProvider } from '@grafana/ui';
+import { type PanelContext, PanelContextProvider } from '@grafana/ui';
 import { createLogLine } from 'app/features/logs/components/mocks/logRow';
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
 import { createLokiDatasource } from 'app/plugins/datasource/loki/mocks/datasource';

--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -1,0 +1,368 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CoreApp, dateTime, EventBusSrv, LogLevel } from '@grafana/data';
+import { type DataSourceSrv, getDataSourceSrv, usePluginLinks } from '@grafana/runtime';
+import { defaultTableOptions } from '@grafana/schema';
+import { PanelContext, PanelContextProvider } from '@grafana/ui';
+import { createLogLine } from 'app/features/logs/components/mocks/logRow';
+import { type LogListModel } from 'app/features/logs/components/panel/processing';
+import { createLokiDatasource } from 'app/plugins/datasource/loki/mocks/datasource';
+
+import {
+  emptyContextData,
+  LogDetailsContext,
+  type LogDetailsContextData,
+} from './LogDetailsContext';
+import { getDefaultLogDetailsWidth, LogsTableDetails } from './LogsTableDetails';
+import { type Options } from './options/types';
+import { defaultOptions } from './panelcfg.gen';
+
+jest.mock('@openfeature/react-sdk', () => ({
+  useBooleanFlagValue: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../../features/logs/components/fieldSelector/FieldSelector');
+jest.mock('../../../features/logs/components/fieldSelector/fieldSelectorUtils');
+
+jest.mock('@grafana/assistant', () => {
+  return {
+    ...jest.requireActual('@grafana/assistant'),
+    useAssistant: jest.fn().mockReturnValue({
+      isLoading: false,
+      isAvailable: true,
+      openAssistant: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: jest.fn(),
+  usePluginLinks: jest.fn(),
+}));
+
+jest.mock('app/features/explore/TraceView/TraceView', () => ({
+  TraceView: () => <div>Trace view</div>,
+}));
+
+afterAll(() => {
+  jest.unmock('app/features/explore/TraceView/TraceView');
+});
+
+const timeRange = {
+  from: dateTime(1757937009041),
+  to: dateTime(1757940609041),
+  raw: {
+    from: 'now-1h',
+    to: 'now',
+  },
+};
+
+const baseOptions: Options = {
+  frameIndex: 0,
+  showHeader: true,
+  ...defaultOptions,
+  ...defaultTableOptions,
+};
+
+let lokiDS = createLokiDatasource(undefined, { uid: 'loki-ds' });
+
+const setup = (
+  detailsOverrides?: Partial<LogDetailsContextData>,
+  optionsOverrides?: Partial<Options>,
+  panelContext?: Partial<PanelContext>,
+  onOptionsChange = jest.fn(),
+  logsOverride?: LogListModel[]
+) => {
+  const logs = logsOverride ?? [
+    createLogLine({
+      logLevel: LogLevel.error,
+      timeEpochMs: 1546297200000,
+      datasourceUid: lokiDS.uid,
+      labels: { svc: 'api' },
+    }),
+  ];
+
+  const detailsData: LogDetailsContextData = {
+    ...emptyContextData,
+    enableLogDetails: true,
+    logs,
+    showDetails: logs,
+    currentLog: logs[0],
+    closeDetails: jest.fn(),
+    setCurrentLog: jest.fn(),
+    toggleDetails: jest.fn(),
+    ...detailsOverrides,
+  };
+
+  const result = render(
+    <PanelContextProvider
+      value={{
+        eventsScope: 'test',
+        eventBus: new EventBusSrv(),
+        app: CoreApp.Dashboard,
+        ...panelContext,
+      }}
+    >
+      <LogDetailsContext.Provider value={detailsData}>
+        <LogsTableDetails
+          options={{ ...baseOptions, ...optionsOverrides }}
+          onOptionsChange={onOptionsChange}
+          timeRange={timeRange}
+          timeZone="UTC"
+        />
+      </LogDetailsContext.Provider>
+    </PanelContextProvider>
+  );
+
+  return { ...result, detailsData, logs };
+};
+
+describe('LogsTableDetails', () => {
+  beforeEach(() => {
+    lokiDS = createLokiDatasource(undefined, { uid: 'loki-ds' });
+    jest.mocked(usePluginLinks).mockReturnValue({
+      links: [],
+      isLoading: false,
+    });
+    jest.mocked(getDataSourceSrv).mockImplementation(
+      () =>
+        ({
+          get: (uid: string) => {
+            if (uid === 'loki-ds') {
+              return Promise.resolve(lokiDS);
+            }
+            return Promise.resolve(null);
+          },
+        }) as unknown as DataSourceSrv
+    );
+  });
+
+  test('returns null when log details are disabled', () => {
+    const { container } = setup({ enableLogDetails: false });
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('returns null when there is no current log', () => {
+    const { container } = setup({ currentLog: undefined });
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders log details for the current log', async () => {
+    setup(undefined, undefined, undefined, jest.fn());
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText('Search field names and values')).toBeInTheDocument();
+  });
+
+  test('does not render tabs for a single open log', async () => {
+    setup();
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  });
+
+  test('renders a tab per open log and switches the active log', async () => {
+    const logA = createLogLine({
+      uid: 'a',
+      logLevel: LogLevel.info,
+      timeEpochMs: 1546297200000,
+      entry: 'First log line content',
+      datasourceUid: lokiDS.uid,
+    });
+    const logB = createLogLine({
+      uid: 'b',
+      logLevel: LogLevel.warn,
+      timeEpochMs: 1546297200001,
+      entry: 'Second log line content',
+      datasourceUid: lokiDS.uid,
+    });
+
+    const setCurrentLog = jest.fn();
+    const detailsData: LogDetailsContextData = {
+      ...emptyContextData,
+      enableLogDetails: true,
+      logs: [logA, logB],
+      showDetails: [logA, logB],
+      currentLog: logB,
+      closeDetails: jest.fn(),
+      setCurrentLog,
+      toggleDetails: jest.fn(),
+    };
+
+    render(
+      <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
+        <LogDetailsContext.Provider value={detailsData}>
+          <LogsTableDetails
+            options={baseOptions}
+            onOptionsChange={jest.fn()}
+            timeRange={timeRange}
+            timeZone="UTC"
+          />
+        </LogDetailsContext.Provider>
+      </PanelContextProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    // Tabs are reversed: last opened appears first.
+    expect(screen.getByRole('tab', { name: /Second log line content/i })).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.click(screen.getByRole('tab', { name: /First log line content/i }));
+
+    expect(setCurrentLog).toHaveBeenCalledWith(logA);
+  });
+
+  test('removes a log from details when the tab remove control is used', async () => {
+    const logA = createLogLine({
+      uid: 'a',
+      logLevel: LogLevel.info,
+      timeEpochMs: 1546297200000,
+      entry: 'Alpha log',
+      datasourceUid: lokiDS.uid,
+    });
+    const logB = createLogLine({
+      uid: 'b',
+      logLevel: LogLevel.warn,
+      timeEpochMs: 1546297200001,
+      entry: 'Beta log',
+      datasourceUid: lokiDS.uid,
+    });
+
+    const toggleDetails = jest.fn();
+
+    const detailsData: LogDetailsContextData = {
+      ...emptyContextData,
+      enableLogDetails: true,
+      logs: [logA, logB],
+      showDetails: [logA, logB],
+      currentLog: logB,
+      closeDetails: jest.fn(),
+      setCurrentLog: jest.fn(),
+      toggleDetails,
+    };
+
+    render(
+      <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
+        <LogDetailsContext.Provider value={detailsData}>
+          <LogsTableDetails
+            options={baseOptions}
+            onOptionsChange={jest.fn()}
+            timeRange={timeRange}
+            timeZone="UTC"
+          />
+        </LogDetailsContext.Provider>
+      </PanelContextProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    const removeButtons = screen.getAllByLabelText('Remove log');
+    await userEvent.click(removeButtons[0]);
+
+    expect(toggleDetails).toHaveBeenCalledWith(logB);
+  });
+
+  test('closes details on Escape when at least one log is open', async () => {
+    const closeDetails = jest.fn();
+   setup({ closeDetails });
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    expect(closeDetails).not.toHaveBeenCalled();
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(closeDetails).toHaveBeenCalledTimes(1);
+  });
+
+  test('forwards label filters to the panel ad-hoc filter handler', async () => {
+    const onAddAdHocFilter = jest.fn();
+    const labeledLog = createLogLine({
+      logLevel: LogLevel.error,
+      timeEpochMs: 1546297200000,
+      datasourceUid: lokiDS.uid,
+      labels: { env: 'prod' },
+    });
+    setup(undefined, undefined, { onAddAdHocFilter }, jest.fn(), [labeledLog]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fields')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText(/^Filter for value/));
+
+    expect(onAddAdHocFilter).toHaveBeenCalledWith({
+      key: 'env',
+      value: 'prod',
+      operator: '=',
+    });
+  });
+
+  test('forwards label filter-out to the panel ad-hoc filter handler', async () => {
+    const onAddAdHocFilter = jest.fn();
+    const labeledLog = createLogLine({
+      logLevel: LogLevel.error,
+      timeEpochMs: 1546297200000,
+      datasourceUid: lokiDS.uid,
+      labels: { env: 'prod' },
+    });
+    setup(undefined, undefined, { onAddAdHocFilter }, jest.fn(), [labeledLog]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fields')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText(/^Filter out value/));
+
+    expect(onAddAdHocFilter).toHaveBeenCalledWith({
+      key: 'env',
+      value: 'prod',
+      operator: '!=',
+    });
+  });
+
+  test('applies logDetailsWidth from panel options on the resizable container', async () => {
+    setup(undefined, { logDetailsWidth: 428 });
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    const sized = document.querySelector('[style*="428px"]');
+    expect(sized).toBeTruthy();
+  });
+});
+
+describe('getDefaultLogDetailsWidth', () => {
+  const originalInnerWidth = window.innerWidth;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  test('uses forty percent of the viewport with a minimum of 400', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 900 });
+    expect(getDefaultLogDetailsWidth()).toBe(Math.max(Math.round(900 * 0.4), 400));
+  });
+
+  test('returns at least 400 for narrow viewports', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 600 });
+    expect(getDefaultLogDetailsWidth()).toBe(400);
+  });
+});

--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -9,11 +9,7 @@ import { createLogLine } from 'app/features/logs/components/mocks/logRow';
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
 import { createLokiDatasource } from 'app/plugins/datasource/loki/mocks/datasource';
 
-import {
-  emptyContextData,
-  LogDetailsContext,
-  type LogDetailsContextData,
-} from './LogDetailsContext';
+import { emptyContextData, LogDetailsContext, type LogDetailsContextData } from './LogDetailsContext';
 import { getDefaultLogDetailsWidth, LogsTableDetails } from './LogsTableDetails';
 import { type Options } from './options/types';
 import { defaultOptions } from './panelcfg.gen';
@@ -198,12 +194,7 @@ describe('LogsTableDetails', () => {
     render(
       <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
         <LogDetailsContext.Provider value={detailsData}>
-          <LogsTableDetails
-            options={baseOptions}
-            onOptionsChange={jest.fn()}
-            timeRange={timeRange}
-            timeZone="UTC"
-          />
+          <LogsTableDetails options={baseOptions} onOptionsChange={jest.fn()} timeRange={timeRange} timeZone="UTC" />
         </LogDetailsContext.Provider>
       </PanelContextProvider>
     );
@@ -253,12 +244,7 @@ describe('LogsTableDetails', () => {
     render(
       <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
         <LogDetailsContext.Provider value={detailsData}>
-          <LogsTableDetails
-            options={baseOptions}
-            onOptionsChange={jest.fn()}
-            timeRange={timeRange}
-            timeZone="UTC"
-          />
+          <LogsTableDetails options={baseOptions} onOptionsChange={jest.fn()} timeRange={timeRange} timeZone="UTC" />
         </LogDetailsContext.Provider>
       </PanelContextProvider>
     );
@@ -275,7 +261,7 @@ describe('LogsTableDetails', () => {
 
   test('closes details on Escape when at least one log is open', async () => {
     const closeDetails = jest.fn();
-   setup({ closeDetails });
+    setup({ closeDetails });
 
     await waitFor(() => {
       expect(screen.getByText('Log line')).toBeInTheDocument();

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -100,7 +100,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
   return (
     <div className={styles.wrapper}>
       <Resizable
-        onResize={handleResize}
+        onResizeStop={handleResize}
         handleClasses={{ left: dragStyles.dragHandleVertical }}
         defaultSize={{ width: detailsWidth, height: '100%' }}
         size={{ width: detailsWidth, height: '100%' }}

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -2,13 +2,23 @@ import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
 import { useState, useCallback, startTransition, useRef, useMemo, useEffect } from 'react';
 
-import { type PanelProps, type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import {
+  type PanelProps,
+  type GrafanaTheme2,
+  type TimeRange,
+  LogsDedupStrategy,
+  store,
+  LogsSortOrder,
+  CoreApp,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDragStyles, Icon, ScrollContainer, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { getDragStyles, Icon, ScrollContainer, Tab, TabsBar, usePanelContext, useStyles2 } from '@grafana/ui';
 import { LogLineDetailsComponent } from 'app/features/logs/components/panel/LogLineDetailsComponent';
 import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLineDetailsHeader';
+import { LogListContextProvider } from 'app/features/logs/components/panel/LogListContext';
 
 import { useLogDetailsContext } from './LogDetailsContext';
+import { SETTING_KEY_ROOT } from './constants';
 import { type Options } from './options/types';
 
 interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
@@ -22,6 +32,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
     useLogDetailsContext();
   const [search, setSearch] = useState('');
   const [detailsWidth, setDetailsWidth] = useState(window.innerWidth * 0.4);
+  const { onAddAdHocFilter, app } = usePanelContext();
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
@@ -57,6 +68,28 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
       });
     },
     [onOptionsChange, options]
+  );
+
+  const handleFilterFor = useCallback(
+    (key: string, value: string) => {
+      onAddAdHocFilter?.({
+        key,
+        value,
+        operator: '=',
+      });
+    },
+    [onAddAdHocFilter]
+  );
+
+  const handleFilterOut = useCallback(
+    (key: string, value: string) => {
+      onAddAdHocFilter?.({
+        key,
+        value,
+        operator: '!=',
+      });
+    },
+    [onAddAdHocFilter]
   );
 
   if (!enableLogDetails || !currentLog) {
@@ -99,22 +132,37 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
               })}
             </TabsBar>
           )}
-          <LogLineDetailsHeader
-            closeDetails={closeDetails}
-            detailsMode="sidebar"
-            log={currentLog}
-            search={search}
-            onSearch={handleSearch}
-          />
-          <ScrollContainer>
-            <LogLineDetailsComponent
+          <LogListContextProvider
+            app={app ?? CoreApp.Unknown}
+            isLabelFilterActive={options.isLabelFilterActive}
+            onClickFilterLabel={handleFilterFor}
+            onClickFilterOutLabel={handleFilterOut}
+            dedupStrategy={LogsDedupStrategy.none}
+            displayedFields={[]}
+            fontSize={store.get(`${SETTING_KEY_ROOT}.fontSize`) ?? 'default'}
+            logs={logs}
+            showControls={false}
+            showTime={false}
+            sortOrder={LogsSortOrder.Ascending}
+            wrapLogMessage
+          >
+            <LogLineDetailsHeader
+              closeDetails={closeDetails}
+              detailsMode="sidebar"
               log={currentLog}
-              logs={logs}
               search={search}
-              timeRange={timeRange}
-              timeZone={timeZone}
+              onSearch={handleSearch}
             />
-          </ScrollContainer>
+            <ScrollContainer>
+              <LogLineDetailsComponent
+                log={currentLog}
+                logs={logs}
+                search={search}
+                timeRange={timeRange}
+                timeZone={timeZone}
+              />
+            </ScrollContainer>
+          </LogListContextProvider>
         </div>
       </Resizable>
     </div>

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -2,20 +2,22 @@ import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
 import { useState, useCallback, startTransition, useRef, useMemo } from 'react';
 
-import { type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import { type PanelProps, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getDragStyles, Icon, ScrollContainer, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import { LogLineDetailsComponent } from 'app/features/logs/components/panel/LogLineDetailsComponent';
 import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLineDetailsHeader';
 
 import { useLogDetailsContext } from './LogDetailsContext';
+import { type Options } from './options/types';
 
-interface Props {
+interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
+  options: Options;
   timeRange: TimeRange;
   timeZone: string;
 }
 
-export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
+export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone }: Props) => {
   const { currentLog, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } = useLogDetailsContext();
   const [search, setSearch] = useState('');
   const [detailsWidth, setDetailsWidth] = useState(window.innerWidth * 0.4);
@@ -32,9 +34,17 @@ export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
 
   const tabs = useMemo(() => showDetails.slice().reverse(), [showDetails]);
 
-  const handleResize = useCallback((event: unknown, direction: unknown, elementRef: HTMLElement) => {
-    setDetailsWidth(elementRef.clientWidth);
-  }, []);
+  const handleResize = useCallback(
+    (event: unknown, direction: unknown, elementRef: HTMLElement) => {
+      const width = elementRef.clientWidth;
+      setDetailsWidth(width);
+      onOptionsChange({
+        ...options,
+        logDetailsWidth: width,
+      });
+    },
+    [onOptionsChange, options]
+  );
 
   if (!enableLogDetails || !currentLog) {
     return null;
@@ -91,6 +101,10 @@ export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
     </div>
   );
 };
+
+export function getLogDetailsWidth() {
+  return Math.max(Math.round(window.innerWidth * 0.4), 400);
+}
 
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
-import { t } from 'i18next';
+import { Resizable } from 're-resizable';
 import { useState, useCallback, startTransition, useRef, useMemo } from 'react';
 
 import { type GrafanaTheme2, type TimeRange } from '@grafana/data';
-import { Icon, ScrollContainer, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { t } from '@grafana/i18n';
+import { getDragStyles, Icon, ScrollContainer, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import { LogLineDetailsComponent } from 'app/features/logs/components/panel/LogLineDetailsComponent';
 import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLineDetailsHeader';
 
@@ -17,8 +18,10 @@ interface Props {
 export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
   const { currentLog, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } = useLogDetailsContext();
   const [search, setSearch] = useState('');
+  const [detailsWidth, setDetailsWidth] = useState(window.innerWidth * 0.4);
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
+  const dragStyles = useStyles2(getDragStyles);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;
@@ -29,60 +32,78 @@ export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
 
   const tabs = useMemo(() => showDetails.slice().reverse(), [showDetails]);
 
+  const handleResize = useCallback((event: unknown, direction: unknown, elementRef: HTMLElement) => {
+    setDetailsWidth(elementRef.clientWidth);
+  }, []);
+
   if (!enableLogDetails || !currentLog) {
     return null;
   }
 
   return (
-    <div className={styles.container}>
-      {showDetails.length > 1 && (
-        <TabsBar>
-          {tabs.map((log) => {
-            return (
-              <Tab
-                key={log.uid}
-                truncate
-                label={log.entry.substring(0, 25)}
-                active={currentLog.uid === log.uid}
-                onChangeTab={() => setCurrentLog(log)}
-                suffix={() => (
-                  <Icon
-                    name="times"
-                    aria-label={t('logs.log-line-details.remove-log', 'Remove log')}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleDetails(log);
-                    }}
+    <div className={styles.wrapper}>
+      <Resizable
+        onResize={handleResize}
+        handleClasses={{ left: dragStyles.dragHandleVertical }}
+        defaultSize={{ width: detailsWidth, height: '100%' }}
+        size={{ width: detailsWidth, height: '100%' }}
+        enable={{ left: true }}
+        minWidth={40}
+      >
+        <div className={styles.container}>
+          {showDetails.length > 1 && (
+            <TabsBar>
+              {tabs.map((log) => {
+                return (
+                  <Tab
+                    key={log.uid}
+                    truncate
+                    label={log.entry.substring(0, 25)}
+                    active={currentLog.uid === log.uid}
+                    onChangeTab={() => setCurrentLog(log)}
+                    suffix={() => (
+                      <Icon
+                        name="times"
+                        aria-label={t('logs.log-line-details.remove-log', 'Remove log')}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleDetails(log);
+                        }}
+                      />
+                    )}
                   />
-                )}
-              />
-            );
-          })}
-        </TabsBar>
-      )}
-      <LogLineDetailsHeader log={currentLog} search={search} onSearch={handleSearch} />
-      <ScrollContainer>
-        <LogLineDetailsComponent
-          log={currentLog}
-          logs={logs}
-          search={search}
-          timeRange={timeRange}
-          timeZone={timeZone}
-        />
-      </ScrollContainer>
+                );
+              })}
+            </TabsBar>
+          )}
+          <LogLineDetailsHeader log={currentLog} search={search} onSearch={handleSearch} />
+          <ScrollContainer>
+            <LogLineDetailsComponent
+              log={currentLog}
+              logs={logs}
+              search={search}
+              timeRange={timeRange}
+              timeZone={timeZone}
+            />
+          </ScrollContainer>
+        </div>
+      </Resizable>
     </div>
   );
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    height: '100%',
+  }),
   container: css({
     backgroundColor: theme.colors.background.elevated,
     border: `1px solid ${theme.colors.border.weak}`,
     boxShadow: theme.shadows.z3,
-    position: 'absolute',
-    top: 0,
-    right: 0,
     zIndex: 99999,
-    width: '25vw',
+    height: '100%',
   }),
 });

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -189,5 +189,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     boxShadow: theme.shadows.z3,
     zIndex: theme.zIndex.navbarFixed,
     height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
   }),
 });

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -187,7 +187,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     backgroundColor: theme.colors.background.elevated,
     border: `1px solid ${theme.colors.border.weak}`,
     boxShadow: theme.shadows.z3,
-    zIndex: 99999,
+    zIndex: theme.zIndex.navbarFixed,
     height: '100%',
   }),
 });

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -20,6 +20,7 @@ import { LogListContextProvider } from 'app/features/logs/components/panel/LogLi
 import { useLogDetailsContext } from './LogDetailsContext';
 import { SETTING_KEY_ROOT } from './constants';
 import { type Options } from './options/types';
+import { isIsLabelFilterActive } from './types';
 
 interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
   options: Options;
@@ -134,7 +135,9 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
           )}
           <LogListContextProvider
             app={app ?? CoreApp.Unknown}
-            isLabelFilterActive={options.isLabelFilterActive}
+            isLabelFilterActive={
+              isIsLabelFilterActive(options.isLabelFilterActive) ? options.isLabelFilterActive : undefined
+            }
             onClickFilterLabel={handleFilterFor}
             onClickFilterOutLabel={handleFilterOut}
             dedupStrategy={LogsDedupStrategy.none}

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -18,7 +18,8 @@ interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
 }
 
 export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone }: Props) => {
-  const { currentLog, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } = useLogDetailsContext();
+  const { currentLog, closeDetails, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } =
+    useLogDetailsContext();
   const [search, setSearch] = useState('');
   const [detailsWidth, setDetailsWidth] = useState(window.innerWidth * 0.4);
   const inputRef = useRef('');
@@ -86,7 +87,13 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
               })}
             </TabsBar>
           )}
-          <LogLineDetailsHeader log={currentLog} search={search} onSearch={handleSearch} />
+          <LogLineDetailsHeader
+            closeDetails={closeDetails}
+            detailsMode="sidebar"
+            log={currentLog}
+            search={search}
+            onSearch={handleSearch}
+          />
           <ScrollContainer>
             <LogLineDetailsComponent
               log={currentLog}

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
-import { useState, useCallback, startTransition, useRef, useMemo } from 'react';
+import { useState, useCallback, startTransition, useRef, useMemo, useEffect } from 'react';
 
 import { type PanelProps, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -25,6 +25,18 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
+
+  useEffect(() => {
+    function handleClose(event: KeyboardEvent) {
+      if (event.key === 'Escape' && showDetails.length > 0) {
+        closeDetails();
+      }
+    }
+    document.addEventListener('keyup', handleClose);
+    return () => {
+      document.removeEventListener('keyup', handleClose);
+    };
+  }, [closeDetails, showDetails.length]);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -32,7 +32,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
   const { currentLog, closeDetails, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } =
     useLogDetailsContext();
   const [search, setSearch] = useState('');
-  const [detailsWidth, setDetailsWidth] = useState(window.innerWidth * 0.4);
+  const [detailsWidth, setDetailsWidth] = useState(options.logDetailsWidth ?? getDefaultLogDetailsWidth());
   const { onAddAdHocFilter, app } = usePanelContext();
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
@@ -172,7 +172,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
   );
 };
 
-export function getLogDetailsWidth() {
+export function getDefaultLogDetailsWidth() {
   return Math.max(Math.round(window.innerWidth * 0.4), 400);
 }
 

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -1,12 +1,13 @@
-import { css } from "@emotion/css";
-import { useState, useCallback, startTransition, useRef } from "react";
+import { css } from '@emotion/css';
+import { t } from 'i18next';
+import { useState, useCallback, startTransition, useRef, useMemo } from 'react';
 
-import { GrafanaTheme2, type TimeRange } from "@grafana/data";
-import { ScrollContainer, useStyles2 } from "@grafana/ui";
-import { LogLineDetailsComponent } from "app/features/logs/components/panel/LogLineDetailsComponent";
-import { LogLineDetailsHeader } from "app/features/logs/components/panel/LogLineDetailsHeader";
+import { type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import { Icon, ScrollContainer, Tab, TabsBar, useStyles2 } from '@grafana/ui';
+import { LogLineDetailsComponent } from 'app/features/logs/components/panel/LogLineDetailsComponent';
+import { LogLineDetailsHeader } from 'app/features/logs/components/panel/LogLineDetailsHeader';
 
-import { useLogDetailsContext } from "./LogDetailsContext";
+import { useLogDetailsContext } from './LogDetailsContext';
 
 interface Props {
   timeRange: TimeRange;
@@ -14,17 +15,19 @@ interface Props {
 }
 
 export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
-  const { currentLog, logs, enableLogDetails } = useLogDetailsContext();
+  const { currentLog, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } = useLogDetailsContext();
   const [search, setSearch] = useState('');
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
 
   const handleSearch = useCallback((newSearch: string) => {
-        inputRef.current = newSearch;
-        startTransition(() => {
-          setSearch(inputRef.current);
-        });
-      }, []);
+    inputRef.current = newSearch;
+    startTransition(() => {
+      setSearch(inputRef.current);
+    });
+  }, []);
+
+  const tabs = useMemo(() => showDetails.slice().reverse(), [showDetails]);
 
   if (!enableLogDetails || !currentLog) {
     return null;
@@ -32,6 +35,31 @@ export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
 
   return (
     <div className={styles.container}>
+      {showDetails.length > 1 && (
+        <TabsBar>
+          {tabs.map((log) => {
+            return (
+              <Tab
+                key={log.uid}
+                truncate
+                label={log.entry.substring(0, 25)}
+                active={currentLog.uid === log.uid}
+                onChangeTab={() => setCurrentLog(log)}
+                suffix={() => (
+                  <Icon
+                    name="times"
+                    aria-label={t('logs.log-line-details.remove-log', 'Remove log')}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleDetails(log);
+                    }}
+                  />
+                )}
+              />
+            );
+          })}
+        </TabsBar>
+      )}
       <LogLineDetailsHeader log={currentLog} search={search} onSearch={handleSearch} />
       <ScrollContainer>
         <LogLineDetailsComponent
@@ -43,8 +71,8 @@ export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
         />
       </ScrollContainer>
     </div>
-  )
-}
+  );
+};
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
@@ -57,4 +85,4 @@ const getStyles = (theme: GrafanaTheme2) => ({
     zIndex: 99999,
     width: '25vw',
   }),
-})
+});

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -20,7 +20,7 @@ import { LogListContextProvider } from 'app/features/logs/components/panel/LogLi
 import { useLogDetailsContext } from './LogDetailsContext';
 import { SETTING_KEY_ROOT } from './constants';
 import { type Options } from './options/types';
-import { isIsLabelFilterActive } from './types';
+import { isCoreApp, isIsLabelFilterActive } from './types';
 
 interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
   options: Options;
@@ -134,7 +134,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
             </TabsBar>
           )}
           <LogListContextProvider
-            app={app ?? CoreApp.Unknown}
+            app={isCoreApp(app) ? app : CoreApp.Unknown}
             isLabelFilterActive={
               isIsLabelFilterActive(options.isLabelFilterActive) ? options.isLabelFilterActive : undefined
             }

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -1,0 +1,60 @@
+import { css } from "@emotion/css";
+import { useState, useCallback, startTransition, useRef } from "react";
+
+import { GrafanaTheme2, type TimeRange } from "@grafana/data";
+import { ScrollContainer, useStyles2 } from "@grafana/ui";
+import { LogLineDetailsComponent } from "app/features/logs/components/panel/LogLineDetailsComponent";
+import { LogLineDetailsHeader } from "app/features/logs/components/panel/LogLineDetailsHeader";
+
+import { useLogDetailsContext } from "./LogDetailsContext";
+
+interface Props {
+  timeRange: TimeRange;
+  timeZone: string;
+}
+
+export const LogsTableDetails = ({ timeRange, timeZone }: Props) => {
+  const { currentLog, logs, enableLogDetails } = useLogDetailsContext();
+  const [search, setSearch] = useState('');
+  const inputRef = useRef('');
+  const styles = useStyles2(getStyles);
+
+  const handleSearch = useCallback((newSearch: string) => {
+        inputRef.current = newSearch;
+        startTransition(() => {
+          setSearch(inputRef.current);
+        });
+      }, []);
+
+  if (!enableLogDetails || !currentLog) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <LogLineDetailsHeader log={currentLog} search={search} onSearch={handleSearch} />
+      <ScrollContainer>
+        <LogLineDetailsComponent
+          log={currentLog}
+          logs={logs}
+          search={search}
+          timeRange={timeRange}
+          timeZone={timeZone}
+        />
+      </ScrollContainer>
+    </div>
+  )
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    backgroundColor: theme.colors.background.elevated,
+    border: `1px solid ${theme.colors.border.weak}`,
+    boxShadow: theme.shadows.z3,
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    zIndex: 99999,
+    width: '25vw',
+  }),
+})

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -64,14 +64,6 @@ export function TableNGWrap({
   const controlsWidth = !showControls ? 0 : controlsExpanded ? CONTROLS_WIDTH_EXPANDED : LOG_LIST_CONTROLS_WIDTH;
   const styles = useStyles2(getStyles, fieldSelectorWidth, height, tableWidth, controlsWidth, !!title);
 
-  // Callbacks
-  const onTableOptionsChange = useCallback(
-    (options: TableOptions) => {
-      onOptionsChange(options);
-    },
-    [onOptionsChange]
-  );
-
   const handleSortOrderChange = useCallback(
     (sortOrder: LogsSortOrder) => {
       getAppEvents().publish(
@@ -132,7 +124,7 @@ export function TableNGWrap({
         renderCounter={renderCounter}
         title={title}
         eventBus={eventBus}
-        onOptionsChange={onTableOptionsChange}
+        onOptionsChange={onOptionsChange}
         onFieldConfigChange={handleTableOnFieldConfigChange}
         replaceVariables={replaceVariables}
         onChangeTimeRange={onChangeTimeRange}

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -61,7 +61,7 @@ export function TableNGWrap({
 
   const [controlsExpanded, setControlsExpanded] = useState(controlsExpandedFromStore);
   const controlsWidth = !showControls ? 0 : controlsExpanded ? CONTROLS_WIDTH_EXPANDED : LOG_LIST_CONTROLS_WIDTH;
-  const styles = useStyles2(getStyles, fieldSelectorWidth, height, tableWidth, controlsWidth, !!title);
+  const styles = useStyles2(getStyles, fieldSelectorWidth, height, tableWidth, controlsWidth);
 
   const handleSortOrderChange = useCallback(
     (sortOrder: LogsSortOrder) => {
@@ -133,23 +133,18 @@ export function TableNGWrap({
 }
 
 const getStyles = (
-  theme: GrafanaTheme2,
+  _: GrafanaTheme2,
   fieldSelectorWidth: number,
   height: number,
   tableWidth: number,
-  controlsWidth: number,
-  hasTitle: boolean
+  controlsWidth: number
 ) => {
-  const listControlsWrapperTableHeaderOffset = '-5px';
   return {
     listControlsWrapper: css({
       height: '100%',
       width: controlsWidth,
       label: 'listControlsWrapper',
       // Needed to keep the panel menu from overlapping the logs options when there's no title
-      marginTop: hasTitle
-        ? 0
-        : `calc(${theme.spacing.gridSize * theme.components.panel.headerHeight}px + ${listControlsWrapperTableHeaderOffset})`,
       position: 'absolute',
       right: 0,
       top: 0,

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -10,7 +10,6 @@ import {
   store,
 } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
-import { type TableOptions } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { getDefaultFieldSelectorWidth } from 'app/features/logs/components/fieldSelector/FieldSelector';
 import { getDefaultControlsExpandedMode } from 'app/features/logs/components/panel/LogListContext';

--- a/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.test.tsx
+++ b/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.test.tsx
@@ -35,7 +35,6 @@ if (!testLogsFrame) {
 }
 
 const ShowDetailsLabelText = 'Show details';
-const ViewLogLineLabelText = 'View log line';
 const CopyLogLineLabelText = 'Copy link to log line';
 const CellValueText = 'Value';
 
@@ -46,7 +45,7 @@ describe('LogsTableCustomCellRenderer', () => {
         supportsPermalink={true}
         logsFrame={testLogsFrame}
         options={{
-          showInspectLogLine: false,
+          enableLogDetails: false,
           showCopyLogLink: false,
         }}
         cellProps={{
@@ -58,7 +57,6 @@ describe('LogsTableCustomCellRenderer', () => {
       />
     );
 
-    expect(screen.queryByLabelText(ViewLogLineLabelText)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(CopyLogLineLabelText)).not.toBeInTheDocument();
     expect(screen.getByText(CellValueText)).toBeVisible();
   });
@@ -72,7 +70,7 @@ describe('LogsTableCustomCellRenderer', () => {
             supportsPermalink={true}
             logsFrame={testLogsFrame}
             options={{
-              showInspectLogLine: true,
+              enableLogDetails: true,
               showCopyLogLink: false,
             }}
             cellProps={{
@@ -85,83 +83,10 @@ describe('LogsTableCustomCellRenderer', () => {
         </LogDetailsContextProvider>
       );
 
-      expect(screen.queryByLabelText(ViewLogLineLabelText)).not.toBeInTheDocument();
       expect(screen.getByLabelText(ShowDetailsLabelText)).toBeInTheDocument();
     });
   });
 
-  describe('Inspect row', () => {
-    it('should render', () => {
-      render(
-        <LogsTableCustomCellRenderer
-          supportsPermalink={true}
-          logsFrame={testLogsFrame}
-          options={{
-            showInspectLogLine: true,
-            showCopyLogLink: false,
-          }}
-          cellProps={{
-            field: testLogsDataFrame[0].fields[1],
-            rowIndex: 0,
-            frame: testLogsDataFrame[0],
-            value: CellValueText,
-          }}
-        />
-      );
-
-      expect(screen.queryByLabelText(ViewLogLineLabelText)).toBeInTheDocument();
-      expect(screen.queryByLabelText(CopyLogLineLabelText)).not.toBeInTheDocument();
-      expect(screen.getByText(CellValueText)).toBeVisible();
-    });
-
-    it('should show body text in inspect modal', async () => {
-      render(
-        <LogsTableCustomCellRenderer
-          supportsPermalink={true}
-          logsFrame={testLogsFrame}
-          options={{
-            showInspectLogLine: true,
-            showCopyLogLink: false,
-          }}
-          cellProps={{
-            field: testLogsDataFrame[0].fields[1],
-            rowIndex: 0,
-            frame: testLogsDataFrame[0],
-            value: CellValueText,
-          }}
-        />
-      );
-      expect(screen.queryByText('log 1')).not.toBeInTheDocument();
-      await userEvent.click(screen.getByLabelText(ViewLogLineLabelText));
-      await waitFor(() => expect(screen.queryByText('log 1')).toBeInTheDocument());
-    });
-
-    it('Should inspect body if body is not selected', async () => {
-      // Something is complaining about invalid timezone, ignore it for now
-      jest.spyOn(console, 'warn').mockImplementation();
-      // Remove body from data frame passed to the table (but it should be in the logs frame)
-      const dataFrame: DataFrame = { ...testLogsDataFrame[0], fields: [testLogsDataFrame[0].fields[0]] };
-      render(
-        <LogsTableCustomCellRenderer
-          supportsPermalink={true}
-          logsFrame={testLogsFrame}
-          options={{
-            showInspectLogLine: true,
-            showCopyLogLink: false,
-          }}
-          cellProps={{
-            field: dataFrame.fields[0],
-            rowIndex: 0,
-            frame: testLogsDataFrame[0],
-            value: CellValueText,
-          }}
-        />
-      );
-      expect(screen.queryByText('log 1')).not.toBeInTheDocument();
-      await userEvent.click(screen.getByLabelText(ViewLogLineLabelText));
-      await waitFor(() => expect(screen.queryByText('log 1')).toBeInTheDocument());
-    });
-  });
   describe('Copy link to log line', () => {
     it('Should not show if permalink support is false', () => {
       render(
@@ -169,7 +94,7 @@ describe('LogsTableCustomCellRenderer', () => {
           supportsPermalink={false}
           logsFrame={testLogsFrame}
           options={{
-            showInspectLogLine: false,
+            enableLogDetails: false,
             showCopyLogLink: true,
           }}
           cellProps={{
@@ -182,7 +107,6 @@ describe('LogsTableCustomCellRenderer', () => {
         />
       );
 
-      expect(screen.queryByLabelText(ViewLogLineLabelText)).not.toBeInTheDocument();
       expect(screen.queryByLabelText(CopyLogLineLabelText)).not.toBeInTheDocument();
       expect(screen.getByText(CellValueText)).toBeVisible();
     });
@@ -192,7 +116,7 @@ describe('LogsTableCustomCellRenderer', () => {
           supportsPermalink={true}
           logsFrame={testLogsFrame}
           options={{
-            showInspectLogLine: false,
+            enableLogDetails: false,
             showCopyLogLink: true,
           }}
           cellProps={{
@@ -205,7 +129,6 @@ describe('LogsTableCustomCellRenderer', () => {
         />
       );
 
-      expect(screen.queryByLabelText(ViewLogLineLabelText)).not.toBeInTheDocument();
       await waitFor(() => expect(screen.queryByLabelText(CopyLogLineLabelText)).toBeInTheDocument());
 
       expect(screen.getByText(CellValueText)).toBeVisible();

--- a/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.test.tsx
+++ b/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
-import { type DataFrame, DataFrameType, FieldType, toDataFrame } from '@grafana/data';
+import { DataFrameType, FieldType, toDataFrame } from '@grafana/data';
 import { createLogLine } from 'app/features/logs/components/mocks/logRow';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, parseLogsFrame } from 'app/features/logs/logsFrame';
 

--- a/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.test.tsx
+++ b/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataFrame, DataFrameType, FieldType, toDataFrame } from '@grafana/data';
+import { createLogLine } from 'app/features/logs/components/mocks/logRow';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, parseLogsFrame } from 'app/features/logs/logsFrame';
+
+import { LogDetailsContextProvider } from '../LogDetailsContext';
 
 import { LogsTableCustomCellRenderer } from './LogsTableCustomCellRenderer';
 
@@ -31,6 +34,7 @@ if (!testLogsFrame) {
   throw new Error('Failed to parse logs frame');
 }
 
+const ShowDetailsLabelText = 'Show details';
 const ViewLogLineLabelText = 'View log line';
 const CopyLogLineLabelText = 'Copy link to log line';
 const CellValueText = 'Value';
@@ -57,6 +61,33 @@ describe('LogsTableCustomCellRenderer', () => {
     expect(screen.queryByLabelText(ViewLogLineLabelText)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(CopyLogLineLabelText)).not.toBeInTheDocument();
     expect(screen.getByText(CellValueText)).toBeVisible();
+  });
+
+  describe('Show details', () => {
+    it('should render', () => {
+      const logs = [createLogLine()];
+      render(
+        <LogDetailsContextProvider enableLogDetails logs={logs}>
+          <LogsTableCustomCellRenderer
+            supportsPermalink={true}
+            logsFrame={testLogsFrame}
+            options={{
+              showInspectLogLine: true,
+              showCopyLogLink: false,
+            }}
+            cellProps={{
+              field: testLogsDataFrame[0].fields[1],
+              rowIndex: 0,
+              frame: testLogsDataFrame[0],
+              value: CellValueText,
+            }}
+          />
+        </LogDetailsContextProvider>
+      );
+
+      expect(screen.queryByLabelText(ViewLogLineLabelText)).not.toBeInTheDocument();
+      expect(screen.getByLabelText(ShowDetailsLabelText)).toBeInTheDocument();
+    });
   });
 
   describe('Inspect row', () => {

--- a/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.tsx
+++ b/public/app/plugins/panel/logstable/cells/LogsTableCustomCellRenderer.tsx
@@ -20,9 +20,9 @@ export function LogsTableCustomCellRenderer(props: {
   const { logsFrame, buildLinkToLog, options, supportsPermalink } = props;
   const { field, value, rowIndex } = props.cellProps;
   const cellPadding =
-    options.showInspectLogLine && options.showCopyLogLink
+    options.enableLogDetails && options.showCopyLogLink
       ? ROW_ACTION_BUTTON_WIDTH
-      : options.showInspectLogLine || options.showCopyLogLink
+      : options.enableLogDetails || options.showCopyLogLink
         ? ROW_ACTION_BUTTON_WIDTH / 2
         : 0;
   const styles = useStyles2(getStyles, cellPadding);
@@ -33,7 +33,6 @@ export function LogsTableCustomCellRenderer(props: {
         {...props.cellProps}
         logsFrame={logsFrame}
         buildLinkToLog={supportsPermalink && options.showCopyLogLink ? buildLinkToLog : undefined}
-        showInspectLogLine={options.showInspectLogLine ?? true}
       />
 
       <span className={styles.firstColumnCell}>

--- a/public/app/plugins/panel/logstable/fields/getFieldWidth.test.ts
+++ b/public/app/plugins/panel/logstable/fields/getFieldWidth.test.ts
@@ -24,15 +24,15 @@ describe('getTimeFieldWidth', () => {
       DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2
     );
   });
-  it('Should return timestamp field width with padding for showInspectLogLine', () => {
-    expect(getTimeFieldWidth(undefined, 0, { showInspectLogLine: true })).toEqual(
+  it('Should return timestamp field width with padding for enableLogDetails', () => {
+    expect(getTimeFieldWidth(undefined, 0, { enableLogDetails: true })).toEqual(
       DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2
     );
   });
   it('Should return timestamp field width with padding for both options', () => {
     expect(
       getTimeFieldWidth(undefined, 0, {
-        showInspectLogLine: true,
+        enableLogDetails: true,
         showCopyLogLink: true,
       })
     ).toEqual(DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH);

--- a/public/app/plugins/panel/logstable/fields/getFieldWidth.ts
+++ b/public/app/plugins/panel/logstable/fields/getFieldWidth.ts
@@ -14,9 +14,9 @@ function getDefaultTimeFieldWidth(fieldIndex: number, options: LogsTableOptions)
     return undefined;
   }
 
-  if (options.showInspectLogLine && options.showCopyLogLink) {
+  if (options.enableLogDetails && options.showCopyLogLink) {
     return DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH;
-  } else if (options.showInspectLogLine || options.showCopyLogLink) {
+  } else if (options.enableLogDetails || options.showCopyLogLink) {
     return DEFAULT_TIME_FIELD_WIDTH + ROW_ACTION_BUTTON_WIDTH / 2;
   }
   return DEFAULT_TIME_FIELD_WIDTH;

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -117,7 +117,7 @@ describe('useOrganizeFields', () => {
     });
   });
   describe('custom cell renderer', () => {
-    test('only used on first column - showInspectLogLine', async () => {
+    test('only used on first column - enableLogDetails', async () => {
       const { result: organizedFields } = renderHook(() =>
         useOrganizeFields({
           extractedFrame,
@@ -126,7 +126,7 @@ describe('useOrganizeFields', () => {
           logsFrame: testLogsFrame,
           onPermalinkClick: () => null,
           options: {
-            showInspectLogLine: true,
+            enableLogDetails: true,
           },
           supportsPermalink: false,
           timeFieldName: LOGS_DATAPLANE_TIMESTAMP_NAME,
@@ -173,7 +173,7 @@ describe('useOrganizeFields', () => {
         expect(organizedFields.current.organizedFrame?.fields[2].config.custom.cellOptions).not.toBeDefined();
       });
     });
-    test('not used if showInspectLogLine or showCopyLogLink is not defined', async () => {
+    test('not used if enableLogDetails is false and showCopyLogLink is not set', async () => {
       const { result: organizedFields } = renderHook(() =>
         useOrganizeFields({
           extractedFrame,
@@ -181,7 +181,7 @@ describe('useOrganizeFields', () => {
           levelFieldName: 'level',
           logsFrame: testLogsFrame,
           onPermalinkClick: () => null,
-          options: {},
+          options: { enableLogDetails: false },
           supportsPermalink: false,
           timeFieldName: LOGS_DATAPLANE_TIMESTAMP_NAME,
           fieldConfig: { defaults: {}, overrides: [] },
@@ -197,11 +197,11 @@ describe('useOrganizeFields', () => {
     test('log line body has no cellOptions when it is moved from the first position', async () => {
       const optionsBodyFirst = {
         displayedFields: [LOG_LINE_BODY_FIELD_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME, 'level'],
-        showInspectLogLine: true,
+        enableLogDetails: true,
       };
       const optionsBodySecond = {
         displayedFields: [LOGS_DATAPLANE_TIMESTAMP_NAME, LOG_LINE_BODY_FIELD_NAME, 'level'],
-        showInspectLogLine: true,
+        enableLogDetails: true,
       };
 
       const { result, rerender } = renderHook(

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -162,7 +162,7 @@ const organizeFields = async (
               : configAfterLevel.custom?.width,
           inspect: configAfterLevel.custom?.inspect ?? doesFieldSupportInspector(field),
           cellOptions:
-            isFirstField && bodyFieldName && (supportsPermalink || options.showInspectLogLine)
+            isFirstField && bodyFieldName && (supportsPermalink || options.enableLogDetails)
               ? {
                   type: TableCellDisplayMode.Custom,
                   cellComponent: (cellProps: CustomCellRendererProps) => (

--- a/public/app/plugins/panel/logstable/module.tsx
+++ b/public/app/plugins/panel/logstable/module.tsx
@@ -6,24 +6,26 @@ import { type FieldConfig as TableFieldConfig, type Options as TableOptions } fr
 
 import { LogsTable } from './LogsTable';
 import { logsTablePanelFieldConfig } from './logsTableFieldConfig';
+import { logsTableMigrationHandler } from './migrations';
 import { defaultOptions, type Options } from './panelcfg.gen';
 import { logstableSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(LogsTable)
+  .setMigrationHandler(logsTableMigrationHandler)
   .useFieldConfig(logsTablePanelFieldConfig)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
     const logsTableCategory = [t('logstable.category-table', 'Logs Table')];
     builder
       .addBooleanSwitch({
-        path: 'showInspectLogLine',
-        name: t('logstable.show-inspect-button.name', 'Show inspect button'),
+        path: 'enableLogDetails',
+        name: t('logstable.enable-log-details.name', 'Enable log details'),
         category: logsTableCategory,
         description: t(
-          'logstable.show-inspect-button.description',
-          'Enables/disables the log line inspect button in the first column of each row'
+          'logstable.enable-log-details.description',
+          'When enabled, shows log details for each row. When disabled, shows the log line inspect button instead.'
         ),
-        defaultValue: defaultOptions.showInspectLogLine,
+        defaultValue: defaultOptions.enableLogDetails,
       })
       .addBooleanSwitch({
         path: 'showCopyLogLink',

--- a/public/app/plugins/panel/logstable/module.tsx
+++ b/public/app/plugins/panel/logstable/module.tsx
@@ -6,12 +6,10 @@ import { type FieldConfig as TableFieldConfig, type Options as TableOptions } fr
 
 import { LogsTable } from './LogsTable';
 import { logsTablePanelFieldConfig } from './logsTableFieldConfig';
-import { logsTableMigrationHandler } from './migrations';
 import { defaultOptions, type Options } from './panelcfg.gen';
 import { logstableSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(LogsTable)
-  .setMigrationHandler(logsTableMigrationHandler)
   .useFieldConfig(logsTablePanelFieldConfig)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);

--- a/public/app/plugins/panel/logstable/module.tsx
+++ b/public/app/plugins/panel/logstable/module.tsx
@@ -19,10 +19,7 @@ export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(
         path: 'enableLogDetails',
         name: t('logstable.enable-log-details.name', 'Enable log details'),
         category: logsTableCategory,
-        description: t(
-          'logstable.enable-log-details.description',
-          'When enabled, shows log details for each row. When disabled, shows the log line inspect button instead.'
-        ),
+        description: t('logstable.enable-log-details.description', 'When enabled, shows log details for each row.'),
         defaultValue: defaultOptions.enableLogDetails,
       })
       .addBooleanSwitch({

--- a/public/app/plugins/panel/logstable/panelcfg.cue
+++ b/public/app/plugins/panel/logstable/panelcfg.cue
@@ -31,6 +31,7 @@ composableKinds: PanelCfg: {
 					showControls?:       bool | *true
 					sortOrder?:          common.LogsSortOrder | (*"Descending" | _)
 					fieldSelectorWidth?: number | *220
+					logDetailsWidth?: number | *400
 					displayedFields?: [...string]
 					buildLinkToLogLine?: _
 					wrapText?:           bool

--- a/public/app/plugins/panel/logstable/panelcfg.cue
+++ b/public/app/plugins/panel/logstable/panelcfg.cue
@@ -26,7 +26,7 @@ composableKinds: PanelCfg: {
 			schema: {
 				Options: {
 					permalinkedLogId?:   string
-					showInspectLogLine?: bool | *true
+					enableLogDetails?: bool | *true
 					showCopyLogLink?:    bool | *false
 					showControls?:       bool | *true
 					sortOrder?:          common.LogsSortOrder | (*"Descending" | _)

--- a/public/app/plugins/panel/logstable/panelcfg.cue
+++ b/public/app/plugins/panel/logstable/panelcfg.cue
@@ -25,14 +25,14 @@ composableKinds: PanelCfg: {
 			version: [0, 0]
 			schema: {
 				Options: {
-					permalinkedLogId?:   string
-					enableLogDetails?: bool | *true
-					showCopyLogLink?:    bool | *false
-					showControls?:       bool | *true
-					sortOrder?:          common.LogsSortOrder | (*"Descending" | _)
-					fieldSelectorWidth?: number | *220
+					permalinkedLogId?:    string
+					enableLogDetails?:    bool | *true
+					showCopyLogLink?:     bool | *false
+					showControls?:        bool | *true
+					sortOrder?:           common.LogsSortOrder | (*"Descending" | _)
+					fieldSelectorWidth?:  number | *220
 					isLabelFilterActive?: _
-					logDetailsWidth?: number | *400
+					logDetailsWidth?:     number | *400
 					displayedFields?: [...string]
 					buildLinkToLogLine?: _
 					wrapText?:           bool

--- a/public/app/plugins/panel/logstable/panelcfg.cue
+++ b/public/app/plugins/panel/logstable/panelcfg.cue
@@ -31,6 +31,7 @@ composableKinds: PanelCfg: {
 					showControls?:       bool | *true
 					sortOrder?:          common.LogsSortOrder | (*"Descending" | _)
 					fieldSelectorWidth?: number | *220
+					isLabelFilterActive?: _
 					logDetailsWidth?: number | *400
 					displayedFields?: [...string]
 					buildLinkToLogLine?: _

--- a/public/app/plugins/panel/logstable/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logstable/panelcfg.gen.ts
@@ -15,23 +15,23 @@ import * as common from '@grafana/schema';
 export interface Options {
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
+  enableLogDetails?: boolean;
   fieldSelectorWidth?: number;
   isLabelFilterActive?: unknown;
   logDetailsWidth?: number;
   permalinkedLogId?: string;
   showControls?: boolean;
   showCopyLogLink?: boolean;
-  showInspectLogLine?: boolean;
   sortOrder?: common.LogsSortOrder;
   wrapText?: boolean;
 }
 
 export const defaultOptions: Partial<Options> = {
   displayedFields: [],
+  enableLogDetails: true,
   fieldSelectorWidth: 220,
   logDetailsWidth: 400,
   showControls: true,
   showCopyLogLink: false,
-  showInspectLogLine: true,
   sortOrder: common.LogsSortOrder.Descending,
 };

--- a/public/app/plugins/panel/logstable/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logstable/panelcfg.gen.ts
@@ -16,6 +16,7 @@ export interface Options {
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
   fieldSelectorWidth?: number;
+  isLabelFilterActive?: unknown;
   logDetailsWidth?: number;
   permalinkedLogId?: string;
   showControls?: boolean;

--- a/public/app/plugins/panel/logstable/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logstable/panelcfg.gen.ts
@@ -16,6 +16,7 @@ export interface Options {
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
   fieldSelectorWidth?: number;
+  logDetailsWidth?: number;
   permalinkedLogId?: string;
   showControls?: boolean;
   showCopyLogLink?: boolean;
@@ -27,6 +28,7 @@ export interface Options {
 export const defaultOptions: Partial<Options> = {
   displayedFields: [],
   fieldSelectorWidth: 220,
+  logDetailsWidth: 400,
   showControls: true,
   showCopyLogLink: false,
   showInspectLogLine: true,

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -13,6 +13,7 @@ import {
 } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
+import { useLogDetailsContext } from '../LogDetailsContext';
 import { type BuildLinkToLogLine } from '../types';
 
 interface Props extends CustomCellRendererProps {
@@ -31,15 +32,20 @@ export function LogsTableRowActionButtons(props: Props) {
   const theme = useTheme2();
   const [isInspecting, setIsInspecting] = useState(false);
   const styles = getStyles(theme);
+  const { enableLogDetails, detailsDisplayed, toggleDetails } = useLogDetailsContext();
 
   const handleViewClick = () => {
     setIsInspecting(true);
   };
 
+  const handleDetailsClick = () => {
+    toggleDetails(rowIndex);
+  };
+
   return (
     <>
       <div className={styles.container}>
-        {showInspectLogLine && (
+        {!enableLogDetails && showInspectLogLine && (
           <div className={styles.buttonWrapper}>
             <IconButton
               className={styles.inspectButton}
@@ -50,6 +56,21 @@ export function LogsTableRowActionButtons(props: Props) {
               size="md"
               name="eye"
               onClick={handleViewClick}
+              tabIndex={0}
+            />
+          </div>
+        )}
+        {enableLogDetails && (
+          <div className={styles.buttonWrapper}>
+            <IconButton
+              className={styles.inspectButton}
+              tooltip={t('explore.logs-table.action-buttons.show-details', 'Show details')}
+              variant={detailsDisplayed(rowIndex) ? 'primary' : 'secondary'}
+              aria-label={t('explore.logs-table.action-buttons.show-details', 'Show details')}
+              tooltipPlacement="top"
+              size="md"
+              name="eye"
+              onClick={handleDetailsClick}
               tabIndex={0}
             />
           </div>

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,16 +1,9 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useCallback } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import {
-  ClipboardButton,
-  type CustomCellRendererProps,
-  IconButton,
-  TableCellInspector,
-  TableCellInspectorMode,
-  useTheme2,
-} from '@grafana/ui';
+import { ClipboardButton, type CustomCellRendererProps, IconButton, useTheme2 } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
 import { useLogDetailsContext } from '../LogDetailsContext';
@@ -18,7 +11,6 @@ import { type BuildLinkToLogLine } from '../types';
 
 interface Props extends CustomCellRendererProps {
   buildLinkToLog?: BuildLinkToLogLine;
-  showInspectLogLine: boolean;
   logsFrame: LogsFrame;
 }
 
@@ -28,38 +20,18 @@ interface Props extends CustomCellRendererProps {
  * @constructor
  */
 export function LogsTableRowActionButtons(props: Props) {
-  const { rowIndex, buildLinkToLog, showInspectLogLine, logsFrame } = props;
+  const { rowIndex, buildLinkToLog, logsFrame } = props;
   const theme = useTheme2();
-  const [isInspecting, setIsInspecting] = useState(false);
   const styles = getStyles(theme);
   const { enableLogDetails, detailsDisplayed, toggleDetails } = useLogDetailsContext();
 
-  const handleViewClick = () => {
-    setIsInspecting(true);
-  };
-
-  const handleDetailsClick = () => {
+  const handleDetailsClick = useCallback(() => {
     toggleDetails(rowIndex);
-  };
+  }, [rowIndex, toggleDetails]);
 
   return (
     <>
       <div className={styles.container}>
-        {!enableLogDetails && showInspectLogLine && (
-          <div className={styles.buttonWrapper}>
-            <IconButton
-              className={styles.inspectButton}
-              tooltip={t('explore.logs-table.action-buttons.view-log-line', 'View log line')}
-              variant="secondary"
-              aria-label={t('explore.logs-table.action-buttons.view-log-line', 'View log line')}
-              tooltipPlacement="top"
-              size="md"
-              name="eye"
-              onClick={handleViewClick}
-              tabIndex={0}
-            />
-          </div>
-        )}
         {enableLogDetails && (
           <div className={styles.buttonWrapper}>
             <IconButton
@@ -100,23 +72,9 @@ export function LogsTableRowActionButtons(props: Props) {
           </div>
         )}
       </div>
-      {isInspecting && (
-        <TableCellInspector
-          value={getLineValue(logsFrame, rowIndex)}
-          mode={TableCellInspectorMode.code}
-          onDismiss={function (): void {
-            setIsInspecting(false);
-          }}
-        />
-      )}
     </>
   );
 }
-
-const getLineValue = (logsFrame: LogsFrame, rowIndex: number) => {
-  const bodyField = logsFrame.bodyField;
-  return bodyField?.values[rowIndex];
-};
 
 export const getStyles = (theme: GrafanaTheme2) => ({
   container: css({

--- a/public/app/plugins/panel/logstable/types.ts
+++ b/public/app/plugins/panel/logstable/types.ts
@@ -21,5 +21,6 @@ export function isIsLabelFilterActive(callback: unknown): callback is LabelFilte
 }
 
 export function isCoreApp(app: unknown): app is CoreApp {
-  return typeof app === 'string' && app in CoreApp;
+  const apps = Object.values(CoreApp).map((coreApp) => coreApp.toString());
+  return typeof app === 'string' && apps.includes(app);
 }

--- a/public/app/plugins/panel/logstable/types.ts
+++ b/public/app/plugins/panel/logstable/types.ts
@@ -4,10 +4,16 @@ import type { Options as LogsTableOptions } from './panelcfg.gen';
 
 export type OnLogsTableOptionsChange = (option: LogsTableOptions & TableOptions) => void;
 export type BuildLinkToLogLine = (logId: string) => string | null;
+export type LabelFilterActiveType = (key: string, value: string, refId?: string) => Promise<boolean>;
+
 export function isOnLogsTableOptionsChange(callback: unknown): callback is OnLogsTableOptionsChange {
   return typeof callback === 'function';
 }
 
 export function isBuildLinkToLogLine(callback: unknown): callback is BuildLinkToLogLine {
+  return typeof callback === 'function';
+}
+
+export function isIsLabelFilterActive(callback: unknown): callback is LabelFilterActiveType {
   return typeof callback === 'function';
 }

--- a/public/app/plugins/panel/logstable/types.ts
+++ b/public/app/plugins/panel/logstable/types.ts
@@ -1,3 +1,5 @@
+import { CoreApp } from '@grafana/data';
+
 import type { Options as TableOptions } from '../table/panelcfg.gen';
 
 import type { Options as LogsTableOptions } from './panelcfg.gen';
@@ -16,4 +18,8 @@ export function isBuildLinkToLogLine(callback: unknown): callback is BuildLinkTo
 
 export function isIsLabelFilterActive(callback: unknown): callback is LabelFilterActiveType {
   return typeof callback === 'function';
+}
+
+export function isCoreApp(app: unknown): app is CoreApp {
+  return typeof app === 'string' && app in CoreApp;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8654,6 +8654,7 @@
         "copy-link": "Copy link to log line",
         "copy-to-clipboard": "Copy to Clipboard",
         "inspect-value": "Inspect value",
+        "show-details": "Show details",
         "view-log-line": "View log line"
       }
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11580,7 +11580,7 @@
     "category-table": "Logs Table",
     "description-show-controls": "Display table controls",
     "enable-log-details": {
-      "description": "When enabled, shows log details for each row. When disabled, shows the log line inspect button instead.",
+      "description": "When enabled, shows log details for each row.",
       "name": "Enable log details"
     },
     "show-copy-log": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11579,13 +11579,13 @@
   "logstable": {
     "category-table": "Logs Table",
     "description-show-controls": "Display table controls",
+    "enable-log-details": {
+      "description": "When enabled, shows log details for each row. When disabled, shows the log line inspect button instead.",
+      "name": "Enable log details"
+    },
     "show-copy-log": {
       "description": "Enables/disables the log line link button in the first column of each row",
       "name": "Show copy log link button"
-    },
-    "show-inspect-button": {
-      "description": "Enables/disables the log line inspect button in the first column of each row",
-      "name": "Show inspect button"
     }
   },
   "manage-dashbaords": {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/116688

This PR adds Log Details support for the table.

https://github.com/user-attachments/assets/94c4f876-17a8-462f-bbf5-c03929937025

- [x] Unit tests
