### PR TITLE
FeatureToggles: Promote teamFolders toggle to public preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -102,6 +102,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `alertRuleRestore`                | Enables the alert rule restore feature                                                                 |
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                        |
 | `alertingListViewV2PreviewToggle` | Enables the alerting list view v2 preview toggle                                                       |
+| `teamFolders`                     | Enables team folders functionality                                                                     |
 | `interactiveLearning`             | Enables the interactive learning app                                                                   |
 | `vizPresets`                      | Enable visualization presets                                                                           |
 | `nestedFramesFieldOverrides`      | Enable field overrides for FieldType.nestedFrames fields (like in nested tables)                       |

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2169,7 +2169,7 @@ var (
 		{
 			Name:        "teamFolders",
 			Description: "Enables team folders functionality",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 			Owner:       grafanaFrontendNavigation,
 			Expression:  "false",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -248,11 +248,11 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-07-17,alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
 2025-07-31,dashboardLevelTimeMacros,experimental,@grafana/dashboards-squad,false,false,true
 2025-07-25,alertmanagerRemoteSecondaryWithRemoteState,experimental,@grafana/alerting-squad,false,false,false
-2025-08-01,restrictedPluginApis,GA,@grafana/plugins-platform-backend,false,false,true
-2025-08-01,favoriteDatasources,experimental,@grafana/plugins-platform-backend,false,false,true
-2025-08-01,newLogContext,experimental,@grafana/observability-logs,false,false,true
-2025-08-01,newClickhouseConfigPageDesign,privatePreview,@grafana/data-sources-plugins,false,false,false
-2025-08-01,teamFolders,experimental,@grafana/grafana-frontend-navigation,false,false,false
+2025-07-31,restrictedPluginApis,GA,@grafana/plugins-platform-backend,false,false,true
+2025-07-31,favoriteDatasources,experimental,@grafana/plugins-platform-backend,false,false,true
+2025-07-31,newLogContext,experimental,@grafana/observability-logs,false,false,true
+2025-07-31,newClickhouseConfigPageDesign,privatePreview,@grafana/data-sources-plugins,false,false,false
+2025-07-31,teamFolders,preview,@grafana/grafana-frontend-navigation,false,false,false
 2025-10-22,interactiveLearning,preview,@grafana/pathfinder,false,false,false
 2025-08-01,alertingTriage,experimental,@grafana/alerting-squad,false,false,false
 2026-02-18,alertingAlertsActivityBanner,experimental,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5427,13 +5427,16 @@
     {
       "metadata": {
         "name": "teamFolders",
-        "resourceVersion": "1771434338561",
+        "resourceVersion": "1776767556250",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-04-21 10:32:36.250731 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables team folders functionality",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "expression": "false"
       }


### PR DESCRIPTION
**What is this about?**
Promotes the `teamFolders` feature toggle from experimental to public preview. Also regenerates the feature toggle artifacts (`toggles_gen.json`, `toggles_gen.csv`) and updates the feature toggles documentation page.

**Why do we need this?**
The team folders feature has matured beyond experimental and is ready for broader exposure under public preview.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.