### PR TITLE
Provisioning: Invalid resources should cause a warning job

### DIFF
--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -31,11 +31,12 @@ var (
 
 // wrapAsValidationErrorIfNeeded wraps certain errors as ResourceValidationError
 // to treat them as warnings rather than hard errors. This includes:
-// - Kubernetes field validation errors
-// - Kubernetes API BadRequest errors (which often wrap dashboard/resource validation errors)
-// - Dashboard validation errors (all DashboardErr types)
-// - Duplicate resource errors
-// - Resource already in repository errors
+//   - Kubernetes field validation errors
+//   - Kubernetes API BadRequest errors (which often wrap dashboard/resource validation errors)
+//   - Kubernetes API Invalid errors (StatusReasonInvalid, HTTP 422)
+//   - Dashboard validation errors (all DashboardErr types)
+//   - Duplicate resource errors
+//   - Resource already in repository errors
 func wrapAsValidationErrorIfNeeded(err error) error {
 	if err == nil {
 		return nil
@@ -53,9 +54,13 @@ func wrapAsValidationErrorIfNeeded(err error) error {
 		return NewResourceValidationError(err)
 	}
 
-	// Check if it's a Kubernetes API BadRequest error (these are usually validation errors)
-	// Dashboard validation errors are wrapped as BadRequest by the dashboard API
-	if apierrors.IsBadRequest(err) {
+	// Check if it's a Kubernetes API validation-shaped error:
+	//   - BadRequest (400): generic validation failure; the dashboard API
+	//     also wraps some of its validation errors as BadRequest.
+	//   - Invalid (422, StatusReasonInvalid): field.ErrorList-based
+	//     rejections, e.g. CUE schema mismatches and immutable-field
+	//     violations.
+	if apierrors.IsBadRequest(err) || apierrors.IsInvalid(err) {
 		return NewResourceValidationError(err)
 	}
 

--- a/pkg/registry/apis/provisioning/resources/resources_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -11,10 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	grafanautils "github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 )
 
 // Use a GVR not in SupportsFolderAnnotation to avoid FolderManager dependency
@@ -474,4 +477,145 @@ func TestDeleteOldResource(t *testing.T) {
 		require.NoError(t, err)
 		mockClient.AssertCalled(t, "Delete", mock.Anything, "old-uid", metav1.DeleteOptions{}, mock.Anything)
 	})
+}
+
+// TestWrapAsValidationErrorIfNeeded pins the classification that decides
+// whether an error produced while writing a resource becomes a job-level
+// warning (non-fatal, the sync continues) or a hard error (fails the sync).
+// Anything wrapped as *ResourceValidationError is later surfaced as a warning
+// by jobs.classifyWarning.
+func TestWrapAsValidationErrorIfNeeded(t *testing.T) {
+	dashboardGK := schema.GroupKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}
+
+	t.Run("nil passes through", func(t *testing.T) {
+		require.NoError(t, wrapAsValidationErrorIfNeeded(nil))
+	})
+
+	t.Run("already a ResourceValidationError is returned unchanged", func(t *testing.T) {
+		original := NewResourceValidationError(errors.New("boom"))
+		got := wrapAsValidationErrorIfNeeded(original)
+		require.Same(t, original, got, "should return the same instance, not rewrap")
+	})
+
+	t.Run("field.Error is wrapped as a warning", func(t *testing.T) {
+		fieldErr := field.Required(field.NewPath("metadata", "name"), "missing name")
+		got := wrapAsValidationErrorIfNeeded(fieldErr)
+		requireWrappedAsValidation(t, got)
+	})
+
+	t.Run("apierrors BadRequest is wrapped as a warning", func(t *testing.T) {
+		badReq := apierrors.NewBadRequest("bad payload")
+		got := wrapAsValidationErrorIfNeeded(badReq)
+		requireWrappedAsValidation(t, got)
+	})
+
+	t.Run("apierrors Invalid (schema type mismatch) is wrapped as a warning", func(t *testing.T) {
+		// Mirrors the dashboard apiserver's strict validation path, which
+		// returns StatusReasonInvalid for CUE "conflicting values" failures.
+		invalid := apierrors.NewInvalid(dashboardGK, "AWSLambda", field.ErrorList{
+			field.Invalid(
+				field.NewPath("spec", "refresh"),
+				field.OmitValueType{},
+				`conflicting values false and string (mismatched types bool and string)`,
+			),
+		})
+		got := wrapAsValidationErrorIfNeeded(invalid)
+		requireWrappedAsValidation(t, got)
+		// The warning message should preserve the apiserver details so
+		// operators can locate the offending field in the file.
+		require.Contains(t, got.Error(), `Dashboard.dashboard.grafana.app "AWSLambda" is invalid`)
+		require.Contains(t, got.Error(), "spec.refresh")
+	})
+
+	t.Run("apierrors Invalid (immutable metadata.name) is wrapped as a warning", func(t *testing.T) {
+		// metadata.name immutability is enforced by apimachinery and returned
+		// as StatusReasonInvalid. This is the "field is immutable" variant
+		// seen when a file changes the name of an existing resource.
+		invalid := apierrors.NewInvalid(dashboardGK, "API-initiation-monitor", field.ErrorList{
+			field.Invalid(
+				field.NewPath("metadata", "name"),
+				"API-initiation-monitor",
+				"field is immutable",
+			),
+		})
+		got := wrapAsValidationErrorIfNeeded(invalid)
+		requireWrappedAsValidation(t, got)
+		require.Contains(t, got.Error(), "metadata.name")
+		require.Contains(t, got.Error(), "field is immutable")
+	})
+
+	t.Run("apierrors Invalid wrapped with fmt.Errorf is still wrapped as a warning", func(t *testing.T) {
+		// The sync path wraps the raw apiserver error with fmt.Errorf(%w).
+		// errors.As / IsInvalid must still traverse the chain.
+		invalid := apierrors.NewInvalid(dashboardGK, "dash", field.ErrorList{
+			field.Invalid(field.NewPath("spec", "refresh"), field.OmitValueType{}, "mismatched types"),
+		})
+		wrapped := fmt.Errorf("writing resource: %w", invalid)
+		got := wrapAsValidationErrorIfNeeded(wrapped)
+		requireWrappedAsValidation(t, got)
+	})
+
+	t.Run("DashboardErr is wrapped as a warning", func(t *testing.T) {
+		dErr := dashboardaccess.DashboardErr{
+			StatusCode: 400,
+			Status:     "bad-request",
+			Reason:     "Dashboard refresh interval is too low",
+		}
+		got := wrapAsValidationErrorIfNeeded(dErr)
+		requireWrappedAsValidation(t, got)
+	})
+
+	t.Run("ErrDuplicateName is wrapped as a warning", func(t *testing.T) {
+		got := wrapAsValidationErrorIfNeeded(fmt.Errorf("dup: %w", ErrDuplicateName))
+		requireWrappedAsValidation(t, got)
+	})
+
+	t.Run("ErrAlreadyInRepository is wrapped as a warning", func(t *testing.T) {
+		got := wrapAsValidationErrorIfNeeded(fmt.Errorf("dup: %w", ErrAlreadyInRepository))
+		requireWrappedAsValidation(t, got)
+	})
+
+	// The following are explicitly NOT wrapped: they represent transient or
+	// authorization issues, or internal failures, where the whole sync should
+	// surface as an error rather than being quietly downgraded to a warning.
+	t.Run("apierrors Forbidden is not wrapped", func(t *testing.T) {
+		forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "g", Resource: "r"}, "foo", errors.New("nope"))
+		got := wrapAsValidationErrorIfNeeded(forbidden)
+		requireNotWrapped(t, got, forbidden)
+	})
+
+	t.Run("apierrors Conflict is not wrapped", func(t *testing.T) {
+		conflict := apierrors.NewConflict(schema.GroupResource{Group: "g", Resource: "r"}, "foo", errors.New("version mismatch"))
+		got := wrapAsValidationErrorIfNeeded(conflict)
+		requireNotWrapped(t, got, conflict)
+	})
+
+	t.Run("apierrors InternalError is not wrapped", func(t *testing.T) {
+		internal := apierrors.NewInternalError(errors.New("kaboom"))
+		got := wrapAsValidationErrorIfNeeded(internal)
+		requireNotWrapped(t, got, internal)
+	})
+
+	t.Run("arbitrary non-apimachinery errors are not wrapped", func(t *testing.T) {
+		plain := errors.New("network timeout")
+		got := wrapAsValidationErrorIfNeeded(plain)
+		requireNotWrapped(t, got, plain)
+	})
+}
+
+func requireWrappedAsValidation(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var validationErr *ResourceValidationError
+	require.True(t, errors.As(err, &validationErr),
+		"error %q should be wrapped as *ResourceValidationError to become a job warning", err)
+}
+
+func requireNotWrapped(t *testing.T, got, original error) {
+	t.Helper()
+	require.Error(t, got)
+	var validationErr *ResourceValidationError
+	require.False(t, errors.As(got, &validationErr),
+		"error %q should NOT be wrapped as *ResourceValidationError (would incorrectly become a warning)", got)
+	require.Same(t, original, got, "non-wrapped errors should be returned unchanged")
 }

