### PR TITLE
[release-13.0.2] Provisioning: folder move should work even on quota

### DIFF
--- a/apps/provisioning/pkg/quotas/mock_quota_tracker.go
+++ b/apps/provisioning/pkg/quotas/mock_quota_tracker.go
@@ -17,6 +17,39 @@ func (_m *MockQuotaTracker) EXPECT() *MockQuotaTracker_Expecter {
 	return &MockQuotaTracker_Expecter{mock: &_m.Mock}
 }
 
+// AllowOverLimit provides a mock function with given fields: n
+func (_m *MockQuotaTracker) AllowOverLimit(n int) {
+	_m.Called(n)
+}
+
+// MockQuotaTracker_AllowOverLimit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllowOverLimit'
+type MockQuotaTracker_AllowOverLimit_Call struct {
+	*mock.Call
+}
+
+// AllowOverLimit is a helper method to define mock.On call
+//   - n int
+func (_e *MockQuotaTracker_Expecter) AllowOverLimit(n interface{}) *MockQuotaTracker_AllowOverLimit_Call {
+	return &MockQuotaTracker_AllowOverLimit_Call{Call: _e.mock.On("AllowOverLimit", n)}
+}
+
+func (_c *MockQuotaTracker_AllowOverLimit_Call) Run(run func(n int)) *MockQuotaTracker_AllowOverLimit_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int))
+	})
+	return _c
+}
+
+func (_c *MockQuotaTracker_AllowOverLimit_Call) Return() *MockQuotaTracker_AllowOverLimit_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockQuotaTracker_AllowOverLimit_Call) RunAndReturn(run func(int)) *MockQuotaTracker_AllowOverLimit_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Release provides a mock function with no fields
 func (_m *MockQuotaTracker) Release() {
 	_m.Called()

--- a/apps/provisioning/pkg/quotas/tracker.go
+++ b/apps/provisioning/pkg/quotas/tracker.go
@@ -10,13 +10,19 @@ type QuotaTracker interface {
 	TryAcquire() bool
 	// Release decrements the resource counter, e.g. after a successful deletion.
 	Release()
+	// AllowOverLimit raises the quota limit by n for the remaining lifetime of
+	// the tracker. This is useful for situations where counting may be inaccurate.
+	AllowOverLimit(n int)
 }
 
 // inMemoryQuotaTracker provides best-effort, in-memory quota enforcement.
 type inMemoryQuotaTracker struct {
+	// limit is immutable after construction
+	limit int64 // 0 means unlimited
+
 	mu      sync.Mutex
 	current int64
-	limit   int64 // 0 means unlimited
+	extra   int64 // additional allowance on top of limit; guarded by mu
 }
 
 // NewInMemoryQuotaTracker creates a new in-memory QuotaTracker.
@@ -35,7 +41,7 @@ func (q *inMemoryQuotaTracker) TryAcquire() bool {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.current >= q.limit {
+	if q.current >= q.limit+q.extra {
 		return false
 	}
 	q.current++
@@ -51,4 +57,13 @@ func (q *inMemoryQuotaTracker) Release() {
 	if q.current > 0 {
 		q.current--
 	}
+}
+
+func (q *inMemoryQuotaTracker) AllowOverLimit(n int) {
+	if q.limit == 0 || n <= 0 {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.extra += int64(n)
 }

--- a/apps/provisioning/pkg/quotas/tracker_test.go
+++ b/apps/provisioning/pkg/quotas/tracker_test.go
@@ -134,6 +134,38 @@ func TestQuotaTracker_ConcurrentAccess(t *testing.T) {
 	assert.Equal(t, int(limit), successCount)
 }
 
+func TestQuotaTracker_AllowOverLimit(t *testing.T) {
+	tracker := NewInMemoryQuotaTracker(10, 10)
+
+	// At limit, acquire should fail
+	require.False(t, tracker.TryAcquire())
+
+	// Raise the limit by 2
+	tracker.AllowOverLimit(2)
+
+	// Now two acquires should succeed
+	require.True(t, tracker.TryAcquire())  // 10 -> 11 (limit is now 12)
+	require.True(t, tracker.TryAcquire())  // 11 -> 12
+	require.False(t, tracker.TryAcquire()) // 12 >= 12, rejected
+}
+
+func TestQuotaTracker_AllowOverLimitUnlimited(t *testing.T) {
+	tracker := NewInMemoryQuotaTracker(0, 0)
+
+	// AllowOverLimit on unlimited tracker should not panic or change behavior
+	tracker.AllowOverLimit(5)
+	require.True(t, tracker.TryAcquire())
+}
+
+func TestQuotaTracker_AllowOverLimitZeroOrNegative(t *testing.T) {
+	tracker := NewInMemoryQuotaTracker(10, 10)
+
+	// Zero and negative values should be no-ops
+	tracker.AllowOverLimit(0)
+	tracker.AllowOverLimit(-1)
+	require.False(t, tracker.TryAcquire())
+}
+
 func TestQuotaTracker_ConcurrentAcquireAndRelease(t *testing.T) {
 	tracker := NewInMemoryQuotaTracker(50, 50)
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -489,8 +489,7 @@ func cleanupRenamedFolders(
 
 			resultBuilder := jobs.NewFolderResult(old.Path).
 				WithAction(repository.FileActionDeleted).
-				WithName(old.UID).
-				WithReason(old.Reason)
+				WithName(old.UID)
 			if err := repositoryResources.RemoveFolder(ctx, old.UID); err != nil {
 				resultBuilder.WithError(fmt.Errorf("delete old folder %s after UID change: %w", old.UID, err))
 			}

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
@@ -330,92 +331,128 @@ func applyChanges(
 	)
 	defer applyChangesSpan.End()
 
-	// Separate changes into categories for proper ordering:
-	// 1. File deletions (free up folder contents early, must happen before folder deletions)
-	// 2. Folder creations (destination folders must exist before renames/creates)
-	// 3. File renames (after destination folders exist, before old folders are deleted)
-	// 4. Folder deletions (old folders are now empty)
-	// 5. File creations/updates (must happen after folder creations)
-	// 6. Old folder deletions (must happen after all children have been re-parented)
-	var fileDeletions []ResourceFileChange
-	var folderCreations []ResourceFileChange
-	var fileRenames []ResourceFileChange
-	var folderDeletions []ResourceFileChange
-	var fileCreations []ResourceFileChange
+	buckets := categorizeChanges(changes)
 
+	// Folder renames (FolderRenamed) are net-zero: each creates a new folder
+	// and deletes the old one in the cleanup phase. Temporarily raise the
+	// quota limit so the creations succeed before the deletions free the slots.
+	if buckets.folderRenames > 0 {
+		quotaTracker.AllowOverLimit(buckets.folderRenames)
+	}
+
+	applyChangesSpan.SetAttributes(
+		attribute.Int("file_renames", len(buckets.fileRenames)),
+		attribute.Int("file_deletions", len(buckets.fileDeletions)),
+		attribute.Int("folder_deletions", len(buckets.folderDeletions)),
+		attribute.Int("folder_creations", len(buckets.folderCreations)),
+		attribute.Int("file_creations", len(buckets.fileCreations)),
+	)
+
+	if len(buckets.fileDeletions) > 0 {
+		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileDeletions, func() error {
+			return applyResourcesInParallel(ctx, buckets.fileDeletions, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
+		}, metrics); err != nil {
+			return err
+		}
+	}
+
+	if len(buckets.folderCreations) > 0 {
+		// Process folder creations/updates shallowest-first so that parent folders are set up (and their old tree entries removed)
+		// before children are walked to ensure consistency in moves and renames.
+		safepath.SortByDepth(buckets.folderCreations, func(c ResourceFileChange) string { return c.Path }, true)
+		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderCreations, func() error {
+			return applyFoldersSerially(ctx, buckets.folderCreations, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
+		}, metrics); err != nil {
+			return err
+		}
+	}
+
+	if len(buckets.fileRenames) > 0 {
+		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileRenames, func() error {
+			return applyResourcesInParallel(ctx, buckets.fileRenames, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
+		}, metrics); err != nil {
+			return err
+		}
+	}
+
+	if len(buckets.folderDeletions) > 0 {
+		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderDeletions, func() error {
+			return applyFoldersSerially(ctx, buckets.folderDeletions, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
+		}, metrics); err != nil {
+			return err
+		}
+	}
+
+	if len(buckets.fileCreations) > 0 {
+		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileCreations, func() error {
+			return applyResourcesInParallel(ctx, buckets.fileCreations, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
+		}, metrics); err != nil {
+			return err
+		}
+	}
+
+	return cleanupRenamedFolders(ctx, buckets.folderCreations, repositoryResources, progress, tracer, metrics)
+}
+
+// changeBuckets groups resource changes by the phase in which they must be applied.
+type changeBuckets struct {
+	fileDeletions   []ResourceFileChange
+	folderCreations []ResourceFileChange
+	fileRenames     []ResourceFileChange
+	folderDeletions []ResourceFileChange
+	fileCreations   []ResourceFileChange
+	folderRenames   int
+}
+
+// categorizeChanges separates changes into ordered phases:
+// 1. File deletions (free up folder contents early, must happen before folder deletions)
+// 2. Folder creations (destination folders must exist before renames/creates)
+// 3. File renames (after destination folders exist, before old folders are deleted)
+// 4. Folder deletions (old folders are now empty)
+// 5. File creations/updates (must happen after folder creations)
+// 6. Old folder deletions (must happen after all children have been re-parented)
+// It also counts folder renames so callers can temporarily lift the quota for the
+// creation phase (the matching deletions happen later in the old-folder cleanup).
+func categorizeChanges(changes []ResourceFileChange) changeBuckets {
+	var buckets changeBuckets
 	for _, change := range changes {
 		isFolder := safepath.IsDir(change.Path)
 
 		switch {
 		case change.Action == repository.FileActionRenamed && !isFolder:
-			fileRenames = append(fileRenames, change)
+			buckets.fileRenames = append(buckets.fileRenames, change)
 		case change.Action == repository.FileActionDeleted && !isFolder:
-			fileDeletions = append(fileDeletions, change)
+			buckets.fileDeletions = append(buckets.fileDeletions, change)
 		case change.Action == repository.FileActionDeleted && isFolder:
-			folderDeletions = append(folderDeletions, change)
+			buckets.folderDeletions = append(buckets.folderDeletions, change)
 		case isFolder:
-			folderCreations = append(folderCreations, change)
+			buckets.folderCreations = append(buckets.folderCreations, change)
+			if change.FolderRenamed {
+				buckets.folderRenames++
+			}
 		default:
-			fileCreations = append(fileCreations, change)
+			buckets.fileCreations = append(buckets.fileCreations, change)
 		}
 	}
+	return buckets
+}
 
-	applyChangesSpan.SetAttributes(
-		attribute.Int("file_renames", len(fileRenames)),
-		attribute.Int("file_deletions", len(fileDeletions)),
-		attribute.Int("folder_deletions", len(folderDeletions)),
-		attribute.Int("folder_creations", len(folderCreations)),
-		attribute.Int("file_creations", len(fileCreations)),
-	)
-
-	if len(fileDeletions) > 0 {
-		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileDeletions, func() error {
-			return applyResourcesInParallel(ctx, fileDeletions, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
-		}, metrics); err != nil {
-			return err
-		}
-	}
-
-	if len(folderCreations) > 0 {
-		// Process folder creations/updates shallowest-first so that parent folders are set up (and their old tree entries removed)
-		// before children are walked to ensure consistency in moves and renames.
-		safepath.SortByDepth(folderCreations, func(c ResourceFileChange) string { return c.Path }, true)
-		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderCreations, func() error {
-			return applyFoldersSerially(ctx, folderCreations, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
-		}, metrics); err != nil {
-			return err
-		}
-	}
-
-	if len(fileRenames) > 0 {
-		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileRenames, func() error {
-			return applyResourcesInParallel(ctx, fileRenames, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
-		}, metrics); err != nil {
-			return err
-		}
-	}
-
-	if len(folderDeletions) > 0 {
-		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFolderDeletions, func() error {
-			return applyFoldersSerially(ctx, folderDeletions, clients, currentRef, repositoryResources, progress, tracer, quotaTracker, folderMetadataEnabled)
-		}, metrics); err != nil {
-			return err
-		}
-	}
-
-	if len(fileCreations) > 0 {
-		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseFileCreations, func() error {
-			return applyResourcesInParallel(ctx, fileCreations, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, quotaTracker, folderMetadataEnabled)
-		}, metrics); err != nil {
-			return err
-		}
-	}
-
-	// Collect and delete old folders after all children have been re-parented.
+// cleanupRenamedFolders deletes the original folders left behind after a UID
+// change. It runs once all children have been re-parented so that the old
+// folder tree is empty and safe to remove.
+func cleanupRenamedFolders(
+	ctx context.Context,
+	folderCreations []ResourceFileChange,
+	repositoryResources resources.RepositoryResources,
+	progress jobs.JobProgressRecorder,
+	tracer tracing.Tracer,
+	metrics jobs.JobMetrics,
+) error {
 	type oldFolder struct {
 		Path string
 		UID  string
 	}
+
 	var oldFolders []oldFolder
 	for _, change := range folderCreations {
 		if change.FolderRenamed {
@@ -423,44 +460,44 @@ func applyChanges(
 		}
 	}
 
-	if len(oldFolders) > 0 {
-		if err := instrumentedFullSyncPhase(jobs.FullSyncPhaseOldFolderCleanup, func() error {
-			safepath.SortByDepth(oldFolders, func(f oldFolder) string { return f.Path }, false)
-			for _, old := range oldFolders {
-				if ctx.Err() != nil {
-					break
-				}
-
-				if err := progress.TooManyErrors(); err != nil {
-					return err
-				}
-
-				// Skip if the replacement folder failed to be created or updated (e.g. UID conflict warning).
-				if progress.HasDirPathFailedCreation(old.Path) || progress.HasChildPathFailedUpdate(old.Path) {
-					skipCtx, skipSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.skip_renamed_folder_deletion")
-					progress.Record(skipCtx, jobs.NewPathOnlyResult(old.Path).
-						WithError(fmt.Errorf("old folder was not deleted because the replacement folder could not be created")).
-						AsSkipped().
-						Build())
-					skipSpan.End()
-					continue
-				}
-
-				resultBuilder := jobs.NewFolderResult(old.Path).
-					WithAction(repository.FileActionDeleted).
-					WithName(old.UID)
-				if err := repositoryResources.RemoveFolder(ctx, old.UID); err != nil {
-					resultBuilder.WithError(fmt.Errorf("delete old folder %s after UID change: %w", old.UID, err))
-				}
-				progress.Record(ctx, resultBuilder.Build())
-			}
-			return nil
-		}, metrics); err != nil {
-			return err
-		}
+	if len(oldFolders) == 0 {
+		return nil
 	}
 
-	return nil
+	logging.FromContext(ctx).Info("folder rename cleanup", "count", len(oldFolders))
+	return instrumentedFullSyncPhase(jobs.FullSyncPhaseOldFolderCleanup, func() error {
+		safepath.SortByDepth(oldFolders, func(f oldFolder) string { return f.Path }, false)
+		for _, old := range oldFolders {
+			if ctx.Err() != nil {
+				break
+			}
+
+			if err := progress.TooManyErrors(); err != nil {
+				return err
+			}
+
+			// Skip if the replacement folder failed to be created or updated (e.g. UID conflict warning).
+			if progress.HasDirPathFailedCreation(old.Path) || progress.HasChildPathFailedUpdate(old.Path) {
+				skipCtx, skipSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes.skip_renamed_folder_deletion")
+				progress.Record(skipCtx, jobs.NewPathOnlyResult(old.Path).
+					WithError(fmt.Errorf("old folder was not deleted because the replacement folder could not be created")).
+					AsSkipped().
+					Build())
+				skipSpan.End()
+				continue
+			}
+
+			resultBuilder := jobs.NewFolderResult(old.Path).
+				WithAction(repository.FileActionDeleted).
+				WithName(old.UID).
+				WithReason(old.Reason)
+			if err := repositoryResources.RemoveFolder(ctx, old.UID); err != nil {
+				resultBuilder.WithError(fmt.Errorf("delete old folder %s after UID change: %w", old.UID, err))
+			}
+			progress.Record(ctx, resultBuilder.Build())
+		}
+		return nil
+	}, metrics)
 }
 
 // applyFoldersSerially processes folder changes one by one.

--- a/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_hierarchical_test.go
@@ -418,6 +418,7 @@ func TestFullSync_HierarchicalErrorHandling(t *testing.T) { // nolint:gocyclo
 			quotaTracker := quotas.NewMockQuotaTracker(t)
 			quotaTracker.EXPECT().TryAcquire().Return(true).Maybe()
 			quotaTracker.EXPECT().Release().Maybe()
+			quotaTracker.EXPECT().AllowOverLimit(mock.Anything).Maybe()
 
 			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()), quotaTracker, false)
 

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental.go
@@ -81,6 +81,13 @@ func IncrementalSync(ctx context.Context, repo repository.Versioned, previousRef
 		repositoryResources.SetTree(tree)
 	}
 
+	// Temporarily raise the quota limit for net-zero folder replacements so
+	// TryAcquire succeeds when creating the new folder before the old one is
+	// deleted in the cleanup phase.
+	if len(replaced) > 0 {
+		quotaTracker.AllowOverLimit(len(replaced))
+	}
+
 	progress.SetTotal(ctx, len(diff))
 	progress.SetMessage(ctx, "replicating versioned changes")
 	applyStart := time.Now()

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -25,6 +25,7 @@ func newPermissiveMockQuotaTracker(t *testing.T) quotas.QuotaTracker {
 	qt := quotas.NewMockQuotaTracker(t)
 	qt.On("TryAcquire").Return(true).Maybe()
 	qt.On("Release").Maybe()
+	qt.On("AllowOverLimit", mock.Anything).Maybe()
 	return qt
 }
 

--- a/pkg/tests/apis/provisioning/quota/foldermetadata/helpers_test.go
+++ b/pkg/tests/apis/provisioning/quota/foldermetadata/helpers_test.go
@@ -1,0 +1,58 @@
+package foldermetadata
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// Folder metadata is enabled by default — we intentionally omit
+// common.WithoutProvisioningFolderMetadata so that _folder.json files
+// are honoured during sync.
+var env = common.NewSharedGitEnv()
+
+func sharedGitHelper(t *testing.T) *common.GitTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.SetQuotaStatus(provisioning.QuotaStatus{})
+	return helper
+}
+
+func sharedGitHelperWithQuota(t *testing.T, maxResources int64) *common.GitTestHelper {
+	t.Helper()
+	helper := env.GetCleanHelper(t)
+	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: maxResources})
+	return helper
+}
+
+func TestMain(m *testing.M) {
+	env.RunTestMain(m)
+}
+
+func folderMetadataJSON(uid, title string) []byte {
+	folder := map[string]any{
+		"apiVersion": "folder.grafana.app/v1",
+		"kind":       "Folder",
+		"metadata": map[string]any{
+			"name": uid,
+		},
+		"spec": map[string]any{
+			"title": title,
+		},
+	}
+	data, _ := json.MarshalIndent(folder, "", "\t")
+	return data
+}
+
+func requireFolderNotExists(t *testing.T, helper *common.GitTestHelper, folderUID string) {
+	t.Helper()
+	_, err := helper.Folders.Resource.Get(context.Background(), folderUID, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "folder %s should not exist, got: %v", folderUID, err)
+}

--- a/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
+++ b/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
@@ -1,0 +1,207 @@
+package foldermetadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
+	t.Run("full sync: folder UID change via _folder.json succeeds at quota limit", func(t *testing.T) {
+		// Quota allows exactly the resources that exist after initial sync.
+		// Changing the folder UID in _folder.json is a replacement (create new +
+		// delete old) that should be net-zero and succeed even at the limit.
+		ctx := context.Background()
+		helper := sharedGitHelperWithQuota(t, 3)
+
+		const repo = "quota-meta-uid-change"
+		_, local := helper.CreateFolderTargetGitRepo(t, repo, map[string][]byte{
+			"subfolder/_folder.json":   folderMetadataJSON("original-uid", "My Folder"),
+			"subfolder/dashboard.json": common.DashboardJSON("dash-uid-change-001", "Dashboard One", 1),
+		})
+
+		// Full sync: root folder + subfolder (original-uid) + dashboard = 3 resources.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
+
+		common.RequireFolderState(t, helper.Folders, "original-uid", "My Folder", "subfolder", repo)
+
+		// Change the UID in _folder.json — this triggers a folder replacement.
+		require.NoError(t, local.UpdateFile("subfolder/_folder.json", string(folderMetadataJSON("new-uid", "My Folder"))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "change folder UID")
+		require.NoError(t, err)
+		_, err = local.Git("push", "origin", "main")
+		require.NoError(t, err)
+
+		// A full sync should replace the folder (delete old, create new) — net zero.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+
+		// The new folder should exist and the old one should be gone.
+		common.RequireFolderState(t, helper.Folders, "new-uid", "My Folder", "subfolder", repo)
+		requireFolderNotExists(t, helper, "original-uid")
+
+		// Resource counts unchanged: root folder + subfolder (new-uid) + dashboard = 3.
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
+	})
+
+	t.Run("full sync: folder UID change is blocked when repo is over quota", func(t *testing.T) {
+		// When the repo is already over quota the pre-sync check blocks any
+		// sync whose net change does not bring the repo back within limits.
+		// A folder UID change (FileActionUpdated, net 0) does not reduce the
+		// count, so the sync is expected to be blocked.
+		ctx := context.Background()
+		helper := sharedGitHelper(t)
+
+		const repo = "quota-meta-uid-over"
+		_, local := helper.CreateFolderTargetGitRepo(t, repo, map[string][]byte{
+			"subfolder/_folder.json":   folderMetadataJSON("stable-uid", "My Folder"),
+			"subfolder/dashboard.json": common.DashboardJSON("dash-over-001", "Dashboard One", 1),
+		})
+
+		// Full sync without quota: root + subfolder + dashboard = 3 resources.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+
+		// Lower the quota below the current count to put the repo over limit.
+		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
+		helper.TriggerRepositoryReconciliation(t, repo)
+		helper.WaitForResourceQuotaLimit(t, repo, 2)
+
+		// Sync once so the "quota exceeded" condition is recorded.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
+
+		// Change the UID in _folder.json while over quota.
+		require.NoError(t, local.UpdateFile("subfolder/_folder.json", string(folderMetadataJSON("replacement-uid", "My Folder"))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "change folder UID while over quota")
+		require.NoError(t, err)
+		_, err = local.Git("push", "origin", "main")
+		require.NoError(t, err)
+
+		// The sync should be blocked by the pre-sync quota check.
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+			"sync should be blocked because the repo is over quota")
+		require.Contains(t, jobObj.Status.Message, "sync skipped",
+			"job message should indicate the sync was skipped due to quota")
+
+		// The original folder should remain unchanged.
+		common.RequireFolderState(t, helper.Folders, "stable-uid", "My Folder", "subfolder", repo)
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+	})
+
+	t.Run("full sync: invalid _folder.json falls back to hash UID under quota pressure", func(t *testing.T) {
+		// When _folder.json is malformed the folder reverts to hash-based
+		// identity. If that UID differs from the stable one a replacement
+		// occurs. At the quota limit this exercises the same create-before-
+		// delete path as a normal UID change.
+		ctx := context.Background()
+		helper := sharedGitHelperWithQuota(t, 3)
+
+		const repo = "quota-meta-invalid"
+		_, local := helper.CreateFolderTargetGitRepo(t, repo, map[string][]byte{
+			"subfolder/_folder.json":   folderMetadataJSON("valid-uid", "My Folder"),
+			"subfolder/dashboard.json": common.DashboardJSON("dash-invalid-001", "Dashboard One", 1),
+		})
+
+		// Full sync: root + subfolder (valid-uid) + dashboard = 3 resources.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
+
+		common.RequireFolderState(t, helper.Folders, "valid-uid", "My Folder", "subfolder", repo)
+
+		// Corrupt _folder.json so it's no longer valid metadata.
+		require.NoError(t, local.UpdateFile("subfolder/_folder.json", "this is not JSON"))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "corrupt folder metadata")
+		require.NoError(t, err)
+		_, err = local.Git("push", "origin", "main")
+		require.NoError(t, err)
+
+		// Full sync: the folder should fall back to hash-based identity.
+		// This may produce warnings about invalid metadata but should not error.
+		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+			Action: provisioning.JobActionPull,
+			Pull:   &provisioning.SyncJobOptions{},
+		})
+		jobObj := &provisioning.Job{}
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+		t.Logf("Job state: %s", jobObj.Status.State)
+		t.Logf("Job message: %s", jobObj.Status.Message)
+		t.Logf("Job warnings: %v", jobObj.Status.Warnings)
+		t.Logf("Job errors: %v", jobObj.Status.Errors)
+
+		require.Empty(t, jobObj.Status.Errors, "invalid metadata should not cause errors")
+
+		// The dashboard should still exist regardless of folder UID changes.
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+	})
+
+	t.Run("incremental sync: folder UID change via _folder.json succeeds at quota limit", func(t *testing.T) {
+		// Same scenario as the full-sync test but via incremental sync.
+		// The replacement folders are processed by deleteFolders() after
+		// applyIncrementalChanges(), so quota must be released in time.
+		ctx := context.Background()
+		helper := sharedGitHelperWithQuota(t, 3)
+
+		const repo = "quota-meta-incr-uid"
+		_, local := helper.CreateFolderTargetGitRepo(t, repo, map[string][]byte{
+			"subfolder/_folder.json":   folderMetadataJSON("incr-original-uid", "My Folder"),
+			"subfolder/dashboard.json": common.DashboardJSON("dash-incr-001", "Dashboard One", 1),
+		})
+
+		// Full sync first to establish baseline.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
+
+		common.RequireFolderState(t, helper.Folders, "incr-original-uid", "My Folder", "subfolder", repo)
+
+		// Change the UID in _folder.json.
+		require.NoError(t, local.UpdateFile("subfolder/_folder.json", string(folderMetadataJSON("incr-new-uid", "My Folder"))))
+		_, err := local.Git("add", ".")
+		require.NoError(t, err)
+		_, err = local.Git("commit", "-m", "change folder UID incrementally")
+		require.NoError(t, err)
+		_, err = local.Git("push", "origin", "main")
+		require.NoError(t, err)
+
+		// Incremental sync should handle the replacement.
+		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
+
+		// The new folder should exist and the old one should be gone.
+		common.RequireFolderState(t, helper.Folders, "incr-new-uid", "My Folder", "subfolder", repo)
+		requireFolderNotExists(t, helper, "incr-original-uid")
+
+		// Resource counts unchanged.
+		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
+	})
+}

