### PR TITLE
Tempo: fix nil dereference and nil frame in backend query handlers

### DIFF
--- a/pkg/tsdb/tempo/trace.go
+++ b/pkg/tsdb/tempo/trace.go
@@ -101,6 +101,14 @@ func (s *Service) getTrace(ctx context.Context, pCtx backend.PluginContext, quer
 			span.SetStatus(codes.Error, err.Error())
 			return &backend.DataResponse{}, fmt.Errorf("failed to transform trace %v to data frame: %w", model.Query, err)
 		}
+
+		if frame == nil {
+			result.Status = http.StatusNotFound
+			err := fmt.Errorf("failed to get trace with id: %s Status: %s", *model.Query, result.Status)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, backend.DownstreamError(err)
+		}
 	} else {
 		var tr tempopb.TraceByIDResponse
 		err = proto.Unmarshal(traceBody, &tr)

--- a/pkg/tsdb/tempo/trace_test.go
+++ b/pkg/tsdb/tempo/trace_test.go
@@ -2,9 +2,14 @@ package tempo
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,5 +45,39 @@ func TestTempo(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(req.Header))
 		assert.Equal(t, "/api/v2/traces/traceID?start=1&end=2", req.URL.String())
+	})
+
+	t.Run("getTrace v1 empty ResourceSpans returns downstream error", func(t *testing.T) {
+		v1Called := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/api/v2/traces/") {
+				w.WriteHeader(http.StatusNotFound) // trigger v1 fallback
+			} else if strings.Contains(r.URL.Path, "/api/traces/") {
+				v1Called = true
+				w.WriteHeader(http.StatusOK) // empty body → empty ResourceSpans → nil frame
+			}
+		}))
+		defer server.Close()
+
+		im := datasource.NewInstanceManager(func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &DatasourceInfo{URL: server.URL, HTTPClient: server.Client()}, nil
+		})
+
+		service := &Service{
+			im:     im,
+			logger: backend.NewLoggerWith("logger", "tempo-test"),
+		}
+
+		pluginCtx := backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{URL: server.URL},
+		}
+		query := backend.DataQuery{JSON: []byte(`{"query": "abc123"}`)}
+
+		res, err := service.getTrace(context.Background(), pluginCtx, query)
+
+		assert.True(t, v1Called, "expected v1 endpoint (/api/traces/) to be called")
+		assert.Nil(t, res)
+		require.Error(t, err)
+		assert.True(t, backend.IsDownstreamError(err))
 	})
 }

--- a/pkg/tsdb/tempo/traceql_query.go
+++ b/pkg/tsdb/tempo/traceql_query.go
@@ -35,6 +35,10 @@ func (s *Service) runTraceQlQuery(ctx context.Context, pCtx backend.PluginContex
 		return nil, backend.DownstreamErrorf("failed to unmarshall Tempo query model: %w", err)
 	}
 
+	if tempoQuery.Query == nil || *tempoQuery.Query == "" {
+		return nil, backend.DownstreamErrorf("query is required")
+	}
+
 	if isMetricsQuery(*tempoQuery.Query) {
 		return s.runTraceQlQueryMetrics(ctx, pCtx, backendQuery, tempoQuery)
 	}

--- a/pkg/tsdb/tempo/traceql_query_test.go
+++ b/pkg/tsdb/tempo/traceql_query_test.go
@@ -75,6 +75,28 @@ func TestCreateMetricsQuery_URLParseError(t *testing.T) {
 	assert.Nil(t, req)
 }
 
+func TestRunTraceQlQuery_NilQuery_ReturnsError(t *testing.T) {
+	service := &Service{logger: backend.NewLoggerWith("logger", "tsdb.tempo.test")}
+	query := backend.DataQuery{JSON: []byte(`{}`)}
+
+	res, err := service.runTraceQlQuery(context.Background(), backend.PluginContext{}, query)
+
+	assert.Nil(t, res)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "query is required")
+}
+
+func TestRunTraceQlQuery_EmptyQuery_ReturnsError(t *testing.T) {
+	service := &Service{logger: backend.NewLoggerWith("logger", "tsdb.tempo.test")}
+	query := backend.DataQuery{JSON: []byte(`{"query": ""}`)}
+
+	res, err := service.runTraceQlQuery(context.Background(), backend.PluginContext{}, query)
+
+	assert.Nil(t, res)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "query is required")
+}
+
 func TestEmptyQueryString_ReturnsFalse(t *testing.T) {
 	result := isMetricsQuery("")
 	assert.False(t, result)


### PR DESCRIPTION
**What is this feature?**

Fixes two nil-related bugs in the Tempo backend query handlers that cause panics and incorrect error propagation.

**Why do we need this feature?**

Investigation of high plugin error rates on the Tempo datasource (error: _"both response and error are nil, but one must be provided" in the [dashboard](https://ops.grafana-ops.net/d/cdsqp9biempdsca/6b3ce21?from=now-7d&to=now&timezone=utc&var-datasource=tempo)

- **`runTraceQlQuery`**: `tempoQuery.Query` is a `*string`. If a query payload omits the `query` field (e.g. an incomplete alert rule), dereferencing `*tempoQuery.Query` panics. Added a nil/empty guard before the dereference, consistent with the same check already present in `runTraceQlQueryMetrics`.
- **`getTrace` V1 path**: when falling back to the V1 trace API (older Tempo servers), `TraceToFrame` returns `(nil, nil)` for an empty trace. The V1 path was missing the nil frame guard that the V2 path already had, causing `frame.RefID = refID` to panic. Now returns a `DownstreamError` with 404 status, consistent with V2 behaviour.

**Who is this feature for?**

N/A

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.