--- a/pkg/tests/apis/provisioning/jobs/job_warning_result_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_warning_result_test.go
@@ -159,6 +159,69 @@ func TestIntegrationProvisioning_JobWarningResult_DashboardRefreshInterval(t *te
 		"should have warning message mentioning refresh interval validation error")
 }
 
+// TestIntegrationProvisioning_JobWarningResult_DashboardSchemaInvalid verifies
+// that Kubernetes apiserver "Invalid" (HTTP 422, StatusReasonInvalid) errors
+// produced by dashboard schema validation during a sync are treated as
+// warnings, not hard errors.
+func TestIntegrationProvisioning_JobWarningResult_DashboardSchemaInvalid(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "job-warning-invalid-schema-repo"
+	testRepo := common.TestRepo{
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies: map[string]string{
+			"../testdata/dashboard-v2-schema-invalid.json": "dashboard-v2-invalid.json",
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	}
+	helper.CreateLocalRepo(t, testRepo)
+
+	// Execute a pull job - this should process the dashboard, hit the v2 CUE
+	// validator via apiserver admission, and classify the resulting IsInvalid
+	// error as a warning rather than a hard error.
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	jobObj := &provisioning.Job{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj)
+	require.NoError(t, err)
+
+	t.Logf("job status: state=%s message=%s", jobObj.Status.State, jobObj.Status.Message)
+	for i, w := range jobObj.Status.Warnings {
+		t.Logf("  warning[%d]: %s", i, w)
+	}
+	for i, e := range jobObj.Status.Errors {
+		t.Logf("  error[%d]: %s", i, e)
+	}
+
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"job should complete with warning state for dashboard schema validation (IsInvalid) error")
+	require.NotEmpty(t, jobObj.Status.Warnings,
+		"job should have warnings for the schema validation error")
+	require.Empty(t, jobObj.Status.Errors,
+		"dashboard schema validation errors should be treated as warnings, not errors")
+
+	// The expected warning shape is produced by apierrors.NewInvalid, wrapped
+	// by the provisioning writer. It contains:
+	//   - the source file path (so users know which file to fix)
+	//   - the "is invalid" marker from StatusReasonInvalid
+	found := false
+	for _, warningMsg := range jobObj.Status.Warnings {
+		if strings.Contains(warningMsg, "dashboard-v2-invalid.json") &&
+			strings.Contains(warningMsg, "is invalid") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found,
+		"should have a warning message mentioning the file and an IsInvalid schema validation error, got: %v",
+		jobObj.Status.Warnings)
+}
+
 func TestIntegrationProvisioning_JobWarningResult_DuplicateName(t *testing.T) {
 	helper := sharedHelper(t)
 

--- a/pkg/tests/apis/provisioning/testdata/dashboard-v2-schema-invalid.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-v2-schema-invalid.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "test-dashboard-v2-schema-invalid"
+  },
+  "spec": {
+    "annotations": [],
+    "cursorSync": "Off",
+    "elements": {},
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "NotAGridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "p1"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [],
+      "hideTimepicker": false
+    },
+    "title": "Invalid v2 Dashboard - bad layout item kind",
+    "variables": []
+  }
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Invalid resource errors as returned from grafana apis should result in a warning status for provisioning jobs.

