### PR TITLE
Frontend: Fix bug for crossorg redirect after login

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -76,11 +76,12 @@ import { NAMESPACES, GRAFANA_NAMESPACE } from './core/internationalization/const
 import { loadTranslations } from './core/internationalization/loadTranslations';
 import { postInitTasks, preInitTasks } from './core/lifecycle-hooks';
 import { setMonacoEnv } from './core/monacoEnv';
+import { handleRedirectTo } from './core/navigation/handleRedirectTo';
 import { interceptLinkClicks } from './core/navigation/patch/interceptLinkClicks';
 import { CorrelationsService } from './core/services/CorrelationsService';
 import { NewFrontendAssetsChecker } from './core/services/NewFrontendAssetsChecker';
 import { backendSrv } from './core/services/backend_srv';
-import { contextSrv, RedirectToUrlKey } from './core/services/context_srv';
+import { contextSrv } from './core/services/context_srv';
 import { initEchoSrv } from './core/services/echo/init';
 import { KeybindingSrv } from './core/services/keybindingSrv';
 import { startMeasure, stopMeasure } from './core/utils/metrics';
@@ -333,68 +334,6 @@ function initExtensions() {
   if (extensionsExports.length > 0) {
     extensionsExports[0].init();
   }
-}
-
-function handleRedirectTo(): void {
-  const queryParams = locationService.getSearch();
-  const redirectToParamKey = 'redirectTo';
-
-  if (queryParams.has('auth_token')) {
-    // URL Login should not be redirected
-    window.sessionStorage.removeItem(RedirectToUrlKey);
-    return;
-  }
-
-  if (queryParams.has(redirectToParamKey) && window.location.pathname !== '/') {
-    const rawRedirectTo = queryParams.get(redirectToParamKey)!;
-    window.sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent(rawRedirectTo));
-    queryParams.delete(redirectToParamKey);
-    window.history.replaceState({}, '', `${window.location.pathname}${queryParams.size > 0 ? `?${queryParams}` : ''}`);
-    return;
-  }
-
-  if (!contextSrv.user.isSignedIn) {
-    return;
-  }
-
-  const redirectTo = window.sessionStorage.getItem(RedirectToUrlKey);
-  if (!redirectTo) {
-    return;
-  }
-
-  window.sessionStorage.removeItem(RedirectToUrlKey);
-  let decodedRedirectTo = decodeURIComponent(redirectTo);
-  if (decodedRedirectTo.startsWith('/goto/')) {
-    // In this case there should be a request to the backend
-    const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
-    window.location.replace(urlToRedirectTo);
-    return;
-  }
-
-  if (URL.canParse(decodedRedirectTo, window.location.origin)) {
-    const redirectUrl = new URL(decodedRedirectTo, window.location.origin);
-
-    // Only allow same-origin redirects to avoid an open redirect via the redirectTo query param.
-    // Note that `window.location.origin` is only used in `new URL()` if the first param isn't 
-    // and absolute URL. 
-    if (redirectUrl.origin === window.location.origin) {
-      const redirectOrgId = redirectUrl.searchParams.get('orgId');
-
-      if (redirectOrgId !== null && redirectOrgId !== '') {
-        const targetOrgId = Number(redirectOrgId);
-
-        if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
-          const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
-          window.location.replace(urlToRedirectTo);
-          return;
-        }
-      }
-    }
-  }
-
-  // Ensure that the appsuburl is stripped from the redirect to in case of a frontend redirect
-  const stripped = locationUtil.stripBaseFromUrl(decodedRedirectTo);
-  locationService.replace(stripped);
 }
 
 export default new GrafanaApp();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -370,6 +370,22 @@ function handleRedirectTo(): void {
     window.location.replace(urlToRedirectTo);
     return;
   }
