### PR TITLE
fix: add index for org_id-id columns to short_url table

### DIFF
--- a/pkg/services/sqlstore/migrations/short_url_mig.go
+++ b/pkg/services/sqlstore/migrations/short_url_mig.go
@@ -28,4 +28,6 @@ func addShortURLMigrations(mg *Migrator) {
 	mg.AddMigration("alter table short_url alter column created_by type to bigint", NewRawSQLMigration("").
 		Mysql("ALTER TABLE short_url MODIFY created_by BIGINT;").
 		Postgres("ALTER TABLE short_url ALTER COLUMN created_by TYPE BIGINT;"))
+
+	mg.AddMigration("add index short_url.org_id-id", NewAddIndexMigration(shortURLV1, &Index{Cols: []string{"org_id", "id"}}))
 }


### PR DESCRIPTION
Patch the index addition into `steady` (https://github.com/grafana/grafana/pull/122955). We need it for the shorturls migration in prod.

Ticket: https://github.com/grafana/search-and-storage-team/issues/686