### PR TITLE
AccessControl: wire SA NameResolver for UID↔ID scope translation in IAM resource permissions

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -109,6 +109,14 @@ func RegisterAPIService(
 
 	rpStorage := resourcepermission.ProvideStorageBackend(dbProvider, mappers)
 
+	// Register the SA UID↔ID resolver so that service account scopes are translated
+	// via the K8s API (mode-agnostic) rather than a direct DB lookup.
+	saResolver := resourcepermission.NewServiceAccountNameResolver(
+		apiserver.ProvideClientGenerator(restConfig),
+		tracing,
+	)
+	mappers.RegisterResolver(schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}, saResolver)
+
 	// When resourcepermissions are in Mode5 (unistore only), search must error; pass nil backend so the handler returns that error.
 	resourcePermsSearchBackend := resource.StorageBackend(rpStorage)
 	if cfg != nil {

--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -118,18 +118,20 @@ type mapperEntry struct {
 }
 
 // MappersRegistry is a registry of resource permission mappers.
-// RegisterMapper must only be called during Wire init (before the server starts serving requests).
+// RegisterMapper and RegisterResolver must only be called during Wire init (before the server starts serving requests).
 // No mutex is needed because all registrations happen sequentially during startup.
 type MappersRegistry struct {
-	entries map[schema.GroupResource]mapperEntry
-	reverse map[string]schema.GroupResource // scope prefix -> GroupResource
+	entries   map[schema.GroupResource]mapperEntry
+	reverse   map[string]schema.GroupResource // scope prefix -> GroupResource
+	resolvers map[schema.GroupResource]NameResolver
 }
 
 // NewMappersRegistry initialises the registry with folders and dashboards (always enabled).
 func NewMappersRegistry() *MappersRegistry {
 	m := &MappersRegistry{
-		entries: make(map[schema.GroupResource]mapperEntry),
-		reverse: make(map[string]schema.GroupResource),
+		entries:   make(map[schema.GroupResource]mapperEntry),
+		reverse:   make(map[string]schema.GroupResource),
+		resolvers: make(map[schema.GroupResource]NameResolver),
 	}
 	m.RegisterMapper(
 		schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"},
@@ -145,6 +147,22 @@ func NewMappersRegistry() *MappersRegistry {
 // ProvideMappersRegistry is a Wire provider that returns a new MappersRegistry.
 func ProvideMappersRegistry() *MappersRegistry {
 	return NewMappersRegistry()
+}
+
+// RegisterResolver registers a NameResolver for the given GroupResource.
+// Must be called during Wire init; no mutex is used.
+func (m *MappersRegistry) RegisterResolver(gr schema.GroupResource, r NameResolver) {
+	m.resolvers[gr] = r
+}
+
+// GetResolver returns the NameResolver for the given GroupResource, or false if none is registered.
+func (m *MappersRegistry) GetResolver(gr schema.GroupResource) (NameResolver, bool) {
+	key, ok := m.findGroupKey(gr)
+	if !ok {
+		return nil, false
+	}
+	r, ok := m.resolvers[key]
+	return r, ok
 }
 
 // RegisterMapper registers a mapper for the given GroupResource.
@@ -289,7 +307,14 @@ func (m *MappersRegistry) ParseScopeCtx(ctx context.Context, ns types.NamespaceI
 	group := resolveGroup(gr.Group, datasourceType)
 
 	name := parts[2]
-	if isIDScoped(entry.mapper) && store != nil {
+	if resolver, ok := m.resolvers[gr]; ok {
+		// K8s API-based ID→UID for resources with a registered resolver (e.g. service accounts).
+		uid, err := resolver.IDToUID(ctx, ns.Value, name)
+		if err != nil {
+			return nil, err
+		}
+		name = uid
+	} else if isIDScoped(entry.mapper) && store != nil {
 		uid, err := legacy.ResolveIDScopeToUIDName(ctx, store, ns, scope)
 		if err != nil {
 			return nil, err

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -1,11 +1,15 @@
 package resourcepermission
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/authlib/types"
 
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
@@ -416,4 +420,92 @@ func TestMapper_AllowsKind_RestrictedList(t *testing.T) {
 	assert.True(t, m.AllowsKind(v0alpha1.ResourcePermissionSpecPermissionKindServiceAccount))
 	assert.True(t, m.AllowsKind(v0alpha1.ResourcePermissionSpecPermissionKindTeam))
 	assert.False(t, m.AllowsKind(v0alpha1.ResourcePermissionSpecPermissionKindBasicRole))
+}
+
+// --- RegisterResolver / GetResolver ---
+
+func TestMappersRegistry_RegisterResolver(t *testing.T) {
+	saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+
+	t.Run("registered resolver is returned by GetResolver", func(t *testing.T) {
+		m := NewMappersRegistry()
+		m.RegisterMapper(saGR, NewIDScopedMapper("serviceaccounts", defaultLevels), nil)
+
+		r := &mockNameResolver{}
+		m.RegisterResolver(saGR, r)
+
+		got, ok := m.GetResolver(saGR)
+		require.True(t, ok)
+		assert.Equal(t, r, got)
+	})
+
+	t.Run("GetResolver returns false for unregistered resource", func(t *testing.T) {
+		m := NewMappersRegistry()
+		_, ok := m.GetResolver(schema.GroupResource{Group: "unknown.app", Resource: "things"})
+		assert.False(t, ok)
+	})
+
+	t.Run("GetResolver uses wildcard group resolution", func(t *testing.T) {
+		m := NewMappersRegistry()
+		wildcardGR := schema.GroupResource{Group: "*.datasource.grafana.app", Resource: "datasources"}
+		m.RegisterMapper(wildcardGR, NewMapper("datasources", defaultLevels), nil)
+
+		r := &mockNameResolver{}
+		m.RegisterResolver(wildcardGR, r)
+
+		// A concrete group that matches the wildcard should find the resolver
+		concreteGR := schema.GroupResource{Group: "loki.datasource.grafana.app", Resource: "datasources"}
+		got, ok := m.GetResolver(concreteGR)
+		require.True(t, ok)
+		assert.Equal(t, r, got)
+	})
+}
+
+// --- ParseScopeCtx with resolver ---
+
+func TestMappersRegistry_ParseScopeCtx_WithResolver(t *testing.T) {
+	ctx := context.Background()
+	ns := types.NamespaceInfo{Value: "org-1"}
+	saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+
+	t.Run("resolver translates id to uid", func(t *testing.T) {
+		m := NewMappersRegistry()
+		m.RegisterMapper(saGR, NewIDScopedMapper("serviceaccounts", defaultLevels), nil)
+		m.RegisterResolver(saGR, &mockNameResolver{idToUID: map[string]string{"42": "sa-uid-abc"}})
+
+		grn, err := m.ParseScopeCtx(ctx, ns, nil, "serviceaccounts:id:42", "")
+		require.NoError(t, err)
+		assert.Equal(t, "sa-uid-abc", grn.Name)
+		assert.Equal(t, "serviceaccounts", grn.Resource)
+		assert.Equal(t, "iam.grafana.app", grn.Group)
+	})
+
+	t.Run("resolver error is propagated", func(t *testing.T) {
+		m := NewMappersRegistry()
+		m.RegisterMapper(saGR, NewIDScopedMapper("serviceaccounts", defaultLevels), nil)
+		m.RegisterResolver(saGR, &mockNameResolver{idToUIDErr: errors.New("k8s unavailable")})
+
+		_, err := m.ParseScopeCtx(ctx, ns, nil, "serviceaccounts:id:42", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "k8s unavailable")
+	})
+
+	t.Run("uid-scoped resource passes name through unchanged", func(t *testing.T) {
+		m := NewMappersRegistry()
+
+		grn, err := m.ParseScopeCtx(ctx, ns, nil, "folders:uid:fold1", "")
+		require.NoError(t, err)
+		assert.Equal(t, "fold1", grn.Name)
+		assert.Equal(t, "folder.grafana.app", grn.Group)
+	})
+
+	t.Run("id-scoped resource without resolver and nil store passes name through", func(t *testing.T) {
+		m := NewMappersRegistry()
+		m.RegisterMapper(saGR, NewIDScopedMapper("serviceaccounts", defaultLevels), nil)
+
+		// No resolver registered, nil store — name is returned as-is (numeric ID)
+		grn, err := m.ParseScopeCtx(ctx, ns, nil, "serviceaccounts:id:42", "")
+		require.NoError(t, err)
+		assert.Equal(t, "42", grn.Name)
+	})
 }

--- a/pkg/registry/apis/iam/resourcepermission/models.go
+++ b/pkg/registry/apis/iam/resourcepermission/models.go
@@ -148,6 +148,33 @@ func (s *ResourcePermSqlBackend) toV0ResourcePermissions(ctx context.Context, ns
 
 	logger := s.logger.FromContext(ctx)
 
+	// Pre-load the ID→UID map for any resource type that has a NameResolver and whose
+	// scopes appear in this result set. This avoids one K8s API call per scope in the loop.
+	saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+	if resolver, ok := s.mappers.GetResolver(saGR); ok {
+		hasSAScope := false
+		for _, a := range assignments {
+			if strings.HasPrefix(a.Scope, "serviceaccounts:id:") {
+				hasSAScope = true
+				break
+			}
+		}
+		if hasSAScope {
+			if idToUID, err := resolver.IDToUIDMap(ctx, ns.Value); err != nil {
+				logger.Warn("Failed to pre-load SA id→uid map, falling back to per-scope lookups", "error", err)
+			} else {
+				for id, uid := range idToUID {
+					cacheKey := "serviceaccounts:id:" + id + ":"
+					scopeCache[cacheKey] = &groupResourceName{
+						Group:    saGR.Group,
+						Resource: saGR.Resource,
+						Name:     uid,
+					}
+				}
+			}
+		}
+	}
+
 	// parseScopeCtxCached resolves and caches scope→GRN lookups.
 	// Returns (nil, nil) for orphaned id-scoped rows so callers can skip them.
 	parseScopeCtxCached := func(scope, datasourceType string) (*groupResourceName, error) {
@@ -276,6 +303,13 @@ func (g *groupResourceName) v0alpha1() v0alpha1.ResourcePermissionspecResource {
 // If the scope is a datasource scope, the datasourceType is used to resolve the concrete group.
 func (s *ResourcePermSqlBackend) ParseScope(scope, datasourceType string) (*groupResourceName, error) {
 	return s.mappers.ParseScope(scope, datasourceType)
+}
+
+// ParseScopeCtx is like ParseScope but also resolves id-scoped resources to UIDs using the
+// registered NameResolver (K8s API) or identity store (DB fallback for teams/users).
+// Use this instead of ParseScope whenever the caller needs a K8s-compatible name.
+func (s *ResourcePermSqlBackend) ParseScopeCtx(ctx context.Context, ns types.NamespaceInfo, scope, datasourceType string) (*groupResourceName, error) {
+	return s.mappers.ParseScopeCtx(ctx, ns, s.identityStore, scope, datasourceType)
 }
 
 // splitResourceName splits a resource name in the format <group>-<resource>-<name>

--- a/pkg/registry/apis/iam/resourcepermission/models_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/models_test.go
@@ -2,14 +2,18 @@ package resourcepermission
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/authlib/types"
 
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
-	"github.com/stretchr/testify/require"
 )
 
 // setupBackendNoDB sets up a ResourcePermSqlBackend with a no-op dbProvider for tests that do not require DB access.
@@ -152,4 +156,70 @@ func TestParseScope(t *testing.T) {
 			require.Equal(t, tt.expected.Name, result.Name)
 		})
 	}
+}
+
+// --- toV0ResourcePermissions with SA resolver ---
+
+func setupBackendWithResolver(t *testing.T, resolver NameResolver) *ResourcePermSqlBackend {
+	noProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return nil, nil
+	}
+	mappers := NewMappersRegistry()
+	backend := ProvideStorageBackend(noProvider, mappers)
+	saGR := schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+	mappers.RegisterResolver(saGR, resolver)
+	return backend
+}
+
+func TestToV0ResourcePermissions_SAResolver(t *testing.T) {
+	ctx := context.Background()
+	ns := types.NamespaceInfo{Value: "org-1"}
+	now := time.Now()
+
+	saAssignment := rbacAssignment{
+		ID:          1,
+		Action:      "serviceaccounts:edit",
+		Scope:       "serviceaccounts:id:42",
+		Created:     now,
+		Updated:     now,
+		SubjectUID:  "user-1",
+		SubjectType: "user",
+	}
+
+	t.Run("IDToUIDMap pre-loads cache, SA name resolves to UID", func(t *testing.T) {
+		resolver := &mockNameResolver{idToUID: map[string]string{"42": "sa-uid-abc"}}
+		backend := setupBackendWithResolver(t, resolver)
+
+		result, err := backend.toV0ResourcePermissions(ctx, ns, []rbacAssignment{saAssignment})
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "sa-uid-abc", result[0].Spec.Resource.Name)
+		assert.Equal(t, "serviceaccounts", result[0].Spec.Resource.Resource)
+		assert.Equal(t, "iam.grafana.app", result[0].Spec.Resource.ApiGroup)
+	})
+
+	t.Run("IDToUIDMap failure falls back to per-scope IDToUID", func(t *testing.T) {
+		// Pre-load fails but per-scope lookup succeeds
+		resolver := &mockNameResolver{
+			idToUID:       map[string]string{"42": "sa-uid-abc"},
+			idToUIDMapErr: errors.New("k8s timeout"),
+		}
+		backend := setupBackendWithResolver(t, resolver)
+
+		result, err := backend.toV0ResourcePermissions(ctx, ns, []rbacAssignment{saAssignment})
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "sa-uid-abc", result[0].Spec.Resource.Name)
+	})
+
+	t.Run("both IDToUIDMap and IDToUID fail: error returned", func(t *testing.T) {
+		resolver := &mockNameResolver{
+			idToUIDMapErr: errors.New("k8s unavailable"),
+			idToUIDErr:    errors.New("k8s unavailable"),
+		}
+		backend := setupBackendWithResolver(t, resolver)
+
+		_, err := backend.toV0ResourcePermissions(ctx, ns, []rbacAssignment{saAssignment})
+		require.Error(t, err)
+	})
 }

--- a/pkg/registry/apis/iam/resourcepermission/name_resolver.go
+++ b/pkg/registry/apis/iam/resourcepermission/name_resolver.go
@@ -1,0 +1,154 @@
+package resourcepermission
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
+)
+
+// NameResolver translates between K8s UIDs and DB numeric IDs for a specific resource type.
+// Resources without a resolver (folders, dashboards) pass names through unchanged since they
+// already use UIDs as their scope attribute.
+type NameResolver interface {
+	// UIDToID converts a K8s UID to a DB numeric ID string.
+	// Used on the write path before generating a legacy RBAC scope.
+	// Returns an error if the UID does not exist — callers must fail fast.
+	UIDToID(ctx context.Context, namespace string, uid string) (string, error)
+
+	// IDToUID converts a DB numeric ID string to a K8s UID.
+	// Used on the read path to rewrite DB scopes back to K8s API names.
+	IDToUID(ctx context.Context, namespace string, id string) (string, error)
+
+	// IDToUIDMap returns the full ID→UID mapping for a namespace in one K8s API call.
+	// Prefer this over IDToUID in a loop when resolving bulk read responses.
+	IDToUIDMap(ctx context.Context, namespace string) (map[string]string, error)
+}
+
+// serviceAccountNameResolver resolves UID↔ID for service accounts via the K8s API.
+// Using K8s API calls (rather than a direct DB lookup) is mode-agnostic: requests
+// route through whatever storage backend (dualwrite, unified, legacy) the SA resource
+// is currently configured for.
+type serviceAccountNameResolver struct {
+	client *iamv0alpha1.ServiceAccountClient
+	tracer trace.Tracer
+	logger log.Logger
+}
+
+func newServiceAccountNameResolver(client *iamv0alpha1.ServiceAccountClient, tracer trace.Tracer) NameResolver {
+	return &serviceAccountNameResolver{
+		client: client,
+		tracer: tracer,
+		logger: log.New("resourceperm.sa-name-resolver"),
+	}
+}
+
+// UIDToID fetches the service account by UID and reads its deprecatedInternalID label
+// to return the DB numeric ID string. Fails fast if the UID is not found.
+func (r *serviceAccountNameResolver) UIDToID(ctx context.Context, namespace, uid string) (string, error) {
+	ctx, span := r.tracer.Start(ctx, "serviceAccountNameResolver.UIDToID",
+		trace.WithAttributes(
+			attribute.String("namespace", namespace),
+			attribute.String("uid", uid),
+		),
+	)
+	defer span.End()
+
+	sa, err := r.client.Get(ctx, resource.Identifier{Namespace: namespace, Name: uid})
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		r.logger.FromContext(ctx).Warn("failed to get service account by uid", "namespace", namespace, "uid", uid, "error", err)
+		if apierrors.IsNotFound(err) {
+			return "", serviceaccounts.ErrServiceAccountNotFound.Errorf("service account with uid %q not found in namespace %q", uid, namespace)
+		}
+		return "", fmt.Errorf("resolving service account uid %q to id: %w", uid, err)
+	}
+
+	id := sa.GetLabels()[utils.LabelKeyDeprecatedInternalID]
+	if id == "" {
+		err := fmt.Errorf("service account %q in namespace %q is missing label %s", uid, namespace, utils.LabelKeyDeprecatedInternalID)
+		span.SetStatus(codes.Error, err.Error())
+		r.logger.FromContext(ctx).Warn("service account missing deprecatedInternalID label", "namespace", namespace, "uid", uid)
+		return "", err
+	}
+
+	span.SetAttributes(attribute.String("id", id))
+	r.logger.FromContext(ctx).Debug("resolved uid to id", "namespace", namespace, "uid", uid, "id", id)
+	return id, nil
+}
+
+// IDToUID lists service accounts filtered by deprecatedInternalID label and returns
+// the metadata.name (UID) of the matching entry.
+func (r *serviceAccountNameResolver) IDToUID(ctx context.Context, namespace, id string) (string, error) {
+	ctx, span := r.tracer.Start(ctx, "serviceAccountNameResolver.IDToUID",
+		trace.WithAttributes(
+			attribute.String("namespace", namespace),
+			attribute.String("id", id),
+		),
+	)
+	defer span.End()
+
+	list, err := r.client.List(ctx, namespace, resource.ListOptions{
+		LabelFilters: []string{utils.LabelKeyDeprecatedInternalID + "=" + id},
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		r.logger.FromContext(ctx).Warn("failed to list service accounts by id", "namespace", namespace, "id", id, "error", err)
+		return "", fmt.Errorf("resolving service account id %q to uid: %w", id, err)
+	}
+
+	if len(list.Items) == 0 {
+		span.SetStatus(codes.Error, "not found")
+		r.logger.FromContext(ctx).Warn("no service account found for id", "namespace", namespace, "id", id)
+		return "", serviceaccounts.ErrServiceAccountNotFound.Errorf("service account with id %q not found in namespace %q", id, namespace)
+	}
+
+	uid := list.Items[0].GetName()
+	span.SetAttributes(attribute.String("uid", uid))
+	r.logger.FromContext(ctx).Debug("resolved id to uid", "namespace", namespace, "id", id, "uid", uid)
+	return uid, nil
+}
+
+// IDToUIDMap lists all service accounts in the namespace and returns a map of
+// DB numeric ID → K8s UID. Use this for bulk read operations to avoid N individual
+// K8s API calls.
+//
+// Caching note: a short-lived per-namespace cache would eliminate most K8s API
+// pressure on the read path. Pending team approval before implementing.
+func (r *serviceAccountNameResolver) IDToUIDMap(ctx context.Context, namespace string) (map[string]string, error) {
+	ctx, span := r.tracer.Start(ctx, "serviceAccountNameResolver.IDToUIDMap",
+		trace.WithAttributes(
+			attribute.String("namespace", namespace),
+		),
+	)
+	defer span.End()
+
+	list, err := r.client.ListAll(ctx, namespace, resource.ListOptions{})
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		r.logger.FromContext(ctx).Warn("failed to list all service accounts", "namespace", namespace, "error", err)
+		return nil, fmt.Errorf("building id→uid map for namespace %q: %w", namespace, err)
+	}
+
+	m := make(map[string]string, len(list.Items))
+	for _, sa := range list.Items {
+		id := sa.GetLabels()[utils.LabelKeyDeprecatedInternalID]
+		if id == "" {
+			continue
+		}
+		m[id] = sa.GetName()
+	}
+
+	span.SetAttributes(attribute.Int("count", len(m)))
+	r.logger.FromContext(ctx).Debug("built id→uid map", "namespace", namespace, "count", len(m))
+	return m, nil
+}

--- a/pkg/registry/apis/iam/resourcepermission/name_resolver.go
+++ b/pkg/registry/apis/iam/resourcepermission/name_resolver.go
@@ -137,6 +137,11 @@ func (r *serviceAccountNameResolver) IDToUID(ctx context.Context, namespace, id 
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		r.logger.FromContext(ctx).Warn("failed to list service accounts by id", "namespace", namespace, "id", id, "error", err)
+		// K8s 404 means the SA resource type is not yet available (e.g. dual-write mode 0/1).
+		// Treat it as "SA not found" so callers can handle it as an orphaned scope.
+		if apierrors.IsNotFound(err) {
+			return "", serviceaccounts.ErrServiceAccountNotFound.Errorf("service account with id %q not found in namespace %q", id, namespace)
+		}
 		return "", fmt.Errorf("resolving service account id %q to uid: %w", id, err)
 	}
 
@@ -173,6 +178,13 @@ func (r *serviceAccountNameResolver) IDToUIDMap(ctx context.Context, namespace s
 	}
 	list, err := client.ListAll(ctx, namespace, resource.ListOptions{})
 	if err != nil {
+		// K8s 404 means the SA resource type is not yet available (e.g. dual-write mode 0/1).
+		// Return an empty map so callers skip the bulk pre-load and each scope falls through
+		// to IDToUID, which also handles the 404 gracefully.
+		if apierrors.IsNotFound(err) {
+			r.logger.FromContext(ctx).Debug("SA K8s API unavailable for bulk id→uid pre-load, skipping", "namespace", namespace)
+			return make(map[string]string), nil
+		}
 		span.SetStatus(codes.Error, err.Error())
 		r.logger.FromContext(ctx).Warn("failed to list all service accounts", "namespace", namespace, "error", err)
 		return nil, fmt.Errorf("building id→uid map for namespace %q: %w", namespace, err)

--- a/pkg/registry/apis/iam/resourcepermission/name_resolver.go
+++ b/pkg/registry/apis/iam/resourcepermission/name_resolver.go
@@ -3,6 +3,7 @@ package resourcepermission
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -38,18 +39,41 @@ type NameResolver interface {
 // Using K8s API calls (rather than a direct DB lookup) is mode-agnostic: requests
 // route through whatever storage backend (dualwrite, unified, legacy) the SA resource
 // is currently configured for.
+//
+// The SA client is created lazily on first use via sync.Once so that the resolver
+// can be safely constructed during Wire init (before the apiserver rest config is ready).
 type serviceAccountNameResolver struct {
-	client *iamv0alpha1.ServiceAccountClient
-	tracer trace.Tracer
-	logger log.Logger
+	generator  resource.ClientGenerator
+	tracer     trace.Tracer
+	logger     log.Logger
+	clientOnce sync.Once
+	client     *iamv0alpha1.ServiceAccountClient
+	clientErr  error
 }
 
-func newServiceAccountNameResolver(client *iamv0alpha1.ServiceAccountClient, tracer trace.Tracer) NameResolver {
+// NewServiceAccountNameResolver creates a NameResolver for service accounts that
+// translates between K8s UIDs and DB numeric IDs via the K8s API.
+// The generator must be lazy (i.e. it may block until the apiserver is ready).
+func NewServiceAccountNameResolver(generator resource.ClientGenerator, tracer trace.Tracer) NameResolver {
 	return &serviceAccountNameResolver{
-		client: client,
-		tracer: tracer,
-		logger: log.New("resourceperm.sa-name-resolver"),
+		generator: generator,
+		tracer:    tracer,
+		logger:    log.New("resourceperm.sa-name-resolver"),
 	}
+}
+
+// getClient initialises the SA K8s client on the first call.
+// Subsequent calls return the cached result. Safe for concurrent use.
+func (r *serviceAccountNameResolver) getClient() (*iamv0alpha1.ServiceAccountClient, error) {
+	r.clientOnce.Do(func() {
+		c, err := r.generator.ClientFor(iamv0alpha1.ServiceAccountKind())
+		if err != nil {
+			r.clientErr = fmt.Errorf("creating service account K8s client: %w", err)
+			return
+		}
+		r.client = iamv0alpha1.NewServiceAccountClient(c)
+	})
+	return r.client, r.clientErr
 }
 
 // UIDToID fetches the service account by UID and reads its deprecatedInternalID label
@@ -63,7 +87,12 @@ func (r *serviceAccountNameResolver) UIDToID(ctx context.Context, namespace, uid
 	)
 	defer span.End()
 
-	sa, err := r.client.Get(ctx, resource.Identifier{Namespace: namespace, Name: uid})
+	client, err := r.getClient()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return "", err
+	}
+	sa, err := client.Get(ctx, resource.Identifier{Namespace: namespace, Name: uid})
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		r.logger.FromContext(ctx).Warn("failed to get service account by uid", "namespace", namespace, "uid", uid, "error", err)
@@ -97,7 +126,12 @@ func (r *serviceAccountNameResolver) IDToUID(ctx context.Context, namespace, id 
 	)
 	defer span.End()
 
-	list, err := r.client.List(ctx, namespace, resource.ListOptions{
+	client, err := r.getClient()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return "", err
+	}
+	list, err := client.List(ctx, namespace, resource.ListOptions{
 		LabelFilters: []string{utils.LabelKeyDeprecatedInternalID + "=" + id},
 	})
 	if err != nil {
@@ -132,7 +166,12 @@ func (r *serviceAccountNameResolver) IDToUIDMap(ctx context.Context, namespace s
 	)
 	defer span.End()
 
-	list, err := r.client.ListAll(ctx, namespace, resource.ListOptions{})
+	client, err := r.getClient()
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	list, err := client.ListAll(ctx, namespace, resource.ListOptions{})
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		r.logger.FromContext(ctx).Warn("failed to list all service accounts", "namespace", namespace, "error", err)

--- a/pkg/registry/apis/iam/resourcepermission/name_resolver_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/name_resolver_test.go
@@ -1,0 +1,44 @@
+package resourcepermission
+
+import (
+	"context"
+	"errors"
+	"maps"
+)
+
+// mockNameResolver is a test double for NameResolver.
+// All methods return the mapped value, or the configured error if set.
+type mockNameResolver struct {
+	uidToID       map[string]string
+	idToUID       map[string]string
+	uidToIDErr    error
+	idToUIDErr    error
+	idToUIDMapErr error
+}
+
+func (m *mockNameResolver) UIDToID(_ context.Context, _, uid string) (string, error) {
+	if m.uidToIDErr != nil {
+		return "", m.uidToIDErr
+	}
+	if id, ok := m.uidToID[uid]; ok {
+		return id, nil
+	}
+	return "", errors.New("uid not found: " + uid)
+}
+
+func (m *mockNameResolver) IDToUID(_ context.Context, _, id string) (string, error) {
+	if m.idToUIDErr != nil {
+		return "", m.idToUIDErr
+	}
+	if uid, ok := m.idToUID[id]; ok {
+		return uid, nil
+	}
+	return "", errors.New("id not found: " + id)
+}
+
+func (m *mockNameResolver) IDToUIDMap(_ context.Context, _ string) (map[string]string, error) {
+	if m.idToUIDMapErr != nil {
+		return nil, m.idToUIDMapErr
+	}
+	return maps.Clone(m.idToUID), nil
+}

--- a/pkg/registry/apis/iam/resourcepermission/search_handler.go
+++ b/pkg/registry/apis/iam/resourcepermission/search_handler.go
@@ -209,8 +209,14 @@ func filterPermissionsByGet(
 	if !ok {
 		return nil
 	}
+	ns, err := types.ParseNamespace(namespace)
+	if err != nil {
+		return nil
+	}
 	filtered, err := iamauthorizer.CanViewTargets(authorizer, ctx, authInfo, perms, func(i int) (string, string, string, string, bool) {
-		grn, err := backend.ParseScope(perms[i].Scope, "")
+		// ParseScopeCtx translates id-scoped names (e.g. serviceaccounts:id:123) to UIDs so
+		// that CanViewTargets receives a K8s-compatible name rather than a numeric DB id.
+		grn, err := backend.ParseScopeCtx(ctx, ns, perms[i].Scope, "")
 		if err != nil {
 			return "", "", "", "", false
 		}

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
@@ -20,9 +21,18 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
-// resolveScope returns the legacy db scope for the given resource name.
-// For id-scoped resources (teams, users, service accounts), translates uid→id via the identity store.
-func resolveScope(ctx context.Context, ns types.NamespaceInfo, store IdentityStore, mapper Mapper, name string) (string, error) {
+// resolveScope returns the legacy DB scope for the given resource name.
+// For resources with a registered NameResolver (e.g. service accounts), calls UIDToID via the
+// K8s API — mode-agnostic and fails fast on lookup failure. For other id-scoped resources
+// (teams, users) falls back to the identity store.
+func resolveScope(ctx context.Context, ns types.NamespaceInfo, store IdentityStore, resolver NameResolver, mapper Mapper, name string) (string, error) {
+	if resolver != nil {
+		id, err := resolver.UIDToID(ctx, ns.Value, name)
+		if err != nil {
+			return "", err
+		}
+		return mapper.Scope(id), nil
+	}
 	scope := mapper.Scope(name)
 	if isIDScoped(mapper) && store != nil {
 		return legacy.ResolveUIDScopeForWrite(ctx, store, ns, scope)
@@ -219,7 +229,8 @@ func (s *ResourcePermSqlBackend) getResourcePermission(ctx context.Context, sql 
 		return nil, apierrors.NewInternalError(err)
 	}
 
-	scope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+	resolver, _ := s.mappers.GetResolver(schema.GroupResource{Group: grn.Group, Resource: grn.Resource})
+	scope, err := resolveScope(ctx, ns, s.identityStore, resolver, mapper, grn.Name)
 	if err != nil {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("resolving scope for %q: %v", grn.Name, err))
 	}
@@ -437,7 +448,8 @@ func (s *ResourcePermSqlBackend) existsResourcePermission(ctx context.Context, t
 func (s *ResourcePermSqlBackend) createResourcePermission(
 	ctx context.Context, dbHelper *legacysql.LegacyDatabaseHelper, ns types.NamespaceInfo, mapper Mapper, grn *groupResourceName, v0ResourcePerm *v0alpha1.ResourcePermission,
 ) (int64, error) {
-	rbacScope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+	resolver, _ := s.mappers.GetResolver(schema.GroupResource{Group: grn.Group, Resource: grn.Resource})
+	rbacScope, err := resolveScope(ctx, ns, s.identityStore, resolver, mapper, grn.Name)
 	if err != nil {
 		return 0, apierrors.NewBadRequest(fmt.Sprintf("resolving scope for %q: %v", grn.Name, err))
 	}
@@ -482,7 +494,8 @@ func (s *ResourcePermSqlBackend) updateResourcePermission(ctx context.Context, d
 		}
 
 		permissionsToAdd, permissionsToRemove := diffPermissions(currentPerms.Spec.Permissions, v0ResourcePerm.Spec.Permissions)
-		rbacScope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+		resolver, _ := s.mappers.GetResolver(schema.GroupResource{Group: grn.Group, Resource: grn.Resource})
+		rbacScope, err := resolveScope(ctx, ns, s.identityStore, resolver, mapper, grn.Name)
 		if err != nil {
 			return fmt.Errorf("resolving scope for %q: %w", grn.Name, err)
 		}
@@ -579,7 +592,8 @@ func (s *ResourcePermSqlBackend) deleteResourcePermission(ctx context.Context, s
 		return err
 	}
 
-	scope, err := resolveScope(ctx, ns, s.identityStore, mapper, grn.Name)
+	resolver, _ := s.mappers.GetResolver(schema.GroupResource{Group: grn.Group, Resource: grn.Resource})
+	scope, err := resolveScope(ctx, ns, s.identityStore, resolver, mapper, grn.Name)
 	if err != nil {
 		return fmt.Errorf("resolving scope for %q: %w", grn.Name, err)
 	}

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -940,3 +940,45 @@ func TestIntegration_Datasource_WriteAndReadBackConcreteGroup(t *testing.T) {
 	assert.Equal(t, "datasources", got.Spec.Resource.Resource)
 	assert.Equal(t, "loki-ds", got.Spec.Resource.Name)
 }
+
+// --- resolveScope ---
+
+func TestResolveScope(t *testing.T) {
+	ctx := context.Background()
+	ns := types.NamespaceInfo{Value: "org-1"}
+
+	t.Run("with resolver: calls UIDToID and returns id-scoped scope", func(t *testing.T) {
+		mapper := NewIDScopedMapper("serviceaccounts", defaultLevels)
+		resolver := &mockNameResolver{uidToID: map[string]string{"sa-uid": "42"}}
+
+		scope, err := resolveScope(ctx, ns, nil, resolver, mapper, "sa-uid")
+		require.NoError(t, err)
+		assert.Equal(t, "serviceaccounts:id:42", scope)
+	})
+
+	t.Run("resolver UIDToID error propagates", func(t *testing.T) {
+		mapper := NewIDScopedMapper("serviceaccounts", defaultLevels)
+		resolver := &mockNameResolver{uidToIDErr: errors.New("sa not found")}
+
+		_, err := resolveScope(ctx, ns, nil, resolver, mapper, "sa-uid")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sa not found")
+	})
+
+	t.Run("nil resolver with uid-scoped mapper: returns scope unchanged", func(t *testing.T) {
+		mapper := NewMapper("folders", defaultLevels)
+
+		scope, err := resolveScope(ctx, ns, nil, nil, mapper, "fold1")
+		require.NoError(t, err)
+		assert.Equal(t, "folders:uid:fold1", scope)
+	})
+
+	t.Run("nil resolver with id-scoped mapper and nil store: returns scope unchanged", func(t *testing.T) {
+		mapper := NewIDScopedMapper("teams", defaultLevels)
+
+		// No resolver, no store — the id-scoped path is skipped when store is nil
+		scope, err := resolveScope(ctx, ns, nil, nil, mapper, "team-1")
+		require.NoError(t, err)
+		assert.Equal(t, "teams:id:team-1", scope)
+	})
+}


### PR DESCRIPTION
## Why

Service account scopes in IAM resource permissions use DB numeric IDs (e.g. `serviceaccounts:id:42`) on the write path, but the K8s API expects UIDs (e.g. `serviceaccounts:uid:abc`). Without translation, reads return raw DB IDs as resource names and writes with K8s names fail to produce a valid RBAC scope.

Closes grafana/identity-access-team#2002

## What

- Defines a `NameResolver` interface (`UIDToID`, `IDToUID`, `IDToUIDMap`) in `pkg/registry/apis/iam/resourcepermission/`
- Implements `serviceAccountNameResolver` — lazily initialises a K8s SA client via `sync.Once` so it is safe to construct at Wire init time (before the apiserver rest config is ready)
- Integrates the resolver into `resolveScope` (write path) and `toV0ResourcePermissions` (read path, with `IDToUIDMap` bulk pre-load to avoid N K8s API calls)
- Registers the resolver in `RegisterAPIService` via `apiserver.ProvideClientGenerator(restConfig)`
- Adds unit tests covering: `RegisterResolver`/`GetResolver`, `ParseScopeCtx` with resolver, `resolveScope`, and `toV0ResourcePermissions` SA pre-load (happy path, `IDToUIDMap` fallback, full error)

## How to test

Unit tests:
```bash
go test ./pkg/registry/apis/iam/resourcepermission/... -run "TestToV0ResourcePermissions_SAResolver|TestMappersRegistry_RegisterResolver|TestMappersRegistry_ParseScopeCtx_WithResolver|TestResolveScope"
```

## Risks / notes

- The lazy `sync.Once` init means a K8s client init failure surfaces only on first SA scope resolution, not at startup — this is intentional and matches the `eventualRestConfigProvider` pattern used elsewhere
- Orphaned SA scopes (SA deleted from DB but permission remains) are dropped with a warn log rather than surfacing an error to the caller
- Enterprise standalone IAM factory change is in the companion PR in grafana-enterprise