### PR TITLE
Dashboards: Make overflowing tabs discoverable with scroll buttons and auto-scroll

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.test.tsx
@@ -1,0 +1,136 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { DashboardScene } from '../DashboardScene';
+
+import { TabItem } from './TabItem';
+import { TabsLayoutManager } from './TabsLayoutManager';
+
+type ResizeObserverCallback = (entries: ResizeObserverEntry[], observer: ResizeObserver) => void;
+
+let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(cb);
+  }
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+
+function triggerResizeObservers() {
+  act(() => {
+    for (const cb of resizeObserverCallbacks) {
+      cb([], {} as ResizeObserver);
+    }
+  });
+}
+
+function getScrollContainer() {
+  // The tabs Droppable is the scroll container; hello-pangea/dnd tags it with this attribute.
+  const el = document.querySelector<HTMLElement>('[data-rfd-droppable-id]');
+  if (!el) {
+    throw new Error('Scroll container not found');
+  }
+  return el;
+}
+
+function setContainerDimensions(
+  el: HTMLElement,
+  { scrollWidth, clientWidth, scrollLeft }: { scrollWidth: number; clientWidth: number; scrollLeft: number }
+) {
+  Object.defineProperty(el, 'scrollWidth', { configurable: true, value: scrollWidth });
+  Object.defineProperty(el, 'clientWidth', { configurable: true, value: clientWidth });
+  Object.defineProperty(el, 'scrollLeft', { configurable: true, value: scrollLeft, writable: true });
+}
+
+function buildManager(titles: string[]) {
+  const tabs = titles.map((title, i) => new TabItem({ key: `tab-${i}`, title }));
+  const manager = new TabsLayoutManager({ key: 'tabs-layout', tabs });
+  new DashboardScene({ body: manager });
+  return manager;
+}
+
+describe('TabsLayoutManagerRenderer scroll buttons', () => {
+  const realResizeObserver = global.ResizeObserver;
+  // jsdom does not implement scrollBy on Element; define it once so it can be spied on.
+  const scrollByMock = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
+      configurable: true,
+      writable: true,
+      value: scrollByMock,
+    });
+  });
+
+  beforeEach(() => {
+    resizeObserverCallbacks = [];
+    global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    scrollByMock.mockReset();
+  });
+
+  afterEach(() => {
+    global.ResizeObserver = realResizeObserver;
+  });
+
+  it('does not render scroll buttons when tabs fit the container', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2']);
+    render(<manager.Component model={manager} />);
+
+    setContainerDimensions(getScrollContainer(), { scrollWidth: 200, clientWidth: 400, scrollLeft: 0 });
+    triggerResizeObservers();
+
+    expect(screen.queryByLabelText('Scroll tabs left')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Scroll tabs right')).not.toBeInTheDocument();
+  });
+
+  it('shows only the right button when overflow is ahead', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    setContainerDimensions(getScrollContainer(), { scrollWidth: 800, clientWidth: 400, scrollLeft: 0 });
+    triggerResizeObservers();
+
+    expect(screen.queryByLabelText('Scroll tabs left')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Scroll tabs right')).toBeInTheDocument();
+  });
+
+  it('shows only the left button when scrolled fully to the right', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    setContainerDimensions(getScrollContainer(), { scrollWidth: 800, clientWidth: 400, scrollLeft: 400 });
+    triggerResizeObservers();
+
+    expect(screen.getByLabelText('Scroll tabs left')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Scroll tabs right')).not.toBeInTheDocument();
+  });
+
+  it('shows both buttons when scrolled somewhere in the middle', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    setContainerDimensions(getScrollContainer(), { scrollWidth: 800, clientWidth: 400, scrollLeft: 200 });
+    triggerResizeObservers();
+
+    expect(screen.getByLabelText('Scroll tabs left')).toBeInTheDocument();
+    expect(screen.getByLabelText('Scroll tabs right')).toBeInTheDocument();
+  });
+
+  it('scrolls the container when buttons are clicked', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    const container = getScrollContainer();
+    setContainerDimensions(container, { scrollWidth: 800, clientWidth: 400, scrollLeft: 200 });
+    triggerResizeObservers();
+
+    fireEvent.click(screen.getByLabelText('Scroll tabs right'));
+    expect(scrollByMock).toHaveBeenLastCalledWith({ left: 400 * 0.8, behavior: 'smooth' });
+
+    fireEvent.click(screen.getByLabelText('Scroll tabs left'));
+    expect(scrollByMock).toHaveBeenLastCalledWith({ left: -(400 * 0.8), behavior: 'smooth' });
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.test.tsx
@@ -45,17 +45,18 @@ function setContainerDimensions(
   Object.defineProperty(el, 'scrollLeft', { configurable: true, value: scrollLeft, writable: true });
 }
 
-function buildManager(titles: string[]) {
+function buildManager(titles: string[], currentTabSlug?: string) {
   const tabs = titles.map((title, i) => new TabItem({ key: `tab-${i}`, title }));
-  const manager = new TabsLayoutManager({ key: 'tabs-layout', tabs });
+  const manager = new TabsLayoutManager({ key: 'tabs-layout', tabs, currentTabSlug });
   new DashboardScene({ body: manager });
   return manager;
 }
 
 describe('TabsLayoutManagerRenderer scroll buttons', () => {
   const realResizeObserver = global.ResizeObserver;
-  // jsdom does not implement scrollBy on Element; define it once so it can be spied on.
+  // jsdom does not implement scrollBy/scrollTo on Element; define once so they can be spied on.
   const scrollByMock = jest.fn();
+  const scrollToMock = jest.fn();
 
   beforeAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
@@ -63,12 +64,18 @@ describe('TabsLayoutManagerRenderer scroll buttons', () => {
       writable: true,
       value: scrollByMock,
     });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      writable: true,
+      value: scrollToMock,
+    });
   });
 
   beforeEach(() => {
     resizeObserverCallbacks = [];
     global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
     scrollByMock.mockReset();
+    scrollToMock.mockReset();
   });
 
   afterEach(() => {
@@ -132,5 +139,208 @@ describe('TabsLayoutManagerRenderer scroll buttons', () => {
 
     fireEvent.click(screen.getByLabelText('Scroll tabs left'));
     expect(scrollByMock).toHaveBeenLastCalledWith({ left: -(400 * 0.8), behavior: 'smooth' });
+  });
+});
+
+describe('TabsLayoutManagerRenderer active tab auto-scroll', () => {
+  const realResizeObserver = global.ResizeObserver;
+  const scrollByMock = jest.fn();
+  const scrollToMock = jest.fn();
+
+  // Matches theme.spacing.gridSize (8) * TAB_FADE_SPACING (6) in the renderer.
+  const FADE_PX = 48;
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
+      configurable: true,
+      writable: true,
+      value: scrollByMock,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      writable: true,
+      value: scrollToMock,
+    });
+  });
+
+  beforeEach(() => {
+    resizeObserverCallbacks = [];
+    global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    scrollByMock.mockReset();
+    scrollToMock.mockReset();
+    // The scroll effect defers the actual scrollTo to the next animation frame.
+    // Fake timers let the tests flush that deferred callback synchronously.
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    global.ResizeObserver = realResizeObserver;
+  });
+
+  // Flush the requestAnimationFrame(s) scheduled by the scroll effect. jsdom
+  // implements rAF via setTimeout under the hood, which Jest's fake timers
+  // advance. The effect uses a double-rAF, so we need to run all timers until
+  // the queue is empty (not just the currently-pending ones).
+  function flushScrollFrame() {
+    act(() => {
+      jest.runAllTimers();
+    });
+  }
+
+  // Stubs the tab's position relative to the scroll container in scroll-coordinate
+  // space. The helper uses getBoundingClientRect for both, so we pair each tab
+  // with the container's rect and derive matching viewport coordinates.
+  function positionTabInScrollContainer(
+    container: HTMLElement,
+    tab: HTMLElement,
+    { scrollOffset, width }: { scrollOffset: number; width: number }
+  ) {
+    const containerLeftInViewport = 50;
+    container.getBoundingClientRect = () =>
+      ({
+        left: containerLeftInViewport,
+        right: containerLeftInViewport + container.clientWidth,
+        top: 0,
+        bottom: 0,
+        width: container.clientWidth,
+        height: 0,
+        x: containerLeftInViewport,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const tabLeftInViewport = containerLeftInViewport + (scrollOffset - container.scrollLeft);
+    tab.getBoundingClientRect = () =>
+      ({
+        left: tabLeftInViewport,
+        right: tabLeftInViewport + width,
+        top: 0,
+        bottom: 0,
+        width,
+        height: 0,
+        x: tabLeftInViewport,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+  }
+
+  it('scrolls an off-screen active tab into view, accounting for the fade region', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    const container = getScrollContainer();
+    setContainerDimensions(container, { scrollWidth: 800, clientWidth: 400, scrollLeft: 0 });
+
+    const targetTab = manager.state.tabs[3].containerRef.current!;
+    positionTabInScrollContainer(container, targetTab, { scrollOffset: 600, width: 100 });
+
+    scrollToMock.mockReset();
+
+    act(() => {
+      manager.setState({ currentTabSlug: 'tab-4' });
+    });
+    flushScrollFrame();
+
+    // tabRight (700) exceeds viewRight (400 - 48 = 352), so scrollTo targets
+    // tabRight - clientWidth + fadePx = 700 - 400 + 48 = 348, clamped to max (400).
+    expect(scrollToMock).toHaveBeenCalledWith({ left: 348, behavior: 'smooth' });
+  });
+
+  it('scrolls an active tab hidden behind the left fade back into view', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    const container = getScrollContainer();
+    setContainerDimensions(container, { scrollWidth: 800, clientWidth: 400, scrollLeft: 300 });
+
+    const targetTab = manager.state.tabs[1].containerRef.current!;
+    // Sits at scrollLeft 320, fully visible numerically but obscured by the fade margin.
+    positionTabInScrollContainer(container, targetTab, { scrollOffset: 320, width: 40 });
+
+    scrollToMock.mockReset();
+
+    act(() => {
+      manager.setState({ currentTabSlug: 'tab-2' });
+    });
+    flushScrollFrame();
+
+    // tabLeft (320) < viewLeft (300 + 48 = 348) → target = tabLeft - fadePx = 272.
+    expect(scrollToMock).toHaveBeenCalledWith({ left: 272, behavior: 'smooth' });
+  });
+
+  it('does not scroll when the active tab is already inside the non-faded window', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    const container = getScrollContainer();
+    setContainerDimensions(container, { scrollWidth: 800, clientWidth: 400, scrollLeft: 0 });
+
+    const targetTab = manager.state.tabs[1].containerRef.current!;
+    // [100, 180] is fully within [48, 352].
+    positionTabInScrollContainer(container, targetTab, { scrollOffset: 100, width: 80 });
+
+    scrollToMock.mockReset();
+
+    act(() => {
+      manager.setState({ currentTabSlug: 'tab-2' });
+    });
+    flushScrollFrame();
+
+    expect(scrollToMock).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to a freshly added tab that is past the visible area', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4']);
+    render(<manager.Component model={manager} />);
+
+    const container = getScrollContainer();
+    setContainerDimensions(container, { scrollWidth: 900, clientWidth: 400, scrollLeft: 0 });
+
+    scrollToMock.mockReset();
+
+    const newTab = new TabItem({ key: 'tab-new', title: 'New Tab' });
+
+    act(() => {
+      manager.setState({
+        tabs: [...manager.state.tabs, newTab],
+        currentTabSlug: newTab.getSlug(),
+      });
+    });
+
+    // After commit, the new tab's ref is attached by React. Stub its rect so
+    // the rAF callback finds a meaningful position.
+    const newTabEl = newTab.containerRef.current!;
+    expect(newTabEl).not.toBeNull();
+    positionTabInScrollContainer(container, newTabEl, { scrollOffset: 820, width: 80 });
+
+    flushScrollFrame();
+
+    // tabLeftInScroll = 820, tabRightInScroll = 900. viewRight = 352, so target =
+    // 900 - 400 + 48 = 548, clamped to max (900 - 400 = 500).
+    expect(scrollToMock).toHaveBeenCalledWith({ left: 500, behavior: 'smooth' });
+  });
+
+  it('clamps the scroll target to the container scroll range', () => {
+    const manager = buildManager(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4'], 'tab-3');
+    render(<manager.Component model={manager} />);
+
+    const container = getScrollContainer();
+    setContainerDimensions(container, { scrollWidth: 800, clientWidth: 400, scrollLeft: 300 });
+
+    const targetTab = manager.state.tabs[0].containerRef.current!;
+    // Tab at the very start; scrolling back would go negative but should clamp to 0.
+    positionTabInScrollContainer(container, targetTab, { scrollOffset: 0, width: 80 });
+
+    scrollToMock.mockReset();
+
+    act(() => {
+      manager.setState({ currentTabSlug: 'tab-1' });
+    });
+    flushScrollFrame();
+
+    expect(scrollToMock).toHaveBeenCalledWith({ left: 0, behavior: 'smooth' });
+    // Sanity-check the fade constant used by the assertions above stays in sync with the renderer.
+    expect(FADE_PX).toBe(48);
   });
 });

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -79,7 +79,11 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
               <Droppable droppableId={key!} direction="horizontal">
                 {(dropProvided) => (
                   <div
-                    className={styles.tabsContainer}
+                    className={cx(styles.tabsContainer, {
+                      [styles.tabsContainerFadeLeft]: canScrollLeft && !canScrollRight,
+                      [styles.tabsContainerFadeRight]: !canScrollLeft && canScrollRight,
+                      [styles.tabsContainerFadeBoth]: canScrollLeft && canScrollRight,
+                    })}
                     ref={mergeRefs(dropProvided.innerRef, scrollContainerRef)}
                     {...dropProvided.droppableProps}
                   >
@@ -90,7 +94,7 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
                 )}
               </Droppable>
               {canScrollLeft && (
-                <div className={cx(styles.scrollFade, styles.scrollFadeLeft)}>
+                <div className={cx(styles.scrollButtonWrapper, styles.scrollButtonWrapperLeft)}>
                   <IconButton
                     className={styles.scrollButton}
                     name="angle-left"
@@ -103,7 +107,7 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
                 </div>
               )}
               {canScrollRight && (
-                <div className={cx(styles.scrollFade, styles.scrollFadeRight)}>
+                <div className={cx(styles.scrollButtonWrapper, styles.scrollButtonWrapperRight)}>
                   <IconButton
                     className={styles.scrollButton}
                     name="angle-right"
@@ -204,7 +208,24 @@ const getStyles = (theme: GrafanaTheme2) => ({
     paddingInline: theme.spacing(0.125),
     paddingTop: '1px',
   }),
-  scrollFade: css({
+  // Fade the tabs themselves to transparent near the overflow edges using a mask.
+  // This avoids painting any color over whatever sits behind the tab bar (canvas,
+  // custom backgrounds, etc.) so the chevron buttons appear to float above the tabs.
+  // The region behind the chevron (spacing(4) ≈ 32px) is fully transparent; the
+  // remaining spacing(2) ≈ 16px is a soft fade into the visible tabs.
+  tabsContainerFadeLeft: css({
+    maskImage: `linear-gradient(to right, transparent 0, transparent ${theme.spacing(4)}, black ${theme.spacing(6)})`,
+    WebkitMaskImage: `linear-gradient(to right, transparent 0, transparent ${theme.spacing(4)}, black ${theme.spacing(6)})`,
+  }),
+  tabsContainerFadeRight: css({
+    maskImage: `linear-gradient(to left, transparent 0, transparent ${theme.spacing(4)}, black ${theme.spacing(6)})`,
+    WebkitMaskImage: `linear-gradient(to left, transparent 0, transparent ${theme.spacing(4)}, black ${theme.spacing(6)})`,
+  }),
+  tabsContainerFadeBoth: css({
+    maskImage: `linear-gradient(to right, transparent 0, transparent ${theme.spacing(4)}, black ${theme.spacing(6)}, black calc(100% - ${theme.spacing(6)}), transparent calc(100% - ${theme.spacing(4)}), transparent 100%)`,
+    WebkitMaskImage: `linear-gradient(to right, transparent 0, transparent ${theme.spacing(4)}, black ${theme.spacing(6)}, black calc(100% - ${theme.spacing(6)}), transparent calc(100% - ${theme.spacing(4)}), transparent 100%)`,
+  }),
+  scrollButtonWrapper: css({
     position: 'absolute',
     top: 0,
     bottom: 0,
@@ -212,19 +233,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     zIndex: 1,
     pointerEvents: 'none',
-    width: theme.spacing(6),
   }),
-  scrollFadeLeft: css({
+  scrollButtonWrapperLeft: css({
     left: 0,
-    justifyContent: 'flex-start',
-    paddingLeft: theme.spacing(0.5),
-    background: `linear-gradient(to right, ${theme.colors.background.primary} 40%, transparent)`,
   }),
-  scrollFadeRight: css({
+  scrollButtonWrapperRight: css({
     right: 0,
-    justifyContent: 'flex-end',
-    paddingRight: theme.spacing(0.5),
-    background: `linear-gradient(to left, ${theme.colors.background.primary} 40%, transparent)`,
   }),
   scrollButton: css({
     pointerEvents: 'auto',

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -1,12 +1,12 @@
 import { css, cx } from '@emotion/css';
 import { DragDropContext, Droppable, type DropResult, type DragStart } from '@hello-pangea/dnd';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Trans } from '@grafana/i18n';
+import { t, Trans } from '@grafana/i18n';
 import { MultiValueVariable, type SceneComponentProps, sceneGraph, useSceneObjectState } from '@grafana/scenes';
-import { Button, TabsBar, useStyles2 } from '@grafana/ui';
+import { Button, IconButton, TabsBar, useStyles2 } from '@grafana/ui';
 
 import { isRepeatCloneOrChildOf } from '../../utils/clone';
 import { getDashboardSceneFor, getLayoutOrchestratorFor } from '../../utils/utils';
@@ -32,6 +32,9 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
   const { hasCopiedTab } = useClipboardState();
   const isNestedInTab = useMemo(() => model.parent instanceof TabItem, [model.parent]);
   const soloPanelContext = useSoloPanelContext();
+
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const { canScrollLeft, canScrollRight, scrollBy } = useScrollOverflow(scrollContainerRef, tabs.length);
 
   useEffect(() => {
     if (currentTab && currentTab.getSlug() !== model.state.currentTabSlug) {
@@ -72,15 +75,47 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
       <TabsBar className={styles.tabsBar}>
         <DragDropContext onBeforeDragStart={onBeforeDragStart} onDragEnd={onDragEnd}>
           <div className={styles.tabsRow} {...{ [DASHBOARD_DROP_TARGET_KEY_ATTR]: key }}>
-            <Droppable droppableId={key!} direction="horizontal">
-              {(dropProvided) => (
-                <div className={styles.tabsContainer} ref={dropProvided.innerRef} {...dropProvided.droppableProps}>
-                  {children}
+            <div className={styles.tabsScrollArea}>
+              <Droppable droppableId={key!} direction="horizontal">
+                {(dropProvided) => (
+                  <div
+                    className={styles.tabsContainer}
+                    ref={mergeRefs(dropProvided.innerRef, scrollContainerRef)}
+                    {...dropProvided.droppableProps}
+                  >
+                    {children}
 
-                  {dropProvided.placeholder}
+                    {dropProvided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+              {canScrollLeft && (
+                <div className={cx(styles.scrollFade, styles.scrollFadeLeft)}>
+                  <IconButton
+                    className={styles.scrollButton}
+                    name="angle-left"
+                    size="md"
+                    variant="secondary"
+                    aria-label={t('dashboard.tabs-layout.scroll-tabs-left', 'Scroll tabs left')}
+                    onClick={() => scrollBy('left')}
+                    onMouseDown={(evt) => evt.preventDefault()}
+                  />
                 </div>
               )}
-            </Droppable>
+              {canScrollRight && (
+                <div className={cx(styles.scrollFade, styles.scrollFadeRight)}>
+                  <IconButton
+                    className={styles.scrollButton}
+                    name="angle-right"
+                    size="md"
+                    variant="secondary"
+                    aria-label={t('dashboard.tabs-layout.scroll-tabs-right', 'Scroll tabs right')}
+                    onClick={() => scrollBy('right')}
+                    onMouseDown={(evt) => evt.preventDefault()}
+                  />
+                </div>
+              )}
+            </div>
             {isEditing && !isClone && (
               <div className={cx(styles.tabControls, layoutControlsStyles.controls, 'dashboard-canvas-controls')}>
                 <Button
@@ -152,14 +187,47 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: '100%',
     alignItems: 'center',
   }),
+  tabsScrollArea: css({
+    position: 'relative',
+    flex: '1 1 auto',
+    minWidth: 0,
+    display: 'flex',
+  }),
   tabsContainer: css({
     display: 'flex',
+    flex: '1 1 auto',
+    minWidth: 0,
     justifyContent: 'flex-start',
     alignItems: 'flex-end',
     overflowX: 'auto',
     overflowY: 'hidden',
     paddingInline: theme.spacing(0.125),
     paddingTop: '1px',
+  }),
+  scrollFade: css({
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    zIndex: 1,
+    pointerEvents: 'none',
+    width: theme.spacing(6),
+  }),
+  scrollFadeLeft: css({
+    left: 0,
+    justifyContent: 'flex-start',
+    paddingLeft: theme.spacing(0.5),
+    background: `linear-gradient(to right, ${theme.colors.background.primary} 40%, transparent)`,
+  }),
+  scrollFadeRight: css({
+    right: 0,
+    justifyContent: 'flex-end',
+    paddingRight: theme.spacing(0.5),
+    background: `linear-gradient(to left, ${theme.colors.background.primary} 40%, transparent)`,
+  }),
+  scrollButton: css({
+    pointerEvents: 'auto',
   }),
   tabControls: css({
     marginLeft: theme.spacing(1),
@@ -168,3 +236,74 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginLeft: theme.spacing(2),
   }),
 });
+
+function mergeRefs<T>(
+  ...refs: Array<React.RefCallback<T> | React.MutableRefObject<T | null> | undefined>
+): React.RefCallback<T> {
+  return (value) => {
+    for (const ref of refs) {
+      if (!ref) {
+        continue;
+      }
+      if (typeof ref === 'function') {
+        ref(value);
+      } else {
+        ref.current = value;
+      }
+    }
+  };
+}
+
+const SCROLL_TOLERANCE_PX = 1;
+
+function useScrollOverflow(elementRef: React.RefObject<HTMLElement | null>, depValue: number) {
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) {
+      return;
+    }
+
+    const update = () => {
+      const hasLeft = el.scrollLeft > SCROLL_TOLERANCE_PX;
+      const hasRight = el.scrollLeft + el.clientWidth < el.scrollWidth - SCROLL_TOLERANCE_PX;
+      setCanScrollLeft(hasLeft);
+      setCanScrollRight(hasRight);
+    };
+
+    update();
+
+    el.addEventListener('scroll', update, { passive: true });
+
+    // Observe the scroll container itself (window resize) and its direct children
+    // (tab title edits, add/remove) so overflow state stays accurate without manual polling.
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    for (const child of Array.from(el.children)) {
+      if (child instanceof Element) {
+        observer.observe(child);
+      }
+    }
+
+    return () => {
+      el.removeEventListener('scroll', update);
+      observer.disconnect();
+    };
+  }, [elementRef, depValue]);
+
+  const scrollBy = useCallback(
+    (direction: 'left' | 'right') => {
+      const el = elementRef.current;
+      if (!el) {
+        return;
+      }
+      const delta = el.clientWidth * 0.8;
+      el.scrollBy({ left: direction === 'left' ? -delta : delta, behavior: 'smooth' });
+    },
+    [elementRef]
+  );
+
+  return { canScrollLeft, canScrollRight, scrollBy };
+}

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -6,7 +6,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { MultiValueVariable, type SceneComponentProps, sceneGraph, useSceneObjectState } from '@grafana/scenes';
-import { Button, IconButton, TabsBar, useStyles2 } from '@grafana/ui';
+import { Button, IconButton, TabsBar, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { isRepeatCloneOrChildOf } from '../../utils/clone';
 import { getDashboardSceneFor, getLayoutOrchestratorFor } from '../../utils/utils';
@@ -23,6 +23,7 @@ import { type TabsLayoutManager } from './TabsLayoutManager';
 export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLayoutManager>) {
   const styles = useStyles2(getStyles);
   const layoutControlsStyles = useStyles2(getLayoutControlsStyles);
+  const theme = useTheme2();
 
   const { tabs, key, placeholder, isDropTarget } = model.useState();
   const currentTab = model.getCurrentTab();
@@ -41,6 +42,51 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
       model.setState({ currentTabSlug: currentTab.getSlug() });
     }
   }, [currentTab, model]);
+
+  // Keep the active tab visible within the horizontal tab strip when it changes
+  // (initial mount, URL/history navigation, programmatic switch, newly added tab).
+  // Reserved margin matches the mask-image "fully opaque" stop so the active tab
+  // never lands in the faded region behind a chevron button.
+  //
+  // The add-tab path is subtle: `addNewTab` sets both `tabs` and `currentTabSlug`
+  // in one setState, but the ensuing commit goes through several intermediate
+  // renders (edit pane selection, isNewElement, DnD re-layout). We:
+  //   - run once synchronously after commit in case the ref is already attached
+  //     and layout is stable (covers the simple switch-tab case);
+  //   - then wait through two animation frames as a fallback. A single rAF can
+  //     still fire before DnD has finished positioning a freshly added
+  //     Draggable; a second rAF gives it another layout/paint cycle.
+  const fadePx = theme.spacing.gridSize * TAB_FADE_SPACING;
+  useEffect(() => {
+    let raf1 = 0;
+    let raf2 = 0;
+
+    const tryScroll = () => {
+      const container = scrollContainerRef.current;
+      const tabEl = currentTab?.containerRef.current ?? null;
+      if (!container || !tabEl) {
+        return false;
+      }
+      scrollTabIntoView(container, tabEl, fadePx);
+      return true;
+    };
+
+    // Try immediately — this is enough when the tab was already in the DOM.
+    tryScroll();
+
+    // Retry after layout has settled. Two frames handle DnD libraries that
+    // re-measure after their own rAF callback.
+    raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        tryScroll();
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+  }, [currentTab, fadePx]);
 
   if (soloPanelContext) {
     return tabs.map((tab) => <TabWrapper tab={tab} manager={model} key={tab.state.key!} />);
@@ -269,6 +315,44 @@ function mergeRefs<T>(
 }
 
 const SCROLL_TOLERANCE_PX = 1;
+
+// Grid-unit multiplier that mirrors the fully-opaque stop of the tabs mask-image
+// fade (see tabsContainerFade*). Kept as a multiple of the theme grid size so the
+// reserved area stays visually consistent with the fade if the theme changes.
+const TAB_FADE_SPACING = 6;
+
+/**
+ * Horizontally scrolls `container` so `tab` is fully visible without landing
+ * under the fade region. Leaves scroll untouched if the tab is already inside
+ * the non-faded window.
+ *
+ * We intentionally use getBoundingClientRect rather than offsetLeft: the tab is
+ * wrapped in a Draggable div that can become the tab's offsetParent, which
+ * makes offsetLeft unreliable as a position in the scroll container's
+ * scroll-coordinate space.
+ */
+function scrollTabIntoView(container: HTMLElement, tab: HTMLElement, fadePx: number) {
+  const containerRect = container.getBoundingClientRect();
+  const tabRect = tab.getBoundingClientRect();
+
+  const tabLeftInScroll = tabRect.left - containerRect.left + container.scrollLeft;
+  const tabRightInScroll = tabLeftInScroll + tabRect.width;
+
+  const viewLeft = container.scrollLeft + fadePx;
+  const viewRight = container.scrollLeft + container.clientWidth - fadePx;
+
+  let target = container.scrollLeft;
+  if (tabLeftInScroll < viewLeft) {
+    target = tabLeftInScroll - fadePx;
+  } else if (tabRightInScroll > viewRight) {
+    target = tabRightInScroll - container.clientWidth + fadePx;
+  } else {
+    return;
+  }
+
+  const max = container.scrollWidth - container.clientWidth;
+  container.scrollTo({ left: Math.max(0, Math.min(max, target)), behavior: 'smooth' });
+}
 
 function useScrollOverflow(elementRef: React.RefObject<HTMLElement | null>, depValue: number) {
   const [canScrollLeft, setCanScrollLeft] = useState(false);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6346,6 +6346,8 @@
         "ungroup-tabs": "Ungroup tabs"
       },
       "name": "Tabs",
+      "scroll-tabs-left": "Scroll tabs left",
+      "scroll-tabs-right": "Scroll tabs right",
       "tab": {
         "new": "New tab",
         "repeat": {


### PR DESCRIPTION
**What is this feature?**

Fixes: https://github.com/grafana/grafana/issues/121841

https://github.com/user-attachments/assets/923369f5-32f4-43cc-a3c1-a9b000ee0c0c


Improves the dashboard tabs layout when there are more tabs than fit in the tab bar:

- Left/right chevron overlay buttons on the tab bar that appear only when the strip overflows horizontally. Clicking smooth-scrolls the strip by roughly one viewport.
- Fade near the overflow edges is rendered via `mask-image` on the tabs container itself instead of a colored gradient wrapper, so the area behind each chevron is fully transparent and the tabs softly fade out into it.
- The active tab is automatically scrolled into view on initial mount, URL/history navigation, programmatic switch, and when a new tab is added, so it never lands behind a chevron's fade region. Uses an immediate post-commit scroll plus a double `requestAnimationFrame` fallback so `@hello-pangea/dnd` finishes positioning a freshly mounted Draggable before we measure.

**Why do we need this feature?**

Previously, when a dashboard had enough tabs to overflow the tab bar, the only way to reach the hidden tabs was trackpad/drag-to-scroll, which is not discoverable — many users did not realize more tabs were available. The fade itself was drawn as a colored gradient using `background.primary`, which showed up as a visible tinted stripe over the canvas background in the light theme. Clicking on or navigating to a tab that was partially hidden also did not bring it into view.

**Who is this feature for?**

Dashboard users and editors working with dashboards that have many tabs, especially in the new dashboard layouts.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Test plan:
- [ ] Open a dashboard with enough tabs to overflow the tab bar — verify the right chevron appears, the left chevron appears after scrolling right, and both appear mid-scroll.
- [ ] Click each chevron and verify the strip smooth-scrolls by roughly one viewport.
- [ ] Resize the viewport so overflow appears/disappears — chevrons should show/hide accordingly.
- [ ] In light theme, verify no tinted stripe appears on the tab bar; tabs simply fade to transparent at the overflow edges.
- [ ] Click a tab that is partially hidden behind a chevron — it should scroll fully into the non-faded area.
- [ ] Navigate to a tab via the dashboard outline, URL change, or browser back/forward — the active tab scrolls into view.
- [ ] Click "+ New tab" at the end of the strip and "Add tab" in the edit-pane sidebar — in both cases the newly added (and now active) tab scrolls into view.
- [ ] Drag-reorder tabs — no regressions; chevrons and fade continue to work.