### PR TITLE
[release-13.0.1] Provisioning: List resources should return correct api version

### DIFF
--- a/pkg/apiserver/registry/generic/versioned_store.go
+++ b/pkg/apiserver/registry/generic/versioned_store.go
@@ -1,0 +1,48 @@
+package generic
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
+)
+
+// VersionedStore wraps a registry.Store and overrides List to re-stamp each
+// item's GroupVersionKind so it matches the API version being served. This is
+// needed when the same Go types are registered under multiple API versions.
+type VersionedStore struct {
+	*registry.Store
+	targetGV schema.GroupVersion
+}
+
+// NewVersionedStore creates a VersionedStore that re-stamps list items to
+// match targetGV. Use this when the underlying store may return items whose
+// GVK differs from the API version being served (shared-type multi-version
+// pattern).
+func NewVersionedStore(store *registry.Store, targetGV schema.GroupVersion) *VersionedStore {
+	return &VersionedStore{Store: store, targetGV: targetGV}
+}
+
+func (v *VersionedStore) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	obj, err := v.Store.List(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := meta.ExtractList(obj)
+	if err != nil {
+		return obj, nil
+	}
+
+	for _, item := range items {
+		gvk := item.GetObjectKind().GroupVersionKind()
+		if gvk.Group == v.targetGV.Group && gvk.Version != v.targetGV.Version {
+			item.GetObjectKind().SetGroupVersionKind(v.targetGV.WithKind(gvk.Kind))
+		}
+	}
+
+	return obj, nil
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -703,7 +703,6 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	}
 
 	repositoryStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, repositoryStorage)
-	b.repoStore = repositoryStorage
 	b.repoLister = repository.NewStorageLister(repositoryStorage)
 
 	// Create admission handler and register mutators/validators
@@ -756,13 +755,25 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 		return fmt.Errorf("failed to create connection storage: %w", err)
 	}
 	connectionStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, connectionsStore)
-	b.connectionStore = connectionsStore
 
-	storage[provisioning.JobResourceInfo.StoragePath()] = jobStore
-	storage[provisioning.RepositoryResourceInfo.StoragePath()] = repositoryStorage
+	// When serving a non-storage version (e.g. v1beta1), wrap the CRUD stores
+	// so that List re-stamps each item's apiVersion to match the served version.
+	// See grafanaregistry.VersionedStore for details on why this is necessary.
+	if b.gv.Version != provisioning.VERSION {
+		storage[provisioning.RepositoryResourceInfo.StoragePath()] = grafanaregistry.NewVersionedStore(repositoryStorage, b.gv)
+		storage[provisioning.ConnectionResourceInfo.StoragePath()] = grafanaregistry.NewVersionedStore(connectionsStore, b.gv)
+		storage[provisioning.JobResourceInfo.StoragePath()] = grafanaregistry.NewVersionedStore(jobStore, b.gv)
+		b.repoStore = grafanaregistry.NewVersionedStore(repositoryStorage, b.gv)
+		b.connectionStore = grafanaregistry.NewVersionedStore(connectionsStore, b.gv)
+	} else {
+		storage[provisioning.RepositoryResourceInfo.StoragePath()] = repositoryStorage
+		storage[provisioning.ConnectionResourceInfo.StoragePath()] = connectionsStore
+		storage[provisioning.JobResourceInfo.StoragePath()] = jobStore
+		b.repoStore = repositoryStorage
+		b.connectionStore = connectionsStore
+	}
 	storage[provisioning.RepositoryResourceInfo.StoragePath("status")] = repositoryStatusStorage
 
-	storage[provisioning.ConnectionResourceInfo.StoragePath()] = connectionsStore
 	storage[provisioning.ConnectionResourceInfo.StoragePath("status")] = connectionStatusStorage
 	storage[provisioning.ConnectionResourceInfo.StoragePath("repositories")] = NewConnectionRepositoriesConnector(b)
 

--- a/pkg/tests/apis/provisioning/apiversion/helper_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/helper_test.go
@@ -1,0 +1,17 @@
+package apiversion
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+var env = common.NewDefaultSharedEnv()
+
+func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
+	return common.SharedHelper(t, env)
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}

