### PR TITLE
FS: Log user agent in request logs

### DIFF
--- a/pkg/services/frontend/context_middleware.go
+++ b/pkg/services/frontend/context_middleware.go
@@ -70,6 +70,11 @@ func setRequestContext(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		reqContext.Logger = reqContext.Logger.New("hostname", hostname)
 	}
 
+	// add user agent to logger context
+	if userAgent := r.UserAgent(); userAgent != "" {
+		reqContext.Logger = reqContext.Logger.New("user_agent", userAgent)
+	}
+
 	// Parse namespace from W3C baggage header
 	var namespace string
 	if baggageHeader := r.Header.Get("baggage"); baggageHeader != "" {

--- a/pkg/services/frontend/context_middleware_test.go
+++ b/pkg/services/frontend/context_middleware_test.go
@@ -1,12 +1,21 @@
 package frontend
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	gokitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/middleware/loggermw"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func TestContextMiddleware(t *testing.T) {
@@ -92,5 +101,56 @@ func TestSetRequestContext(t *testing.T) {
 		namespace, ok := request.NamespaceFrom(ctx)
 		assert.False(t, ok, "Namespace should not be present in context")
 		assert.Empty(t, namespace, "Namespace should be empty when namespace member not in baggage")
+	})
+}
+
+func TestRequestLogIncludesUserAgent(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.RouterLogging = true
+	features := featuremgmt.WithFeatures()
+
+	service := &frontendService{cfg: cfg, features: features}
+
+	// setRequestContext builds reqContext.Logger from log.New("context"). Swap the
+	// cached instance's inner logger to capture the access log line emitted by
+	// loggermw, while preserving the contextual fields added via .New(...).
+	var buf bytes.Buffer
+	contextLogger := log.New("context")
+	contextLogger.Swap(gokitlog.NewLogfmtLogger(gokitlog.NewSyncWriter(&buf)))
+	t.Cleanup(func() {
+		contextLogger.Swap(gokitlog.NewLogfmtLogger(gokitlog.NewSyncWriter(io.Discard)))
+	})
+
+	loggerMW := loggermw.Provide(cfg, features)
+
+	m := web.New()
+	m.UseMiddleware(service.contextMiddleware())
+	m.UseMiddleware(loggerMW.Middleware())
+	m.Get("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("includes user_agent field when User-Agent header is set", func(t *testing.T) {
+		buf.Reset()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("User-Agent", "TestAgent/1.0")
+		rec := httptest.NewRecorder()
+
+		m.ServeHTTP(rec, req)
+
+		assert.Contains(t, buf.String(), "Request Completed")
+		assert.Contains(t, buf.String(), "user_agent=TestAgent/1.0")
+	})
+
+	t.Run("omits user_agent field when User-Agent header is not set", func(t *testing.T) {
+		buf.Reset()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Del("User-Agent")
+		rec := httptest.NewRecorder()
+
+		m.ServeHTTP(rec, req)
+
+		assert.Contains(t, buf.String(), "Request Completed")
+		assert.NotContains(t, buf.String(), "user_agent")
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Adds the request `User-Agent` header as a `user_agent` field on the frontend service's logger context. It then appears in the "Request Completed" access log line alongside existing fields like `hostname` and `traceID`.

**Why do we need this feature?**

Having the user agent in access logs makes it easier to diagnose client-specific issues (browsers, bots, health checkers) hitting the frontend service.

**Who is this feature for?**

Engineers operating and debugging the frontend service.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.