### PR TITLE
unified-storage: patch client RV validation to slow

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -784,7 +784,11 @@ func (s *Storage) validateMinimumResourceVersion(minimumResourceVersion string, 
 	// Enforce the storage.Interface guarantee that the resource version of the returned data
 	// "will be at least 'resourceVersion'".
 	if rvMin > rvActual {
-		return storage.NewTooLargeResourceVersionError(minimumRV, actualRevision, 0)
+		// NOTE, the etcd3 flavor throws a 504 using storage.NewTooLargeResourceVersionError
+		// We are throwing a 401 because this is a client error rather than a server error
+		return apierrors.NewResourceExpired(
+			fmt.Sprintf("too large resource version: %d (current %d)", rvMin, rvActual),
+		)
 	}
 	return nil
 }

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -40,6 +40,7 @@ import (
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager"
 )
 
 const (
@@ -768,9 +769,21 @@ func (s *Storage) validateMinimumResourceVersion(minimumResourceVersion string, 
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 
+	// Normalize both to microsecond format for cross-format comparison.
+	// RVs may be in either snowflake or microsecond format depending
+	// on which backend produced them.
+	rvMin := int64(minimumRV)
+	if !resource.IsSnowflake(rvMin) {
+		rvMin = rvmanager.SnowflakeFromRV(rvMin)
+	}
+	rvActual := int64(actualRevision)
+	if !resource.IsSnowflake(rvActual) {
+		rvActual = rvmanager.SnowflakeFromRV(rvActual)
+	}
+
 	// Enforce the storage.Interface guarantee that the resource version of the returned data
 	// "will be at least 'resourceVersion'".
-	if minimumRV > actualRevision {
+	if rvMin > rvActual {
 		return storage.NewTooLargeResourceVersionError(minimumRV, actualRevision, 0)
 	}
 	return nil

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -880,7 +880,7 @@ func (d *dataStore) applyBackwardsCompatibleChanges(ctx context.Context, tx db.T
 	// In compatibility mode, the previous RV, when available, is saved as a microsecond
 	// timestamp, as is done in the SQL backend.
 	previousRV := event.PreviousRV
-	if event.PreviousRV > 0 && isSnowflake(event.PreviousRV) {
+	if event.PreviousRV > 0 && IsSnowflake(event.PreviousRV) {
 		previousRV = rvmanager.RVFromSnowflake(event.PreviousRV)
 	}
 
@@ -1090,9 +1090,9 @@ func (d *dataStore) syncLegacyResourceFromHistory(ctx context.Context, execer db
 	return nil
 }
 
-// isSnowflake returns whether the argument passed is a snowflake ID (new) or a microsecond timestamp (old).
+// IsSnowflake returns whether the argument passed is a snowflake ID (new) or a microsecond timestamp (old).
 // Snowflake IDs always have 19 digits. A 19-digit microsecond timestamp (10^18 µs) would correspond
 // to year ~33658, so any number with fewer than 19 digits is unambiguously a legacy microsecond timestamp.
-func isSnowflake(rv int64) bool {
+func IsSnowflake(rv int64) bool {
 	return rv >= 1e18
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1877,7 +1877,7 @@ func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
 // Unix timestamps (SQL backend).
 func resourceVersionTime(rv int64) time.Time {
 	micro := rv
-	if isSnowflake(rv) {
+	if IsSnowflake(rv) {
 		micro = rvmanager.RVFromSnowflake(rv)
 	}
 	return time.UnixMicro(micro)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -594,10 +594,22 @@ func (b *kvStorageBackend) garbageCollectionCutoffTimestamp(group, resourceName 
 		cutoffTimestamp = time.Now().Add(-b.garbageCollection.DashboardsMaxAge).UnixMicro()
 	}
 
-	if !isSnowflake(cutoffTimestamp) {
+	if !IsSnowflake(cutoffTimestamp) {
 		cutoffTimestamp = rvmanager.SnowflakeFromRV(cutoffTimestamp)
 	}
 	return cutoffTimestamp
+}
+
+// toSnowflakeRV converts a microsecond RV to snowflake format if needed.
+// This ensures the KV backend is compatible with both RV formats during the
+// backend transition period.
+//
+// TODO: remove when compatibility with SQL backend is no longer needed.
+func toSnowflakeRV(rv int64) int64 {
+	if rv > 0 && !IsSnowflake(rv) {
+		return rvmanager.SnowflakeFromRV(rv)
+	}
+	return rv
 }
 
 // WriteEvent writes a resource event (create/update/delete) to the storage backend.
@@ -607,6 +619,8 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 	if err := event.Validate(); err != nil {
 		return 0, fmt.Errorf("invalid event: %w", err)
 	}
+
+	event.PreviousRV = toSnowflakeRV(event.PreviousRV)
 
 	rv := k.snowflake.Generate().Int64()
 
@@ -799,6 +813,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 	}
 
 	namespace := convertEmptyToClusterNamespace(req.Key.Namespace, k.withExperimentalClusterScope)
+	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
 
 	// If a specific resource version is requested, validate that it's not too high
 	if req.ResourceVersion > 0 {
@@ -875,6 +890,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 	}
 
 	namespace := convertEmptyToClusterNamespace(req.Options.Key.Namespace, k.withExperimentalClusterScope)
+	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
 
 	// Parse continue token if provided
 	listOptions := ListRequestOptions{
@@ -900,7 +916,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 			listOptions.ContinueNamespace = token.Namespace
 		}
 		listOptions.ContinueName = token.Name
-		listOptions.ResourceVersion = token.ResourceVersion
+		listOptions.ResourceVersion = toSnowflakeRV(token.ResourceVersion)
 	}
 
 	// We set the listRV to the last event resource version.
@@ -1155,6 +1171,8 @@ func (k *kvStorageBackend) ListModifiedSince(ctx context.Context, key Namespaced
 		}
 	}
 
+	sinceRv = toSnowflakeRV(sinceRv)
+
 	latestEvent, err := k.eventStore.LastEventKey(ctx)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -1351,6 +1369,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		return 0, err
 	}
 	key := req.Options.Key
+	req.ResourceVersion = toSnowflakeRV(req.ResourceVersion)
 	// Parse continue token if provided
 	lastSeenRV := int64(0)
 	sortAscending := req.GetVersionMatchV2() == resourcepb.ResourceVersionMatchV2_NotOlderThan
@@ -1359,7 +1378,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		if err != nil {
 			return 0, fmt.Errorf("invalid continue token: %w", err)
 		}
-		lastSeenRV = token.ResourceVersion
+		lastSeenRV = toSnowflakeRV(token.ResourceVersion)
 		sortAscending = token.SortAscending
 	}
 

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -625,10 +625,22 @@ func (b *backend) GetResourceStats(ctx context.Context, nsr resource.NamespacedR
 	return res, err
 }
 
+// toMicrosecondRV converts a snowflake RV to microsecond format if needed.
+// This ensures that RVs arriving at the SQL backend are in the native
+// microsecond format. No-op for values ≤ 0 or values already in microsecond format.
+func toMicrosecondRV(rv int64) int64 {
+	if rv > 0 && resource.IsSnowflake(rv) {
+		return rvmanager.RVFromSnowflake(rv)
+	}
+	return rv
+}
+
 func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (int64, error) {
 	if b.disableStorageServices {
 		return 0, fmt.Errorf("storage backend is not enabled")
 	}
+	event.PreviousRV = toMicrosecondRV(event.PreviousRV)
+
 	_, span := tracer.Start(ctx, "sql.backend.WriteEvent")
 	defer span.End()
 	// TODO: validate key ?
@@ -875,6 +887,8 @@ func (b *backend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest)
 	_, span := tracer.Start(ctx, "sql.backend.ReadResource")
 	defer span.End()
 
+	req.ResourceVersion = toMicrosecondRV(req.ResourceVersion)
+
 	// TODO: validate key ?
 
 	if req.ResourceVersion > 0 {
@@ -908,6 +922,8 @@ func (b *backend) ListIterator(ctx context.Context, req *resourcepb.ListRequest,
 	ctx, span := tracer.Start(ctx, "sql.backend.ListIterator")
 	defer span.End()
 
+	req.ResourceVersion = toMicrosecondRV(req.ResourceVersion)
+
 	if err := resource.MigrateListRequestVersionMatch(req, b.log); err != nil {
 		return 0, err
 	}
@@ -930,6 +946,7 @@ func (b *backend) ListHistory(ctx context.Context, req *resourcepb.ListRequest, 
 	ctx, span := tracer.Start(ctx, "sql.backend.ListHistory")
 	defer span.End()
 
+	req.ResourceVersion = toMicrosecondRV(req.ResourceVersion)
 	return b.getHistory(ctx, req, cb)
 }
 
@@ -980,6 +997,8 @@ func (b *backend) listLatest(ctx context.Context, req *resourcepb.ListRequest, c
 // ListModifiedSince will return all resources that have changed since the given resource version.
 // If a resource has changes, only the latest change will be returned.
 func (b *backend) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64, _ *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
+	sinceRv = toMicrosecondRV(sinceRv)
+
 	// We don't use an explicit transaction for fetching LatestRV and subsequent fetching of resources.
 	// To guarantee that we don't include events with RV > LatestRV, we include the check in SQL query.
 
@@ -1056,7 +1075,7 @@ func (b *backend) listAtRevision(ctx context.Context, req *resourcepb.ListReques
 		if err != nil {
 			return 0, fmt.Errorf("get continue token (%q): %w", req.NextPageToken, err)
 		}
-		iter.listRV = continueToken.ResourceVersion
+		iter.listRV = toMicrosecondRV(continueToken.ResourceVersion)
 		iter.offset = continueToken.StartOffset
 
 		if req.ResourceVersion != 0 && req.ResourceVersion != iter.listRV {

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -82,6 +82,7 @@ func RunSQLStorageBackendCompatibilityTest(t *testing.T, newSqlBackend NewBacken
 		{"concurrent operations stress", runTestConcurrentOperationsStress},
 		{"optimistic locking database integrity", runTestOptimisticLockingDatabaseIntegrity},
 		{"bulk import compatibility", runTestBulkImportCompatibility},
+		{"cross backend rv list compatibility", runTestCrossBackendRVListCompatibility},
 	}
 
 	for _, tc := range cases {
@@ -2232,5 +2233,85 @@ func runSearchCompatibilityScenario(t *testing.T, cfg searchCompatibilityTestCon
 		verifySearchServerResults(t, searchServer, cfg.namespace, "Updated", 2, []string{
 			alphaName(1), betaName(1),
 		})
+	})
+}
+
+// runTestCrossBackendRVListCompatibility verifies that a ResourceVersion obtained
+// from one backend can be used to list a point-in-time snapshot from the other
+// backend. This exercises cross-format RV handling (microsecond ↔ snowflake).
+func runTestCrossBackendRVListCompatibility(t *testing.T, sqlBackend, kvBackend resource.StorageBackend, nsPrefix string, _ sqldb.DB) {
+	ctx := newIntegrationTestContext(t)
+
+	sqlServer := createStorageServer(t, sqlBackend)
+	kvServer := createStorageServer(t, kvBackend)
+
+	// testCrossBackendList creates resources via backend A, captures a
+	// point-in-time RV, creates more resources, then lists from backend B
+	// using A's RV. Backend B must return only the resources that existed at
+	// A's RV — not the ones created afterward. This catches missing RV
+	// format conversions: without conversion, a snowflake RV (very large)
+	// passed to the SQL backend would match all rows via `<= RV`, and a
+	// microsecond RV (very small) passed to the KV backend would match none.
+	testCrossBackendList := func(t *testing.T, serverA, serverB resource.ResourceServer, expectSnowflakeRV bool, ns string) {
+		listOpts := &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "playlists",
+			Namespace: ns,
+		}}
+
+		// Create 2 resources via backend A.
+		for i := 1; i <= 2; i++ {
+			createPlaylistResource(t, serverA, ctx, PlaylistResourceOptions{
+				Name:       fmt.Sprintf("res-%d", i),
+				Namespace:  ns,
+				UID:        fmt.Sprintf("uid-%d", i),
+				Generation: 1,
+				Title:      fmt.Sprintf("Playlist %d", i),
+			})
+		}
+
+		// List from backend A to capture a point-in-time RV.
+		listA, err := serverA.List(ctx, &resourcepb.ListRequest{Options: listOpts})
+		require.NoError(t, err)
+		require.Nil(t, listA.Error)
+		require.Len(t, listA.Items, 2)
+		rvFromA := listA.ResourceVersion
+		require.Greater(t, rvFromA, int64(0))
+		require.Equal(t, expectSnowflakeRV, resource.IsSnowflake(rvFromA), "RV format should match the producing backend")
+
+		// Create 2 more resources after the captured RV.
+		for i := 3; i <= 4; i++ {
+			createPlaylistResource(t, serverA, ctx, PlaylistResourceOptions{
+				Name:       fmt.Sprintf("res-%d", i),
+				Namespace:  ns,
+				UID:        fmt.Sprintf("uid-%d", i),
+				Generation: 1,
+				Title:      fmt.Sprintf("Playlist %d", i),
+			})
+		}
+
+		// Sanity: listing latest from A should return all 4 items.
+		listAll, err := serverA.List(ctx, &resourcepb.ListRequest{Options: listOpts})
+		require.NoError(t, err)
+		require.Nil(t, listAll.Error)
+		require.Len(t, listAll.Items, 4)
+
+		// List from backend B at A's RV — must return exactly the 2
+		// resources that existed at that point, not all 4.
+		listB, err := serverB.List(ctx, &resourcepb.ListRequest{
+			ResourceVersion: rvFromA,
+			Options:         listOpts,
+		})
+		require.NoError(t, err)
+		require.Nil(t, listB.Error)
+		require.Len(t, listB.Items, 2, "listing with cross-backend RV should return only the resources that existed at that RV")
+	}
+
+	t.Run("SQL to KV", func(t *testing.T) {
+		testCrossBackendList(t, sqlServer, kvServer, false, nsPrefix+"-rv-sql2kv")
+	})
+
+	t.Run("KV to SQL", func(t *testing.T) {
+		testCrossBackendList(t, kvServer, sqlServer, true, nsPrefix+"-rv-kv2sql")
 	})
 }


### PR DESCRIPTION
Patch #122387 and #122367 to slow.