### PR TITLE
FS: Allow configuring settings service cache TTL

### DIFF
--- a/pkg/services/frontend/settings_service.go
+++ b/pkg/services/frontend/settings_service.go
@@ -26,6 +26,7 @@ import (
 // url =
 // qps =
 // burst =
+// cache_ttl =
 //
 // Returns nil if not configured (this is not an error condition). Errors returned should
 // be considered critical.
@@ -34,6 +35,7 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 	settingsServiceURL := settingsSec.Key("url").String()
 	settingsServiceQPS := float32(settingsSec.Key("qps").MustFloat64(0))
 	settingsServiceBurst := settingsSec.Key("burst").MustInt(0)
+	settingsServiceCacheTTL := settingsSec.Key("cache_ttl").MustDuration(0)
 	if settingsServiceURL == "" {
 		// If settings service URL is not configured, return nil *without* error
 		return nil, nil
@@ -69,6 +71,7 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 		TLSClientConfig:     tlsConfig,
 		QPS:                 settingsServiceQPS,
 		Burst:               settingsServiceBurst,
+		CacheTTL:            settingsServiceCacheTTL,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create settings service client: %w", err)


### PR DESCRIPTION
**What is this feature?**

Adds a new `cache_ttl` key to the `[settings_service]` ini section consumed by the frontend service. The value is passed through as `CacheTTL` on the settings service client config. Default is `0`, which preserves existing behavior (the settings client falls back to its own built-in default).

**Why do we need this feature?**

The settings client's cache TTL was previously hardcoded from the frontend service's perspective — there was no way to tune it without a rebuild. Making it configurable lets operators adjust staleness/load tradeoffs per environment, and allows disabling the cache entirely (by setting a negative duration, which the settings client treats as "no cache").

The goal is to increase the cache TTL to ~30s or 1m to reduce the impact of traffic spikes.

**Who is this feature for?**

Operators running the frontend service target.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.