### PR TITLE
fix(ngalert): release stale transition value maps after full eval pipeline to reduce OOM

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -121,6 +121,7 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 	for _, alertState := range transitions {
 		alerts = append(alerts, state.StateToPostableAlert(alertState, srv.appUrl, srv.featureManager))
 	}
+	state.ReleaseEvictedStaleTransitionValueMaps(transitions)
 
 	return response.JSON(http.StatusOK, alerts)
 }

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -194,6 +194,7 @@ func (e *Engine) Test(ctx context.Context, user identity.Requester, rule *models
 				return false, err
 			}
 		}
+		state.ReleaseEvictedStaleTransitionValueMaps(states)
 		return idx <= evaluations, nil
 	}
 

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -474,7 +474,7 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 		))
 	}
 	start = a.clock.Now()
-	_ = a.stateManager.ProcessEvalResults(
+	transitions := a.stateManager.ProcessEvalResults(
 		ctx,
 		e.scheduledAt,
 		e.rule,
@@ -489,6 +489,7 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			sendDuration.Observe(a.clock.Now().Sub(start).Seconds())
 		},
 	)
+	state.ReleaseEvictedStaleTransitionValueMaps(transitions)
 	processDuration.Observe(a.clock.Now().Sub(start).Seconds())
 
 	return nil

