### PR TITLE
Scopes: Remove scope_node from URL when using defaultPath

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,19 +1,4 @@
 {
-  "e2e/cypress/support/commands.js": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 1
-    }
-  },
-  "e2e/utils/support/localStorage.ts": {
-    "@grafana/no-direct-local-storage-access": {
-      "count": 2
-    }
-  },
-  "e2e/utils/support/types.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
   "packages/grafana-data/src/dataframe/CircularDataFrame.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -534,7 +534,7 @@ describe('ScopesService', () => {
     });
 
     describe('defaultPath support', () => {
-      it('should extract scope_node from defaultPath when available', () => {
+      it('should not write scope_node to URL when defaultPath is available', () => {
         if (!selectorStateSubscription) {
           throw new Error('selectorStateSubscription not set');
         }
@@ -559,11 +559,12 @@ describe('ScopesService', () => {
           }
         );
 
-        // Should use 'correct-node' from defaultPath, not 'old-node' from appliedScopes
+        // When defaultPath is available, scope_node is redundant (it is re-derived
+        // from defaultPath on load), so the URL param is cleared.
         expect(locationService.partial).toHaveBeenCalledWith(
           {
             scopes: ['scope1'],
-            scope_node: 'correct-node',
+            scope_node: null,
             scope_parent: null,
           },
           true
@@ -641,10 +642,12 @@ describe('ScopesService', () => {
         );
       });
 
-      it('should detect changes in defaultPath-derived scopeNodeId', () => {
+      it('should not update URL when only defaultPath changes and scopes are unchanged', () => {
         if (!selectorStateSubscription) {
           throw new Error('selectorStateSubscription not set');
         }
+
+        jest.clearAllMocks();
 
         selectorStateSubscription(
           {
@@ -675,15 +678,9 @@ describe('ScopesService', () => {
           }
         );
 
-        // Should detect the change in defaultPath-derived scopeNodeId
-        expect(locationService.partial).toHaveBeenCalledWith(
-          {
-            scopes: ['scope1'],
-            scope_node: 'new-node',
-            scope_parent: null,
-          },
-          true
-        );
+        // scope_node is no longer synced when defaultPath is present, so a
+        // defaultPath-only change does not trigger a URL update.
+        expect(locationService.partial).not.toHaveBeenCalled();
       });
     });
 
@@ -931,7 +928,7 @@ describe('ScopesService', () => {
       );
     });
 
-    it('should use defaultPath for scope_node when enabling scopes', () => {
+    it('should clear scope_node when enabling scopes for a scope with defaultPath', () => {
       selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'old-node' }];
       selectorService.state.scopes = {
         scope1: {
@@ -946,10 +943,11 @@ describe('ScopesService', () => {
 
       service.setEnabled(true);
 
-      // Should use defaultPath instead of scopeNodeId from appliedScopes
+      // When defaultPath is available, scope_node is redundant and should be
+      // cleared from the URL (passing null removes any stale value).
       expect(locationService.partial).toHaveBeenCalledWith(
         expect.objectContaining({
-          scope_node: 'correct-node-from-defaultPath',
+          scope_node: null,
         }),
         true
       );

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -7,6 +7,7 @@ import { type LocationService, type ScopesContextValue, type ScopesContextValueS
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
 import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNavgiationUtils';
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
+import { type ScopesMap, type SelectedScope } from './selector/types';
 
 export interface State {
   enabled: boolean;
@@ -170,22 +171,8 @@ export class ScopesService implements ScopesContextValue {
         const oldScopeNames = prevState.appliedScopes.map((scope) => scope.scopeId);
         const newScopeNames = state.appliedScopes.map((scope) => scope.scopeId);
 
-        // Extract scopeNodeId from defaultPath when available
-        const getScopeNodeId = (appliedScopes: typeof state.appliedScopes, scopes: typeof state.scopes) => {
-          const firstScope = appliedScopes[0];
-          if (!firstScope) {
-            return undefined;
-          }
-          const scope = scopes[firstScope.scopeId];
-          // Prefer defaultPath when available
-          if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
-            return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
-          }
-          return firstScope.scopeNodeId;
-        };
-
-        const oldScopeNodeId = getScopeNodeId(prevState.appliedScopes, prevState.scopes);
-        const newScopeNodeId = getScopeNodeId(state.appliedScopes, state.scopes);
+        const oldScopeNodeId = this.getScopeNodeIdForUrl(prevState.appliedScopes, prevState.scopes);
+        const newScopeNodeId = this.getScopeNodeIdForUrl(state.appliedScopes, state.scopes);
 
         const scopesChanged = !isEqual(oldScopeNames, newScopeNames);
         const scopeNodeChanged = oldScopeNodeId !== newScopeNodeId;
@@ -260,11 +247,12 @@ export class ScopesService implements ScopesContextValue {
     if (this.state.enabled !== enabled) {
       this.updateState({ enabled });
       if (enabled) {
-        const scopeNodeId = this.getScopeNodeIdForUrl();
+        const { appliedScopes, scopes } = this.selectorService.state;
+        const scopeNodeId = this.getScopeNodeIdForUrl(appliedScopes, scopes);
         this.locationService.partial(
           {
-            scopes: this.selectorService.state.appliedScopes.map((s) => s.scopeId),
-            scope_node: scopeNodeId,
+            scopes: appliedScopes.map((s) => s.scopeId),
+            scope_node: scopeNodeId ?? null,
             scope_parent: null,
           },
           true
@@ -274,25 +262,27 @@ export class ScopesService implements ScopesContextValue {
   };
 
   /**
-   * Extracts the scopeNodeId for URL syncing, preferring defaultPath when available.
-   * When a scope has defaultPath, that is the source of truth for the node ID.
+   * Returns the scope node id to sync with the URL, or `undefined` when the
+   * URL should not carry `scope_node` at all.
+   *
+   * We skip writing `scope_node` when the scope has a non-empty `defaultPath`,
+   * since that value is redundant — it is re-derived from `defaultPath` on load
+   * and kept in sync by the selector service. Bookmarked URLs that still carry
+   * `scope_node=...` continue to work via the read path.
    * @private
    */
-  private getScopeNodeIdForUrl(): string | undefined {
-    const firstScope = this.selectorService.state.appliedScopes[0];
+  private getScopeNodeIdForUrl(appliedScopes: SelectedScope[], scopes: ScopesMap): string | undefined {
+    const firstScope = appliedScopes[0];
     if (!firstScope) {
       return undefined;
     }
 
-    const scope = this.selectorService.state.scopes[firstScope.scopeId];
+    const scope = scopes[firstScope.scopeId];
 
-    // Prefer scopeNodeId from defaultPath if available (most reliable source)
     if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
-      // Extract scopeNodeId from the last element of defaultPath
-      return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
+      return undefined;
     }
 
-    // Fallback to next in priority order: scopeNodeId from appliedScopes
     return firstScope.scopeNodeId;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Does not set `scope_node` i the URL of a selected scope has `defaultPath` set. Also refactors the method for getting the scopeNodeId so we don't have a duplicate.

**Why do we need this feature?**

`scope_node` is redundant, as the source of truth is defaultPath. Otherwise the URL is polluted.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/hyperion-planning/issues/542

**Special notes for your reviewer:**
With the devenv scopes, select `gdev-scopes -> Production -> Shared Service` or `gdev-scopes -> Test cases -> Shared Service`. No `scope_node` should be set in the URL. When opening the selector the "Production" node should be open and expanded.



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