--- a/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
+++ b/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
@@ -26,7 +26,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		})
 
 		// Full sync: root folder + subfolder (original-uid) + dashboard = 3 resources.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -43,7 +43,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		// A full sync should replace the folder (delete old, create new) — net zero.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 
 		// The new folder should exist and the old one should be gone.
 		common.RequireFolderState(t, helper.Folders, "new-uid", "My Folder", "subfolder", repo)
@@ -70,7 +70,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		})
 
 		// Full sync without quota: root + subfolder + dashboard = 3 resources.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
 
@@ -80,7 +80,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		helper.WaitForResourceQuotaLimit(t, repo, 2)
 
 		// Sync once so the "quota exceeded" condition is recorded.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaExceeded)
 
 		// Change the UID in _folder.json while over quota.
@@ -125,7 +125,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		})
 
 		// Full sync: root + subfolder (valid-uid) + dashboard = 3 resources.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -176,7 +176,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		})
 
 		// Full sync first to establish baseline.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
+		common.SyncAndWaitWithSuccess(t, helper, repo)
 		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
 		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -193,7 +193,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		// Incremental sync should handle the replacement.
-		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
+		common.SyncAndWaitSuccessfulIncremental(t, helper, repo)
 
 		// The new folder should exist and the old one should be gone.
 		common.RequireFolderState(t, helper.Folders, "incr-new-uid", "My Folder", "subfolder", repo)


### PR DESCRIPTION
Backport d81e3c782e5856a2664aaf0caf74c1d81194b909 from #122832

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Folder moves creates a folder before deleting the old one. Before this PR, this could cause quota tracking to block it if reaching the limit. This PR relax quota tracking so folder moves can happen without consuming quota. There is a chance that other resources spend the extra quota before the folder move in incremental (due to the operation order) but the end result is going to be the same as the quota reconciles with reality after the sync.

**Why do we need this feature?**

Without it, a folder move may be block when reaching the quota, which is not the expected behavior (folder move may temporarily create an extra folder, but that's temporal as a folder delete would follow the creation).

**Who is this feature for?**

Provisioning customers.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/git-ui-sync-project/issues/1019

**Special notes for your reviewer:**

Please check that:
- [ x] It works as expected from a user's perspective.
- [ x] If this is a pre-GA feature, it is behind a feature toggle.
- [ x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