--- a/pkg/services/ngalert/state/manager_memory_test.go
+++ b/pkg/services/ngalert/state/manager_memory_test.go
@@ -1,0 +1,350 @@
+package state
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
+)
+
+// staleValuesAssertHistorian fails the test if Record sees a stale (evicted) transition without
+// the expected Values — proves Values must not be cleared before the historian runs.
+type staleValuesAssertHistorian struct {
+	t *testing.T
+}
+
+func (h *staleValuesAssertHistorian) Record(_ context.Context, _ history_model.RuleMeta, states []StateTransition) <-chan error {
+	for _, tr := range states {
+		if tr.State == nil || !tr.State.IsStale() {
+			continue
+		}
+		require.NotNil(h.t, tr.State.Values)
+		require.InDelta(h.t, 1.0, tr.State.Values["A"], 1e-9)
+		require.InDelta(h.t, 2.0, tr.State.Values["B"], 1e-9)
+	}
+	ch := make(chan error)
+	close(ch)
+	return ch
+}
+
+func TestValuesAvailableToHistorianAfterEviction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clk := clock.NewMock()
+
+	cfg := ManagerCfg{
+		Metrics:       nil,
+		ExternalURL:   nil,
+		InstanceStore: nil,
+		Images:        &NoopImageService{},
+		Clock:         clk,
+		Historian:     &staleValuesAssertHistorian{t: t},
+		Tracer:        tracing.InitializeTracerForTest(),
+		Log:           log.New("ngalert.state.manager"),
+	}
+	st := NewManager(cfg, NewNoopPersister())
+
+	rule := models.RuleGen.With(models.RuleGen.WithFor(0), models.RuleGen.WithMissingSeriesEvalsToResolve(1)).GenerateRef()
+
+	a, b := 1.0, 2.0
+	vals := map[string]eval.NumberValueCapture{
+		"A": {Value: &a},
+		"B": {Value: &b},
+	}
+
+	initResults := eval.Results{
+		eval.ResultGen(eval.WithState(eval.Alerting), eval.WithLabels(data.Labels{"series": "x"}), eval.WithValues(vals))(),
+		eval.ResultGen(eval.WithState(eval.Alerting), eval.WithLabels(data.Labels{"series": "y"}), eval.WithValues(vals))(),
+	}
+	st.ProcessEvalResults(ctx, clk.Now(), rule, initResults, nil, nil)
+
+	clk.Add(time.Duration(rule.IntervalSeconds) * time.Second)
+	// Only one series in this evaluation; the other becomes missing then stale and is evicted.
+	nextResults := eval.Results{
+		eval.ResultGen(eval.WithState(eval.Alerting), eval.WithLabels(data.Labels{"series": "x"}), eval.WithValues(vals))(),
+	}
+
+	transitions := st.ProcessEvalResults(ctx, clk.Now(), rule, nextResults, nil, nil)
+
+	var sawStale bool
+	for _, tr := range transitions {
+		if tr.State == nil || !tr.State.IsStale() {
+			continue
+		}
+		sawStale = true
+		require.NotNil(t, tr.State.Values)
+		require.InDelta(t, 1.0, tr.State.Values["A"], 1e-9)
+		require.InDelta(t, 2.0, tr.State.Values["B"], 1e-9)
+	}
+	require.True(t, sawStale, "expected at least one stale evicted transition")
+
+	ReleaseEvictedStaleTransitionValueMaps(transitions)
+
+	for _, tr := range transitions {
+		if tr.State == nil || !tr.State.IsStale() {
+			continue
+		}
+		require.Nil(t, tr.State.Values)
+		if tr.State.LatestResult != nil {
+			require.Nil(t, tr.State.LatestResult.Values)
+		}
+	}
+}
+
+func TestProcessMissingSeriesStatesSkipsCurrentlyEvaluated(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clk := clock.NewMock()
+
+	cfg := ManagerCfg{
+		Metrics:       nil,
+		ExternalURL:   nil,
+		InstanceStore: nil,
+		Images:        &NoopImageService{},
+		Clock:         clk,
+		Historian:     nil,
+		Tracer:        tracing.InitializeTracerForTest(),
+		Log:           log.New("ngalert.state.manager"),
+	}
+	st := NewManager(cfg, NewNoopPersister())
+	rule := models.RuleGen.With(models.RuleGen.WithFor(0), models.RuleGen.WithMissingSeriesEvalsToResolve(1)).GenerateRef()
+
+	results := eval.Results{
+		newEvalResultWithValues(clk.Now(), data.Labels{"series": "a"}, 16),
+		newEvalResultWithValues(clk.Now(), data.Labels{"series": "b"}, 16),
+	}
+
+	st.ProcessEvalResults(ctx, clk.Now(), rule, results, nil, nil)
+
+	logger := log.New("test")
+	_, staleCount := st.processMissingSeriesStates(logger, clk.Now(), rule, func(string) *models.Image { return nil })
+	require.Equal(t, 0, staleCount)
+
+	currentStates := st.GetStatesForRuleUID(ctx, rule.OrgID, rule.UID)
+	require.Len(t, currentStates, 2)
+}
+
+func TestMemoryGrowthBoundedAcrossEvalCycles(t *testing.T) {
+	ctx := context.Background()
+	clk := clock.NewMock()
+
+	cfg := ManagerCfg{
+		Metrics:       nil,
+		ExternalURL:   nil,
+		InstanceStore: nil,
+		Images:        &NoopImageService{},
+		Clock:         clk,
+		Historian:     nil,
+		Tracer:        tracing.InitializeTracerForTest(),
+		Log:           log.New("ngalert.state.manager"),
+	}
+	st := NewManager(cfg, NewNoopPersister())
+	rule := models.RuleGen.With(models.RuleGen.WithFor(0), models.RuleGen.WithMissingSeriesEvalsToResolve(1)).GenerateRef()
+
+	runtime.GC()
+	var ms1, ms2 runtime.MemStats
+	runtime.ReadMemStats(&ms1)
+
+	const cycles = 500
+	const seriesPerCycle = 50
+	const valuesPerSeries = 256
+
+	for cycle := 0; cycle < cycles; cycle++ {
+		clk.Add(time.Duration(rule.IntervalSeconds) * time.Second)
+		limit := seriesPerCycle
+		if cycle%2 == 1 {
+			limit = seriesPerCycle / 2
+		}
+		results := make(eval.Results, 0, limit)
+		for i := 0; i < limit; i++ {
+			results = append(results, newEvalResultWithValues(clk.Now(), data.Labels{
+				"series": seriesLabel(i),
+				"cycle":  seriesLabel(cycle % 10),
+			}, valuesPerSeries))
+		}
+		tr := st.ProcessEvalResults(ctx, clk.Now(), rule, results, nil, nil)
+		ReleaseEvictedStaleTransitionValueMaps(tr)
+		runtime.GC()
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&ms2)
+
+	growth := ms2.HeapAlloc - ms1.HeapAlloc
+	require.Less(t, int64(growth), int64(20*1024*1024), "heap should not grow >20MB over cycles")
+}
+
+func TestMemoryReleasedAfterFullPipeline(t *testing.T) {
+	ctx := context.Background()
+	clk := clock.NewMock()
+
+	cfg := ManagerCfg{
+		Metrics:       nil,
+		ExternalURL:   nil,
+		InstanceStore: nil,
+		Images:        &NoopImageService{},
+		Clock:         clk,
+		Historian:     nil,
+		Tracer:        tracing.InitializeTracerForTest(),
+		Log:           log.New("ngalert.state.manager"),
+	}
+	st := NewManager(cfg, NewNoopPersister())
+	rule := models.RuleGen.With(models.RuleGen.WithFor(0), models.RuleGen.WithMissingSeriesEvalsToResolve(1)).GenerateRef()
+
+	runtime.GC()
+	var ms1, ms2 runtime.MemStats
+	runtime.ReadMemStats(&ms1)
+
+	const cycles = 200
+	const nSeries = 100
+	const valuesPerSeries = 64
+
+	for c := 0; c < cycles; c++ {
+		clk.Add(time.Duration(rule.IntervalSeconds) * time.Second)
+		full := make(eval.Results, 0, nSeries)
+		for i := 0; i < nSeries; i++ {
+			full = append(full, newEvalResultWithValues(clk.Now(), data.Labels{
+				"series": seriesLabel(i),
+				"wave":   seriesLabel(c % 7),
+			}, valuesPerSeries))
+		}
+		tr1 := st.ProcessEvalResults(ctx, clk.Now(), rule, full, nil, nil)
+		ReleaseEvictedStaleTransitionValueMaps(tr1)
+
+		clk.Add(time.Duration(rule.IntervalSeconds) * time.Second)
+		// One series remains; the other nSeries-1 go missing and are evicted as stale on this tick.
+		one := eval.Results{
+			newEvalResultWithValues(clk.Now(), data.Labels{"series": "a", "wave": seriesLabel(c % 7)}, valuesPerSeries),
+		}
+		tr2 := st.ProcessEvalResults(ctx, clk.Now(), rule, one, nil, nil)
+		ReleaseEvictedStaleTransitionValueMaps(tr2)
+		runtime.GC()
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&ms2)
+
+	growth := ms2.HeapAlloc - ms1.HeapAlloc
+	require.Less(t, int64(growth), int64(30*1024*1024), "heap should not grow >30MB over churn with stale evictions")
+}
+
+func TestStaleStatesConcurrentSafety(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clk := clock.NewMock()
+
+	cfg := ManagerCfg{
+		Metrics:       nil,
+		ExternalURL:   nil,
+		InstanceStore: nil,
+		Images:        &NoopImageService{},
+		Clock:         clk,
+		Historian:     nil,
+		Tracer:        tracing.InitializeTracerForTest(),
+		Log:           log.New("ngalert.state.manager"),
+	}
+	st := NewManager(cfg, NewNoopPersister())
+
+	const workers = 10
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for w := 0; w < workers; w++ {
+		rule := models.RuleGen.With(
+			models.RuleGen.WithFor(0),
+			models.RuleGen.WithMissingSeriesEvalsToResolve(1),
+		).GenerateRef()
+
+		go func(rule *models.AlertRule, worker int) {
+			defer wg.Done()
+			now := clk.Now().Add(time.Duration(worker+1) * time.Second)
+			results := eval.Results{
+				newEvalResultWithValues(now, data.Labels{"series": "a"}, 64),
+				newEvalResultWithValues(now, data.Labels{"series": "b"}, 64),
+			}
+			tr1 := st.ProcessEvalResults(ctx, now, rule, results, nil, nil)
+			ReleaseEvictedStaleTransitionValueMaps(tr1)
+
+			now2 := now.Add(time.Duration(rule.IntervalSeconds) * time.Second)
+			tr2 := st.ProcessEvalResults(ctx, now2, rule, eval.Results{
+				newEvalResultWithValues(now2, data.Labels{"series": "a"}, 64),
+			}, nil, nil)
+			ReleaseEvictedStaleTransitionValueMaps(tr2)
+		}(rule, w)
+	}
+
+	wg.Wait()
+}
+
+func TestReleaseEvictedStaleTransitionValueMapsSkipsLiveStates(t *testing.T) {
+	t.Parallel()
+
+	s := &State{
+		State:       eval.Alerting,
+		StateReason: "",
+		Values:      map[string]float64{"K": 1},
+		LatestResult: &Evaluation{
+			Values: map[string]float64{"K": 1},
+		},
+	}
+	tr := StateTransition{State: s}
+	ReleaseEvictedStaleTransitionValueMaps(StateTransitions{tr})
+	require.Contains(t, s.Values, "K")
+	require.Contains(t, s.LatestResult.Values, "K")
+
+	s2 := &State{
+		State:       eval.Normal,
+		StateReason: models.StateReasonMissingSeries,
+		Values:      map[string]float64{"K": 2},
+		LatestResult: &Evaluation{
+			Values: map[string]float64{"K": 2},
+		},
+	}
+	tr2 := StateTransition{State: s2}
+	ReleaseEvictedStaleTransitionValueMaps(StateTransitions{tr2})
+	require.Nil(t, s2.Values)
+	require.Nil(t, s2.LatestResult.Values)
+}
+
+func newEvalResultWithValues(evaluatedAt time.Time, labels data.Labels, n int) eval.Result {
+	values := make(map[string]eval.NumberValueCapture, n)
+	for i := 0; i < n; i++ {
+		v := float64(i)
+		values[seriesLabel(i)] = eval.NumberValueCapture{
+			Var:    seriesLabel(i),
+			Labels: labels.Copy(),
+			Value:  &v,
+			Type:   "reduce",
+		}
+	}
+	return eval.Result{
+		Instance:           labels,
+		State:              eval.Alerting,
+		Values:             values,
+		EvaluatedAt:        evaluatedAt,
+		EvaluationDuration: 5 * time.Millisecond,
+		EvaluationString:   "",
+	}
+}
+
+func seriesLabel(i int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	if i >= 0 && i < len(letters) {
+		return string(letters[i])
+	}
+	return "x" + string(rune('a'+(i%26)))
+}