**Why do we need this feature?**

There should not be classified as errors cause they represent a problem with a particular synced file, not a problem within the system. Warnings allow for other resources to sync and inform users on problems that need solving.

We have seen resource errors in hosted grafana that should've been warnings:

* 'writing resource from file grafana/AWS/Dev/aws-lambda.json: Dashboard.dashboard.grafana.app "AWSLambda" is invalid: spec.refresh: Invalid value: conflicting values false and string (mismatched types bool and string)'
 * 'writing resource from file grafana-o11y/Dashboards/api-hit-count-per-uri.json: Dashboard.dashboard.grafana.app "faec32ad-2163-4431-abc9-b688e880e1
b4" is invalid: spec.templating.list.0.datasource: Invalid value: conflicting values "Loki" and {type?:string,uid?:string} (mismatched types string and
 struct)'
 * 'writing resource from file grafana-o11y/Dashboards/api-success-failure-and-error-monitoring.json: Dashboard.dashboard.grafana.app "API-initiation-
monitor" is invalid: metadata.name: Invalid value: "API-initiation-monitor": field is immutable'

**Who is this feature for?**

Provisioning customers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1084

**Special notes for your reviewer:**

Please check that:
- [ x] It works as expected from a user's perspective.
- [ x] If this is a pre-GA feature, it is behind a feature toggle.
- [ x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
