### PR TITLE
Revert "i18n: prevents loading of en-US translations"

### DIFF
--- a/public/app/core/internationalization/loadTranslations.ts
+++ b/public/app/core/internationalization/loadTranslations.ts
@@ -1,7 +1,5 @@
 import { type BackendModule } from 'i18next';
 
-import { DEFAULT_LANGUAGE } from '@grafana/i18n';
-
 import { LANGUAGES } from './constants';
 
 const getLanguagePartFromCode = (code: string) => code.split('-')[0].toLowerCase();
@@ -17,11 +15,6 @@ export const loadTranslations: BackendModule = {
 
     if (!localeDef) {
       return callback(new Error(`No message loader available for ${language}`), null);
-    }
-
-    // don't load messages for DEFAULT_LANGUAGE as they are already embedded in the source code
-    if (localeDef.code === DEFAULT_LANGUAGE) {
-      return callback(null, {});
     }
 
     const namespaceLoader = localeDef.loader[namespace];


### PR DESCRIPTION
Reverts grafana/grafana#120923

This pull request makes a small adjustment to the translation loading logic by removing a check that previously prevented loading messages for the default language. Now, translation messages will be loaded for all languages, including the default otherwise pluralization wont work.