+
+  if (URL.canParse(decodedRedirectTo, window.location.origin)) {
+    const redirectUrl = new URL(decodedRedirectTo, window.location.origin);
+    const redirectOrgId = redirectUrl.searchParams.get('orgId');
+
+    if (redirectOrgId !== null && redirectOrgId !== '') {
+      const targetOrgId = Number(redirectOrgId);
+
+      if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
+        const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
+        window.location.replace(urlToRedirectTo);
+        return;
+      }
+    }
+  }
+  
   // Ensure that the appsuburl is stripped from the redirect to in case of a frontend redirect
   const stripped = locationUtil.stripBaseFromUrl(decodedRedirectTo);
   locationService.replace(stripped);

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -373,19 +373,25 @@ function handleRedirectTo(): void {
 
   if (URL.canParse(decodedRedirectTo, window.location.origin)) {
     const redirectUrl = new URL(decodedRedirectTo, window.location.origin);
-    const redirectOrgId = redirectUrl.searchParams.get('orgId');
 
-    if (redirectOrgId !== null && redirectOrgId !== '') {
-      const targetOrgId = Number(redirectOrgId);
+    // Only allow same-origin redirects to avoid an open redirect via the redirectTo query param.
+    // Note that `window.location.origin` is only used in `new URL()` if the first param isn't 
+    // and absolute URL. 
+    if (redirectUrl.origin === window.location.origin) {
+      const redirectOrgId = redirectUrl.searchParams.get('orgId');
 
-      if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
-        const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
-        window.location.replace(urlToRedirectTo);
-        return;
+      if (redirectOrgId !== null && redirectOrgId !== '') {
+        const targetOrgId = Number(redirectOrgId);
+
+        if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
+          const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
+          window.location.replace(urlToRedirectTo);
+          return;
+        }
       }
     }
   }
-  
+
   // Ensure that the appsuburl is stripped from the redirect to in case of a frontend redirect
   const stripped = locationUtil.stripBaseFromUrl(decodedRedirectTo);
   locationService.replace(stripped);

--- a/public/app/core/navigation/handleRedirectTo.test.ts
+++ b/public/app/core/navigation/handleRedirectTo.test.ts
@@ -1,0 +1,97 @@
+import { type GrafanaConfig, locationUtil } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+
+import { contextSrv, RedirectToUrlKey } from '../services/context_srv';
+
+import { handleRedirectTo } from './handleRedirectTo';
+
+describe('handleRedirectTo', () => {
+  // These tests replace shared globals and singleton methods, so keep the originals to restore test isolation.
+  const originalLocation = window.location;
+  const originalReplace = locationService.replace;
+  const originalGetSearch = locationService.getSearch;
+  const originalIsSignedIn = contextSrv.user.isSignedIn;
+  const originalOrgId = contextSrv.user.orgId;
+  const originalCanParse = URL.canParse;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+
+    locationUtil.initialize({
+      config: { appSubUrl: '/grafana' } as GrafanaConfig,
+      getVariablesUrlParams: jest.fn(),
+      getTimeRangeForUrl: jest.fn(),
+    });
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        origin: 'http://grafana.local',
+        pathname: '/',
+        replace: jest.fn(),
+      },
+    });
+
+    const mockLocationService = locationService as jest.Mocked<typeof locationService>;
+    mockLocationService.replace = jest.fn();
+    mockLocationService.getSearch = jest.fn().mockReturnValue(new URLSearchParams());
+
+    // JSDOM in this test environment does not provide URL.canParse(), but the production code uses it.
+    // Mirror the browser behavior so these tests exercise the real same-origin/orgId branch.
+    URL.canParse = (url, base) => {
+      try {
+        new URL(url, base);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    contextSrv.user.isSignedIn = false;
+    contextSrv.user.orgId = 1;
+  });
+
+  afterEach(() => {
+    locationService.replace = originalReplace;
+    locationService.getSearch = originalGetSearch;
+    contextSrv.user.isSignedIn = originalIsSignedIn;
+    contextSrv.user.orgId = originalOrgId;
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    URL.canParse = originalCanParse;
+    jest.restoreAllMocks();
+  });
+
+  it('does not hard redirect cross-origin URLs even when orgId changes', () => {
+    contextSrv.user.isSignedIn = true;
+    contextSrv.user.orgId = 1;
+    sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent('https://evil.com/d/test?orgId=2'));
+
+    handleRedirectTo();
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(locationService.replace).toHaveBeenCalledWith('https://evil.com/d/test?orgId=2');
+  });
+
+  it('hard redirects same-origin URLs that switch orgs', () => {
+    contextSrv.user.isSignedIn = true;
+    contextSrv.user.orgId = 1;
+    sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent('/grafana/d/test?orgId=2'));
+
+    handleRedirectTo();
+
+    expect(window.location.replace).toHaveBeenCalledWith('/grafana/d/test?orgId=2');
+    expect(locationService.replace).not.toHaveBeenCalled();
+  });
+
+  it('falls back to frontend navigation for same-origin redirects in the current org', () => {
+    contextSrv.user.isSignedIn = true;
+    contextSrv.user.orgId = 1;
+    sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent('/grafana/d/test?orgId=1'));
+
+    handleRedirectTo();
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(locationService.replace).toHaveBeenCalledWith('/d/test?orgId=1');
+  });
+});

