### PR TITLE
annotations: use btree_gin for tag and scope indexes

### DIFF
--- a/pkg/registry/apps/annotation/migrations/00002_enable_btree_gin.sql
+++ b/pkg/registry/apps/annotation/migrations/00002_enable_btree_gin.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+-- Enable btree_gin extension to support composite GIN indexes with B-tree types (e.g. namespace + tags).
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+
+-- +goose Down
+DROP EXTENSION IF EXISTS btree_gin;

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -37,8 +37,8 @@ FOR VALUES FROM (%d) TO (%d);
 	createTimeIndexSQL      = `CREATE INDEX IF NOT EXISTS %s ON %s (namespace, time);`
 	createDashboardIndexSQL = `CREATE INDEX IF NOT EXISTS %s ON %s (namespace, dashboard_uid, panel_id, time);`
 	createTimeEndIndexSQL   = `CREATE INDEX IF NOT EXISTS %s ON %s (namespace, time_end) WHERE time_end IS NOT NULL;`
-	createTagsIndexSQL      = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (tags);`
-	createScopesIndexSQL    = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (scopes);`
+	createTagsIndexSQL      = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (namespace, tags);`
+	createScopesIndexSQL    = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (namespace, scopes);`
 
 	listPartitionsSQL = `
 SELECT


### PR DESCRIPTION
This PR updates the indexes on the `tags` and `scopes` columns of the `annotations` table in the Postgres store of the new annotations API to be `btree_gin` indexes so that they can be properly scoped to `namespace`. All queries to the store will be scoped by namespace, so this provides a more performant way to do containment queries for tags and scopes when listing annotations.