### PR TITLE
Alerting:  Forward per-integration notification rate limits to remote AM 

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -403,7 +403,7 @@ available_encryption_providers =
 disable_gravatar = false
 
 # The base URL to use for fetching Gravatar profile images.
-gravatar_url = https://secure.gravatar.com/avatar 
+gravatar_url = https://secure.gravatar.com/avatar
 
 # data source proxy whitelist (ip_or_domain:port separated by spaces)
 data_source_proxy_whitelist =
@@ -1694,6 +1694,16 @@ rule_query_offset = 1m
 # This default is used when the X-Grafana-Alerting-Datasource-UID header is not provided.
 # If not set, the header becomes required.
 default_datasource_uid =
+
+[unified_alerting.notification_rate_limits]
+# Per-integration notification rate limits in notifications/sec.
+# Each key is an integration name, each value is the allowed rate.
+# A value of 0 (or negative) blocks all notifications for that integration; omit the key
+# to apply no override and fall through to the default limits.
+# Currently forwarded to the remote Alertmanager only; not yet applied to the built-in Alertmanager.
+# Example:
+# email = 0.5
+# slack = 2.0
 
 [recording_rules]
 # Enable recording rules.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2119,6 +2119,22 @@ Set the default data source UID to use for query execution when importing Promet
 
 <hr>
 
+### `[unified_alerting.notification_rate_limits]`
+
+Per-integration notification rate limits, in notifications per second. Each key is an integration name (for example `email`, `slack`) and the value is the maximum rate. A value of `0` (or negative) blocks all notifications for that integration; omit the integration entirely to apply no override and fall through to the default limits.
+
+These limits are forwarded to the remote Alertmanager via `RuntimeConfig`. They are not yet applied to the built-in Grafana Alertmanager.
+
+Example:
+
+```ini
+[unified_alerting.notification_rate_limits]
+email = 0.5
+slack = 2.0
+```
+
+<hr>
+
 ### `[annotations]`
 
 #### `cleanupjob_batchsize`

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -224,7 +224,8 @@ func (ng *AlertNG) init() error {
 			StaticHeaders:  ng.Cfg.Smtp.StaticHeaders,
 		}
 		runtimeConfig := remoteClient.RuntimeConfig{
-			DispatchTimer: notifier.GetDispatchTimer(ng.FeatureToggles).String(),
+			DispatchTimer:          notifier.GetDispatchTimer(ng.FeatureToggles).String(),
+			NotificationRateLimits: ng.Cfg.UnifiedAlerting.NotificationRateLimits,
 		}
 
 		cfg := remote.AlertmanagerConfig{

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -30,6 +30,10 @@ func (u *GrafanaAlertmanagerConfig) MarshalJSON() ([]byte, error) {
 
 type RuntimeConfig struct {
 	DispatchTimer string `json:"dispatch_timer"`
+	// NotificationRateLimits contains per-integration notification rate limits in notifications/sec.
+	// A value of 0 (or negative) blocks all notifications for that integration; omit the key
+	// to apply no override and fall through to the default limits.
+	NotificationRateLimits map[string]float64 `json:"notification_rate_limits,omitempty"`
 }
 
 type UserGrafanaConfig struct {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -155,6 +155,12 @@ type UnifiedAlertingSettings struct {
 	BacktestingMaxEvaluations int
 
 	IgnorePendingForNoDataAndError bool
+
+	// NotificationRateLimits contains per-integration notification rate limits in notifications/sec.
+	// A value of 0 (or negative) blocks all notifications for that integration; omit the key to
+	// apply no override and fall through to the default limits.
+	// Forwarded to the remote Alertmanager via RuntimeConfig. Not yet applied to the built-in Alertmanager.
+	NotificationRateLimits map[string]float64
 }
 
 type RecordingRuleSettings struct {
@@ -470,6 +476,19 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	}
 
 	uaCfg.RemoteAlertmanager = uaCfgRemoteAM
+
+	rateLimitsSection := iniFile.Section("unified_alerting.notification_rate_limits")
+	if keys := rateLimitsSection.Keys(); len(keys) > 0 {
+		limits := make(map[string]float64, len(keys))
+		for _, key := range keys {
+			v, err := key.Float64()
+			if err != nil {
+				return fmt.Errorf("invalid value for [unified_alerting.notification_rate_limits] %q: %w", key.Name(), err)
+			}
+			limits[key.Name()] = v
+		}
+		uaCfg.NotificationRateLimits = limits
+	}
 
 	screenshots := iniFile.Section("unified_alerting.screenshots")
 	uaCfgScreenshots := uaCfg.Screenshots


### PR DESCRIPTION
## Summary

- Adds a new `[unified_alerting.notification_rate_limits]` ini subsection where operators configure per-integration notification rate limits in notifications/second (e.g. `email = 0.5`, `slack = 2.0`).
- Values are forwarded to the remote Alertmanager via `RuntimeConfig.NotificationRateLimits`, which applies them as per-tenant overrides.

## Motivation

Enables per-plan notification throttling (driven by the remote Alertmanager) to prevent abuse of notification integrations while keeping alerting enabled.

## Behavior

- A value of `0` (or negative) blocks all notifications for that integration.
- Omitting a key applies no override and falls through to the default limits.
- Env overrides work as expected: `GF_UNIFIED_ALERTING_NOTIFICATION_RATE_LIMITS_EMAIL=0.5`.

## Scope / Deferred

- The setting lives on `UnifiedAlertingSettings` (not `RemoteAlertmanagerSettings`) so the built-in Grafana Alertmanager can consume the same config later without another move.
- Applying the override to the built-in Alertmanager is **not in this PR**. It requires extending the `Limits` interface in `github.com/grafana/alerting` with `NotificationRateLimit` / `NotificationBurstSize` and adding a rate-limiter stage to the built-in notify pipeline. Tracked as follow-up.