--- a/pkg/services/ngalert/state/transition_release.go
+++ b/pkg/services/ngalert/state/transition_release.go
@@ -1,0 +1,25 @@
+package state
+
+// ReleaseEvictedStaleTransitionValueMaps drops large evaluation maps from transitions whose alert
+// instances were evicted from the scheduler cache (missing series resolved to Normal with
+// StateReasonMissingSeries).
+//
+// Call this only after ProcessEvalResults has finished persisting, recording history, and sending
+// notifications — i.e. after the function returns — so downstream consumers have read Values /
+// LatestResult.Values.
+//
+// Important: do not clear Values for transitions that still back in-cache alert instances:
+// StateTransition embeds the same *State pointer that lives in the cache for active series.
+// IsStale() is true only for evicted missing-series instances, so those are safe to release.
+func ReleaseEvictedStaleTransitionValueMaps(transitions StateTransitions) {
+	for i := range transitions {
+		s := transitions[i].State
+		if s == nil || !s.IsStale() {
+			continue
+		}
+		s.Values = nil
+		if s.LatestResult != nil {
+			s.LatestResult.Values = nil
+		}
+	}
+}

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
@@ -93,7 +93,12 @@ export class ConditionalRenderingVariable extends SceneObjectBase<ConditionalRen
       return undefined;
     }
 
