### PR TITLE
I18n: Revert "Skip loading en-US translations at runtime in plugins"

### DIFF
--- a/packages/grafana-i18n/src/i18n.test.tsx
+++ b/packages/grafana-i18n/src/i18n.test.tsx
@@ -25,63 +25,39 @@ describe('i18n', () => {
   describe('loadNamespacedResources', () => {
     it('should load all resources for a plugin', async () => {
       const loaders: ResourceLoader[] = [
-        () => Promise.resolve({ hello: 'Bonjour' }),
+        () => Promise.resolve({ hello: 'Hi' }),
         () => Promise.resolve({ i18n: 'i18n' }),
       ];
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
 
-      await loadNamespacedResources('test', 'fr-FR', loaders);
+      await loadNamespacedResources('test', 'en-US', loaders);
 
       expect(addResourceBundleSpy).toHaveBeenCalledTimes(2);
-      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(1, 'fr-FR', 'test', { hello: 'Bonjour' }, true, false);
-      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'fr-FR', 'test', { i18n: 'i18n' }, true, false);
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(1, 'en-US', 'test', { hello: 'Hi' }, true, false);
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'en-US', 'test', { i18n: 'i18n' }, true, false);
     });
 
-    it('should load all resources for a plugin even if a loader throws', async () => {
+    it('should load all resources  for a plugin even if a loader throws', async () => {
       const loaders: ResourceLoader[] = [
-        () => Promise.reject({ hello: 'Bonjour' }),
+        () => Promise.reject({ hello: 'Hi' }),
         () => Promise.resolve({ i18n: 'i18n' }),
       ];
       jest.spyOn(console, 'error').mockImplementation();
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
 
-      await loadNamespacedResources('test', 'fr-FR', loaders);
+      await loadNamespacedResources('test', 'en-US', loaders);
 
       expect(addResourceBundleSpy).toHaveBeenCalledTimes(1);
-      expect(addResourceBundleSpy).toHaveBeenCalledWith('fr-FR', 'test', { i18n: 'i18n' }, true, false);
+      expect(addResourceBundleSpy).toHaveBeenCalledWith('en-US', 'test', { i18n: 'i18n' }, true, false);
     });
 
     it('should not load resources if no loaders are provided', async () => {
       const loaders: ResourceLoader[] = [];
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
 
-      await loadNamespacedResources('test', 'fr-FR', loaders);
-
-      expect(addResourceBundleSpy).toHaveBeenCalledTimes(0);
-    });
-
-    it('should load resources for pseudo locale', async () => {
-      const loaders: ResourceLoader[] = [jest.fn(() => Promise.resolve({ hello: 'Hi' }))];
-      const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
-
-      await loadNamespacedResources('test', 'pseudo', loaders);
-
-      expect(loaders[0]).toHaveBeenCalled();
-      expect(addResourceBundleSpy).toHaveBeenCalledWith('en-US', 'test', { hello: 'Hi' }, true, false);
-    });
-
-    it('should not load resources for the default language', async () => {
-      const loaders: ResourceLoader[] = [
-        jest.fn(() => Promise.resolve({ hello: 'Hi' })),
-        jest.fn(() => Promise.resolve({ i18n: 'i18n' })),
-      ];
-      const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
-
       await loadNamespacedResources('test', 'en-US', loaders);
 
-      expect(loaders[0]).not.toHaveBeenCalled();
-      expect(loaders[1]).not.toHaveBeenCalled();
-      expect(addResourceBundleSpy).not.toHaveBeenCalled();
+      expect(addResourceBundleSpy).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -139,41 +115,39 @@ describe('i18n', () => {
   describe('initPluginTranslations', () => {
     it('should not initialize the i18n instance and the react i18n instance if they are already initialized', async () => {
       const loaders: ResourceLoader[] = [
-        () => Promise.resolve({ hello: 'Bonjour' }),
+        () => Promise.resolve({ hello: 'Hi' }),
         () => Promise.resolve({ i18n: 'i18n' }),
       ];
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
       const useSpy = jest.spyOn(i18n, 'use').mockImplementation();
       const initSpy = jest.spyOn(i18n, 'init').mockImplementation();
       jest.replaceProperty(i18n, 'options', { react: {}, resources: {} });
-      jest.replaceProperty(i18n, 'resolvedLanguage', 'fr-FR');
 
       const { language } = await initPluginTranslations('test', loaders);
 
-      expect(language).toBe('fr-FR');
+      expect(language).toBe('en-US');
       expect(useSpy).not.toHaveBeenCalled();
       expect(initSpy).not.toHaveBeenCalled();
       expect(setDefaults).not.toHaveBeenCalled();
       expect(setI18n).not.toHaveBeenCalled();
       expect(addResourceBundleSpy).toHaveBeenCalledTimes(2);
-      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(1, 'fr-FR', 'test', { hello: 'Bonjour' }, true, false);
-      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'fr-FR', 'test', { i18n: 'i18n' }, true, false);
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(1, 'en-US', 'test', { hello: 'Hi' }, true, false);
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'en-US', 'test', { i18n: 'i18n' }, true, false);
     });
 
     it('should initialize the i18n instance and the react i18n instance if they are not initialized', async () => {
       const loaders: ResourceLoader[] = [
-        () => Promise.resolve({ hello: 'Bonjour' }),
+        () => Promise.resolve({ hello: 'Hi' }),
         () => Promise.resolve({ i18n: 'i18n' }),
       ];
       const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
       const useSpy = jest.spyOn(i18n, 'use').mockImplementation(() => i18n);
       const initSpy = jest.spyOn(i18n, 'init').mockImplementation();
       jest.replaceProperty(i18n, 'options', { react: undefined, resources: undefined });
-      jest.replaceProperty(i18n, 'resolvedLanguage', 'fr-FR');
 
       const { language } = await initPluginTranslations('test', loaders);
 
-      expect(language).toBe('fr-FR');
+      expect(language).toBe('en-US');
       expect(useSpy).toHaveBeenCalledTimes(1);
       expect(useSpy).toHaveBeenCalledWith(initReactI18next);
       expect(initSpy).toHaveBeenCalledTimes(1);
@@ -187,25 +161,8 @@ describe('i18n', () => {
       expect(setI18n).toHaveBeenCalledTimes(1);
       expect(setI18n).toHaveBeenCalledWith(i18n);
       expect(addResourceBundleSpy).toHaveBeenCalledTimes(2);
-      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(1, 'fr-FR', 'test', { hello: 'Bonjour' }, true, false);
-      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'fr-FR', 'test', { i18n: 'i18n' }, true, false);
-    });
-
-    it('should not load resources when language is the default language', async () => {
-      const loaders: ResourceLoader[] = [
-        jest.fn(() => Promise.resolve({ hello: 'Hi' })),
-        jest.fn(() => Promise.resolve({ i18n: 'i18n' })),
-      ];
-      const addResourceBundleSpy = jest.spyOn(i18n, 'addResourceBundle');
-      jest.replaceProperty(i18n, 'options', { react: {}, resources: {} });
-      jest.replaceProperty(i18n, 'resolvedLanguage', undefined);
-
-      const { language } = await initPluginTranslations('test', loaders);
-
-      expect(language).toBe('en-US');
-      expect(loaders[0]).not.toHaveBeenCalled();
-      expect(loaders[1]).not.toHaveBeenCalled();
-      expect(addResourceBundleSpy).not.toHaveBeenCalled();
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(1, 'en-US', 'test', { hello: 'Hi' }, true, false);
+      expect(addResourceBundleSpy).toHaveBeenNthCalledWith(2, 'en-US', 'test', { i18n: 'i18n' }, true, false);
     });
   });
 });

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -38,12 +38,6 @@ export async function loadNamespacedResources(namespace: string, language: strin
 
   const resolvedLanguage = language === PSEUDO_LOCALE ? DEFAULT_LANGUAGE : language;
 
-  // Don't load resources for the default language as they are already embedded in the source code.
-  // Pseudo-locale still needs the default-language resources loaded for post-processing.
-  if (language === DEFAULT_LANGUAGE) {
-    return;
-  }
-
   return Promise.all(
     loaders.map(async (loader) => {
       try {

--- a/public/app/features/plugins/importer/addTranslationsToI18n.test.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.test.ts
@@ -40,19 +40,6 @@ describe('addTranslationsToI18n', () => {
     server.close();
   });
 
-  it('should not load translations when resolved language matches fallback language', async () => {
-    await addTranslationsToI18n({
-      resolvedLanguage: 'en-US',
-      fallbackLanguage: 'en-US',
-      pluginId: 'test-panel',
-      translations: {
-        'en-US': '/public/plugins/test-panel/locales/en-US/test-panel.json',
-      },
-    });
-
-    expect(addResourceBundleSpy).not.toHaveBeenCalled();
-  });
-
   it('should add translations that match the resolved language first', async () => {
     const translations = {
       'en-US': '/public/plugins/test-panel/locales/en-US/test-panel.json',
@@ -117,16 +104,16 @@ describe('addTranslationsToI18n', () => {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     await addTranslationsToI18n({
-      resolvedLanguage: 'pt-BR',
+      resolvedLanguage: 'en-US',
       fallbackLanguage: 'en-US',
       pluginId: 'test-panel',
       translations,
     });
 
     expect(consoleSpy).toHaveBeenCalledWith('Could not find default export for plugin test-panel', {
-      resolvedLanguage: 'pt-BR',
+      resolvedLanguage: 'en-US',
       fallbackLanguage: 'en-US',
-      path: '/public/plugins/test-panel/locales/pt-BR/no-default-export.json',
+      path: '/public/plugins/test-panel/locales/en-US/no-default-export.json',
     });
   });
 
@@ -139,17 +126,17 @@ describe('addTranslationsToI18n', () => {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     await addTranslationsToI18n({
-      resolvedLanguage: 'pt-BR',
-      fallbackLanguage: 'en-US',
+      resolvedLanguage: 'en-US',
+      fallbackLanguage: 'pt-BR',
       pluginId: 'test-panel',
       translations,
     });
 
     expect(consoleSpy).toHaveBeenCalledWith('Could not load translation for plugin test-panel', {
-      resolvedLanguage: 'pt-BR',
-      fallbackLanguage: 'en-US',
+      resolvedLanguage: 'en-US',
+      fallbackLanguage: 'pt-BR',
       error: new TypeError('Failed to fetch'),
-      path: '/public/plugins/test-panel/locales/pt-BR/unknown.json',
+      path: '/public/plugins/test-panel/locales/en-US/unknown.json',
     });
   });
 });

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { addResourceBundle } from '@grafana/i18n/internal';
 
 import { SystemJS } from '../loader/systemjs';
@@ -17,10 +16,6 @@ export async function addTranslationsToI18n({
   pluginId,
   translations,
 }: AddTranslationsToI18nOptions): Promise<void> {
-  if (resolvedLanguage === DEFAULT_LANGUAGE) {
-    return;
-  }
-
   const resolvedPath = translations[resolvedLanguage];
   const fallbackPath = translations[fallbackLanguage];
   const path = resolvedPath ?? fallbackPath;

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -82,17 +82,7 @@ const server = setupServer(
         },
       })
   ),
-  http.get(
-    '/public/plugins/test-panel/locales/pt-BR/no-default-export.json',
-    () =>
-      new HttpResponse(mockTranslationWithNoDefaultExport, {
-        headers: {
-          'Content-Type': 'text/javascript',
-        },
-      })
-  ),
-  http.get('/public/plugins/test-panel/locales/en-US/unknown.json', () => HttpResponse.error()),
-  http.get('/public/plugins/test-panel/locales/pt-BR/unknown.json', () => HttpResponse.error())
+  http.get('/public/plugins/test-panel/locales/en-US/unknown.json', () => HttpResponse.error())
 );
 
 export { server };


### PR DESCRIPTION
## Summary

Reverts #122188. That PR added early returns in `loadNamespacedResources` and `addTranslationsToI18n` that skipped loading translation bundles when the resolved language was `en-US`, aiming to avoid ~500KB of redundant JSON (English strings are already inlined via `t()` / `<Trans>`).

The optimization broke pluralization globally: i18next needs the resource bundle loaded — even for the default language — to resolve plural keys (`items_one` / `items_other`). Without the en-US bundle, every plural collapsed to the base key (e.g. "12 item" instead of "12 items").

Fixes #122481.

## Test plan

- [x] `yarn jest --no-watch packages/grafana-i18n/src/i18n.test.tsx public/app/features/plugins/importer/addTranslationsToI18n.test.ts` — 14/14 passing (the pre-#122188 tests restored by this revert).
- [ ] Manual: Dashboards → folder with >1 dashboard → Delete → modal should read "Delete N **items**" (plural), not "Delete N item".
- [ ] Manual: switch language to a non-English locale; non-English bundles still load (the revert does not regress that path).
- [ ] Manual: pseudo locale still wraps strings as expected.

## Notes

- The branch starts from `main` with a single commit; the diff is the exact inverse of the squash merge `267b3271128` (same 5 files, additions/deletions swapped).
- A narrower fix (load only plural keys for the default language) was explored on `fix/i18n/lazy-loading-plurals` but we're going with the full revert for safety. We can revisit the size optimization separately once the plural-loading mechanics are worked out.