### PR TITLE
ci: add grafana-frontend-navigation to frontend test coverage opt-in teams

### DIFF
--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -26,7 +26,8 @@ jobs:
         [
           "@grafana/datapro",
           "@grafana/dataviz-squad",
-          "@grafana/grafana-operator-experience-squad"
+          "@grafana/grafana-operator-experience-squad",
+          "@grafana/grafana-frontend-navigation"
         ]
     steps:
       - name: Define opted-in teams


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `@grafana/grafana-frontend-navigation` to the list of opt-in teams in the `Check Frontend Test Coverage` CI workflow.

The team is already using `@grafana/grafana-frontend-navigation` as their CODEOWNERS handle throughout the repository, so this change will cause the coverage job to run for files they own on each PR.

## Changes

- `.github/workflows/check-frontend-test-coverage.yml`: appended `@grafana/grafana-frontend-navigation` to the `opted-in-teams` output list in the `setup` job.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49a9f072-d989-48d4-975e-bdea9836dab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49a9f072-d989-48d4-975e-bdea9836dab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

