### PR TITLE
docs: fix typos (seperate -> separate, creataed -> created)

### DIFF
--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -7,7 +7,7 @@ Exhaustive documentation on OpenFeature can be found at [OpenFeature.dev](https:
 ## Steps to adding a feature flag
 
 1. Define the feature flag in [registry.go](../pkg/services/featuremgmt/registry.go).
-   - New flags must by named with a component, seperated by a dot. e.g `grafana.newPreferencesPage`.
+   - New flags must by named with a component, separated by a dot. e.g `grafana.newPreferencesPage`.
    - Set the `Generate` field to control which clients are generated for your flag (see [Generation targets](#generation-targets) below).
    - To see what each feature stage means, look at the [related comments](../pkg/services/featuremgmt/features.go).
    - If you are a community member, use the [CODEOWNERS](../.github/CODEOWNERS) file to determine which team owns the package you are updating.
@@ -159,7 +159,7 @@ If using non-boolean flags (a unique feature of the new feature flag system), ex
 
 For advanced, non-React contexts (utilities, class methods, callbacks), you can use the OpenFeature client directly.
 
-However, because this is seperate from the React render loop there are important caveats you must be aware of:
+However, because this is separate from the React render loop there are important caveats you must be aware of:
 
 - Flag values are loaded asynchronously, so you cannot call `getBooleanValue()` just at the top-level of a module. You must wait until `app.ts` has initialised until you call a flag otherwise you will only get the default value
 - Flag values can change over the lifetime of the session, so do not store or cache the result. Always evaluate flags just in time when you use them, preferably in the if statement, for example.

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -120,7 +120,7 @@ Backporting is the process of copying the pull request into the version branch o
 
 Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will automatically be creataed.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, separate backport PRs will automatically be created.
 
 #### Required labels
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1566,7 +1566,7 @@ Options are `debug`, `info`, `warn`, `error`. `critical` is an alias for `error`
 Optional settings to set different levels for specific loggers.
 For example: `filters = sqlstore:debug`
 
-You can use multiple filters with a comma-seperated list:
+You can use multiple filters with a comma-separated list:
 For example: `filters = sqlstore:debug,plugins:info`
 
 The equivalent for a `docker-compose.yaml` looks like this:


### PR DESCRIPTION

**Repo:** grafana/grafana (⭐ 62000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Fixes four spelling typos across contributor and configuration docs:
three instances of "seperate" -> "separate" in `contribute/feature-toggles.md`,
`contribute/merge-pull-request.md`, and `docs/sources/setup-grafana/configure-grafana/_index.md`,
plus one instance of "creataed" -> "created" in `contribute/merge-pull-request.md`.

## Why
These typos appear in user-facing contributor documentation and the
public Grafana configuration reference, where polish matters for
credibility and searchability. The fixes are purely textual and
carry no behavioural risk.

## Testing
Visual review of the changed lines. The files are markdown docs;
no build or test step is required. `git diff --stat` confirms only
docs files are touched.

## Risk
Low — documentation-only spelling corrections, no code paths affected.
