### PR TITLE
Alerting: Fix label overflow in alert detail view

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -171,7 +171,7 @@ const RuleViewer = () => {
     >
       {shouldUseConsistencyCheck && <PrometheusConsistencyCheck ruleIdentifier={identifier} />}
       <div className={styles.layout}>
-        <Stack direction="column" gap={2}>
+        <Stack direction="column" gap={2} minWidth={0}>
           {/* tabs and tab content */}
           <TabContent>
             {activeTab === ActiveTab.Query && <QueryResults rule={rule} />}


### PR DESCRIPTION
**What is this feature?**

Adds `minWidth={0}` to the top-level `Stack` in `RuleViewer` so that flex children can shrink below their intrinsic content size.

**Why do we need this feature?**

Without this fix, long labels in the alert detail view overflow their container instead of truncating, because the flex child retains a minimum width equal to its content.

**Who is this feature for?**

Users who view alert rule details that contain long label values.

**Which issue(s) does this PR fix?**

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.