--- a/public/app/core/navigation/handleRedirectTo.test.ts
+++ b/public/app/core/navigation/handleRedirectTo.test.ts
@@ -62,6 +62,63 @@ describe('handleRedirectTo', () => {
     jest.restoreAllMocks();
   });
 
+  it('clears the stored redirect when handling URL login', () => {
+    const mockLocationService = locationService as jest.Mocked<typeof locationService>;
+    mockLocationService.getSearch.mockReturnValue(new URLSearchParams('auth_token=test-token'));
+    sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent('/grafana/d/test?orgId=2'));
+
+    handleRedirectTo();
+
+    expect(sessionStorage.getItem(RedirectToUrlKey)).toBeNull();
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(locationService.replace).not.toHaveBeenCalled();
+  });
+
+  it('stores redirectTo from non-root paths and removes it from the URL', () => {
+    const mockLocationService = locationService as jest.Mocked<typeof locationService>;
+    const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+    const queryParams = new URLSearchParams();
+    queryParams.set('redirectTo', '/grafana/d/test?orgId=2');
+    queryParams.set('foo', 'bar');
+    mockLocationService.getSearch.mockReturnValue(queryParams);
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        pathname: '/login',
+      },
+    });
+
+    handleRedirectTo();
+
+    expect(sessionStorage.getItem(RedirectToUrlKey)).toBe(encodeURIComponent('/grafana/d/test?orgId=2'));
+    expect(queryParams.has('redirectTo')).toBe(false);
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/login');
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(locationService.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not consume the stored redirect before the user is signed in', () => {
+    sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent('/grafana/d/test?orgId=2'));
+
+    handleRedirectTo();
+
+    expect(sessionStorage.getItem(RedirectToUrlKey)).toBe(encodeURIComponent('/grafana/d/test?orgId=2'));
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(locationService.replace).not.toHaveBeenCalled();
+  });
+
+  it('hard redirects goto URLs through the backend', () => {
+    contextSrv.user.isSignedIn = true;
+    sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent('/goto/abc123'));
+
+    handleRedirectTo();
+
+    expect(window.location.replace).toHaveBeenCalledWith('/grafana/goto/abc123');
+    expect(locationService.replace).not.toHaveBeenCalled();
+  });
+
   it('does not hard redirect cross-origin URLs even when orgId changes', () => {
     contextSrv.user.isSignedIn = true;
     contextSrv.user.orgId = 1;

--- a/public/app/core/navigation/handleRedirectTo.test.ts
+++ b/public/app/core/navigation/handleRedirectTo.test.ts
@@ -12,7 +12,6 @@ describe('handleRedirectTo', () => {
   const originalGetSearch = locationService.getSearch;
   const originalIsSignedIn = contextSrv.user.isSignedIn;
   const originalOrgId = contextSrv.user.orgId;
-  const originalCanParse = URL.canParse;
 
   beforeEach(() => {
     sessionStorage.clear();
@@ -37,17 +36,6 @@ describe('handleRedirectTo', () => {
     mockLocationService.replace = jest.fn();
     mockLocationService.getSearch = jest.fn().mockReturnValue(new URLSearchParams());
 
-    // JSDOM in this test environment does not provide URL.canParse(), but the production code uses it.
-    // Mirror the browser behavior so these tests exercise the real same-origin/orgId branch.
-    URL.canParse = (url, base) => {
-      try {
-        new URL(url, base);
-        return true;
-      } catch {
-        return false;
-      }
-    };
-
     contextSrv.user.isSignedIn = false;
     contextSrv.user.orgId = 1;
   });
@@ -58,7 +46,6 @@ describe('handleRedirectTo', () => {
     contextSrv.user.isSignedIn = originalIsSignedIn;
     contextSrv.user.orgId = originalOrgId;
     Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
-    URL.canParse = originalCanParse;
     jest.restoreAllMocks();
   });
 

--- a/public/app/core/navigation/handleRedirectTo.ts
+++ b/public/app/core/navigation/handleRedirectTo.ts
@@ -50,7 +50,7 @@ export function handleRedirectTo(): void {
     if (redirectUrl.origin === window.location.origin) {
       const redirectOrgId = redirectUrl.searchParams.get('orgId');
 
-      if (redirectOrgId !== null && redirectOrgId !== '') {
+      if (redirectOrgId) {
         const targetOrgId = Number(redirectOrgId);
 
         if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {

--- a/public/app/core/navigation/handleRedirectTo.ts
+++ b/public/app/core/navigation/handleRedirectTo.ts
@@ -41,23 +41,25 @@ export function handleRedirectTo(): void {
     return;
   }
 
-  if (URL.canParse(decodedRedirectTo, window.location.origin)) {
-    const redirectUrl = new URL(decodedRedirectTo, window.location.origin);
+  let redirectUrl: URL | undefined;
 
-    // Only allow same-origin redirects to avoid an open redirect via the redirectTo query param.
-    // Note that `window.location.origin` is only used in `new URL()` if the first param isn't
-    // an absolute URL.
-    if (redirectUrl.origin === window.location.origin) {
-      const redirectOrgId = redirectUrl.searchParams.get('orgId');
+  try {
+    redirectUrl = new URL(decodedRedirectTo, window.location.origin);
+  } catch {}
 
-      if (redirectOrgId) {
-        const targetOrgId = Number(redirectOrgId);
+  // Only allow same-origin redirects to avoid an open redirect via the redirectTo query param.
+  // Note that `window.location.origin` is only used in `new URL()` if the first param isn't
+  // an absolute URL.
+  if (redirectUrl?.origin === window.location.origin) {
+    const redirectOrgId = redirectUrl.searchParams.get('orgId');
 
-        if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
-          const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
-          window.location.replace(urlToRedirectTo);
-          return;
-        }
+    if (redirectOrgId) {
+      const targetOrgId = Number(redirectOrgId);
+
+      if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
+        const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
+        window.location.replace(urlToRedirectTo);
+        return;
       }
     }
   }

--- a/public/app/core/navigation/handleRedirectTo.ts
+++ b/public/app/core/navigation/handleRedirectTo.ts
@@ -1,0 +1,68 @@
+import { locationUtil } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+
+import { contextSrv, RedirectToUrlKey } from '../services/context_srv';
+
+const redirectToParamKey = 'redirectTo';
+
+export function handleRedirectTo(): void {
+  const queryParams = locationService.getSearch();
+
+  if (queryParams.has('auth_token')) {
+    // URL Login should not be redirected
+    window.sessionStorage.removeItem(RedirectToUrlKey);
+    return;
+  }
+
+  if (queryParams.has(redirectToParamKey) && window.location.pathname !== '/') {
+    const rawRedirectTo = queryParams.get(redirectToParamKey)!;
+    window.sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent(rawRedirectTo));
+    queryParams.delete(redirectToParamKey);
+    window.history.replaceState({}, '', `${window.location.pathname}${queryParams.size > 0 ? `?${queryParams}` : ''}`);
+    return;
+  }
+
+  if (!contextSrv.user.isSignedIn) {
+    return;
+  }
+
+  const redirectTo = window.sessionStorage.getItem(RedirectToUrlKey);
+  if (!redirectTo) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(RedirectToUrlKey);
+  const decodedRedirectTo = decodeURIComponent(redirectTo);
+
+  if (decodedRedirectTo.startsWith('/goto/')) {
+    // In this case there should be a request to the backend
+    const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
+    window.location.replace(urlToRedirectTo);
+    return;
+  }
+
+  if (URL.canParse(decodedRedirectTo, window.location.origin)) {
+    const redirectUrl = new URL(decodedRedirectTo, window.location.origin);
+
+    // Only allow same-origin redirects to avoid an open redirect via the redirectTo query param.
+    // Note that `window.location.origin` is only used in `new URL()` if the first param isn't
+    // an absolute URL.
+    if (redirectUrl.origin === window.location.origin) {
+      const redirectOrgId = redirectUrl.searchParams.get('orgId');
+
+      if (redirectOrgId !== null && redirectOrgId !== '') {
+        const targetOrgId = Number(redirectOrgId);
+
+        if (Number.isFinite(targetOrgId) && targetOrgId !== contextSrv.user.orgId) {
+          const urlToRedirectTo = locationUtil.assureBaseUrl(decodedRedirectTo);
+          window.location.replace(urlToRedirectTo);
+          return;
+        }
+      }
+    }
+  }
+
+  // Ensure that the appSubUrl is stripped from the redirect to in case of a frontend redirect
+  const stripped = locationUtil.stripBaseFromUrl(decodedRedirectTo);
+  locationService.replace(stripped);
+}


### PR DESCRIPTION
In response to [this support escalation/bug report](https://github.com/grafana/support-escalations/issues/21796). This fixes a bug where a logged out user tries to visit a dashboard for an org different from the last one that were using and they get a 404 page. In other words, they:
1. Visit a dashboard in `org1`
2. Log out
3. Go directly to a dashboard in `org2` with a long URL
4. Log in
5. Get redirected to a 404 because their org was never switch over to the one in the URL.

This was not an issue for the short URLs.