### PR TITLE
Dashboards: Fix flaky browse spec by using unique UIDs per run

### DIFF
--- a/e2e-playwright/dashboards-suite/dashboard-browse.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-browse.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@grafana/plugin-e2e';
 
 import testDashboard from '../dashboards/TestDashboard.json';
 
+// Unique suffix to avoid UID/title collisions with parallel specs that share this fixture.
+const SUFFIX = Date.now().toString(36);
+const dashName = `E2E Test - Import Dashboard ${SUFFIX}`;
+const dashUid = `e2e-browse-${SUFFIX}`;
+
 test.use({
   featureToggles: {
     dashboardNewLayouts: process.env.FORCE_V2_DASHBOARDS_API === 'true',
@@ -20,7 +25,7 @@ test.describe(
       // Import the test dashboard
       const response = await request.post('/api/dashboards/import', {
         data: {
-          dashboard: testDashboard,
+          dashboard: { ...testDashboard, uid: dashUid, title: dashName },
           folderUid: '',
           overwrite: true,
           inputs: [],
@@ -43,9 +48,7 @@ test.describe(
 
       // Folders and dashboards should be visible
       await expect(page.getByTestId(selectors.pages.BrowseDashboards.table.row('gdev dashboards'))).toBeVisible();
-      await expect(
-        page.getByTestId(selectors.pages.BrowseDashboards.table.row('E2E Test - Import Dashboard'))
-      ).toBeVisible();
+      await expect(page.getByTestId(selectors.pages.BrowseDashboards.table.row(dashName))).toBeVisible();
 
       // gdev dashboards folder is collapsed - its content should not be visible
       await expect(page.getByTestId(selectors.pages.BrowseDashboards.table.row('Bar Gauge Demo'))).toBeHidden();
@@ -90,7 +93,7 @@ test.describe(
 
       // Select the imported dashboard using checkbox
       await page
-        .getByTestId(selectors.pages.BrowseDashboards.table.row('E2E Test - Import Dashboard'))
+        .getByTestId(selectors.pages.BrowseDashboards.table.row(dashName))
         .getByRole('checkbox')
         .click({ force: true });
 
@@ -100,9 +103,7 @@ test.describe(
       // Confirm deletion in modal
       await page.getByPlaceholder('Type "Delete" to confirm').fill('Delete');
       await page.getByTestId(selectors.pages.ConfirmModal.delete).click();
-      await expect(
-        page.getByTestId(selectors.pages.BrowseDashboards.table.row('E2E Test - Import Dashboard'))
-      ).toBeHidden();
+      await expect(page.getByTestId(selectors.pages.BrowseDashboards.table.row(dashName))).toBeHidden();
     });
   }
 );

--- a/e2e-playwright/dashboards-suite/import-dashboard.spec.ts
+++ b/e2e-playwright/dashboards-suite/import-dashboard.spec.ts
@@ -2,6 +2,12 @@ import { test, expect } from '@grafana/plugin-e2e';
 
 import testDashboard from '../dashboards/TestDashboard.json';
 
+// Unique suffix to avoid UID/title collisions with parallel specs that share this fixture.
+const SUFFIX = Date.now().toString(36);
+const dashName = `E2E Import ${SUFFIX}`;
+const dashUid = `e2e-import-${SUFFIX}`;
+const uniqueDashboard = { ...testDashboard, uid: dashUid, title: dashName };
+
 test.use({
   featureToggles: {
     dashboardNewLayouts: process.env.FORCE_V2_DASHBOARDS_API === 'true',
@@ -25,7 +31,7 @@ test.describe(
 
       // Fill in the dashboard JSON and name
       const textarea = dashboardPage.getByGrafanaSelector(selectors.components.DashboardImportPage.textarea);
-      await textarea.fill(JSON.stringify(testDashboard));
+      await textarea.fill(JSON.stringify(uniqueDashboard));
 
       // Submit the JSON
       await dashboardPage.getByGrafanaSelector(selectors.components.DashboardImportPage.submit).click();
@@ -35,7 +41,7 @@ test.describe(
       await expect(nameField).toBeVisible();
       await nameField.click();
       await nameField.clear();
-      await nameField.fill(testDashboard.title);
+      await nameField.fill(dashName);
 
       await dashboardPage.getByGrafanaSelector(selectors.components.ImportDashboardForm.submit).click();
 
@@ -49,7 +55,7 @@ test.describe(
 
       // Verify the dashboard title is present in the breadcrumbs
       await expect(
-        dashboardPage.getByGrafanaSelector(selectors.components.Breadcrumbs.breadcrumb(testDashboard.title))
+        dashboardPage.getByGrafanaSelector(selectors.components.Breadcrumbs.breadcrumb(dashName))
       ).toBeVisible();
 
       // Verify that specific panels from the test dashboard are loaded


### PR DESCRIPTION
**What is this feature?**

Make the `dashboard-browse` and `import-dashboard` Playwright specs each clone `TestDashboard.json` with a unique UID and title per run, instead of importing the same hardcoded fixture. A `Date.now().toString(36)` suffix per spec guarantees no collision between parallel runs.



