### PR TITLE
IAM: Handle the path when no user is authenticated in UserK8sService

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -176,7 +176,7 @@ func setupDB(b testing.TB) benchScenario {
 	cache := localcache.ProvideService()
 	userSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, teamSvc, cache, tracing.InitializeTracerForTest(),
-		&quotatest.FakeQuotaService{}, bundleregistry.ProvideService(), nil,
+		&quotatest.FakeQuotaService{}, bundleregistry.ProvideService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(b, err)
 

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social/socialtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfotest"
@@ -53,6 +54,7 @@ func setUpGetOrgUsersDB(t *testing.T, sqlStore db.DB, cfg *setting.Cfg) {
 	usrSvc, err := userimpl.ProvideService(
 		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/auth/idtest"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -92,6 +93,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 		hs.userService = userSvc
@@ -167,6 +169,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 		_, err = userSvc.Create(context.Background(), &createUserCmd)
@@ -199,6 +202,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, sc.cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 		usr, err := userSvc.Create(context.Background(), &createUserCmd)
@@ -494,6 +498,7 @@ func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPSer
 	userSvc, err := userimpl.ProvideService(
 		sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 
@@ -725,6 +730,7 @@ func TestIntegrationUser_UpdateEmail(t *testing.T) {
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, settings, nil, nil, tracing.InitializeTracerForTest(),
 			quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -441,7 +441,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
+	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1140,7 +1140,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
+	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider, eventualRestConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1760,7 +1760,7 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (Runner, error) {
 		return Runner{}, err
 	}
 	cacheService := localcache.ProvideService()
-	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider)
+	userimplService, err := userimpl.ProvideService(sqlStore, orgService, cfg, teamimplService, cacheService, tracingService, quotaService, bundleregistryService, eventualRestConfigProvider, eventualRestConfigProvider)
 	if err != nil {
 		return Runner{}, err
 	}

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	rs "github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -633,6 +634,7 @@ func setupTestEnv(t testing.TB) (*database.AccessControlStore, rs.Store, user.Se
 	userService, err := userimpl.ProvideService(
 		sql, orgService, cfg, teamService, localcache.ProvideService(), tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 	return acstore, permissionStore, userService, teamService, orgService, sql

--- a/pkg/services/accesscontrol/dualwrite/collectors_test.go
+++ b/pkg/services/accesscontrol/dualwrite/collectors_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -66,6 +67,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	userService, err := userimpl.ProvideService(
 		sql, orgService, cfg, teamService, localcache.ProvideService(), tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -68,7 +68,7 @@ func ProvideFolderPermissions(
 		tracing.InitializeTracerForTest(),
 		quotaService,
 		bundleregistry.ProvideService(),
-		nil,
+		nil, apiserver.WithoutRestConfig,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -715,6 +716,7 @@ func setupTestEnvironment(t *testing.T, ops Options) (*Service, user.Service, te
 	userSvc, err := userimpl.ProvideService(
 		sql, orgSvc, cfg, teamSvc, nil, tracer,
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	datasourcesService "github.com/grafana/grafana/pkg/services/datasources/service"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -150,7 +151,7 @@ func generateTeamsAndUsers(b *testing.B, store db.DB, cfg *setting.Cfg, users in
 	require.NoError(b, err)
 	usrSvc, err := userimpl.ProvideService(
 		store, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		qs, supportbundlestest.NewFakeBundleService(), nil)
+		qs, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig)
 	require.NoError(b, err)
 	userIds := make([]int64, 0)
 	teamIds := make([]int64, 0)

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -528,6 +529,7 @@ func seedResourcePermissions(
 	usrSvc, err := userimpl.ProvideService(
 		sql, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/apiserver/restconfig.go
+++ b/pkg/services/apiserver/restconfig.go
@@ -58,6 +58,14 @@ func ProvideDirectRestConfigProvider() DirectRestConfigProvider {
 	}
 }
 
+// ProvideRestConfigProvider provides a RestConfigProvider for use in
+// CLI wire sets that don't start the full apiserver.
+func ProvideRestConfigProvider() RestConfigProvider {
+	return &eventualRestConfigProvider{
+		ready: make(chan struct{}),
+	}
+}
+
 var (
 	_ RestConfigProvider       = (*eventualRestConfigProvider)(nil)
 	_ DirectRestConfigProvider = (*eventualRestConfigProvider)(nil)

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -370,6 +371,7 @@ func createUserInOrg(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUs
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -353,6 +354,7 @@ func setupTestScenario(t *testing.T) scenarioContext {
 	usrSvc, err := userimpl.ProvideService(
 		sqlStore, orgSvc, cfg, nil, nil, tracer,
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 	_, err = usrSvc.Create(context.Background(), &cmd)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -534,6 +535,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		usrSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 		_, err = usrSvc.Create(context.Background(), &cmd)

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/searchusers/sortopts"
@@ -1120,6 +1121,7 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	usrSvc, err := userimpl.ProvideService(
 		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -72,6 +73,7 @@ func testScenario(t *testing.T, desc string, isViewer bool, hasDatasourceExplore
 		usrSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, cfg, nil, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -115,7 +115,7 @@ func TestIntegrationQuotaCommandsAndQueries(t *testing.T) {
 	require.NoError(t, err)
 	userService, err := userimpl.ProvideService(
 		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 	setupEnv(t, sqlStore, cfg, b, quotaService)

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
@@ -253,6 +254,7 @@ func setupTestDatabase(t *testing.T) (db.DB, *ServiceAccountsStoreImpl) {
 	userSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 	return db, ProvideServiceAccountsStore(cfg, db, apiKeyService, kvStore, userSvc, orgService)

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
@@ -51,7 +52,7 @@ func SetupUserServiceAccount(t *testing.T, db db.DB, cfg *setting.Cfg, testUser 
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 
@@ -132,7 +133,7 @@ func SetupUsersServiceAccounts(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, t
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		sqlStore, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/correlations/correlationstest"
@@ -154,6 +155,7 @@ func populateDB(t *testing.T, db db.DB, cfg *setting.Cfg) org.Service {
 	userSvc, _ := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		&quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 
 	bus := bus.ProvideBus(tracing.InitializeTracerForTest())

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
@@ -56,6 +57,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 		userSvc, err := userimpl.ProvideService(
 			sqlStore, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 
@@ -484,6 +486,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				userSvc, err := userimpl.ProvideService(
 					sqlStore, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
 					quotaService, supportbundlestest.NewFakeBundleService(), nil,
+					apiserver.WithoutRestConfig,
 				)
 				require.NoError(t, err)
 				setup()
@@ -640,6 +643,7 @@ func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 		userSvc, err := userimpl.ProvideService(
 			store, orgSvc, cfg, teamSvc, nil, tracing.InitializeTracerForTest(),
 			quotaService, supportbundlestest.NewFakeBundleService(), nil,
+			apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
@@ -45,7 +46,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	userStore := ProvideStore(ss, setting.NewCfg())
 	usrSvc, err := ProvideService(
 		ss, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 	usr := &user.SignedInUser{
@@ -585,7 +586,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		require.NoError(t, err)
 		usrSvc, err := ProvideService(
 			ss, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-			quotaService, supportbundlestest.NewFakeBundleService(), nil,
+			quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 		)
 		require.NoError(t, err)
 
@@ -1136,7 +1137,7 @@ func createOrgAndUserSvc(t *testing.T, store db.DB, cfg *setting.Cfg) (org.Servi
 	require.NoError(t, err)
 	usrSvc, err := ProvideService(
 		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -31,6 +31,7 @@ type Service struct {
 	openFeatureClient *openfeature.Client
 	logger            log.Logger
 	tracer            tracing.Tracer
+	cfg               *setting.Cfg
 }
 
 var _ user.Service = (*Service)(nil)
@@ -41,13 +42,14 @@ func ProvideService(db db.DB,
 	teamService team.Service,
 	cacheService *localcache.CacheService, tracer tracing.Tracer,
 	quotaService quota.Service, bundleRegistry supportbundles.Service,
-	configProvider apiserver.DirectRestConfigProvider) (*Service, error) {
+	configProvider apiserver.DirectRestConfigProvider,
+	restConfigProvider apiserver.RestConfigProvider) (*Service, error) {
 	legacyService, err := NewLegacyService(db, orgService, cfg, teamService, cacheService, tracer, quotaService, bundleRegistry)
 	if err != nil {
 		return nil, err
 	}
 
-	k8sService := userk8s.NewUserK8sService(log.New("user.k8s"), cfg, configProvider, tracer)
+	k8sService := userk8s.NewUserK8sService(log.New("user.k8s"), cfg, configProvider, restConfigProvider, tracer)
 
 	return &Service{
 		legacyService:     legacyService,
@@ -55,6 +57,7 @@ func ProvideService(db db.DB,
 		openFeatureClient: openfeature.NewDefaultClient(),
 		logger:            log.New("user"),
 		tracer:            tracer,
+		cfg:               cfg,
 	}, nil
 }
 
@@ -186,19 +189,17 @@ func (s *Service) GetSignedInUser(ctx context.Context, cmd *user.GetSignedInUser
 	ctxLogger := s.logger.FromContext(ctx)
 
 	if s.isKubernetesUserServiceEnabled(ctx) {
-		if hasOrgID(ctx) || cmd.OrgID > 0 {
-			result, err := s.k8sService.GetSignedInUser(ctx, cmd)
-			if err == nil {
-				span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
-				return result, nil
-			}
-			// Fall back to legacy is needed on the following cases:
-			// -  When the user is not found in k8s. It happens with integration tests where the user is created in the legacy store but not in k8s.
-			// -  When there is no request context (e.g. calls from the k8s API server handler).
-			ctxLogger.Warn("k8s GetSignedInUser failed, falling back to legacy", "userID", cmd.UserID, "err", err)
-		} else {
-			ctxLogger.Warn("no orgID in context, falling back to legacy", "method", "GetSignedInUser")
+		k8sCmd := *cmd
+		if !hasOrgID(ctx) && k8sCmd.OrgID == 0 {
+			k8sCmd.OrgID = s.cfg.DefaultOrgID()
 		}
+
+		result, err := s.k8sService.GetSignedInUser(ctx, &k8sCmd)
+		if err == nil {
+			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
+			return result, nil
+		}
+		ctxLogger.Warn("k8s GetSignedInUser failed, falling back to legacy", "userID", cmd.UserID, "err", err)
 	}
 
 	span.SetAttributes(attribute.Bool("fallback_to_legacy", true))

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	clientrest "k8s.io/client-go/rest"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -37,41 +38,59 @@ var userGVR = schema.GroupVersionResource{
 }
 
 type UserK8sService struct {
-	logger          log.Logger
-	namespaceMapper request.NamespaceMapper
-	configProvider  apiserver.DirectRestConfigProvider
-	config          *setting.Cfg
-	tracer          tracing.Tracer
+	logger             log.Logger
+	namespaceMapper    request.NamespaceMapper
+	configProvider     apiserver.DirectRestConfigProvider
+	restConfigProvider apiserver.RestConfigProvider
+	config             *setting.Cfg
+	tracer             tracing.Tracer
 }
 
 var _ user.Service = (*UserK8sService)(nil)
 
-func NewUserK8sService(logger log.Logger, cfg *setting.Cfg, configProvider apiserver.DirectRestConfigProvider, tracer tracing.Tracer) *UserK8sService {
+func NewUserK8sService(logger log.Logger, cfg *setting.Cfg, configProvider apiserver.DirectRestConfigProvider, restConfigProvider apiserver.RestConfigProvider, tracer tracing.Tracer) *UserK8sService {
 	return &UserK8sService{
-		logger:          logger,
-		namespaceMapper: request.GetNamespaceMapper(cfg),
-		configProvider:  configProvider,
-		config:          cfg,
-		tracer:          tracer,
+		logger:             logger,
+		namespaceMapper:    request.GetNamespaceMapper(cfg),
+		configProvider:     configProvider,
+		restConfigProvider: restConfigProvider,
+		config:             cfg,
+		tracer:             tracer,
 	}
 }
 
-func (s *UserK8sService) getClient(ctx context.Context, namespace string) (dynamic.ResourceInterface, error) {
+func (s *UserK8sService) getClient(ctx context.Context, orgID int64, namespace string) (dynamic.ResourceInterface, context.Context, error) {
 	if s.configProvider == nil {
-		return nil, errors.New("config provider not initialized")
+		return nil, ctx, errors.New("config provider not initialized")
 	}
 
+	var restCfg *clientrest.Config
 	reqCtx := contexthandler.FromContext(ctx)
-	if reqCtx == nil {
-		return nil, errors.New("no request context")
+	if reqCtx != nil && reqCtx.IsSignedIn {
+		restCfg = s.configProvider.GetDirectRestConfig(reqCtx)
+	} else {
+		// No authenticated user: either called from an auth hook before authentication
+		// completes (reqCtx.IsSignedIn is false), or outside an HTTP request entirely.
+		// Use the loopback REST config with service identity so the in-process apiserver
+		// can authorise the request.
+		var err error
+		ctx, _ = identity.WithServiceIdentity(ctx, orgID)
+		restCfg, err = s.restConfigProvider.GetRestConfig(ctx)
+		if err != nil {
+			return nil, ctx, err
+		}
 	}
 
-	dyn, err := dynamic.NewForConfig(s.configProvider.GetDirectRestConfig(reqCtx))
+	if restCfg == nil {
+		return nil, ctx, errors.New("failed to get rest config")
+	}
+
+	dyn, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
-		return nil, err
+		return nil, ctx, err
 	}
 
-	return dyn.Resource(userGVR).Namespace(namespace), nil
+	return dyn.Resource(userGVR).Namespace(namespace), ctx, nil
 }
 
 func (s *UserK8sService) Create(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error) {
@@ -91,7 +110,7 @@ func (s *UserK8sService) Create(ctx context.Context, cmd *user.CreateUserCommand
 	namespace := s.namespaceMapper(orgID)
 	span.SetAttributes(attribute.Int64("orgID", orgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, orgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		return nil, err
@@ -179,7 +198,7 @@ func (s *UserK8sService) GetByID(ctx context.Context, cmd *user.GetUserByIDQuery
 	namespace := s.namespaceMapper(orgID)
 	span.SetAttributes(attribute.Int64("orgID", orgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, orgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		span.RecordError(err)
@@ -228,7 +247,7 @@ func (s *UserK8sService) GetByLogin(ctx context.Context, cmd *user.GetUserByLogi
 	namespace := s.namespaceMapper(orgID)
 	span.SetAttributes(attribute.Int64("orgID", orgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, orgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		return nil, err
@@ -271,7 +290,7 @@ func (s *UserK8sService) GetByEmail(ctx context.Context, cmd *user.GetUserByEmai
 	namespace := s.namespaceMapper(orgID)
 	span.SetAttributes(attribute.Int64("orgID", orgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, orgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		return nil, err
@@ -305,7 +324,7 @@ func (s *UserK8sService) Update(ctx context.Context, cmd *user.UpdateUserCommand
 	namespace := s.namespaceMapper(orgID)
 	span.SetAttributes(attribute.Int64("orgID", orgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, orgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		span.RecordError(err)
@@ -371,7 +390,7 @@ func (s *UserK8sService) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateU
 	namespace := s.namespaceMapper(cmd.OrgID)
 	span.SetAttributes(attribute.Int64("orgID", cmd.OrgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, cmd.OrgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		span.RecordError(err)
@@ -437,7 +456,7 @@ func (s *UserK8sService) GetSignedInUser(ctx context.Context, cmd *user.GetSigne
 	namespace := s.namespaceMapper(orgID)
 	span.SetAttributes(attribute.Int64("orgID", orgID))
 
-	client, err := s.getClient(ctx, namespace)
+	client, ctx, err := s.getClient(ctx, orgID, namespace)
 	if err != nil {
 		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
 		span.RecordError(err)

--- a/pkg/services/user/userk8s/user_test.go
+++ b/pkg/services/user/userk8s/user_test.go
@@ -3,6 +3,7 @@ package userk8s
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -1253,10 +1254,11 @@ func TestUserK8sService_UpdateLastSeenAt(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:         "returns error when no request context",
+			name:         "succeeds with service identity when no request context",
 			cmd:          &user.UpdateUserLastSeenAtCommand{UserID: 42, OrgID: 1},
+			cfg:          &setting.Cfg{UserLastSeenUpdateInterval: 5 * time.Minute},
 			noReqContext: true,
-			expectErr:    true,
+			serverFn:     makeListResponse(42, 0),
 		},
 		{
 			name:        "returns error when config provider not initialized",
@@ -1552,10 +1554,21 @@ func TestUserK8sService_GetSignedInUser(t *testing.T) {
 			expectErr:   true,
 		},
 		{
-			name:         "returns error when no request context",
-			cmd:          &user.GetSignedInUserQuery{UserID: 42, OrgID: 1},
-			noReqContext: true,
-			expectErr:    true,
+			name:           "succeeds with service identity when no request context",
+			cmd:            &user.GetSignedInUserQuery{UserID: 42, OrgID: 1},
+			noReqContext:   true,
+			serverResponse: makeUserListResponse(newTestK8sUser("some-uid", "org-1", "jdoe", "jdoe@example.com")),
+			expectUser: &user.SignedInUser{
+				UserUID:        "some-uid",
+				OrgID:          1,
+				OrgRole:        "Admin",
+				Login:          "jdoe",
+				Email:          "jdoe@example.com",
+				Name:           "John Doe",
+				IsGrafanaAdmin: true,
+				EmailVerified:  true,
+				LastSeenAt:     time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC),
+			},
 		},
 		{
 			name:        "returns error when no requester and no OrgID in query",
@@ -1684,6 +1697,17 @@ func (m *mockDirectRestConfigProvider) IsReady() bool {
 	return true
 }
 
+type mockRestConfigProvider struct {
+	restConfig *rest.Config
+}
+
+func (m *mockRestConfigProvider) GetRestConfig(_ context.Context) (*rest.Config, error) {
+	if m.restConfig == nil {
+		return nil, errors.New("rest config not available")
+	}
+	return m.restConfig, nil
+}
+
 func contextWithReqContext() context.Context {
 	reqCtx := &contextmodel.ReqContext{}
 	return context.WithValue(context.Background(), ctxkey.Key{}, reqCtx)
@@ -1704,12 +1728,15 @@ func setupServiceAndCtx(t *testing.T, s svcTestSetup) (*UserK8sService, context.
 
 	var svc *UserK8sService
 	if s.nilProvider {
-		svc = NewUserK8sService(log.NewNopLogger(), s.cfg, nil, tracer)
+		svc = NewUserK8sService(log.NewNopLogger(), s.cfg, nil, nil, tracer)
 	} else {
 		ts := httptest.NewServer(http.HandlerFunc(s.serverResponse))
 		t.Cleanup(ts.Close)
+		restCfg := &rest.Config{Host: ts.URL}
 		svc = NewUserK8sService(log.NewNopLogger(), s.cfg, &mockDirectRestConfigProvider{
-			restConfig: &rest.Config{Host: ts.URL},
+			restConfig: restCfg,
+		}, &mockRestConfigProvider{
+			restConfig: restCfg,
 		}, tracer)
 	}
 

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/folder"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -1640,7 +1641,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/tests/api/correlations/common_test.go
+++ b/pkg/tests/api/correlations/common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/server"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -169,6 +170,7 @@ func (c TestContext) createUser(cmd user.CreateUserCommand) User {
 	usrSvc, err := userimpl.ProvideService(
 		store, orgService, c.env.Cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(c.t, err)
 

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
@@ -205,6 +206,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/tests/api/shorturl/short_url_test.go
+++ b/pkg/tests/api/shorturl/short_url_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
@@ -119,6 +120,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/tests/api/stats/admin_test.go
+++ b/pkg/tests/api/stats/admin_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
@@ -99,6 +100,7 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
 		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/server"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
@@ -926,7 +927,7 @@ func CreateUser(t *testing.T, store db.DB, cfg *setting.Cfg, cmd user.CreateUser
 	orgService, err := orgimpl.ProvideService(store, cfg, quotaService)
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
-		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(), quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		store, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(), quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 

--- a/pkg/tests/utils.go
+++ b/pkg/tests/utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
@@ -37,7 +38,7 @@ func CreateUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	require.NoError(t, err)
 	usrSvc, err := userimpl.ProvideService(
 		db, orgService, cfg, nil, nil, tracing.InitializeTracerForTest(),
-		quotaService, supportbundlestest.NewFakeBundleService(), nil,
+		quotaService, supportbundlestest.NewFakeBundleService(), nil, apiserver.WithoutRestConfig,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The `getClient` method from `UserK8sService` now handles two authentication paths:

- Authenticated user request (reqCtx != nil && reqCtx.IsSignedIn): uses GetDirectRestConfig(reqCtx) as before, scoping the k8s call to the signed-in user's identity.
- No authenticated user (auth hook, background call): sets service identity and obtains the loopback REST config via RestConfigProvider.GetRestConfig(ctx). The loopback transport preserves the Go context, so the in-process api server sees the service identity for authorization. This is the same pattern already used in [cleanup.go](https://github.com/grafana/grafana/blob/0f75e1a9309038fd2875209dcebfe0cc66983a18/pkg/services/cleanup/cleanup.go#L260-L266).

`userimpl.GetSignedInUser` no longer falls back to the legacy store when no orgID is in context. Instead it defaults to `cfg.DefaultOrgID()` and always attempts the k8s path first, with the existing legacy fallback retained for the case where the user genuinely doesn't exist in k8s (e.g. integration tests).

**Why do we need this feature?**

Auth proxy login does not carry an org ID in the request, so `orgIDFromRequest` returns 0 and the context has no valid orgID at authentication time. With `kubernetesUsersRedirect` enabled this caused GetSignedInUser to log `no orgID in context, falling back to legacy` and skip the k8s store entirely on every auth proxy request.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