-    const variable = sceneGraph.getVariables(object).getByName(this.state.variable);
+    // sceneGraph.lookupVariable walks up the scene graph parent chain,
+    // respecting section-level $variables on rows/tabs before reaching
+    // the dashboard root. This correctly handles repeated panel clones
+    // whose local $variables only contains the repeat variable and would
+    // otherwise shadow dashboard-level variables. See: GitHub issue #120327
+    const variable = sceneGraph.lookupVariable(this.state.variable, object);
 
     if (!variable) {
       return undefined;

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
@@ -345,7 +345,10 @@ describe('AutoGridItem repeat + conditional rendering', () => {
       renderHidden: false,
     });
 
-    const { gridItem, hideVar, regionVar } = setupDashboardWithAutoGridItem({ repeatByValues: true, conditionalGroup: group });
+    const { gridItem, hideVar, regionVar } = setupDashboardWithAutoGridItem({
+      repeatByValues: true,
+      conditionalGroup: group,
+    });
 
     const force = () => {
       gridItem.state.conditionalRendering?.forceCheck();

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
@@ -1,5 +1,15 @@
-import { SceneGridLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import {
+  ConstantVariable,
+  CustomVariable,
+  SceneGridLayout,
+  SceneQueryRunner,
+  SceneVariableSet,
+  SwitchVariable,
+  VizPanel,
+} from '@grafana/scenes';
 
+import { ConditionalRenderingVariable } from '../../conditional-rendering/conditions/ConditionalRenderingVariable';
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DashboardEditActionEvent } from '../../edit-pane/shared';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { DashboardScene, type DashboardSceneState } from '../DashboardScene';
@@ -180,6 +190,257 @@ describe('AutoGridLayoutManager', () => {
 
       expect(autoLayout.state.layout.state.isDraggable).toBe(false);
     });
+  });
+});
+
+describe('AutoGridItem repeat + conditional rendering', () => {
+  function createGroupWithVariableEquals(variable: string, value: string): ConditionalRenderingGroup {
+    const condition = new ConditionalRenderingVariable({
+      variable,
+      operator: '=',
+      value,
+      result: undefined,
+    });
+
+    return new ConditionalRenderingGroup({
+      condition: 'and',
+      visibility: 'show',
+      conditions: [condition],
+      result: true,
+      renderHidden: false,
+    });
+  }
+
+  function setupDashboardWithAutoGridItem({
+    repeatByValues,
+    conditionalGroup,
+  }: {
+    repeatByValues: boolean;
+    conditionalGroup: ConditionalRenderingGroup;
+  }) {
+    const valuesVar = new CustomVariable({
+      name: 'Values',
+      query: 'Value1,Value2',
+      options: [
+        { label: 'Value1', value: 'Value1' },
+        { label: 'Value2', value: 'Value2' },
+      ],
+      value: ['Value1', 'Value2'],
+      text: ['Value1', 'Value2'],
+      isMulti: true,
+    });
+
+    const hideVar = new SwitchVariable({
+      name: 'Hide',
+      value: 'false',
+      enabledValue: 'true',
+      disabledValue: 'false',
+    });
+
+    const regionVar = new ConstantVariable({
+      name: 'Region',
+      value: 'US',
+    });
+
+    const variables = new SceneVariableSet({
+      variables: [valuesVar, hideVar, regionVar],
+    });
+
+    const panel = new VizPanel({
+      title: 'Panel 1',
+      key: 'panel-1',
+      pluginId: 'table',
+      $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
+    });
+
+    const gridItem = new AutoGridItem({
+      key: 'grid-item-1',
+      body: panel,
+      variableName: repeatByValues ? 'Values' : undefined,
+      conditionalRendering: conditionalGroup,
+    });
+
+    const manager = new AutoGridLayoutManager({
+      key: 'test-AutoGridLayoutManager',
+      layout: new AutoGridLayout({ children: [gridItem] }),
+    });
+
+    const dashboard = new DashboardScene({ body: manager, $variables: variables });
+
+    // Activate the dashboard and create repeat clones for the tests.
+    dashboard.activate();
+    gridItem.performRepeat();
+
+    return { gridItem, valuesVar, hideVar, regionVar };
+  }
+
+  it('repeated panel respects conditional rendering based on non-repeat variable', () => {
+    const group = createGroupWithVariableEquals('Hide', 'false');
+    const { gridItem, hideVar } = setupDashboardWithAutoGridItem({ repeatByValues: true, conditionalGroup: group });
+
+    // Hide = false -> visible
+    hideVar.setState({ value: 'false' });
+    gridItem.state.conditionalRendering?.forceCheck();
+    gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result)).toBe(true);
+
+    // Hide = true -> hidden
+    hideVar.setState({ value: 'true' });
+    gridItem.state.conditionalRendering?.forceCheck();
+    gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result === false)).toBe(true);
+
+    // Hide = false again -> visible
+    hideVar.setState({ value: 'false' });
+    gridItem.state.conditionalRendering?.forceCheck();
+    gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result)).toBe(true);
+  });
+
+  it('non-repeated panel conditional rendering still works correctly after fix', () => {
+    const group = createGroupWithVariableEquals('Hide', 'false');
+    const { gridItem, hideVar } = setupDashboardWithAutoGridItem({ repeatByValues: false, conditionalGroup: group });
+
+    hideVar.setState({ value: 'false' });
+    gridItem.state.conditionalRendering?.forceCheck();
+    expect(gridItem.state.conditionalRendering?.state.result).toBe(true);
+
+    hideVar.setState({ value: 'true' });
+    gridItem.state.conditionalRendering?.forceCheck();
+    expect(gridItem.state.conditionalRendering?.state.result).toBe(false);
+  });
+
+  it('repeated panel can use its own repeat variable in conditional rendering', () => {
+    const group = createGroupWithVariableEquals('Values', 'Value1');
+    const { gridItem } = setupDashboardWithAutoGridItem({ repeatByValues: true, conditionalGroup: group });
+
+    gridItem.state.conditionalRendering?.forceCheck();
+    gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+
+    // Source panel should resolve Values=Value1, clone should resolve Values=Value2.
+    expect(gridItem.state.conditionalRendering?.state.result).toBe(true);
+    expect(gridItem.state.repeatedConditionalRendering).toHaveLength(1);
+    expect(gridItem.state.repeatedConditionalRendering?.[0].state.result).toBe(false);
+  });
+
+  it('repeated panel with multiple conditional rendering conditions evaluates all correctly', () => {
+    const hideCondition = new ConditionalRenderingVariable({
+      variable: 'Hide',
+      operator: '=',
+      value: 'false',
+      result: undefined,
+    });
+    const regionCondition = new ConditionalRenderingVariable({
+      variable: 'Region',
+      operator: '=',
+      value: 'US',
+      result: undefined,
+    });
+
+    const group = new ConditionalRenderingGroup({
+      condition: 'and',
+      visibility: 'show',
+      conditions: [hideCondition, regionCondition],
+      result: true,
+      renderHidden: false,
+    });
+
+    const { gridItem, hideVar, regionVar } = setupDashboardWithAutoGridItem({ repeatByValues: true, conditionalGroup: group });
+
+    const force = () => {
+      gridItem.state.conditionalRendering?.forceCheck();
+      gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+    };
+
+    // Hide=false + Region=US: visible
+    hideVar.setState({ value: 'false' });
+    regionVar.setState({ value: 'US' });
+    force();
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result)).toBe(true);
+
+    // Hide=true + Region=US: hidden
+    hideVar.setState({ value: 'true' });
+    regionVar.setState({ value: 'US' });
+    force();
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result === false)).toBe(true);
+
+    // Hide=false + Region=EU: hidden
+    hideVar.setState({ value: 'false' });
+    regionVar.setState({ value: 'EU' });
+    force();
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result === false)).toBe(true);
+
+    // Hide=true + Region=EU: hidden
+    hideVar.setState({ value: 'true' });
+    regionVar.setState({ value: 'EU' });
+    force();
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result === false)).toBe(true);
+  });
+
+  it('repeated panel resolves variable from intermediate ancestor before reaching dashboard root', () => {
+    const valuesVar = new CustomVariable({
+      name: 'Values',
+      query: 'Value1,Value2',
+      options: [
+        { label: 'Value1', value: 'Value1' },
+        { label: 'Value2', value: 'Value2' },
+      ],
+      value: ['Value1', 'Value2'],
+      text: ['Value1', 'Value2'],
+      isMulti: true,
+    });
+
+    const hideVar = new SwitchVariable({
+      name: 'Hide',
+      value: 'false',
+      enabledValue: 'true',
+      disabledValue: 'false',
+    });
+
+    const middleVariables = new SceneVariableSet({ variables: [hideVar] });
+
+    const group = createGroupWithVariableEquals('Hide', 'false');
+
+    const panel = new VizPanel({
+      title: 'Panel 1',
+      key: 'panel-1',
+      pluginId: 'table',
+      $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
+    });
+
+    const gridItem = new AutoGridItem({
+      key: 'grid-item-1',
+      body: panel,
+      variableName: 'Values',
+      conditionalRendering: group,
+    });
+
+    // Simulate a row/tab level $variables scope sitting between the clone and the dashboard root.
+    const middleLayout = new AutoGridLayout({ children: [gridItem], $variables: middleVariables });
+
+    const manager = new AutoGridLayoutManager({
+      key: 'test-AutoGridLayoutManager',
+      layout: middleLayout,
+    });
+
+    // Dashboard root intentionally does NOT define Hide to verify the intermediate scope is used.
+    const dashboard = new DashboardScene({
+      body: manager,
+      $variables: new SceneVariableSet({ variables: [valuesVar] }),
+    });
+
+    dashboard.activate();
+    gridItem.performRepeat();
+
+    gridItem.state.conditionalRendering?.forceCheck();
+    gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result)).toBe(true);
+
+    // Flip Hide -> should hide repeated clones.
+    hideVar.setState({ value: 'true' });
+    gridItem.state.conditionalRendering?.forceCheck();
+    gridItem.state.repeatedConditionalRendering?.forEach((g) => g.forceCheck());
+    expect(gridItem.state.repeatedConditionalRendering?.every((g) => g.state.result === false)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #123017

## Root cause

\`ProcessEvalResults\` builds a \`[]StateTransition\` slice holding \`*State\` pointers. Each \`State\` carries \`Values map[string]float64\` and \`LatestResult.Values map[string]float64\` — one entry per expression ref ID per active series. For workloads with series churn, these maps accumulate significant memory that is retained until the next GC cycle long after the values are no longer needed.

The v13.0.0 refactor of \`processMissingSeriesStates\` to buffer stale fingerprints before deletion (instead of inline deletion) means stale \`*State\` objects now travel further through the pipeline before release, directly worsening the spike pattern users are reporting.

## What was tried first (and why it was wrong)

An initial approach zeroed \`State.Values\` inside \`processMissingSeriesStates\` before eviction. This ran before \`compat.go\`, \`historian/annotation.go\`, \`historian/loki.go\`, and \`persister_sync.go\` all read \`State.Values\`, causing silent data loss in alert annotations, Loki history, and the instance database. That change was fully reverted.

## This fix

Add \`ReleaseEvictedStaleTransitionValueMaps\` in \`transition_release.go\`, which nils \`Values\` and \`LatestResult.Values\` only on transitions where \`State.IsStale()\` is true (i.e. \`StateReasonMissingSeries\` — already evicted from the rule cache). Call it from all three production paths after all consumers finish:

- \`pkg/services/ngalert/schedule/alert_rule.go\` — main scheduler path, after \`ProcessEvalResults\` returns
- \`pkg/services/ngalert/backtesting/engine.go\` — after Loki row building
- \`pkg/services/ngalert/api/api_testing.go\` — after building postable alerts

Live \`*State\` objects (\`IsStale() == false\`) share the same pointer as active-series transitions and are not touched.

## Call order proof (ProcessEvalResults line numbers)

\`\`\`
345–347  setNextStateForRule + processMissingSeriesStates
353      allChanges = merged transitions
362      persister.Sync(allChanges)          ← reads LatestResult.Values
363–364  historian.Record(allChanges)        ← reads State.Values
369–370  send(statesToSend)                  ← compat reads Values for annotations
373      return allChanges
         ↑ ReleaseEvictedStaleTransitionValueMaps called by caller AFTER this
\`\`\`

## Note on idle baseline memory

\`pkg/infra/features/cache.go\` (entirely new in v13) uses an unbounded \`xsync.Map\` for HTTP response caching with no eviction cap. This likely contributes to the idle baseline increase (~150MB → ~330MB) but requires a design decision on eviction policy / LRU. Flagging for maintainer input — not changed in this PR.

## Tests

| Test | What it covers |
|---|---|
| \`TestValuesAvailableToHistorianAfterEviction\` | Values intact through pipeline, nil only after release |
| \`TestMemoryReleasedAfterFullPipeline\` | 200 cycles × 100-series churn, heap growth < 30MB |
| \`TestMemoryGrowthBoundedAcrossEvalCycles\` | 500 cycles, heap growth < 20MB |
| \`TestReleaseEvictedStaleTransitionValueMapsSkipsLiveStates\` | Live alerting states unaffected |
| \`TestStaleStatesConcurrentSafety\` | Race-detector validated concurrency |

