### PR TITLE
Provisioning: tread k8s API Invalid errors as warnings during sync

### DIFF
--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -33,6 +33,7 @@ var (
 // to treat them as warnings rather than hard errors. This includes:
 // - Kubernetes field validation errors
 // - Kubernetes API BadRequest errors (which often wrap dashboard/resource validation errors)
+// - Kubernetes API Invalid errors
 // - Dashboard validation errors (all DashboardErr types)
 // - Duplicate resource errors
 // - Resource already in repository errors
@@ -67,6 +68,14 @@ func wrapAsValidationErrorIfNeeded(err error) error {
 
 	// Check if it's a duplicate name error or already in repository error
 	if errors.Is(err, ErrDuplicateName) || errors.Is(err, ErrAlreadyInRepository) {
+		return NewResourceValidationError(err)
+	}
+
+	// Kubernetes API Invalid errors (StatusReason=Invalid, HTTP 422) cover CUE
+	// schema mismatches from admission Validate hooks and immutable-field
+	// rejections from the meta validator. Surface them as warnings so a single
+	// broken resource does not abort the whole sync.
+	if apierrors.IsInvalid(err) {
 		return NewResourceValidationError(err)
 	}
 

--- a/pkg/registry/apis/provisioning/resources/resources_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_test.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -11,10 +13,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	grafanautils "github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 )
 
 // Use a GVR not in SupportsFolderAnnotation to avoid FolderManager dependency
@@ -474,4 +478,141 @@ func TestDeleteOldResource(t *testing.T) {
 		require.NoError(t, err)
 		mockClient.AssertCalled(t, "Delete", mock.Anything, "old-uid", metav1.DeleteOptions{}, mock.Anything)
 	})
+}
+
+func TestWrapAsValidationError(t *testing.T) {
+	t.Parallel()
+
+	dashboardGK := schema.GroupKind{Group: "dashboard.grafana.app", Kind: "Dashboard"}
+
+	invalidRefreshBool := apierrors.NewInvalid(dashboardGK, "AWSLambda", field.ErrorList{
+		field.Invalid(field.NewPath("spec", "refresh"), false, "mismatched types bool and string"),
+	})
+	invalidDatasourceStruct := apierrors.NewInvalid(dashboardGK, "dash", field.ErrorList{
+		field.Invalid(field.NewPath("spec", "templating", "list").Index(0).Child("datasource"), "Loki", "mismatched types string and struct"),
+	})
+	invalidImmutableName := apierrors.NewInvalid(dashboardGK, "API-initiation-monitor", field.ErrorList{
+		field.Forbidden(field.NewPath("metadata", "name"), "field is immutable"),
+	})
+
+	type assertion func(t *testing.T, input, got error)
+
+	passThroughUnchanged := func(t *testing.T, input, got error) {
+		t.Helper()
+		require.Same(t, input, got, "pass-through case must return the exact same error value")
+	}
+
+	returnsNil := func(t *testing.T, _, got error) {
+		t.Helper()
+		require.NoError(t, got)
+	}
+
+	wrappedAsValidationError := func(substrings ...string) assertion {
+		return func(t *testing.T, _, got error) {
+			t.Helper()
+			var validationErr *ResourceValidationError
+			require.True(t, errors.As(got, &validationErr), "expected *ResourceValidationError, got %T: %v", got, got)
+			require.NotNil(t, validationErr)
+			for _, s := range substrings {
+				require.True(t, strings.Contains(got.Error(), s), "expected error text to contain %q, got %q", s, got.Error())
+			}
+		}
+	}
+
+	// wrappedAsValidationErrorKeepsIsInvalid asserts both that the error is
+	// wrapped and that apierrors.IsInvalid still returns true on the wrapped
+	// value — downstream consumers must still be able to introspect.
+	wrappedAsValidationErrorKeepsIsInvalid := func(substrings ...string) assertion {
+		inner := wrappedAsValidationError(substrings...)
+		return func(t *testing.T, input, got error) {
+			t.Helper()
+			inner(t, input, got)
+			require.True(t, apierrors.IsInvalid(got), "apierrors.IsInvalid(got) must still be true after wrapping")
+		}
+	}
+
+	cases := []struct {
+		name   string
+		input  error
+		assert assertion
+	}{
+		{
+			name:   "nil_input",
+			input:  nil,
+			assert: returnsNil,
+		},
+		{
+			name:   "already_wrapped_pass_through",
+			input:  NewResourceValidationError(errors.New("x")),
+			assert: passThroughUnchanged,
+		},
+		{
+			name:   "field_error",
+			input:  field.Required(field.NewPath("spec", "name"), "missing"),
+			assert: wrappedAsValidationError("spec.name", "missing"),
+		},
+		{
+			name:   "bad_request",
+			input:  apierrors.NewBadRequest("dashboard validation failed"),
+			assert: wrappedAsValidationError("dashboard validation failed"),
+		},
+		{
+			name:   "dashboard_err",
+			input:  dashboardaccess.DashboardErr{StatusCode: 400, Status: "invalid", Reason: "bad dashboard"},
+			assert: wrappedAsValidationError("bad dashboard"),
+		},
+		{
+			name:   "duplicate_name",
+			input:  fmt.Errorf("wrapped: %w", ErrDuplicateName),
+			assert: wrappedAsValidationError("duplicate name"),
+		},
+		{
+			name:   "already_in_repository",
+			input:  fmt.Errorf("wrapped: %w", ErrAlreadyInRepository),
+			assert: wrappedAsValidationError("already in repository"),
+		},
+		{
+			name:   "invalid_cue_refresh_bool",
+			input:  invalidRefreshBool,
+			assert: wrappedAsValidationErrorKeepsIsInvalid("spec.refresh", "mismatched types"),
+		},
+		{
+			name:   "invalid_cue_datasource_struct",
+			input:  invalidDatasourceStruct,
+			assert: wrappedAsValidationErrorKeepsIsInvalid("spec.templating.list[0].datasource"),
+		},
+		{
+			name:   "invalid_immutable_name",
+			input:  invalidImmutableName,
+			assert: wrappedAsValidationErrorKeepsIsInvalid("metadata.name", "field is immutable"),
+		},
+		{
+			name:   "invalid_wrapped_in_fmt_errorf",
+			input:  fmt.Errorf("writing resource: %w", invalidImmutableName),
+			assert: wrappedAsValidationErrorKeepsIsInvalid("field is immutable"),
+		},
+		{
+			name:   "default_passthrough_generic_error",
+			input:  errors.New("connection refused"),
+			assert: passThroughUnchanged,
+		},
+		{
+			name:   "default_passthrough_internal_server_error",
+			input:  apierrors.NewInternalError(errors.New("etcd down")),
+			assert: passThroughUnchanged,
+		},
+		{
+			name:   "default_passthrough_not_found",
+			input:  apierrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "x"),
+			assert: passThroughUnchanged,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := wrapAsValidationErrorIfNeeded(tc.input)
+			tc.assert(t, tc.input, got)
+		})
+	}
 }

