### PR TITLE
Settings: Fix GF_UNIFIED_STORAGE_* env overrides for bare section keys

### DIFF
--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -60,6 +60,10 @@ var MigratedUnifiedResources = map[string]bool{
 // underscore in the resource portion of the env var name maps unambiguously
 // back to a dot. The key names are matched from a known list
 // ([knownUnifiedStorageKeys]) to preserve their original camelCase.
+//
+// Env vars that do not match a known camelCase resource suffix are treated
+// as keys on the bare [unified_storage] section (lowercased snake_case),
+// e.g. GF_UNIFIED_STORAGE_MIGRATION_CACHE_SIZE_KB → migration_cache_size_kb.
 func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
 	envPrefix := EnvSectionPrefix("unified_storage")
 
@@ -81,6 +85,7 @@ func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
 
 		// Try to match a known key suffix. The key is always the last component
 		// after the final underscore that matches a known key name.
+		matched := false
 		for envKeySuffix, iniKeyName := range knownUnifiedStorageKeys {
 			suffix := "_" + envKeySuffix
 			if !strings.HasSuffix(remainder, suffix) {
@@ -96,8 +101,21 @@ func (cfg *Cfg) applyUnifiedStorageEnvOverrides() {
 			cfg.Raw.Section(sectionName).Key(iniKeyName).SetValue(envValue)
 			cfg.appliedEnvOverrides = append(cfg.appliedEnvOverrides,
 				fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
+			matched = true
 			break
 		}
+		if matched {
+			continue
+		}
+
+		// Fallback: bare [unified_storage] section key (lowercased snake_case).
+		keyName := strings.ToLower(remainder)
+		if keyName == "" {
+			continue
+		}
+		cfg.Raw.Section("unified_storage").Key(keyName).SetValue(envValue)
+		cfg.appliedEnvOverrides = append(cfg.appliedEnvOverrides,
+			fmt.Sprintf("%s=%s", envKey, RedactedValue(envKey, envValue)))
 	}
 }
 

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -154,6 +154,24 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, rest.DualWriterMode(2), value.DualWriterMode)
 	})
 
+	t.Run("env vars populate bare [unified_storage] section keys", func(t *testing.T) {
+		// These env vars target keys in the bare [unified_storage] section
+		// that are not pre-defined in defaults.ini.
+		t.Setenv("GF_UNIFIED_STORAGE_MIGRATION_CACHE_SIZE_KB", "2000000")
+		t.Setenv("GF_UNIFIED_STORAGE_MIGRATION_PARQUET_BUFFER", "true")
+		t.Setenv("GF_UNIFIED_STORAGE_INDEX_WORKERS", "3")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		assert.Equal(t, 2000000, cfg.MigrationCacheSizeKB)
+		assert.True(t, cfg.MigrationParquetBuffer)
+		assert.Equal(t, 3, cfg.IndexWorkers)
+	})
+
 	t.Run("read unified_storage configs with defaults", func(t *testing.T) {
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})


### PR DESCRIPTION
**What is this feature?**

Makes `GF_UNIFIED_STORAGE_*` environment variables work for keys in the bare `[unified_storage]` ini section. Env vars that do not match a known camelCase resource-scoped suffix (`_DUALWRITERMODE` / `_ENABLEMIGRATION`) now fall back to setting a lowercased snake_case key on `[unified_storage]` — e.g. `GF_UNIFIED_STORAGE_MIGRATION_CACHE_SIZE_KB=2000000` sets `migration_cache_size_kb = 2000000`.

**Why do we need this feature?**

After #120162, the generic env-override second pass explicitly skips everything prefixed with `GF_UNIFIED_STORAGE_` to avoid clobbering the camelCase keys used by `[unified_storage.<resource>]` sections, delegating to `applyUnifiedStorageEnvOverrides`. That function only recognised resource-scoped camelCase suffixes, so env vars targeting the bare `[unified_storage]` section (which are not pre-defined in `defaults.ini`) were silently dropped.

**Who is this feature for?**

Operators configuring Grafana purely via environment variables (Docker, Kubernetes) who rely on `GF_UNIFIED_STORAGE_*` overrides to tune unified storage migrations and indexing.

**Which issue(s) does this PR fix?**:

Fixes #122993

**Special notes for your reviewer:**

- Resource-scoped overrides (e.g. `GF_UNIFIED_STORAGE_<resource>_DUALWRITERMODE`) behaviour is unchanged.
- The generic second pass in `applyEnvVariableOverrides` is untouched, so the existing duplicate-key guard for camelCase resource keys still holds.
- Test added in `pkg/setting/setting_unified_storage_test.go` covering `MIGRATION_CACHE_SIZE_KB`, `MIGRATION_PARQUET_BUFFER`, and `INDEX_WORKERS`.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.