--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -1,0 +1,271 @@
+package apiversion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+const (
+	v0alpha1APIVersion = "provisioning.grafana.app/v0alpha1"
+	v1beta1APIVersion  = "provisioning.grafana.app/v1beta1"
+)
+
+func repositoryBody(name, apiVersion, provisioningPath string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       "Repository",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"title": "API Version Test - " + name,
+			"type":  "local",
+			"local": map[string]interface{}{
+				"path": provisioningPath,
+			},
+			"workflows": []string{"write"},
+			"sync": map[string]interface{}{
+				"enabled":         false,
+				"target":          "folder",
+				"intervalSeconds": 60,
+			},
+		},
+	}
+}
+
+func connectionBody(name, apiVersion string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       "Connection",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"title": "Version Test Connection - " + name,
+			"type":  "github",
+			"github": map[string]interface{}{
+				"appID":          "123456",
+				"installationID": "789012",
+			},
+		},
+		"secure": map[string]interface{}{
+			"privateKey": map[string]interface{}{
+				"create": common.TestGithubPrivateKeyBase64(),
+			},
+		},
+	}
+}
+
+// TestIntegrationVersionConsistency verifies that the provisioning API returns
+// the correct apiVersion in responses matching the endpoint version, regardless
+// of which version was used for creation. Covers GET, LIST, CREATE, UPDATE, and
+// DELETE across both Repository and Connection resources.
+func TestIntegrationVersionConsistency(t *testing.T) {
+	helper := sharedHelper(t)
+
+	type resourceDef struct {
+		resource string
+		body     func(name, apiVersion string) map[string]interface{}
+	}
+
+	resources := []resourceDef{
+		{
+			resource: "repositories",
+			body: func(name, apiVersion string) map[string]interface{} {
+				return repositoryBody(name, apiVersion, helper.ProvisioningPath)
+			},
+		},
+		{
+			resource: "connections",
+			body:     connectionBody,
+		},
+	}
+
+	versionCombos := []struct {
+		name            string
+		createVersion   string
+		queryVersion    string
+		expectedVersion string
+	}{
+		{"same v1beta1", "v1beta1", "v1beta1", v1beta1APIVersion},
+		{"same v0alpha1", "v0alpha1", "v0alpha1", v0alpha1APIVersion},
+		{"create v0alpha1 query v1beta1", "v0alpha1", "v1beta1", v1beta1APIVersion},
+		{"create v1beta1 query v0alpha1", "v1beta1", "v0alpha1", v0alpha1APIVersion},
+	}
+
+	t.Run("GET returns endpoint version", func(t *testing.T) {
+		for _, res := range resources {
+			t.Run(res.resource, func(t *testing.T) {
+				for i, tc := range versionCombos {
+					t.Run(tc.name, func(t *testing.T) {
+						name := fmt.Sprintf("ver-get-%s-%d", res.resource[:4], i)
+						body := res.body(name, "provisioning.grafana.app/"+tc.createVersion)
+						helper.RESTDo(t, "POST", tc.createVersion, res.resource, body)
+
+						obj := helper.RESTDo(t, "GET", tc.queryVersion, res.resource+"/"+name)
+						assert.Equal(t, tc.expectedVersion, obj["apiVersion"])
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("LIST returns endpoint version for list and all items", func(t *testing.T) {
+		for _, res := range resources {
+			t.Run(res.resource, func(t *testing.T) {
+				for _, version := range []string{"v0alpha1", "v1beta1"} {
+					t.Run(version, func(t *testing.T) {
+						expected := "provisioning.grafana.app/" + version
+						obj := helper.RESTDo(t, "GET", version, res.resource)
+						assert.Equal(t, expected, obj["apiVersion"])
+
+						items, _ := obj["items"].([]interface{})
+						require.GreaterOrEqual(t, len(items), 1, "list should contain at least one item")
+						for i, item := range items {
+							itemObj, ok := item.(map[string]interface{})
+							require.True(t, ok, "item %d should be a map", i)
+							assert.Equal(t, expected, itemObj["apiVersion"], "item %d", i)
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("CREATE response returns endpoint version", func(t *testing.T) {
+		for _, version := range []string{"v0alpha1", "v1beta1"} {
+			t.Run(version, func(t *testing.T) {
+				expected := "provisioning.grafana.app/" + version
+				name := "ver-create-" + version
+				body := repositoryBody(name, expected, helper.ProvisioningPath)
+				obj := helper.RESTDo(t, "POST", version, "repositories", body)
+				assert.Equal(t, expected, obj["apiVersion"])
+			})
+		}
+	})
+
+	t.Run("UPDATE response returns endpoint version", func(t *testing.T) {
+		for _, version := range []string{"v0alpha1", "v1beta1"} {
+			t.Run(version, func(t *testing.T) {
+				expected := "provisioning.grafana.app/" + version
+				name := "ver-update-" + version
+				body := repositoryBody(name, expected, helper.ProvisioningPath)
+				helper.RESTDo(t, "POST", version, "repositories", body)
+
+				current := helper.RESTDo(t, "GET", version, "repositories/"+name)
+				require.NoError(t, unstructured.SetNestedField(current, "Updated Title", "spec", "title"))
+
+				obj := helper.RESTDo(t, "PUT", version, "repositories/"+name, current)
+				assert.Equal(t, expected, obj["apiVersion"])
+			})
+		}
+	})
+
+	t.Run("DELETE response returns endpoint version", func(t *testing.T) {
+		for _, version := range []string{"v0alpha1", "v1beta1"} {
+			t.Run(version, func(t *testing.T) {
+				expected := "provisioning.grafana.app/" + version
+				name := "ver-delete-" + version
+				body := repositoryBody(name, expected, helper.ProvisioningPath)
+				helper.RESTDo(t, "POST", version, "repositories", body)
+
+				obj := helper.RESTDo(t, "DELETE", version, "repositories/"+name)
+				if kind, _ := obj["kind"].(string); kind == "Repository" {
+					assert.Equal(t, expected, obj["apiVersion"])
+				}
+			})
+		}
+	})
+}
+
+// TestIntegrationDynamicClientVersionConsistency verifies version consistency
+// when using the typed dynamic client (schema.GroupVersionResource with v1beta1).
+func TestIntegrationDynamicClientVersionConsistency(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+	repoClient := common.GetRepositoryClientV1Beta1(helper.K8sTestHelper)
+
+	t.Run("create and get", func(t *testing.T) {
+		repo := &unstructured.Unstructured{
+			Object: repositoryBody("dyn-v1beta1-repo", v1beta1APIVersion, helper.ProvisioningPath),
+		}
+
+		created, err := repoClient.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1APIVersion, created.GetAPIVersion())
+
+		fetched, err := repoClient.Resource.Get(ctx, "dyn-v1beta1-repo", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1APIVersion, fetched.GetAPIVersion())
+	})
+
+	t.Run("list", func(t *testing.T) {
+		list, err := repoClient.Resource.List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1APIVersion, list.GetAPIVersion())
+
+		for i, item := range list.Items {
+			assert.Equal(t, v1beta1APIVersion, item.GetAPIVersion(),
+				"item %d (%s)", i, item.GetName())
+		}
+	})
+}
+
+// TestIntegrationAPIGroupDiscoveryVersions checks that the provisioning API
+// group advertises both v0alpha1 and v1beta1, and that v1beta1 resource
+// endpoints exist with the expected resources.
+func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	t.Run("API group lists both versions", func(t *testing.T) {
+		result := helper.AdminREST.Get().AbsPath("/apis/provisioning.grafana.app").Do(ctx)
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var group metav1.APIGroup
+		require.NoError(t, json.Unmarshal(raw, &group))
+
+		versions := make(map[string]bool)
+		for _, v := range group.Versions {
+			versions[v.Version] = true
+		}
+		assert.True(t, versions["v0alpha1"], "v0alpha1 should be listed")
+		assert.True(t, versions["v1beta1"], "v1beta1 should be listed")
+	})
+
+	t.Run("v1beta1 resource list contains expected resources", func(t *testing.T) {
+		result := helper.AdminREST.Get().
+			AbsPath("/apis/provisioning.grafana.app/v1beta1").
+			Do(ctx)
+		require.NoError(t, result.Error())
+
+		raw, err := result.Raw()
+		require.NoError(t, err)
+
+		var resourceList metav1.APIResourceList
+		require.NoError(t, json.Unmarshal(raw, &resourceList))
+
+		assert.Equal(t, v1beta1APIVersion, resourceList.GroupVersion)
+
+		resourceNames := make(map[string]bool)
+		for _, r := range resourceList.APIResources {
+			resourceNames[r.Name] = true
+		}
+		assert.True(t, resourceNames["repositories"], "repositories should be in v1beta1")
+		assert.True(t, resourceNames["connections"], "connections should be in v1beta1")
+	})
+}

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -2795,3 +2795,70 @@ func SharedHelper(t *testing.T, env *SharedEnv) *ProvisioningTestHelper {
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
 	return helper
 }
+
+// RESTDo performs a REST request against the provisioning API and returns the>>>
+// response as an unstructured map. The subpath is appended to
+// /apis/provisioning.grafana.app/<version>/namespaces/<namespace>/.
+func (h *ProvisioningTestHelper) RESTDo(t *testing.T, method, version, subpath string, body ...map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	ns := h.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	absPath := fmt.Sprintf("/apis/provisioning.grafana.app/%s/namespaces/%s/%s", version, ns, subpath)
+
+	req := h.AdminREST.Verb(method).AbsPath(absPath)
+	if len(body) > 0 && body[0] != nil {
+		bodyBytes, err := json.Marshal(body[0])
+		require.NoError(t, err)
+		req = req.Body(bodyBytes).SetHeader("Content-Type", "application/json")
+	}
+
+	result := req.Do(context.Background())
+	require.NoError(t, result.Error())
+
+	raw, err := result.Raw()
+	require.NoError(t, err)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &obj))
+	return obj
+}
+
+// LabelPendingDelete is the label key written by the tenant watcher to mark
+// resources whose namespace is pending deletion.
+const LabelPendingDelete = "cloud.grafana.com/pending-delete"
+
+// SetPendingDeleteLabel adds the pending-delete label to the named resource.
+// It retries on 409 Conflict to handle concurrent status updates from the controller.
+func SetPendingDeleteLabel(t *testing.T, resource dynamic.ResourceInterface, name string) {
+	t.Helper()
+	err := RetryOnConflict(func() error {
+		obj, err := resource.Get(t.Context(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		labels := obj.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[LabelPendingDelete] = "true"
+		obj.SetLabels(labels)
+		_, err = resource.Update(t.Context(), obj, metav1.UpdateOptions{})
+		return err
+	})
+	require.NoError(t, err, "setting the pending-delete label on %q should be allowed", name)
+}
+
+// RetryOnConflict retries fn on 409 Conflict up to 5 times, returning the last
+// error (or nil on success).
+func RetryOnConflict(fn func() error) error {
+	var err error
+	for range 10 {
+		err = fn()
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+	}
+	return err
+}


### PR DESCRIPTION
Backport 78209194abd22e118bd4bf757f6150691326fb86 from #122653

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As a result of using a go type alias for two different API versions (v0alpha1 and v1beta1), k8s machinery is not able to return the correct version on LIST operations (it work wells for individual item operations, though). The result is that the list itself is properly versioned, but the objects in the list pick the first version registered for the shared go type:

```
{
  "kind": "RepositoryList",
  "apiVersion": "provisioning.grafana.app/v1beta1",
  "metadata": {
    "resourceVersion": "1776155089026743"
  },
  "items": [
    {
      "kind": "Repository",
      "apiVersion": "provisioning.grafana.app/v0alpha1", <--------
      "metadata": {
```

This PR aims to create a wrapper over the list operation that corrects that. It's been tested that the solution works:

```
{
  "kind": "RepositoryList",
  "apiVersion": "provisioning.grafana.app/v1beta1",
  "metadata": {
    "resourceVersion": "1776240441839983"
  },
  "items": [
    {
      "kind": "Repository",
      "apiVersion": "provisioning.grafana.app/v1beta1", <----------
      "metadata": {
```

**Why do we need this feature?**

Without it, the LIST APIs for provisioning v1beta1 return an incorrect api version. This can break clients expectations and prevent them from working with the updated API.

**Who is this feature for?**

Anyone using v1beta1 provisioning apis.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/1034

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