--- a/pkg/tests/apis/provisioning/jobs/job_warning_result_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_warning_result_test.go
@@ -12,6 +12,36 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+// assertJobWarningWith asserts that a completed job landed in JobStateWarning
+// with at least one warning whose text contains every expected substring and
+// no error entries. Returns the matching warning for additional assertions.
+func assertJobWarningWith(t *testing.T, job map[string]any, expectedSubs ...string) string {
+	t.Helper()
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job, jobObj))
+
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"job should complete with warning state; warnings=%v errors=%v", jobObj.Status.Warnings, jobObj.Status.Errors)
+	require.NotEmpty(t, jobObj.Status.Warnings, "job should have at least one warning")
+	require.Empty(t, jobObj.Status.Errors, "validation errors should be surfaced as warnings, not errors")
+
+	for _, warning := range jobObj.Status.Warnings {
+		match := true
+		for _, sub := range expectedSubs {
+			if !strings.Contains(warning, sub) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return warning
+		}
+	}
+	require.Failf(t, "warning not found",
+		"expected a warning containing all of %v; warnings=%v", expectedSubs, jobObj.Status.Warnings)
+	return ""
+}
+
 func TestIntegrationProvisioning_JobWarningResult(t *testing.T) {
 	helper := sharedHelper(t)
 
@@ -205,4 +235,132 @@ func TestIntegrationProvisioning_JobWarningResult_DuplicateName(t *testing.T) {
 	}
 	require.True(t, found,
 		"should have warning message mentioning duplicate resource name")
+}
+
+// Dashboard validation errors (K8s apierrors.IsInvalid) must surface as
+// sync warnings so a single broken dashboard does not abort the whole repo.
+
+// TestIntegrationProvisioning_JobWarningResult_DashboardCUEEditableBool covers
+// the CUE-scalar-type-mismatch error shape (bool field populated with a string,
+// producing "mismatched types" via the dashboard Validate hook).
+func TestIntegrationProvisioning_JobWarningResult_DashboardCUEEditableBool(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "job-warning-cue-editable-bool"
+	testRepo := common.TestRepo{
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies: map[string]string{
+			"../testdata/dashboard-invalid-editable.json": "dashboard-editable.json",
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	}
+	helper.CreateLocalRepo(t, testRepo)
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	assertJobWarningWith(t, job.Object,
+		"writing resource from file dashboard-editable.json",
+		"editable",
+	)
+}
+
+// TestIntegrationProvisioning_JobWarningResult_DashboardCUEPreloadBool covers
+// a second CUE-type-mismatch shape: a field declared as bool in the schema
+// populated with a string value. Paired with the editable-bool test, it
+// exercises two distinct CUE paths through the admission Validate hook.
+func TestIntegrationProvisioning_JobWarningResult_DashboardCUEPreloadBool(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "job-warning-cue-preload-bool"
+	testRepo := common.TestRepo{
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies: map[string]string{
+			"../testdata/dashboard-invalid-preload.json": "dashboard-preload.json",
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	}
+	helper.CreateLocalRepo(t, testRepo)
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	assertJobWarningWith(t, job.Object,
+		"writing resource from file dashboard-preload.json",
+		"preload",
+	)
+}
+
+// TestIntegrationProvisioning_JobWarningResult_InvalidDashboardsDoNotConsumeErrorBudget
+// verifies that apierrors.IsInvalid failures are classified as warnings, not
+// hard errors — so they do not count toward StrictMaxErrors(20). Without this
+// behaviour, any repo with more than 20 malformed dashboards would abort sync
+// with JobStateError; with it, the sync completes as JobStateWarning regardless
+// of how many invalid dashboards are present.
+//
+// The test pulls 25 dashboards (strictly more than StrictMaxErrors) where each
+// one triggers a CUE type mismatch via the dashboard admission Validate hook.
+// All 25 must surface as warnings, errorCount must stay at zero, and the job
+// must reach JobStateWarning rather than JobStateError.
+func TestIntegrationProvisioning_JobWarningResult_InvalidDashboardsDoNotConsumeErrorBudget(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "job-warning-error-budget"
+	// StrictMaxErrors is 20 (jobs/sync/worker.go). We emit strictly more so a
+	// regression that reclassifies IsInvalid as a hard error would trip it.
+	const invalidDashboardCount = 25
+
+	testRepo := common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	}
+	helper.CreateLocalRepo(t, testRepo)
+
+	// Emit N distinct v2beta1 dashboards, each with a CUE type mismatch on
+	// "editable" (bool field populated with a string). Each write produces
+	// apierrors.NewInvalid from the dashboard admission Validate hook. The
+	// classifier must route every one of them to a warning; any reclassified
+	// as an error would be counted in errorCount and, past the 20th, would
+	// cause StrictMaxErrors to abort the sync with JobStateError.
+	for i := range invalidDashboardCount {
+		body := fmt.Appendf(nil, `{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {"name": "strict-max-%d"},
+  "spec": {
+    "title": "strict max dashboard %d",
+    "editable": "maybe",
+    "layout": {"kind": "GridLayout", "spec": {"items": []}}
+  }
+}
+`, i, i)
+		helper.WriteToProvisioningPath(t, fmt.Sprintf("dashboard-strict-%02d.json", i), body)
+	}
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"job must complete with warning state — a JobStateError here means %d IsInvalid failures consumed the error budget and tripped StrictMaxErrors; state=%s errors=%v",
+		invalidDashboardCount, jobObj.Status.State, jobObj.Status.Errors)
+	require.Empty(t, jobObj.Status.Errors,
+		"errorCount must stay at zero — IsInvalid failures should never consume the error budget")
+	require.GreaterOrEqual(t, len(jobObj.Status.Warnings), invalidDashboardCount,
+		"expected at least %d warnings (one per invalid dashboard); got %d: %v",
+		invalidDashboardCount, len(jobObj.Status.Warnings), jobObj.Status.Warnings)
 }

--- a/pkg/tests/apis/provisioning/testdata/dashboard-invalid-editable.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-invalid-editable.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "invalid-editable"
+  },
+  "spec": {
+    "title": "dashboard with invalid editable type",
+    "editable": "maybe",
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": []
+      }
+    }
+  }
+}

--- a/pkg/tests/apis/provisioning/testdata/dashboard-invalid-preload.json
+++ b/pkg/tests/apis/provisioning/testdata/dashboard-invalid-preload.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "invalid-preload"
+  },
+  "spec": {
+    "title": "dashboard with invalid preload type",
+    "preload": "yes",
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1084

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
